### PR TITLE
[logger] Resolve thread name once and pass through logging chain

### DIFF
--- a/esphome/components/logger/task_log_buffer_esp32.cpp
+++ b/esphome/components/logger/task_log_buffer_esp32.cpp
@@ -59,7 +59,7 @@ void TaskLogBuffer::release_message_main_loop(void *token) {
   last_processed_counter_ = message_counter_.load(std::memory_order_relaxed);
 }
 
-bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, TaskHandle_t task_handle,
+bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *thread_name,
                                              const char *format, va_list args) {
   // First, calculate the exact length needed using a null buffer (no actual writing)
   va_list args_copy;
@@ -95,7 +95,6 @@ bool TaskLogBuffer::send_message_thread_safe(uint8_t level, const char *tag, uin
   // Store the thread name now instead of waiting until main loop processing
   // This avoids crashes if the task completes or is deleted between when this message
   // is enqueued and when it's processed by the main loop
-  const char *thread_name = pcTaskGetName(task_handle);
   if (thread_name != nullptr) {
     strncpy(msg->thread_name, thread_name, sizeof(msg->thread_name) - 1);
     msg->thread_name[sizeof(msg->thread_name) - 1] = '\0';  // Ensure null termination

--- a/esphome/components/logger/task_log_buffer_esp32.h
+++ b/esphome/components/logger/task_log_buffer_esp32.h
@@ -58,7 +58,7 @@ class TaskLogBuffer {
   void release_message_main_loop(void *token);
 
   // Thread-safe - send a message to the ring buffer from any thread
-  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, TaskHandle_t task_handle,
+  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *thread_name,
                                 const char *format, va_list args);
 
   // Check if there are messages ready to be processed using an atomic counter for performance

--- a/esphome/components/logger/task_log_buffer_host.cpp
+++ b/esphome/components/logger/task_log_buffer_host.cpp
@@ -70,8 +70,8 @@ void TaskLogBufferHost::commit_write_slot_(int slot_index) {
   }
 }
 
-bool TaskLogBufferHost::send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *format,
-                                                 va_list args) {
+bool TaskLogBufferHost::send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *thread_name,
+                                                 const char *format, va_list args) {
   // Acquire a slot
   int slot_index = this->acquire_write_slot_();
   if (slot_index < 0) {
@@ -85,11 +85,9 @@ bool TaskLogBufferHost::send_message_thread_safe(uint8_t level, const char *tag,
   msg.tag = tag;
   msg.line = line;
 
-  // Get thread name using pthread
-  char thread_name_buf[LogMessage::MAX_THREAD_NAME_SIZE];
-  // pthread_getname_np works the same on Linux and macOS
-  if (pthread_getname_np(pthread_self(), thread_name_buf, sizeof(thread_name_buf)) == 0) {
-    strncpy(msg.thread_name, thread_name_buf, sizeof(msg.thread_name) - 1);
+  // Store the thread name now to avoid crashes if thread exits before processing
+  if (thread_name != nullptr) {
+    strncpy(msg.thread_name, thread_name, sizeof(msg.thread_name) - 1);
     msg.thread_name[sizeof(msg.thread_name) - 1] = '\0';
   } else {
     msg.thread_name[0] = '\0';

--- a/esphome/components/logger/task_log_buffer_host.h
+++ b/esphome/components/logger/task_log_buffer_host.h
@@ -86,7 +86,8 @@ class TaskLogBufferHost {
 
   // Thread-safe - send a message to the buffer from any thread
   // Returns true if message was queued, false if buffer is full
-  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *format, va_list args);
+  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *thread_name,
+                                const char *format, va_list args);
 
   // Check if there are messages ready to be processed
   inline bool HOT has_messages() const {

--- a/esphome/components/logger/task_log_buffer_libretiny.cpp
+++ b/esphome/components/logger/task_log_buffer_libretiny.cpp
@@ -101,7 +101,7 @@ void TaskLogBufferLibreTiny::release_message_main_loop() {
 }
 
 bool TaskLogBufferLibreTiny::send_message_thread_safe(uint8_t level, const char *tag, uint16_t line,
-                                                      TaskHandle_t task_handle, const char *format, va_list args) {
+                                                      const char *thread_name, const char *format, va_list args) {
   // First, calculate the exact length needed using a null buffer (no actual writing)
   va_list args_copy;
   va_copy(args_copy, args);
@@ -162,7 +162,6 @@ bool TaskLogBufferLibreTiny::send_message_thread_safe(uint8_t level, const char 
   msg->line = line;
 
   // Store the thread name now to avoid crashes if task is deleted before processing
-  const char *thread_name = pcTaskGetTaskName(task_handle);
   if (thread_name != nullptr) {
     strncpy(msg->thread_name, thread_name, sizeof(msg->thread_name) - 1);
     msg->thread_name[sizeof(msg->thread_name) - 1] = '\0';

--- a/esphome/components/logger/task_log_buffer_libretiny.h
+++ b/esphome/components/logger/task_log_buffer_libretiny.h
@@ -70,7 +70,7 @@ class TaskLogBufferLibreTiny {
   void release_message_main_loop();
 
   // Thread-safe - send a message to the buffer from any thread
-  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, TaskHandle_t task_handle,
+  bool send_message_thread_safe(uint8_t level, const char *tag, uint16_t line, const char *thread_name,
                                 const char *format, va_list args);
 
   // Fast check using volatile counter - no lock needed


### PR DESCRIPTION
# What does this implement/fix?

Eliminate redundant `xTaskGetCurrentTaskHandle()` calls on the logging hot path by resolving the thread name once in `log_vprintf_` and passing it through as `const char*` to all downstream functions.

**Before:** `format_log_to_buffer_with_terminator_()` internally called `get_thread_name_()` on every log message, which called `xTaskGetCurrentTaskHandle()` a second time (it was already called in `log_vprintf_()` to check if we're on the main task). On the main task path (99.9% of logs), this redundant call existed just to return `nullptr`. On Host, `send_message_thread_safe()` also independently called `pthread_self()` and `pthread_getname_np()` to resolve the thread name separately from the caller.

**After:** Thread name is resolved once at the top of `log_vprintf_` and passed through the entire chain. The main task fast path passes `nullptr` directly with no extra task handle lookup. Non-main threads resolve the name once and pass it to both the ring buffer and emergency console fallback.

### Key changes:
- `send_message_thread_safe()` on all 3 platforms (ESP32, LibreTiny, Host) changed from `TaskHandle_t`/implicit to `const char *thread_name`
- `log_vprintf_non_main_thread_()` unified to a single signature across all platforms
- `format_log_to_buffer_with_terminator_()` takes explicit `thread_name` parameter instead of calling `get_thread_name_()` internally
- `get_thread_name_()` overloads reorganized into clean `#if/#elif/#endif` chain with `TaskHandle_t` primary overload on ESP32/LibreTiny
- Host/Zephyr `get_thread_name_()` uses `std::span<char>` for buffer safety
- Documented Zephyr single-task path thread safety limitation as TODO

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - internal refactor, no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test non-main thread logging with a button that spawns a FreeRTOS task
button:
  - platform: template
    name: Thread Log Test
    on_press:
      - lambda: |-
          xTaskCreate([](void *) {
            ESP_LOGI("thread_test", "Hello from non-main thread!");
            vTaskDelete(nullptr);
          }, "log_test", 4096, nullptr, 1, nullptr);
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).