### PR TITLE
[template] Convert alarm sensor type to PROGMEM_STRING_TABLE and narrow enum to uint8_t

### DIFF
--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.cpp
@@ -5,6 +5,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::template_ {
 
@@ -28,18 +29,11 @@ void TemplateAlarmControlPanel::add_sensor(binary_sensor::BinarySensor *sensor, 
   this->sensor_data_.push_back(sd);
 };
 
+// Alarm sensor type strings indexed by AlarmSensorType enum (0-3): DELAYED, INSTANT, DELAYED_FOLLOWER, INSTANT_ALWAYS
+PROGMEM_STRING_TABLE(AlarmSensorTypeStrings, "delayed", "instant", "delayed_follower", "instant_always");
+
 static const LogString *sensor_type_to_string(AlarmSensorType type) {
-  switch (type) {
-    case ALARM_SENSOR_TYPE_INSTANT:
-      return LOG_STR("instant");
-    case ALARM_SENSOR_TYPE_DELAYED_FOLLOWER:
-      return LOG_STR("delayed_follower");
-    case ALARM_SENSOR_TYPE_INSTANT_ALWAYS:
-      return LOG_STR("instant_always");
-    case ALARM_SENSOR_TYPE_DELAYED:
-    default:
-      return LOG_STR("delayed");
-  }
+  return AlarmSensorTypeStrings::get_log_str(static_cast<uint8_t>(type), 0);
 }
 #endif
 

--- a/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
+++ b/esphome/components/template/alarm_control_panel/template_alarm_control_panel.h
@@ -26,7 +26,7 @@ enum BinarySensorFlags : uint16_t {
   BINARY_SENSOR_MODE_BYPASS_AUTO = 1 << 4,
 };
 
-enum AlarmSensorType : uint16_t {
+enum AlarmSensorType : uint8_t {
   ALARM_SENSOR_TYPE_DELAYED = 0,
   ALARM_SENSOR_TYPE_INSTANT,
   ALARM_SENSOR_TYPE_DELAYED_FOLLOWER,


### PR DESCRIPTION
# What does this implement/fix?

Convert `sensor_type_to_string()` switch in the template alarm control panel to `PROGMEM_STRING_TABLE`, moving string literals to PROGMEM on ESP8266.

Also narrows `AlarmSensorType` from `uint16_t` to `uint8_t` — it only has 4 values (0-3). This saves a byte per `SensorInfo` struct (the struct now packs to 4 bytes instead of 6 with padding).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes
