### PR TITLE
[wifi] Fix wifi.connected condition returning false in connect state listener automations

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -632,6 +632,11 @@ class WiFiComponent : public Component {
   /// Free scan results memory unless a component needs them
   void release_scan_results_();
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  /// Notify connect state listeners (called after state machine reaches STA_CONNECTED)
+  void notify_connect_state_listeners_();
+#endif
+
 #ifdef USE_ESP8266
   static void wifi_event_callback(System_Event_t *event);
   void wifi_scan_done_callback_(void *arg, STATUS status);
@@ -737,6 +742,16 @@ class WiFiComponent : public Component {
   bool is_high_performance_mode_{false};
 
   SemaphoreHandle_t high_performance_semaphore_{nullptr};
+#endif
+
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  // Pending listener notifications deferred until state machine reaches appropriate state.
+  // Listeners are notified after state transitions complete so conditions like
+  // wifi.connected return correct values in automations.
+  // Uses bitfields to minimize memory; more flags may be added as needed.
+  struct {
+    bool connect_state : 1;  // Notify connect state listeners after STA_CONNECTED
+  } pending_{};
 #endif
 
 #ifdef USE_WIFI_CONNECT_TRIGGER

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -252,6 +252,10 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
   return network::IPAddress(dns_ip);
 }
 
+// Pico W uses polling for connection state detection.
+// Connect state listener notifications are deferred until after the state machine
+// transitions (in check_connecting_finished) so that conditions like wifi.connected
+// return correct values in automations.
 void WiFiComponent::wifi_loop_() {
   // Handle scan completion
   if (this->state_ == WIFI_COMPONENT_STATE_STA_SCANNING && !cyw43_wifi_scan_active(&cyw43_state)) {
@@ -278,11 +282,9 @@ void WiFiComponent::wifi_loop_() {
     s_sta_was_connected = true;
     ESP_LOGV(TAG, "Connected");
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
-    String ssid = WiFi.SSID();
-    bssid_t bssid = this->wifi_bssid();
-    for (auto *listener : this->connect_state_listeners_) {
-      listener->on_wifi_connect_state(StringRef(ssid.c_str(), ssid.length()), bssid);
-    }
+    // Defer listener notification until state machine reaches STA_CONNECTED
+    // This ensures wifi.connected condition returns true in listener automations
+    this->pending_.connect_state = true;
 #endif
     // For static IP configurations, notify IP listeners immediately as the IP is already configured
 #if defined(USE_WIFI_IP_STATE_LISTENERS) && defined(USE_WIFI_MANUAL_IP)


### PR DESCRIPTION
# What does this implement/fix?

Fixes `wifi.connected` condition returning `false` when checked from `wifi_info` text sensor's `on_value` trigger or other connect state listeners.

**Root cause:** Connect state listeners were being notified before the WiFi state machine transitioned to `WIFI_COMPONENT_STATE_STA_CONNECTED`. When user automations checked `wifi.connected` in their `on_value` handlers, `is_connected()` would return `false` because:
1. `wifi_loop_()` processed the connect event and called listeners
2. But `check_connecting_finished()` hadn't yet set `state_ = WIFI_COMPONENT_STATE_STA_CONNECTED`
3. `is_connected()` requires `state_ == WIFI_COMPONENT_STATE_STA_CONNECTED`

**Fix:** Defer connect state listener notification until after the state machine has fully transitioned:
1. Platform event handlers now set `pending_.connect_state = true` instead of calling listeners directly
2. `notify_connect_state_listeners_()` is called from `check_connecting_finished()` **after** `state_ = WIFI_COMPONENT_STATE_STA_CONNECTED`
3. Listeners now receive notification only when `wifi.connected` will return `true`

The `pending_` struct uses bitfields to minimize memory and is designed to accommodate additional deferred callbacks in the future. On ESP8266, several other listener callbacks (disconnect, IP, scan) still run in system context with limited stack (~2KB) and should be migrated to use this pattern to avoid stack overflow - comments have been added to track this technical debt.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13682

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config now works correctly - blue_led turns ON when WiFi connects
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

text_sensor:
  - platform: wifi_info
    ssid:
      name: "WiFi SSID"
      on_value:
        - if:
            condition:
              wifi.connected:
            then:
              - switch.turn_on: blue_led  # Now works!
            else:
              - switch.turn_off: blue_led

switch:
  - platform: gpio
    pin: GPIO2
    id: blue_led
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
