### PR TITLE
[vbus] Add DeltaSol BS/2 support with sensors and binary sensors

### DIFF
--- a/esphome/components/vbus/__init__.py
+++ b/esphome/components/vbus/__init__.py
@@ -16,6 +16,7 @@ CONF_VBUS_ID = "vbus_id"
 
 CONF_DELTASOL_BS_PLUS = "deltasol_bs_plus"
 CONF_DELTASOL_BS_2009 = "deltasol_bs_2009"
+CONF_DELTASOL_BS2 = "deltasol_bs2"
 CONF_DELTASOL_C = "deltasol_c"
 CONF_DELTASOL_CS2 = "deltasol_cs2"
 CONF_DELTASOL_CS_PLUS = "deltasol_cs_plus"

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -17,6 +17,7 @@ from esphome.const import (
 from .. import (
     CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_BS_PLUS,
+    CONF_DELTASOL_BS2,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,
     CONF_DELTASOL_CS_PLUS,
@@ -27,6 +28,7 @@ from .. import (
 
 DeltaSol_BS_Plus = vbus_ns.class_("DeltaSolBSPlusBSensor", cg.Component)
 DeltaSol_BS_2009 = vbus_ns.class_("DeltaSolBS2009BSensor", cg.Component)
+DeltaSol_BS2 = vbus_ns.class_("DeltaSolBS2BSensor", cg.Component)
 DeltaSol_C = vbus_ns.class_("DeltaSolCBSensor", cg.Component)
 DeltaSol_CS2 = vbus_ns.class_("DeltaSolCS2BSensor", cg.Component)
 DeltaSol_CS_Plus = vbus_ns.class_("DeltaSolCSPlusBSensor", cg.Component)
@@ -116,6 +118,28 @@ CONFIG_SCHEMA = cv.typed_schema(
                 ): binary_sensor.binary_sensor_schema(
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
                 ),
+            }
+        ),
+        CONF_DELTASOL_BS2: cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(DeltaSol_BS2),
+                cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
+                cv.Optional(CONF_SENSOR1_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR2_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR3_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_SENSOR4_ERROR): binary_sensor.binary_sensor_schema(
+                    device_class=DEVICE_CLASS_PROBLEM,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                )
             }
         ),
         CONF_DELTASOL_C: cv.COMPONENT_SCHEMA.extend(
@@ -274,6 +298,23 @@ async def to_code(config):
                 config[CONF_FROST_PROTECTION_ACTIVE]
             )
             cg.add(var.set_frost_protection_active_bsensor(sens))
+
+    elif config[CONF_MODEL] == CONF_DELTASOL_BS2:
+        cg.add(var.set_command(0x0100))
+        cg.add(var.set_source(0x4278))
+        cg.add(var.set_dest(0x0010))
+        if CONF_SENSOR1_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR1_ERROR])
+            cg.add(var.set_s1_error_bsensor(sens))
+        if CONF_SENSOR2_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR2_ERROR])
+            cg.add(var.set_s2_error_bsensor(sens))
+        if CONF_SENSOR3_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR3_ERROR])
+            cg.add(var.set_s3_error_bsensor(sens))
+        if CONF_SENSOR4_ERROR in config:
+            sens = await binary_sensor.new_binary_sensor(config[CONF_SENSOR4_ERROR])
+            cg.add(var.set_s4_error_bsensor(sens))
 
     elif config[CONF_MODEL] == CONF_DELTASOL_C:
         cg.add(var.set_command(0x0100))

