### PR TITLE
[esp32] Restore develop branch for dev platform version, bump platformio

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -517,7 +517,7 @@ ESP_IDF_PLATFORM_VERSION_LOOKUP = {
 PLATFORM_VERSION_LOOKUP = {
     "recommended": cv.Version(55, 3, 36),
     "latest": cv.Version(55, 3, 36),
-    "dev": cv.Version(55, 3, 36),
+    "dev": "https://github.com/pioarduino/platform-espressif32.git#develop",
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ tornado==6.5.4
 tzlocal==5.3.1    # from time
 tzdata>=2021.1  # from time
 pyserial==3.5
-platformio==6.1.18  # When updating platformio, also update /docker/Dockerfile
+platformio==6.1.19
 esptool==5.1.0
 click==8.1.7
 esphome-dashboard==20260110.0


### PR DESCRIPTION
# What does this implement/fix?

Restores the pioarduino platform-espressif32 develop branch for the "dev" platform version. This was removed in October 2025 when the develop branch was temporarily broken, but it should now be functional again.

Also bumps PlatformIO from 6.1.18 to 6.1.19 as required by the develop branch, and removes an outdated comment about updating the Dockerfile (which no longer has a separate platformio version).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    version: dev
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).