### PR TITLE
[dashboard] Close WebSocket after process exit to prevent zombie connections

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -317,6 +317,7 @@ class EsphomeCommandWebSocket(CheckOriginMixin, tornado.websocket.WebSocketHandl
             # Check if the proc was not forcibly closed
             _LOGGER.info("Process exited with return code %s", returncode)
             self.write_message({"event": "exit", "code": returncode})
+            self.close()
 
     def on_close(self) -> None:
         # Check if proc exists (if 'start' has been run)


### PR DESCRIPTION
# What does this implement/fix?

When a subprocess (compile, upload, logs, etc.) exited, `_proc_on_exit` sent the `{"event": "exit", "code": ...}` message but never closed the server-side WebSocket. This left zombie connections open until the client eventually disconnected on its own.

This adds a `self.close()` call after the exit message is written, ensuring the server properly tears down the WebSocket connection once the process is done.

Related frontend: esphome/dashboard#869

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: esphome/dashboard#869

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is an internal dashboard fix, no config.yaml changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).