### PR TITLE
[water_heater] Store mode strings in flash and avoid heap allocation in set_mode

### DIFF
--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 #include "esphome/core/controller_registry.h"
+#include "esphome/core/progmem.h"
 
 #include <cmath>
 
@@ -22,23 +23,23 @@ WaterHeaterCall &WaterHeaterCall::set_mode(WaterHeaterMode mode) {
   return *this;
 }
 
-WaterHeaterCall &WaterHeaterCall::set_mode(const std::string &mode) {
-  if (str_equals_case_insensitive(mode, "OFF")) {
+WaterHeaterCall &WaterHeaterCall::set_mode(const char *mode) {
+  if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("OFF")) == 0) {
     this->set_mode(WATER_HEATER_MODE_OFF);
-  } else if (str_equals_case_insensitive(mode, "ECO")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("ECO")) == 0) {
     this->set_mode(WATER_HEATER_MODE_ECO);
-  } else if (str_equals_case_insensitive(mode, "ELECTRIC")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("ELECTRIC")) == 0) {
     this->set_mode(WATER_HEATER_MODE_ELECTRIC);
-  } else if (str_equals_case_insensitive(mode, "PERFORMANCE")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("PERFORMANCE")) == 0) {
     this->set_mode(WATER_HEATER_MODE_PERFORMANCE);
-  } else if (str_equals_case_insensitive(mode, "HIGH_DEMAND")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("HIGH_DEMAND")) == 0) {
     this->set_mode(WATER_HEATER_MODE_HIGH_DEMAND);
-  } else if (str_equals_case_insensitive(mode, "HEAT_PUMP")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("HEAT_PUMP")) == 0) {
     this->set_mode(WATER_HEATER_MODE_HEAT_PUMP);
-  } else if (str_equals_case_insensitive(mode, "GAS")) {
+  } else if (ESPHOME_strcasecmp_P(mode, ESPHOME_PSTR("GAS")) == 0) {
     this->set_mode(WATER_HEATER_MODE_GAS);
   } else {
-    ESP_LOGW(TAG, "'%s' - Unrecognized mode %s", this->parent_->get_name().c_str(), mode.c_str());
+    ESP_LOGW(TAG, "'%s' - Unrecognized mode %s", this->parent_->get_name().c_str(), mode);
   }
   return *this;
 }

--- a/esphome/components/water_heater/water_heater.h
+++ b/esphome/components/water_heater/water_heater.h
@@ -75,7 +75,8 @@ class WaterHeaterCall {
   WaterHeaterCall(WaterHeater *parent);
 
   WaterHeaterCall &set_mode(WaterHeaterMode mode);
-  WaterHeaterCall &set_mode(const std::string &mode);
+  WaterHeaterCall &set_mode(const char *mode);
+  WaterHeaterCall &set_mode(const std::string &mode) { return this->set_mode(mode.c_str()); }
   WaterHeaterCall &set_target_temperature(float temperature);
   WaterHeaterCall &set_target_temperature_low(float temperature);
   WaterHeaterCall &set_target_temperature_high(float temperature);


### PR DESCRIPTION
# What does this implement/fix?

Avoid heap allocation in `WaterHeaterCall::set_mode()` and store string literals in flash on ESP8266.

Changes:
- Add `set_mode(const char *mode)` as the base implementation
- Make `set_mode(const std::string &mode)` an inline wrapper that calls the `const char*` overload
- Use `ESPHOME_strcasecmp_P` with `ESPHOME_PSTR` for flash-aware string comparison

This avoids creating a temporary `std::string` when calling `set_mode()` with a `const char*` argument, and on ESP8266 the mode string literals ("OFF", "ECO", "ELECTRIC", etc.) are stored in flash instead of RAM.

Follows the same pattern used in `cover.cpp` and `valve.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
water_heater:
  - platform: ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
