### PR TITLE
[speaker.media_player] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/mixer/speaker/automation.h
+++ b/esphome/components/mixer/speaker/automation.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "mixer_speaker.h"
 
 #ifdef USE_ESP32

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -519,9 +519,9 @@ void SpeakerMediaPlayer::set_mute_state_(bool mute_state) {
 
   if (old_mute_state != mute_state) {
     if (mute_state) {
-      this->defer([this]() { this->mute_trigger_->trigger(); });
+      this->defer([this]() { this->mute_trigger_.trigger(); });
     } else {
-      this->defer([this]() { this->unmute_trigger_->trigger(); });
+      this->defer([this]() { this->unmute_trigger_.trigger(); });
     }
   }
 }
@@ -550,7 +550,7 @@ void SpeakerMediaPlayer::set_volume_(float volume, bool publish) {
     this->set_mute_state_(false);
   }
 
-  this->defer([this, volume]() { this->volume_trigger_->trigger(volume); });
+  this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });
 }
 
 }  // namespace speaker

--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -84,9 +84,9 @@ class SpeakerMediaPlayer : public Component,
     this->media_format_ = media_format;
   }
 
-  Trigger<> *get_mute_trigger() const { return this->mute_trigger_; }
-  Trigger<> *get_unmute_trigger() const { return this->unmute_trigger_; }
-  Trigger<float> *get_volume_trigger() const { return this->volume_trigger_; }
+  Trigger<> *get_mute_trigger() { return &this->mute_trigger_; }
+  Trigger<> *get_unmute_trigger() { return &this->unmute_trigger_; }
+  Trigger<float> *get_volume_trigger() { return &this->volume_trigger_; }
 
   void play_file(audio::AudioFile *media_file, bool announcement, bool enqueue);
 
@@ -154,9 +154,9 @@ class SpeakerMediaPlayer : public Component,
   // Used to save volume/mute state for restoration on reboot
   ESPPreferenceObject pref_;
 
-  Trigger<> *mute_trigger_ = new Trigger<>();
-  Trigger<> *unmute_trigger_ = new Trigger<>();
-  Trigger<float> *volume_trigger_ = new Trigger<float>();
+  Trigger<> mute_trigger_;
+  Trigger<> unmute_trigger_;
+  Trigger<float> volume_trigger_;
 };
 
 }  // namespace speaker


### PR DESCRIPTION
# What does this implement/fix?

Changes speaker media player's 3 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *mute_trigger_ = new Trigger<>();
Trigger<> *unmute_trigger_ = new Trigger<>();
Trigger<float> *volume_trigger_ = new Trigger<float>();

// After
Trigger<> mute_trigger_;
Trigger<> unmute_trigger_;
Trigger<float> volume_trigger_;
```

**Memory savings per speaker media player instance:**
- Before: 3 x 16 bytes heap = 48 bytes + fragmentation
- After: 3 x 4 bytes inline = 12 bytes
- **Saves: ~36 bytes per instance**

This follows the same pattern established in #13689 (voice_assistant), #13705 (sprinkler), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
media_player:
  - platform: speaker
    name: "Media Player"
    dac_type: external
    i2s_dout_pin: GPIO25
    mode: stereo
    on_mute:
      - logger.log: "Muted"
    on_unmute:
      - logger.log: "Unmuted"
    on_volume:
      - logger.log:
          format: "Volume changed to %.2f"
          args: [ x ]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
