### PR TITLE
[core] Convert entity string lookups to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/alarm_control_panel/alarm_control_panel_state.cpp
+++ b/esphome/components/alarm_control_panel/alarm_control_panel_state.cpp
@@ -1,32 +1,15 @@
 #include "alarm_control_panel_state.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::alarm_control_panel {
 
+// Alarm control panel state strings indexed by AlarmControlPanelState enum (0-9)
+PROGMEM_STRING_TABLE(AlarmControlPanelStateStrings, "DISARMED", "ARMED_HOME", "ARMED_AWAY", "ARMED_NIGHT",
+                     "ARMED_VACATION", "ARMED_CUSTOM_BYPASS", "PENDING", "ARMING", "DISARMING", "TRIGGERED", "UNKNOWN");
+
 const LogString *alarm_control_panel_state_to_string(AlarmControlPanelState state) {
-  switch (state) {
-    case ACP_STATE_DISARMED:
-      return LOG_STR("DISARMED");
-    case ACP_STATE_ARMED_HOME:
-      return LOG_STR("ARMED_HOME");
-    case ACP_STATE_ARMED_AWAY:
-      return LOG_STR("ARMED_AWAY");
-    case ACP_STATE_ARMED_NIGHT:
-      return LOG_STR("ARMED_NIGHT");
-    case ACP_STATE_ARMED_VACATION:
-      return LOG_STR("ARMED_VACATION");
-    case ACP_STATE_ARMED_CUSTOM_BYPASS:
-      return LOG_STR("ARMED_CUSTOM_BYPASS");
-    case ACP_STATE_PENDING:
-      return LOG_STR("PENDING");
-    case ACP_STATE_ARMING:
-      return LOG_STR("ARMING");
-    case ACP_STATE_DISARMING:
-      return LOG_STR("DISARMING");
-    case ACP_STATE_TRIGGERED:
-      return LOG_STR("TRIGGERED");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return AlarmControlPanelStateStrings::get_log_str(static_cast<uint8_t>(state),
+                                                    AlarmControlPanelStateStrings::LAST_INDEX);
 }
 
 }  // namespace esphome::alarm_control_panel

--- a/esphome/components/climate/climate_mode.cpp
+++ b/esphome/components/climate/climate_mode.cpp
@@ -1,109 +1,44 @@
 #include "climate_mode.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::climate {
 
