### PR TITLE
[speaker] Replace set_retry with set_interval to avoid heap allocation

### DIFF
--- a/esphome/components/speaker/media_player/speaker_media_player.h
+++ b/esphome/components/speaker/media_player/speaker_media_player.h
@@ -112,6 +112,9 @@ class SpeakerMediaPlayer : public Component,
   /// media pipelines are defined.
   inline bool single_pipeline_() { return (this->media_speaker_ == nullptr); }
 
+  /// Stops the media pipeline and polls until stopped to unpause it, avoiding an audible glitch.
+  void stop_and_unpause_media_();
+
   // Processes commands from media_control_command_queue_.
   void watch_media_commands_();
 
@@ -141,6 +144,8 @@ class SpeakerMediaPlayer : public Component,
 
   bool is_paused_{false};
   bool is_muted_{false};
+  uint8_t unpause_media_remaining_{0};
+  uint8_t unpause_announcement_remaining_{0};
 
   // The amount to change the volume on volume up/down commands
   float volume_increment_;


### PR DESCRIPTION
# What does this implement/fix?

Replace 3 `set_retry` call sites with `set_interval` + countdown counter. See #13845 for full rationale on deprecating `set_retry`.

All 3 call sites used fixed-interval polling (no backoff) to check if a pipeline had stopped before unpausing, making `set_interval` a direct fit.

The duplicate media pipeline stop-and-unpause pattern (used in both the "play while paused" and STOP command paths) is extracted into a `stop_and_unpause_media_()` helper.

On counter exhaustion without the pipeline reaching STOPPED, the interval is cancelled without unpausing — matching the original `set_retry` behavior.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- #13845

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactor only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).