### PR TITLE
[mqtt] resolve warnings related to use of ip.str()

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -139,7 +139,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
     this->lwt_retain_ = retain;
   }
   void set_server(network::IPAddress ip, uint16_t port) final {
-    this->host_ = ip.str();
+    char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    this->host_ = ip.str_to(ip_buf);
     this->port_ = port;
   }
   void set_server(const char *host, uint16_t port) final {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Recent performance changes have caused a deprecation warning in mqtt component
Fix for:
Compilation of mqtt on an esp32 is logging:
In file included from src/esphome/components/mqtt/mqtt_client.h:17,
                 from src/esphome/components/mqtt/mqtt_component.h:13,
                 from src/esphome/components/mqtt/mqtt_valve.h:4,
                 from src/esphome/components/mqtt/mqtt_valve.cpp:1:
src/esphome/components/mqtt/mqtt_backend_esp32.h: In member function 'virtual void esphome::mqtt::MQTTBackendESP32::set_server(esphome::network::IPAddress, uint16_t)':
src/esphome/components/mqtt/mqtt_backend_esp32.h:142:25: warning: 'std::string esphome::network::IPAddress::str() const' is deprecated: Use str_to() instead. Removed in 2026.8.0 [-Wdeprecated-declarations]
  142 |     this->host_ = ip.str();
      |                   ~~~~~~^~
In file included from src/esphome/components/mqtt/mqtt_client.h:8:
src/esphome/components/network/ip_address.h:154:15: note: declared here
  154 |   std::string str() const {
      |               ^~~


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
