### PR TITLE
[rdm6300] Add ID-20LA compatibility by skipping CR/LF bytes

### DIFF
--- a/esphome/components/rdm6300/rdm6300.cpp
+++ b/esphome/components/rdm6300/rdm6300.cpp
@@ -34,6 +34,8 @@ void rdm6300::RDM6300Component::loop() {
         this->buffer_[this->read_state_ / 2] += value;
       }
       this->read_state_++;
+    } else if (data == 0x0D || data == 0x0A) {
+      // Skip CR/LF bytes (ID-20LA compatibility)
     } else if (data != RDM6300_END_BYTE) {
       ESP_LOGW(TAG, "Invalid end byte from RDM6300!");
       this->read_state_ = RDM6300_STATE_WAITING_FOR_START;


### PR DESCRIPTION
# What does this implement/fix?

The ID-20LA RFID reader sends CR/LF (0x0D 0x0A) before the end byte (ETX), which was causing "Invalid end byte from RDM6300!" errors.

The ID-20LA format is:
- `0x02` (STX) - start byte
- 12 ASCII hex characters (data + checksum)
- `0x0D 0x0A` (CR/LF)
- `0x03` (ETX) - end byte

The fix skips CR/LF bytes when waiting for the end byte after reading the 12 data characters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13753

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  rx_pin: GPIO16
  baud_rate: 9600

rdm6300:

binary_sensor:
  - platform: rdm6300
    uid: 123456
    name: "RFID Tag"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).