### PR TITLE
[gpio] Convert interrupt_type_to_string to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
@@ -1,5 +1,6 @@
 #include "gpio_binary_sensor.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome {
 namespace gpio {
@@ -7,17 +8,12 @@ namespace gpio {
 static const char *const TAG = "gpio.binary_sensor";
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+// Interrupt type strings indexed by InterruptType enum (1-3): RISING_EDGE, FALLING_EDGE, ANY_EDGE
+// Index 0 is a placeholder (no enum value 0), also used as fallback for out-of-range
+PROGMEM_STRING_TABLE(InterruptTypeStrings, "UNKNOWN", "RISING_EDGE", "FALLING_EDGE", "ANY_EDGE");
+
 static const LogString *interrupt_type_to_string(gpio::InterruptType type) {
-  switch (type) {
-    case gpio::INTERRUPT_RISING_EDGE:
-      return LOG_STR("RISING_EDGE");
-    case gpio::INTERRUPT_FALLING_EDGE:
-      return LOG_STR("FALLING_EDGE");
-    case gpio::INTERRUPT_ANY_EDGE:
-      return LOG_STR("ANY_EDGE");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return InterruptTypeStrings::get_log_str(static_cast<uint8_t>(type), 0);
 }
 
 static const LogString *gpio_mode_to_string(bool use_interrupt) {

--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.cpp
@@ -8,8 +8,8 @@ namespace gpio {
 static const char *const TAG = "gpio.binary_sensor";
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
-// Interrupt type strings indexed by InterruptType enum (1-3): RISING_EDGE, FALLING_EDGE, ANY_EDGE
-// Index 0 is a placeholder (no enum value 0), also used as fallback for out-of-range
+// Interrupt type strings indexed by edge-triggered InterruptType values:
+// indices 1-3: RISING_EDGE, FALLING_EDGE, ANY_EDGE; other values (e.g. level-triggered) map to UNKNOWN (index 0).
 PROGMEM_STRING_TABLE(InterruptTypeStrings, "UNKNOWN", "RISING_EDGE", "FALLING_EDGE", "ANY_EDGE");
 
 static const LogString *interrupt_type_to_string(gpio::InterruptType type) {


### PR DESCRIPTION
# What does this implement/fix?

Converts `interrupt_type_to_string()` in `gpio_binary_sensor.cpp` from a switch statement to `PROGMEM_STRING_TABLE`, following the pattern established in #13659. This eliminates the compiler-generated CSWTCH jump table from RAM on ESP8266.

The `InterruptType` enum starts at 1 (not 0), so index 0 serves as both a placeholder and the out-of-range fallback ("UNKNOWN").

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13659 (`PROGMEM_STRING_TABLE` macro)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, not user-facing)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using gpio binary_sensor with interrupt mode benefits automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal API only
