### PR TITLE
[preferences] Use static storage for singletons and flash buffer

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -203,10 +203,11 @@ class ESP32Preferences : public ESPPreferences {
   }
 };
 
+static ESP32Preferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *prefs = new ESP32Preferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  prefs->open();
-  global_preferences = prefs;
+  s_preferences.open();
+  global_preferences = &s_preferences;
 }
 
 }  // namespace esp32

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -17,10 +17,6 @@ namespace esphome::esp8266 {
 
 static const char *const TAG = "esp8266.preferences";
 
-static uint32_t *s_flash_storage = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_prevent_write = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_flash_dirty = false;           // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 static constexpr uint32_t ESP_RTC_USER_MEM_START = 0x60001200;
 static constexpr uint32_t ESP_RTC_USER_MEM_SIZE_WORDS = 128;
 static constexpr uint32_t ESP_RTC_USER_MEM_SIZE_BYTES = ESP_RTC_USER_MEM_SIZE_WORDS * 4;
@@ -42,6 +38,11 @@ static constexpr uint32_t ESP8266_FLASH_STORAGE_SIZE = 128;
 #else
 static constexpr uint32_t ESP8266_FLASH_STORAGE_SIZE = 64;
 #endif
+
+static uint32_t
+    s_flash_storage[ESP8266_FLASH_STORAGE_SIZE];  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_prevent_write = false;              // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_flash_dirty = false;                // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static inline bool esp_rtc_user_mem_read(uint32_t index, uint32_t *dest) {
   if (index >= ESP_RTC_USER_MEM_SIZE_WORDS) {
@@ -180,7 +181,6 @@ class ESP8266Preferences : public ESPPreferences {
   uint32_t current_flash_offset = 0;  // in words
 
   void setup() {
-    s_flash_storage = new uint32_t[ESP8266_FLASH_STORAGE_SIZE];  // NOLINT
     ESP_LOGVV(TAG, "Loading preferences from flash");
 
     {
@@ -283,10 +283,11 @@ class ESP8266Preferences : public ESPPreferences {
   }
 };
 
+static ESP8266Preferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *pref = new ESP8266Preferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  pref->setup();
-  global_preferences = pref;
+  s_preferences.setup();
+  global_preferences = &s_preferences;
 }
 void preferences_prevent_write(bool prevent) { s_prevent_write = prevent; }
 

--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -66,10 +66,11 @@ ESPPreferenceObject HostPreferences::make_preference(size_t length, uint32_t typ
   return ESPPreferenceObject(backend);
 };
 
+static HostPreferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *pref = new HostPreferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  host_preferences = pref;
-  global_preferences = pref;
+  host_preferences = &s_preferences;
+  global_preferences = &s_preferences;
 }
 
 bool HostPreferenceBackend::save(const uint8_t *data, size_t len) {

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -189,10 +189,11 @@ class LibreTinyPreferences : public ESPPreferences {
   }
 };
 
+static LibreTinyPreferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *prefs = new LibreTinyPreferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  prefs->open();
-  global_preferences = prefs;
+  s_preferences.open();
+  global_preferences = &s_preferences;
 }
 
 }  // namespace libretiny

--- a/esphome/components/rp2040/preferences.cpp
+++ b/esphome/components/rp2040/preferences.cpp
@@ -18,11 +18,12 @@ namespace rp2040 {
 
 static const char *const TAG = "rp2040.preferences";
 
-static bool s_prevent_write = false;        // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static uint8_t *s_flash_storage = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_flash_dirty = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static constexpr uint32_t RP2040_FLASH_STORAGE_SIZE = 512;
 
-static const uint32_t RP2040_FLASH_STORAGE_SIZE = 512;
+static bool s_prevent_write = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static uint8_t
+    s_flash_storage[RP2040_FLASH_STORAGE_SIZE];  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+static bool s_flash_dirty = false;               // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // Stack buffer size for preferences - covers virtually all real-world preferences without heap allocation
 static constexpr size_t PREF_BUFFER_SIZE = 64;
@@ -91,7 +92,6 @@ class RP2040Preferences : public ESPPreferences {
 
   RP2040Preferences() : eeprom_sector_(&_EEPROM_start) {}
   void setup() {
-    s_flash_storage = new uint8_t[RP2040_FLASH_STORAGE_SIZE];  // NOLINT
     ESP_LOGVV(TAG, "Loading preferences from flash");
     memcpy(s_flash_storage, this->eeprom_sector_, RP2040_FLASH_STORAGE_SIZE);
   }
@@ -149,10 +149,11 @@ class RP2040Preferences : public ESPPreferences {
   uint8_t *eeprom_sector_;
 };
 
+static RP2040Preferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *prefs = new RP2040Preferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  prefs->setup();
-  global_preferences = prefs;
+  s_preferences.setup();
+  global_preferences = &s_preferences;
 }
 void preferences_prevent_write(bool prevent) { s_prevent_write = prevent; }
 

--- a/esphome/components/zephyr/preferences.cpp
+++ b/esphome/components/zephyr/preferences.cpp
@@ -152,10 +152,11 @@ class ZephyrPreferences : public ESPPreferences {
   }
 };
 
+static ZephyrPreferences s_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 void setup_preferences() {
-  auto *prefs = new ZephyrPreferences();  // NOLINT(cppcoreguidelines-owning-memory)
-  global_preferences = prefs;
-  prefs->open();
+  global_preferences = &s_preferences;
+  s_preferences.open();
 }
 
 }  // namespace zephyr


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocated preference singletons and flash storage buffers with static storage across all platforms.

The `setup_preferences()` function is called unconditionally on every platform during startup - preferences are always used. Dynamic heap allocation for something that is always created and never freed was wasteful.

> [!NOTE]
> **Memory Impact Analysis:** CI memory analysis will show static RAM increasing. This is **not** new memory usage - it's the same data moving from heap to static. This is actually a net RAM reduction because:
- Heap allocations have tracking overhead (8-16 bytes per allocation depending on platform)
- These objects remain allocated for the entire device lifetime, so heap allocation provides no benefit
- Static allocation eliminates heap fragmentation risk from these permanent allocations

## Changes

| Platform | Change |
|----------|--------|
| ESP8266 | `ESP8266Preferences` singleton + `s_flash_storage[64/128]` buffer now static |
| ESP32 | `ESP32Preferences` singleton now static |
| LibreTiny | `LibreTinyPreferences` singleton now static |
| RP2040 | `RP2040Preferences` singleton + `s_flash_storage[512]` buffer now static |
| Host | `HostPreferences` singleton now static |
| Zephyr | `ZephyrPreferences` singleton now static |

**Total: 8 heap allocations eliminated** (6 singletons + 2 flash storage buffers)

The preference backends (`*PreferenceBackend` objects) remain heap-allocated since their count varies per configuration and is only known at runtime.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
