### PR TITLE
[nextion] Batch UART reads to reduce loop overhead

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,14 +397,8 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,6 +397,8 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,14 +397,8 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,8 +397,10 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
-  if (avail == 0) {
+  if (avail <= 0) {
     return;
   }
 

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -411,7 +411,7 @@ void Nextion::process_serial_() {
     }
     avail -= to_read;
 
-    this->command_data_.append(reinterpret_cast<char *>(buf), to_read);
+    this->command_data_.append(reinterpret_cast<const char *>(buf), to_read);
   }
 }
 // nextion.tech/instruction-set/

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,8 +397,12 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
-  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
+  if (avail <= 0) {
+    return;
+  }
+
+  // Read all available bytes in batches to reduce UART call overhead.
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -397,11 +397,21 @@ bool Nextion::remove_from_q_(bool report_empty) {
 }
 
 void Nextion::process_serial_() {
-  uint8_t d;
+  int avail = this->available();
+  if (avail == 0) {
+    return;
+  }
 
-  while (this->available()) {
-    read_byte(&d);
-    this->command_data_ += d;
+  // Read all available bytes in batches to reduce UART call overhead.
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+
+    this->command_data_.append(reinterpret_cast<char *>(buf), to_read);
   }
 }
 // nextion.tech/instruction-set/


### PR DESCRIPTION
# What does this implement/fix?

Batch UART reads in the Nextion `process_serial_()` method to reduce per-byte UART call overhead.

The previous implementation called `read_byte()` for each byte and appended it individually to `command_data_` via `+= char`. Each `read_byte()` internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in multiple UART calls per byte.

This change reads all available bytes into a stack buffer via `read_array()`, then appends each batch to `command_data_` with a single `append(ptr, len)` call. This reduces both UART call overhead and string reallocation overhead.

Nextion displays support baud rates up to 921600, making this particularly impactful at high speeds.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Not tested on hardware (no Nextion display available), but follows the same proven pattern as cse7766 (#13817), ld2410 (#13820), ld2412 (#13819), ld2420 (#13821), ld2450 (#13818), and modbus (#13822).

## Example entry for `config.yaml`:

No configuration changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.