### PR TITLE
[esp32_hosted] Replace set_retry with set_interval to avoid heap allocation

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -127,15 +127,18 @@ void Esp32HostedUpdate::setup() {
   this->status_clear_error();
   this->publish_state();
 #else
-  // HTTP mode: retry initial check every 10s until network is ready (max 6 attempts)
+  // HTTP mode: check every 10s until network is ready (max 6 attempts)
   // Only if update interval is > 1 minute to avoid redundant checks
   if (this->get_update_interval() > 60000) {
-    this->set_retry("initial_check", 10000, 6, [this](uint8_t) {
-      if (!network::is_connected()) {
-        return RetryResult::RETRY;
+    this->initial_check_remaining_ = 6;
+    this->set_interval("initial_check", 10000, [this]() {
+      bool connected = network::is_connected();
+      if (--this->initial_check_remaining_ == 0 || connected) {
+        this->cancel_interval("initial_check");
+        if (connected) {
+          this->check();
+        }
       }
-      this->check();
-      return RetryResult::DONE;
     });
   }
 #endif

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -27,6 +27,11 @@ static const char *const TAG = "esp32_hosted.update";
 // Older coprocessor firmware versions have a 1500-byte limit per RPC call
 constexpr size_t CHUNK_SIZE = 1500;
 
+#ifdef USE_ESP32_HOSTED_HTTP_UPDATE
+// Interval/timeout IDs (uint32_t to avoid string comparison)
+constexpr uint32_t INITIAL_CHECK_INTERVAL_ID = 0;
+#endif
+
 // Compile-time version string from esp_hosted_host_fw_ver.h macros
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
@@ -131,10 +136,10 @@ void Esp32HostedUpdate::setup() {
   // Only if update interval is > 1 minute to avoid redundant checks
   if (this->get_update_interval() > 60000) {
     this->initial_check_remaining_ = 6;
-    this->set_interval("initial_check", 10000, [this]() {
+    this->set_interval(INITIAL_CHECK_INTERVAL_ID, 10000, [this]() {
       bool connected = network::is_connected();
       if (--this->initial_check_remaining_ == 0 || connected) {
-        this->cancel_interval("initial_check");
+        this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
         if (connected) {
           this->check();
         }

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.h
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.h
@@ -44,6 +44,7 @@ class Esp32HostedUpdate : public update::UpdateEntity, public PollingComponent {
   // HTTP mode helpers
   bool fetch_manifest_();
   bool stream_firmware_to_coprocessor_();
+  uint8_t initial_check_remaining_{0};
 #else
   // Embedded mode members
   const uint8_t *firmware_data_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Replace `set_retry` with `set_interval` + countdown counter for the initial network check. See #13845 for full rationale on deprecating `set_retry`.

The original code used fixed-interval polling (no backoff) to wait for network connectivity, making `set_interval` a direct fit.

- Uses `constexpr uint32_t` interval ID instead of a string name to avoid string comparison overhead in the scheduler
- Wraps `initial_check_remaining_` member in `#ifdef USE_ESP32_HOSTED_HTTP_UPDATE` to avoid increasing object size in embedded-mode builds

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

- #13845

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactor only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).