### PR TITLE
[lvgl] Fix crash with unconfigured `top_layer`

### DIFF
--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -436,6 +436,8 @@ def container_schema(widget_type: WidgetType, extras=None):
     schema = schema.extend(widget_type.schema)
 
     def validator(value):
+        if value is None:
+            return None
         return append_layout_schema(schema, value)(value)
 
     return validator

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -436,9 +436,7 @@ def container_schema(widget_type: WidgetType, extras=None):
     schema = schema.extend(widget_type.schema)
 
     def validator(value):
-        # Don't add a layout if there is nothing to layout.
-        if not value:
-            return value
+        value = value or {}
         return append_layout_schema(schema, value)(value)
 
     return validator

--- a/esphome/components/lvgl/schemas.py
+++ b/esphome/components/lvgl/schemas.py
@@ -436,8 +436,9 @@ def container_schema(widget_type: WidgetType, extras=None):
     schema = schema.extend(widget_type.schema)
 
     def validator(value):
-        if value is None:
-            return None
+        # Don't add a layout if there is nothing to layout.
+        if not value:
+            return value
         return append_layout_schema(schema, value)(value)
 
     return validator

--- a/tests/components/lvgl/test.host.yaml
+++ b/tests/components/lvgl/test.host.yaml
@@ -20,6 +20,8 @@ lvgl:
   - id: lvgl_0
     default_font: space16
     displays: sdl0
+    top_layer:
+
   - id: lvgl_1
     displays: sdl1
     on_idle:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Configuring:

```
lvgl:
  top_layer:
```

with no data triggered a crash.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13835

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
