### PR TITLE
[mqtt] Move switch string tables to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
+++ b/esphome/components/mqtt/mqtt_alarm_control_panel.cpp
@@ -13,31 +13,12 @@ static const char *const TAG = "mqtt.alarm_control_panel";
 
 using namespace esphome::alarm_control_panel;
 
+// Alarm state MQTT strings indexed by AlarmControlPanelState enum (0-9)
+PROGMEM_STRING_TABLE(AlarmMqttStateStrings, "disarmed", "armed_home", "armed_away", "armed_night", "armed_vacation",
+                     "armed_custom_bypass", "pending", "arming", "disarming", "triggered", "unknown");
+
 static ProgmemStr alarm_state_to_mqtt_str(AlarmControlPanelState state) {
-  switch (state) {
-    case ACP_STATE_DISARMED:
-      return ESPHOME_F("disarmed");
-    case ACP_STATE_ARMED_HOME:
-      return ESPHOME_F("armed_home");
-    case ACP_STATE_ARMED_AWAY:
-      return ESPHOME_F("armed_away");
-    case ACP_STATE_ARMED_NIGHT:
-      return ESPHOME_F("armed_night");
-    case ACP_STATE_ARMED_VACATION:
-      return ESPHOME_F("armed_vacation");
-    case ACP_STATE_ARMED_CUSTOM_BYPASS:
-      return ESPHOME_F("armed_custom_bypass");
-    case ACP_STATE_PENDING:
-      return ESPHOME_F("pending");
-    case ACP_STATE_ARMING:
-      return ESPHOME_F("arming");
-    case ACP_STATE_DISARMING:
-      return ESPHOME_F("disarming");
-    case ACP_STATE_TRIGGERED:
-      return ESPHOME_F("triggered");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return AlarmMqttStateStrings::get_progmem_str(static_cast<uint8_t>(state), AlarmMqttStateStrings::LAST_INDEX);
 }
 
 MQTTAlarmControlPanelComponent::MQTTAlarmControlPanelComponent(AlarmControlPanel *alarm_control_panel)

--- a/esphome/components/mqtt/mqtt_climate.cpp
+++ b/esphome/components/mqtt/mqtt_climate.cpp
@@ -13,109 +13,44 @@ static const char *const TAG = "mqtt.climate";
 
 using namespace esphome::climate;
 
+// Climate mode MQTT strings indexed by ClimateMode enum (0-6): OFF, HEAT_COOL, COOL, HEAT, FAN_ONLY, DRY, AUTO
+PROGMEM_STRING_TABLE(ClimateMqttModeStrings, "off", "heat_cool", "cool", "heat", "fan_only", "dry", "auto", "unknown");
+
 static ProgmemStr climate_mode_to_mqtt_str(ClimateMode mode) {
-  switch (mode) {
-    case CLIMATE_MODE_OFF:
-      return ESPHOME_F("off");
-    case CLIMATE_MODE_HEAT_COOL:
-      return ESPHOME_F("heat_cool");
-    case CLIMATE_MODE_AUTO:
-      return ESPHOME_F("auto");
-    case CLIMATE_MODE_COOL:
-      return ESPHOME_F("cool");
-    case CLIMATE_MODE_HEAT:
-      return ESPHOME_F("heat");
-    case CLIMATE_MODE_FAN_ONLY:
-      return ESPHOME_F("fan_only");
-    case CLIMATE_MODE_DRY:
-      return ESPHOME_F("dry");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return ClimateMqttModeStrings::get_progmem_str(static_cast<uint8_t>(mode), ClimateMqttModeStrings::LAST_INDEX);
 }
+
+// Climate action MQTT strings indexed by ClimateAction enum (0,2-6): OFF, (gap), COOLING, HEATING, IDLE, DRYING, FAN
+PROGMEM_STRING_TABLE(ClimateMqttActionStrings, "off", "unknown", "cooling", "heating", "idle", "drying", "fan",
+                     "unknown");
 
 static ProgmemStr climate_action_to_mqtt_str(ClimateAction action) {
-  switch (action) {
-    case CLIMATE_ACTION_OFF:
-      return ESPHOME_F("off");
-    case CLIMATE_ACTION_COOLING:
-      return ESPHOME_F("cooling");
-    case CLIMATE_ACTION_HEATING:
-      return ESPHOME_F("heating");
-    case CLIMATE_ACTION_IDLE:
-      return ESPHOME_F("idle");
-    case CLIMATE_ACTION_DRYING:
-      return ESPHOME_F("drying");
-    case CLIMATE_ACTION_FAN:
-      return ESPHOME_F("fan");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return ClimateMqttActionStrings::get_progmem_str(static_cast<uint8_t>(action), ClimateMqttActionStrings::LAST_INDEX);
 }
+
+// Climate fan mode MQTT strings indexed by ClimateFanMode enum (0-9)
+PROGMEM_STRING_TABLE(ClimateMqttFanModeStrings, "on", "off", "auto", "low", "medium", "high", "middle", "focus",
+                     "diffuse", "quiet", "unknown");
 
 static ProgmemStr climate_fan_mode_to_mqtt_str(ClimateFanMode fan_mode) {
-  switch (fan_mode) {
-    case CLIMATE_FAN_ON:
-      return ESPHOME_F("on");
-    case CLIMATE_FAN_OFF:
-      return ESPHOME_F("off");
-    case CLIMATE_FAN_AUTO:
-      return ESPHOME_F("auto");
-    case CLIMATE_FAN_LOW:
-      return ESPHOME_F("low");
-    case CLIMATE_FAN_MEDIUM:
-      return ESPHOME_F("medium");
-    case CLIMATE_FAN_HIGH:
-      return ESPHOME_F("high");
-    case CLIMATE_FAN_MIDDLE:
-      return ESPHOME_F("middle");
-    case CLIMATE_FAN_FOCUS:
-      return ESPHOME_F("focus");
-    case CLIMATE_FAN_DIFFUSE:
-      return ESPHOME_F("diffuse");
-    case CLIMATE_FAN_QUIET:
-      return ESPHOME_F("quiet");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return ClimateMqttFanModeStrings::get_progmem_str(static_cast<uint8_t>(fan_mode),
+                                                    ClimateMqttFanModeStrings::LAST_INDEX);
 }
+
+// Climate swing mode MQTT strings indexed by ClimateSwingMode enum (0-3): OFF, BOTH, VERTICAL, HORIZONTAL
+PROGMEM_STRING_TABLE(ClimateMqttSwingModeStrings, "off", "both", "vertical", "horizontal", "unknown");
 
 static ProgmemStr climate_swing_mode_to_mqtt_str(ClimateSwingMode swing_mode) {
-  switch (swing_mode) {
-    case CLIMATE_SWING_OFF:
-      return ESPHOME_F("off");
-    case CLIMATE_SWING_BOTH:
-      return ESPHOME_F("both");
-    case CLIMATE_SWING_VERTICAL:
-      return ESPHOME_F("vertical");
-    case CLIMATE_SWING_HORIZONTAL:
-      return ESPHOME_F("horizontal");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return ClimateMqttSwingModeStrings::get_progmem_str(static_cast<uint8_t>(swing_mode),
+                                                      ClimateMqttSwingModeStrings::LAST_INDEX);
 }
 
+// Climate preset MQTT strings indexed by ClimatePreset enum (0-7)
+PROGMEM_STRING_TABLE(ClimateMqttPresetStrings, "none", "home", "away", "boost", "comfort", "eco", "sleep", "activity",
+                     "unknown");
+
 static ProgmemStr climate_preset_to_mqtt_str(ClimatePreset preset) {
-  switch (preset) {
-    case CLIMATE_PRESET_NONE:
-      return ESPHOME_F("none");
-    case CLIMATE_PRESET_HOME:
-      return ESPHOME_F("home");
-    case CLIMATE_PRESET_ECO:
-      return ESPHOME_F("eco");
-    case CLIMATE_PRESET_AWAY:
-      return ESPHOME_F("away");
-    case CLIMATE_PRESET_BOOST:
-      return ESPHOME_F("boost");
-    case CLIMATE_PRESET_COMFORT:
-      return ESPHOME_F("comfort");
-    case CLIMATE_PRESET_SLEEP:
-      return ESPHOME_F("sleep");
-    case CLIMATE_PRESET_ACTIVITY:
-      return ESPHOME_F("activity");
-    default:
-      return ESPHOME_F("unknown");
-  }
+  return ClimateMqttPresetStrings::get_progmem_str(static_cast<uint8_t>(preset), ClimateMqttPresetStrings::LAST_INDEX);
 }
 
 void MQTTClimateComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -14,6 +14,9 @@ namespace esphome::mqtt {
 
 static const char *const TAG = "mqtt.component";
 
+// Entity category MQTT strings indexed by EntityCategory enum: NONE(0) is skipped, CONFIG(1), DIAGNOSTIC(2)
+PROGMEM_STRING_TABLE(EntityCategoryMqttStrings, "", "config", "diagnostic");
+
 // Helper functions for building topic strings on stack
 inline char *append_str(char *p, const char *s, size_t len) {
   memcpy(p, s, len);
@@ -213,13 +216,9 @@ bool MQTTComponent::send_discovery_() {
         // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
         const auto entity_category = this->get_entity()->get_entity_category();
-        switch (entity_category) {
-          case ENTITY_CATEGORY_NONE:
-            break;
-          case ENTITY_CATEGORY_CONFIG:
-          case ENTITY_CATEGORY_DIAGNOSTIC:
-            root[MQTT_ENTITY_CATEGORY] = entity_category == ENTITY_CATEGORY_CONFIG ? "config" : "diagnostic";
-            break;
+        if (entity_category != ENTITY_CATEGORY_NONE) {
+          root[MQTT_ENTITY_CATEGORY] =
+              EntityCategoryMqttStrings::get_progmem_str(static_cast<uint8_t>(entity_category), 1);
         }
 
         if (config.state_topic) {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -218,7 +218,9 @@ bool MQTTComponent::send_discovery_() {
         const auto entity_category = this->get_entity()->get_entity_category();
         if (entity_category != ENTITY_CATEGORY_NONE) {
           root[MQTT_ENTITY_CATEGORY] =
-              EntityCategoryMqttStrings::get_progmem_str(static_cast<uint8_t>(entity_category), 1);
+              EntityCategoryMqttStrings::get_progmem_str(
+                  static_cast<uint8_t>(entity_category),
+                  static_cast<uint8_t>(ENTITY_CATEGORY_CONFIG));
         }
 
         if (config.state_topic) {

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -217,10 +217,8 @@ bool MQTTComponent::send_discovery_() {
 
         const auto entity_category = this->get_entity()->get_entity_category();
         if (entity_category != ENTITY_CATEGORY_NONE) {
-          root[MQTT_ENTITY_CATEGORY] =
-              EntityCategoryMqttStrings::get_progmem_str(
-                  static_cast<uint8_t>(entity_category),
-                  static_cast<uint8_t>(ENTITY_CATEGORY_CONFIG));
+          root[MQTT_ENTITY_CATEGORY] = EntityCategoryMqttStrings::get_progmem_str(
+              static_cast<uint8_t>(entity_category), static_cast<uint8_t>(ENTITY_CATEGORY_CONFIG));
         }
 
         if (config.state_topic) {

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -54,7 +54,8 @@ void MQTTNumberComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
   }
   const auto mode = this->number_->traits.get_mode();
   if (mode != NUMBER_MODE_AUTO) {
-    root[MQTT_MODE] = NumberMqttModeStrings::get_progmem_str(static_cast<uint8_t>(mode), 1);
+    root[MQTT_MODE] = NumberMqttModeStrings::get_progmem_str(
+        static_cast<uint8_t>(mode), static_cast<uint8_t>(NUMBER_MODE_BOX));
   }
   const auto device_class = this->number_->traits.get_device_class_ref();
   if (!device_class.empty()) {

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -1,5 +1,6 @@
 #include "mqtt_number.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 #include "mqtt_const.h"
 
@@ -11,6 +12,9 @@ namespace esphome::mqtt {
 static const char *const TAG = "mqtt.number";
 
 using namespace esphome::number;
+
+// Number mode MQTT strings indexed by NumberMode enum: AUTO(0) is skipped, BOX(1), SLIDER(2)
+PROGMEM_STRING_TABLE(NumberMqttModeStrings, "", "box", "slider");
 
 MQTTNumberComponent::MQTTNumberComponent(Number *number) : number_(number) {}
 
@@ -48,15 +52,9 @@ void MQTTNumberComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
   if (!unit_of_measurement.empty()) {
     root[MQTT_UNIT_OF_MEASUREMENT] = unit_of_measurement;
   }
-  switch (this->number_->traits.get_mode()) {
-    case NUMBER_MODE_AUTO:
-      break;
-    case NUMBER_MODE_BOX:
-      root[MQTT_MODE] = "box";
-      break;
-    case NUMBER_MODE_SLIDER:
-      root[MQTT_MODE] = "slider";
-      break;
+  const auto mode = this->number_->traits.get_mode();
+  if (mode != NUMBER_MODE_AUTO) {
+    root[MQTT_MODE] = NumberMqttModeStrings::get_progmem_str(static_cast<uint8_t>(mode), 1);
   }
   const auto device_class = this->number_->traits.get_device_class_ref();
   if (!device_class.empty()) {

--- a/esphome/components/mqtt/mqtt_number.cpp
+++ b/esphome/components/mqtt/mqtt_number.cpp
@@ -54,8 +54,8 @@ void MQTTNumberComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
   }
   const auto mode = this->number_->traits.get_mode();
   if (mode != NUMBER_MODE_AUTO) {
-    root[MQTT_MODE] = NumberMqttModeStrings::get_progmem_str(
-        static_cast<uint8_t>(mode), static_cast<uint8_t>(NUMBER_MODE_BOX));
+    root[MQTT_MODE] =
+        NumberMqttModeStrings::get_progmem_str(static_cast<uint8_t>(mode), static_cast<uint8_t>(NUMBER_MODE_BOX));
   }
   const auto device_class = this->number_->traits.get_device_class_ref();
   if (!device_class.empty()) {

--- a/esphome/components/mqtt/mqtt_text.cpp
+++ b/esphome/components/mqtt/mqtt_text.cpp
@@ -38,7 +38,9 @@ const EntityBase *MQTTTextComponent::get_entity() const { return this->text_; }
 
 void MQTTTextComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
-  root[MQTT_MODE] = TextMqttModeStrings::get_progmem_str(static_cast<uint8_t>(this->text_->traits.get_mode()), 0);
+  root[MQTT_MODE] = TextMqttModeStrings::get_progmem_str(
+      static_cast<uint8_t>(this->text_->traits.get_mode()),
+      static_cast<uint8_t>(TEXT_MODE_TEXT));
 
   config.command_topic = true;
 }

--- a/esphome/components/mqtt/mqtt_text.cpp
+++ b/esphome/components/mqtt/mqtt_text.cpp
@@ -38,9 +38,8 @@ const EntityBase *MQTTTextComponent::get_entity() const { return this->text_; }
 
 void MQTTTextComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
-  root[MQTT_MODE] = TextMqttModeStrings::get_progmem_str(
-      static_cast<uint8_t>(this->text_->traits.get_mode()),
-      static_cast<uint8_t>(TEXT_MODE_TEXT));
+  root[MQTT_MODE] = TextMqttModeStrings::get_progmem_str(static_cast<uint8_t>(this->text_->traits.get_mode()),
+                                                         static_cast<uint8_t>(TEXT_MODE_TEXT));
 
   config.command_topic = true;
 }

--- a/esphome/components/mqtt/mqtt_text.cpp
+++ b/esphome/components/mqtt/mqtt_text.cpp
@@ -1,5 +1,6 @@
 #include "mqtt_text.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 #include "mqtt_const.h"
 
@@ -11,6 +12,9 @@ namespace esphome::mqtt {
 static const char *const TAG = "mqtt.text";
 
 using namespace esphome::text;
+
+// Text mode MQTT strings indexed by TextMode enum (0-1): TEXT, PASSWORD
+PROGMEM_STRING_TABLE(TextMqttModeStrings, "text", "password");
 
 MQTTTextComponent::MQTTTextComponent(Text *text) : text_(text) {}
 
@@ -34,14 +38,7 @@ const EntityBase *MQTTTextComponent::get_entity() const { return this->text_; }
 
 void MQTTTextComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryConfig &config) {
   // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
-  switch (this->text_->traits.get_mode()) {
-    case TEXT_MODE_TEXT:
-      root[MQTT_MODE] = "text";
-      break;
-    case TEXT_MODE_PASSWORD:
-      root[MQTT_MODE] = "password";
-      break;
-  }
+  root[MQTT_MODE] = TextMqttModeStrings::get_progmem_str(static_cast<uint8_t>(this->text_->traits.get_mode()), 0);
 
   config.command_topic = true;
 }


### PR DESCRIPTION
# What does this implement/fix?

Replace switch statements with `PROGMEM_STRING_TABLE` lookups across MQTT component files, moving string literals to PROGMEM on ESP8266 to save RAM.

**Converted 10 switches across 6 files:**

- `mqtt_client.cpp`: Disconnect reason (0-8) — also adds missing `DNS_RESOLVE_ERROR` string
- `mqtt_climate.cpp`: Mode, action, fan mode, swing mode, preset (5 switches)
- `mqtt_alarm_control_panel.cpp`: Alarm state (0-9)
- `mqtt_text.cpp`: Text mode (0-1)
- `mqtt_number.cpp`: Number mode (0-2, with AUTO no-op guard)
- `mqtt_component.cpp`: Entity category (0-2, with NONE no-op guard)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes
