### PR TITLE
[ld2412] Batch UART reads to reduce loop overhead

### DIFF
--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,8 +310,10 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
-  if (avail == 0) {
+  if (avail <= 0) {
     return;
   }
 

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,6 +310,8 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,8 +310,12 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
-  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
+  if (avail <= 0) {
+    return;
+  }
+
+  // Read all available bytes in batches to reduce UART call overhead.
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,14 +310,8 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,8 +310,23 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
-  while (this->available()) {
-    this->readline_(this->read());
+  int avail = this->available();
+  if (avail == 0) {
+    return;
+  }
+
+  // Read all available bytes in batches to reduce UART call overhead.
+  uint8_t buf[MAX_LINE_LENGTH];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+
+    for (size_t i = 0; i < to_read; i++) {
+      this->readline_(buf[i]);
+    }
   }
 }
 

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -310,14 +310,8 @@ void LD2412Component::restart_and_read_all_info() {
 }
 
 void LD2412Component::loop() {
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));


### PR DESCRIPTION
# What does this implement/fix?

Batch UART reads in the LD2412 component loop to reduce per-byte UART call overhead.

The previous implementation called `read()` for each byte, which internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in multiple UART calls per byte. This change reads all available bytes into a stack buffer via a single `read_array()` call per batch, then processes them in-memory.

The processing logic (`readline_()`) is unchanged — only the UART I/O pattern changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

No configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.