### PR TITLE
[pylontech] Batch UART reads to reduce loop overhead

### DIFF
--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -56,17 +56,23 @@ void PylontechComponent::setup() {
 void PylontechComponent::update() { this->write_str("pwr\n"); }
 
 void PylontechComponent::loop() {
-  if (this->available() > 0) {
+  int avail = this->available();
+  if (avail > 0) {
     // pylontech sends a lot of data very suddenly
     // we need to quickly put it all into our own buffer, otherwise the uart's buffer will overflow
-    uint8_t data;
     int recv = 0;
-    while (this->available() > 0) {
-      if (this->read_byte(&data)) {
-        buffer_[buffer_index_write_] += (char) data;
-        recv++;
-        if (buffer_[buffer_index_write_].back() == static_cast<char>(ASCII_LF) ||
-            buffer_[buffer_index_write_].length() >= MAX_DATA_LENGTH_BYTES) {
+    uint8_t buf[64];
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
+        break;
+      }
+      avail -= to_read;
+      recv += to_read;
+
+      for (size_t i = 0; i < to_read; i++) {
+        buffer_[buffer_index_write_] += (char) buf[i];
+        if (buf[i] == ASCII_LF || buffer_[buffer_index_write_].length() >= MAX_DATA_LENGTH_BYTES) {
           // complete line received
           buffer_index_write_ = (buffer_index_write_ + 1) % NUM_BUFFERS;
         }

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -56,6 +56,8 @@ void PylontechComponent::setup() {
 void PylontechComponent::update() { this->write_str("pwr\n"); }
 
 void PylontechComponent::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail > 0) {
     // pylontech sends a lot of data very suddenly

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -56,8 +56,6 @@ void PylontechComponent::setup() {
 void PylontechComponent::update() { this->write_str("pwr\n"); }
 
 void PylontechComponent::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail > 0) {
     // pylontech sends a lot of data very suddenly


### PR DESCRIPTION
# What does this implement/fix?

Batch UART reads in the Pylontech component loop to reduce per-byte UART call overhead.

The previous implementation called `read_byte()` for each byte, which internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in multiple UART calls per byte. This change reads all available bytes into a stack buffer via a single `read_array()` call per batch, then processes them in-memory.

This is especially relevant for Pylontech since it runs at 115200 baud and the existing code comment notes that "pylontech sends a lot of data very suddenly" — batching gets bytes out of the UART hardware buffer faster, reducing the risk of overflow mentioned in the comment.

The processing logic (line splitting on LF, max length check) is unchanged — only the UART I/O pattern changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Not tested on hardware (no Pylontech device available), but follows the same proven pattern as cse7766 (#13817), ld2410 (#13820), ld2412 (#13819), ld2420 (#13821), ld2450 (#13818), modbus (#13822), and nextion (#13823).

## Example entry for `config.yaml`:

No configuration changes.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.