### PR TITLE
[debug] Move ESP8266 switch tables to flash with PROGMEM_STRING_TABLE

### DIFF
--- a/esphome/components/debug/debug_esp8266.cpp
+++ b/esphome/components/debug/debug_esp8266.cpp
@@ -1,6 +1,7 @@
 #include "debug_component.h"
 #ifdef USE_ESP8266
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 #include <Esp.h>
 
 extern "C" {
@@ -19,27 +20,31 @@ namespace debug {
 
 static const char *const TAG = "debug";
 
+// PROGMEM string table for reset reasons, indexed by reason code (0-6), with "Unknown" as fallback
+// clang-format off
+PROGMEM_STRING_TABLE(ResetReasonStrings,
+  "Power On",                  // 0 = REASON_DEFAULT_RST
+  "Hardware Watchdog",         // 1 = REASON_WDT_RST
+  "Exception",                 // 2 = REASON_EXCEPTION_RST
+  "Software Watchdog",         // 3 = REASON_SOFT_WDT_RST
+  "Software/System restart",   // 4 = REASON_SOFT_RESTART
+  "Deep-Sleep Wake",           // 5 = REASON_DEEP_SLEEP_AWAKE
+  "External System",           // 6 = REASON_EXT_SYS_RST
+  "Unknown"                    // 7 = fallback
+);
+// clang-format on
+static_assert(REASON_DEFAULT_RST == 0, "Reset reason enum values must match table indices");
+static_assert(REASON_EXT_SYS_RST == 6, "Reset reason enum values must match table indices");
+
+// PROGMEM string table for flash chip modes, indexed by mode code (0-3), with "UNKNOWN" as fallback
+PROGMEM_STRING_TABLE(FlashModeStrings, "QIO", "QOUT", "DIO", "DOUT", "UNKNOWN");
+static_assert(FM_QIO == 0, "Flash mode enum values must match table indices");
+static_assert(FM_DOUT == 3, "Flash mode enum values must match table indices");
+
 // Get reset reason string from reason code (no heap allocation)
 // Returns LogString* pointing to flash (PROGMEM) on ESP8266
 static const LogString *get_reset_reason_str(uint32_t reason) {
-  switch (reason) {
-    case REASON_DEFAULT_RST:
-      return LOG_STR("Power On");
-    case REASON_WDT_RST:
-      return LOG_STR("Hardware Watchdog");
-    case REASON_EXCEPTION_RST:
-      return LOG_STR("Exception");
-    case REASON_SOFT_WDT_RST:
-      return LOG_STR("Software Watchdog");
-    case REASON_SOFT_RESTART:
-      return LOG_STR("Software/System restart");
-    case REASON_DEEP_SLEEP_AWAKE:
-      return LOG_STR("Deep-Sleep Wake");
-    case REASON_EXT_SYS_RST:
-      return LOG_STR("External System");
-    default:
-      return LOG_STR("Unknown");
-  }
+  return ResetReasonStrings::get_log_str(reason, ResetReasonStrings::LAST_INDEX);
 }
 
 // Size for core version hex buffer
@@ -92,23 +97,8 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   constexpr size_t size = DEVICE_INFO_BUFFER_SIZE;
   char *buf = buffer.data();
 
-  const LogString *flash_mode;
-  switch (ESP.getFlashChipMode()) {  // NOLINT(readability-static-accessed-through-instance)
-    case FM_QIO:
-      flash_mode = LOG_STR("QIO");
-      break;
-    case FM_QOUT:
-      flash_mode = LOG_STR("QOUT");
-      break;
-    case FM_DIO:
-      flash_mode = LOG_STR("DIO");
-      break;
-    case FM_DOUT:
-      flash_mode = LOG_STR("DOUT");
-      break;
-    default:
-      flash_mode = LOG_STR("UNKNOWN");
-  }
+  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
+  const LogString *flash_mode = FlashModeStrings::get_log_str(ESP.getFlashChipMode(), FlashModeStrings::LAST_INDEX);
   uint32_t flash_size = ESP.getFlashChipSize() / 1024;       // NOLINT(readability-static-accessed-through-instance)
   uint32_t flash_speed = ESP.getFlashChipSpeed() / 1000000;  // NOLINT(readability-static-accessed-through-instance)
   ESP_LOGD(TAG, "Flash Chip: Size=%" PRIu32 "kB Speed=%" PRIu32 "MHz Mode=%s", flash_size, flash_speed,

--- a/esphome/components/debug/debug_esp8266.cpp
+++ b/esphome/components/debug/debug_esp8266.cpp
@@ -34,17 +34,24 @@ PROGMEM_STRING_TABLE(ResetReasonStrings,
 );
 // clang-format on
 static_assert(REASON_DEFAULT_RST == 0, "Reset reason enum values must match table indices");
+static_assert(REASON_WDT_RST == 1, "Reset reason enum values must match table indices");
+static_assert(REASON_EXCEPTION_RST == 2, "Reset reason enum values must match table indices");
+static_assert(REASON_SOFT_WDT_RST == 3, "Reset reason enum values must match table indices");
+static_assert(REASON_SOFT_RESTART == 4, "Reset reason enum values must match table indices");
+static_assert(REASON_DEEP_SLEEP_AWAKE == 5, "Reset reason enum values must match table indices");
 static_assert(REASON_EXT_SYS_RST == 6, "Reset reason enum values must match table indices");
 
 // PROGMEM string table for flash chip modes, indexed by mode code (0-3), with "UNKNOWN" as fallback
 PROGMEM_STRING_TABLE(FlashModeStrings, "QIO", "QOUT", "DIO", "DOUT", "UNKNOWN");
 static_assert(FM_QIO == 0, "Flash mode enum values must match table indices");
+static_assert(FM_QOUT == 1, "Flash mode enum values must match table indices");
+static_assert(FM_DIO == 2, "Flash mode enum values must match table indices");
 static_assert(FM_DOUT == 3, "Flash mode enum values must match table indices");
 
 // Get reset reason string from reason code (no heap allocation)
 // Returns LogString* pointing to flash (PROGMEM) on ESP8266
 static const LogString *get_reset_reason_str(uint32_t reason) {
-  return ResetReasonStrings::get_log_str(reason, ResetReasonStrings::LAST_INDEX);
+  return ResetReasonStrings::get_log_str(static_cast<uint8_t>(reason), ResetReasonStrings::LAST_INDEX);
 }
 
 // Size for core version hex buffer
@@ -97,8 +104,9 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   constexpr size_t size = DEVICE_INFO_BUFFER_SIZE;
   char *buf = buffer.data();
 
-  // NOLINTNEXTLINE(readability-static-accessed-through-instance)
-  const LogString *flash_mode = FlashModeStrings::get_log_str(ESP.getFlashChipMode(), FlashModeStrings::LAST_INDEX);
+  const LogString *flash_mode = FlashModeStrings::get_log_str(
+      static_cast<uint8_t>(ESP.getFlashChipMode()),  // NOLINT(readability-static-accessed-through-instance)
+      FlashModeStrings::LAST_INDEX);
   uint32_t flash_size = ESP.getFlashChipSize() / 1024;       // NOLINT(readability-static-accessed-through-instance)
   uint32_t flash_speed = ESP.getFlashChipSpeed() / 1000000;  // NOLINT(readability-static-accessed-through-instance)
   ESP_LOGD(TAG, "Flash Chip: Size=%" PRIu32 "kB Speed=%" PRIu32 "MHz Mode=%s", flash_size, flash_speed,


### PR DESCRIPTION
# What does this implement/fix?

Move two compiler-generated switch tables (`CSWTCH$22` 28B, `CSWTCH$53` 16B) from DRAM to flash on ESP8266 by replacing `switch` statements with `PROGMEM_STRING_TABLE` lookups in the debug component.

Both tables map sequential enum values to string pointers:
- **Reset reasons** (28B): `REASON_DEFAULT_RST`..`REASON_EXT_SYS_RST` (0-6) with "Unknown" fallback
- **Flash modes** (16B): `FM_QIO`..`FM_DOUT` (0-3) with "UNKNOWN" fallback

`static_assert`s verify the enum values match the expected table indices at compile time.

**Saves 44 bytes of DRAM** on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
debug:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
