### PR TITLE
[thermostat] Remove dead null checks for triggers

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -586,9 +586,7 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
     }
     this->action = action;
     this->prev_action_trigger_ = trig;
-    if (trig != nullptr) {
-      trig->trigger();
-    }
+    trig->trigger();
     // if enabled, call the fan_only action with cooling/heating actions
     if (trig_fan != nullptr) {
       ESP_LOGVV(TAG, "Calling FAN_ONLY action with HEATING/COOLING action");
@@ -686,9 +684,7 @@ void ThermostatClimate::switch_to_humidity_control_action_(HumidificationAction 
   }
   this->humidification_action = action;
   this->prev_humidity_control_trigger_ = trig;
-  if (trig != nullptr) {
-    trig->trigger();
-  }
+  trig->trigger();
 }
 
 void ThermostatClimate::switch_to_fan_mode_(climate::ClimateFanMode fan_mode, bool publish_state) {
@@ -756,9 +752,7 @@ void ThermostatClimate::switch_to_fan_mode_(climate::ClimateFanMode fan_mode, bo
       this->prev_fan_mode_trigger_ = nullptr;
     }
     this->start_timer_(thermostat::THERMOSTAT_TIMER_FAN_MODE);
-    if (trig != nullptr) {
-      trig->trigger();
-    }
+    trig->trigger();
     this->prev_fan_mode_ = fan_mode;
     this->prev_fan_mode_trigger_ = trig;
   }
@@ -802,9 +796,7 @@ void ThermostatClimate::switch_to_mode_(climate::ClimateMode mode, bool publish_
       mode = climate::CLIMATE_MODE_OFF;
       // trig = this->off_mode_trigger_;
   }
-  if (trig != nullptr) {
-    trig->trigger();
-  }
+  trig->trigger();
   this->mode = mode;
   this->prev_mode_ = mode;
   this->prev_mode_trigger_ = trig;
@@ -844,9 +836,7 @@ void ThermostatClimate::switch_to_swing_mode_(climate::ClimateSwingMode swing_mo
       swing_mode = climate::CLIMATE_SWING_OFF;
       // trig = &this->swing_mode_off_trigger_;
   }
-  if (trig != nullptr) {
-    trig->trigger();
-  }
+  trig->trigger();
   this->swing_mode = swing_mode;
   this->prev_swing_mode_ = swing_mode;
   this->prev_swing_mode_trigger_ = trig;


### PR DESCRIPTION
# What does this implement/fix?

Removes dead `if (trig != nullptr)` checks that were never reachable.

The original constructor unconditionally allocated all 34 triggers:
```cpp
ThermostatClimate::ThermostatClimate()
    : cool_action_trigger_(new Trigger<>()),
      supplemental_cool_action_trigger_(new Trigger<>()),
      // ... 32 more triggers
      humidity_control_off_action_trigger_(new Trigger<>()) {}
```

Since triggers were always allocated, they were never null, making these checks dead code. After #13692 changed triggers to embedded members, the checks remain dead (embedded members always have valid addresses).

**Removed dead checks in:**
- `switch_to_action_()`
- `switch_to_humidity_control_action_()`
- `switch_to_fan_mode_()`
- `switch_to_mode_()`
- `switch_to_swing_mode_()`

**Note:** The null check in `trigger_supplemental_action_()` is **preserved** because `trig` legitimately starts as `nullptr` and is only conditionally assigned.

This was identified by Copilot code review on #13692.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Follow-up to #13692

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal cleanup
climate:
  - platform: thermostat
    name: "Thermostat"
    sensor: my_sensor
    idle_action:
      - logger.log: "Idle"
    heat_action:
      - logger.log: "Heating"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). -- existing integration tests cover all trigger paths

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
