### PR TITLE
[epaper_spi] Refactor initialise for future use

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -115,7 +115,8 @@ class EPaperBase : public Display,
   bool is_idle_() const;
   void setup_pins_() const;
   virtual bool reset();
-  virtual void initialise(bool partial);
+  virtual bool initialise(bool partial);
+  void send_init_sequence_(const uint8_t *sequence, size_t length);
   void wait_for_idle_(bool should_wait);
   bool init_buffer_(size_t buffer_length);
   bool rotate_coordinates_(int &x, int &y);

--- a/esphome/components/epaper_spi/epaper_waveshare.cpp
+++ b/esphome/components/epaper_spi/epaper_waveshare.cpp
@@ -4,7 +4,7 @@ namespace esphome::epaper_spi {
 
 static const char *const TAG = "epaper_spi.waveshare";
 
-void EpaperWaveshare::initialise(bool partial) {
+bool EpaperWaveshare::initialise(bool partial) {
   EPaperBase::initialise(partial);
   if (partial) {
     this->cmd_data(0x32, this->partial_lut_, this->partial_lut_length_);
@@ -17,6 +17,7 @@ void EpaperWaveshare::initialise(bool partial) {
     this->cmd_data(0x3C, {0x05});
   }
   this->send_red_ = true;
+  return true;
 }
 
 void EpaperWaveshare::set_window() {

--- a/esphome/components/epaper_spi/epaper_waveshare.h
+++ b/esphome/components/epaper_spi/epaper_waveshare.h
@@ -18,7 +18,7 @@ class EpaperWaveshare : public EPaperMono {
         partial_lut_length_(partial_lut_length) {}
 
  protected:
-  void initialise(bool partial) override;
+  bool initialise(bool partial) override;
   void set_window() override;
   void refresh_screen(bool partial) override;
   void deep_sleep() override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

`EPaperBase` extensions:
- Allow subclasses to send own multiregister init sequences (e.g. fast init) without duplicating `EPaperBase` code
- Allow subclasses to perform multiple init state loops, resembling reset state,
  - to allow busy waiting
  - to avoid exceeding loop max time

No regression expected for existing models.
No user exposed change.

Refined init stepping+transfer shall be used by future model extensions, see e.g. #13758 for illustration. Latter was test base, i.e. not all other `epaper_spi` supported real hardware variants available locally.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Planned future feature PR #13758 to use this

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (nonpublic API)

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A: No regression on any existing model
```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing regression tests should still pass

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
    - No user exposed functionality nor configuration variables.