### PR TITLE
[voice_assistant] Replace timer unordered_map with vector to eliminate per-tick heap allocation

### DIFF
--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -371,7 +371,12 @@ async def to_code(config):
     if on_timer_tick := config.get(CONF_ON_TIMER_TICK):
         await automation.build_automation(
             var.get_timer_tick_trigger(),
-            [(cg.std_vector.template(Timer), "timers")],
+            [
+                (
+                    cg.std_vector.template(Timer).operator("const").operator("ref"),
+                    "timers",
+                )
+            ],
             on_timer_tick,
         )
         has_timers = True

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -225,7 +225,7 @@ class VoiceAssistant : public Component {
   Trigger<Timer> *get_timer_updated_trigger() { return &this->timer_updated_trigger_; }
   Trigger<Timer> *get_timer_cancelled_trigger() { return &this->timer_cancelled_trigger_; }
   Trigger<Timer> *get_timer_finished_trigger() { return &this->timer_finished_trigger_; }
-  Trigger<std::vector<Timer>> *get_timer_tick_trigger() { return &this->timer_tick_trigger_; }
+  Trigger<const std::vector<Timer> &> *get_timer_tick_trigger() { return &this->timer_tick_trigger_; }
   void set_has_timers(bool has_timers) { this->has_timers_ = has_timers; }
   const std::vector<Timer> &get_timers() const { return this->timers_; }
 
@@ -272,7 +272,7 @@ class VoiceAssistant : public Component {
   Trigger<Timer> timer_finished_trigger_;
   Trigger<Timer> timer_updated_trigger_;
   Trigger<Timer> timer_cancelled_trigger_;
-  Trigger<std::vector<Timer>> timer_tick_trigger_;
+  Trigger<const std::vector<Timer> &> timer_tick_trigger_;
   bool has_timers_{false};
   bool timer_tick_running_{false};
 

--- a/esphome/components/voice_assistant/voice_assistant.h
+++ b/esphome/components/voice_assistant/voice_assistant.h
@@ -24,7 +24,6 @@
 #include "esphome/components/socket/socket.h"
 
 #include <span>
-#include <unordered_map>
 #include <vector>
 
 namespace esphome {
@@ -228,7 +227,7 @@ class VoiceAssistant : public Component {
   Trigger<Timer> *get_timer_finished_trigger() { return &this->timer_finished_trigger_; }
   Trigger<std::vector<Timer>> *get_timer_tick_trigger() { return &this->timer_tick_trigger_; }
   void set_has_timers(bool has_timers) { this->has_timers_ = has_timers; }
-  const std::unordered_map<std::string, Timer> &get_timers() const { return this->timers_; }
+  const std::vector<Timer> &get_timers() const { return this->timers_; }
 
  protected:
   bool allocate_buffers_();
@@ -267,7 +266,7 @@ class VoiceAssistant : public Component {
 
   api::APIConnection *api_client_{nullptr};
 
-  std::unordered_map<std::string, Timer> timers_;
+  std::vector<Timer> timers_;
   void timer_tick_();
   Trigger<Timer> timer_started_trigger_;
   Trigger<Timer> timer_finished_trigger_;

--- a/tests/components/voice_assistant/common-idf.yaml
+++ b/tests/components/voice_assistant/common-idf.yaml
@@ -68,3 +68,24 @@ voice_assistant:
     - logger.log:
         format: "Voice assistant error - code %s, message: %s"
         args: [code.c_str(), message.c_str()]
+  on_timer_started:
+    - logger.log:
+        format: "Timer started: %s"
+        args: [timer.id.c_str()]
+  on_timer_updated:
+    - logger.log:
+        format: "Timer updated: %s"
+        args: [timer.id.c_str()]
+  on_timer_cancelled:
+    - logger.log:
+        format: "Timer cancelled: %s"
+        args: [timer.id.c_str()]
+  on_timer_finished:
+    - logger.log:
+        format: "Timer finished: %s"
+        args: [timer.id.c_str()]
+  on_timer_tick:
+    - lambda: |-
+        for (auto &timer : timers) {
+          ESP_LOGD("timer", "Timer %s: %" PRIu32 "s left", timer.name.c_str(), timer.seconds_left);
+        }

--- a/tests/components/voice_assistant/common.yaml
+++ b/tests/components/voice_assistant/common.yaml
@@ -58,3 +58,24 @@ voice_assistant:
     - logger.log:
         format: "Voice assistant error - code %s, message: %s"
         args: [code.c_str(), message.c_str()]
+  on_timer_started:
+    - logger.log:
+        format: "Timer started: %s"
+        args: [timer.id.c_str()]
+  on_timer_updated:
+    - logger.log:
+        format: "Timer updated: %s"
+        args: [timer.id.c_str()]
+  on_timer_cancelled:
+    - logger.log:
+        format: "Timer cancelled: %s"
+        args: [timer.id.c_str()]
+  on_timer_finished:
+    - logger.log:
+        format: "Timer finished: %s"
+        args: [timer.id.c_str()]
+  on_timer_tick:
+    - lambda: |-
+        for (auto &timer : timers) {
+          ESP_LOGD("timer", "Timer %s: %" PRIu32 "s left", timer.name.c_str(), timer.seconds_left);
+        }


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::unordered_map<std::string, Timer>` with `std::vector<Timer>` for timer storage in the voice assistant component.

The original `unordered_map` made sense as a general-purpose choice — it gives O(1) lookup by timer ID for add/remove operations. However, in practice users typically have 1–2 active timers at most, and add/remove events are infrequent (a few times a day). The hot path is `timer_tick_()` which runs every second and needs to iterate all timers. The map was being fully iterated into a freshly-allocated `std::vector<Timer>` each tick, copying every `Timer` struct (including its two `std::string` members) just to pass it to the trigger.

Switching to `std::vector<Timer>` optimizes for the hot path: the tick loop now just decrements integers on 1–2 structs in contiguous memory and passes a const reference directly to the trigger — zero allocation, zero copies. Linear search for the infrequent add/remove-by-ID operations is negligible on 1–2 elements.

**Before (every tick):**
- Hash table overhead (~500+ bytes for bucket storage)
- `std::vector<Timer>` heap allocation
- Full copy of every `Timer` including string allocations

**After (every tick):**
- Just integer decrements on 1–2 contiguous structs
- Zero allocation — trigger receives a `const` reference directly to the member vector
- Zero copies — timers are updated in-place, no intermediate buffer
- No hash table overhead

Also updated the automation arg type to `const std::vector<Timer> &` so that `on_timer_tick` lambdas receive a const reference instead of a by-value copy, and added timer automation tests to both common test configs.

### Migration

`get_timers()` now returns `const std::vector<Timer> &` instead of `const std::unordered_map<std::string, Timer> &`. Code that iterates timers using map pair semantics (`.second`) needs updating — the vector iterates `Timer` directly.

**Before:**
```cpp
const auto timers = id(va).get_timers();
auto output_timer = timers.begin()->second;
for (auto &iterable_timer : timers) {
  if (iterable_timer.second.is_active && iterable_timer.second.seconds_left <= output_timer.seconds_left) {
    output_timer = iterable_timer.second;
  }
}
id(first_active_timer) = output_timer;
```

**After:**
```cpp
const auto &timers = id(va).get_timers();
auto output_timer = *timers.begin();
for (const auto &timer : timers) {
  if (timer.is_active && timer.seconds_left <= output_timer.seconds_left) {
    output_timer = timer;
  }
}
id(first_active_timer) = output_timer;
```

**Before:**
```cpp
const auto timers = id(va).get_timers();
bool output = false;
if (timers.size() > 0) {
  for (auto &iterable_timer : timers) {
    if(iterable_timer.second.is_active) {
      output = true;
    }
  }
}
id(is_timer_active) = output;
```

**After:**
```cpp
const auto &timers = id(va).get_timers();
bool output = false;
for (const auto &timer : timers) {
  if (timer.is_active) {
    output = true;
  }
}
id(is_timer_active) = output;
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required — internal optimization only
voice_assistant:
  on_timer_tick:
    then:
      - lambda: |-
          for (auto &timer : timers) {
            ESP_LOGD("timer", "Timer %s: %" PRIu32 "s left", timer.name.c_str(), timer.seconds_left);
          }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).