### PR TITLE
[template.lock] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/template/lock/template_lock.cpp
+++ b/esphome/components/template/lock/template_lock.cpp
@@ -7,8 +7,7 @@ using namespace esphome::lock;
 
 static const char *const TAG = "template.lock";
 
-TemplateLock::TemplateLock()
-    : lock_trigger_(new Trigger<>()), unlock_trigger_(new Trigger<>()), open_trigger_(new Trigger<>()) {}
+TemplateLock::TemplateLock() = default;
 
 void TemplateLock::setup() {
   if (!this->f_.has_value())
@@ -28,11 +27,11 @@ void TemplateLock::control(const lock::LockCall &call) {
 
   auto state = *call.get_state();
   if (state == LOCK_STATE_LOCKED) {
-    this->prev_trigger_ = this->lock_trigger_;
-    this->lock_trigger_->trigger();
+    this->prev_trigger_ = &this->lock_trigger_;
+    this->lock_trigger_.trigger();
   } else if (state == LOCK_STATE_UNLOCKED) {
-    this->prev_trigger_ = this->unlock_trigger_;
-    this->unlock_trigger_->trigger();
+    this->prev_trigger_ = &this->unlock_trigger_;
+    this->unlock_trigger_.trigger();
   }
 
   if (this->optimistic_)
@@ -42,14 +41,11 @@ void TemplateLock::open_latch() {
   if (this->prev_trigger_ != nullptr) {
     this->prev_trigger_->stop_action();
   }
-  this->prev_trigger_ = this->open_trigger_;
-  this->open_trigger_->trigger();
+  this->prev_trigger_ = &this->open_trigger_;
+  this->open_trigger_.trigger();
 }
 void TemplateLock::set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 float TemplateLock::get_setup_priority() const { return setup_priority::HARDWARE; }
-Trigger<> *TemplateLock::get_lock_trigger() const { return this->lock_trigger_; }
-Trigger<> *TemplateLock::get_unlock_trigger() const { return this->unlock_trigger_; }
-Trigger<> *TemplateLock::get_open_trigger() const { return this->open_trigger_; }
 void TemplateLock::dump_config() {
   LOG_LOCK("", "Template Lock", this);
   ESP_LOGCONFIG(TAG, "  Optimistic: %s", YESNO(this->optimistic_));

--- a/esphome/components/template/lock/template_lock.h
+++ b/esphome/components/template/lock/template_lock.h
@@ -15,9 +15,9 @@ class TemplateLock final : public lock::Lock, public Component {
   void dump_config() override;
 
   template<typename F> void set_state_lambda(F &&f) { this->f_.set(std::forward<F>(f)); }
-  Trigger<> *get_lock_trigger() const;
-  Trigger<> *get_unlock_trigger() const;
-  Trigger<> *get_open_trigger() const;
+  Trigger<> *get_lock_trigger() { return &this->lock_trigger_; }
+  Trigger<> *get_unlock_trigger() { return &this->unlock_trigger_; }
+  Trigger<> *get_open_trigger() { return &this->open_trigger_; }
   void set_optimistic(bool optimistic);
   void loop() override;
 
@@ -29,9 +29,9 @@ class TemplateLock final : public lock::Lock, public Component {
 
   TemplateLambda<lock::LockState> f_;
   bool optimistic_{false};
-  Trigger<> *lock_trigger_;
-  Trigger<> *unlock_trigger_;
-  Trigger<> *open_trigger_;
+  Trigger<> lock_trigger_;
+  Trigger<> unlock_trigger_;
+  Trigger<> open_trigger_;
   Trigger<> *prev_trigger_{nullptr};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Changes template lock's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *lock_trigger_;
Trigger<> *unlock_trigger_;
Trigger<> *open_trigger_;
// Constructor: new Trigger<>() for each

// After
Trigger<> lock_trigger_;
Trigger<> unlock_trigger_;
Trigger<> open_trigger_;
```

**Memory savings per template lock instance:**
- Before: 3 x 16 bytes heap = 48 bytes + fragmentation
- After: 3 x 4 bytes inline = 12 bytes
- **Saves: ~36 bytes per instance**

This follows the same pattern established in #13691 (template.switch), #13694 (template.number), #13696 (template.cover), #13697 (template.valve), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
lock:
  - platform: template
    name: "Template Lock"
    lock_action:
      - logger.log: "Locking"
    unlock_action:
      - logger.log: "Unlocking"
    open_action:
      - logger.log: "Opening latch"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
