### PR TITLE
[core] Deprecate set_retry, cancel_retry, and RetryResult

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -152,7 +152,10 @@ void Component::set_retry(const std::string &name, uint32_t initial_wait_time, u
 
 void Component::set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                           std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_retry(this, name, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+#pragma GCC diagnostic pop
 }
 
 bool Component::cancel_retry(const std::string &name) {  // NOLINT
@@ -163,7 +166,10 @@ bool Component::cancel_retry(const std::string &name) {  // NOLINT
 }
 
 bool Component::cancel_retry(const char *name) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   return App.scheduler.cancel_retry(this, name);
+#pragma GCC diagnostic pop
 }
 
 void Component::set_timeout(const std::string &name, uint32_t timeout, std::function<void()> &&f) {  // NOLINT
@@ -203,10 +209,18 @@ bool Component::cancel_interval(uint32_t id) { return App.scheduler.cancel_inter
 
 void Component::set_retry(uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
                           std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_retry(this, id, initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+#pragma GCC diagnostic pop
 }
 
-bool Component::cancel_retry(uint32_t id) { return App.scheduler.cancel_retry(this, id); }
+bool Component::cancel_retry(uint32_t id) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  return App.scheduler.cancel_retry(this, id);
+#pragma GCC diagnostic pop
+}
 
 void Component::call_loop() { this->loop(); }
 void Component::call_setup() { this->setup(); }
@@ -371,7 +385,10 @@ void Component::set_interval(uint32_t interval, std::function<void()> &&f) {  //
 }
 void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,
                           float backoff_increase_factor) {  // NOLINT
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   App.scheduler.set_retry(this, "", initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
+#pragma GCC diagnostic pop
 }
 bool Component::is_failed() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 bool Component::is_ready() const {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -68,6 +68,7 @@ extern const uint8_t STATUS_LED_OK;
 extern const uint8_t STATUS_LED_WARNING;
 extern const uint8_t STATUS_LED_ERROR;
 
+// Remove before 2026.8.0
 enum class RetryResult { DONE, RETRY };
 
 extern const uint16_t WARN_IF_BLOCKING_OVER_MS;
@@ -347,68 +348,40 @@ class Component {
   bool cancel_interval(const char *name);         // NOLINT
   bool cancel_interval(uint32_t id);              // NOLINT
 
-  /** Set an retry function with a unique name. Empty name means no cancelling possible.
-   *
-   * This will call the retry function f on the next scheduler loop. f should return RetryResult::DONE if
-   * it is successful and no repeat is required. Otherwise, returning RetryResult::RETRY will call f
-   * again in the future.
-   *
-   * The first retry of f happens after `initial_wait_time` milliseconds. The delay between retries is
-   * increased by multiplying by `backoff_increase_factor` each time. If no backoff_increase_factor is
-   * supplied (default = 1.0), the wait time will stay constant.
-   *
-   * The retry function f needs to accept a single argument: the number of attempts remaining. On the
-   * final retry of f, this value will be 0.
-   *
-   * This retry function can also be cancelled by name via cancel_retry().
-   *
-   * IMPORTANT: Do not rely on this having correct timing. This is only called from
-   * loop() and therefore can be significantly delayed.
-   *
-   * REMARK: It is an error to supply a negative or zero `backoff_increase_factor`, and 1.0 will be used instead.
-   *
-   * REMARK: The interval between retries is stored into a `uint32_t`, so this doesn't behave correctly
-   * if `initial_wait_time * (backoff_increase_factor ** (max_attempts - 2))` overflows.
-   *
-   * @param name The identifier for this retry function.
-   * @param initial_wait_time The time in ms before f is called again
-   * @param max_attempts The maximum number of executions
-   * @param f The function (or lambda) that should be called
-   * @param backoff_increase_factor time between retries is multiplied by this factor on every retry after the first
-   * @see cancel_retry()
-   */
-  // Remove before 2026.7.0
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  /// @deprecated set_retry is deprecated. Use set_timeout or set_interval instead. Removed in 2026.8.0.
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,       // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(const char *name, uint32_t initial_wait_time, uint8_t max_attempts,              // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
-  /** Set a retry function with a numeric ID (zero heap allocation).
-   *
-   * @param id The numeric identifier for this retry function
-   * @param initial_wait_time The wait time after the first execution
-   * @param max_attempts The max number of attempts
-   * @param f The function to call
-   * @param backoff_increase_factor The factor to increase the retry interval by
-   */
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,                   // NOLINT
                  std::function<RetryResult(uint8_t)> &&f, float backoff_increase_factor = 1.0f);  // NOLINT
 
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> &&f,  // NOLINT
                  float backoff_increase_factor = 1.0f);                                                      // NOLINT
 
-  /** Cancel a retry function.
-   *
-   * @param name The identifier for this retry function.
-   * @return Whether a retry function was deleted.
-   */
-  // Remove before 2026.7.0
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
   bool cancel_retry(const std::string &name);  // NOLINT
-  bool cancel_retry(const char *name);         // NOLINT
-  bool cancel_retry(uint32_t id);              // NOLINT
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
+  bool cancel_retry(const char *name);  // NOLINT
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
+  bool cancel_retry(uint32_t id);  // NOLINT
 
   /** Set a timeout function with a unique name.
    *

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -252,6 +252,11 @@ bool HOT Scheduler::cancel_interval(Component *component, uint32_t id) {
   return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::INTERVAL);
 }
 
+// Suppress deprecation warnings for RetryResult usage in the still-present (but deprecated) retry implementation.
+// Remove before 2026.8.0 along with all retry code.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 struct RetryArgs {
   // Ordered to minimize padding on 32-bit systems
   std::function<RetryResult(uint8_t)> func;
@@ -363,6 +368,8 @@ void HOT Scheduler::set_retry(Component *component, uint32_t id, uint32_t initia
 bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
   return this->cancel_retry_(component, NameType::NUMERIC_ID, nullptr, id);
 }
+
+#pragma GCC diagnostic pop  // End suppression of deprecated RetryResult warnings
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // IMPORTANT: This method should only be called from the main thread (loop task).

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -72,18 +72,30 @@ class Scheduler {
   bool cancel_interval(Component *component, const char *name);
   bool cancel_interval(Component *component, uint32_t id);
 
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(Component *component, const std::string &name, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(Component *component, const char *name, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
-  /// Set a retry with a numeric ID (zero heap allocation)
+  // Remove before 2026.8.0
+  ESPDEPRECATED("set_retry is deprecated and will be removed in 2026.8.0. Use set_timeout or set_interval instead.",
+                "2026.2.0")
   void set_retry(Component *component, uint32_t id, uint32_t initial_wait_time, uint8_t max_attempts,
                  std::function<RetryResult(uint8_t)> func, float backoff_increase_factor = 1.0f);
 
-  ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
   bool cancel_retry(Component *component, const std::string &name);
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
   bool cancel_retry(Component *component, const char *name);
+  // Remove before 2026.8.0
+  ESPDEPRECATED("cancel_retry is deprecated and will be removed in 2026.8.0.", "2026.2.0")
   bool cancel_retry(Component *component, uint32_t id);
 
   // Calculate when the next scheduled item should run
@@ -231,11 +243,14 @@ class Scheduler {
                          uint32_t hash_or_id, uint32_t delay, std::function<void()> func, bool is_retry = false,
                          bool skip_cancel = false);
 
-  // Common implementation for retry
+  // Common implementation for retry - Remove before 2026.8.0
   // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   void set_retry_common_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id,
                          uint32_t initial_wait_time, uint8_t max_attempts, std::function<RetryResult(uint8_t)> func,
                          float backoff_increase_factor);
+#pragma GCC diagnostic pop
   // Common implementation for cancel_retry
   bool cancel_retry_(Component *component, NameType name_type, const char *static_name, uint32_t hash_or_id);
 


### PR DESCRIPTION
# What does this implement/fix?

Deprecates the entire `set_retry` / `cancel_retry` / `RetryResult` API surface. Deprecated in 2026.2.0, removal in 2026.8.0.

## Why deprecate

**Hidden heap allocation footgun.** Every `set_retry` call does a `std::make_shared<RetryArgs>()`, allocating a control block + `RetryArgs` struct on the heap. This is invisible to component authors who think they're using a lightweight scheduler primitive. On devices that run for months with small heaps, every allocation/deallocation cycle contributes to fragmentation. `set_interval` and `set_timeout` avoid this entirely.

**Wastes flash and RAM in every firmware.** The retry machinery — `RetryArgs` struct, `retry_handler()`, `set_retry_common_()`, three overloads of `set_retry`, three overloads of `cancel_retry`, the `std::function<RetryResult(uint8_t)>` template instantiation (heavier than `std::function<void()>`) — is compiled into every firmware whether or not any component uses it. No core component uses it anymore.

**The abstraction didn't match real usage.** All 4 internal callers were using `set_retry` as a fixed-interval poll (backoff factor 1.0, always returning `RETRY`). Only one component (ms8607) used backoff, and it had exactly 3 attempts at hardcoded timing. These are trivially served by `set_interval` + counter or chained `set_timeout`. Components that actually need retry-with-backoff should build their own logic — they'll have better control over timing, cancellation, and error handling than a one-size-fits-all scheduler primitive can provide.

**Confusing immediate-first-execution semantics.** `set_retry` executes the callback immediately (delay=0) before waiting `initial_wait_time` for subsequent attempts. This is counterintuitive — callers expected it to wait first, like `set_interval` does. The lps22 component is a clear example: it triggers an ADC conversion then calls `set_retry(5ms, ...)`, but the callback fires at 0ms when the conversion hasn't completed yet, wasting the first attempt every time. The API's surprising behavior led to subtly wrong designs that happened to work only because the retry mechanism masked the bug.

**No longer needed as a workaround.** Historically, calling `cancel_interval` or `cancel_timeout` from inside a callback was subtly broken in the scheduler, which may have driven component authors toward `set_retry` as a workaround for self-cancelling patterns. The scheduler has since been reworked and this behavior is now tested and reliable, so the workaround is no longer necessary.

## Depends on

These PRs remove all internal usage first:

- #13841 [lps22] Replace set_retry with set_interval
- #13842 [ms8607] Replace set_retry with set_timeout chain
- #13843 [speaker] Replace set_retry with set_interval
- #13844 [esp32_hosted] Replace set_retry with set_interval

## What changed

- `RetryResult` enum: marked `ESPDEPRECATED`
- All `set_retry` overloads (std::string, const char*, uint32_t, unnamed): marked `ESPDEPRECATED`
- All `cancel_retry` overloads: marked `ESPDEPRECATED`
- Added `#pragma GCC diagnostic` suppression in internal implementation code so the deprecated methods can still call each other without warnings during the deprecation period

## Types of changes

- [x] Developer breaking change (an API change that could break external components)

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal API deprecation only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).