### PR TITLE
[web_server] Fix ESP8266 watchdog panic by deferring actions to main loop

### DIFF
--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -42,13 +42,12 @@ using ParamNameType = const __FlashStringHelper *;
 using ParamNameType = const char *;
 #endif
 
-// ESP8266 is single-threaded, so actions can execute directly in request context.
-// Multi-core platforms need to defer to main loop thread for thread safety.
-#ifdef USE_ESP8266
-#define DEFER_ACTION(capture, action) action
-#else
+// All platforms need to defer actions to main loop thread.
+// Multi-core platforms need this for thread safety.
+// ESP8266 needs this because ESPAsyncWebServer callbacks run in "sys" context
+// (SDK system context), not "cont" context (continuation/main loop). Calling
+// yield() from sys context causes a panic in the Arduino core.
 #define DEFER_ACTION(capture, action) this->defer([capture]() mutable { action; })
-#endif
 
 /// Result of matching a URL against an entity
 struct EntityMatchResult {


### PR DESCRIPTION
# What does this implement/fix?

Fix ESP8266 watchdog panic when triggering actions from `web_server` by always deferring action execution to the main loop.

The commit bbe11555 (PR #13261) incorrectly assumed that ESP8266 `ESPAsyncWebServer` callbacks run in the main loop context and could directly execute actions without deferring. This assumption was wrong.

On ESP8266, there are two execution contexts:
- **`cont`** (continuation) - normal user code (`loop()`, `setup()`)
- **`sys`** (system) - SDK callbacks, timers, interrupts

`ESPAsyncWebServer` callbacks run in **sys context**, not cont context. When code in sys context calls `yield()`, the Arduino core [explicitly panics](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_main.cpp#L190-L198):

```cpp
extern "C" void __yield() {
    if (cont_can_suspend(g_pcont)) {
        esp_schedule();
        esp_suspend_within_cont();
    } else {
        panic();  // Line 197 - what we're hitting!
    }
}
```

This caused crashes when:
- Pressing buttons that trigger UART operations (which use `yield()` in `check_read_timeout_()`)
- Pressing the restart button
- Any action that eventually calls `yield()`

The fix removes the ESP8266 special case and ensures all platforms defer actions to the main loop, which is the safe context for executing arbitrary user code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13681

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes a crash in the existing web_server component
esphome:
  name: esp8266-button-test

esp8266:
  board: esp01_1m

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

web_server:
  port: 80

button:
  - platform: restart
    name: "Test Restart Button"

  - platform: template
    name: "Test Button"
    on_press:
      then:
        - logger.log: "Button pressed from web_server without crashing!"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
