### PR TITLE
[ms8607] Replace set_retry with set_timeout chain to avoid heap allocation

### DIFF
--- a/esphome/components/ms8607/ms8607.h
+++ b/esphome/components/ms8607/ms8607.h
@@ -44,6 +44,8 @@ class MS8607Component : public PollingComponent, public i2c::I2CDevice {
   void set_humidity_device(MS8607HumidityDevice *humidity_device) { humidity_device_ = humidity_device; }
 
  protected:
+  /// Attempt to reset both I2C devices, retrying with backoff on failure
+  void try_reset_();
   /**
    Read and store the Pressure & Temperature calibration settings from the PROM.
    Intended to be called during setup(), this will set the `failure_reason_`
@@ -102,6 +104,8 @@ class MS8607Component : public PollingComponent, public i2c::I2CDevice {
   enum class SetupStatus;
   /// Current step in the multi-step & possibly delayed setup() process
   SetupStatus setup_status_;
+  uint32_t reset_interval_{5};
+  uint8_t reset_attempts_remaining_{0};
 };
 
 }  // namespace ms8607


### PR DESCRIPTION
# What does this implement/fix?

Replace `set_retry` with a `try_reset_()` method that chains named `set_timeout` calls with manual backoff. See #13845 for full rationale on deprecating `set_retry`.

This is the only component that used backoff (5.0x factor), so `set_timeout` chains are used instead of `set_interval`. The delays are sequential (5ms then 25ms), giving cumulative timing of now, +5ms, +30ms.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- #13845

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactor only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).