### PR TITLE
[core] Add missing uint32_t ID overloads for defer() and cancel_defer()

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -359,6 +359,10 @@ void Component::defer(const std::string &name, std::function<void()> &&f) {  // 
 void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));
 }
+void Component::defer(uint32_t id, std::function<void()> &&f) {  // NOLINT
+  App.scheduler.set_timeout(this, id, 0, std::move(f));
+}
+bool Component::cancel_defer(uint32_t id) { return App.scheduler.cancel_timeout(this, id); }
 void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), timeout, std::move(f));
 }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -494,11 +494,15 @@ class Component {
   /// Defer a callback to the next loop() call.
   void defer(std::function<void()> &&f);  // NOLINT
 
+  /// Defer a callback with a numeric ID (zero heap allocation)
+  void defer(uint32_t id, std::function<void()> &&f);  // NOLINT
+
   /// Cancel a defer callback using the specified name, name must not be empty.
   // Remove before 2026.7.0
   ESPDEPRECATED("Use const char* overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_defer(const std::string &name);  // NOLINT
   bool cancel_defer(const char *name);         // NOLINT
+  bool cancel_defer(uint32_t id);              // NOLINT
 
   // Ordered for optimal packing on 32-bit systems
   const LogString *component_source_{nullptr};

--- a/tests/integration/fixtures/scheduler_numeric_id_test.yaml
+++ b/tests/integration/fixtures/scheduler_numeric_id_test.yaml
@@ -20,6 +20,9 @@ globals:
   - id: retry_counter
     type: int
     initial_value: '0'
+  - id: defer_counter
+    type: int
+    initial_value: '0'
   - id: tests_done
     type: bool
     initial_value: 'false'
@@ -136,11 +139,49 @@ script:
           App.scheduler.cancel_retry(component1, 6002U);
           ESP_LOGI("test", "Cancelled numeric retry 6002");
 
+          // Test 12: defer with numeric ID (Component method)
+          class TestDeferComponent : public Component {
+          public:
+            void test_defer_methods() {
+              // Test defer with uint32_t ID - should execute on next loop
+              this->defer(7001U, []() {
+                ESP_LOGI("test", "Component numeric defer 7001 fired");
+                id(defer_counter) += 1;
+              });
+
+              // Test another defer with numeric ID
+              this->defer(7002U, []() {
+                ESP_LOGI("test", "Component numeric defer 7002 fired");
+                id(defer_counter) += 1;
+              });
+            }
+          };
+
+          static TestDeferComponent test_defer_component;
+          test_defer_component.test_defer_methods();
+
+          // Test 13: cancel_defer with numeric ID (Component method)
+          class TestCancelDeferComponent : public Component {
+          public:
+            void test_cancel_defer() {
+              // Set a defer that should be cancelled
+              this->defer(8001U, []() {
+                ESP_LOGE("test", "ERROR: Numeric defer 8001 should have been cancelled");
+              });
+              // Cancel it immediately
+              bool cancelled = this->cancel_defer(8001U);
+              ESP_LOGI("test", "Cancelled numeric defer 8001: %s", cancelled ? "true" : "false");
+            }
+          };
+
+          static TestCancelDeferComponent test_cancel_defer_component;
+          test_cancel_defer_component.test_cancel_defer();
+
   - id: report_results
     then:
       - lambda: |-
-          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d, Retries: %d",
-                   id(timeout_counter), id(interval_counter), id(retry_counter));
+          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d, Retries: %d, Defers: %d",
+                   id(timeout_counter), id(interval_counter), id(retry_counter), id(defer_counter));
 
 sensor:
   - platform: template


### PR DESCRIPTION
# What does this implement/fix?

Add missing `uint32_t` ID overloads for `defer()` and `cancel_defer()` methods.

The scheduler methods `set_timeout`, `set_interval`, and `set_retry` all have `uint32_t` ID overloads that allow zero-heap-allocation scheduling. However, `defer()` (which is a convenience wrapper around `set_timeout` with timeout=0) was missing these overloads.

This adds:
- `void defer(uint32_t id, std::function<void()> &&f)` - Defer a callback with a numeric ID
- `bool cancel_defer(uint32_t id)` - Cancel a deferred callback using a numeric ID

This enables components to use numeric IDs for deferred callbacks, avoiding heap allocation for the name string.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API, not user-facing)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal API change, no configuration required
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
