### PR TITLE
[hlk_fm22x] Replace per-cycle vector allocation with member buffer

### DIFF
--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "hlk_fm22x";
 void HlkFm22xComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up HLK-FM22X...");
   this->set_enrolling_(false);
-  while (this->available()) {
+  while (this->available() > 0) {
     this->read();
   }
   this->defer([this]() { this->send_command_(HlkFm22xCommand::GET_STATUS); });
@@ -84,7 +84,7 @@ void HlkFm22xComponent::send_command_(HlkFm22xCommand command, const uint8_t *da
   }
   this->wait_cycles_ = 0;
   this->active_command_ = command;
-  while (this->available())
+  while (this->available() > 0)
     this->read();
   this->write((uint8_t) (START_CODE >> 8));
   this->write((uint8_t) (START_CODE & 0xFF));
@@ -136,7 +136,7 @@ void HlkFm22xComponent::recv_command_() {
   if (length > HLK_FM22X_MAX_RESPONSE_SIZE) {
     ESP_LOGE(TAG, "Response too large: %u bytes", length);
     // Discard exactly the remaining payload and checksum for this frame
-    for (uint16_t i = 0; i < length + 1 && this->available(); ++i)
+    for (uint16_t i = 0; i < length + 1 && this->available() > 0; ++i)
       this->read();
     return;
   }

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -135,7 +135,8 @@ void HlkFm22xComponent::recv_command_() {
 
   if (length > HLK_FM22X_MAX_RESPONSE_SIZE) {
     ESP_LOGE(TAG, "Response too large: %u bytes", length);
-    while (this->available())
+    // Discard exactly the remaining payload and checksum for this frame
+    for (uint16_t i = 0; i < length + 1 && this->available(); ++i)
       this->read();
     return;
   }

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -135,6 +135,8 @@ void HlkFm22xComponent::recv_command_() {
 
   if (length > HLK_FM22X_MAX_RESPONSE_SIZE) {
     ESP_LOGE(TAG, "Response too large: %u bytes", length);
+    while (this->available())
+      this->read();
     return;
   }
 
@@ -169,10 +171,14 @@ void HlkFm22xComponent::recv_command_() {
 }
 
 void HlkFm22xComponent::handle_note_(const uint8_t *data, size_t length) {
+  if (length < 1) {
+    ESP_LOGE(TAG, "Empty note data");
+    return;
+  }
   switch (data[0]) {
     case HlkFm22xNoteType::FACE_STATE:
       if (length < 17) {
-        ESP_LOGE(TAG, "Invalid face note data size: %u", length);
+        ESP_LOGE(TAG, "Invalid face note data size: %zu", length);
         break;
       }
       {
@@ -212,6 +218,10 @@ void HlkFm22xComponent::handle_note_(const uint8_t *data, size_t length) {
 void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
   auto expected = this->active_command_;
   this->active_command_ = HlkFm22xCommand::NONE;
+  if (length < 2) {
+    ESP_LOGE(TAG, "Reply too short: %zu bytes", length);
+    return;
+  }
   if (data[0] != (uint8_t) expected) {
     ESP_LOGE(TAG, "Unexpected response command. Expected: 0x%.2X, Received: 0x%.2X", expected, data[0]);
     return;
@@ -238,9 +248,13 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
   }
   switch (expected) {
     case HlkFm22xCommand::VERIFY: {
+      if (length < 4 + HLK_FM22X_NAME_SIZE) {
+        ESP_LOGE(TAG, "VERIFY response too short: %zu bytes", length);
+        break;
+      }
       int16_t face_id = ((int16_t) data[2] << 8) | data[3];
       const char *name_ptr = reinterpret_cast<const char *>(data + 4);
-      ESP_LOGD(TAG, "Face verified. ID: %d, name: %.*s", face_id, HLK_FM22X_NAME_SIZE, name_ptr);
+      ESP_LOGD(TAG, "Face verified. ID: %d, name: %.*s", face_id, (int) HLK_FM22X_NAME_SIZE, name_ptr);
       if (this->last_face_id_sensor_ != nullptr) {
         this->last_face_id_sensor_->publish_state(face_id);
       }
@@ -266,7 +280,7 @@ void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
       this->defer([this]() { this->send_command_(HlkFm22xCommand::GET_VERSION); });
       break;
     case HlkFm22xCommand::GET_VERSION:
-      if (this->version_text_sensor_ != nullptr) {
+      if (this->version_text_sensor_ != nullptr && length > 2) {
         this->version_text_sensor_->publish_state(reinterpret_cast<const char *>(data + 2), length - 2);
       }
       this->defer([this]() { this->get_face_count_(); });

--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -1,15 +1,11 @@
 #include "hlk_fm22x.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include <array>
 #include <cinttypes>
 
 namespace esphome::hlk_fm22x {
 
 static const char *const TAG = "hlk_fm22x";
-
-// Maximum response size is 36 bytes (VERIFY reply: face_id + 32-byte name)
-static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 36;
 
 void HlkFm22xComponent::setup() {
   ESP_LOGCONFIG(TAG, "Setting up HLK-FM22X...");
@@ -35,7 +31,7 @@ void HlkFm22xComponent::update() {
 }
 
 void HlkFm22xComponent::enroll_face(const std::string &name, HlkFm22xFaceDirection direction) {
-  if (name.length() > 31) {
+  if (name.length() > HLK_FM22X_NAME_SIZE - 1) {
     ESP_LOGE(TAG, "enroll_face(): name too long '%s'", name.c_str());
     return;
   }
@@ -137,17 +133,21 @@ void HlkFm22xComponent::recv_command_() {
   checksum ^= byte;
   length |= byte;
 
-  std::vector<uint8_t> data;
-  data.reserve(length);
+  if (length > HLK_FM22X_MAX_RESPONSE_SIZE) {
+    ESP_LOGE(TAG, "Response too large: %u bytes", length);
+    return;
+  }
+
   for (uint16_t idx = 0; idx < length; ++idx) {
     byte = this->read();
     checksum ^= byte;
-    data.push_back(byte);
+    this->recv_buf_[idx] = byte;
   }
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char hex_buf[format_hex_pretty_size(HLK_FM22X_MAX_RESPONSE_SIZE)];
-  ESP_LOGV(TAG, "Recv type: 0x%.2X, data: %s", response_type, format_hex_pretty_to(hex_buf, data.data(), data.size()));
+  ESP_LOGV(TAG, "Recv type: 0x%.2X, data: %s", response_type,
+           format_hex_pretty_to(hex_buf, this->recv_buf_.data(), length));
 #endif
 
   byte = this->read();
@@ -157,10 +157,10 @@ void HlkFm22xComponent::recv_command_() {
   }
   switch (response_type) {
     case HlkFm22xResponseType::NOTE:
-      this->handle_note_(data);
+      this->handle_note_(this->recv_buf_.data(), length);
       break;
     case HlkFm22xResponseType::REPLY:
-      this->handle_reply_(data);
+      this->handle_reply_(this->recv_buf_.data(), length);
       break;
     default:
       ESP_LOGW(TAG, "Unexpected response type: 0x%.2X", response_type);
@@ -168,11 +168,11 @@ void HlkFm22xComponent::recv_command_() {
   }
 }
 
-void HlkFm22xComponent::handle_note_(const std::vector<uint8_t> &data) {
+void HlkFm22xComponent::handle_note_(const uint8_t *data, size_t length) {
   switch (data[0]) {
     case HlkFm22xNoteType::FACE_STATE:
-      if (data.size() < 17) {
-        ESP_LOGE(TAG, "Invalid face note data size: %u", data.size());
+      if (length < 17) {
+        ESP_LOGE(TAG, "Invalid face note data size: %u", length);
         break;
       }
       {
@@ -209,7 +209,7 @@ void HlkFm22xComponent::handle_note_(const std::vector<uint8_t> &data) {
   }
 }
 
-void HlkFm22xComponent::handle_reply_(const std::vector<uint8_t> &data) {
+void HlkFm22xComponent::handle_reply_(const uint8_t *data, size_t length) {
   auto expected = this->active_command_;
   this->active_command_ = HlkFm22xCommand::NONE;
   if (data[0] != (uint8_t) expected) {
@@ -239,15 +239,15 @@ void HlkFm22xComponent::handle_reply_(const std::vector<uint8_t> &data) {
   switch (expected) {
     case HlkFm22xCommand::VERIFY: {
       int16_t face_id = ((int16_t) data[2] << 8) | data[3];
-      std::string name(data.begin() + 4, data.begin() + 36);
-      ESP_LOGD(TAG, "Face verified. ID: %d, name: %s", face_id, name.c_str());
+      const char *name_ptr = reinterpret_cast<const char *>(data + 4);
+      ESP_LOGD(TAG, "Face verified. ID: %d, name: %.*s", face_id, HLK_FM22X_NAME_SIZE, name_ptr);
       if (this->last_face_id_sensor_ != nullptr) {
         this->last_face_id_sensor_->publish_state(face_id);
       }
       if (this->last_face_name_text_sensor_ != nullptr) {
-        this->last_face_name_text_sensor_->publish_state(name);
+        this->last_face_name_text_sensor_->publish_state(name_ptr, HLK_FM22X_NAME_SIZE);
       }
-      this->face_scan_matched_callback_.call(face_id, name);
+      this->face_scan_matched_callback_.call(face_id, std::string(name_ptr, HLK_FM22X_NAME_SIZE));
       break;
     }
     case HlkFm22xCommand::ENROLL: {
@@ -267,8 +267,7 @@ void HlkFm22xComponent::handle_reply_(const std::vector<uint8_t> &data) {
       break;
     case HlkFm22xCommand::GET_VERSION:
       if (this->version_text_sensor_ != nullptr) {
-        std::string version(data.begin() + 2, data.end());
-        this->version_text_sensor_->publish_state(version);
+        this->version_text_sensor_->publish_state(reinterpret_cast<const char *>(data + 2), length - 2);
       }
       this->defer([this]() { this->get_face_count_(); });
       break;

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -7,12 +7,15 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
 
+#include <array>
 #include <utility>
-#include <vector>
 
 namespace esphome::hlk_fm22x {
 
 static const uint16_t START_CODE = 0xEFAA;
+static constexpr size_t HLK_FM22X_NAME_SIZE = 32;
+// Maximum response size is 36 bytes (VERIFY reply: face_id + 32-byte name)
+static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 36;
 enum HlkFm22xCommand {
   NONE = 0x00,
   RESET = 0x10,
@@ -118,10 +121,11 @@ class HlkFm22xComponent : public PollingComponent, public uart::UARTDevice {
   void get_face_count_();
   void send_command_(HlkFm22xCommand command, const uint8_t *data = nullptr, size_t size = 0);
   void recv_command_();
-  void handle_note_(const std::vector<uint8_t> &data);
-  void handle_reply_(const std::vector<uint8_t> &data);
+  void handle_note_(const uint8_t *data, size_t length);
+  void handle_reply_(const uint8_t *data, size_t length);
   void set_enrolling_(bool enrolling);
 
+  std::array<uint8_t, HLK_FM22X_MAX_RESPONSE_SIZE> recv_buf_;
   HlkFm22xCommand active_command_ = HlkFm22xCommand::NONE;
   uint16_t wait_cycles_ = 0;
   sensor::Sensor *face_count_sensor_{nullptr};

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -14,7 +14,7 @@ namespace esphome::hlk_fm22x {
 
 static const uint16_t START_CODE = 0xEFAA;
 static constexpr size_t HLK_FM22X_NAME_SIZE = 32;
-// Maximum response size is 36 bytes (VERIFY reply: face_id + 32-byte name)
+// Maximum response payload: 1-byte command + 1-byte result + 2-byte face_id + 32-byte name = 36
 static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 36;
 enum HlkFm22xCommand {
   NONE = 0x00,

--- a/esphome/components/hlk_fm22x/hlk_fm22x.h
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.h
@@ -14,7 +14,7 @@ namespace esphome::hlk_fm22x {
 
 static const uint16_t START_CODE = 0xEFAA;
 static constexpr size_t HLK_FM22X_NAME_SIZE = 32;
-// Maximum response payload: 1-byte command + 1-byte result + 2-byte face_id + 32-byte name = 36
+// Maximum response payload: command(1) + result(1) + face_id(2) + name(32) = 36
 static constexpr size_t HLK_FM22X_MAX_RESPONSE_SIZE = 36;
 enum HlkFm22xCommand {
   NONE = 0x00,


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::vector<uint8_t>` in `recv_command_()` with a member `std::array<uint8_t, 36>` buffer to eliminate heap allocation on every polling cycle. This reduces heap fragmentation on long-running devices.

Additional improvements:
- Add bounds check rejecting responses larger than the 36-byte protocol maximum
- Use `const uint8_t *` + `size_t` instead of `const std::vector<uint8_t>&` for handler signatures
- Use `TextSensor::publish_state(const char*, size_t)` overload to avoid temporary `std::string` construction for version and face name publishing
- Extract `HLK_FM22X_NAME_SIZE` constexpr to replace magic number `32`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 115200

hlk_fm22x:
  on_face_scan_matched:
    - logger.log:
        format: "Face matched: %d %s"
        args: [face_id, name.c_str()]
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).