### PR TITLE
[light] Avoid heap allocation for AutomationLightEffect trigger

### DIFF
--- a/esphome/components/light/base_light_effects.h
+++ b/esphome/components/light/base_light_effects.h
@@ -138,20 +138,20 @@ class LambdaLightEffect : public LightEffect {
 class AutomationLightEffect : public LightEffect {
  public:
   AutomationLightEffect(const char *name) : LightEffect(name) {}
-  void stop() override { this->trig_->stop_action(); }
+  void stop() override { this->trig_.stop_action(); }
   void apply() override {
-    if (!this->trig_->is_action_running()) {
-      this->trig_->trigger();
+    if (!this->trig_.is_action_running()) {
+      this->trig_.trigger();
     }
   }
-  Trigger<> *get_trig() const { return trig_; }
+  Trigger<> *get_trig() { return &this->trig_; }
 
   /// Get the current effect index for use in automations.
   /// Useful for automations that need to know which effect is running.
   uint32_t get_current_index() const { return this->get_index(); }
 
  protected:
-  Trigger<> *trig_{new Trigger<>};
+  Trigger<> trig_;
 };
 
 struct StrobeLightEffectColor {


### PR DESCRIPTION
# What does this implement/fix?

Changes `AutomationLightEffect`'s trigger from heap-allocated pointer to embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<> *trig_{new Trigger<>};

// After
Trigger<> trig_;
```

**Memory savings per AutomationLightEffect instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per light effect automation**

This follows the same pattern established in #13694, #13709, #13710, #13711, #13712, and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
light:
  - platform: monochromatic
    name: "My Light"
    output: my_output
    effects:
      - automation:
          name: "My Effect"
          sequence:
            - light.turn_on:
                id: my_light
                brightness: 100%
            - delay: 1s
            - light.turn_on:
                id: my_light
                brightness: 50%
            - delay: 1s
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
