### PR TITLE
[display] Avoid compiler-generated lookup table in RAM on ESP8266

### DIFF
--- a/esphome/components/display/display_color_utils.h
+++ b/esphome/components/display/display_color_utils.h
@@ -16,22 +16,19 @@ class ColorUtil {
     uint8_t second_bits = 0;
     uint8_t third_bits = 0;
 
-    switch (color_bitness) {
-      case COLOR_BITNESS_888:
-        first_bits = 8;
-        second_bits = 8;
-        third_bits = 8;
-        break;
-      case COLOR_BITNESS_565:
-        first_bits = 5;
-        second_bits = 6;
-        third_bits = 5;
-        break;
-      case COLOR_BITNESS_332:
-        first_bits = 3;
-        second_bits = 3;
-        third_bits = 2;
-        break;
+    // Avoid switch to prevent compiler-generated lookup table in RAM on ESP8266
+    if (color_bitness == COLOR_BITNESS_888) {
+      first_bits = 8;
+      second_bits = 8;
+      third_bits = 8;
+    } else if (color_bitness == COLOR_BITNESS_565) {
+      first_bits = 5;
+      second_bits = 6;
+      third_bits = 5;
+    } else {
+      first_bits = 3;
+      second_bits = 3;
+      third_bits = 2;
     }
 
     first_color = right_bit_aligned ? esp_scale(((colorcode >> (second_bits + third_bits)) & ((1 << first_bits) - 1)),


### PR DESCRIPTION
# What does this implement/fix?

Replace the `switch` on `color_bitness` in `ColorUtil::to_color()` with an if-else chain to prevent the compiler from generating CSWTCH lookup tables that consume DRAM on ESP8266.

This saves 6 bytes of DRAM (2 tables × 3 bytes) from `display.cpp.o` on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
display:
  platform: ssd1306_i2c
  model: "SSD1306 128x64"
  address: 0x3C
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).