### PR TITLE
[update] Move update_state_to_string to update component and convert to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/update/update_entity.cpp
+++ b/esphome/components/update/update_entity.cpp
@@ -2,11 +2,19 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome {
 namespace update {
 
 static const char *const TAG = "update";
+
+// Update state strings indexed by UpdateState enum (0-3): UNKNOWN, NO UPDATE, UPDATE AVAILABLE, INSTALLING
+PROGMEM_STRING_TABLE(UpdateStateStrings, "UNKNOWN", "NO UPDATE", "UPDATE AVAILABLE", "INSTALLING");
+
+const LogString *update_state_to_string(UpdateState state) {
+  return UpdateStateStrings::get_log_str(static_cast<uint8_t>(state), 0);
+}
 
 void UpdateEntity::publish_state() {
   ESP_LOGD(TAG,

--- a/esphome/components/update/update_entity.cpp
+++ b/esphome/components/update/update_entity.cpp
@@ -13,7 +13,8 @@ static const char *const TAG = "update";
 PROGMEM_STRING_TABLE(UpdateStateStrings, "UNKNOWN", "NO UPDATE", "UPDATE AVAILABLE", "INSTALLING");
 
 const LogString *update_state_to_string(UpdateState state) {
-  return UpdateStateStrings::get_log_str(static_cast<uint8_t>(state), 0);
+  return UpdateStateStrings::get_log_str(static_cast<uint8_t>(state),
+                                         static_cast<uint8_t>(UpdateState::UPDATE_STATE_UNKNOWN));
 }
 
 void UpdateEntity::publish_state() {

--- a/esphome/components/update/update_entity.h
+++ b/esphome/components/update/update_entity.h
@@ -27,6 +27,8 @@ enum UpdateState : uint8_t {
   UPDATE_STATE_INSTALLING,
 };
 
+const LogString *update_state_to_string(UpdateState state);
+
 class UpdateEntity : public EntityBase, public EntityBase_DeviceClass {
  public:
   void publish_state();

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -29,6 +29,10 @@
 #include "esphome/components/climate/climate.h"
 #endif
 
+#ifdef USE_UPDATE
+#include "esphome/components/update/update_entity.h"
+#endif
+
 #ifdef USE_WATER_HEATER
 #include "esphome/components/water_heater/water_heater.h"
 #endif
@@ -2104,19 +2108,6 @@ std::string WebServer::event_json_(event::Event *obj, StringRef event_type, Json
 #endif
 
 #ifdef USE_UPDATE
-static const LogString *update_state_to_string(update::UpdateState state) {
-  switch (state) {
-    case update::UPDATE_STATE_NO_UPDATE:
-      return LOG_STR("NO UPDATE");
-    case update::UPDATE_STATE_AVAILABLE:
-      return LOG_STR("UPDATE AVAILABLE");
-    case update::UPDATE_STATE_INSTALLING:
-      return LOG_STR("INSTALLING");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
-}
-
 void WebServer::on_update(update::UpdateEntity *obj) {
   this->events_.deferrable_send_state(obj, "state", update_state_json_generator);
 }
@@ -2158,7 +2149,7 @@ std::string WebServer::update_json_(update::UpdateEntity *obj, JsonDetail start_
   JsonObject root = builder.root();
 
   char buf[PSTR_LOCAL_SIZE];
-  set_json_icon_state_value(root, obj, "update", PSTR_LOCAL(update_state_to_string(obj->state)),
+  set_json_icon_state_value(root, obj, "update", PSTR_LOCAL(update::update_state_to_string(obj->state)),
                             obj->update_info.latest_version, start_config);
   if (start_config == DETAIL_ALL) {
     root[ESPHOME_F("current_version")] = obj->update_info.current_version;


### PR DESCRIPTION
# What does this implement/fix?

Moves `update_state_to_string()` from a local `static` function in `web_server.cpp` to the `update` component where the `UpdateState` enum is defined, and converts it to use `PROGMEM_STRING_TABLE` following the pattern from #13659.

## Changes

1. **`update/update_entity.h`**: Added `update_state_to_string()` declaration next to the `UpdateState` enum
2. **`update/update_entity.cpp`**: Added `PROGMEM_STRING_TABLE` definition and function implementation. `UPDATE_STATE_UNKNOWN` at index 0 doubles as the out-of-range fallback
3. **`web_server/web_server.cpp`**: Removed the local `static` copy, added `#include "update_entity.h"`, qualified call as `update::update_state_to_string()`

This makes the string conversion available to any component that needs it, not just the web server.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13659 (`PROGMEM_STRING_TABLE` macro)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, not user-facing)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using update + web_server benefits automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal API only