--- a/esphome/components/vbus/binary_sensor/__init__.py
+++ b/esphome/components/vbus/binary_sensor/__init__.py
@@ -15,9 +15,9 @@ from esphome.const import (
 )
 
 from .. import (
+    CONF_DELTASOL_BS2,
     CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_BS_PLUS,
-    CONF_DELTASOL_BS2,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,
     CONF_DELTASOL_CS_PLUS,
@@ -139,7 +139,7 @@ CONFIG_SCHEMA = cv.typed_schema(
                 cv.Optional(CONF_SENSOR4_ERROR): binary_sensor.binary_sensor_schema(
                     device_class=DEVICE_CLASS_PROBLEM,
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
-                )
+                ),
             }
         ),
         CONF_DELTASOL_C: cv.COMPONENT_SCHEMA.extend(

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -129,6 +129,26 @@ void DeltaSolCSPlusBSensor::handle_message(std::vector<uint8_t> &message) {
     this->s4_error_bsensor_->publish_state(message[20] & 8);
 }
 
+void DeltaSolBS2BSensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "DeltaSol BS/2 (DrainBack):");
+  LOG_BINARY_SENSOR("  ", "Sensor 1 Error", this->s1_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 2 Error", this->s2_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 3 Error", this->s3_error_bsensor_);
+  LOG_BINARY_SENSOR("  ", "Sensor 4 Error", this->s4_error_bsensor_);
+}
+
+void DeltaSolBS2BSensor::handle_message(std::vector<uint8_t> &message) {
+  if (this->s1_error_bsensor_ != nullptr)
+    this->s1_error_bsensor_->publish_state(message[10] & 1);
+  if (this->s2_error_bsensor_ != nullptr)
+    this->s2_error_bsensor_->publish_state(message[10] & 2);
+  if (this->s3_error_bsensor_ != nullptr)
+    this->s3_error_bsensor_->publish_state(message[10] & 4);
+  if (this->s4_error_bsensor_ != nullptr)
+    this->s4_error_bsensor_->publish_state(message[10] & 8);
+}
+
+
 void VBusCustomBSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "VBus Custom Binary Sensor:");
   if (this->source_ == 0xffff) {

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.cpp
@@ -148,7 +148,6 @@ void DeltaSolBS2BSensor::handle_message(std::vector<uint8_t> &message) {
     this->s4_error_bsensor_->publish_state(message[10] & 8);
 }
 
-
 void VBusCustomBSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "VBus Custom Binary Sensor:");
   if (this->source_ == 0xffff) {

--- a/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
+++ b/esphome/components/vbus/binary_sensor/vbus_binary_sensor.h
@@ -111,6 +111,23 @@ class DeltaSolCSPlusBSensor : public VBusListener, public Component {
   void handle_message(std::vector<uint8_t> &message) override;
 };
 
+class DeltaSolBS2BSensor : public VBusListener, public Component {
+ public:
+  void dump_config() override;
+  void set_s1_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s1_error_bsensor_ = bsensor; }
+  void set_s2_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s2_error_bsensor_ = bsensor; }
+  void set_s3_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s3_error_bsensor_ = bsensor; }
+  void set_s4_error_bsensor(binary_sensor::BinarySensor *bsensor) { this->s4_error_bsensor_ = bsensor; }
+
+ protected:
+  binary_sensor::BinarySensor *s1_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s2_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s3_error_bsensor_{nullptr};
+  binary_sensor::BinarySensor *s4_error_bsensor_{nullptr};
+
+  void handle_message(std::vector<uint8_t> &message) override;
+};
+
 class VBusCustomSubBSensor;
 
 class VBusCustomBSensor : public VBusListener, public Component {

--- a/esphome/components/vbus/sensor/__init__.py
+++ b/esphome/components/vbus/sensor/__init__.py
@@ -31,8 +31,8 @@ from esphome.const import (
 )
 
 from .. import (
-    CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_BS2,
+    CONF_DELTASOL_BS_2009,
     CONF_DELTASOL_BS_PLUS,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,

--- a/esphome/components/vbus/sensor/__init__.py
+++ b/esphome/components/vbus/sensor/__init__.py
@@ -32,6 +32,7 @@ from esphome.const import (
 
 from .. import (
     CONF_DELTASOL_BS_2009,
+    CONF_DELTASOL_BS2,
     CONF_DELTASOL_BS_PLUS,
     CONF_DELTASOL_C,
     CONF_DELTASOL_CS2,
@@ -43,6 +44,7 @@ from .. import (
 
 DeltaSol_BS_Plus = vbus_ns.class_("DeltaSolBSPlusSensor", cg.Component)
 DeltaSol_BS_2009 = vbus_ns.class_("DeltaSolBS2009Sensor", cg.Component)
+DeltaSol_BS2 = vbus_ns.class_("DeltaSolBS2Sensor", cg.Component)
 DeltaSol_C = vbus_ns.class_("DeltaSolCSensor", cg.Component)
 DeltaSol_CS2 = vbus_ns.class_("DeltaSolCS2Sensor", cg.Component)
 DeltaSol_CS_Plus = vbus_ns.class_("DeltaSolCSPlusSensor", cg.Component)
@@ -220,6 +222,79 @@ CONFIG_SCHEMA = cv.typed_schema(
                     device_class=DEVICE_CLASS_DURATION,
                     state_class=STATE_CLASS_MEASUREMENT,
                     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+                cv.Optional(CONF_VERSION): sensor.sensor_schema(
+                    accuracy_decimals=2,
+                    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                ),
+            }
+        ),
+        CONF_DELTASOL_BS2: cv.COMPONENT_SCHEMA.extend(
+            {
+                cv.GenerateID(): cv.declare_id(DeltaSol_BS2),
+                cv.GenerateID(CONF_VBUS_ID): cv.use_id(VBus),
+                cv.Optional(CONF_TEMPERATURE_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_3): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_TEMPERATURE_4): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_CELSIUS,
+                    icon=ICON_THERMOMETER,
+                    accuracy_decimals=1,
+                    device_class=DEVICE_CLASS_TEMPERATURE,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_PUMP_SPEED_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_PERCENT,
+                    icon=ICON_PERCENT,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_EMPTY,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_PUMP_SPEED_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_PERCENT,
+                    icon=ICON_PERCENT,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_EMPTY,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_OPERATING_HOURS_1): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_HOUR,
+                    icon=ICON_TIMER,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_DURATION,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_OPERATING_HOURS_2): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_HOUR,
+                    icon=ICON_TIMER,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_DURATION,
+                    state_class=STATE_CLASS_MEASUREMENT,
+                ),
+                cv.Optional(CONF_HEAT_QUANTITY): sensor.sensor_schema(
+                    unit_of_measurement=UNIT_WATT_HOURS,
+                    icon=ICON_RADIATOR,
+                    accuracy_decimals=0,
+                    device_class=DEVICE_CLASS_ENERGY,
+                    state_class=STATE_CLASS_TOTAL_INCREASING,
                 ),
                 cv.Optional(CONF_VERSION): sensor.sensor_schema(
                     accuracy_decimals=2,
@@ -556,6 +631,41 @@ async def to_code(config):
         if CONF_TIME in config:
             sens = await sensor.new_sensor(config[CONF_TIME])
             cg.add(var.set_time_sensor(sens))
+        if CONF_VERSION in config:
+            sens = await sensor.new_sensor(config[CONF_VERSION])
+            cg.add(var.set_version_sensor(sens))
+
+    elif config[CONF_MODEL] == CONF_DELTASOL_BS2:
+        cg.add(var.set_command(0x0100))
+        cg.add(var.set_source(0x4278))
+        cg.add(var.set_dest(0x0010))
+        if CONF_TEMPERATURE_1 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_1])
+            cg.add(var.set_temperature1_sensor(sens))
+        if CONF_TEMPERATURE_2 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_2])
+            cg.add(var.set_temperature2_sensor(sens))
+        if CONF_TEMPERATURE_3 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_3])
+            cg.add(var.set_temperature3_sensor(sens))
+        if CONF_TEMPERATURE_4 in config:
+            sens = await sensor.new_sensor(config[CONF_TEMPERATURE_4])
+            cg.add(var.set_temperature4_sensor(sens))
+        if CONF_PUMP_SPEED_1 in config:
+            sens = await sensor.new_sensor(config[CONF_PUMP_SPEED_1])
+            cg.add(var.set_pump_speed1_sensor(sens))
+        if CONF_PUMP_SPEED_2 in config:
+            sens = await sensor.new_sensor(config[CONF_PUMP_SPEED_2])
+            cg.add(var.set_pump_speed2_sensor(sens))
+        if CONF_OPERATING_HOURS_1 in config:
+            sens = await sensor.new_sensor(config[CONF_OPERATING_HOURS_1])
+            cg.add(var.set_operating_hours1_sensor(sens))
+        if CONF_OPERATING_HOURS_2 in config:
+            sens = await sensor.new_sensor(config[CONF_OPERATING_HOURS_2])
+            cg.add(var.set_operating_hours2_sensor(sens))
+        if CONF_HEAT_QUANTITY in config:
+            sens = await sensor.new_sensor(config[CONF_HEAT_QUANTITY])
+            cg.add(var.set_heat_quantity_sensor(sens))
         if CONF_VERSION in config:
             sens = await sensor.new_sensor(config[CONF_VERSION])
             cg.add(var.set_version_sensor(sens))

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -246,8 +246,7 @@ void DeltaSolBS2Sensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
   if (this->heat_quantity_sensor_ != nullptr) {
-    float heat_wh = get_u16(message, 16) + get_u16(message, 18) * 1000.0f +
-                    get_u16(message, 20) * 1000000.0f;
+    float heat_wh = get_u16(message, 16) + get_u16(message, 18) * 1000.0f + get_u16(message, 20) * 1000000.0f;
     this->heat_quantity_sensor_->publish_state(heat_wh);
   }
   if (this->version_sensor_ != nullptr)

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -214,6 +214,46 @@ void DeltaSolCSPlusSensor::handle_message(std::vector<uint8_t> &message) {
     this->flow_rate_sensor_->publish_state(get_u16(message, 38));
 }
 
+void DeltaSolBS2Sensor::dump_config() {
+  ESP_LOGCONFIG(TAG, "DeltaSol BS/2 (DrainBack):");
+  LOG_SENSOR("  ", "Temperature 1", this->temperature1_sensor_);
+  LOG_SENSOR("  ", "Temperature 2", this->temperature2_sensor_);
+  LOG_SENSOR("  ", "Temperature 3", this->temperature3_sensor_);
+  LOG_SENSOR("  ", "Temperature 4", this->temperature4_sensor_);
+  LOG_SENSOR("  ", "Pump Speed 1", this->pump_speed1_sensor_);
+  LOG_SENSOR("  ", "Pump Speed 2", this->pump_speed2_sensor_);
+  LOG_SENSOR("  ", "Operating Hours 1", this->operating_hours1_sensor_);
+  LOG_SENSOR("  ", "Operating Hours 2", this->operating_hours2_sensor_);
+  LOG_SENSOR("  ", "Heat Quantity", this->heat_quantity_sensor_);
+  LOG_SENSOR("  ", "FW Version", this->version_sensor_);
+}
+
+void DeltaSolBS2Sensor::handle_message(std::vector<uint8_t> &message) {
+  if (this->temperature1_sensor_ != nullptr)
+    this->temperature1_sensor_->publish_state(get_i16(message, 0) * 0.1f);
+  if (this->temperature2_sensor_ != nullptr)
+    this->temperature2_sensor_->publish_state(get_i16(message, 2) * 0.1f);
+  if (this->temperature3_sensor_ != nullptr)
+    this->temperature3_sensor_->publish_state(get_i16(message, 4) * 0.1f);
+  if (this->temperature4_sensor_ != nullptr)
+    this->temperature4_sensor_->publish_state(get_i16(message, 6) * 0.1f);
+  if (this->pump_speed1_sensor_ != nullptr)
+    this->pump_speed1_sensor_->publish_state(message[8]);
+  if (this->pump_speed2_sensor_ != nullptr)
+    this->pump_speed2_sensor_->publish_state(message[9]);
+  if (this->operating_hours1_sensor_ != nullptr)
+    this->operating_hours1_sensor_->publish_state(get_u16(message, 12));
+  if (this->operating_hours2_sensor_ != nullptr)
+    this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
+  if (this->heat_quantity_sensor_ != nullptr) {
+    float heat_wh = get_u16(message, 16) + get_u16(message, 18) * 1000.0f +
+                    get_u16(message, 20) * 1000000.0f;
+    this->heat_quantity_sensor_->publish_state(heat_wh);
+  }
+  if (this->version_sensor_ != nullptr)
+    this->version_sensor_->publish_state(get_u16(message, 24) * 0.01f);
+}
+
 void VBusCustomSensor::dump_config() {
   ESP_LOGCONFIG(TAG, "VBus Custom Sensor:");
   if (this->source_ == 0xffff) {

--- a/esphome/components/vbus/sensor/vbus_sensor.h
+++ b/esphome/components/vbus/sensor/vbus_sensor.h
@@ -157,6 +157,36 @@ class DeltaSolCSPlusSensor : public VBusListener, public Component {
   void handle_message(std::vector<uint8_t> &message) override;
 };
 
+class DeltaSolBS2Sensor : public VBusListener, public Component {
+ public:
+  void dump_config() override;
+
+  void set_temperature1_sensor(sensor::Sensor *sensor) { this->temperature1_sensor_ = sensor; }
+  void set_temperature2_sensor(sensor::Sensor *sensor) { this->temperature2_sensor_ = sensor; }
+  void set_temperature3_sensor(sensor::Sensor *sensor) { this->temperature3_sensor_ = sensor; }
+  void set_temperature4_sensor(sensor::Sensor *sensor) { this->temperature4_sensor_ = sensor; }
+  void set_pump_speed1_sensor(sensor::Sensor *sensor) { this->pump_speed1_sensor_ = sensor; }
+  void set_pump_speed2_sensor(sensor::Sensor *sensor) { this->pump_speed2_sensor_ = sensor; }
+  void set_operating_hours1_sensor(sensor::Sensor *sensor) { this->operating_hours1_sensor_ = sensor; }
+  void set_operating_hours2_sensor(sensor::Sensor *sensor) { this->operating_hours2_sensor_ = sensor; }
+  void set_heat_quantity_sensor(sensor::Sensor *sensor) { this->heat_quantity_sensor_ = sensor; }
+  void set_version_sensor(sensor::Sensor *sensor) { this->version_sensor_ = sensor; }
+
+ protected:
+  sensor::Sensor *temperature1_sensor_{nullptr};
+  sensor::Sensor *temperature2_sensor_{nullptr};
+  sensor::Sensor *temperature3_sensor_{nullptr};
+  sensor::Sensor *temperature4_sensor_{nullptr};
+  sensor::Sensor *pump_speed1_sensor_{nullptr};
+  sensor::Sensor *pump_speed2_sensor_{nullptr};
+  sensor::Sensor *operating_hours1_sensor_{nullptr};
+  sensor::Sensor *operating_hours2_sensor_{nullptr};
+  sensor::Sensor *heat_quantity_sensor_{nullptr};
+  sensor::Sensor *version_sensor_{nullptr};
+
+  void handle_message(std::vector<uint8_t> &message) override;
+};
+
 class VBusCustomSubSensor;
 
 class VBusCustomSensor : public VBusListener, public Component {

--- a/tests/components/vbus/common.yaml
+++ b/tests/components/vbus/common.yaml
@@ -66,4 +66,3 @@ sensor:
       name: BS2 Heat Quantity
     version:
       name: BS2 Firmware Version
-

--- a/tests/components/vbus/common.yaml
+++ b/tests/components/vbus/common.yaml
@@ -4,11 +4,21 @@ binary_sensor:
   - platform: vbus
     model: deltasol_bs_plus
     relay1:
-      name: Relay 1 On
+      name: BS Plus Relay 1 On
     relay2:
-      name: Relay 2 On
+      name: BS Plus Relay 2 On
     sensor1_error:
-      name: Sensor 1 Error
+      name: BS Plus Sensor 1 Error
+  - platform: vbus
+    model: deltasol_bs2
+    sensor1_error:
+      name: BS2 Sensor 1 Error
+    sensor2_error:
+      name: BS2 Sensor 2 Error
+    sensor3_error:
+      name: BS2 Sensor 3 Error
+    sensor4_error:
+      name: BS2 Sensor 4 Error
   - platform: vbus
     model: custom
     command: 0x100
@@ -23,14 +33,37 @@ sensor:
   - platform: vbus
     model: deltasol c
     temperature_1:
-      name: Temperature 1
+      name: DeltaSol C Temperature 1
     temperature_2:
-      name: Temperature 2
+      name: DeltaSol C Temperature 2
     temperature_3:
-      name: Temperature 3
+      name: DeltaSol C Temperature 3
     operating_hours_1:
-      name: Operating Hours 1
+      name: DeltaSol C Operating Hours 1
     heat_quantity:
-      name: Heat Quantity
+      name: DeltaSol C Heat Quantity
     time:
-      name: System Time
+      name: DeltaSol C System Time
+  - platform: vbus
+    model: deltasol_bs2
+    temperature_1:
+      name: BS2 Temperature 1
+    temperature_2:
+      name: BS2 Temperature 2
+    temperature_3:
+      name: BS2 Temperature 3
+    temperature_4:
+      name: BS2 Temperature 4
+    pump_speed_1:
+      name: BS2 Pump Speed 1
+    pump_speed_2:
+      name: BS2 Pump Speed 2
+    operating_hours_1:
+      name: BS2 Operating Hours 1
+    operating_hours_2:
+      name: BS2 Operating Hours 2
+    heat_quantity:
+      name: BS2 Heat Quantity
+    version:
+      name: BS2 Firmware Version
+


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the Resol DeltaSol BS/2 (DrainBack) solar controller in the vbus component.

- Add `deltasol_bs2` model with source address 0x4278
- **Sensors:** temperatures 1–4, pump speeds 1–2, operating hours 1–2, heat quantity, firmware version
- **Binary sensors:** sensor 1–4 error


The implementation is based on the Resol VBus protocol specification and has been tested on real hardware where it works as expected.

Implementation based on the Resol VBus protocol specification:  
https://hobbyelektronik.org/w/images/0/04/VBus-Protokollspezifikation.pdf

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/6032

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:
```aml
# Example config.yaml for DeltaSol BS/2 (DrainBack)
uart:
  - id: vbus_uart
    tx_pin: GPIO17
    rx_pin: GPIO16
    baud_rate: 9600

vbus:
  - id: vbus_main
    uart_id: vbus_uart

sensor:
  - platform: vbus
    model: deltasol_bs2
    vbus_id: vbus_main
    temperature_1:
      name: "Collector Temperature"
    temperature_2:
      name: "Tank Bottom"
    temperature_3:
      name: "Tank Top"
    temperature_4:
      name: "Other"
    pump_speed_1:
      name: "Pump Speed 1"
    pump_speed_2:
      name: "Pump Speed 2"
    heat_quantity:
      name: "Heat Quantity"
    version:
      name: "Firmware Version"

binary_sensor:
  - platform: vbus
    model: deltasol_bs2
    vbus_id: vbus_main
    sensor1_error:
      name: "Sensor 1 Error"
    sensor2_error:
      name: "Sensor 2 Error"
    sensor3_error:
      name: "Sensor 3 Error"
    sensor4_error:
      name: "Sensor 4 Error"
```

Checklist:
- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under tests/ folder).
   - No new tests added; existing vbus tests cover the build. Happy to add a test config for deltasol_bs2 if requested.
- [x] Documentation added/updated in esphome-docs.