### PR TITLE
[api] Eliminate intermediate buffers in protobuf dump helpers

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -23,15 +23,8 @@ static inline void append_field_prefix(DumpBuffer &out, const char *field_name, 
   out.append(indent, ' ').append(field_name).append(": ");
 }
 
-static inline void append_with_newline(DumpBuffer &out, const char *str) {
-  out.append(str);
-  out.append("\n");
-}
-
 static inline void append_uint(DumpBuffer &out, uint32_t value) {
-  char buf[16];
-  snprintf(buf, sizeof(buf), "%" PRIu32, value);
-  out.append(buf);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu32, value));
 }
 
 // RAII helper for message dump formatting
@@ -49,31 +42,23 @@ class MessageDumpHelper {
 
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRId32, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRId32 "\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, uint32_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRIu32, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu32 "\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, float value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%g", value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%g\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, uint64_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRIu64, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu64 "\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, bool value, int indent = 2) {
@@ -112,7 +97,7 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
   char hex_buf[format_hex_pretty_size(160)];
   append_field_prefix(out, field_name, indent);
   format_hex_pretty_to(hex_buf, data, len);
-  append_with_newline(out, hex_buf);
+  out.append(hex_buf).append("\n");
 }
 
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -402,6 +402,16 @@ class DumpBuffer {
   const char *c_str() const { return buf_; }
   size_t size() const { return pos_; }
 
+  /// Get writable buffer pointer for use with buf_append_printf
+  char *data() { return buf_; }
+  /// Get current position for use with buf_append_printf
+  size_t pos() const { return pos_; }
+  /// Update position after buf_append_printf call
+  void set_pos(size_t pos) {
+    pos_ = pos;
+    buf_[pos_] = '\0';
+  }
+
  private:
   void append_impl_(const char *str, size_t len) {
     size_t space = CAPACITY - 1 - pos_;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -408,7 +408,11 @@ class DumpBuffer {
   size_t pos() const { return pos_; }
   /// Update position after buf_append_printf call
   void set_pos(size_t pos) {
-    pos_ = pos;
+    if (pos >= CAPACITY) {
+      pos_ = CAPACITY - 1;
+    } else {
+      pos_ = pos;
+    }
     buf_[pos_] = '\0';
   }
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2599,15 +2599,8 @@ static inline void append_field_prefix(DumpBuffer &out, const char *field_name, 
   out.append(indent, ' ').append(field_name).append(": ");
 }
 
-static inline void append_with_newline(DumpBuffer &out, const char *str) {
-  out.append(str);
-  out.append("\\n");
-}
-
 static inline void append_uint(DumpBuffer &out, uint32_t value) {
-  char buf[16];
-  snprintf(buf, sizeof(buf), "%" PRIu32, value);
-  out.append(buf);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu32, value));
 }
 
 // RAII helper for message dump formatting
@@ -2625,31 +2618,23 @@ class MessageDumpHelper {
 
 // Helper functions to reduce code duplication in dump methods
 static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRId32, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRId32 "\\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, uint32_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRIu32, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu32 "\\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, float value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%g", value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%g\\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, uint64_t value, int indent = 2) {
-  char buffer[64];
   append_field_prefix(out, field_name, indent);
-  snprintf(buffer, 64, "%" PRIu64, value);
-  append_with_newline(out, buffer);
+  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRIu64 "\\n", value));
 }
 
 static void dump_field(DumpBuffer &out, const char *field_name, bool value, int indent = 2) {
@@ -2689,7 +2674,7 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
   char hex_buf[format_hex_pretty_size(160)];
   append_field_prefix(out, field_name, indent);
   format_hex_pretty_to(hex_buf, data, len);
-  append_with_newline(out, hex_buf);
+  out.append(hex_buf).append("\\n");
 }
 
 """


### PR DESCRIPTION
# What does this implement/fix?

Eliminates intermediate stack buffers in API protobuf dump functions by using `buf_append_printf` to write directly into the `DumpBuffer`.

Previously, numeric values were formatted into a temporary 64-byte stack buffer with `snprintf`, then copied to the DumpBuffer:

```cpp
static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
  char buffer[64];  // intermediate buffer
  append_field_prefix(out, field_name, indent);
  snprintf(buffer, 64, "%" PRId32, value);
  append_with_newline(out, buffer);  // copy to DumpBuffer
}
```

Now values are formatted directly into DumpBuffer using `buf_append_printf`:

```cpp
static void dump_field(DumpBuffer &out, const char *field_name, int32_t value, int indent = 2) {
  append_field_prefix(out, field_name, indent);
  out.set_pos(buf_append_printf(out.data(), DumpBuffer::CAPACITY, out.pos(), "%" PRId32 "\n", value));
}
```

Changes:
- Added `data()`, `pos()`, and `set_pos()` methods to `DumpBuffer` class in `proto.h`
- Updated `api_protobuf.py` generator to use `buf_append_printf` for numeric dump functions
- Removed unused `append_with_newline` helper function

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
# Enable very verbose logging to see dump output:
logger:
  level: VERY_VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
