### PR TITLE
[wizard] Use secrets module for fallback AP password generation

### DIFF
--- a/esphome/wizard.py
+++ b/esphome/wizard.py
@@ -1,6 +1,5 @@
 import base64
 from pathlib import Path
-import random
 import secrets
 import string
 from typing import Literal, NotRequired, TypedDict, Unpack
@@ -130,7 +129,7 @@ def wizard_file(**kwargs: Unpack[WizardFileKwargs]) -> str:
     if len(ap_name) > 32:
         ap_name = ap_name_base
     kwargs["fallback_name"] = ap_name
-    kwargs["fallback_psk"] = "".join(random.choice(letters) for _ in range(12))
+    kwargs["fallback_psk"] = "".join(secrets.choice(letters) for _ in range(12))
 
     base = BASE_CONFIG_FRIENDLY if kwargs.get("friendly_name") else BASE_CONFIG
 

--- a/tests/unit_tests/test_wizard.py
+++ b/tests/unit_tests/test_wizard.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pytest import MonkeyPatch
@@ -632,3 +632,14 @@ def test_wizard_accepts_rpipico_board(tmp_path: Path, monkeypatch: MonkeyPatch):
     # rpipico doesn't support WiFi, so no api_encryption_key or ota_password
     assert "api_encryption_key" not in call_kwargs
     assert "ota_password" not in call_kwargs
+
+
+def test_fallback_psk_uses_secrets_choice(
+    default_config: dict[str, Any],
+) -> None:
+    """Test that fallback PSK is generated using secrets.choice."""
+    with patch("esphome.wizard.secrets.choice", return_value="X") as mock_choice:
+        config = wz.wizard_file(**default_config)
+
+    assert 'password: "XXXXXXXXXXXX"' in config
+    assert mock_choice.call_count == 12


### PR DESCRIPTION
# What does this implement/fix?

Replace `random.choice()` with `secrets.choice()` for generating the fallback hotspot password. The `random` module uses Mersenne Twister which is not cryptographically secure. The `secrets` module is the correct choice for credential generation.

The file already imports and uses `secrets` for other credential generation (API encryption key, OTA password).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Python-side change only, uses stdlib `secrets` module.

## Example entry for `config.yaml`:

```yaml
# n/a - no configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).