### PR TITLE
[template.output] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/template/output/template_output.h
+++ b/esphome/components/template/output/template_output.h
@@ -8,22 +8,22 @@ namespace esphome::template_ {
 
 class TemplateBinaryOutput final : public output::BinaryOutput {
  public:
-  Trigger<bool> *get_trigger() const { return trigger_; }
+  Trigger<bool> *get_trigger() { return &this->trigger_; }
 
  protected:
-  void write_state(bool state) override { this->trigger_->trigger(state); }
+  void write_state(bool state) override { this->trigger_.trigger(state); }
 
-  Trigger<bool> *trigger_ = new Trigger<bool>();
+  Trigger<bool> trigger_;
 };
 
 class TemplateFloatOutput final : public output::FloatOutput {
  public:
-  Trigger<float> *get_trigger() const { return trigger_; }
+  Trigger<float> *get_trigger() { return &this->trigger_; }
 
  protected:
-  void write_state(float state) override { this->trigger_->trigger(state); }
+  void write_state(float state) override { this->trigger_.trigger(state); }
 
-  Trigger<float> *trigger_ = new Trigger<float>();
+  Trigger<float> trigger_;
 };
 
 }  // namespace esphome::template_


### PR DESCRIPTION
# What does this implement/fix?

Changes template output's 2 triggers from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (both classes)
Trigger<T> *trigger_ = new Trigger<T>();

// After
Trigger<T> trigger_;
```

**Memory savings per template output instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per TemplateBinaryOutput and ~12 bytes per TemplateFloatOutput**

This follows the same pattern established in #13691 (template.switch), #13694 (template.number), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
output:
  - platform: template
    id: binary_output
    type: binary
    write_action:
      - logger.log: "Binary output changed"

  - platform: template
    id: float_output
    type: float
    write_action:
      - logger.log: "Float output changed"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
