### PR TITLE
[modbus] Batch UART reads to reduce loop overhead

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -19,28 +19,24 @@ void Modbus::setup() {
 void Modbus::loop() {
   const uint32_t now = App.get_loop_component_start_time();
 
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
+  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
-  if (avail > 0) {
-    // Read all available bytes in batches to reduce UART call overhead.
-    uint8_t buf[64];
-    while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
-      if (!this->read_array(buf, to_read)) {
-        break;
-      }
-      avail -= to_read;
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
 
-      for (size_t i = 0; i < to_read; i++) {
-        if (this->parse_modbus_byte_(buf[i])) {
-          this->last_modbus_byte_ = now;
-        } else {
-          size_t at = this->rx_buffer_.size();
-          if (at > 0) {
-            ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse failed", at);
-            this->rx_buffer_.clear();
-          }
+    for (size_t i = 0; i < to_read; i++) {
+      if (this->parse_modbus_byte_(buf[i])) {
+        this->last_modbus_byte_ = now;
+      } else {
+        size_t at = this->rx_buffer_.size();
+        if (at > 0) {
+          ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse failed", at);
+          this->rx_buffer_.clear();
         }
       }
     }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -19,16 +19,27 @@ void Modbus::setup() {
 void Modbus::loop() {
   const uint32_t now = App.get_loop_component_start_time();
 
-  while (this->available()) {
-    uint8_t byte;
-    this->read_byte(&byte);
-    if (this->parse_modbus_byte_(byte)) {
-      this->last_modbus_byte_ = now;
-    } else {
-      size_t at = this->rx_buffer_.size();
-      if (at > 0) {
-        ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse failed", at);
-        this->rx_buffer_.clear();
+  int avail = this->available();
+  if (avail > 0) {
+    // Read all available bytes in batches to reduce UART call overhead.
+    uint8_t buf[64];
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
+        break;
+      }
+      avail -= to_read;
+
+      for (size_t i = 0; i < to_read; i++) {
+        if (this->parse_modbus_byte_(buf[i])) {
+          this->last_modbus_byte_ = now;
+        } else {
+          size_t at = this->rx_buffer_.size();
+          if (at > 0) {
+            ESP_LOGV(TAG, "Clearing buffer of %d bytes - parse failed", at);
+            this->rx_buffer_.clear();
+          }
+        }
       }
     }
   }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -19,6 +19,8 @@ void Modbus::setup() {
 void Modbus::loop() {
   const uint32_t now = App.get_loop_component_start_time();
 
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail > 0) {
     // Read all available bytes in batches to reduce UART call overhead.


### PR DESCRIPTION
# What does this implement/fix?

Batch UART reads in the Modbus component loop to reduce per-byte UART call overhead.

The previous implementation called `read_byte()` for each byte, which internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in multiple UART calls per byte. This change reads all available bytes into a stack buffer via a single `read_array()` call per batch, then processes them in-memory.

The processing logic (`parse_modbus_byte_()`, buffer clearing on parse failure) is unchanged — only the UART I/O pattern changes.

Measured 25-33% loop time reduction on other components with the same pattern (ld2450: 2348ms → 1577ms per 60s, cse7766: 597ms → 430ms per 60s).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Not tested on hardware (no Modbus device available), but follows the same proven pattern as cse7766 (#13817), ld2410 (#13820), ld2412 (#13819), ld2420 (#13821), and ld2450 (#13818).

## Example entry for `config.yaml`:

No configuration changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.