### PR TITLE
[esp32] Remove specific claims from framework migration message

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1169,8 +1169,8 @@ def _show_framework_migration_message(name: str, variant: str) -> None:
         + "(We've been warning about this change since ESPHome 2025.8.0)\n"
         + "\n"
         + "Why we made this change:\n"
-        + color(AnsiFore.GREEN, "  ✨ Up to 40% smaller firmware binaries\n")
-        + color(AnsiFore.GREEN, "  ⚡ 2-3x faster compile times\n")
+        + color(AnsiFore.GREEN, "  ✨ Smaller firmware binaries\n")
+        + color(AnsiFore.GREEN, "  ⚡ Faster compile times\n")
         + color(AnsiFore.GREEN, "  🚀 Better performance and newer features\n")
         + color(AnsiFore.GREEN, "  🔧 More actively maintained by ESPHome\n")
         + "\n"


### PR DESCRIPTION
## What does this implement/fix?

Removes specific "Up to 40%" and "2-3x faster" claims from the framework migration message as the differences between Arduino and ESP-IDF are now less significant.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (documentation, refactoring, dependency updates, etc.)

## Related esphome-docs PR

https://github.com/esphome/esphome-docs/pull/6036

🤖 Generated with [Claude Code](https://claude.ai/code)