### PR TITLE
[cc1101] Avoid heap allocation for trigger

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -156,7 +156,7 @@ void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float 
   for (auto &listener : this->listeners_) {
     listener->on_packet(packet, freq_offset, rssi, lqi);
   }
-  this->packet_trigger_->trigger(packet, freq_offset, rssi, lqi);
+  this->packet_trigger_.trigger(packet, freq_offset, rssi, lqi);
 }
 
 void CC1101Component::loop() {

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -79,7 +79,7 @@ class CC1101Component : public Component,
   // Packet mode operations
   CC1101Error transmit_packet(const std::vector<uint8_t> &packet);
   void register_listener(CC1101Listener *listener) { this->listeners_.push_back(listener); }
-  Trigger<std::vector<uint8_t>, float, float, uint8_t> *get_packet_trigger() const { return this->packet_trigger_; }
+  Trigger<std::vector<uint8_t>, float, float, uint8_t> *get_packet_trigger() { return &this->packet_trigger_; }
 
  protected:
   uint16_t chip_id_{0};
@@ -96,8 +96,7 @@ class CC1101Component : public Component,
 
   // Packet handling
   void call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi);
-  Trigger<std::vector<uint8_t>, float, float, uint8_t> *packet_trigger_{
-      new Trigger<std::vector<uint8_t>, float, float, uint8_t>()};
+  Trigger<std::vector<uint8_t>, float, float, uint8_t> packet_trigger_;
   std::vector<uint8_t> packet_;
   std::vector<CC1101Listener *> listeners_;
 


### PR DESCRIPTION
# What does this implement/fix?

Changes cc1101's packet trigger from heap-allocated pointer to embedded member, eliminating unnecessary heap allocation.

```cpp
// Before
Trigger<std::vector<uint8_t>, float, float, uint8_t> *packet_trigger_{
    new Trigger<std::vector<uint8_t>, float, float, uint8_t>()};

// After
Trigger<std::vector<uint8_t>, float, float, uint8_t> packet_trigger_;
```

**Memory savings per CC1101Component instance:**
- Before: 1 x 16 bytes heap = 16 bytes + fragmentation
- After: 1 x 4 bytes inline = 4 bytes
- **Saves: ~12 bytes per instance**

This follows the same pattern established in #13698 (sx127x), #13699 (sx126x), and other recent trigger optimization PRs.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- Spotted while reviewing #13677 - the `new Trigger<>()` pattern has been copy-pasted across the codebase since 2019

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No change to user-facing config - this is an internal optimization
cc1101:
  cs_pin: GPIO5
  gdo0_pin: GPIO4
  on_packet:
    - logger.log:
        format: "Received packet with %d bytes"
        args: [x.size()]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)
