### PR TITLE
[lps22] Replace set_retry with set_interval to avoid heap allocation

### DIFF
--- a/esphome/components/lps22/lps22.h
+++ b/esphome/components/lps22/lps22.h
@@ -17,10 +17,11 @@ class LPS22Component : public sensor::Sensor, public PollingComponent, public i2
   void dump_config() override;
 
  protected:
+  void try_read_();
+
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *pressure_sensor_{nullptr};
-
-  RetryResult try_read_();
+  uint8_t read_attempts_remaining_{0};
 };
 
 }  // namespace lps22


### PR DESCRIPTION
# What does this implement/fix?

Replace `set_retry` with `set_interval` + countdown counter. See #13845 for full rationale on deprecating `set_retry`.

The original code used fixed-interval polling (no backoff), making `set_interval` a direct fit. The `set_interval` approach also fixes a subtle bug: the original `set_retry` fired the callback immediately (0ms) right after triggering the one-shot ADC conversion, which would always fail since the sensor needs at least 5ms to complete. `set_interval` correctly waits before the first check.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- #13845

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactor only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).