### PR TITLE
[rtttl] Fix dotted note parsing order to match RTTTL spec

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -292,23 +292,24 @@ void Rtttl::loop() {
 
   // now, get scale
   uint8_t scale = get_integer_();
-
-  // now, get optional '.' dotted note (must be after scale per RTTTL spec)
-  if (this->rtttl_[this->position_] == '.') {
-    this->note_duration_ += this->note_duration_ / 2;
-    this->position_++;
-  }
-  if (scale == 0)
+  if (scale == 0) {
     scale = this->default_octave_;
+  }
 
   if (scale < 4 || scale > 7) {
     ESP_LOGE(TAG, "Octave must be between 4 and 7 (it is %d)", scale);
     this->finish_();
     return;
   }
-  bool need_note_gap = false;
+
+  // now, get optional '.' dotted note
+  if (this->rtttl_[this->position_] == '.') {
+    this->note_duration_ += this->note_duration_ / 2;
+    this->position_++;
+  }
 
   // Now play the note
+  bool need_note_gap = false;
   if (note) {
     auto note_index = (scale - 4) * 12 + note;
     if (note_index < 0 || note_index >= (int) sizeof(NOTES)) {

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -290,14 +290,14 @@ void Rtttl::loop() {
     this->position_++;
   }
 
-  // now, get optional '.' dotted note
+  // now, get scale
+  uint8_t scale = get_integer_();
+
+  // now, get optional '.' dotted note (must be after scale per RTTTL spec)
   if (this->rtttl_[this->position_] == '.') {
     this->note_duration_ += this->note_duration_ / 2;
     this->position_++;
   }
-
-  // now, get scale
-  uint8_t scale = get_integer_();
   if (scale == 0)
     scale = this->default_octave_;
 


### PR DESCRIPTION
## What does this implement/fix?

Fixes the RTTTL parser to handle dotted notes correctly according to the RTTTL specification.

The RTTTL specification defines the note format as:
```
[duration][note][#][octave][.]
```

But the code was parsing the dot **before** the octave:
```
[duration][note][#][.][octave]
```

This caused notes like `16c5.` (dotted 16th note C in octave 5) to be parsed incorrectly - the dot was not consumed during note parsing, and on the next iteration it was interpreted as a pause (since `.` is not a valid note letter).

References:
- http://merwin.bespin.org/t4a/specs/nokia_rtttl.txt
- https://www.mobilefish.com/tutorials/rtttl/rtttl_quickguide_specification.html

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13674

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes needed. The fix corrects parsing of standard RTTTL strings:

```yaml
# This now works correctly:
rtttl.play:
  rtttl: "BaraBadaBastu:d=4,o=4,b=106:16c5.,32c5,16c5.,32d5,8e5"
```

Before: `16c5.` was parsed as `16c5` + pause
After: `16c5.` is correctly parsed as a dotted 16th note C in octave 5

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.ai/code)