### PR TITLE
[dlms_meter] Rename test UART package key to match directory name

### DIFF
--- a/tests/components/dlms_meter/test.esp32-ard.yaml
+++ b/tests/components/dlms_meter/test.esp32-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_2400/esp32-ard.yaml
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp32-ard.yaml
 
 <<: !include common-generic.yaml

--- a/tests/components/dlms_meter/test.esp32-idf.yaml
+++ b/tests/components/dlms_meter/test.esp32-idf.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_2400/esp32-idf.yaml
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp32-idf.yaml
 
 <<: !include common-netznoe.yaml

--- a/tests/components/dlms_meter/test.esp8266-ard.yaml
+++ b/tests/components/dlms_meter/test.esp8266-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_2400/esp8266-ard.yaml
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp8266-ard.yaml
 
 <<: !include common-generic.yaml


### PR DESCRIPTION
# What does this implement/fix?

Rename the UART package key in dlms_meter test files from `uart` to `uart_2400` to match the actual package directory name.

This fixes a test grouping conflict where dlms_meter (2400 baud) and dsmr/midea (9600 baud) both used `uart` as the package key but with different configurations. The test infrastructure detected this as a conflict and refused to merge them, even though they should be treated as separate packages.

With this fix:
- `dsmr` and `midea` can be grouped together (both use `uart` package at 9600 baud)
- `dlms_meter` is tested separately (uses `uart_2400` package at 2400 baud)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). N/A
