### PR TITLE
[web_server_idf] Use C++17 nested namespace style

### DIFF
--- a/esphome/components/web_server_idf/multipart.cpp
+++ b/esphome/components/web_server_idf/multipart.cpp
@@ -6,8 +6,7 @@
 #include <cstring>
 #include "multipart_parser.h"
 
-namespace esphome {
-namespace web_server_idf {
+namespace esphome::web_server_idf {
 
 static const char *const TAG = "multipart";
 
@@ -249,6 +248,5 @@ std::string str_trim(const std::string &str) {
   return str.substr(start, end - start + 1);
 }
 
-}  // namespace web_server_idf
-}  // namespace esphome
+}  // namespace esphome::web_server_idf
 #endif  // defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)

--- a/esphome/components/web_server_idf/multipart.h
+++ b/esphome/components/web_server_idf/multipart.h
@@ -10,8 +10,7 @@
 #include <string>
 #include <utility>
 
-namespace esphome {
-namespace web_server_idf {
+namespace esphome::web_server_idf {
 
 // Wrapper around zorxx/multipart-parser for ESP-IDF OTA uploads
 class MultipartReader {
@@ -81,6 +80,5 @@ bool parse_multipart_boundary(const char *content_type, const char **boundary_st
 // Trim whitespace from both ends of a string
 std::string str_trim(const std::string &str);
 
-}  // namespace web_server_idf
-}  // namespace esphome
+}  // namespace esphome::web_server_idf
 #endif  // defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -8,8 +8,7 @@
 
 #include "utils.h"
 
-namespace esphome {
-namespace web_server_idf {
+namespace esphome::web_server_idf {
 
 static const char *const TAG = "web_server_idf_utils";
 
@@ -119,6 +118,5 @@ const char *stristr(const char *haystack, const char *needle) {
   return nullptr;
 }
 
-}  // namespace web_server_idf
-}  // namespace esphome
+}  // namespace esphome::web_server_idf
 #endif  // USE_ESP32

--- a/esphome/components/web_server_idf/utils.h
+++ b/esphome/components/web_server_idf/utils.h
@@ -5,8 +5,7 @@
 #include <string>
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace web_server_idf {
+namespace esphome::web_server_idf {
 
 /// Decode URL-encoded string in-place (e.g., %20 -> space, + -> space)
 /// Returns the new length of the decoded string
@@ -29,6 +28,5 @@ bool str_ncmp_ci(const char *s1, const char *s2, size_t n);
 // Case-insensitive string search (like strstr but case-insensitive)
 const char *stristr(const char *haystack, const char *needle);
 
-}  // namespace web_server_idf
-}  // namespace esphome
+}  // namespace esphome::web_server_idf
 #endif  // USE_ESP32

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -30,8 +30,7 @@
 #include <cerrno>
 #include <sys/socket.h>
 
-namespace esphome {
-namespace web_server_idf {
+namespace esphome::web_server_idf {
 
 #ifndef HTTPD_409
 #define HTTPD_409 "409 Conflict"
@@ -897,7 +896,6 @@ esp_err_t AsyncWebServer::handle_multipart_upload_(httpd_req_t *r, const char *c
 }
 #endif  // USE_WEBSERVER_OTA
 
-}  // namespace web_server_idf
-}  // namespace esphome
+}  // namespace esphome::web_server_idf
 
 #endif  // !defined(USE_ESP32)


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace declaration style (`namespace esphome::web_server_idf`) instead of separate nested declarations in the web_server_idf component.

The header file (`web_server_idf.h`) is left unchanged since it contains forward declarations for `esphome::web_server::WebServer` that require the `namespace esphome` block to remain open.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - code style only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).