### PR TITLE
[pulse_counter][hlw8012] Fix ESP-IDF build by re-enabling legacy driver component

### DIFF
--- a/esphome/components/hlw8012/sensor.py
+++ b/esphome/components/hlw8012/sensor.py
@@ -1,6 +1,7 @@
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.esp32 import include_builtin_idf_component
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHANGE_MODE_EVERY,
@@ -25,6 +26,7 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
+from esphome.core import CORE
 
 AUTO_LOAD = ["pulse_counter"]
 
@@ -91,6 +93,12 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config):
+    if CORE.is_esp32:
+        # Re-enable ESP-IDF's legacy driver component (excluded by default to save compile time)
+        # HLW8012 uses pulse_counter's PCNT storage which requires driver/pcnt.h
+        # TODO: Remove this once pulse_counter migrates to new PCNT API (driver/pulse_cnt.h)
+        include_builtin_idf_component("driver")
+
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
 

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -6,6 +6,10 @@
 
 #include <cinttypes>
 
+// TODO: Migrate from legacy PCNT API (driver/pcnt.h) to new PCNT API (driver/pulse_cnt.h)
+// The legacy PCNT API is deprecated in ESP-IDF 5.x. Migration would allow removing the
+// "driver" IDF component dependency. See:
+// https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-5.x/5.0/peripherals.html#id6
 #if defined(USE_ESP32) && !defined(USE_ESP32_VARIANT_ESP32C3)
 #include <driver/pcnt.h>
 #define HAS_PCNT

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -1,6 +1,7 @@
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.esp32 import include_builtin_idf_component
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_COUNT_MODE,
@@ -126,7 +127,14 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
-    var = await sensor.new_sensor(config, config.get(CONF_USE_PCNT))
+    use_pcnt = config.get(CONF_USE_PCNT)
+    if CORE.is_esp32 and use_pcnt:
+        # Re-enable ESP-IDF's legacy driver component (excluded by default to save compile time)
+        # Provides driver/pcnt.h header for hardware pulse counter API
+        # TODO: Remove this once pulse_counter migrates to new PCNT API (driver/pulse_cnt.h)
+        include_builtin_idf_component("driver")
+
+    var = await sensor.new_sensor(config, use_pcnt)
     await cg.register_component(var, config)
 
     pin = await cg.gpio_pin_expression(config[CONF_PIN])


### PR DESCRIPTION
# What does this implement/fix?

Fix ESP-IDF build failures for `pulse_counter` and `hlw8012` components by re-enabling the legacy driver component.

The legacy PCNT driver (`driver/pcnt.h`) is required by these components but the `driver` IDF component was excluded by default to save compile time. This mirrors the fix in #13732 for `opentherm`.

**Error before fix:**
```
src/esphome/components/pulse_counter/pulse_counter_sensor.h:14:10: fatal error: driver/pcnt.h: No such file or directory
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13732

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# pulse_counter example
sensor:
  - platform: pulse_counter
    pin: GPIO5
    name: "Pulse Counter"

# hlw8012 example
sensor:
  - platform: hlw8012
    sel_pin: GPIO12
    cf_pin: GPIO5
    cf1_pin: GPIO14
    voltage:
      name: "Voltage"
    current:
      name: "Current"
    power:
      name: "Power"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
