### PR TITLE
[dsmr] Batch UART reads to reduce per-loop overhead

### DIFF
--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -40,9 +40,7 @@ bool Dsmr::ready_to_request_data_() {
       this->start_requesting_data_();
     }
     if (!this->requesting_data_) {
-      while (this->available()) {
-        this->read();
-      }
+      this->drain_rx_buffer_();
     }
   }
   return this->requesting_data_;
@@ -115,10 +113,16 @@ void Dsmr::stop_requesting_data_() {
     } else {
       ESP_LOGV(TAG, "Stop reading data from P1 port");
     }
-    while (this->available()) {
-      this->read();
-    }
+    this->drain_rx_buffer_();
     this->requesting_data_ = false;
+  }
+}
+
+void Dsmr::drain_rx_buffer_() {
+  uint8_t buf[64];
+  int avail;
+  while ((avail = this->available()) > 0) {
+    this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)));
   }
 }
 
@@ -133,120 +137,144 @@ void Dsmr::reset_telegram_() {
 
 void Dsmr::receive_telegram_() {
   while (this->available_within_timeout_()) {
-    const char c = this->read();
+    // Read all available bytes in batches to reduce UART call overhead.
+    uint8_t buf[64];
+    int avail = this->available();
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read))
+        return;
+      avail -= to_read;
 
-    // Find a new telegram header, i.e. forward slash.
-    if (c == '/') {
-      ESP_LOGV(TAG, "Header of telegram found");
-      this->reset_telegram_();
-      this->header_found_ = true;
-    }
-    if (!this->header_found_)
-      continue;
+      for (size_t i = 0; i < to_read; i++) {
+        const char c = static_cast<char>(buf[i]);
 
-    // Check for buffer overflow.
-    if (this->bytes_read_ >= this->max_telegram_len_) {
-      this->reset_telegram_();
-      ESP_LOGE(TAG, "Error: telegram larger than buffer (%d bytes)", this->max_telegram_len_);
-      return;
-    }
+        // Find a new telegram header, i.e. forward slash.
+        if (c == '/') {
+          ESP_LOGV(TAG, "Header of telegram found");
+          this->reset_telegram_();
+          this->header_found_ = true;
+        }
+        if (!this->header_found_)
+          continue;
 
-    // Some v2.2 or v3 meters will send a new value which starts with '('
-    // in a new line, while the value belongs to the previous ObisId. For
-    // proper parsing, remove these new line characters.
-    if (c == '(') {
-      while (true) {
-        auto previous_char = this->telegram_[this->bytes_read_ - 1];
-        if (previous_char == '\n' || previous_char == '\r') {
-          this->bytes_read_--;
-        } else {
-          break;
+        // Check for buffer overflow.
+        if (this->bytes_read_ >= this->max_telegram_len_) {
+          this->reset_telegram_();
+          ESP_LOGE(TAG, "Error: telegram larger than buffer (%d bytes)", this->max_telegram_len_);
+          return;
+        }
+
+        // Some v2.2 or v3 meters will send a new value which starts with '('
+        // in a new line, while the value belongs to the previous ObisId. For
+        // proper parsing, remove these new line characters.
+        if (c == '(') {
+          while (true) {
+            auto previous_char = this->telegram_[this->bytes_read_ - 1];
+            if (previous_char == '\n' || previous_char == '\r') {
+              this->bytes_read_--;
+            } else {
+              break;
+            }
+          }
+        }
+
+        // Store the byte in the buffer.
+        this->telegram_[this->bytes_read_] = c;
+        this->bytes_read_++;
+
+        // Check for a footer, i.e. exclamation mark, followed by a hex checksum.
+        if (c == '!') {
+          ESP_LOGV(TAG, "Footer of telegram found");
+          this->footer_found_ = true;
+          continue;
+        }
+        // Check for the end of the hex checksum, i.e. a newline.
+        if (this->footer_found_ && c == '\n') {
+          // Parse the telegram and publish sensor values.
+          this->parse_telegram();
+          this->reset_telegram_();
+          return;
         }
       }
-    }
-
-    // Store the byte in the buffer.
-    this->telegram_[this->bytes_read_] = c;
-    this->bytes_read_++;
-
-    // Check for a footer, i.e. exclamation mark, followed by a hex checksum.
-    if (c == '!') {
-      ESP_LOGV(TAG, "Footer of telegram found");
-      this->footer_found_ = true;
-      continue;
-    }
-    // Check for the end of the hex checksum, i.e. a newline.
-    if (this->footer_found_ && c == '\n') {
-      // Parse the telegram and publish sensor values.
-      this->parse_telegram();
-      this->reset_telegram_();
-      return;
     }
   }
 }
 
 void Dsmr::receive_encrypted_telegram_() {
   while (this->available_within_timeout_()) {
-    const char c = this->read();
+    // Read all available bytes in batches to reduce UART call overhead.
+    uint8_t buf[64];
+    int avail = this->available();
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read))
+        return;
+      avail -= to_read;
 
-    // Find a new telegram start byte.
-    if (!this->header_found_) {
-      if ((uint8_t) c != 0xDB) {
-        continue;
+      for (size_t i = 0; i < to_read; i++) {
+        const char c = static_cast<char>(buf[i]);
+
+        // Find a new telegram start byte.
+        if (!this->header_found_) {
+          if ((uint8_t) c != 0xDB) {
+            continue;
+          }
+          ESP_LOGV(TAG, "Start byte 0xDB of encrypted telegram found");
+          this->reset_telegram_();
+          this->header_found_ = true;
+        }
+
+        // Check for buffer overflow.
+        if (this->crypt_bytes_read_ >= this->max_telegram_len_) {
+          this->reset_telegram_();
+          ESP_LOGE(TAG, "Error: encrypted telegram larger than buffer (%d bytes)", this->max_telegram_len_);
+          return;
+        }
+
+        // Store the byte in the buffer.
+        this->crypt_telegram_[this->crypt_bytes_read_] = c;
+        this->crypt_bytes_read_++;
+
+        // Read the length of the incoming encrypted telegram.
+        if (this->crypt_telegram_len_ == 0 && this->crypt_bytes_read_ > 20) {
+          // Complete header + data bytes
+          this->crypt_telegram_len_ = 13 + (this->crypt_telegram_[11] << 8 | this->crypt_telegram_[12]);
+          ESP_LOGV(TAG, "Encrypted telegram length: %d bytes", this->crypt_telegram_len_);
+        }
+
+        // Check for the end of the encrypted telegram.
+        if (this->crypt_telegram_len_ == 0 || this->crypt_bytes_read_ != this->crypt_telegram_len_) {
+          continue;
+        }
+        ESP_LOGV(TAG, "End of encrypted telegram found");
+
+        // Decrypt the encrypted telegram.
+        GCM<AES128> *gcmaes128{new GCM<AES128>()};
+        gcmaes128->setKey(this->decryption_key_.data(), gcmaes128->keySize());
+        // the iv is 8 bytes of the system title + 4 bytes frame counter
+        // system title is at byte 2 and frame counter at byte 15
+        for (int i = 10; i < 14; i++)
+          this->crypt_telegram_[i] = this->crypt_telegram_[i + 4];
+        constexpr uint16_t iv_size{12};
+        gcmaes128->setIV(&this->crypt_telegram_[2], iv_size);
+        gcmaes128->decrypt(reinterpret_cast<uint8_t *>(this->telegram_),
+                           // the ciphertext start at byte 18
+                           &this->crypt_telegram_[18],
+                           // cipher size
+                           this->crypt_bytes_read_ - 17);
+        delete gcmaes128;  // NOLINT(cppcoreguidelines-owning-memory)
+
+        this->bytes_read_ = strnlen(this->telegram_, this->max_telegram_len_);
+        ESP_LOGV(TAG, "Decrypted telegram size: %d bytes", this->bytes_read_);
+        ESP_LOGVV(TAG, "Decrypted telegram: %s", this->telegram_);
+
+        // Parse the decrypted telegram and publish sensor values.
+        this->parse_telegram();
+        this->reset_telegram_();
+        return;
       }
-      ESP_LOGV(TAG, "Start byte 0xDB of encrypted telegram found");
-      this->reset_telegram_();
-      this->header_found_ = true;
     }
-
-    // Check for buffer overflow.
-    if (this->crypt_bytes_read_ >= this->max_telegram_len_) {
-      this->reset_telegram_();
-      ESP_LOGE(TAG, "Error: encrypted telegram larger than buffer (%d bytes)", this->max_telegram_len_);
-      return;
-    }
-
-    // Store the byte in the buffer.
-    this->crypt_telegram_[this->crypt_bytes_read_] = c;
-    this->crypt_bytes_read_++;
-
-    // Read the length of the incoming encrypted telegram.
-    if (this->crypt_telegram_len_ == 0 && this->crypt_bytes_read_ > 20) {
-      // Complete header + data bytes
-      this->crypt_telegram_len_ = 13 + (this->crypt_telegram_[11] << 8 | this->crypt_telegram_[12]);
-      ESP_LOGV(TAG, "Encrypted telegram length: %d bytes", this->crypt_telegram_len_);
-    }
-
-    // Check for the end of the encrypted telegram.
-    if (this->crypt_telegram_len_ == 0 || this->crypt_bytes_read_ != this->crypt_telegram_len_) {
-      continue;
-    }
-    ESP_LOGV(TAG, "End of encrypted telegram found");
-
-    // Decrypt the encrypted telegram.
-    GCM<AES128> *gcmaes128{new GCM<AES128>()};
-    gcmaes128->setKey(this->decryption_key_.data(), gcmaes128->keySize());
-    // the iv is 8 bytes of the system title + 4 bytes frame counter
-    // system title is at byte 2 and frame counter at byte 15
-    for (int i = 10; i < 14; i++)
-      this->crypt_telegram_[i] = this->crypt_telegram_[i + 4];
-    constexpr uint16_t iv_size{12};
-    gcmaes128->setIV(&this->crypt_telegram_[2], iv_size);
-    gcmaes128->decrypt(reinterpret_cast<uint8_t *>(this->telegram_),
-                       // the ciphertext start at byte 18
-                       &this->crypt_telegram_[18],
-                       // cipher size
-                       this->crypt_bytes_read_ - 17);
-    delete gcmaes128;  // NOLINT(cppcoreguidelines-owning-memory)
-
-    this->bytes_read_ = strnlen(this->telegram_, this->max_telegram_len_);
-    ESP_LOGV(TAG, "Decrypted telegram size: %d bytes", this->bytes_read_);
-    ESP_LOGVV(TAG, "Decrypted telegram: %s", this->telegram_);
-
-    // Parse the decrypted telegram and publish sensor values.
-    this->parse_telegram();
-    this->reset_telegram_();
-    return;
   }
 }
 

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -134,7 +134,6 @@ void Dsmr::reset_telegram_() {
   this->bytes_read_ = 0;
   this->crypt_bytes_read_ = 0;
   this->crypt_telegram_len_ = 0;
-  this->last_read_time_ = 0;
 }
 
 void Dsmr::receive_telegram_() {

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -122,7 +122,9 @@ void Dsmr::drain_rx_buffer_() {
   uint8_t buf[64];
   int avail;
   while ((avail = this->available()) > 0) {
-    this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)));
+    if (!this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)))) {
+      break;
+    }
   }
 }
 

