### PR TITLE
[cse7766] Batch UART reads to reduce loop overhead

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -15,8 +15,9 @@ void CSE7766Component::loop() {
     this->raw_data_index_ = 0;
   }
 
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
+  // Early return avoids stack adjustment for the batch buffer below
+  // and prevents updating last_transmission_ when no data is available.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -15,9 +15,7 @@ void CSE7766Component::loop() {
     this->raw_data_index_ = 0;
   }
 
-  // Early return avoids stack adjustment for the batch buffer below
-  // and prevents updating last_transmission_ when no data is available.
-  // loop() runs ~7000/min so most calls have nothing to read.
+  // Early return prevents updating last_transmission_ when no data is available.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -22,26 +22,29 @@ void CSE7766Component::loop() {
 
   this->last_transmission_ = now;
 
-  // Read all available bytes at once to reduce UART call overhead.
+  // Read all available bytes in batches to reduce UART call overhead.
   // At 4800 baud (~480 bytes/sec) with ~122 Hz loop rate, typically ~4 bytes per call.
   uint8_t buf[CSE7766_RAW_DATA_SIZE];
-  size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
-  this->read_array(buf, to_read);
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    this->read_array(buf, to_read);
+    avail -= to_read;
 
-  for (size_t i = 0; i < to_read; i++) {
-    this->raw_data_[this->raw_data_index_] = buf[i];
-    if (!this->check_byte_()) {
-      this->raw_data_index_ = 0;
-      this->status_set_warning();
-      continue;
+    for (size_t i = 0; i < to_read; i++) {
+      this->raw_data_[this->raw_data_index_] = buf[i];
+      if (!this->check_byte_()) {
+        this->raw_data_index_ = 0;
+        this->status_set_warning();
+        continue;
+      }
+
+      if (this->raw_data_index_ == CSE7766_RAW_DATA_SIZE - 1) {
+        this->parse_data_();
+        this->status_clear_warning();
+      }
+
+      this->raw_data_index_ = (this->raw_data_index_ + 1) % CSE7766_RAW_DATA_SIZE;
     }
-
-    if (this->raw_data_index_ == CSE7766_RAW_DATA_SIZE - 1) {
-      this->parse_data_();
-      this->status_clear_warning();
-    }
-
-    this->raw_data_index_ = (this->raw_data_index_ + 1) % CSE7766_RAW_DATA_SIZE;
   }
 }
 

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -27,7 +27,9 @@ void CSE7766Component::loop() {
   uint8_t buf[CSE7766_RAW_DATA_SIZE];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
-    this->read_array(buf, to_read);
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
     avail -= to_read;
 
     for (size_t i = 0; i < to_read; i++) {

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -15,8 +15,10 @@ void CSE7766Component::loop() {
     this->raw_data_index_ = 0;
   }
 
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
-  if (avail == 0) {
+  if (avail <= 0) {
     return;
   }
 

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -7,7 +7,6 @@ namespace esphome {
 namespace cse7766 {
 
 static const char *const TAG = "cse7766";
-static constexpr size_t CSE7766_RAW_DATA_SIZE = 24;
 
 void CSE7766Component::loop() {
   const uint32_t now = App.get_loop_component_start_time();
@@ -16,25 +15,33 @@ void CSE7766Component::loop() {
     this->raw_data_index_ = 0;
   }
 
-  if (this->available() == 0) {
+  int avail = this->available();
+  if (avail == 0) {
     return;
   }
 
   this->last_transmission_ = now;
-  while (this->available() != 0) {
-    this->read_byte(&this->raw_data_[this->raw_data_index_]);
+
+  // Read all available bytes at once to reduce UART call overhead.
+  // At 4800 baud (~480 bytes/sec) with ~122 Hz loop rate, typically ~4 bytes per call.
+  uint8_t buf[CSE7766_RAW_DATA_SIZE];
+  size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+  this->read_array(buf, to_read);
+
+  for (size_t i = 0; i < to_read; i++) {
+    this->raw_data_[this->raw_data_index_] = buf[i];
     if (!this->check_byte_()) {
       this->raw_data_index_ = 0;
       this->status_set_warning();
       continue;
     }
 
-    if (this->raw_data_index_ == 23) {
+    if (this->raw_data_index_ == CSE7766_RAW_DATA_SIZE - 1) {
       this->parse_data_();
       this->status_clear_warning();
     }
 
-    this->raw_data_index_ = (this->raw_data_index_ + 1) % 24;
+    this->raw_data_index_ = (this->raw_data_index_ + 1) % CSE7766_RAW_DATA_SIZE;
   }
 }
 
@@ -53,14 +60,15 @@ bool CSE7766Component::check_byte_() {
     return true;
   }
 
-  if (index == 23) {
+  if (index == CSE7766_RAW_DATA_SIZE - 1) {
     uint8_t checksum = 0;
-    for (uint8_t i = 2; i < 23; i++) {
+    for (uint8_t i = 2; i < CSE7766_RAW_DATA_SIZE - 1; i++) {
       checksum += this->raw_data_[i];
     }
 
-    if (checksum != this->raw_data_[23]) {
-      ESP_LOGW(TAG, "Invalid checksum from CSE7766: 0x%02X != 0x%02X", checksum, this->raw_data_[23]);
+    if (checksum != this->raw_data_[CSE7766_RAW_DATA_SIZE - 1]) {
+      ESP_LOGW(TAG, "Invalid checksum from CSE7766: 0x%02X != 0x%02X", checksum,
+               this->raw_data_[CSE7766_RAW_DATA_SIZE - 1]);
       return false;
     }
     return true;

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -8,6 +8,8 @@
 namespace esphome {
 namespace cse7766 {
 
+static constexpr size_t CSE7766_RAW_DATA_SIZE = 24;
+
 class CSE7766Component : public Component, public uart::UARTDevice {
  public:
   void set_voltage_sensor(sensor::Sensor *voltage_sensor) { voltage_sensor_ = voltage_sensor; }
@@ -33,7 +35,7 @@ class CSE7766Component : public Component, public uart::UARTDevice {
                          this->raw_data_[start_index + 2]);
   }
 
-  uint8_t raw_data_[24];
+  uint8_t raw_data_[CSE7766_RAW_DATA_SIZE];
   uint8_t raw_data_index_{0};
   uint32_t last_transmission_{0};
   sensor::Sensor *voltage_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Batch UART reads in the CSE7766 loop to reduce per-iteration overhead.

The previous code read bytes one at a time via `read_byte()` inside a `while (available())` loop. Each `read_byte()` call chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in 3 UART calls per byte (2x `available()` + 1x `readBytes`). With ~4 bytes arriving per loop iteration at 4800 baud, that was ~13 UART operations per loop call.

The new code calls `available()` once, then `read_array(buf, avail)` to bulk-read into a stack buffer, and processes the buffered bytes with the same validation logic. This reduces UART operations to 3 total per loop call regardless of byte count.

Also replaced magic number `24`/`23` with the existing `CSE7766_RAW_DATA_SIZE` constant and moved it to the header so both `.h` and `.cpp` share it.

**Measured on ESP8266 (Sonoff plug, CSE7766 at 4800 baud):**

| Metric | Before | After | Change |
|---|---|---|---|
| Total/60s | ~590ms | ~430ms | **-27%** |
| Avg per call | 0.08ms | 0.06ms | **-25%** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - this is an internal optimization.
# Existing CSE7766 configurations work unchanged.
sensor:
  - platform: cse7766
    voltage:
      name: "Voltage"
    current:
      name: "Current"
    power:
      name: "Power"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
