### PR TITLE
[template.datetime] Avoid heap allocation for triggers

### DIFF
--- a/esphome/components/template/datetime/template_date.cpp
+++ b/esphome/components/template/datetime/template_date.cpp
@@ -62,7 +62,7 @@ void TemplateDate::control(const datetime::DateCall &call) {
   if (has_day)
     value.day_of_month = *call.get_day();
 
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   if (this->optimistic_) {
     if (has_year)

--- a/esphome/components/template/datetime/template_date.h
+++ b/esphome/components/template/datetime/template_date.h
@@ -22,7 +22,7 @@ class TemplateDate final : public datetime::DateEntity, public PollingComponent 
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<ESPTime> *get_set_trigger() const { return this->set_trigger_; }
+  Trigger<ESPTime> *get_set_trigger() { return &this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 
   void set_initial_value(ESPTime initial_value) { this->initial_value_ = initial_value; }
@@ -34,7 +34,7 @@ class TemplateDate final : public datetime::DateEntity, public PollingComponent 
   bool optimistic_{false};
   ESPTime initial_value_{};
   bool restore_value_{false};
-  Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
+  Trigger<ESPTime> set_trigger_;
   TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;

--- a/esphome/components/template/datetime/template_datetime.cpp
+++ b/esphome/components/template/datetime/template_datetime.cpp
@@ -80,7 +80,7 @@ void TemplateDateTime::control(const datetime::DateTimeCall &call) {
   if (has_second)
     value.second = *call.get_second();
 
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   if (this->optimistic_) {
     if (has_year)

--- a/esphome/components/template/datetime/template_datetime.h
+++ b/esphome/components/template/datetime/template_datetime.h
@@ -22,7 +22,7 @@ class TemplateDateTime final : public datetime::DateTimeEntity, public PollingCo
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<ESPTime> *get_set_trigger() const { return this->set_trigger_; }
+  Trigger<ESPTime> *get_set_trigger() { return &this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 
   void set_initial_value(ESPTime initial_value) { this->initial_value_ = initial_value; }
@@ -34,7 +34,7 @@ class TemplateDateTime final : public datetime::DateTimeEntity, public PollingCo
   bool optimistic_{false};
   ESPTime initial_value_{};
   bool restore_value_{false};
-  Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
+  Trigger<ESPTime> set_trigger_;
   TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;

--- a/esphome/components/template/datetime/template_time.cpp
+++ b/esphome/components/template/datetime/template_time.cpp
@@ -62,7 +62,7 @@ void TemplateTime::control(const datetime::TimeCall &call) {
   if (has_second)
     value.second = *call.get_second();
 
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   if (this->optimistic_) {
     if (has_hour)

--- a/esphome/components/template/datetime/template_time.h
+++ b/esphome/components/template/datetime/template_time.h
@@ -22,7 +22,7 @@ class TemplateTime final : public datetime::TimeEntity, public PollingComponent 
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<ESPTime> *get_set_trigger() const { return this->set_trigger_; }
+  Trigger<ESPTime> *get_set_trigger() { return &this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
 
   void set_initial_value(ESPTime initial_value) { this->initial_value_ = initial_value; }
@@ -34,7 +34,7 @@ class TemplateTime final : public datetime::TimeEntity, public PollingComponent 
   bool optimistic_{false};
   ESPTime initial_value_{};
   bool restore_value_{false};
-  Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();
+  Trigger<ESPTime> set_trigger_;
   TemplateLambda<ESPTime> f_;
 
   ESPPreferenceObject pref_;


### PR DESCRIPTION
# What does this implement/fix?

Changes template datetime's 3 triggers (across date, time, and datetime entities) from heap-allocated pointers to embedded members, eliminating unnecessary heap allocations.

```cpp
// Before (all three files)
Trigger<ESPTime> *set_trigger_ = new Trigger<ESPTime>();

// After
Trigger<ESPTime> set_trigger_;
```

**Memory savings per template datetime instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per TemplateDate, TemplateTime, or TemplateDateTime instance**

This follows the same pattern established in #13694 (template.number), #13709 (template.output), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
datetime:
  - platform: template
    name: "Template Date"
    type: date
    set_action:
      - logger.log: "Date set"

  - platform: template
    name: "Template Time"
    type: time
    set_action:
      - logger.log: "Time set"

  - platform: template
    name: "Template DateTime"
    type: datetime
    set_action:
      - logger.log: "DateTime set"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
