### PR TITLE
[web_server] Add some more missing ESPHOME_F macros

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -454,7 +454,7 @@ void WebServer::handle_index_request(AsyncWebServerRequest *request) {
 
 #ifdef USE_WEBSERVER_PRIVATE_NETWORK_ACCESS
 void WebServer::handle_pna_cors_request(AsyncWebServerRequest *request) {
-  AsyncWebServerResponse *response = request->beginResponse(200, "");
+  AsyncWebServerResponse *response = request->beginResponse(200, ESPHOME_F(""));
   response->addHeader(ESPHOME_F("Access-Control-Allow-Private-Network"), ESPHOME_F("true"));
   response->addHeader(ESPHOME_F("Private-Network-Access-Name"), App.get_name().c_str());
   char mac_s[18];
@@ -1975,7 +1975,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     // Only allow transmit if the device supports it
     if (!obj->has_transmitter()) {
-      request->send(400, ESPHOME_F("text/plain"), "Device does not support transmission");
+      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Device does not support transmission"));
       return;
     }
 
@@ -2001,7 +2001,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
     // Parse base64url-encoded raw timings (required)
     // Base64url is URL-safe: uses A-Za-z0-9-_ (no special characters needing escaping)
     if (!request->hasParam(ESPHOME_F("data"))) {
-      request->send(400, ESPHOME_F("text/plain"), "Missing 'data' parameter");
+      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Missing 'data' parameter"));
       return;
     }
 
@@ -2011,7 +2011,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     // Validate base64url is not empty
     if (encoded.empty()) {
-      request->send(400, ESPHOME_F("text/plain"), "Empty 'data' parameter");
+      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Empty 'data' parameter"));
       return;
     }
 
@@ -2485,7 +2485,7 @@ void WebServer::handleRequest(AsyncWebServerRequest *request) {
   else {
     // No matching handler found - send 404
     ESP_LOGV(TAG, "Request for unknown URL: %s", url.c_str());
-    request->send(404, "text/plain", "Not Found");
+    request->send(404, ESPHOME_F("text/plain"), ESPHOME_F("Not Found"));
   }
 }
 

--- a/esphome/components/web_server/web_server_v1.cpp
+++ b/esphome/components/web_server/web_server_v1.cpp
@@ -74,7 +74,7 @@ void WebServer::set_css_url(const char *css_url) { this->css_url_ = css_url; }
 void WebServer::set_js_url(const char *js_url) { this->js_url_ = js_url; }
 
 void WebServer::handle_index_request(AsyncWebServerRequest *request) {
-  AsyncResponseStream *stream = request->beginResponseStream("text/html");
+  AsyncResponseStream *stream = request->beginResponseStream(ESPHOME_F("text/html"));
   const std::string &title = App.get_name();
   stream->print(ESPHOME_F("<!DOCTYPE html><html lang=\"en\"><head><meta charset=UTF-8><meta "
                           "name=viewport content=\"width=device-width, initial-scale=1,user-scalable=no\"><title>"));


### PR DESCRIPTION

# What does this implement/fix?

There were still a few strings that could be moved to flash on ESP8266

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
