### PR TITLE
[web_server_idf] Add const char* overloads for getParam/hasParam to avoid temporary string allocations

### DIFF
--- a/esphome/components/web_server_idf/utils.h
+++ b/esphome/components/web_server_idf/utils.h
@@ -15,7 +15,10 @@ size_t url_decode(char *str);
 bool request_has_header(httpd_req_t *req, const char *name);
 optional<std::string> request_get_header(httpd_req_t *req, const char *name);
 optional<std::string> request_get_url_query(httpd_req_t *req);
-optional<std::string> query_key_value(const std::string &query_url, const std::string &key);
+optional<std::string> query_key_value(const char *query_url, size_t query_len, const char *key);
+inline optional<std::string> query_key_value(const std::string &query_url, const std::string &key) {
+  return query_key_value(query_url.c_str(), query_url.size(), key.c_str());
+}
 
 // Helper function for case-insensitive character comparison
 inline bool char_equals_ci(char a, char b) { return ::tolower(a) == ::tolower(b); }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -366,7 +366,7 @@ void AsyncWebServerRequest::requestAuthentication(const char *realm) const {
 }
 #endif
 
-AsyncWebParameter *AsyncWebServerRequest::getParam(const std::string &name) {
+AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
   // Check cache first - only successful lookups are cached
   for (auto *param : this->params_) {
     if (param->name() == name) {
@@ -375,11 +375,11 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const std::string &name) {
   }
 
   // Look up value from query strings
-  optional<std::string> val = query_key_value(this->post_query_, name);
+  optional<std::string> val = query_key_value(this->post_query_.c_str(), this->post_query_.size(), name);
   if (!val.has_value()) {
     auto url_query = request_get_url_query(*this);
     if (url_query.has_value()) {
-      val = query_key_value(url_query.value(), name);
+      val = query_key_value(url_query.value().c_str(), url_query.value().size(), name);
     }
   }
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -162,19 +162,24 @@ class AsyncWebServerRequest {
   }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
-  bool hasParam(const std::string &name) { return this->getParam(name) != nullptr; }
+  bool hasParam(const char *name) { return this->getParam(name) != nullptr; }
   // NOLINTNEXTLINE(readability-identifier-naming)
-  AsyncWebParameter *getParam(const std::string &name);
+  bool hasParam(const std::string &name) { return this->getParam(name.c_str()) != nullptr; }
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebParameter *getParam(const char *name);
+  // NOLINTNEXTLINE(readability-identifier-naming)
+  AsyncWebParameter *getParam(const std::string &name) { return this->getParam(name.c_str()); }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
   bool hasArg(const char *name) { return this->hasParam(name); }
-  std::string arg(const std::string &name) {
+  std::string arg(const char *name) {
     auto *param = this->getParam(name);
     if (param) {
       return param->value();
     }
     return {};
   }
+  std::string arg(const std::string &name) { return this->arg(name.c_str()); }
 
   operator httpd_req_t *() const { return this->req_; }
   optional<std::string> get_header(const char *name) const;


### PR DESCRIPTION
# What does this implement/fix?

Add `const char *` overloads for `getParam()`, `hasParam()`, and `query_key_value()` to avoid unnecessary temporary `std::string` heap allocations.

All callers of `getParam()` and `hasParam()` use `ESPHOME_F("literal")` which returns `const char *`:
```cpp
request->getParam(ESPHOME_F("detail"));
request->hasParam(ESPHOME_F("position"));
```

Previously, the `const std::string &` parameter forced a temporary `std::string` heap allocation for every call. With these overloads, callers passing `const char *` avoid the allocation entirely, while callers with `std::string` still work via the delegating overload.

**Changes:**
- `getParam(const char *name)` - new primary implementation
- `getParam(const std::string &name)` - delegates to `const char *` version
- `hasParam(const char *name)` - new overload
- `hasParam(const std::string &name)` - delegates to `const char *` version
- `arg(const char *name)` - new overload
- `arg(const std::string &name)` - delegates to `const char *` version
- `query_key_value(const char *query_url, size_t query_len, const char *key)` - new primary implementation
- `query_key_value(const std::string &, const std::string &)` - inline wrapper for compatibility

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
web_server:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
