### PR TITLE
[rd03d] Batch UART reads to reduce per-loop overhead

### DIFF
--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -81,8 +81,6 @@ void RD03DComponent::dump_config() {
 }
 
 void RD03DComponent::loop() {
-  // All current UART available() implementations return >= 0,
-  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
   if (avail <= 0)
     return;

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -81,12 +81,8 @@ void RD03DComponent::dump_config() {
 }
 
 void RD03DComponent::loop() {
-  // Early return avoids stack adjustment for the batch buffer below.
-  // loop() runs ~7000/min so most calls have nothing to read.
+  // Read all available bytes in batches to reduce UART call overhead.
   int avail = this->available();
-  if (avail <= 0)
-    return;
-
   uint8_t buf[64];
   while (avail > 0) {
     size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -81,6 +81,8 @@ void RD03DComponent::dump_config() {
 }
 
 void RD03DComponent::loop() {
+  // All current UART available() implementations return >= 0,
+  // use <= 0 to future-proof against any that may return negative on error.
   int avail = this->available();
   if (avail <= 0)
     return;

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -1,4 +1,5 @@
 #include "rd03d.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <cmath>
 
@@ -80,37 +81,49 @@ void RD03DComponent::dump_config() {
 }
 
 void RD03DComponent::loop() {
-  while (this->available()) {
-    uint8_t byte = this->read();
-    ESP_LOGVV(TAG, "Received byte: 0x%02X, buffer_pos: %d", byte, this->buffer_pos_);
+  int avail = this->available();
+  if (avail <= 0)
+    return;
 
-    // Check if we're looking for frame header
-    if (this->buffer_pos_ < FRAME_HEADER_SIZE) {
-      if (byte == FRAME_HEADER[this->buffer_pos_]) {
-        this->buffer_[this->buffer_pos_++] = byte;
-      } else if (byte == FRAME_HEADER[0]) {
-        // Start over if we see a potential new header
-        this->buffer_[0] = byte;
-        this->buffer_pos_ = 1;
-      } else {
+  uint8_t buf[64];
+  while (avail > 0) {
+    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    if (!this->read_array(buf, to_read)) {
+      break;
+    }
+    avail -= to_read;
+    for (size_t i = 0; i < to_read; i++) {
+      uint8_t byte = buf[i];
+      ESP_LOGVV(TAG, "Received byte: 0x%02X, buffer_pos: %d", byte, this->buffer_pos_);
+
+      // Check if we're looking for frame header
+      if (this->buffer_pos_ < FRAME_HEADER_SIZE) {
+        if (byte == FRAME_HEADER[this->buffer_pos_]) {
+          this->buffer_[this->buffer_pos_++] = byte;
+        } else if (byte == FRAME_HEADER[0]) {
+          // Start over if we see a potential new header
+          this->buffer_[0] = byte;
+          this->buffer_pos_ = 1;
+        } else {
+          this->buffer_pos_ = 0;
+        }
+        continue;
+      }
+
+      // Accumulate data bytes
+      this->buffer_[this->buffer_pos_++] = byte;
+
+      // Check if we have a complete frame
+      if (this->buffer_pos_ == FRAME_SIZE) {
+        // Validate footer
+        if (this->buffer_[FRAME_SIZE - 2] == FRAME_FOOTER[0] && this->buffer_[FRAME_SIZE - 1] == FRAME_FOOTER[1]) {
+          this->process_frame_();
+        } else {
+          ESP_LOGW(TAG, "Invalid frame footer: 0x%02X 0x%02X (expected 0x55 0xCC)", this->buffer_[FRAME_SIZE - 2],
+                   this->buffer_[FRAME_SIZE - 1]);
+        }
         this->buffer_pos_ = 0;
       }
-      continue;
-    }
-
-    // Accumulate data bytes
-    this->buffer_[this->buffer_pos_++] = byte;
-
-    // Check if we have a complete frame
-    if (this->buffer_pos_ == FRAME_SIZE) {
-      // Validate footer
-      if (this->buffer_[FRAME_SIZE - 2] == FRAME_FOOTER[0] && this->buffer_[FRAME_SIZE - 1] == FRAME_FOOTER[1]) {
-        this->process_frame_();
-      } else {
-        ESP_LOGW(TAG, "Invalid frame footer: 0x%02X 0x%02X (expected 0x55 0xCC)", this->buffer_[FRAME_SIZE - 2],
-                 this->buffer_[FRAME_SIZE - 1]);
-      }
-      this->buffer_pos_ = 0;
     }
   }
 }

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -81,6 +81,8 @@ void RD03DComponent::dump_config() {
 }
 
 void RD03DComponent::loop() {
+  // Early return avoids stack adjustment for the batch buffer below.
+  // loop() runs ~7000/min so most calls have nothing to read.
   int avail = this->available();
   if (avail <= 0)
     return;


### PR DESCRIPTION
# What does this implement/fix?

Batches UART reads in the rd03d radar component to reduce per-loop overhead. Each `read()` call internally chains through `read_array(data, 1)` → `check_read_timeout_(1)` → `available()`, resulting in ~3 UART driver calls per byte. At 256000 baud this is significant — batching into a 64-byte stack buffer reduces this to ~3 calls per batch.

The per-byte processing logic (header sync, byte accumulation, frame completion/footer validation) is preserved identically inside the inner loop.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).