### PR TITLE
[media_player] Store command strings in flash and avoid heap allocation in set_command

### DIFF
--- a/esphome/components/media_player/media_player.cpp
+++ b/esphome/components/media_player/media_player.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome {
 namespace media_player {
@@ -107,25 +108,25 @@ MediaPlayerCall &MediaPlayerCall::set_command(optional<MediaPlayerCommand> comma
   this->command_ = command;
   return *this;
 }
-MediaPlayerCall &MediaPlayerCall::set_command(const std::string &command) {
-  if (str_equals_case_insensitive(command, "PLAY")) {
+MediaPlayerCall &MediaPlayerCall::set_command(const char *command) {
+  if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("PLAY")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_PLAY);
-  } else if (str_equals_case_insensitive(command, "PAUSE")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("PAUSE")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_PAUSE);
-  } else if (str_equals_case_insensitive(command, "STOP")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("STOP")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_STOP);
-  } else if (str_equals_case_insensitive(command, "MUTE")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("MUTE")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_MUTE);
-  } else if (str_equals_case_insensitive(command, "UNMUTE")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("UNMUTE")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_UNMUTE);
-  } else if (str_equals_case_insensitive(command, "TOGGLE")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TOGGLE")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_TOGGLE);
-  } else if (str_equals_case_insensitive(command, "TURN_ON")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TURN_ON")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_TURN_ON);
-  } else if (str_equals_case_insensitive(command, "TURN_OFF")) {
+  } else if (ESPHOME_strcasecmp_P(command, ESPHOME_PSTR("TURN_OFF")) == 0) {
     this->set_command(MEDIA_PLAYER_COMMAND_TURN_OFF);
   } else {
-    ESP_LOGW(TAG, "'%s' - Unrecognized command %s", this->parent_->get_name().c_str(), command.c_str());
+    ESP_LOGW(TAG, "'%s' - Unrecognized command %s", this->parent_->get_name().c_str(), command);
   }
   return *this;
 }

--- a/esphome/components/media_player/media_player.h
+++ b/esphome/components/media_player/media_player.h
@@ -114,7 +114,8 @@ class MediaPlayerCall {
 
   MediaPlayerCall &set_command(MediaPlayerCommand command);
   MediaPlayerCall &set_command(optional<MediaPlayerCommand> command);
-  MediaPlayerCall &set_command(const std::string &command);
+  MediaPlayerCall &set_command(const char *command);
+  MediaPlayerCall &set_command(const std::string &command) { return this->set_command(command.c_str()); }
 
   MediaPlayerCall &set_media_url(const std::string &url);
 


### PR DESCRIPTION
# What does this implement/fix?

Avoid heap allocation in `MediaPlayerCall::set_command()` and store command string literals in flash on ESP8266.

Changes:
- Add `set_command(const char *command)` as the base implementation
- Make `set_command(const std::string &command)` an inline wrapper that calls the `const char*` overload
- Use `ESPHOME_strcasecmp_P` with `ESPHOME_PSTR` for flash-aware string comparison

This avoids creating a temporary `std::string` when calling `set_command()` with a `const char*` argument, and on ESP8266 the command string literals ("PLAY", "PAUSE", "STOP", "MUTE", "UNMUTE", "TOGGLE", "TURN_ON", "TURN_OFF") are stored in flash instead of RAM.

Follows the same pattern used in `cover.cpp` and `valve.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
media_player:
  - platform: ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
