### PR TITLE
[sprinkler] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -29,7 +29,7 @@ void SprinklerControllerNumber::setup() {
 }
 
 void SprinklerControllerNumber::control(float value) {
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   this->publish_state(value);
 
@@ -39,8 +39,7 @@ void SprinklerControllerNumber::control(float value) {
 
 void SprinklerControllerNumber::dump_config() { LOG_NUMBER("", "Sprinkler Controller Number", this); }
 
-SprinklerControllerSwitch::SprinklerControllerSwitch()
-    : turn_on_trigger_(new Trigger<>()), turn_off_trigger_(new Trigger<>()) {}
+SprinklerControllerSwitch::SprinklerControllerSwitch() = default;
 
 void SprinklerControllerSwitch::loop() {
   // Loop is only enabled when f_ has a value (see setup())
@@ -56,11 +55,11 @@ void SprinklerControllerSwitch::write_state(bool state) {
   }
 
   if (state) {
-    this->prev_trigger_ = this->turn_on_trigger_;
-    this->turn_on_trigger_->trigger();
+    this->prev_trigger_ = &this->turn_on_trigger_;
+    this->turn_on_trigger_.trigger();
   } else {
-    this->prev_trigger_ = this->turn_off_trigger_;
-    this->turn_off_trigger_->trigger();
+    this->prev_trigger_ = &this->turn_off_trigger_;
+    this->turn_off_trigger_.trigger();
   }
 
   this->publish_state(state);
@@ -68,9 +67,6 @@ void SprinklerControllerSwitch::write_state(bool state) {
 
 void SprinklerControllerSwitch::set_state_lambda(std::function<optional<bool>()> &&f) { this->f_ = f; }
 float SprinklerControllerSwitch::get_setup_priority() const { return setup_priority::HARDWARE; }
-
-Trigger<> *SprinklerControllerSwitch::get_turn_on_trigger() const { return this->turn_on_trigger_; }
-Trigger<> *SprinklerControllerSwitch::get_turn_off_trigger() const { return this->turn_off_trigger_; }
 
 void SprinklerControllerSwitch::setup() {
   this->state = this->get_initial_state_with_restore_mode().value_or(false);

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -76,7 +76,7 @@ class SprinklerControllerNumber : public number::Number, public Component {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
 
-  Trigger<float> *get_set_trigger() const { return set_trigger_; }
+  Trigger<float> *get_set_trigger() { return &this->set_trigger_; }
   void set_initial_value(float initial_value) { initial_value_ = initial_value; }
   void set_restore_value(bool restore_value) { this->restore_value_ = restore_value; }
 
@@ -84,7 +84,7 @@ class SprinklerControllerNumber : public number::Number, public Component {
   void control(float value) override;
   float initial_value_{NAN};
   bool restore_value_{true};
-  Trigger<float> *set_trigger_ = new Trigger<float>();
+  Trigger<float> set_trigger_;
 
   ESPPreferenceObject pref_;
 };
@@ -97,8 +97,8 @@ class SprinklerControllerSwitch : public switch_::Switch, public Component {
   void dump_config() override;
 
   void set_state_lambda(std::function<optional<bool>()> &&f);
-  Trigger<> *get_turn_on_trigger() const;
-  Trigger<> *get_turn_off_trigger() const;
+  Trigger<> *get_turn_on_trigger() { return &this->turn_on_trigger_; }
+  Trigger<> *get_turn_off_trigger() { return &this->turn_off_trigger_; }
   void loop() override;
 
   float get_setup_priority() const override;
@@ -107,8 +107,8 @@ class SprinklerControllerSwitch : public switch_::Switch, public Component {
   void write_state(bool state) override;
 
   optional<std::function<optional<bool>()>> f_;
-  Trigger<> *turn_on_trigger_;
-  Trigger<> *turn_off_trigger_;
+  Trigger<> turn_on_trigger_;
+  Trigger<> turn_off_trigger_;
   Trigger<> *prev_trigger_{nullptr};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Changes sprinkler's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

**SprinklerControllerNumber:**
```cpp
// Before
Trigger<float> *set_trigger_ = new Trigger<float>();

// After
Trigger<float> set_trigger_;
```

**SprinklerControllerSwitch:**
```cpp
// Before
Trigger<> *turn_on_trigger_;
Trigger<> *turn_off_trigger_;
// Constructor: new Trigger<>() for each

// After
Trigger<> turn_on_trigger_;
Trigger<> turn_off_trigger_;
```

**Memory savings per sprinkler controller instance:**
- SprinklerControllerNumber: 1 trigger x 12 bytes = 12 bytes
- SprinklerControllerSwitch: 2 triggers x 12 bytes = 24 bytes per switch
- **Total per full sprinkler setup: 36+ bytes** (varies based on configuration)

This follows the same pattern established in #13691 (template.switch), #13704 (template.lock), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
sprinkler:
  - id: lawn_sprinkler
    main_switch: "Lawn Sprinklers"
    auto_advance_switch: "Auto Advance"
    valves:
      - valve_switch: "Front Yard"
        enable_switch: "Enable Front Yard"
        run_duration: 15min
        valve_switch_id: relay1
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
