### PR TITLE
[template.water_heater] Avoid heap allocation for trigger

### DIFF
--- a/esphome/components/template/water_heater/template_water_heater.cpp
+++ b/esphome/components/template/water_heater/template_water_heater.cpp
@@ -5,7 +5,7 @@ namespace esphome::template_ {
 
 static const char *const TAG = "template.water_heater";
 
-TemplateWaterHeater::TemplateWaterHeater() : set_trigger_(new Trigger<>()) {}
+TemplateWaterHeater::TemplateWaterHeater() = default;
 
 void TemplateWaterHeater::setup() {
   if (this->restore_mode_ == TemplateWaterHeaterRestoreMode::WATER_HEATER_RESTORE ||
@@ -78,7 +78,7 @@ void TemplateWaterHeater::control(const water_heater::WaterHeaterCall &call) {
     }
   }
 
-  this->set_trigger_->trigger();
+  this->set_trigger_.trigger();
 
   if (this->optimistic_) {
     this->publish_state();

--- a/esphome/components/template/water_heater/template_water_heater.h
+++ b/esphome/components/template/water_heater/template_water_heater.h
@@ -28,7 +28,7 @@ class TemplateWaterHeater : public Component, public water_heater::WaterHeater {
     this->supported_modes_ = modes;
   }
 
-  Trigger<> *get_set_trigger() const { return this->set_trigger_; }
+  Trigger<> *get_set_trigger() { return &this->set_trigger_; }
 
   void setup() override;
   void loop() override;
@@ -42,7 +42,7 @@ class TemplateWaterHeater : public Component, public water_heater::WaterHeater {
   water_heater::WaterHeaterTraits traits() override;
 
   // Ordered to minimize padding on 32-bit: 4-byte members first, then smaller
-  Trigger<> *set_trigger_;
+  Trigger<> set_trigger_;
   TemplateLambda<float> current_temperature_f_;
   TemplateLambda<water_heater::WaterHeaterMode> mode_f_;
   TemplateWaterHeaterRestoreMode restore_mode_{WATER_HEATER_NO_RESTORE};


### PR DESCRIPTION
# What does this implement/fix?

Changes template water heater's trigger from heap-allocated pointer to embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<> set_trigger_;  // Already embedded in header but constructor wasn't = default

// After (cpp)
TemplateWaterHeater::TemplateWaterHeater() = default;
this->set_trigger_.trigger();  // Dot notation for embedded member
```

**Memory savings per template water heater instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13694 (template.number), #13709 (template.output), #13710 (template.datetime), #13711 (template.text), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
water_heater:
  - platform: template
    name: "Template Water Heater"
    set_action:
      - logger.log: "Water heater mode changed"
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
