### PR TITLE
[e131] Remove unnecessary heap allocation from packet receive loop

### DIFF
--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -55,7 +55,6 @@ void E131Component::setup() {
 }
 
 void E131Component::loop() {
-  std::vector<uint8_t> payload;
   E131Packet packet;
   int universe = 0;
   uint8_t buf[1460];
@@ -64,11 +63,9 @@ void E131Component::loop() {
   if (len == -1) {
     return;
   }
-  payload.resize(len);
-  memmove(&payload[0], buf, len);
 
-  if (!this->packet_(payload, universe, packet)) {
-    ESP_LOGV(TAG, "Invalid packet received of size %zu.", payload.size());
+  if (!this->packet_(buf, (size_t) len, universe, packet)) {
+    ESP_LOGV(TAG, "Invalid packet received of size %zd.", len);
     return;
   }
 

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -38,7 +38,7 @@ class E131Component : public esphome::Component {
   void set_method(E131ListenMethod listen_method) { this->listen_method_ = listen_method; }
 
  protected:
-  bool packet_(const std::vector<uint8_t> &data, int &universe, E131Packet &packet);
+  bool packet_(const uint8_t *data, size_t len, int &universe, E131Packet &packet);
   bool process_(int universe, const E131Packet &packet);
   bool join_igmp_groups_();
   void join_(int universe);

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -116,11 +116,11 @@ void E131Component::leave_(int universe) {
   ESP_LOGD(TAG, "Left %d universe for E1.31.", universe);
 }
 
-bool E131Component::packet_(const std::vector<uint8_t> &data, int &universe, E131Packet &packet) {
-  if (data.size() < E131_MIN_PACKET_SIZE)
+bool E131Component::packet_(const uint8_t *data, size_t len, int &universe, E131Packet &packet) {
+  if (len < E131_MIN_PACKET_SIZE)
     return false;
 
-  auto *sbuff = reinterpret_cast<const E131RawPacket *>(&data[0]);
+  auto *sbuff = reinterpret_cast<const E131RawPacket *>(data);
 
   if (memcmp(sbuff->acn_id, ACN_ID, sizeof(sbuff->acn_id)) != 0)
     return false;


### PR DESCRIPTION
# What does this implement/fix?

Remove a per-packet `std::vector<uint8_t>` heap allocation in `E131Component::loop()`. The received UDP data was already sitting in the stack buffer `buf[1460]`, but was being copied into a vector solely to satisfy the `packet_()` method signature. E1.31 runs at up to 44 Hz per universe, causing ~44 needless alloc/free cycles per second per universe.

The fix changes the internal `packet_()` method to accept `const uint8_t *data, size_t len` and passes the stack buffer directly, eliminating the vector, its `resize()`, and the `memmove()` copy entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).