+// Climate mode strings indexed by ClimateMode enum (0-6): OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY, DRY, AUTO
+PROGMEM_STRING_TABLE(ClimateModeStrings, "OFF", "HEAT_COOL", "COOL", "HEAT", "FAN_ONLY", "DRY", "AUTO", "UNKNOWN");
+
 const LogString *climate_mode_to_string(ClimateMode mode) {
-  switch (mode) {
-    case CLIMATE_MODE_OFF:
-      return LOG_STR("OFF");
-    case CLIMATE_MODE_HEAT_COOL:
-      return LOG_STR("HEAT_COOL");
-    case CLIMATE_MODE_AUTO:
-      return LOG_STR("AUTO");
-    case CLIMATE_MODE_COOL:
-      return LOG_STR("COOL");
-    case CLIMATE_MODE_HEAT:
-      return LOG_STR("HEAT");
-    case CLIMATE_MODE_FAN_ONLY:
-      return LOG_STR("FAN_ONLY");
-    case CLIMATE_MODE_DRY:
-      return LOG_STR("DRY");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return ClimateModeStrings::get_log_str(static_cast<uint8_t>(mode), ClimateModeStrings::LAST_INDEX);
 }
+
+// Climate action strings indexed by ClimateAction enum (0,2-6): OFF, (gap), COOLING, HEATING, IDLE, DRYING, FAN
+PROGMEM_STRING_TABLE(ClimateActionStrings, "OFF", "UNKNOWN", "COOLING", "HEATING", "IDLE", "DRYING", "FAN", "UNKNOWN");
+
 const LogString *climate_action_to_string(ClimateAction action) {
-  switch (action) {
-    case CLIMATE_ACTION_OFF:
-      return LOG_STR("OFF");
-    case CLIMATE_ACTION_COOLING:
-      return LOG_STR("COOLING");
-    case CLIMATE_ACTION_HEATING:
-      return LOG_STR("HEATING");
-    case CLIMATE_ACTION_IDLE:
-      return LOG_STR("IDLE");
-    case CLIMATE_ACTION_DRYING:
-      return LOG_STR("DRYING");
-    case CLIMATE_ACTION_FAN:
-      return LOG_STR("FAN");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return ClimateActionStrings::get_log_str(static_cast<uint8_t>(action), ClimateActionStrings::LAST_INDEX);
 }
+
+// Climate fan mode strings indexed by ClimateFanMode enum (0-9): ON, OFF, AUTO, LOW, MEDIUM, HIGH, MIDDLE, FOCUS,
+// DIFFUSE, QUIET
+PROGMEM_STRING_TABLE(ClimateFanModeStrings, "ON", "OFF", "AUTO", "LOW", "MEDIUM", "HIGH", "MIDDLE", "FOCUS", "DIFFUSE",
+                     "QUIET", "UNKNOWN");
 
 const LogString *climate_fan_mode_to_string(ClimateFanMode fan_mode) {
-  switch (fan_mode) {
-    case climate::CLIMATE_FAN_ON:
-      return LOG_STR("ON");
-    case climate::CLIMATE_FAN_OFF:
-      return LOG_STR("OFF");
-    case climate::CLIMATE_FAN_AUTO:
-      return LOG_STR("AUTO");
-    case climate::CLIMATE_FAN_LOW:
-      return LOG_STR("LOW");
-    case climate::CLIMATE_FAN_MEDIUM:
-      return LOG_STR("MEDIUM");
-    case climate::CLIMATE_FAN_HIGH:
-      return LOG_STR("HIGH");
-    case climate::CLIMATE_FAN_MIDDLE:
-      return LOG_STR("MIDDLE");
-    case climate::CLIMATE_FAN_FOCUS:
-      return LOG_STR("FOCUS");
-    case climate::CLIMATE_FAN_DIFFUSE:
-      return LOG_STR("DIFFUSE");
-    case climate::CLIMATE_FAN_QUIET:
-      return LOG_STR("QUIET");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return ClimateFanModeStrings::get_log_str(static_cast<uint8_t>(fan_mode), ClimateFanModeStrings::LAST_INDEX);
 }
+
+// Climate swing mode strings indexed by ClimateSwingMode enum (0-3): OFF, BOTH, VERTICAL, HORIZONTAL
+PROGMEM_STRING_TABLE(ClimateSwingModeStrings, "OFF", "BOTH", "VERTICAL", "HORIZONTAL", "UNKNOWN");
 
 const LogString *climate_swing_mode_to_string(ClimateSwingMode swing_mode) {
-  switch (swing_mode) {
-    case climate::CLIMATE_SWING_OFF:
-      return LOG_STR("OFF");
-    case climate::CLIMATE_SWING_BOTH:
-      return LOG_STR("BOTH");
-    case climate::CLIMATE_SWING_VERTICAL:
-      return LOG_STR("VERTICAL");
-    case climate::CLIMATE_SWING_HORIZONTAL:
-      return LOG_STR("HORIZONTAL");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return ClimateSwingModeStrings::get_log_str(static_cast<uint8_t>(swing_mode), ClimateSwingModeStrings::LAST_INDEX);
 }
 
+// Climate preset strings indexed by ClimatePreset enum (0-7): NONE, HOME, AWAY, BOOST, COMFORT, ECO, SLEEP, ACTIVITY
+PROGMEM_STRING_TABLE(ClimatePresetStrings, "NONE", "HOME", "AWAY", "BOOST", "COMFORT", "ECO", "SLEEP", "ACTIVITY",
+                     "UNKNOWN");
+
 const LogString *climate_preset_to_string(ClimatePreset preset) {
-  switch (preset) {
-    case climate::CLIMATE_PRESET_NONE:
-      return LOG_STR("NONE");
-    case climate::CLIMATE_PRESET_HOME:
-      return LOG_STR("HOME");
-    case climate::CLIMATE_PRESET_ECO:
-      return LOG_STR("ECO");
-    case climate::CLIMATE_PRESET_AWAY:
-      return LOG_STR("AWAY");
-    case climate::CLIMATE_PRESET_BOOST:
-      return LOG_STR("BOOST");
-    case climate::CLIMATE_PRESET_COMFORT:
-      return LOG_STR("COMFORT");
-    case climate::CLIMATE_PRESET_SLEEP:
-      return LOG_STR("SLEEP");
-    case climate::CLIMATE_PRESET_ACTIVITY:
-      return LOG_STR("ACTIVITY");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return ClimatePresetStrings::get_log_str(static_cast<uint8_t>(preset), ClimatePresetStrings::LAST_INDEX);
 }
 
 }  // namespace esphome::climate

--- a/esphome/components/fan/fan.cpp
+++ b/esphome/components/fan/fan.cpp
@@ -2,21 +2,18 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome {
 namespace fan {
 
 static const char *const TAG = "fan";
 
+// Fan direction strings indexed by FanDirection enum (0-1): FORWARD, REVERSE, plus UNKNOWN
+PROGMEM_STRING_TABLE(FanDirectionStrings, "FORWARD", "REVERSE", "UNKNOWN");
+
 const LogString *fan_direction_to_string(FanDirection direction) {
-  switch (direction) {
-    case FanDirection::FORWARD:
-      return LOG_STR("FORWARD");
-    case FanDirection::REVERSE:
-      return LOG_STR("REVERSE");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return FanDirectionStrings::get_log_str(static_cast<uint8_t>(direction), FanDirectionStrings::LAST_INDEX);
 }
 
 FanCall &FanCall::set_preset_mode(const std::string &preset_mode) {

--- a/esphome/components/lock/lock.cpp
+++ b/esphome/components/lock/lock.cpp
@@ -8,22 +8,11 @@ namespace esphome::lock {
 
 static const char *const TAG = "lock";
 
+// Lock state strings indexed by LockState enum (0-5): NONE(UNKNOWN), LOCKED, UNLOCKED, JAMMED, LOCKING, UNLOCKING
+PROGMEM_STRING_TABLE(LockStateStrings, "UNKNOWN", "LOCKED", "UNLOCKED", "JAMMED", "LOCKING", "UNLOCKING", "UNKNOWN");
+
 const LogString *lock_state_to_string(LockState state) {
-  switch (state) {
-    case LOCK_STATE_LOCKED:
-      return LOG_STR("LOCKED");
-    case LOCK_STATE_UNLOCKED:
-      return LOG_STR("UNLOCKED");
-    case LOCK_STATE_JAMMED:
-      return LOG_STR("JAMMED");
-    case LOCK_STATE_LOCKING:
-      return LOG_STR("LOCKING");
-    case LOCK_STATE_UNLOCKING:
-      return LOG_STR("UNLOCKING");
-    case LOCK_STATE_NONE:
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return LockStateStrings::get_log_str(static_cast<uint8_t>(state), LockStateStrings::LAST_INDEX);
 }
 
 Lock::Lock() : state(LOCK_STATE_NONE) {}

--- a/esphome/components/lock/lock.cpp
+++ b/esphome/components/lock/lock.cpp
@@ -9,10 +9,11 @@ namespace esphome::lock {
 static const char *const TAG = "lock";
 
 // Lock state strings indexed by LockState enum (0-5): NONE(UNKNOWN), LOCKED, UNLOCKED, JAMMED, LOCKING, UNLOCKING
-PROGMEM_STRING_TABLE(LockStateStrings, "UNKNOWN", "LOCKED", "UNLOCKED", "JAMMED", "LOCKING", "UNLOCKING", "UNKNOWN");
+// Index 0 is UNKNOWN (for LOCK_STATE_NONE), also used as fallback for out-of-range
+PROGMEM_STRING_TABLE(LockStateStrings, "UNKNOWN", "LOCKED", "UNLOCKED", "JAMMED", "LOCKING", "UNLOCKING");
 
 const LogString *lock_state_to_string(LockState state) {
-  return LockStateStrings::get_log_str(static_cast<uint8_t>(state), LockStateStrings::LAST_INDEX);
+  return LockStateStrings::get_log_str(static_cast<uint8_t>(state), 0);
 }
 
 Lock::Lock() : state(LOCK_STATE_NONE) {}

--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -233,25 +233,13 @@ void WaterHeater::set_visual_target_temperature_step_override(float visual_targe
 }
 #endif
 
+// Water heater mode strings indexed by WaterHeaterMode enum (0-6): OFF, ECO, ELECTRIC, PERFORMANCE, HIGH_DEMAND,
+// HEAT_PUMP, GAS
+PROGMEM_STRING_TABLE(WaterHeaterModeStrings, "OFF", "ECO", "ELECTRIC", "PERFORMANCE", "HIGH_DEMAND", "HEAT_PUMP", "GAS",
+                     "UNKNOWN");
+
 const LogString *water_heater_mode_to_string(WaterHeaterMode mode) {
-  switch (mode) {
-    case WATER_HEATER_MODE_OFF:
-      return LOG_STR("OFF");
-    case WATER_HEATER_MODE_ECO:
-      return LOG_STR("ECO");
-    case WATER_HEATER_MODE_ELECTRIC:
-      return LOG_STR("ELECTRIC");
-    case WATER_HEATER_MODE_PERFORMANCE:
-      return LOG_STR("PERFORMANCE");
-    case WATER_HEATER_MODE_HIGH_DEMAND:
-      return LOG_STR("HIGH_DEMAND");
-    case WATER_HEATER_MODE_HEAT_PUMP:
-      return LOG_STR("HEAT_PUMP");
-    case WATER_HEATER_MODE_GAS:
-      return LOG_STR("GAS");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return WaterHeaterModeStrings::get_log_str(static_cast<uint8_t>(mode), WaterHeaterModeStrings::LAST_INDEX);
 }
 
 void WaterHeater::dump_traits_(const char *tag) {


### PR DESCRIPTION
# What does this implement/fix?

Converts entity string lookup functions from switch statements to `PROGMEM_STRING_TABLE`, following the pattern established in #13659. This eliminates compiler-generated CSWTCH jump tables from RAM on ESP8266.

## Converted functions

1. **`lock/lock.cpp`**: `lock_state_to_string()` — 6 states (NONE maps to UNKNOWN at index 0)
2. **`alarm_control_panel/alarm_control_panel_state.cpp`**: `alarm_control_panel_state_to_string()` — 10 states
3. **`fan/fan.cpp`**: `fan_direction_to_string()` — 2 directions
4. **`water_heater/water_heater.cpp`**: `water_heater_mode_to_string()` — 7 modes
5. **`climate/climate_mode.cpp`**: 5 functions:
   - `climate_mode_to_string()` — 7 modes
   - `climate_action_to_string()` — 7 values (with placeholder at index 1 for enum gap)
   - `climate_fan_mode_to_string()` — 10 fan modes
   - `climate_swing_mode_to_string()` — 4 swing modes
   - `climate_preset_to_string()` — 8 presets

All tables include an "UNKNOWN" fallback as the last entry, used via `LAST_INDEX` for out-of-range values.

### Note on ClimateAction

The `ClimateAction` enum has a gap at value 1 (values are 0, 2, 3, 4, 5, 6 — matching `ClimateMode` values). An "UNKNOWN" placeholder is inserted at index 1 to maintain correct index-based lookup.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13659 (`PROGMEM_STRING_TABLE` macro)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, not user-facing)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using climate, lock, fan, alarm_control_panel, or water_heater benefits automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal API only
