### PR TITLE
[tuya] Batch UART reads to reduce per-loop overhead

### DIFF
--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -31,22 +31,18 @@ void Tuya::setup() {
 }
 
 void Tuya::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
+  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
-  if (avail > 0) {
-    // Read all available bytes in batches to reduce UART call overhead.
-    uint8_t buf[64];
-    while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
-      if (!this->read_array(buf, to_read)) {
-        break;
-      }
-      avail -= to_read;
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
 
-      for (size_t i = 0; i < to_read; i++) {
-        this->handle_char_(buf[i]);
-      }
+    for (size_t i = 0; i < to_read; i++) {
+      this->handle_char_(buf[i]);
     }
   }
   process_command_queue_();

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -31,10 +31,21 @@ void Tuya::setup() {
 }
 
 void Tuya::loop() {
-  while (this->available()) {
-    uint8_t c;
-    this->read_byte(&c);
-    this->handle_char_(c);
+  int avail = this->available();
+  if (avail > 0) {
+    // Read all available bytes in batches to reduce UART call overhead.
+    uint8_t buf[64];
+    while (avail > 0) {
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
+        break;
+      }
+      avail -= to_read;
+
+      for (size_t i = 0; i < to_read; i++) {
+        this->handle_char_(buf[i]);
+      }
+    }
   }
   process_command_queue_();
 }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -31,6 +31,8 @@ void Tuya::setup() {
 }
 
 void Tuya::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail > 0) {
     // Read all available bytes in batches to reduce UART call overhead.


### PR DESCRIPTION
# What does this implement/fix?

Replaces byte-at-a-time `read_byte()` calls with batched `read_array()` in the Tuya component's `loop()`.

Each `read_byte()` internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in ~3 UART driver calls per byte. Batching into a 64-byte stack buffer reduces this to ~3 calls per loop iteration regardless of how many bytes are available.

Tuya is one of the most widely used UART components in ESPHome. At up to 115200 baud, the per-byte overhead adds up during protocol exchanges with the MCU.

Part of a series: #13817, #13818, #13819, #13820, #13821, #13822, #13823, #13824, #13825, #13826

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

I don't have a Tuya device to test with but the change follows the same pattern as the other batch read PRs. Processing logic is unchanged — only the UART I/O path changes.

## Example entry for `config.yaml`:

n/a — no configuration changes

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).