### PR TITLE
[micro_wake_word] Avoid heap allocation for trigger

### DIFF
--- a/esphome/components/micro_wake_word/micro_wake_word.cpp
+++ b/esphome/components/micro_wake_word/micro_wake_word.cpp
@@ -325,7 +325,7 @@ void MicroWakeWord::loop() {
           ESP_LOGD(TAG, "Detected '%s' with sliding average probability is %.2f and max probability is %.2f",
                    detection_event.wake_word->c_str(), (detection_event.average_probability / uint8_to_float_divisor),
                    (detection_event.max_probability / uint8_to_float_divisor));
-          this->wake_word_detected_trigger_->trigger(*detection_event.wake_word);
+          this->wake_word_detected_trigger_.trigger(*detection_event.wake_word);
           if (this->stop_after_detection_) {
             this->stop();
           }

--- a/esphome/components/micro_wake_word/micro_wake_word.h
+++ b/esphome/components/micro_wake_word/micro_wake_word.h
@@ -60,7 +60,7 @@ class MicroWakeWord : public Component
 
   void set_stop_after_detection(bool stop_after_detection) { this->stop_after_detection_ = stop_after_detection; }
 
-  Trigger<std::string> *get_wake_word_detected_trigger() const { return this->wake_word_detected_trigger_; }
+  Trigger<std::string> *get_wake_word_detected_trigger() { return &this->wake_word_detected_trigger_; }
 
   void add_wake_word_model(WakeWordModel *model);
 
@@ -78,7 +78,7 @@ class MicroWakeWord : public Component
 
  protected:
   microphone::MicrophoneSource *microphone_source_{nullptr};
-  Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();
+  Trigger<std::string> wake_word_detected_trigger_;
   State state_{State::STOPPED};
 
   std::weak_ptr<RingBuffer> ring_buffer_;


### PR DESCRIPTION
# What does this implement/fix?

Changes micro_wake_word's trigger from heap-allocated pointer to embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::string> *wake_word_detected_trigger_ = new Trigger<std::string>();

// After
Trigger<std::string> wake_word_detected_trigger_;
```

**Memory savings per MicroWakeWord instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13689 (voice_assistant), #13712, #13713, and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
micro_wake_word:
  on_wake_word_detected:
    - logger.log:
        format: "Wake word detected: %s"
        args: [x.c_str()]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
