### PR TITLE
[seeed_mr24hpc1/mr60fda2/mr60bha2] Batch UART reads to reduce per-loop overhead

### DIFF
--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -106,6 +106,8 @@ void MR24HPC1Component::update_() {
 
 // main loop
 void MR24HPC1Component::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail > 0) {
     // Read all available bytes in batches to reduce UART call overhead.

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -106,22 +106,18 @@ void MR24HPC1Component::update_() {
 
 // main loop
 void MR24HPC1Component::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
+  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
-  if (avail > 0) {
-    // Read all available bytes in batches to reduce UART call overhead.
-    uint8_t buf[64];
-    while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
-      if (!this->read_array(buf, to_read)) {
-        break;
-      }
-      avail -= to_read;
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
 
-      for (size_t i = 0; i < to_read; i++) {
-        this->r24_split_data_frame_(buf[i]);  // split data frame
-      }
+    for (size_t i = 0; i < to_read; i++) {
+      this->r24_split_data_frame_(buf[i]);  // split data frame
     }
   }
 

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -106,12 +106,21 @@ void MR24HPC1Component::update_() {
 
 // main loop
 void MR24HPC1Component::loop() {
-  uint8_t byte;
+  int avail = this->available();
+  if (avail > 0) {
+    // Read all available bytes in batches to reduce UART call overhead.
+    uint8_t buf[64];
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
+        break;
+      }
+      avail -= to_read;
 
-  // Is there data on the serial port
-  while (this->available()) {
-    this->read_byte(&byte);
-    this->r24_split_data_frame_(byte);  // split data frame
+      for (size_t i = 0; i < to_read; i++) {
+        this->r24_split_data_frame_(buf[i]);  // split data frame
+      }
+    }
   }
 
   if ((this->s_output_info_switch_flag_ == OUTPUT_SWTICH_OFF) &&

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -30,14 +30,25 @@ void MR60BHA2Component::dump_config() {
 
 // main loop
 void MR60BHA2Component::loop() {
-  uint8_t byte;
+  int avail = this->available();
+  if (avail == 0) {
+    return;
+  }
 
-  // Is there data on the serial port
-  while (this->available()) {
-    this->read_byte(&byte);
-    this->rx_message_.push_back(byte);
-    if (!this->validate_message_()) {
-      this->rx_message_.clear();
+  // Read all available bytes in batches to reduce UART call overhead.
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+
+    for (size_t i = 0; i < to_read; i++) {
+      this->rx_message_.push_back(buf[i]);
+      if (!this->validate_message_()) {
+        this->rx_message_.clear();
+      }
     }
   }
 }

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -30,8 +30,6 @@ void MR60BHA2Component::dump_config() {
 
 // main loop
 void MR60BHA2Component::loop() {
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -30,14 +30,8 @@ void MR60BHA2Component::dump_config() {
 
 // main loop
 void MR60BHA2Component::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -30,8 +30,10 @@ void MR60BHA2Component::dump_config() {
 
 // main loop
 void MR60BHA2Component::loop() {
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
-  if (avail == 0) {
+  if (avail <= 0) {
     return;
   }
 

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -30,6 +30,8 @@ void MR60BHA2Component::dump_config() {
 
 // main loop
 void MR60BHA2Component::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -49,8 +49,6 @@ void MR60FDA2Component::setup() {
 
 // main loop
 void MR60FDA2Component::loop() {
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -49,14 +49,8 @@ void MR60FDA2Component::setup() {
 
 // main loop
 void MR60FDA2Component::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
-  int avail = this->available();
-  if (avail <= 0) {
-    return;
-  }
-
   // Read all available bytes in batches to reduce UART call overhead.
+  int avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -49,6 +49,8 @@ void MR60FDA2Component::setup() {
 
 // main loop
 void MR60FDA2Component::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0) {
     return;

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -49,12 +49,23 @@ void MR60FDA2Component::setup() {
 
 // main loop
 void MR60FDA2Component::loop() {
-  uint8_t byte;
+  int avail = this->available();
+  if (avail == 0) {
+    return;
+  }
 
-  // Is there data on the serial port
-  while (this->available()) {
-    this->read_byte(&byte);
-    this->split_frame_(byte);  // split data frame
+  // Read all available bytes in batches to reduce UART call overhead.
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+
+    for (size_t i = 0; i < to_read; i++) {
+      this->split_frame_(buf[i]);  // split data frame
+    }
   }
 }
 

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -49,8 +49,10 @@ void MR60FDA2Component::setup() {
 
 // main loop
 void MR60FDA2Component::loop() {
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
-  if (avail == 0) {
+  if (avail <= 0) {
     return;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Replaces byte-at-a-time `read_byte()` calls with batched `read_array()` in all three Seeed MR sensor components (mr24hpc1, mr60fda2, mr60bha2).

Each `read_byte()` internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in ~3 UART driver calls per byte. Batching into a 64-byte stack buffer reduces this to ~3 calls per loop iteration regardless of how many bytes are available.

All three components share the same byte-at-a-time pattern and run at 115200 baud, so they are updated together.

Part of a series: #13817, #13818, #13819, #13820, #13821, #13822, #13823, #13824

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

I don't have these sensors to test with but the change follows the same pattern as the other batch read PRs. Processing logic is unchanged — only the UART I/O path changes.

## Example entry for `config.yaml`:

n/a — no configuration changes

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).