### PR TITLE
[pipsolar] Batch UART reads to reduce per-loop overhead

### DIFF
--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -13,9 +13,12 @@ void Pipsolar::setup() {
 }
 
 void Pipsolar::empty_uart_buffer_() {
-  uint8_t byte;
-  while (this->available()) {
-    this->read_byte(&byte);
+  uint8_t buf[64];
+  int avail;
+  while ((avail = this->available()) > 0) {
+    if (!this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)))) {
+      break;
+    }
   }
 }
 
@@ -94,32 +97,47 @@ void Pipsolar::loop() {
   }
 
   if (this->state_ == STATE_COMMAND || this->state_ == STATE_POLL) {
-    while (this->available()) {
-      uint8_t byte;
-      this->read_byte(&byte);
-
-      // make sure data and null terminator fit in buffer
-      if (this->read_pos_ >= PIPSOLAR_READ_BUFFER_LENGTH - 1) {
-        this->read_pos_ = 0;
-        this->empty_uart_buffer_();
-        ESP_LOGW(TAG, "response data too long, discarding.");
+    int avail = this->available();
+    while (avail > 0) {
+      uint8_t buf[64];
+      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      if (!this->read_array(buf, to_read)) {
         break;
       }
-      this->read_buffer_[this->read_pos_] = byte;
-      this->read_pos_++;
+      avail -= to_read;
+      bool done = false;
+      for (size_t i = 0; i < to_read; i++) {
+        uint8_t byte = buf[i];
 
-      // end of answer
-      if (byte == 0x0D) {
-        this->read_buffer_[this->read_pos_] = 0;
-        this->empty_uart_buffer_();
-        if (this->state_ == STATE_POLL) {
-          this->state_ = STATE_POLL_COMPLETE;
+        // make sure data and null terminator fit in buffer
+        if (this->read_pos_ >= PIPSOLAR_READ_BUFFER_LENGTH - 1) {
+          this->read_pos_ = 0;
+          this->empty_uart_buffer_();
+          ESP_LOGW(TAG, "response data too long, discarding.");
+          done = true;
+          break;
         }
-        if (this->state_ == STATE_COMMAND) {
-          this->state_ = STATE_COMMAND_COMPLETE;
+        this->read_buffer_[this->read_pos_] = byte;
+        this->read_pos_++;
+
+        // end of answer
+        if (byte == 0x0D) {
+          this->read_buffer_[this->read_pos_] = 0;
+          this->empty_uart_buffer_();
+          if (this->state_ == STATE_POLL) {
+            this->state_ = STATE_POLL_COMPLETE;
+          }
+          if (this->state_ == STATE_COMMAND) {
+            this->state_ = STATE_COMMAND_COMPLETE;
+          }
+          done = true;
+          break;
         }
       }
-    }  // available
+      if (done) {
+        break;
+      }
+    }
   }
   if (this->state_ == STATE_COMMAND) {
     if (millis() - this->command_start_millis_ > esphome::pipsolar::Pipsolar::COMMAND_TIMEOUT) {


### PR DESCRIPTION
# What does this implement/fix?

Batches UART reads in the pipsolar component to reduce per-loop overhead. Each `read_byte()` call internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in ~3 UART driver calls per byte. Batching into a 64-byte stack buffer reduces this to ~3 calls per batch.

### Changes

**`empty_uart_buffer_()`** — Replaced byte-at-a-time drain loop with batched `read_array()`. Includes `read_array()` return value check to prevent infinite spin on read failure.

**Main read loop in `loop()`** — Replaced `while (this->available()) { read_byte() }` with outer batch loop + inner per-byte processing. All per-byte logic (buffer overflow check, byte storage, 0x0D end-of-message detection) preserved identically. Both overflow and end-of-message paths still call `empty_uart_buffer_()` to drain remaining data.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).