--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -85,6 +85,7 @@ class Dsmr : public Component, public uart::UARTDevice {
   void receive_telegram_();
   void receive_encrypted_telegram_();
   void reset_telegram_();
+  void drain_rx_buffer_();
 
   /// Wait for UART data to become available within the read timeout.
   ///


### PR DESCRIPTION
# What does this implement/fix?

Replaces byte-at-a-time `read()` calls with batched `read_array()` in all four UART read sites in the DSMR component:

- **`receive_telegram_()`** — main plaintext telegram processing loop
- **`receive_encrypted_telegram_()`** — encrypted telegram processing loop
- **`ready_to_request_data_()`** — drain loop when sinking serial data between requests
- **`stop_requesting_data_()`** — drain loop after telegram is parsed

Each `read()` call takes a per-call mutex on ESP-IDF, and chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`. Batching into a 64-byte stack buffer amortizes this overhead across many bytes instead of paying it per byte.

Also extracts a `drain_rx_buffer_()` helper to deduplicate the two drain sites.

Additionally fixes a latent bug where `reset_telegram_()` set `last_read_time_ = 0`. With byte-at-a-time reads this never triggered because the next byte would immediately refresh `last_read_time_` in `available_within_timeout_()`. With batched reads, the entire buffer is consumed at once, so `millis() - 0` (time since boot) immediately exceeded the receive timeout. Fix confirmed on real hardware by @PolarGoose.

Part of a series: #13817, #13818, #13819, #13820, #13821, #13822, #13823, #13824, #13825

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on real DSMR hardware by @PolarGoose.

## Example entry for `config.yaml`:

n/a — no configuration changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).