### PR TITLE
[sprinkler] Convert state and request origin strings to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include <cinttypes>
 #include <utility>
 
@@ -1544,42 +1545,19 @@ void Sprinkler::log_multiplier_zero_warning_(const LogString *method_name) {
   ESP_LOGW(TAG, "%s called but multiplier is set to zero; no action taken", LOG_STR_ARG(method_name));
 }
 
+// Request origin strings indexed by SprinklerValveRunRequestOrigin enum (0-2): USER, CYCLE, QUEUE
+PROGMEM_STRING_TABLE(SprinklerRequestOriginStrings, "USER", "CYCLE", "QUEUE", "UNKNOWN");
+
 const LogString *Sprinkler::req_as_str_(SprinklerValveRunRequestOrigin origin) {
-  switch (origin) {
-    case USER:
-      return LOG_STR("USER");
-
-    case CYCLE:
-      return LOG_STR("CYCLE");
-
-    case QUEUE:
-      return LOG_STR("QUEUE");
-
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return SprinklerRequestOriginStrings::get_log_str(static_cast<uint8_t>(origin),
+                                                    SprinklerRequestOriginStrings::LAST_INDEX);
 }
 
+// Sprinkler state strings indexed by SprinklerState enum (0-4): IDLE, STARTING, ACTIVE, STOPPING, BYPASS
+PROGMEM_STRING_TABLE(SprinklerStateStrings, "IDLE", "STARTING", "ACTIVE", "STOPPING", "BYPASS", "UNKNOWN");
+
 const LogString *Sprinkler::state_as_str_(SprinklerState state) {
-  switch (state) {
-    case IDLE:
-      return LOG_STR("IDLE");
-
-    case STARTING:
-      return LOG_STR("STARTING");
-
-    case ACTIVE:
-      return LOG_STR("ACTIVE");
-
-    case STOPPING:
-      return LOG_STR("STOPPING");
-
-    case BYPASS:
-      return LOG_STR("BYPASS");
-
-    default:
-      return LOG_STR("UNKNOWN");
-  }
+  return SprinklerStateStrings::get_log_str(static_cast<uint8_t>(state), SprinklerStateStrings::LAST_INDEX);
 }
 
 void Sprinkler::start_timer_(const SprinklerTimerIndex timer_index) {


### PR DESCRIPTION
# What does this implement/fix?

Convert `req_as_str_()` and `state_as_str_()` switches in the sprinkler component to `PROGMEM_STRING_TABLE`, moving string literals to PROGMEM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes
