### PR TITLE
[mqtt] Avoid heap allocation in on_log by using const char* publish overload

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -170,10 +170,8 @@ void MQTTClientComponent::send_device_info_() {
 void MQTTClientComponent::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {
   (void) tag;
   if (level <= this->log_level_ && this->is_connected()) {
-    this->publish({.topic = this->log_message_.topic,
-                   .payload = std::string(message, message_len),
-                   .qos = this->log_message_.qos,
-                   .retain = this->log_message_.retain});
+    this->publish(this->log_message_.topic.c_str(), message, message_len, this->log_message_.qos,
+                  this->log_message_.retain);
   }
 }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

The `on_log` callback was constructing a temporary `MQTTMessage` struct on every log line, which:

1. Copied `this->log_message_.topic` into a new `std::string` (heap allocation)
2. Created a new `std::string(message, message_len)` for the payload (heap allocation)

This happens on every log message at runtime and contributes to heap fragmentation over time.

The fix uses the existing `const char*` publish overload directly, avoiding both allocations entirely.

**Before:**
```cpp
this->publish({.topic = this->log_message_.topic,
               .payload = std::string(message, message_len),
               .qos = this->log_message_.qos,
               .retain = this->log_message_.retain});
```

**After:**
```cpp
this->publish(this->log_message_.topic.c_str(), message, message_len,
              this->log_message_.qos, this->log_message_.retain);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
mqtt:
  broker: mqtt.example.com
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).