### PR TITLE
[cse7766] Fix power reading stuck when load switches off

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -152,6 +152,10 @@ void CSE7766Component::parse_data_() {
     if (this->power_sensor_ != nullptr) {
       this->power_sensor_->publish_state(power);
     }
+  } else if (this->power_sensor_ != nullptr) {
+    // No valid power measurement from chip - publish 0W to avoid stale readings
+    // This typically happens when current is below the measurable threshold (~50mA)
+    this->power_sensor_->publish_state(0.0f);
   }
 
   float current = 0.0f;


### PR DESCRIPTION
# What does this implement/fix?

When the load is switched off and current drops below the CSE7766 chip's measurable threshold (~50mA), the chip sets `have_power=false` indicating no valid power measurement. The code was not publishing any value in this case, leaving the power sensor stuck at its last reading (e.g., 200W) for 10-20 seconds until the chip reports valid power data again.

This regression was introduced in 2024.2.0 when PR #6180 refactored the code from an accumulator-based design to direct publishing. The original code handled this case by incrementing `power_counts_` when `have_voltage && !have_power`, effectively publishing 0W.

The fix adds an else clause to publish 0W when `have_power` is false, consistent with how the current sensor already handles low/zero current (it publishes 0A when below the measurable threshold).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13613

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Standard CSE7766 configuration (no changes needed)
sensor:
  - platform: cse7766
    voltage:
      name: "Voltage"
    current:
      name: "Current"
    power:
      name: "Power"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
