### PR TITLE
[components] Remove redundant setup priority overrides that duplicate default

### DIFF
--- a/esphome/components/absolute_humidity/absolute_humidity.cpp
+++ b/esphome/components/absolute_humidity/absolute_humidity.cpp
@@ -45,8 +45,6 @@ void AbsoluteHumidityComponent::dump_config() {
                 this->temperature_sensor_->get_name().c_str(), this->humidity_sensor_->get_name().c_str());
 }
 
-float AbsoluteHumidityComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void AbsoluteHumidityComponent::loop() {
   if (!this->next_update_) {
     return;

--- a/esphome/components/absolute_humidity/absolute_humidity.h
+++ b/esphome/components/absolute_humidity/absolute_humidity.h
@@ -24,7 +24,6 @@ class AbsoluteHumidityComponent : public sensor::Sensor, public Component {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
 
  protected:

--- a/esphome/components/adc/adc_sensor.h
+++ b/esphome/components/adc/adc_sensor.h
@@ -68,11 +68,6 @@ class ADCSensor : public sensor::Sensor, public PollingComponent, public voltage
   /// This method is called during the ESPHome setup process to log the configuration.
   void dump_config() override;
 
-  /// Return the setup priority for this component.
-  /// Components with higher priority are initialized earlier during setup.
-  /// @return A float representing the setup priority.
-  float get_setup_priority() const override;
-
 #ifdef USE_ZEPHYR
   /// Set the ADC channel to be used by the ADC sensor.
   /// @param channel Pointer to an adc_dt_spec structure representing the ADC channel.

--- a/esphome/components/adc/adc_sensor_common.cpp
+++ b/esphome/components/adc/adc_sensor_common.cpp
@@ -79,7 +79,5 @@ void ADCSensor::set_sample_count(uint8_t sample_count) {
 
 void ADCSensor::set_sampling_mode(SamplingMode sampling_mode) { this->sampling_mode_ = sampling_mode; }
 
-float ADCSensor::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace adc
 }  // namespace esphome

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.cpp
@@ -9,8 +9,6 @@ static const char *const TAG = "adc128s102.sensor";
 
 ADC128S102Sensor::ADC128S102Sensor(uint8_t channel) : channel_(channel) {}
 
-float ADC128S102Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void ADC128S102Sensor::dump_config() {
   LOG_SENSOR("", "ADC128S102 Sensor", this);
   ESP_LOGCONFIG(TAG, "  Pin: %u", this->channel_);

--- a/esphome/components/adc128s102/sensor/adc128s102_sensor.h
+++ b/esphome/components/adc128s102/sensor/adc128s102_sensor.h
@@ -19,7 +19,6 @@ class ADC128S102Sensor : public PollingComponent,
 
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   float sample() override;
 
  protected:

--- a/esphome/components/aht10/aht10.cpp
+++ b/esphome/components/aht10/aht10.cpp
@@ -150,8 +150,6 @@ void AHT10Component::update() {
   this->restart_read_();
 }
 
-float AHT10Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void AHT10Component::dump_config() {
   ESP_LOGCONFIG(TAG, "AHT10:");
   LOG_I2C_DEVICE(this);

--- a/esphome/components/aht10/aht10.h
+++ b/esphome/components/aht10/aht10.h
@@ -16,7 +16,6 @@ class AHT10Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void set_variant(AHT10Variant variant) { this->variant_ = variant; }
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/am2315c/am2315c.cpp
+++ b/esphome/components/am2315c/am2315c.cpp
@@ -176,7 +176,5 @@ void AM2315C::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-float AM2315C::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace am2315c
 }  // namespace esphome

--- a/esphome/components/am2315c/am2315c.h
+++ b/esphome/components/am2315c/am2315c.h
@@ -33,7 +33,6 @@ class AM2315C : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override;
   void setup() override;
-  float get_setup_priority() const override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { this->temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { this->humidity_sensor_ = humidity_sensor; }

--- a/esphome/components/am2320/am2320.cpp
+++ b/esphome/components/am2320/am2320.cpp
@@ -51,7 +51,6 @@ void AM2320Component::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
-float AM2320Component::get_setup_priority() const { return setup_priority::DATA; }
 
 bool AM2320Component::read_bytes_(uint8_t a_register, uint8_t *data, uint8_t len, uint32_t conversion) {
   if (!this->write_bytes(a_register, data, 2)) {

--- a/esphome/components/am2320/am2320.h
+++ b/esphome/components/am2320/am2320.h
@@ -11,7 +11,6 @@ class AM2320Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -384,7 +384,6 @@ void APDS9960::process_dataset_(int up, int down, int left, int right) {
     }
   }
 }
-float APDS9960::get_setup_priority() const { return setup_priority::DATA; }
 bool APDS9960::is_proximity_enabled_() const {
   return
 #ifdef USE_SENSOR

--- a/esphome/components/apds9960/apds9960.h
+++ b/esphome/components/apds9960/apds9960.h
@@ -32,7 +32,6 @@ class APDS9960 : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void loop() override;
 

--- a/esphome/components/aqi/aqi_sensor.h
+++ b/esphome/components/aqi/aqi_sensor.h
@@ -10,7 +10,6 @@ class AQISensor : public sensor::Sensor, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void set_pm_2_5_sensor(sensor::Sensor *sensor) { this->pm_2_5_sensor_ = sensor; }
   void set_pm_10_0_sensor(sensor::Sensor *sensor) { this->pm_10_0_sensor_ = sensor; }

--- a/esphome/components/as3935/as3935.cpp
+++ b/esphome/components/as3935/as3935.cpp
@@ -41,8 +41,6 @@ void AS3935Component::dump_config() {
 #endif
 }
 
-float AS3935Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void AS3935Component::loop() {
   if (!this->irq_pin_->digital_read())
     return;

--- a/esphome/components/as3935/as3935.h
+++ b/esphome/components/as3935/as3935.h
@@ -74,7 +74,6 @@ class AS3935Component : public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
 
   void set_irq_pin(GPIOPin *irq_pin) { irq_pin_ = irq_pin; }

--- a/esphome/components/as5600/sensor/as5600_sensor.cpp
+++ b/esphome/components/as5600/sensor/as5600_sensor.cpp
@@ -22,8 +22,6 @@ static const uint8_t REGISTER_STATUS = 0x0B;     // 8 bytes  / R
 static const uint8_t REGISTER_AGC = 0x1A;        // 8 bytes  / R
 static const uint8_t REGISTER_MAGNITUDE = 0x1B;  // 16 bytes / R
 
-float AS5600Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void AS5600Sensor::dump_config() {
   LOG_SENSOR("", "AS5600 Sensor", this);
   ESP_LOGCONFIG(TAG, "  Out of Range Mode: %u", this->out_of_range_mode_);

--- a/esphome/components/as5600/sensor/as5600_sensor.h
+++ b/esphome/components/as5600/sensor/as5600_sensor.h
@@ -14,7 +14,6 @@ class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, 
  public:
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void set_angle_sensor(sensor::Sensor *angle_sensor) { this->angle_sensor_ = angle_sensor; }
   void set_raw_angle_sensor(sensor::Sensor *raw_angle_sensor) { this->raw_angle_sensor_ = raw_angle_sensor; }

--- a/esphome/components/as7341/as7341.cpp
+++ b/esphome/components/as7341/as7341.cpp
@@ -58,8 +58,6 @@ void AS7341Component::dump_config() {
   LOG_SENSOR("  ", "NIR", this->nir_);
 }
 
-float AS7341Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void AS7341Component::update() {
   this->read_channels(this->channel_readings_);
 

--- a/esphome/components/as7341/as7341.h
+++ b/esphome/components/as7341/as7341.h
@@ -78,7 +78,6 @@ class AS7341Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_f1_sensor(sensor::Sensor *f1_sensor) { this->f1_ = f1_sensor; }

--- a/esphome/components/atm90e26/atm90e26.cpp
+++ b/esphome/components/atm90e26/atm90e26.cpp
@@ -146,7 +146,6 @@ void ATM90E26Component::dump_config() {
   LOG_SENSOR("  ", "Active Reverse Energy A", this->reverse_active_energy_sensor_);
   LOG_SENSOR("  ", "Frequency", this->freq_sensor_);
 }
-float ATM90E26Component::get_setup_priority() const { return setup_priority::DATA; }
 
 uint16_t ATM90E26Component::read16_(uint8_t a_register) {
   uint8_t data[2];

--- a/esphome/components/atm90e26/atm90e26.h
+++ b/esphome/components/atm90e26/atm90e26.h
@@ -13,7 +13,6 @@ class ATM90E26Component : public PollingComponent,
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_voltage_sensor(sensor::Sensor *obj) { this->voltage_sensor_ = obj; }

--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -265,6 +265,4 @@ void BH1750Sensor::fail_and_reset_() {
   this->state_ = IDLE;
 }
 
-float BH1750Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace esphome::bh1750

--- a/esphome/components/bh1750/bh1750.h
+++ b/esphome/components/bh1750/bh1750.h
@@ -21,7 +21,6 @@ class BH1750Sensor : public sensor::Sensor, public PollingComponent, public i2c:
   void dump_config() override;
   void update() override;
   void loop() override;
-  float get_setup_priority() const override;
 
  protected:
   // State machine states

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -199,7 +199,6 @@ void BME280Component::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
   ESP_LOGCONFIG(TAG, "    Oversampling: %s", oversampling_to_str(this->humidity_oversampling_));
 }
-float BME280Component::get_setup_priority() const { return setup_priority::DATA; }
 
 inline uint8_t oversampling_to_time(BME280Oversampling over_sampling) { return (1 << uint8_t(over_sampling)) >> 1; }
 

--- a/esphome/components/bme280_base/bme280_base.h
+++ b/esphome/components/bme280_base/bme280_base.h
@@ -76,7 +76,6 @@ class BME280Component : public PollingComponent {
   // (In most use cases you won't need these)
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -233,8 +233,6 @@ void BME680Component::dump_config() {
   }
 }
 
-float BME680Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void BME680Component::update() {
   uint8_t meas_control = 0;  // No need to fetch, we're setting all fields
   meas_control |= (this->temperature_oversampling_ & 0b111) << 5;

--- a/esphome/components/bme680/bme680.h
+++ b/esphome/components/bme680/bme680.h
@@ -99,7 +99,6 @@ class BME680Component : public PollingComponent, public i2c::I2CDevice {
   // (In most use cases you won't need these)
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -181,8 +181,6 @@ void BME680BSECComponent::dump_config() {
   LOG_SENSOR("  ", "Breath VOC Equivalent", this->breath_voc_equivalent_sensor_);
 }
 
-float BME680BSECComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void BME680BSECComponent::loop() {
   this->run_();
 

--- a/esphome/components/bme680_bsec/bme680_bsec.h
+++ b/esphome/components/bme680_bsec/bme680_bsec.h
@@ -64,7 +64,6 @@ class BME680BSECComponent : public Component, public i2c::I2CDevice {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
 
  protected:

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -106,8 +106,6 @@ void BME68xBSEC2Component::dump_config() {
 #endif
 }
 
-float BME68xBSEC2Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void BME68xBSEC2Component::loop() {
   this->run_();
 

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -48,7 +48,6 @@ class BME68xBSEC2Component : public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
 
   void set_algorithm_output(AlgorithmOutput algorithm_output) { this->algorithm_output_ = algorithm_output; }

--- a/esphome/components/bmi160/bmi160.cpp
+++ b/esphome/components/bmi160/bmi160.cpp
@@ -263,7 +263,6 @@ void BMI160Component::update() {
 
   this->status_clear_warning();
 }
-float BMI160Component::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace bmi160
 }  // namespace esphome

--- a/esphome/components/bmi160/bmi160.h
+++ b/esphome/components/bmi160/bmi160.h
@@ -14,8 +14,6 @@ class BMI160Component : public PollingComponent, public i2c::I2CDevice {
 
   void update() override;
 
-  float get_setup_priority() const override;
-
   void set_accel_x_sensor(sensor::Sensor *accel_x_sensor) { accel_x_sensor_ = accel_x_sensor; }
   void set_accel_y_sensor(sensor::Sensor *accel_y_sensor) { accel_y_sensor_ = accel_y_sensor; }
   void set_accel_z_sensor(sensor::Sensor *accel_z_sensor) { accel_z_sensor_ = accel_z_sensor; }

--- a/esphome/components/bmp085/bmp085.cpp
+++ b/esphome/components/bmp085/bmp085.cpp
@@ -131,7 +131,6 @@ bool BMP085Component::set_mode_(uint8_t mode) {
   ESP_LOGV(TAG, "Setting mode to 0x%02X", mode);
   return this->write_byte(BMP085_REGISTER_CONTROL, mode);
 }
-float BMP085Component::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace bmp085
 }  // namespace esphome

--- a/esphome/components/bmp085/bmp085.h
+++ b/esphome/components/bmp085/bmp085.h
@@ -18,8 +18,6 @@ class BMP085Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override;
-
  protected:
   struct CalibrationData {
     int16_t ac1, ac2, ac3;

--- a/esphome/components/bmp280_base/bmp280_base.cpp
+++ b/esphome/components/bmp280_base/bmp280_base.cpp
@@ -148,7 +148,6 @@ void BMP280Component::dump_config() {
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
   ESP_LOGCONFIG(TAG, "    Oversampling: %s", oversampling_to_str(this->pressure_oversampling_));
 }
-float BMP280Component::get_setup_priority() const { return setup_priority::DATA; }
 
 inline uint8_t oversampling_to_time(BMP280Oversampling over_sampling) { return (1 << uint8_t(over_sampling)) >> 1; }
 

--- a/esphome/components/bmp280_base/bmp280_base.h
+++ b/esphome/components/bmp280_base/bmp280_base.h
@@ -64,7 +64,6 @@ class BMP280Component : public PollingComponent {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/bmp3xx_base/bmp3xx_base.cpp
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.cpp
@@ -179,7 +179,6 @@ void BMP3XXComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "    Oversampling: %s", LOG_STR_ARG(oversampling_to_str(this->pressure_oversampling_)));
   }
 }
-float BMP3XXComponent::get_setup_priority() const { return setup_priority::DATA; }
 
 inline uint8_t oversampling_to_time(Oversampling over_sampling) { return (1 << uint8_t(over_sampling)); }
 

--- a/esphome/components/bmp3xx_base/bmp3xx_base.h
+++ b/esphome/components/bmp3xx_base/bmp3xx_base.h
@@ -73,7 +73,6 @@ class BMP3XXComponent : public PollingComponent {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/cd74hc4067/cd74hc4067.cpp
+++ b/esphome/components/cd74hc4067/cd74hc4067.cpp
@@ -7,8 +7,6 @@ namespace cd74hc4067 {
 
 static const char *const TAG = "cd74hc4067";
 
-float CD74HC4067Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void CD74HC4067Component::setup() {
   this->pin_s0_->setup();
   this->pin_s1_->setup();

--- a/esphome/components/cd74hc4067/cd74hc4067.h
+++ b/esphome/components/cd74hc4067/cd74hc4067.h
@@ -13,7 +13,6 @@ class CD74HC4067Component : public Component {
   /// Set up the internal sensor array.
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   /// setting pin active by setting the right combination of the four multiplexer input pins
   void activate_pin(uint8_t pin);

--- a/esphome/components/cm1106/cm1106.h
+++ b/esphome/components/cm1106/cm1106.h
@@ -10,8 +10,6 @@ namespace cm1106 {
 
 class CM1106Component : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
-
   void setup() override;
   void update() override;
   void dump_config() override;

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -10,8 +10,6 @@ namespace combination {
 
 class CombinationComponent : public Component, public sensor::Sensor {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
-
   /// @brief Logs all source sensor's names
   virtual void log_source_sensors() = 0;
 

--- a/esphome/components/cse7761/cse7761.cpp
+++ b/esphome/components/cse7761/cse7761.cpp
@@ -62,8 +62,6 @@ void CSE7761Component::dump_config() {
   this->check_uart_settings(38400, 1, uart::UART_CONFIG_PARITY_EVEN, 8);
 }
 
-float CSE7761Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void CSE7761Component::update() {
   if (this->data_.ready) {
     this->get_data_();

--- a/esphome/components/cse7761/cse7761.h
+++ b/esphome/components/cse7761/cse7761.h
@@ -28,7 +28,6 @@ class CSE7761Component : public PollingComponent, public uart::UARTDevice {
   void set_current_2_sensor(sensor::Sensor *current_sensor_2) { current_sensor_2_ = current_sensor_2; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -37,7 +37,6 @@ void CSE7766Component::loop() {
     this->raw_data_index_ = (this->raw_data_index_ + 1) % 24;
   }
 }
-float CSE7766Component::get_setup_priority() const { return setup_priority::DATA; }
 
 bool CSE7766Component::check_byte_() {
   uint8_t index = this->raw_data_index_;

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -23,7 +23,6 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   void set_power_factor_sensor(sensor::Sensor *power_factor_sensor) { power_factor_sensor_ = power_factor_sensor; }
 
   void loop() override;
-  float get_setup_priority() const override;
   void dump_config() override;
 
  protected:

--- a/esphome/components/current_based/current_based_cover.cpp
+++ b/esphome/components/current_based/current_based_cover.cpp
@@ -159,7 +159,6 @@ void CurrentBasedCover::dump_config() {
                 this->start_sensing_delay_ / 1e3f, YESNO(this->malfunction_detection_));
 }
 
-float CurrentBasedCover::get_setup_priority() const { return setup_priority::DATA; }
 void CurrentBasedCover::stop_prev_trigger_() {
   if (this->prev_command_trigger_ != nullptr) {
     this->prev_command_trigger_->stop_action();

--- a/esphome/components/current_based/current_based_cover.h
+++ b/esphome/components/current_based/current_based_cover.h
@@ -14,7 +14,6 @@ class CurrentBasedCover : public cover::Cover, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   Trigger<> *get_stop_trigger() { return &this->stop_trigger_; }
 

--- a/esphome/components/daly_bms/daly_bms.cpp
+++ b/esphome/components/daly_bms/daly_bms.cpp
@@ -104,8 +104,6 @@ void DalyBmsComponent::loop() {
   }
 }
 
-float DalyBmsComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void DalyBmsComponent::request_data_(uint8_t data_id) {
   uint8_t request_message[DALY_FRAME_SIZE];
 

--- a/esphome/components/daly_bms/daly_bms.h
+++ b/esphome/components/daly_bms/daly_bms.h
@@ -72,7 +72,6 @@ class DalyBmsComponent : public PollingComponent, public uart::UARTDevice {
   void update() override;
   void loop() override;
 
-  float get_setup_priority() const override;
   void set_address(uint8_t address) { this->addr_ = address; }
 
  protected:

--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -63,8 +63,6 @@ void DHT::update() {
   }
 }
 
-float DHT::get_setup_priority() const { return setup_priority::DATA; }
-
 void DHT::set_dht_model(DHTModel model) {
   this->model_ = model;
   this->is_auto_detect_ = model == DHT_MODEL_AUTO_DETECT;

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -51,8 +51,6 @@ class DHT : public PollingComponent {
   void dump_config() override;
   /// Update sensor values and push them to the frontend.
   void update() override;
-  /// HARDWARE_LATE setup priority.
-  float get_setup_priority() const override;
 
  protected:
   bool read_sensor_(float *temperature, float *humidity, bool report_errors);

--- a/esphome/components/dht12/dht12.cpp
+++ b/esphome/components/dht12/dht12.cpp
@@ -49,7 +49,7 @@ void DHT12Component::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
-float DHT12Component::get_setup_priority() const { return setup_priority::DATA; }
+
 bool DHT12Component::read_data_(uint8_t *data) {
   if (!this->read_bytes(0, data, 5)) {
     ESP_LOGW(TAG, "Updating DHT12 failed!");

--- a/esphome/components/dht12/dht12.h
+++ b/esphome/components/dht12/dht12.h
@@ -11,7 +11,6 @@ class DHT12Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -98,8 +98,6 @@ void DPS310Component::dump_config() {
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
 }
 
-float DPS310Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void DPS310Component::update() {
   if (!this->update_in_progress_) {
     this->update_in_progress_ = true;

--- a/esphome/components/dps310/dps310.h
+++ b/esphome/components/dps310/dps310.h
@@ -40,7 +40,6 @@ class DPS310Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -26,8 +26,6 @@ void DS1307Component::dump_config() {
   RealTimeClock::dump_config();
 }
 
-float DS1307Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void DS1307Component::read_time() {
   if (!this->read_rtc_()) {
     return;

--- a/esphome/components/ds1307/ds1307.h
+++ b/esphome/components/ds1307/ds1307.h
@@ -12,7 +12,6 @@ class DS1307Component : public time::RealTimeClock, public i2c::I2CDevice {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void read_time();
   void write_time();
 

--- a/esphome/components/duty_cycle/duty_cycle_sensor.cpp
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.cpp
@@ -43,8 +43,6 @@ void DutyCycleSensor::update() {
   this->last_update_ = now;
 }
 
-float DutyCycleSensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void IRAM_ATTR DutyCycleSensorStore::gpio_intr(DutyCycleSensorStore *arg) {
   const bool new_level = arg->pin.digital_read();
   if (new_level == arg->last_level)

--- a/esphome/components/duty_cycle/duty_cycle_sensor.h
+++ b/esphome/components/duty_cycle/duty_cycle_sensor.h
@@ -22,7 +22,6 @@ class DutyCycleSensor : public sensor::Sensor, public PollingComponent {
   void set_pin(InternalGPIOPin *pin) { pin_ = pin; }
 
   void setup() override;
-  float get_setup_priority() const override;
   void dump_config() override;
   void update() override;
 

--- a/esphome/components/ee895/ee895.cpp
+++ b/esphome/components/ee895/ee895.cpp
@@ -55,8 +55,6 @@ void EE895Component::dump_config() {
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
 }
 
-float EE895Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void EE895Component::update() {
   write_command_(TEMPERATURE_ADDRESS, 2);
   this->set_timeout(50, [this]() {

--- a/esphome/components/ee895/ee895.h
+++ b/esphome/components/ee895/ee895.h
@@ -14,7 +14,6 @@ class EE895Component : public PollingComponent, public i2c::I2CDevice {
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_pressure_sensor(sensor::Sensor *pressure_sensor) { pressure_sensor_ = pressure_sensor; }
 
-  float get_setup_priority() const override;
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/emc2101/sensor/emc2101_sensor.cpp
+++ b/esphome/components/emc2101/sensor/emc2101_sensor.cpp
@@ -7,8 +7,6 @@ namespace emc2101 {
 
 static const char *const TAG = "EMC2101.sensor";
 
-float EMC2101Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void EMC2101Sensor::dump_config() {
   ESP_LOGCONFIG(TAG, "Emc2101 sensor:");
   LOG_SENSOR("  ", "Internal temperature", this->internal_temperature_sensor_);

--- a/esphome/components/emc2101/sensor/emc2101_sensor.h
+++ b/esphome/components/emc2101/sensor/emc2101_sensor.h
@@ -15,8 +15,6 @@ class EMC2101Sensor : public PollingComponent {
   void dump_config() override;
   /** Used by ESPHome framework. */
   void update() override;
-  /** Used by ESPHome framework. */
-  float get_setup_priority() const override;
 
   /** Used by ESPHome framework. */
   void set_internal_temperature_sensor(sensor::Sensor *sensor) { this->internal_temperature_sensor_ = sensor; }

--- a/esphome/components/endstop/endstop_cover.cpp
+++ b/esphome/components/endstop/endstop_cover.cpp
@@ -111,7 +111,7 @@ void EndstopCover::dump_config() {
   LOG_BINARY_SENSOR("  ", "Open Endstop", this->open_endstop_);
   LOG_BINARY_SENSOR("  ", "Close Endstop", this->close_endstop_);
 }
-float EndstopCover::get_setup_priority() const { return setup_priority::DATA; }
+
 void EndstopCover::stop_prev_trigger_() {
   if (this->prev_command_trigger_ != nullptr) {
     this->prev_command_trigger_->stop_action();

--- a/esphome/components/endstop/endstop_cover.h
+++ b/esphome/components/endstop/endstop_cover.h
@@ -13,7 +13,6 @@ class EndstopCover : public cover::Cover, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   Trigger<> *get_open_trigger() { return &this->open_trigger_; }
   Trigger<> *get_close_trigger() { return &this->close_trigger_; }

--- a/esphome/components/ens210/ens210.cpp
+++ b/esphome/components/ens210/ens210.cpp
@@ -136,8 +136,6 @@ void ENS210Component::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-float ENS210Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void ENS210Component::update() {
   // Execute a single measurement
   if (!this->write_byte(ENS210_REGISTER_SENS_RUN, 0x00)) {

--- a/esphome/components/ens210/ens210.h
+++ b/esphome/components/ens210/ens210.h
@@ -10,7 +10,6 @@ namespace ens210 {
 /// This class implements support for the ENS210 relative humidity and temperature i2c sensor.
 class ENS210Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  float get_setup_priority() const override;
   void dump_config() override;
   void setup() override;
   void update() override;

--- a/esphome/components/esp32_camera/esp32_camera.cpp
+++ b/esphome/components/esp32_camera/esp32_camera.cpp
@@ -235,8 +235,6 @@ void ESP32Camera::loop() {
   this->single_requesters_ = 0;
 }
 
-float ESP32Camera::get_setup_priority() const { return setup_priority::DATA; }
-
 /* ---------------- constructors ---------------- */
 ESP32Camera::ESP32Camera() {
   this->config_.pin_pwdn = -1;

--- a/esphome/components/esp32_camera/esp32_camera.h
+++ b/esphome/components/esp32_camera/esp32_camera.h
@@ -159,7 +159,6 @@ class ESP32Camera : public camera::Camera {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   /* public API (specific) */
   void start_stream(camera::CameraRequester requester) override;
   void stop_stream(camera::CameraRequester requester) override;

--- a/esphome/components/esp32_touch/esp32_touch.h
+++ b/esphome/components/esp32_touch/esp32_touch.h
@@ -51,7 +51,6 @@ class ESP32TouchComponent : public Component {
   void setup() override;
   void dump_config() override;
   void loop() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   void on_shutdown() override;
 

--- a/esphome/components/gdk101/gdk101.cpp
+++ b/esphome/components/gdk101/gdk101.cpp
@@ -77,8 +77,6 @@ void GDK101Component::dump_config() {
 #endif  // USE_TEXT_SENSOR
 }
 
-float GDK101Component::get_setup_priority() const { return setup_priority::DATA; }
-
 bool GDK101Component::read_bytes_with_retry_(uint8_t a_register, uint8_t *data, uint8_t len) {
   uint8_t retry = NUMBER_OF_READ_RETRIES;
   bool status = false;

--- a/esphome/components/gdk101/gdk101.h
+++ b/esphome/components/gdk101/gdk101.h
@@ -40,7 +40,6 @@ class GDK101Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/gp8403/gp8403.h
+++ b/esphome/components/gp8403/gp8403.h
@@ -20,7 +20,6 @@ class GP8403Component : public Component, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
   void set_model(GP8403Model model) { this->model_ = model; }
   void set_voltage(gp8403::GP8403Voltage voltage) { this->voltage_ = voltage; }
 

--- a/esphome/components/hc8/hc8.cpp
+++ b/esphome/components/hc8/hc8.cpp
@@ -86,8 +86,6 @@ void HC8Component::calibrate(uint16_t baseline) {
   this->flush();
 }
 
-float HC8Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void HC8Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "HC8:\n"

--- a/esphome/components/hc8/hc8.h
+++ b/esphome/components/hc8/hc8.h
@@ -11,8 +11,6 @@ namespace esphome::hc8 {
 
 class HC8Component : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override;
-
   void setup() override;
   void update() override;
   void dump_config() override;

--- a/esphome/components/hdc1080/hdc1080.h
+++ b/esphome/components/hdc1080/hdc1080.h
@@ -16,8 +16,6 @@ class HDC1080Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};

--- a/esphome/components/hlw8012/hlw8012.cpp
+++ b/esphome/components/hlw8012/hlw8012.cpp
@@ -48,7 +48,6 @@ void HLW8012Component::dump_config() {
   LOG_SENSOR("  ", "Power", this->power_sensor_);
   LOG_SENSOR("  ", "Energy", this->energy_sensor_);
 }
-float HLW8012Component::get_setup_priority() const { return setup_priority::DATA; }
 void HLW8012Component::update() {
   // HLW8012 has 50% duty cycle
   pulse_counter::pulse_counter_t raw_cf = this->cf_store_.read_raw_value();

--- a/esphome/components/hlw8012/hlw8012.h
+++ b/esphome/components/hlw8012/hlw8012.h
@@ -31,7 +31,6 @@ class HLW8012Component : public PollingComponent {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_initial_mode(HLW8012InitialMode initial_mode) {

--- a/esphome/components/hm3301/hm3301.cpp
+++ b/esphome/components/hm3301/hm3301.cpp
@@ -31,8 +31,6 @@ void HM3301Component::dump_config() {
   LOG_SENSOR("  ", "AQI", this->aqi_sensor_);
 }
 
-float HM3301Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void HM3301Component::update() {
   if (this->read(data_buffer_, 29) != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "Read result failed");

--- a/esphome/components/hm3301/hm3301.h
+++ b/esphome/components/hm3301/hm3301.h
@@ -23,7 +23,6 @@ class HM3301Component : public PollingComponent, public i2c::I2CDevice {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/hmc5883l/hmc5883l.cpp
+++ b/esphome/components/hmc5883l/hmc5883l.cpp
@@ -83,7 +83,6 @@ void HMC5883LComponent::dump_config() {
   LOG_SENSOR("  ", "Z Axis", this->z_sensor_);
   LOG_SENSOR("  ", "Heading", this->heading_sensor_);
 }
-float HMC5883LComponent::get_setup_priority() const { return setup_priority::DATA; }
 void HMC5883LComponent::update() {
   uint16_t raw_x, raw_y, raw_z;
   if (!this->read_byte_16(HMC5883L_REGISTER_DATA_X_MSB, &raw_x) ||

--- a/esphome/components/hmc5883l/hmc5883l.h
+++ b/esphome/components/hmc5883l/hmc5883l.h
@@ -39,7 +39,6 @@ class HMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_oversampling(HMC5883LOversampling oversampling) { oversampling_ = oversampling; }

--- a/esphome/components/homeassistant/time/homeassistant_time.cpp
+++ b/esphome/components/homeassistant/time/homeassistant_time.cpp
@@ -11,8 +11,6 @@ void HomeassistantTime::dump_config() {
   RealTimeClock::dump_config();
 }
 
-float HomeassistantTime::get_setup_priority() const { return setup_priority::DATA; }
-
 void HomeassistantTime::setup() { global_homeassistant_time = this; }
 
 void HomeassistantTime::update() { api::global_api_server->request_time(); }

--- a/esphome/components/homeassistant/time/homeassistant_time.h
+++ b/esphome/components/homeassistant/time/homeassistant_time.h
@@ -13,7 +13,6 @@ class HomeassistantTime : public time::RealTimeClock {
   void update() override;
   void dump_config() override;
   void set_epoch_time(uint32_t epoch) { this->synchronize_epoch_(epoch); }
-  float get_setup_priority() const override;
 };
 
 extern HomeassistantTime *global_homeassistant_time;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/honeywell_hih_i2c/honeywell_hih.cpp
+++ b/esphome/components/honeywell_hih_i2c/honeywell_hih.cpp
@@ -91,7 +91,5 @@ void HoneywellHIComponent::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
-float HoneywellHIComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace honeywell_hih_i2c
 }  // namespace esphome

--- a/esphome/components/honeywell_hih_i2c/honeywell_hih.h
+++ b/esphome/components/honeywell_hih_i2c/honeywell_hih.h
@@ -11,7 +11,6 @@ namespace honeywell_hih_i2c {
 class HoneywellHIComponent : public PollingComponent, public i2c::I2CDevice {
  public:
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
   void update() override;
 

--- a/esphome/components/hte501/hte501.cpp
+++ b/esphome/components/hte501/hte501.cpp
@@ -43,7 +43,6 @@ void HTE501Component::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-float HTE501Component::get_setup_priority() const { return setup_priority::DATA; }
 void HTE501Component::update() {
   uint8_t address_1[] = {0x2C, 0x1B};
   this->write(address_1, 2);

--- a/esphome/components/hte501/hte501.h
+++ b/esphome/components/hte501/hte501.h
@@ -13,7 +13,6 @@ class HTE501Component : public PollingComponent, public i2c::I2CDevice {
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
 
-  float get_setup_priority() const override;
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/htu21d/htu21d.cpp
+++ b/esphome/components/htu21d/htu21d.cpp
@@ -143,7 +143,5 @@ uint8_t HTU21DComponent::get_heater_level() {
   return raw_heater & 0xF;
 }
 
-float HTU21DComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace htu21d
 }  // namespace esphome

--- a/esphome/components/htu21d/htu21d.h
+++ b/esphome/components/htu21d/htu21d.h
@@ -28,8 +28,6 @@ class HTU21DComponent : public PollingComponent, public i2c::I2CDevice {
   void set_heater_level(uint8_t level);
   uint8_t get_heater_level();
 
-  float get_setup_priority() const override;
-
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};

--- a/esphome/components/htu31d/htu31d.cpp
+++ b/esphome/components/htu31d/htu31d.cpp
@@ -259,11 +259,5 @@ void HTU31DComponent::set_heater_state(bool desired) {
   }
 }
 
-/**
- * Sets the startup priority for this component.
- *
- * @returns The startup priority
- */
-float HTU31DComponent::get_setup_priority() const { return setup_priority::DATA; }
 }  // namespace htu31d
 }  // namespace esphome

--- a/esphome/components/htu31d/htu31d.h
+++ b/esphome/components/htu31d/htu31d.h
@@ -20,8 +20,6 @@ class HTU31DComponent : public PollingComponent, public i2c::I2CDevice {
   void set_heater_state(bool desired);
   bool is_heater_enabled();
 
-  float get_setup_priority() const override;
-
  protected:
   bool reset_();
   uint32_t read_serial_num_();

--- a/esphome/components/hx711/hx711.cpp
+++ b/esphome/components/hx711/hx711.cpp
@@ -22,7 +22,6 @@ void HX711Sensor::dump_config() {
   LOG_PIN("  SCK Pin: ", this->sck_pin_);
   LOG_UPDATE_INTERVAL(this);
 }
-float HX711Sensor::get_setup_priority() const { return setup_priority::DATA; }
 void HX711Sensor::update() {
   uint32_t result;
   if (this->read_sensor_(&result)) {

--- a/esphome/components/hx711/hx711.h
+++ b/esphome/components/hx711/hx711.h
@@ -23,7 +23,6 @@ class HX711Sensor : public sensor::Sensor, public PollingComponent {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.cpp
@@ -284,7 +284,5 @@ void HydreonRGxxComponent::process_line_() {
   }
 }
 
-float HydreonRGxxComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace hydreon_rgxx
 }  // namespace esphome

--- a/esphome/components/hydreon_rgxx/hydreon_rgxx.h
+++ b/esphome/components/hydreon_rgxx/hydreon_rgxx.h
@@ -53,8 +53,6 @@ class HydreonRGxxComponent : public PollingComponent, public uart::UARTDevice {
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override;
-
   void set_disable_led(bool disable_led) { this->disable_led_ = disable_led; }
 
  protected:

--- a/esphome/components/hyt271/hyt271.cpp
+++ b/esphome/components/hyt271/hyt271.cpp
@@ -46,7 +46,5 @@ void HYT271Component::update() {
     this->status_clear_warning();
   });
 }
-float HYT271Component::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace hyt271
 }  // namespace esphome

--- a/esphome/components/hyt271/hyt271.h
+++ b/esphome/components/hyt271/hyt271.h
@@ -16,8 +16,6 @@ class HYT271Component : public PollingComponent, public i2c::I2CDevice {
   /// Update the sensor values (temperature+humidity).
   void update() override;
 
-  float get_setup_priority() const override;
-
  protected:
   sensor::Sensor *temperature_{nullptr};
   sensor::Sensor *humidity_{nullptr};

--- a/esphome/components/ina219/ina219.cpp
+++ b/esphome/components/ina219/ina219.cpp
@@ -151,8 +151,6 @@ void INA219Component::dump_config() {
   LOG_SENSOR("  ", "Power", this->power_sensor_);
 }
 
-float INA219Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void INA219Component::update() {
   if (this->bus_voltage_sensor_ != nullptr) {
     uint16_t raw_bus_voltage;

--- a/esphome/components/ina219/ina219.h
+++ b/esphome/components/ina219/ina219.h
@@ -13,7 +13,6 @@ class INA219Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void on_powerdown() override;
 

--- a/esphome/components/ina226/ina226.cpp
+++ b/esphome/components/ina226/ina226.cpp
@@ -104,8 +104,6 @@ void INA226Component::dump_config() {
   LOG_SENSOR("  ", "Power", this->power_sensor_);
 }
 
-float INA226Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void INA226Component::update() {
   if (this->bus_voltage_sensor_ != nullptr) {
     uint16_t raw_bus_voltage;

--- a/esphome/components/ina226/ina226.h
+++ b/esphome/components/ina226/ina226.h
@@ -45,7 +45,6 @@ class INA226Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_shunt_resistance_ohm(float shunt_resistance_ohm) { shunt_resistance_ohm_ = shunt_resistance_ohm; }

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -79,8 +79,6 @@ void INA2XX::setup() {
   this->state_ = State::IDLE;
 }
 
-float INA2XX::get_setup_priority() const { return setup_priority::DATA; }
-
 void INA2XX::update() {
   ESP_LOGD(TAG, "Updating");
   if (this->is_ready() && this->state_ == State::IDLE) {

--- a/esphome/components/ina2xx_base/ina2xx_base.h
+++ b/esphome/components/ina2xx_base/ina2xx_base.h
@@ -114,7 +114,6 @@ enum INAModel : uint8_t { INA_UNKNOWN = 0, INA_228, INA_229, INA_238, INA_239, I
 class INA2XX : public PollingComponent {
  public:
   void setup() override;
-  float get_setup_priority() const override;
   void update() override;
   void loop() override;
   void dump_config() override;

--- a/esphome/components/ina3221/ina3221.cpp
+++ b/esphome/components/ina3221/ina3221.cpp
@@ -113,7 +113,6 @@ void INA3221Component::update() {
   }
 }
 
-float INA3221Component::get_setup_priority() const { return setup_priority::DATA; }
 void INA3221Component::set_shunt_resistance(int channel, float resistance_ohm) {
   this->channels_[channel].shunt_resistance_ = resistance_ohm;
 }

--- a/esphome/components/ina3221/ina3221.h
+++ b/esphome/components/ina3221/ina3221.h
@@ -12,7 +12,6 @@ class INA3221Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override;
 
   void set_bus_voltage_sensor(int channel, sensor::Sensor *obj) { this->channels_[channel].bus_voltage_sensor_ = obj; }
   void set_shunt_voltage_sensor(int channel, sensor::Sensor *obj) {

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -30,8 +30,6 @@ void KamstrupKMPComponent::dump_config() {
   this->check_uart_settings(1200, 2, uart::UART_CONFIG_PARITY_NONE, 8);
 }
 
-float KamstrupKMPComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void KamstrupKMPComponent::update() {
   if (this->heat_energy_sensor_ != nullptr) {
     this->command_queue_.push(CMD_HEAT_ENERGY);

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.h
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.h
@@ -83,7 +83,6 @@ class KamstrupKMPComponent : public PollingComponent, public uart::UARTDevice {
   void set_flow_sensor(sensor::Sensor *sensor) { this->flow_sensor_ = sensor; }
   void set_volume_sensor(sensor::Sensor *sensor) { this->volume_sensor_ = sensor; }
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void loop() override;
   void add_custom_sensor(sensor::Sensor *sensor, uint16_t command) {

--- a/esphome/components/kmeteriso/kmeteriso.cpp
+++ b/esphome/components/kmeteriso/kmeteriso.cpp
@@ -47,8 +47,6 @@ void KMeterISOComponent::setup() {
   }
 }
 
-float KMeterISOComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void KMeterISOComponent::update() {
   uint8_t read_buf[4];
 

--- a/esphome/components/kmeteriso/kmeteriso.h
+++ b/esphome/components/kmeteriso/kmeteriso.h
@@ -17,7 +17,6 @@ class KMeterISOComponent : public PollingComponent, public i2c::I2CDevice {
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   void setup() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/m5stack_8angle/m5stack_8angle.cpp
+++ b/esphome/components/m5stack_8angle/m5stack_8angle.cpp
@@ -69,7 +69,5 @@ int8_t M5Stack8AngleComponent::read_switch() {
   }
 }
 
-float M5Stack8AngleComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace m5stack_8angle
 }  // namespace esphome

--- a/esphome/components/m5stack_8angle/m5stack_8angle.h
+++ b/esphome/components/m5stack_8angle/m5stack_8angle.h
@@ -21,7 +21,6 @@ class M5Stack8AngleComponent : public i2c::I2CDevice, public Component {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   float read_knob_pos(uint8_t channel, AnalogBits bits = AnalogBits::BITS_8);
   int32_t read_knob_pos_raw(uint8_t channel, AnalogBits bits = AnalogBits::BITS_8);
   int8_t read_switch();

--- a/esphome/components/max17043/max17043.cpp
+++ b/esphome/components/max17043/max17043.cpp
@@ -81,8 +81,6 @@ void MAX17043Component::dump_config() {
   LOG_SENSOR("  ", "Battery Level", this->battery_remaining_sensor_);
 }
 
-float MAX17043Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void MAX17043Component::sleep_mode() {
   if (!this->is_failed()) {
     if (!this->write_byte_16(MAX17043_CONFIG, MAX17043_CONFIG_POWER_UP_DEFAULT | MAX17043_CONFIG_SLEEP_MASK)) {

--- a/esphome/components/max17043/max17043.h
+++ b/esphome/components/max17043/max17043.h
@@ -11,7 +11,6 @@ class MAX17043Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void sleep_mode();
 

--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -31,7 +31,6 @@ void MAX31855Sensor::dump_config() {
     ESP_LOGCONFIG(TAG, "  Reference temperature disabled.");
   }
 }
-float MAX31855Sensor::get_setup_priority() const { return setup_priority::DATA; }
 void MAX31855Sensor::read_data_() {
   this->enable();
   delay(1);

--- a/esphome/components/max31855/max31855.h
+++ b/esphome/components/max31855/max31855.h
@@ -18,7 +18,6 @@ class MAX31855Sensor : public sensor::Sensor,
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void update() override;
 

--- a/esphome/components/max31856/max31856.cpp
+++ b/esphome/components/max31856/max31856.cpp
@@ -197,7 +197,5 @@ uint32_t MAX31856Sensor::read_register24_(uint8_t reg) {
   return value;
 }
 
-float MAX31856Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace max31856
 }  // namespace esphome

--- a/esphome/components/max31856/max31856.h
+++ b/esphome/components/max31856/max31856.h
@@ -76,7 +76,6 @@ class MAX31856Sensor : public sensor::Sensor,
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void set_filter(MAX31856ConfigFilter filter) { this->filter_ = filter; }
   void set_thermocouple_type(MAX31856ThermocoupleType thermocouple_type) {
     this->thermocouple_type_ = thermocouple_type;

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -90,8 +90,6 @@ void MAX31865Sensor::dump_config() {
                 (filter_ == FILTER_60HZ ? "60 Hz" : (filter_ == FILTER_50HZ ? "50 Hz" : "Unknown!")));
 }
 
-float MAX31865Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void MAX31865Sensor::read_data_() {
   // Read temperature, disable V_BIAS (save power)
   const uint16_t rtd_resistance_register = this->read_register_16_(RTD_RESISTANCE_MSB_REG);

--- a/esphome/components/max31865/max31865.h
+++ b/esphome/components/max31865/max31865.h
@@ -34,7 +34,6 @@ class MAX31865Sensor : public sensor::Sensor,
   void set_num_rtd_wires(uint8_t rtd_wires) { rtd_wires_ = rtd_wires; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void update() override;
 

--- a/esphome/components/max44009/max44009.cpp
+++ b/esphome/components/max44009/max44009.cpp
@@ -51,8 +51,6 @@ void MAX44009Sensor::dump_config() {
   }
 }
 
-float MAX44009Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void MAX44009Sensor::update() {
   // update sensor illuminance value
   float lux = this->read_illuminance_();

--- a/esphome/components/max44009/max44009.h
+++ b/esphome/components/max44009/max44009.h
@@ -16,7 +16,6 @@ class MAX44009Sensor : public sensor::Sensor, public PollingComponent, public i2
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void set_mode(MAX44009Mode mode);
   bool set_continuous_mode();

--- a/esphome/components/max6675/max6675.cpp
+++ b/esphome/components/max6675/max6675.cpp
@@ -23,7 +23,6 @@ void MAX6675Sensor::dump_config() {
   LOG_PIN("  CS Pin: ", this->cs_);
   LOG_UPDATE_INTERVAL(this);
 }
-float MAX6675Sensor::get_setup_priority() const { return setup_priority::DATA; }
 void MAX6675Sensor::read_data_() {
   this->enable();
   delay(1);

--- a/esphome/components/max6675/max6675.h
+++ b/esphome/components/max6675/max6675.h
@@ -14,7 +14,6 @@ class MAX6675Sensor : public sensor::Sensor,
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void update() override;
 

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.cpp
@@ -7,8 +7,6 @@ namespace mcp3008 {
 
 static const char *const TAG = "mcp3008.sensor";
 
-float MCP3008Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void MCP3008Sensor::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "MCP3008Sensor:\n"

--- a/esphome/components/mcp3008/sensor/mcp3008_sensor.h
+++ b/esphome/components/mcp3008/sensor/mcp3008_sensor.h
@@ -19,7 +19,6 @@ class MCP3008Sensor : public PollingComponent,
 
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   float sample() override;
 
  protected:

--- a/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
+++ b/esphome/components/mcp3204/sensor/mcp3204_sensor.cpp
@@ -7,8 +7,6 @@ namespace mcp3204 {
 
 static const char *const TAG = "mcp3204.sensor";
 
-float MCP3204Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void MCP3204Sensor::dump_config() {
   LOG_SENSOR("", "MCP3204 Sensor", this);
   ESP_LOGCONFIG(TAG,

--- a/esphome/components/mcp3204/sensor/mcp3204_sensor.h
+++ b/esphome/components/mcp3204/sensor/mcp3204_sensor.h
@@ -19,7 +19,6 @@ class MCP3204Sensor : public PollingComponent,
 
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   float sample() override;
 
  protected:

--- a/esphome/components/mcp9808/mcp9808.cpp
+++ b/esphome/components/mcp9808/mcp9808.cpp
@@ -73,7 +73,6 @@ void MCP9808Sensor::update() {
   this->publish_state(temp);
   this->status_clear_warning();
 }
-float MCP9808Sensor::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace mcp9808
 }  // namespace esphome

--- a/esphome/components/mcp9808/mcp9808.h
+++ b/esphome/components/mcp9808/mcp9808.h
@@ -11,7 +11,6 @@ class MCP9808Sensor : public sensor::Sensor, public PollingComponent, public i2c
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void update() override;
 };

--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -137,8 +137,6 @@ bool MHZ19Component::mhz19_write_command_(const uint8_t *command, uint8_t *respo
   return this->read_array(response, MHZ19_RESPONSE_LENGTH);
 }
 
-float MHZ19Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void MHZ19Component::dump_config() {
   ESP_LOGCONFIG(TAG, "MH-Z19:");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);

--- a/esphome/components/mhz19/mhz19.h
+++ b/esphome/components/mhz19/mhz19.h
@@ -22,8 +22,6 @@ enum MHZ19DetectionRange {
 
 class MHZ19Component : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override;
-
   void setup() override;
   void update() override;
   void dump_config() override;

--- a/esphome/components/mics_4514/mics_4514.cpp
+++ b/esphome/components/mics_4514/mics_4514.cpp
@@ -37,7 +37,6 @@ void MICS4514Component::dump_config() {
   LOG_SENSOR("  ", "Hydrogen", this->hydrogen_sensor_);
   LOG_SENSOR("  ", "Ammonia", this->ammonia_sensor_);
 }
-float MICS4514Component::get_setup_priority() const { return setup_priority::DATA; }
 void MICS4514Component::update() {
   if (!this->warmed_up_) {
     return;

--- a/esphome/components/mics_4514/mics_4514.h
+++ b/esphome/components/mics_4514/mics_4514.h
@@ -19,7 +19,6 @@ class MICS4514Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/mlx90393/sensor_mlx90393.cpp
+++ b/esphome/components/mlx90393/sensor_mlx90393.cpp
@@ -132,8 +132,6 @@ void MLX90393Cls::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->t_sensor_);
 }
 
-float MLX90393Cls::get_setup_priority() const { return setup_priority::DATA; }
-
 void MLX90393Cls::update() {
   MLX90393::txyz data;
 

--- a/esphome/components/mlx90393/sensor_mlx90393.h
+++ b/esphome/components/mlx90393/sensor_mlx90393.h
@@ -25,7 +25,6 @@ class MLX90393Cls : public PollingComponent, public i2c::I2CDevice, public MLX90
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_drdy_gpio(GPIOPin *pin) { drdy_pin_ = pin; }

--- a/esphome/components/mlx90614/mlx90614.cpp
+++ b/esphome/components/mlx90614/mlx90614.cpp
@@ -71,8 +71,6 @@ void MLX90614Component::dump_config() {
   LOG_SENSOR("  ", "Object", this->object_sensor_);
 }
 
-float MLX90614Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void MLX90614Component::update() {
   uint8_t emissivity[3];
   if (this->read_register(MLX90614_EMISSIVITY, emissivity, 3) != i2c::ERROR_OK) {

--- a/esphome/components/mlx90614/mlx90614.h
+++ b/esphome/components/mlx90614/mlx90614.h
@@ -12,7 +12,6 @@ class MLX90614Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override;
 
   void set_ambient_sensor(sensor::Sensor *ambient_sensor) { ambient_sensor_ = ambient_sensor; }
   void set_object_sensor(sensor::Sensor *object_sensor) { object_sensor_ = object_sensor; }

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -91,8 +91,6 @@ void MMC5603Component::dump_config() {
   LOG_SENSOR("  ", "Heading", this->heading_sensor_);
 }
 
-float MMC5603Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void MMC5603Component::update() {
   uint8_t ctrl0 = (this->auto_set_reset_) ? 0x21 : 0x01;
   if (!this->write_byte(MMC56X3_CTRL0_REG, ctrl0)) {

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -17,7 +17,6 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_datarate(MMC5603Datarate datarate) { datarate_ = datarate; }

--- a/esphome/components/mmc5983/mmc5983.cpp
+++ b/esphome/components/mmc5983/mmc5983.cpp
@@ -133,7 +133,5 @@ void MMC5983Component::dump_config() {
   LOG_SENSOR("  ", "Z", this->z_sensor_);
 }
 
-float MMC5983Component::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace mmc5983
 }  // namespace esphome

--- a/esphome/components/mmc5983/mmc5983.h
+++ b/esphome/components/mmc5983/mmc5983.h
@@ -12,7 +12,6 @@ class MMC5983Component : public PollingComponent, public i2c::I2CDevice {
   void update() override;
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void set_x_sensor(sensor::Sensor *x_sensor) { x_sensor_ = x_sensor; }
   void set_y_sensor(sensor::Sensor *y_sensor) { y_sensor_ = y_sensor; }

--- a/esphome/components/mpu6050/mpu6050.cpp
+++ b/esphome/components/mpu6050/mpu6050.cpp
@@ -140,7 +140,6 @@ void MPU6050Component::update() {
 
   this->status_clear_warning();
 }
-float MPU6050Component::get_setup_priority() const { return setup_priority::DATA; }
 
 }  // namespace mpu6050
 }  // namespace esphome

--- a/esphome/components/mpu6050/mpu6050.h
+++ b/esphome/components/mpu6050/mpu6050.h
@@ -14,8 +14,6 @@ class MPU6050Component : public PollingComponent, public i2c::I2CDevice {
 
   void update() override;
 
-  float get_setup_priority() const override;
-
   void set_accel_x_sensor(sensor::Sensor *accel_x_sensor) { accel_x_sensor_ = accel_x_sensor; }
   void set_accel_y_sensor(sensor::Sensor *accel_y_sensor) { accel_y_sensor_ = accel_y_sensor; }
   void set_accel_z_sensor(sensor::Sensor *accel_z_sensor) { accel_z_sensor_ = accel_z_sensor; }

--- a/esphome/components/mpu6886/mpu6886.cpp
+++ b/esphome/components/mpu6886/mpu6886.cpp
@@ -146,7 +146,5 @@ void MPU6886Component::update() {
   this->status_clear_warning();
 }
 
-float MPU6886Component::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace mpu6886
 }  // namespace esphome

--- a/esphome/components/mpu6886/mpu6886.h
+++ b/esphome/components/mpu6886/mpu6886.h
@@ -14,8 +14,6 @@ class MPU6886Component : public PollingComponent, public i2c::I2CDevice {
 
   void update() override;
 
-  float get_setup_priority() const override;
-
   void set_accel_x_sensor(sensor::Sensor *accel_x_sensor) { accel_x_sensor_ = accel_x_sensor; }
   void set_accel_y_sensor(sensor::Sensor *accel_y_sensor) { accel_y_sensor_ = accel_y_sensor; }
   void set_accel_z_sensor(sensor::Sensor *accel_z_sensor) { accel_z_sensor_ = accel_z_sensor; }

--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -38,7 +38,6 @@ void MS5611Component::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Pressure", this->pressure_sensor_);
 }
-float MS5611Component::get_setup_priority() const { return setup_priority::DATA; }
 void MS5611Component::update() {
   // request temperature reading
   if (!this->write_bytes(MS5611_CMD_CONV_D2 + 0x08, nullptr, 0)) {

--- a/esphome/components/ms5611/ms5611.h
+++ b/esphome/components/ms5611/ms5611.h
@@ -11,7 +11,6 @@ class MS5611Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }

--- a/esphome/components/msa3xx/msa3xx.cpp
+++ b/esphome/components/msa3xx/msa3xx.cpp
@@ -287,7 +287,6 @@ void MSA3xxComponent::update() {
   this->status_.never_published = false;
   this->status_clear_warning();
 }
-float MSA3xxComponent::get_setup_priority() const { return setup_priority::DATA; }
 
 void MSA3xxComponent::set_offset(float offset_x, float offset_y, float offset_z) {
   this->offset_x_ = offset_x;

--- a/esphome/components/msa3xx/msa3xx.h
+++ b/esphome/components/msa3xx/msa3xx.h
@@ -220,8 +220,6 @@ class MSA3xxComponent : public PollingComponent, public i2c::I2CDevice {
   void loop() override;
   void update() override;
 
-  float get_setup_priority() const override;
-
   void set_model(Model model) { this->model_ = model; }
   void set_offset(float offset_x, float offset_y, float offset_z);
   void set_range(Range range) { this->range_ = range; }

--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -296,8 +296,6 @@ void NAU7802Sensor::loop() {
   }
 }
 
-float NAU7802Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void NAU7802Sensor::update() {
   if (!this->is_data_ready_()) {
     ESP_LOGW(TAG, "No measurements ready!");

--- a/esphome/components/nau7802/nau7802.h
+++ b/esphome/components/nau7802/nau7802.h
@@ -62,7 +62,6 @@ class NAU7802Sensor : public sensor::Sensor, public PollingComponent, public i2c
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -193,7 +193,6 @@ void Nextion::dump_config() {
 #endif
 }
 
-float Nextion::get_setup_priority() const { return setup_priority::DATA; }
 void Nextion::update() {
   if (!this->is_setup()) {
     return;

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1048,7 +1048,6 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
   void setup() override;
   void set_brightness(float brightness) { this->brightness_ = brightness; }
-  float get_setup_priority() const override;
   void update() override;
   void loop() override;
   void set_writer(const nextion_writer_t &writer);

--- a/esphome/components/npi19/npi19.cpp
+++ b/esphome/components/npi19/npi19.cpp
@@ -29,8 +29,6 @@ void NPI19Component::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }
 
-float NPI19Component::get_setup_priority() const { return setup_priority::DATA; }
-
 i2c::ErrorCode NPI19Component::read_(uint16_t &raw_temperature, uint16_t &raw_pressure) {
   // initiate data read from device
   i2c::ErrorCode w_err = write(&READ_COMMAND, sizeof(READ_COMMAND));

--- a/esphome/components/npi19/npi19.h
+++ b/esphome/components/npi19/npi19.h
@@ -15,7 +15,6 @@ class NPI19Component : public PollingComponent, public i2c::I2CDevice {
     this->raw_pressure_sensor_ = raw_pressure_sensor;
   }
 
-  float get_setup_priority() const override;
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/ntc/ntc.cpp
+++ b/esphome/components/ntc/ntc.cpp
@@ -12,7 +12,6 @@ void NTC::setup() {
     this->process_(this->sensor_->state);
 }
 void NTC::dump_config() { LOG_SENSOR("", "NTC Sensor", this); }
-float NTC::get_setup_priority() const { return setup_priority::DATA; }
 void NTC::process_(float value) {
   if (std::isnan(value)) {
     this->publish_state(NAN);

--- a/esphome/components/ntc/ntc.h
+++ b/esphome/components/ntc/ntc.h
@@ -14,7 +14,6 @@ class NTC : public Component, public sensor::Sensor {
   void set_c(double c) { c_ = c; }
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
  protected:
   void process_(float value);

--- a/esphome/components/opt3001/opt3001.cpp
+++ b/esphome/components/opt3001/opt3001.cpp
@@ -116,7 +116,5 @@ void OPT3001Sensor::update() {
   });
 }
 
-float OPT3001Sensor::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace opt3001
 }  // namespace esphome

--- a/esphome/components/opt3001/opt3001.h
+++ b/esphome/components/opt3001/opt3001.h
@@ -12,7 +12,6 @@ class OPT3001Sensor : public sensor::Sensor, public PollingComponent, public i2c
  public:
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override;
 
  protected:
   // checks if one-shot is complete before reading the result and returning it

--- a/esphome/components/pcf85063/pcf85063.cpp
+++ b/esphome/components/pcf85063/pcf85063.cpp
@@ -26,8 +26,6 @@ void PCF85063Component::dump_config() {
   RealTimeClock::dump_config();
 }
 
-float PCF85063Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void PCF85063Component::read_time() {
   if (!this->read_rtc_()) {
     return;

--- a/esphome/components/pcf85063/pcf85063.h
+++ b/esphome/components/pcf85063/pcf85063.h
@@ -12,7 +12,6 @@ class PCF85063Component : public time::RealTimeClock, public i2c::I2CDevice {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void read_time();
   void write_time();
 

--- a/esphome/components/pcf8563/pcf8563.cpp
+++ b/esphome/components/pcf8563/pcf8563.cpp
@@ -26,8 +26,6 @@ void PCF8563Component::dump_config() {
   RealTimeClock::dump_config();
 }
 
-float PCF8563Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void PCF8563Component::read_time() {
   if (!this->read_rtc_()) {
     return;

--- a/esphome/components/pcf8563/pcf8563.h
+++ b/esphome/components/pcf8563/pcf8563.h
@@ -12,7 +12,6 @@ class PCF8563Component : public time::RealTimeClock, public i2c::I2CDevice {
   void setup() override;
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void read_time();
   void write_time();
 

--- a/esphome/components/pm1006/pm1006.cpp
+++ b/esphome/components/pm1006/pm1006.cpp
@@ -44,8 +44,6 @@ void PM1006Component::loop() {
   }
 }
 
-float PM1006Component::get_setup_priority() const { return setup_priority::DATA; }
-
 uint8_t PM1006Component::pm1006_checksum_(const uint8_t *command_data, uint8_t length) const {
   uint8_t sum = 0;
   for (uint8_t i = 0; i < length; i++) {

--- a/esphome/components/pm1006/pm1006.h
+++ b/esphome/components/pm1006/pm1006.h
@@ -18,8 +18,6 @@ class PM1006Component : public PollingComponent, public uart::UARTDevice {
   void loop() override;
   void update() override;
 
-  float get_setup_priority() const override;
-
  protected:
   optional<bool> check_byte_() const;
   void parse_data_();

--- a/esphome/components/pm2005/pm2005.h
+++ b/esphome/components/pm2005/pm2005.h
@@ -14,8 +14,6 @@ enum SensorType {
 
 class PM2005Component : public PollingComponent, public i2c::I2CDevice {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
-
   void set_sensor_type(SensorType sensor_type) { this->sensor_type_ = sensor_type; }
 
   void set_pm_1_0_sensor(sensor::Sensor *pm_1_0_sensor) { this->pm_1_0_sensor_ = pm_1_0_sensor; }

--- a/esphome/components/pmwcs3/pmwcs3.cpp
+++ b/esphome/components/pmwcs3/pmwcs3.cpp
@@ -53,8 +53,6 @@ void PMWCS3Component::water_calibration() {
 
 void PMWCS3Component::update() { this->read_data_(); }
 
-float PMWCS3Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void PMWCS3Component::dump_config() {
   ESP_LOGCONFIG(TAG, "PMWCS3");
   LOG_I2C_DEVICE(this);

--- a/esphome/components/pmwcs3/pmwcs3.h
+++ b/esphome/components/pmwcs3/pmwcs3.h
@@ -14,7 +14,6 @@ class PMWCS3Component : public PollingComponent, public i2c::I2CDevice {
  public:
   void update() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   void set_e25_sensor(sensor::Sensor *e25_sensor) { e25_sensor_ = e25_sensor; }
   void set_ec_sensor(sensor::Sensor *ec_sensor) { ec_sensor_ = ec_sensor; }

--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -426,8 +426,6 @@ bool PN532::write_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *message) {
   return false;
 }
 
-float PN532::get_setup_priority() const { return setup_priority::DATA; }
-
 void PN532::dump_config() {
   ESP_LOGCONFIG(TAG, "PN532:");
   switch (this->error_code_) {

--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -35,7 +35,6 @@ class PN532 : public PollingComponent {
   void dump_config() override;
 
   void update() override;
-  float get_setup_priority() const override;
 
   void loop() override;
   void on_powerdown() override { powerdown(); }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -125,8 +125,6 @@ void PulseMeterSensor::loop() {
   }
 }
 
-float PulseMeterSensor::get_setup_priority() const { return setup_priority::DATA; }
-
 void PulseMeterSensor::dump_config() {
   LOG_SENSOR("", "Pulse Meter", this);
   LOG_PIN("  Pin: ", this->pin_);

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -27,7 +27,6 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
 
   void setup() override;
   void loop() override;
-  float get_setup_priority() const override;
   void dump_config() override;
 
  protected:

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -97,7 +97,5 @@ void PylontechComponent::process_line_(std::string &buffer) {
   }
 }
 
-float PylontechComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace pylontech
 }  // namespace esphome

--- a/esphome/components/pylontech/pylontech.h
+++ b/esphome/components/pylontech/pylontech.h
@@ -34,8 +34,6 @@ class PylontechComponent : public PollingComponent, public uart::UARTDevice {
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override;
-
   void register_listener(PylontechListener *listener) { this->listeners_.push_back(listener); }
 
  protected:

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -86,8 +86,6 @@ void QMC5883LComponent::dump_config() {
   LOG_PIN("  DRDY Pin: ", this->drdy_pin_);
 }
 
-float QMC5883LComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void QMC5883LComponent::update() {
   i2c::ErrorCode err;
   uint8_t status = false;

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -31,7 +31,6 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
   void set_drdy_pin(GPIOPin *pin) { drdy_pin_ = pin; }

--- a/esphome/components/rd03d/rd03d.h
+++ b/esphome/components/rd03d/rd03d.h
@@ -42,7 +42,6 @@ class RD03DComponent : public Component, public uart::UARTDevice {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
 #ifdef USE_SENSOR
   void set_target_count_sensor(sensor::Sensor *sensor) { this->target_count_sensor_ = sensor; }

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -16,7 +16,6 @@ namespace resampler {
 
 class ResamplerSpeaker : public Component, public speaker::Speaker {
  public:
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
   void setup() override;
   void loop() override;
 

--- a/esphome/components/rotary_encoder/rotary_encoder.cpp
+++ b/esphome/components/rotary_encoder/rotary_encoder.cpp
@@ -235,7 +235,6 @@ void RotaryEncoderSensor::loop() {
   }
 }
 
-float RotaryEncoderSensor::get_setup_priority() const { return setup_priority::DATA; }
 void RotaryEncoderSensor::set_restore_mode(RotaryEncoderRestoreMode restore_mode) {
   this->restore_mode_ = restore_mode;
 }

--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -82,8 +82,6 @@ class RotaryEncoderSensor : public sensor::Sensor, public Component {
   void dump_config() override;
   void loop() override;
 
-  float get_setup_priority() const override;
-
   void add_on_clockwise_callback(std::function<void()> callback) {
     this->on_clockwise_callback_.add(std::move(callback));
   }

--- a/esphome/components/rx8130/rx8130.h
+++ b/esphome/components/rx8130/rx8130.h
@@ -14,8 +14,6 @@ class RX8130Component : public time::RealTimeClock, public i2c::I2CDevice {
   void dump_config() override;
   void read_time();
   void write_time();
-  /// Ensure RTC is initialized at the correct time in the setup sequence
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   void stop_(bool stop);

--- a/esphome/components/sdp3x/sdp3x.cpp
+++ b/esphome/components/sdp3x/sdp3x.cpp
@@ -114,7 +114,5 @@ void SDP3XComponent::read_pressure_() {
   this->status_clear_warning();
 }
 
-float SDP3XComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace sdp3x
 }  // namespace esphome

--- a/esphome/components/sdp3x/sdp3x.h
+++ b/esphome/components/sdp3x/sdp3x.h
@@ -17,7 +17,6 @@ class SDP3XComponent : public PollingComponent, public sensirion_common::Sensiri
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override;
   void set_measurement_mode(MeasurementMode mode) { measurement_mode_ = mode; }
 
  protected:

--- a/esphome/components/sds011/sds011.cpp
+++ b/esphome/components/sds011/sds011.cpp
@@ -108,8 +108,6 @@ void SDS011Component::loop() {
   }
 }
 
-float SDS011Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void SDS011Component::set_rx_mode_only(bool rx_mode_only) { this->rx_mode_only_ = rx_mode_only; }
 
 void SDS011Component::sds011_write_command_(const uint8_t *command_data) {

--- a/esphome/components/sds011/sds011.h
+++ b/esphome/components/sds011/sds011.h
@@ -21,8 +21,6 @@ class SDS011Component : public Component, public uart::UARTDevice {
   void dump_config() override;
   void loop() override;
 
-  float get_setup_priority() const override;
-
   void set_update_interval(uint32_t val) { /* ignore */
   }
   void set_update_interval_min(uint8_t update_interval_min);

--- a/esphome/components/sht3xd/sht3xd.cpp
+++ b/esphome/components/sht3xd/sht3xd.cpp
@@ -72,8 +72,6 @@ void SHT3XDComponent::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-float SHT3XDComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void SHT3XDComponent::update() {
   if (this->status_has_warning()) {
     ESP_LOGD(TAG, "Retrying to reconnect the sensor.");

--- a/esphome/components/sht3xd/sht3xd.h
+++ b/esphome/components/sht3xd/sht3xd.h
@@ -17,7 +17,6 @@ class SHT3XDComponent : public PollingComponent, public sensirion_common::Sensir
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void set_heater_enabled(bool heater_enabled) { heater_enabled_ = heater_enabled; }
 

--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -63,8 +63,6 @@ void SHTCXComponent::dump_config() {
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
 }
 
-float SHTCXComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 void SHTCXComponent::update() {
   if (this->status_has_warning()) {
     ESP_LOGW(TAG, "Retrying communication");

--- a/esphome/components/shtcx/shtcx.h
+++ b/esphome/components/shtcx/shtcx.h
@@ -17,7 +17,6 @@ class SHTCXComponent : public PollingComponent, public sensirion_common::Sensiri
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void soft_reset();
   void sleep();

--- a/esphome/components/smt100/smt100.cpp
+++ b/esphome/components/smt100/smt100.cpp
@@ -44,8 +44,6 @@ void SMT100Component::loop() {
   }
 }
 
-float SMT100Component::get_setup_priority() const { return setup_priority::DATA; }
-
 void SMT100Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SMT100:");
 

--- a/esphome/components/smt100/smt100.h
+++ b/esphome/components/smt100/smt100.h
@@ -17,8 +17,6 @@ class SMT100Component : public PollingComponent, public uart::UARTDevice {
   void loop() override;
   void update() override;
 
-  float get_setup_priority() const override;
-
   void set_counts_sensor(sensor::Sensor *counts_sensor) { this->counts_sensor_ = counts_sensor; }
   void set_permittivity_sensor(sensor::Sensor *permittivity_sensor) {
     this->permittivity_sensor_ = permittivity_sensor;

--- a/esphome/components/sonoff_d1/sonoff_d1.h
+++ b/esphome/components/sonoff_d1/sonoff_d1.h
@@ -53,7 +53,6 @@ class SonoffD1Output : public light::LightOutput, public uart::UARTDevice, publi
   void setup() override{};
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return esphome::setup_priority::DATA; }
 
   // Custom methods
   void set_use_rm433_remote(const bool use_rm433_remote) { this->use_rm433_remote_ = use_rm433_remote; }

--- a/esphome/components/spi_device/spi_device.cpp
+++ b/esphome/components/spi_device/spi_device.cpp
@@ -23,7 +23,5 @@ void SPIDeviceComponent::dump_config() {
   }
 }
 
-float SPIDeviceComponent::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace spi_device
 }  // namespace esphome

--- a/esphome/components/spi_device/spi_device.h
+++ b/esphome/components/spi_device/spi_device.h
@@ -13,8 +13,6 @@ class SPIDeviceComponent : public Component,
   void setup() override;
   void dump_config() override;
 
-  float get_setup_priority() const override;
-
  protected:
 };
 

--- a/esphome/components/sts3x/sts3x.cpp
+++ b/esphome/components/sts3x/sts3x.cpp
@@ -41,7 +41,7 @@ void STS3XComponent::dump_config() {
 
   LOG_SENSOR("  ", "STS3x", this);
 }
-float STS3XComponent::get_setup_priority() const { return setup_priority::DATA; }
+
 void STS3XComponent::update() {
   if (this->status_has_warning()) {
     ESP_LOGD(TAG, "Retrying to reconnect the sensor.");

--- a/esphome/components/sts3x/sts3x.h
+++ b/esphome/components/sts3x/sts3x.h
@@ -14,7 +14,6 @@ class STS3XComponent : public sensor::Sensor, public PollingComponent, public se
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 };
 

--- a/esphome/components/sy6970/sy6970.h
+++ b/esphome/components/sy6970/sy6970.h
@@ -87,7 +87,6 @@ class SY6970Component : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
   // Listener registration
   void add_listener(SY6970Listener *listener) { this->listeners_.push_back(listener); }

--- a/esphome/components/t6615/t6615.cpp
+++ b/esphome/components/t6615/t6615.cpp
@@ -86,7 +86,6 @@ void T6615Component::query_ppm_() {
   this->send_ppm_command_();
 }
 
-float T6615Component::get_setup_priority() const { return setup_priority::DATA; }
 void T6615Component::dump_config() {
   ESP_LOGCONFIG(TAG, "T6615:");
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);

--- a/esphome/components/t6615/t6615.h
+++ b/esphome/components/t6615/t6615.h
@@ -22,8 +22,6 @@ enum class T6615Command : uint8_t {
 
 class T6615Component : public PollingComponent, public uart::UARTDevice {
  public:
-  float get_setup_priority() const override;
-
   void loop() override;
   void update() override;
   void dump_config() override;

--- a/esphome/components/tc74/tc74.cpp
+++ b/esphome/components/tc74/tc74.cpp
@@ -61,7 +61,5 @@ void TC74Component::read_temperature_() {
   this->status_clear_warning();
 }
 
-float TC74Component::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace tc74
 }  // namespace esphome

--- a/esphome/components/tc74/tc74.h
+++ b/esphome/components/tc74/tc74.h
@@ -15,8 +15,6 @@ class TC74Component : public PollingComponent, public i2c::I2CDevice, public sen
   /// Update the sensor value (temperature).
   void update() override;
 
-  float get_setup_priority() const override;
-
  protected:
   /// Internal method to read the temperature from the component after it has been scheduled.
   void read_temperature_();

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -56,7 +56,6 @@ void TCS34725Component::dump_config() {
   LOG_SENSOR("  ", "Illuminance", this->illuminance_sensor_);
   LOG_SENSOR("  ", "Color Temperature", this->color_temperature_sensor_);
 }
-float TCS34725Component::get_setup_priority() const { return setup_priority::DATA; }
 
 /*!
  *  @brief  Converts the raw R/G/B values to color temperature in degrees

--- a/esphome/components/tcs34725/tcs34725.h
+++ b/esphome/components/tcs34725/tcs34725.h
@@ -52,7 +52,6 @@ class TCS34725Component : public PollingComponent, public i2c::I2CDevice {
   }
 
   void setup() override;
-  float get_setup_priority() const override;
   void update() override;
   void dump_config() override;
 

--- a/esphome/components/tee501/tee501.cpp
+++ b/esphome/components/tee501/tee501.cpp
@@ -43,7 +43,6 @@ void TEE501Component::dump_config() {
   LOG_SENSOR("  ", "TEE501", this);
 }
 
-float TEE501Component::get_setup_priority() const { return setup_priority::DATA; }
 void TEE501Component::update() {
   uint8_t address_1[] = {0x2C, 0x1B};
   this->write(address_1, 2);

--- a/esphome/components/tee501/tee501.h
+++ b/esphome/components/tee501/tee501.h
@@ -12,7 +12,6 @@ class TEE501Component : public sensor::Sensor, public PollingComponent, public i
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
 
  protected:

--- a/esphome/components/tem3200/tem3200.cpp
+++ b/esphome/components/tem3200/tem3200.cpp
@@ -51,8 +51,6 @@ void TEM3200Component::dump_config() {
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
 }
 
-float TEM3200Component::get_setup_priority() const { return setup_priority::DATA; }
-
 i2c::ErrorCode TEM3200Component::read_(uint8_t &status, uint16_t &raw_temperature, uint16_t &raw_pressure) {
   uint8_t response[4] = {0x00, 0x00, 0x00, 0x00};
 

--- a/esphome/components/tem3200/tem3200.h
+++ b/esphome/components/tem3200/tem3200.h
@@ -15,7 +15,6 @@ class TEM3200Component : public PollingComponent, public i2c::I2CDevice {
     this->raw_pressure_sensor_ = raw_pressure_sensor;
   }
 
-  float get_setup_priority() const override;
   void setup() override;
   void dump_config() override;
   void update() override;

--- a/esphome/components/time_based/time_based_cover.cpp
+++ b/esphome/components/time_based/time_based_cover.cpp
@@ -51,7 +51,7 @@ void TimeBasedCover::loop() {
     this->last_publish_time_ = now;
   }
 }
-float TimeBasedCover::get_setup_priority() const { return setup_priority::DATA; }
+
 CoverTraits TimeBasedCover::get_traits() {
   auto traits = CoverTraits();
   traits.set_supports_stop(true);

--- a/esphome/components/time_based/time_based_cover.h
+++ b/esphome/components/time_based/time_based_cover.h
@@ -12,7 +12,6 @@ class TimeBasedCover : public cover::Cover, public Component {
   void setup() override;
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
   Trigger<> *get_open_trigger() { return &this->open_trigger_; }
   Trigger<> *get_close_trigger() { return &this->close_trigger_; }

--- a/esphome/components/tmp102/tmp102.cpp
+++ b/esphome/components/tmp102/tmp102.cpp
@@ -46,7 +46,5 @@ void TMP102Component::update() {
   });
 }
 
-float TMP102Component::get_setup_priority() const { return setup_priority::DATA; }
-
 }  // namespace tmp102
 }  // namespace esphome

--- a/esphome/components/tmp102/tmp102.h
+++ b/esphome/components/tmp102/tmp102.h
@@ -11,8 +11,6 @@ class TMP102Component : public PollingComponent, public i2c::I2CDevice, public s
  public:
   void dump_config() override;
   void update() override;
-
-  float get_setup_priority() const override;
 };
 
 }  // namespace tmp102

--- a/esphome/components/tmp117/tmp117.cpp
+++ b/esphome/components/tmp117/tmp117.cpp
@@ -45,7 +45,7 @@ void TMP117Component::dump_config() {
   }
   LOG_SENSOR("  ", "Temperature", this);
 }
-float TMP117Component::get_setup_priority() const { return setup_priority::DATA; }
+
 bool TMP117Component::read_data_(int16_t *data) {
   if (!this->read_byte_16(0, (uint16_t *) data)) {
     ESP_LOGW(TAG, "Updating TMP117 failed!");

--- a/esphome/components/tmp117/tmp117.h
+++ b/esphome/components/tmp117/tmp117.h
@@ -11,7 +11,6 @@ class TMP117Component : public PollingComponent, public i2c::I2CDevice, public s
  public:
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void update() override;
   void set_config(uint16_t config) { config_ = config; };
 

--- a/esphome/components/tsl2561/tsl2561.cpp
+++ b/esphome/components/tsl2561/tsl2561.cpp
@@ -144,7 +144,7 @@ void TSL2561Sensor::set_integration_time(TSL2561IntegrationTime integration_time
 }
 void TSL2561Sensor::set_gain(TSL2561Gain gain) { this->gain_ = gain; }
 void TSL2561Sensor::set_is_cs_package(bool package_cs) { this->package_cs_ = package_cs; }
-float TSL2561Sensor::get_setup_priority() const { return setup_priority::DATA; }
+
 bool TSL2561Sensor::tsl2561_write_byte(uint8_t a_register, uint8_t value) {
   return this->write_byte(a_register | TSL2561_COMMAND_BIT, value);
 }

--- a/esphome/components/tsl2561/tsl2561.h
+++ b/esphome/components/tsl2561/tsl2561.h
@@ -67,7 +67,6 @@ class TSL2561Sensor : public sensor::Sensor, public PollingComponent, public i2c
   void setup() override;
   void dump_config() override;
   void update() override;
-  float get_setup_priority() const override;
 
   bool tsl2561_read_byte(uint8_t a_register, uint8_t *value);
   bool tsl2561_read_uint(uint8_t a_register, uint16_t *value);

--- a/esphome/components/tsl2591/tsl2591.cpp
+++ b/esphome/components/tsl2591/tsl2591.cpp
@@ -247,8 +247,6 @@ void TSL2591Component::set_power_save_mode(bool enable) { this->power_save_mode_
 
 void TSL2591Component::set_name(const char *name) { this->name_ = name; }
 
-float TSL2591Component::get_setup_priority() const { return setup_priority::DATA; }
-
 bool TSL2591Component::is_adc_valid() {
   uint8_t status;
   if (!this->read_byte(TSL2591_COMMAND_BIT | TSL2591_REGISTER_STATUS, &status)) {

--- a/esphome/components/tsl2591/tsl2591.h
+++ b/esphome/components/tsl2591/tsl2591.h
@@ -249,8 +249,6 @@ class TSL2591Component : public PollingComponent, public i2c::I2CDevice {
   void dump_config() override;
   /** Used by ESPHome framework. */
   void update() override;
-  /** Used by ESPHome framework. */
-  float get_setup_priority() const override;
 
  protected:
   const char *name_;

--- a/esphome/components/tx20/tx20.cpp
+++ b/esphome/components/tx20/tx20.cpp
@@ -38,8 +38,6 @@ void Tx20Component::loop() {
   }
 }
 
-float Tx20Component::get_setup_priority() const { return setup_priority::DATA; }
-
 std::string Tx20Component::get_wind_cardinal_direction() const { return this->wind_cardinal_direction_; }
 
 void Tx20Component::decode_and_publish_() {

--- a/esphome/components/tx20/tx20.h
+++ b/esphome/components/tx20/tx20.h
@@ -35,7 +35,6 @@ class Tx20Component : public Component {
 
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
   void loop() override;
 
  protected:

--- a/esphome/components/ultrasonic/ultrasonic_sensor.h
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.h
@@ -27,8 +27,6 @@ class UltrasonicSensorComponent : public sensor::Sensor, public PollingComponent
   void dump_config() override;
   void update() override;
 
-  float get_setup_priority() const override { return setup_priority::DATA; }
-
   /// Set the time in µs the trigger pin should be enabled for in µs, defaults to 10µs (for HC-SR04)
   void set_pulse_time_us(uint32_t pulse_time_us) { this->pulse_time_us_ = pulse_time_us; }
 

--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -32,7 +32,6 @@ void VersionTextSensor::setup() {
   version_str[sizeof(version_str) - 1] = '\0';
   this->publish_state(version_str);
 }
-float VersionTextSensor::get_setup_priority() const { return setup_priority::DATA; }
 void VersionTextSensor::set_hide_timestamp(bool hide_timestamp) { this->hide_timestamp_ = hide_timestamp; }
 void VersionTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Version Text Sensor", this); }
 

--- a/esphome/components/version/version_text_sensor.h
+++ b/esphome/components/version/version_text_sensor.h
@@ -11,7 +11,6 @@ class VersionTextSensor : public text_sensor::TextSensor, public Component {
   void set_hide_timestamp(bool hide_timestamp);
   void setup() override;
   void dump_config() override;
-  float get_setup_priority() const override;
 
  protected:
   bool hide_timestamp_{false};

--- a/esphome/components/wts01/wts01.h
+++ b/esphome/components/wts01/wts01.h
@@ -13,7 +13,6 @@ class WTS01Sensor : public sensor::Sensor, public uart::UARTDevice, public Compo
  public:
   void loop() override;
   void dump_config() override;
-  float get_setup_priority() const override { return setup_priority::DATA; }
 
  protected:
   uint8_t buffer_[PACKET_SIZE];


### PR DESCRIPTION
# What does this implement/fix?

Remove redundant `get_setup_priority()` overrides that return `setup_priority::DATA` from 88 components.

Since the base `Component::get_setup_priority()` already returns `setup_priority::DATA` by default, these overrides are unnecessary and just add code bloat.

### Changes

Removed the following from each affected component:
- **In .cpp files**: `float ClassName::get_setup_priority() const { return setup_priority::DATA; }`
- **In .h files**: `float get_setup_priority() const override;`

### Affected components (88 total)

**Header-only inline implementations (14 files):**
`rx8130`, `aqi`, `esp32_touch`, `wts01`, `hdc1080`, `ultrasonic`, `gp8403`, `sy6970`, `rd03d`, `cm1106`, `sonoff_d1`, `combination`, `pm2005`, `resampler`

**Full .cpp + .h pairs (74 components):**
`absolute_humidity`, `adc`, `adc128s102`, `aht10`, `am2315c`, `am2320`, `apds9960`, `as3935`, `as5600`, `as7341`, `atm90e26`, `bh1750`, `bme280_base`, `bme680`, `bme680_bsec`, `bme68x_bsec2`, `bmi160`, `bmp085`, `bmp280_base`, `bmp3xx_base`, `cd74hc4067`, `cse7761`, `cse7766`, `current_based`, `daly_bms`, `dht`, `dht12`, `dps310`, `ds1307`, `duty_cycle`, `ee895`, `emc2101`, `endstop`, `ens210`, `esp32_camera`, `gdk101`, `hc8`, `hlw8012`, `hm3301`, `hmc5883l`, `homeassistant_time`, `honeywell_hih`, `hte501`, `htu21d`, `htu31d`, `hx711`, `hydreon_rgxx`, `hyt271`, `ina219`, `ina226`, `ina2xx_base`, `ina3221`, `kamstrup_kmp`, `kmeteriso`, `m5stack_8angle`, `max17043`, `max31855`, `max31856`, `max31865`, `max44009`, `max6675`, `mcp3008`, `mcp3204`, `mcp9808`, `mhz19`, `mics_4514`, `mlx90393`, `mlx90614`, `mmc5603`, `mmc5983`, `mpu6050`, `mpu6886`, `ms5611`, `msa3xx`, `nau7802`, `nextion`, `npi19`, `ntc`, `opt3001`, `pcf8563`, `pcf85063`, `pm1006`, `pmwcs3`, `pn532`, `pulse_meter`, `pylontech`, `qmc5883l`, `rotary_encoder`, `sdp3x`, `sds011`, `sht3xd`, `shtcx`, `smt100`, `spi_device`, `sts3x`, `t6615`, `tc74`, `tcs34725`, `tee501`, `tem3200`, `time_based`, `tmp102`, `tmp117`, `tsl2561`, `tsl2591`, `tx20`, `version`

### Verification

All affected components were verified to inherit from either:
- `Component` directly
- `PollingComponent` (which inherits from `Component` without overriding `get_setup_priority()`)
- `RealTimeClock` (which inherits from `PollingComponent` without overriding)
- Plus mixin classes like `I2CDevice`, `UARTDevice`, `SPIDevice` which don't extend `Component`

Components that override `get_setup_priority()` to return something other than `DATA` (like `DATA - 1`) were intentionally NOT modified.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is a code cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
