### PR TITLE
[rd03d] Revert incorrect field order swap

### DIFF
--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -132,18 +132,15 @@ void RD03DComponent::process_frame_() {
     // Header is 4 bytes, each target is 8 bytes
     uint8_t offset = FRAME_HEADER_SIZE + (i * TARGET_DATA_SIZE);
 
-    // Extract raw bytes for this target
-    // Note: Despite datasheet Table 5-2 showing order as X, Y, Speed, Resolution,
-    // actual radar output has Resolution before Speed (verified empirically -
-    // stationary targets were showing non-zero speed with original field order)
+    // Extract raw bytes for this target (per datasheet Table 5-2: X, Y, Speed, Resolution)
     uint8_t x_low = this->buffer_[offset + 0];
     uint8_t x_high = this->buffer_[offset + 1];
     uint8_t y_low = this->buffer_[offset + 2];
     uint8_t y_high = this->buffer_[offset + 3];
-    uint8_t res_low = this->buffer_[offset + 4];
-    uint8_t res_high = this->buffer_[offset + 5];
-    uint8_t speed_low = this->buffer_[offset + 6];
-    uint8_t speed_high = this->buffer_[offset + 7];
+    uint8_t speed_low = this->buffer_[offset + 4];
+    uint8_t speed_high = this->buffer_[offset + 5];
+    uint8_t res_low = this->buffer_[offset + 6];
+    uint8_t res_high = this->buffer_[offset + 7];
 
     // Decode values per RD-03D format
     int16_t x = decode_value(x_low, x_high);


### PR DESCRIPTION
## What does this implement/fix?

Reverts the incorrect speed/resolution field order swap from PR #13495. Testing confirmed the datasheet order (X, Y, Speed, Resolution at offsets 0-7) is correct. The swapped order caused constant incorrect speed readings (-3600 mm/s) regardless of actual target movement.

Note that this radar is not capable of detecting objects that are not moving-  this is definitely the correct field ordering and works properly on my radar.  I have conducted a walk test and the numbers are both reasonable and have the correct sign.

The change that was merged for the bug that https://github.com/Jamie-Howard-Maker reported seems to have broken it for me, on closer inspection, and they never replied to the issue thread, so I think this should get rolled back.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature (if applicable):**

- fixes #13484

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
uart:
  rx_pin: GPIO3
  baud_rate: 256000

rd03d:

sensor:
  - platform: rd03d
    target_1:
      x:
        name: "Target 1 X"
      y:
        name: "Target 1 Y"
      speed:
        name: "Target 1 Speed"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).