### PR TITLE
[adc] Fix ESP32-C2 ADC calibration to use line fitting

### DIFF
--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -74,10 +74,9 @@ void ADCSensor::setup() {
   if (this->calibration_handle_ == nullptr) {
     adc_cali_handle_t handle = nullptr;
 
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
-    // RISC-V variants and S3 use curve fitting calibration
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+    // RISC-V variants (except C2) and S3 use curve fitting calibration
     adc_cali_curve_fitting_config_t cali_config = {};  // Zero initialize first
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     cali_config.chan = this->channel_;
@@ -95,14 +94,14 @@ void ADCSensor::setup() {
       ESP_LOGW(TAG, "Curve fitting calibration failed with error %d, will use uncalibrated readings", err);
       this->setup_flags_.calibration_complete = false;
     }
-#else  // Other ESP32 variants use line fitting calibration
+#else  // ESP32, ESP32-S2, and ESP32-C2 use line fitting calibration
     adc_cali_line_fitting_config_t cali_config = {
       .unit_id = this->adc_unit_,
       .atten = this->attenuation_,
       .bitwidth = ADC_BITWIDTH_DEFAULT,
-#if !defined(USE_ESP32_VARIANT_ESP32S2)
+#if !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32C2)
       .default_vref = 1100,  // Default reference voltage in mV
-#endif  // !defined(USE_ESP32_VARIANT_ESP32S2)
+#endif  // !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32C2)
     };
     err = adc_cali_create_scheme_line_fitting(&cali_config, &handle);
     if (err == ESP_OK) {
@@ -113,7 +112,7 @@ void ADCSensor::setup() {
       ESP_LOGW(TAG, "Line fitting calibration failed with error %d, will use uncalibrated readings", err);
       this->setup_flags_.calibration_complete = false;
     }
-#endif  // USE_ESP32_VARIANT_ESP32C2 || ESP32C3 || ESP32C5 || ESP32C6 || ESP32C61 || ESP32H2 || ESP32P4 || ESP32S3
+#endif  // ESP32C3 || ESP32C5 || ESP32C6 || ESP32C61 || ESP32H2 || ESP32P4 || ESP32S3
   }
 
   this->setup_flags_.init_complete = true;
@@ -185,13 +184,12 @@ float ADCSensor::sample_fixed_attenuation_() {
     } else {
       ESP_LOGW(TAG, "ADC calibration conversion failed with error %d, disabling calibration", err);
       if (this->calibration_handle_ != nullptr) {
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
         adc_cali_delete_scheme_curve_fitting(this->calibration_handle_);
 #else   // Other ESP32 variants use line fitting calibration
         adc_cali_delete_scheme_line_fitting(this->calibration_handle_);
-#endif  // USE_ESP32_VARIANT_ESP32C2 || ESP32C3 || ESP32C5 || ESP32C6 || ESP32C61 || ESP32H2 || ESP32P4 || ESP32S3
+#endif  // ESP32C3 || ESP32C5 || ESP32C6 || ESP32C61 || ESP32H2 || ESP32P4 || ESP32S3
         this->calibration_handle_ = nullptr;
       }
     }
@@ -219,9 +217,8 @@ float ADCSensor::sample_autorange_() {
     // Need to recalibrate for the new attenuation
     if (this->calibration_handle_ != nullptr) {
       // Delete old calibration handle
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
       adc_cali_delete_scheme_curve_fitting(this->calibration_handle_);
 #else
       adc_cali_delete_scheme_line_fitting(this->calibration_handle_);
@@ -232,9 +229,8 @@ float ADCSensor::sample_autorange_() {
     // Create new calibration handle for this attenuation
     adc_cali_handle_t handle = nullptr;
 
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
     adc_cali_curve_fitting_config_t cali_config = {};
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
     cali_config.chan = this->channel_;
@@ -251,7 +247,7 @@ float ADCSensor::sample_autorange_() {
       .unit_id = this->adc_unit_,
       .atten = atten,
       .bitwidth = ADC_BITWIDTH_DEFAULT,
-#if !defined(USE_ESP32_VARIANT_ESP32S2)
+#if !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32C2)
       .default_vref = 1100,
 #endif
     };
@@ -268,9 +264,8 @@ float ADCSensor::sample_autorange_() {
     if (err != ESP_OK) {
       ESP_LOGW(TAG, "ADC read failed in autorange with error %d", err);
       if (handle != nullptr) {
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
         adc_cali_delete_scheme_curve_fitting(handle);
 #else
         adc_cali_delete_scheme_line_fitting(handle);
@@ -291,9 +286,8 @@ float ADCSensor::sample_autorange_() {
         ESP_LOGVV(TAG, "Autorange atten=%d: UNCALIBRATED FALLBACK - raw=%d -> %.6fV (3.3V ref)", atten, raw, voltage);
       }
       // Clean up calibration handle
-#if USE_ESP32_VARIANT_ESP32C2 || USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || \
-    USE_ESP32_VARIANT_ESP32C6 || USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || \
-    USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
+#if USE_ESP32_VARIANT_ESP32C3 || USE_ESP32_VARIANT_ESP32C5 || USE_ESP32_VARIANT_ESP32C6 || \
+    USE_ESP32_VARIANT_ESP32C61 || USE_ESP32_VARIANT_ESP32H2 || USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S3
       adc_cali_delete_scheme_curve_fitting(handle);
 #else
       adc_cali_delete_scheme_line_fitting(handle);

--- a/tests/components/adc/test.esp32-c2-idf.yaml
+++ b/tests/components/adc/test.esp32-c2-idf.yaml
@@ -1,0 +1,12 @@
+sensor:
+  - id: my_sensor
+    platform: adc
+    pin: GPIO1
+    name: ADC Test sensor
+    update_interval: "1:01"
+    attenuation: 2.5db
+    unit_of_measurement: "°C"
+    icon: "mdi:water-percent"
+    accuracy_decimals: 5
+    setup_priority: -100
+    force_update: true

--- a/tests/test_build_components/build_components_base.esp32-c2-idf.yaml
+++ b/tests/test_build_components/build_components_base.esp32-c2-idf.yaml
@@ -1,0 +1,20 @@
+esphome:
+  name: componenttestesp32c2idf
+  friendly_name: $component_name
+
+esp32:
+  board: esp32-c2-devkitm-1
+  framework:
+    type: esp-idf
+  # Use custom partition table with larger app partition (3MB)
+  # Default IDF partitions only allow 1.75MB which is too small for grouped tests
+  partitions: ../partitions_testing.csv
+
+logger:
+  level: VERY_VERBOSE
+
+packages:
+  component_under_test: !include
+    file: $component_test_file
+    vars:
+      component_test_file: $component_test_file


### PR DESCRIPTION
## What does this implement/fix?

Fixes ESP32-C2 ADC calibration by correcting the calibration scheme selection. ESP32-C2 uses **line fitting** calibration (like ESP32 and S2), NOT curve fitting (like C3/C5/C6/H2/S3).

The previous commit (#13749) incorrectly added C2 to the curve fitting checks, which caused compilation to fail with:
```
error: 'adc_cali_curve_fitting_config_t' was not declared in this scope
```

This fix:
- Removes `USE_ESP32_VARIANT_ESP32C2` from all curve fitting calibration scheme checks
- Excludes C2 from `default_vref` field assignment (like S2, C2's line fitting config doesn't have this field)
- Adds ESP32-C2 component test infrastructure (`build_components_base.esp32-c2-idf.yaml`)
- Adds ADC component test for ESP32-C2 (`test.esp32-c2-idf.yaml`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13736 (the original issue that #13749 attempted to fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: adc
    pin: GPIO1
    name: "ADC Sensor"
    attenuation: auto
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).