### PR TITLE
[light] Store "none" effect string in flash and avoid heap allocation

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -4,6 +4,7 @@
 #include "light_state.h"
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::light {
 
@@ -509,7 +510,7 @@ color_mode_bitmask_t LightCall::get_suitable_color_modes_mask_() {
 }
 
 LightCall &LightCall::set_effect(const char *effect, size_t len) {
-  if (len == 4 && strncasecmp(effect, "none", 4) == 0) {
+  if (len == 4 && ESPHOME_strncasecmp_P(effect, ESPHOME_PSTR("none"), 4) == 0) {
     this->set_effect(0);
     return *this;
   }

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -12,6 +12,7 @@
 #include "light_transformer.h"
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/progmem.h"
 #include <strings.h>
 #include <vector>
 
@@ -188,16 +189,19 @@ class LightState : public EntityBase, public Component {
   uint32_t get_current_effect_index() const { return this->active_effect_index_; }
 
   /// Get effect index by name. Returns 0 if effect not found.
-  uint32_t get_effect_index(const std::string &effect_name) const {
-    if (str_equals_case_insensitive(effect_name, "none")) {
+  uint32_t get_effect_index(const char *effect_name) const {
+    if (ESPHOME_strcasecmp_P(effect_name, ESPHOME_PSTR("none")) == 0) {
       return 0;
     }
     for (size_t i = 0; i < this->effects_.size(); i++) {
-      if (str_equals_case_insensitive(effect_name, this->effects_[i]->get_name())) {
+      if (strcasecmp(effect_name, this->effects_[i]->get_name().c_str()) == 0) {
         return i + 1;  // Effects are 1-indexed in active_effect_index_
       }
     }
     return 0;  // Effect not found
+  }
+  uint32_t get_effect_index(const std::string &effect_name) const {
+    return this->get_effect_index(effect_name.c_str());
   }
 
   /// Get effect by index. Returns nullptr if index is invalid.


### PR DESCRIPTION
# What does this implement/fix?

Store "none" effect string literal in flash on ESP8266 and avoid heap allocation in `get_effect_index()`.

Changes:
- `light_state.h`:
  - Add `get_effect_index(const char *)` as the base implementation using `ESPHOME_strcasecmp_P`
  - Make `get_effect_index(const std::string &)` an inline wrapper
- `light_call.cpp`:
  - Use `ESPHOME_strncasecmp_P` with `ESPHOME_PSTR("none")` for flash-aware comparison

This avoids creating a temporary `std::string` when calling `get_effect_index()` with a `const char*` argument, and on ESP8266 the "none" string literal is stored in flash instead of RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
light:
  - platform: ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
