### PR TITLE
[rtttl] Convert state_to_string to PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -376,7 +376,7 @@ void Rtttl::loop() {
 }
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-// RTTTL state strings indexed by State enum (0-4): STOPPED, INIT, STARTING, RUNNING, STOPPING
+// RTTTL state strings indexed by State enum (0-4): STOPPED, INIT, STARTING, RUNNING, STOPPING, plus UNKNOWN fallback
 PROGMEM_STRING_TABLE(RtttlStateStrings, "STATE_STOPPED", "STATE_INIT", "STATE_STARTING", "STATE_RUNNING",
                      "STATE_STOPPING", "UNKNOWN");
 

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include "esphome/core/hal.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome {
 namespace rtttl {
@@ -375,22 +376,13 @@ void Rtttl::loop() {
 }
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+// RTTTL state strings indexed by State enum (0-4): STOPPED, INIT, STARTING, RUNNING, STOPPING
+PROGMEM_STRING_TABLE(RtttlStateStrings, "STATE_STOPPED", "STATE_INIT", "STATE_STARTING", "STATE_RUNNING",
+                     "STATE_STOPPING", "UNKNOWN");
+
 static const LogString *state_to_string(State state) {
-  switch (state) {
-    case STATE_STOPPED:
-      return LOG_STR("STATE_STOPPED");
-    case STATE_STARTING:
-      return LOG_STR("STATE_STARTING");
-    case STATE_RUNNING:
-      return LOG_STR("STATE_RUNNING");
-    case STATE_STOPPING:
-      return LOG_STR("STATE_STOPPING");
-    case STATE_INIT:
-      return LOG_STR("STATE_INIT");
-    default:
-      return LOG_STR("UNKNOWN");
-  }
-};
+  return RtttlStateStrings::get_log_str(static_cast<uint8_t>(state), RtttlStateStrings::LAST_INDEX);
+}
 #endif
 
 void Rtttl::set_state_(State state) {


### PR DESCRIPTION
# What does this implement/fix?

Convert `state_to_string()` switch in the RTTTL component to `PROGMEM_STRING_TABLE`, moving string literals to PROGMEM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13659

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A — no user-facing changes
