### PR TITLE
[epaper_spi] Validate BUSY pin as input instead of output

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -86,13 +86,6 @@ def model_schema(config):
         )
         .extend(
             {
-                model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
-                model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
-                model.option(CONF_RESET_PIN): pins.gpio_output_pin_schema,
-            }
-        )
-        .extend(
-            {
                 cv.Optional(CONF_ROTATION, default=0): validate_rotation,
                 cv.Required(CONF_MODEL): cv.one_of(model.name, upper=True),
                 cv.Optional(CONF_UPDATE_INTERVAL, default=cv.UNDEFINED): cv.All(
@@ -105,7 +98,10 @@ def model_schema(config):
                     }
                 ),
                 cv.Optional(CONF_FULL_UPDATE_EVERY, default=1): cv.int_range(1, 255),
+                model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
+                model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
                 model.option(CONF_DC_PIN, fallback=None): pins.gpio_output_pin_schema,
+                model.option(CONF_RESET_PIN): pins.gpio_output_pin_schema,
                 cv.GenerateID(): cv.declare_id(class_name),
                 cv.GenerateID(CONF_INIT_SEQUENCE_ID): cv.declare_id(cg.uint8),
                 cv_dimensions(CONF_DIMENSIONS): DIMENSION_SCHEMA,

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -76,47 +76,42 @@ def model_schema(config):
         model.get_default(CONF_MINIMUM_UPDATE_INTERVAL, "1s")
     )
     cv_dimensions = cv.Optional if model.get_default(CONF_WIDTH) else cv.Required
-    return (
-        display.FULL_DISPLAY_SCHEMA.extend(
-            spi.spi_device_schema(
-                cs_pin_required=False,
-                default_mode="MODE0",
-                default_data_rate=model.get_default(CONF_DATA_RATE, 10_000_000),
-            )
+    return display.FULL_DISPLAY_SCHEMA.extend(
+        spi.spi_device_schema(
+            cs_pin_required=False,
+            default_mode="MODE0",
+            default_data_rate=model.get_default(CONF_DATA_RATE, 10_000_000),
         )
-        .extend(
-            {
-                cv.Optional(CONF_ROTATION, default=0): validate_rotation,
-                cv.Required(CONF_MODEL): cv.one_of(model.name, upper=True),
-                cv.Optional(CONF_UPDATE_INTERVAL, default=cv.UNDEFINED): cv.All(
-                    update_interval, cv.Range(min=minimum_update_interval)
-                ),
-                cv.Optional(CONF_TRANSFORM): cv.Schema(
-                    {
-                        cv.Required(CONF_MIRROR_X): cv.boolean,
-                        cv.Required(CONF_MIRROR_Y): cv.boolean,
-                    }
-                ),
-                cv.Optional(CONF_FULL_UPDATE_EVERY, default=1): cv.int_range(1, 255),
-                model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
-                model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
-                model.option(CONF_DC_PIN, fallback=None): pins.gpio_output_pin_schema,
-                model.option(CONF_RESET_PIN): pins.gpio_output_pin_schema,
-                cv.GenerateID(): cv.declare_id(class_name),
-                cv.GenerateID(CONF_INIT_SEQUENCE_ID): cv.declare_id(cg.uint8),
-                cv_dimensions(CONF_DIMENSIONS): DIMENSION_SCHEMA,
-                model.option(CONF_ENABLE_PIN): cv.ensure_list(
-                    pins.gpio_output_pin_schema
-                ),
-                model.option(CONF_INIT_SEQUENCE, cv.UNDEFINED): cv.ensure_list(
-                    map_sequence
-                ),
-                model.option(CONF_RESET_DURATION, cv.UNDEFINED): cv.All(
-                    cv.positive_time_period_milliseconds,
-                    cv.Range(max=core.TimePeriod(milliseconds=500)),
-                ),
-            }
-        )
+    ).extend(
+        {
+            cv.Optional(CONF_ROTATION, default=0): validate_rotation,
+            cv.Required(CONF_MODEL): cv.one_of(model.name, upper=True),
+            cv.Optional(CONF_UPDATE_INTERVAL, default=cv.UNDEFINED): cv.All(
+                update_interval, cv.Range(min=minimum_update_interval)
+            ),
+            cv.Optional(CONF_TRANSFORM): cv.Schema(
+                {
+                    cv.Required(CONF_MIRROR_X): cv.boolean,
+                    cv.Required(CONF_MIRROR_Y): cv.boolean,
+                }
+            ),
+            cv.Optional(CONF_FULL_UPDATE_EVERY, default=1): cv.int_range(1, 255),
+            model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
+            model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
+            model.option(CONF_DC_PIN, fallback=None): pins.gpio_output_pin_schema,
+            model.option(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+            cv.GenerateID(): cv.declare_id(class_name),
+            cv.GenerateID(CONF_INIT_SEQUENCE_ID): cv.declare_id(cg.uint8),
+            cv_dimensions(CONF_DIMENSIONS): DIMENSION_SCHEMA,
+            model.option(CONF_ENABLE_PIN): cv.ensure_list(pins.gpio_output_pin_schema),
+            model.option(CONF_INIT_SEQUENCE, cv.UNDEFINED): cv.ensure_list(
+                map_sequence
+            ),
+            model.option(CONF_RESET_DURATION, cv.UNDEFINED): cv.All(
+                cv.positive_time_period_milliseconds,
+                cv.Range(max=core.TimePeriod(milliseconds=500)),
+            ),
+        }
     )
 
 

--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -86,8 +86,9 @@ def model_schema(config):
         )
         .extend(
             {
-                model.option(pin): pins.gpio_output_pin_schema
-                for pin in (CONF_RESET_PIN, CONF_CS_PIN, CONF_BUSY_PIN)
+                model.option(CONF_BUSY_PIN): pins.gpio_input_pin_schema,
+                model.option(CONF_CS_PIN): pins.gpio_output_pin_schema,
+                model.option(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             }
         )
         .extend(

--- a/tests/component_tests/epaper_spi/test_init.py
+++ b/tests/component_tests/epaper_spi/test_init.py
@@ -289,3 +289,56 @@ def test_model_with_full_update_every(
             "full_update_every": 10,
         }
     )
+
+
+def test_busy_pin_input_mode_ssd1677(
+    set_core_config: SetCoreConfigCallable,
+    set_component_config: Callable[[str, Any], None],
+) -> None:
+    """Test that busy_pin has input mode and cs/dc/reset pins have output mode for ssd1677."""
+    set_core_config(
+        PlatformFramework.ESP32_IDF,
+        platform_data={KEY_BOARD: "esp32dev", KEY_VARIANT: VARIANT_ESP32},
+    )
+
+    # Configure SPI component which is required by epaper_spi
+    set_component_config("spi", {"id": "spi_bus", "clk_pin": 18, "mosi_pin": 19})
+
+    result = run_schema_validation(
+        {
+            "id": "test_display",
+            "model": "ssd1677",
+            "dc_pin": 21,
+            "busy_pin": 22,
+            "reset_pin": 23,
+            "cs_pin": 5,
+            "dimensions": {
+                "width": 200,
+                "height": 200,
+            },
+        }
+    )
+
+    # Verify that busy_pin has input mode set
+    assert CONF_BUSY_PIN in result
+    busy_pin_config = result[CONF_BUSY_PIN]
+    assert "mode" in busy_pin_config
+    assert busy_pin_config["mode"]["input"] is True
+
+    # Verify that cs_pin has output mode set
+    assert CONF_CS_PIN in result
+    cs_pin_config = result[CONF_CS_PIN]
+    assert "mode" in cs_pin_config
+    assert cs_pin_config["mode"]["output"] is True
+
+    # Verify that dc_pin has output mode set
+    assert CONF_DC_PIN in result
+    dc_pin_config = result[CONF_DC_PIN]
+    assert "mode" in dc_pin_config
+    assert dc_pin_config["mode"]["output"] is True
+
+    # Verify that reset_pin has output mode set
+    assert CONF_RESET_PIN in result
+    reset_pin_config = result[CONF_RESET_PIN]
+    assert "mode" in reset_pin_config
+    assert reset_pin_config["mode"]["output"] is True


### PR DESCRIPTION
# What does this implement/fix?

`epaper_spi` validates and generated BUSY pin as output instead of input pin. In generated `main.cpp`, BUSY is also printed as `output: true`, e.g. like this with config snippet:

```C
  //   busy_pin:
  //     number: 19
  //     inverted: true
  //     mode:
  //       output: true
  //       input: false
  //       open_drain: false
  //       pullup: false
  //       pulldown: false
...
  esp32_esp32internalgpiopin_id_4->set_flags(gpio::Flags::FLAG_OUTPUT);
  display_epaper->set_busy_pin(esp32_esp32internalgpiopin_id_4);
```

This is unreasonable: In SPI display transfers the BUSY pin is input from MCU view.

When configuring the BUSY pin explicitly as input in YAML, it will be correct in generated output. However, this could be ensured by cv.

Former deprecated `waveshare_epaper` (path: esphome/components/waveshare_epaper/display.py) correctly validated BUSY as input. See e.g. https://github.com/esphome/esphome/blob/2025.12.5/esphome/components/waveshare_epaper/display.py#L210

Found while adding new `epaper_spi` board in esphome/esphome#13758.
As issue is separate from adding new feature, separate PR was created.

Debatable whether "Python breaking change".
But IMHO is does not break any documented Python or C++ public API, nor documentation:
https://esphome.io/components/display/epaper_spi/
Furthermore, fixing early avoids need to change later when `epaper_spi` gets wider deployed.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes  [discussions/3477](https://github.com/orgs/esphome/discussions/3477)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: epaper_spi
    model: Waveshare-1.54in-G   # whatever model

    cs_pin: GPIO06
    dc_pin: GPIO07
    reset_pin: GPIO18
    busy_pin:
      number: GPIO19
      inverted: true
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
