### PR TITLE
[uart] Convert parity_to_str to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/uart/uart.cpp
+++ b/esphome/components/uart/uart.cpp
@@ -3,11 +3,15 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include <cinttypes>
 
 namespace esphome::uart {
 
 static const char *const TAG = "uart";
+
+// UART parity strings indexed by UARTParityOptions enum (0-2): NONE, EVEN, ODD
+PROGMEM_STRING_TABLE(UARTParityStrings, "NONE", "EVEN", "ODD", "UNKNOWN");
 
 void UARTDevice::check_uart_settings(uint32_t baud_rate, uint8_t stop_bits, UARTParityOptions parity,
                                      uint8_t data_bits) {
@@ -30,16 +34,7 @@ void UARTDevice::check_uart_settings(uint32_t baud_rate, uint8_t stop_bits, UART
 }
 
 const LogString *parity_to_str(UARTParityOptions parity) {
-  switch (parity) {
-    case UART_CONFIG_PARITY_NONE:
-      return LOG_STR("NONE");
-    case UART_CONFIG_PARITY_EVEN:
-      return LOG_STR("EVEN");
-    case UART_CONFIG_PARITY_ODD:
-      return LOG_STR("ODD");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return UARTParityStrings::get_log_str(static_cast<uint8_t>(parity), UARTParityStrings::LAST_INDEX);
 }
 
 }  // namespace esphome::uart


### PR DESCRIPTION
# What does this implement/fix?

Convert `parity_to_str()` switch in the UART component to `PROGMEM_STRING_TABLE`, moving string literals to PROGMEM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes
