### PR TITLE
[template.text] Avoid heap allocation for trigger

### DIFF
--- a/esphome/components/template/text/template_text.cpp
+++ b/esphome/components/template/text/template_text.cpp
@@ -47,7 +47,7 @@ void TemplateText::update() {
 }
 
 void TemplateText::control(const std::string &value) {
-  this->set_trigger_->trigger(value);
+  this->set_trigger_.trigger(value);
 
   if (this->optimistic_)
     this->publish_state(value);

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -68,7 +68,7 @@ class TemplateText final : public text::Text, public PollingComponent {
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
-  Trigger<std::string> *get_set_trigger() const { return this->set_trigger_; }
+  Trigger<std::string> *get_set_trigger() { return &this->set_trigger_; }
   void set_optimistic(bool optimistic) { this->optimistic_ = optimistic; }
   void set_initial_value(const char *initial_value) { this->initial_value_ = initial_value; }
   /// Prevent accidental use of std::string which would dangle
@@ -79,7 +79,7 @@ class TemplateText final : public text::Text, public PollingComponent {
   void control(const std::string &value) override;
   bool optimistic_ = false;
   const char *initial_value_{nullptr};
-  Trigger<std::string> *set_trigger_ = new Trigger<std::string>();
+  Trigger<std::string> set_trigger_;
   TemplateLambda<std::string> f_{};
 
   TemplateTextSaverBase *pref_ = nullptr;


### PR DESCRIPTION
# What does this implement/fix?

Changes template text's trigger from heap-allocated pointer to embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::string> *set_trigger_ = new Trigger<std::string>();

// After
Trigger<std::string> set_trigger_;
```

**Memory savings per template text instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13694 (template.number), #13709 (template.output), #13710 (template.datetime), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
text:
  - platform: template
    name: "Template Text"
    set_action:
      - logger.log:
          format: "Text set to: %s"
          args: [ x.c_str() ]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
