### PR TITLE
2026.1.4

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -528,7 +528,7 @@ esphome/components/uart/packet_transport/* @clydebarrow
 esphome/components/udp/* @clydebarrow
 esphome/components/ufire_ec/* @pvizeli
 esphome/components/ufire_ise/* @pvizeli
-esphome/components/ultrasonic/* @OttoWinter
+esphome/components/ultrasonic/* @ssieb @swoboda1337
 esphome/components/update/* @jesserockz
 esphome/components/uponor_smatrix/* @kroimon
 esphome/components/usb_cdc_acm/* @kbx81

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.1.3
+PROJECT_NUMBER         = 2026.1.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -152,6 +152,10 @@ void CSE7766Component::parse_data_() {
     if (this->power_sensor_ != nullptr) {
       this->power_sensor_->publish_state(power);
     }
+  } else if (this->power_sensor_ != nullptr) {
+    // No valid power measurement from chip - publish 0W to avoid stale readings
+    // This typically happens when current is below the measurable threshold (~50mA)
+    this->power_sensor_->publish_state(0.0f);
   }
 
   float current = 0.0f;

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -193,11 +193,14 @@ bool Esp32HostedUpdate::fetch_manifest_() {
     int read_or_error = container->read(buf, sizeof(buf));
     App.feed_wdt();
     yield();
-    auto result = http_request::http_read_loop_result(read_or_error, last_data_time, read_timeout);
+    auto result =
+        http_request::http_read_loop_result(read_or_error, last_data_time, read_timeout, container->is_read_complete());
     if (result == http_request::HttpReadLoopResult::RETRY)
       continue;
+    // Note: COMPLETE is currently unreachable since the loop condition checks bytes_read < content_length,
+    // but this is defensive code in case chunked transfer encoding support is added in the future.
     if (result != http_request::HttpReadLoopResult::DATA)
-      break;  // ERROR or TIMEOUT
+      break;  // COMPLETE, ERROR, or TIMEOUT
     json_str.append(reinterpret_cast<char *>(buf), read_or_error);
   }
   container->end();
@@ -318,9 +321,14 @@ bool Esp32HostedUpdate::stream_firmware_to_coprocessor_() {
     App.feed_wdt();
     yield();
 
-    auto result = http_request::http_read_loop_result(read_or_error, last_data_time, read_timeout);
+    auto result =
+        http_request::http_read_loop_result(read_or_error, last_data_time, read_timeout, container->is_read_complete());
     if (result == http_request::HttpReadLoopResult::RETRY)
       continue;
+    // Note: COMPLETE is currently unreachable since the loop condition checks bytes_read < content_length,
+    // but this is defensive code in case chunked transfer encoding support is added in the future.
+    if (result == http_request::HttpReadLoopResult::COMPLETE)
+      break;
     if (result != http_request::HttpReadLoopResult::DATA) {
       if (result == http_request::HttpReadLoopResult::TIMEOUT) {
         ESP_LOGE(TAG, "Timeout reading firmware data");

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -130,9 +130,13 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
     App.feed_wdt();
     yield();
 
-    auto result = http_read_loop_result(bufsize_or_error, last_data_time, read_timeout);
+    auto result = http_read_loop_result(bufsize_or_error, last_data_time, read_timeout, container->is_read_complete());
     if (result == HttpReadLoopResult::RETRY)
       continue;
+    // Note: COMPLETE is currently unreachable since the loop condition checks bytes_read < content_length,
+    // but this is defensive code in case chunked transfer encoding support is added for OTA in the future.
+    if (result == HttpReadLoopResult::COMPLETE)
+      break;
     if (result != HttpReadLoopResult::DATA) {
       if (result == HttpReadLoopResult::TIMEOUT) {
         ESP_LOGE(TAG, "Timeout reading data");

--- a/esphome/components/max7219/display.py
+++ b/esphome/components/max7219/display.py
@@ -28,11 +28,10 @@ CONFIG_SCHEMA = (
 
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    var = cg.new_Pvariable(config[CONF_ID], config[CONF_NUM_CHIPS])
     await spi.register_spi_device(var, config, write_only=True)
     await display.register_display(var, config)
 
-    cg.add(var.set_num_chips(config[CONF_NUM_CHIPS]))
     cg.add(var.set_intensity(config[CONF_INTENSITY]))
     cg.add(var.set_reverse(config[CONF_REVERSE_ENABLE]))
 

--- a/esphome/components/max7219/max7219.cpp
+++ b/esphome/components/max7219/max7219.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace max7219 {
+namespace esphome::max7219 {
 
 static const char *const TAG = "max7219";
 
@@ -115,12 +114,14 @@ const uint8_t MAX7219_ASCII_TO_RAW[95] PROGMEM = {
 };
 
 float MAX7219Component::get_setup_priority() const { return setup_priority::PROCESSOR; }
+
+MAX7219Component::MAX7219Component(uint8_t num_chips) : num_chips_(num_chips) {
+  this->buffer_ = new uint8_t[this->num_chips_ * 8];  // NOLINT
+  memset(this->buffer_, 0, this->num_chips_ * 8);
+}
+
 void MAX7219Component::setup() {
   this->spi_setup();
-  this->buffer_ = new uint8_t[this->num_chips_ * 8];  // NOLINT
-  for (uint8_t i = 0; i < this->num_chips_ * 8; i++)
-    this->buffer_[i] = 0;
-
   // let's assume the user has all 8 digits connected, only important in daisy chained setups anyway
   this->send_to_all_(MAX7219_REGISTER_SCAN_LIMIT, 7);
   // let's use our own ASCII -> led pattern encoding
@@ -229,7 +230,6 @@ void MAX7219Component::set_intensity(uint8_t intensity) {
     this->intensity_ = intensity;
   }
 }
-void MAX7219Component::set_num_chips(uint8_t num_chips) { this->num_chips_ = num_chips; }
 
 uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time) {
   char buffer[64];
@@ -240,5 +240,4 @@ uint8_t MAX7219Component::strftime(uint8_t pos, const char *format, ESPTime time
 }
 uint8_t MAX7219Component::strftime(const char *format, ESPTime time) { return this->strftime(0, format, time); }
 
-}  // namespace max7219
-}  // namespace esphome
+}  // namespace esphome::max7219

--- a/esphome/components/max7219/max7219.h
+++ b/esphome/components/max7219/max7219.h
@@ -6,8 +6,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/components/display/display.h"
 
-namespace esphome {
-namespace max7219 {
+namespace esphome::max7219 {
 
 class MAX7219Component;
 
@@ -17,6 +16,8 @@ class MAX7219Component : public PollingComponent,
                          public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
                                                spi::CLOCK_PHASE_LEADING, spi::DATA_RATE_1MHZ> {
  public:
+  explicit MAX7219Component(uint8_t num_chips);
+
   void set_writer(max7219_writer_t &&writer);
 
   void setup() override;
@@ -30,7 +31,6 @@ class MAX7219Component : public PollingComponent,
   void display();
 
   void set_intensity(uint8_t intensity);
-  void set_num_chips(uint8_t num_chips);
   void set_reverse(bool reverse) { this->reverse_ = reverse; };
 
   /// Evaluate the printf-format and print the result at the given position.
@@ -56,10 +56,9 @@ class MAX7219Component : public PollingComponent,
   uint8_t intensity_{15};     // Intensity of the display from 0 to 15 (most)
   bool intensity_changed_{};  // True if we need to re-send the intensity
   uint8_t num_chips_{1};
-  uint8_t *buffer_;
+  uint8_t *buffer_{nullptr};
   bool reverse_{false};
   max7219_writer_t writer_{};
 };
 
-}  // namespace max7219
-}  // namespace esphome
+}  // namespace esphome::max7219

--- a/esphome/components/mipi_spi/mipi_spi.cpp
+++ b/esphome/components/mipi_spi/mipi_spi.cpp
@@ -1,6 +1,39 @@
 #include "mipi_spi.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace mipi_spi {}  // namespace mipi_spi
-}  // namespace esphome
+namespace esphome::mipi_spi {
+
+void internal_dump_config(const char *model, int width, int height, int offset_width, int offset_height, uint8_t madctl,
+                          bool invert_colors, int display_bits, bool is_big_endian, const optional<uint8_t> &brightness,
+                          GPIOPin *cs, GPIOPin *reset, GPIOPin *dc, int spi_mode, uint32_t data_rate, int bus_width) {
+  ESP_LOGCONFIG(TAG,
+                "MIPI_SPI Display\n"
+                "  Model: %s\n"
+                "  Width: %d\n"
+                "  Height: %d\n"
+                "  Swap X/Y: %s\n"
+                "  Mirror X: %s\n"
+                "  Mirror Y: %s\n"
+                "  Invert colors: %s\n"
+                "  Color order: %s\n"
+                "  Display pixels: %d bits\n"
+                "  Endianness: %s\n"
+                "  SPI Mode: %d\n"
+                "  SPI Data rate: %uMHz\n"
+                "  SPI Bus width: %d",
+                model, width, height, YESNO(madctl & MADCTL_MV), YESNO(madctl & (MADCTL_MX | MADCTL_XFLIP)),
+                YESNO(madctl & (MADCTL_MY | MADCTL_YFLIP)), YESNO(invert_colors), (madctl & MADCTL_BGR) ? "BGR" : "RGB",
+                display_bits, is_big_endian ? "Big" : "Little", spi_mode, static_cast<unsigned>(data_rate / 1000000),
+                bus_width);
+  LOG_PIN("  CS Pin: ", cs);
+  LOG_PIN("  Reset Pin: ", reset);
+  LOG_PIN("  DC Pin: ", dc);
+  if (offset_width != 0)
+    ESP_LOGCONFIG(TAG, "  Offset width: %d", offset_width);
+  if (offset_height != 0)
+    ESP_LOGCONFIG(TAG, "  Offset height: %d", offset_height);
+  if (brightness.has_value())
+    ESP_LOGCONFIG(TAG, "  Brightness: %u", brightness.value());
+}
+
+}  // namespace esphome::mipi_spi

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -63,6 +63,11 @@ enum BusType {
   BUS_TYPE_SINGLE_16 = 16,  // Single bit bus, but 16 bits per transfer
 };
 
+// Helper function for dump_config - defined in mipi_spi.cpp to allow use of LOG_PIN macro
+void internal_dump_config(const char *model, int width, int height, int offset_width, int offset_height, uint8_t madctl,
+                          bool invert_colors, int display_bits, bool is_big_endian, const optional<uint8_t> &brightness,
+                          GPIOPin *cs, GPIOPin *reset, GPIOPin *dc, int spi_mode, uint32_t data_rate, int bus_width);
+
 /**
  * Base class for MIPI SPI displays.
  * All the methods are defined here in the header file, as it is not possible to define templated methods in a cpp file.
@@ -201,40 +206,9 @@ class MipiSpi : public display::Display,
   }
 
   void dump_config() override {
-    esph_log_config(TAG,
-                    "MIPI_SPI Display\n"
-                    "  Model: %s\n"
-                    "  Width: %u\n"
-                    "  Height: %u",
-                    this->model_, WIDTH, HEIGHT);
-    if constexpr (OFFSET_WIDTH != 0)
-      esph_log_config(TAG, "  Offset width: %u", OFFSET_WIDTH);
-    if constexpr (OFFSET_HEIGHT != 0)
-      esph_log_config(TAG, "  Offset height: %u", OFFSET_HEIGHT);
-    esph_log_config(TAG,
-                    "  Swap X/Y: %s\n"
-                    "  Mirror X: %s\n"
-                    "  Mirror Y: %s\n"
-                    "  Invert colors: %s\n"
-                    "  Color order: %s\n"
-                    "  Display pixels: %d bits\n"
-                    "  Endianness: %s\n",
-                    YESNO(this->madctl_ & MADCTL_MV), YESNO(this->madctl_ & (MADCTL_MX | MADCTL_XFLIP)),
-                    YESNO(this->madctl_ & (MADCTL_MY | MADCTL_YFLIP)), YESNO(this->invert_colors_),
-                    this->madctl_ & MADCTL_BGR ? "BGR" : "RGB", DISPLAYPIXEL * 8, IS_BIG_ENDIAN ? "Big" : "Little");
-    if (this->brightness_.has_value())
-      esph_log_config(TAG, "  Brightness: %u", this->brightness_.value());
-    if (this->cs_ != nullptr)
-      esph_log_config(TAG, "  CS Pin: %s", this->cs_->dump_summary().c_str());
-    if (this->reset_pin_ != nullptr)
-      esph_log_config(TAG, "  Reset Pin: %s", this->reset_pin_->dump_summary().c_str());
-    if (this->dc_pin_ != nullptr)
-      esph_log_config(TAG, "  DC Pin: %s", this->dc_pin_->dump_summary().c_str());
-    esph_log_config(TAG,
-                    "  SPI Mode: %d\n"
-                    "  SPI Data rate: %dMHz\n"
-                    "  SPI Bus width: %d",
-                    this->mode_, static_cast<unsigned>(this->data_rate_ / 1000000), BUS_TYPE);
+    internal_dump_config(this->model_, WIDTH, HEIGHT, OFFSET_WIDTH, OFFSET_HEIGHT, this->madctl_, this->invert_colors_,
+                         DISPLAYPIXEL * 8, IS_BIG_ENDIAN, this->brightness_, this->cs_, this->reset_pin_, this->dc_pin_,
+                         this->mode_, this->data_rate_, BUS_TYPE);
   }
 
  protected:

--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -139,7 +139,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
     this->lwt_retain_ = retain;
   }
   void set_server(network::IPAddress ip, uint16_t port) final {
-    this->host_ = ip.str();
+    char ip_buf[network::IP_ADDRESS_BUFFER_SIZE];
+    this->host_ = ip.str_to(ip_buf);
     this->port_ = port;
   }
   void set_server(const char *host, uint16_t port) final {

--- a/esphome/components/ultrasonic/__init__.py
+++ b/esphome/components/ultrasonic/__init__.py
@@ -1,1 +1,1 @@
-CODEOWNERS = ["@OttoWinter"]
+CODEOWNERS = ["@swoboda1337", "@ssieb"]

--- a/esphome/components/ultrasonic/sensor.py
+++ b/esphome/components/ultrasonic/sensor.py
@@ -34,7 +34,7 @@ CONFIG_SCHEMA = (
         {
             cv.Required(CONF_TRIGGER_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_ECHO_PIN): pins.internal_gpio_input_pin_schema,
-            cv.Optional(CONF_TIMEOUT): cv.distance,
+            cv.Optional(CONF_TIMEOUT, default="2m"): cv.distance,
             cv.Optional(
                 CONF_PULSE_TIME, default="10us"
             ): cv.positive_time_period_microseconds,
@@ -52,12 +52,5 @@ async def to_code(config):
     cg.add(var.set_trigger_pin(trigger))
     echo = await cg.gpio_pin_expression(config[CONF_ECHO_PIN])
     cg.add(var.set_echo_pin(echo))
-
-    # Remove before 2026.8.0
-    if CONF_TIMEOUT in config:
-        _LOGGER.warning(
-            "'timeout' option is deprecated and will be removed in 2026.8.0. "
-            "The option has no effect and can be safely removed."
-        )
-
+    cg.add(var.set_timeout_us(config[CONF_TIMEOUT] / (0.000343 / 2)))
     cg.add(var.set_pulse_time_us(config[CONF_PULSE_TIME]))

--- a/esphome/components/ultrasonic/ultrasonic_sensor.h
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.h
@@ -11,6 +11,8 @@ namespace esphome::ultrasonic {
 struct UltrasonicSensorStore {
   static void gpio_intr(UltrasonicSensorStore *arg);
 
+  ISRInternalGPIOPin echo_pin_isr;
+  volatile uint32_t wait_start_us{0};
   volatile uint32_t echo_start_us{0};
   volatile uint32_t echo_end_us{0};
   volatile bool echo_start{false};
@@ -29,6 +31,8 @@ class UltrasonicSensorComponent : public sensor::Sensor, public PollingComponent
 
   float get_setup_priority() const override { return setup_priority::DATA; }
 
+  /// Set the maximum time in µs to wait for the echo to return
+  void set_timeout_us(uint32_t timeout_us) { this->timeout_us_ = timeout_us; }
   /// Set the time in µs the trigger pin should be enabled for in µs, defaults to 10µs (for HC-SR04)
   void set_pulse_time_us(uint32_t pulse_time_us) { this->pulse_time_us_ = pulse_time_us; }
 
@@ -41,6 +45,7 @@ class UltrasonicSensorComponent : public sensor::Sensor, public PollingComponent
   ISRInternalGPIOPin trigger_pin_isr_;
   InternalGPIOPin *echo_pin_;
   UltrasonicSensorStore store_;
+  uint32_t timeout_us_{};
   uint32_t pulse_time_us_{};
 
   uint32_t measurement_start_us_{0};

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1383,6 +1383,12 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
 
     this->release_scan_results_();
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+    // Notify listeners now that state machine has reached STA_CONNECTED
+    // This ensures wifi.connected condition returns true in listener automations
+    this->notify_connect_state_listeners_();
+#endif
+
     return;
   }
 
@@ -2089,6 +2095,21 @@ void WiFiComponent::release_scan_results_() {
 #endif
   }
 }
+
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+void WiFiComponent::notify_connect_state_listeners_() {
+  if (!this->pending_.connect_state)
+    return;
+  this->pending_.connect_state = false;
+  // Get current SSID and BSSID from the WiFi driver
+  char ssid_buf[SSID_BUFFER_SIZE];
+  const char *ssid = this->wifi_ssid_to(ssid_buf);
+  bssid_t bssid = this->wifi_bssid();
+  for (auto *listener : this->connect_state_listeners_) {
+    listener->on_wifi_connect_state(StringRef(ssid, strlen(ssid)), bssid);
+  }
+}
+#endif  // USE_WIFI_CONNECT_STATE_LISTENERS
 
 void WiFiComponent::check_roaming_(uint32_t now) {
   // Guard: not for hidden networks (may not appear in scan)

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -618,6 +618,11 @@ class WiFiComponent : public Component {
   /// Free scan results memory unless a component needs them
   void release_scan_results_();
 
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  /// Notify connect state listeners (called after state machine reaches STA_CONNECTED)
+  void notify_connect_state_listeners_();
+#endif
+
 #ifdef USE_ESP8266
   static void wifi_event_callback(System_Event_t *event);
   void wifi_scan_done_callback_(void *arg, STATUS status);
@@ -719,6 +724,16 @@ class WiFiComponent : public Component {
   bool is_high_performance_mode_{false};
 
   SemaphoreHandle_t high_performance_semaphore_{nullptr};
+#endif
+
+#ifdef USE_WIFI_CONNECT_STATE_LISTENERS
+  // Pending listener notifications deferred until state machine reaches appropriate state.
+  // Listeners are notified after state transitions complete so conditions like
+  // wifi.connected return correct values in automations.
+  // Uses bitfields to minimize memory; more flags may be added as needed.
+  struct {
+    bool connect_state : 1;  // Notify connect state listeners after STA_CONNECTED
+  } pending_{};
 #endif
 
   // Pointers at the end (naturally aligned)

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.1.3"
+__version__ = "2026.1.4"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -356,6 +356,10 @@ void Component::defer(const std::string &name, std::function<void()> &&f) {  // 
 void Component::defer(const char *name, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, name, 0, std::move(f));
 }
+void Component::defer(uint32_t id, std::function<void()> &&f) {  // NOLINT
+  App.scheduler.set_timeout(this, id, 0, std::move(f));
+}
+bool Component::cancel_defer(uint32_t id) { return App.scheduler.cancel_timeout(this, id); }
 void Component::set_timeout(uint32_t timeout, std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), timeout, std::move(f));
 }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -494,11 +494,15 @@ class Component {
   /// Defer a callback to the next loop() call.
   void defer(std::function<void()> &&f);  // NOLINT
 
+  /// Defer a callback with a numeric ID (zero heap allocation)
+  void defer(uint32_t id, std::function<void()> &&f);  // NOLINT
+
   /// Cancel a defer callback using the specified name, name must not be empty.
   // Remove before 2026.7.0
   ESPDEPRECATED("Use const char* overload instead. Removed in 2026.7.0", "2026.1.0")
   bool cancel_defer(const std::string &name);  // NOLINT
   bool cancel_defer(const char *name);         // NOLINT
+  bool cancel_defer(uint32_t id);              // NOLINT
 
   // Ordered for optimal packing on 32-bit systems
   const LogString *component_source_{nullptr};

--- a/tests/components/mipi_spi/test.esp8266-ard.yaml
+++ b/tests/components/mipi_spi/test.esp8266-ard.yaml
@@ -1,0 +1,10 @@
+substitutions:
+  dc_pin: GPIO15
+  cs_pin: GPIO5
+  enable_pin: GPIO4
+  reset_pin: GPIO16
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/integration/fixtures/scheduler_numeric_id_test.yaml
+++ b/tests/integration/fixtures/scheduler_numeric_id_test.yaml
@@ -20,6 +20,9 @@ globals:
   - id: retry_counter
     type: int
     initial_value: '0'
+  - id: defer_counter
+    type: int
+    initial_value: '0'
   - id: tests_done
     type: bool
     initial_value: 'false'
@@ -136,11 +139,49 @@ script:
           App.scheduler.cancel_retry(component1, 6002U);
           ESP_LOGI("test", "Cancelled numeric retry 6002");
 
+          // Test 12: defer with numeric ID (Component method)
+          class TestDeferComponent : public Component {
+          public:
+            void test_defer_methods() {
+              // Test defer with uint32_t ID - should execute on next loop
+              this->defer(7001U, []() {
+                ESP_LOGI("test", "Component numeric defer 7001 fired");
+                id(defer_counter) += 1;
+              });
+
+              // Test another defer with numeric ID
+              this->defer(7002U, []() {
+                ESP_LOGI("test", "Component numeric defer 7002 fired");
+                id(defer_counter) += 1;
+              });
+            }
+          };
+
+          static TestDeferComponent test_defer_component;
+          test_defer_component.test_defer_methods();
+
+          // Test 13: cancel_defer with numeric ID (Component method)
+          class TestCancelDeferComponent : public Component {
+          public:
+            void test_cancel_defer() {
+              // Set a defer that should be cancelled
+              this->defer(8001U, []() {
+                ESP_LOGE("test", "ERROR: Numeric defer 8001 should have been cancelled");
+              });
+              // Cancel it immediately
+              bool cancelled = this->cancel_defer(8001U);
+              ESP_LOGI("test", "Cancelled numeric defer 8001: %s", cancelled ? "true" : "false");
+            }
+          };
+
+          static TestCancelDeferComponent test_cancel_defer_component;
+          test_cancel_defer_component.test_cancel_defer();
+
   - id: report_results
     then:
       - lambda: |-
-          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d, Retries: %d",
-                   id(timeout_counter), id(interval_counter), id(retry_counter));
+          ESP_LOGI("test", "Final results - Timeouts: %d, Intervals: %d, Retries: %d, Defers: %d",
+                   id(timeout_counter), id(interval_counter), id(retry_counter), id(defer_counter));
 
 sensor:
   - platform: template


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [mipi_spi] Fix log_pin() FlashStringHelper compatibility [esphome#13624](https://github.com/esphome/esphome/pull/13624)
- [max7219] Allocate buffer in constructor [esphome#13660](https://github.com/esphome/esphome/pull/13660)
- [mqtt] resolve warnings related to use of ip.str() [esphome#13719](https://github.com/esphome/esphome/pull/13719)
- [core] Add missing uint32_t ID overloads for defer() and cancel_defer() [esphome#13720](https://github.com/esphome/esphome/pull/13720)
- [http_request] Fix requests taking full timeout when response is already complete [esphome#13649](https://github.com/esphome/esphome/pull/13649)
- [cse7766] Fix power reading stuck when load switches off [esphome#13734](https://github.com/esphome/esphome/pull/13734)
- [wifi] Fix wifi.connected condition returning false in connect state listener automations [esphome#13733](https://github.com/esphome/esphome/pull/13733)
- [ultrasonic] adjust timeouts and bring the parameter back [esphome#13738](https://github.com/esphome/esphome/pull/13738)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
