### PR TITLE
[opentherm] Fix ESP-IDF build by re-enabling legacy driver component

### DIFF
--- a/esphome/components/opentherm/__init__.py
+++ b/esphome/components/opentherm/__init__.py
@@ -4,8 +4,10 @@ from typing import Any
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.esp32 import include_builtin_idf_component
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TRIGGER_ID, PLATFORM_ESP32, PLATFORM_ESP8266
+from esphome.core import CORE
 
 from . import const, generate, schema, validate
 
@@ -83,6 +85,12 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: dict[str, Any]) -> None:
+    if CORE.using_esp_idf:
+        # Re-enable ESP-IDF's legacy driver component (excluded by default to save compile time)
+        # Provides driver/timer.h header for hardware timer API
+        # TODO: Remove this once opentherm migrates to GPTimer API (driver/gptimer.h)
+        include_builtin_idf_component("driver")
+
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/opentherm/__init__.py
+++ b/esphome/components/opentherm/__init__.py
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config: dict[str, Any]) -> None:
-    if CORE.using_esp_idf:
+    if CORE.is_esp32:
         # Re-enable ESP-IDF's legacy driver component (excluded by default to save compile time)
         # Provides driver/timer.h header for hardware timer API
         # TODO: Remove this once opentherm migrates to GPTimer API (driver/gptimer.h)

--- a/esphome/components/opentherm/opentherm.cpp
+++ b/esphome/components/opentherm/opentherm.cpp
@@ -8,6 +8,8 @@
 #include "opentherm.h"
 #include "esphome/core/helpers.h"
 #include <cinttypes>
+// TODO: Migrate from legacy timer API (driver/timer.h) to GPTimer API (driver/gptimer.h)
+// The legacy timer API is deprecated in ESP-IDF 5.x. See opentherm.h for details.
 #ifdef USE_ESP32
 #include "driver/timer.h"
 #include "esp_err.h"

--- a/esphome/components/opentherm/opentherm.h
+++ b/esphome/components/opentherm/opentherm.h
@@ -12,6 +12,10 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+// TODO: Migrate from legacy timer API (driver/timer.h) to GPTimer API (driver/gptimer.h)
+// The legacy timer API is deprecated in ESP-IDF 5.x. Migration would allow removing the
+// "driver" IDF component dependency. See:
+// https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/peripherals.html#id4
 #ifdef USE_ESP32
 #include "driver/timer.h"
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fix opentherm component build failure on ESP32 with ESP-IDF framework after #13664 excluded the `driver` IDF component by default.

The opentherm component uses the legacy timer API (`driver/timer.h`) which requires the `driver` IDF component. This PR re-enables it for opentherm and adds TODO comments noting future migration to the GPTimer API (`driver/gptimer.h`).

Error before fix:
```
src/esphome/components/opentherm/opentherm.h:16:10: fatal error: driver/timer.h: No such file or directory
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes build regression from #13664

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard opentherm config - no changes needed
opentherm:
  in_pin: GPIO4
  out_pin: GPIO5
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
