### PR TITLE
[core] Add missing requests dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ resvg-py==0.2.6
 freetype-py==2.5.1
 jinja2==3.1.6
 bleak==2.1.1
+requests==2.32.5
 
 # esp-idf >= 5.0 requires this
 pyparsing >= 3.0


### PR DESCRIPTION
# What does this implement/fix?

`requests` is imported in multiple modules across the codebase but was never declared as an explicit dependency in `requirements.txt`. It only worked because it was pulled in transitively by another package (likely `platformio` or `esphome-dashboard`).

Files that import `requests`:
- `esphome/external_files.py`
- `esphome/dashboard/web_server.py`
- `esphome/components/font/__init__.py`
- `esphome/components/esp32/__init__.py`
- `esphome/components/shelly_dimmer/light.py`
- `esphome/components/dashboard_import/__init__.py`

This adds `requests==2.32.5` as an explicit dependency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13800

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes, this is a Python dependency fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).