### PR TITLE
[esp32] Use underscores in arduino_libs_stub folder name

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1467,7 +1467,7 @@ async def to_code(config):
                     [_format_framework_espidf_version(idf_ver, None)],
                 )
                 # Use stub package to skip downloading precompiled libs
-                stubs_dir = CORE.relative_build_path("arduino-libs-stub")
+                stubs_dir = CORE.relative_build_path("arduino_libs_stub")
                 cg.add_platformio_option(
                     "platform_packages", [f"{ARDUINO_LIBS_PKG}@file://{stubs_dir}"]
                 )


### PR DESCRIPTION
# What does this implement/fix?

Renames the Arduino libs stub directory from `arduino-libs-stub` to `arduino_libs_stub` for consistency with other build directory names in ESPHome (which use underscores rather than hyphens).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal build directory naming only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). (N/A - naming change only)

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)