### PR TITLE
[remote_transmitter] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -83,7 +83,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   uint32_t on_time, off_time;
   this->calculate_on_off_time_(this->temp_.get_carrier_frequency(), &on_time, &off_time);
   this->target_time_ = 0;
-  this->transmit_trigger_->trigger();
+  this->transmit_trigger_.trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     InterruptLock lock;
     for (int32_t item : this->temp_.get_data()) {
@@ -102,7 +102,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (i + 1 < send_times)
       this->target_time_ += send_wait;
   }
-  this->complete_trigger_->trigger();
+  this->complete_trigger_.trigger();
 }
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -57,8 +57,8 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   void set_non_blocking(bool non_blocking) { this->non_blocking_ = non_blocking; }
 #endif
 
-  Trigger<> *get_transmit_trigger() const { return this->transmit_trigger_; };
-  Trigger<> *get_complete_trigger() const { return this->complete_trigger_; };
+  Trigger<> *get_transmit_trigger() { return &this->transmit_trigger_; }
+  Trigger<> *get_complete_trigger() { return &this->complete_trigger_; }
 
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
@@ -96,8 +96,8 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 #endif
   uint8_t carrier_duty_percent_;
 
-  Trigger<> *transmit_trigger_{new Trigger<>()};
-  Trigger<> *complete_trigger_{new Trigger<>()};
+  Trigger<> transmit_trigger_;
+  Trigger<> complete_trigger_;
 };
 
 }  // namespace remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -203,7 +203,7 @@ void RemoteTransmitterComponent::wait_for_rmt_() {
     this->status_set_warning();
   }
 
-  this->complete_trigger_->trigger();
+  this->complete_trigger_.trigger();
 }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
@@ -264,7 +264,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     return;
   }
 
-  this->transmit_trigger_->trigger();
+  this->transmit_trigger_.trigger();
 
   rmt_transmit_config_t config;
   memset(&config, 0, sizeof(config));
@@ -333,7 +333,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     ESP_LOGE(TAG, "Empty data");
     return;
   }
-  this->transmit_trigger_->trigger();
+  this->transmit_trigger_.trigger();
   for (uint32_t i = 0; i < send_times; i++) {
     rmt_transmit_config_t config;
     memset(&config, 0, sizeof(config));
@@ -354,7 +354,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
     if (i + 1 < send_times)
       delayMicroseconds(send_wait);
   }
-  this->complete_trigger_->trigger();
+  this->complete_trigger_.trigger();
 }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Changes remote_transmitter's 2 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before
Trigger<> *transmit_trigger_{new Trigger<>()};
Trigger<> *complete_trigger_{new Trigger<>()};

// After
Trigger<> transmit_trigger_;
Trigger<> complete_trigger_;
```

**Memory savings per remote_transmitter instance:**
- Before: 2 x 16 bytes heap = 32 bytes + fragmentation
- After: 2 x 4 bytes inline = 8 bytes
- **Saves: ~24 bytes per instance**

This follows the same pattern established in #13698 (sx127x), #13699 (sx126x), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
remote_transmitter:
  pin: GPIO18
  carrier_duty_percent: 50%
  on_transmit:
    - logger.log: "Transmitting"
  on_complete:
    - logger.log: "Transmission complete"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
