### PR TITLE
[light] Convert color_mode_to_human to PROGMEM_STRING_TABLE using to_bit()

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -4,6 +4,7 @@
 #include "light_state.h"
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::light {
 
@@ -51,26 +52,13 @@ static void log_invalid_parameter(const char *name, const LogString *message) {
     return *this; \
   }
 
+// Color mode human-readable strings indexed by ColorModeBitPolicy::to_bit() (0-9)
+// Index 0 is Unknown (for ColorMode::UNKNOWN), also used as fallback for out-of-range
+PROGMEM_STRING_TABLE(ColorModeHumanStrings, "Unknown", "On/Off", "Brightness", "White", "Color temperature",
+                     "Cold/warm white", "RGB", "RGBW", "RGB + color temperature", "RGB + cold/warm white");
+
 static const LogString *color_mode_to_human(ColorMode color_mode) {
-  if (color_mode == ColorMode::ON_OFF)
-    return LOG_STR("On/Off");
-  if (color_mode == ColorMode::BRIGHTNESS)
-    return LOG_STR("Brightness");
-  if (color_mode == ColorMode::WHITE)
-    return LOG_STR("White");
-  if (color_mode == ColorMode::COLOR_TEMPERATURE)
-    return LOG_STR("Color temperature");
-  if (color_mode == ColorMode::COLD_WARM_WHITE)
-    return LOG_STR("Cold/warm white");
-  if (color_mode == ColorMode::RGB)
-    return LOG_STR("RGB");
-  if (color_mode == ColorMode::RGB_WHITE)
-    return LOG_STR("RGBW");
-  if (color_mode == ColorMode::RGB_COLD_WARM_WHITE)
-    return LOG_STR("RGB + cold/warm white");
-  if (color_mode == ColorMode::RGB_COLOR_TEMPERATURE)
-    return LOG_STR("RGB + color temperature");
-  return LOG_STR("Unknown");
+  return ColorModeHumanStrings::get_log_str(ColorModeBitPolicy::to_bit(color_mode), 0);
 }
 
 // Helper to log percentage values


### PR DESCRIPTION
# What does this implement/fix?

Converts `color_mode_to_human()` in `light_call.cpp` from a chain of if-statements to `PROGMEM_STRING_TABLE`, using the existing `ColorModeBitPolicy::to_bit()` to map non-contiguous bitmask `ColorMode` values to contiguous indices.

This was previously considered not viable because `ColorMode` values are bitmask combinations (e.g., `ON_OFF=0x01`, `BRIGHTNESS=0x03`, `RGB_WHITE=0x27`), but `to_bit()` already provides a compact mapping to indices 0-9 and is used by `light_json_schema.cpp` for the same purpose.

## Changes

- **`light/light_call.cpp`**: Replaced 10-branch if-chain with `PROGMEM_STRING_TABLE` + `ColorModeBitPolicy::to_bit()` lookup. Index 0 ("Unknown") serves as both the `ColorMode::UNKNOWN` value and the out-of-range fallback.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13659 (`PROGMEM_STRING_TABLE` macro)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, not user-facing)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization
# Any config using light benefits automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - Internal API only
