### PR TITLE
[dashboard] Use constant-time comparison for username check

### DIFF
--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -85,7 +85,9 @@ class DashboardSettings:
         if not self.using_auth:
             return True
         # Compare in constant running time (to prevent timing attacks)
-        username_matches = hmac.compare_digest(username, self.username)
+        username_matches = hmac.compare_digest(
+            username.encode("utf-8"), self.username.encode("utf-8")
+        )
         password_matches = hmac.compare_digest(
             self.password_hash, password_hash(password)
         )

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -32,7 +32,7 @@ class DashboardSettings:
     def __init__(self) -> None:
         """Initialize the dashboard settings."""
         self.config_dir: Path = None
-        self.password_hash: str = ""
+        self.password_hash: bytes = b""
         self.username: str = ""
         self.using_password: bool = False
         self.on_ha_addon: bool = False
@@ -84,7 +84,7 @@ class DashboardSettings:
     def check_password(self, username: str, password: str) -> bool:
         if not self.using_auth:
             return True
-        # Compare both in constant running time (to prevent timing attacks)
+        # Compare in constant running time (to prevent timing attacks)
         username_matches = hmac.compare_digest(username, self.username)
         password_matches = hmac.compare_digest(
             self.password_hash, password_hash(password)

--- a/esphome/dashboard/settings.py
+++ b/esphome/dashboard/settings.py
@@ -84,11 +84,12 @@ class DashboardSettings:
     def check_password(self, username: str, password: str) -> bool:
         if not self.using_auth:
             return True
-        if username != self.username:
-            return False
-
-        # Compare password in constant running time (to prevent timing attacks)
-        return hmac.compare_digest(self.password_hash, password_hash(password))
+        # Compare both in constant running time (to prevent timing attacks)
+        username_matches = hmac.compare_digest(username, self.username)
+        password_matches = hmac.compare_digest(
+            self.password_hash, password_hash(password)
+        )
+        return username_matches and password_matches
 
     def rel_path(self, *args: Any) -> Path:
         """Return a path relative to the ESPHome config folder."""

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -225,16 +225,12 @@ def test_config_path_parent_resolves_to_config_dir(tmp_path: Path) -> None:
 
 
 @pytest.fixture
-def auth_settings(tmp_path: Path) -> DashboardSettings:
-    """Create DashboardSettings with auth configured."""
-    settings = DashboardSettings()
-    resolved_dir = tmp_path.resolve()
-    settings.config_dir = resolved_dir
-    settings.absolute_config_dir = resolved_dir
-    settings.username = "admin"
-    settings.using_password = True
-    settings.password_hash = password_hash("correctpassword")
-    return settings
+def auth_settings(dashboard_settings: DashboardSettings) -> DashboardSettings:
+    """Create DashboardSettings with auth configured, based on dashboard_settings."""
+    dashboard_settings.username = "admin"
+    dashboard_settings.using_password = True
+    dashboard_settings.password_hash = password_hash("correctpassword")
+    return dashboard_settings
 
 
 def test_check_password_correct_credentials(auth_settings: DashboardSettings) -> None:
@@ -264,6 +260,7 @@ def test_check_password_no_auth(dashboard_settings: DashboardSettings) -> None:
 
 def test_check_password_ha_addon_no_password(
     dashboard_settings: DashboardSettings,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test check_password doesn't crash in HA add-on mode without a password.
 
@@ -271,6 +268,7 @@ def test_check_password_ha_addon_no_password(
     is False, leaving password_hash as b"". This must not raise TypeError
     in hmac.compare_digest.
     """
+    monkeypatch.delenv("DISABLE_HA_AUTHENTICATION", raising=False)
     dashboard_settings.on_ha_addon = True
     dashboard_settings.using_password = False
     # password_hash stays as default b""

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -260,3 +260,18 @@ def test_check_password_both_wrong(auth_settings: DashboardSettings) -> None:
 def test_check_password_no_auth(dashboard_settings: DashboardSettings) -> None:
     """Test check_password returns True when auth is not configured."""
     assert dashboard_settings.check_password("anyone", "anything") is True
+
+
+def test_check_password_ha_addon_no_password(
+    dashboard_settings: DashboardSettings,
+) -> None:
+    """Test check_password doesn't crash in HA add-on mode without a password.
+
+    In HA add-on mode, using_ha_addon_auth can be True while using_password
+    is False, leaving password_hash as b"". This must not raise TypeError
+    in hmac.compare_digest.
+    """
+    dashboard_settings.on_ha_addon = True
+    dashboard_settings.using_password = False
+    # password_hash stays as default b""
+    assert dashboard_settings.check_password("anyone", "anything") is False

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -1,4 +1,4 @@
-"""Tests for dashboard settings Path-related functionality."""
+"""Tests for DashboardSettings (path resolution and authentication)."""
 
 from __future__ import annotations
 

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -10,6 +10,7 @@ import pytest
 
 from esphome.core import CORE
 from esphome.dashboard.settings import DashboardSettings
+from esphome.dashboard.util.password import password_hash
 
 
 @pytest.fixture
@@ -221,3 +222,41 @@ def test_config_path_parent_resolves_to_config_dir(tmp_path: Path) -> None:
     # Verify that CORE.config_path itself uses the sentinel file
     assert CORE.config_path.name == "___DASHBOARD_SENTINEL___.yaml"
     assert not CORE.config_path.exists()  # Sentinel file doesn't actually exist
+
+
+@pytest.fixture
+def auth_settings(tmp_path: Path) -> DashboardSettings:
+    """Create DashboardSettings with auth configured."""
+    settings = DashboardSettings()
+    resolved_dir = tmp_path.resolve()
+    settings.config_dir = resolved_dir
+    settings.absolute_config_dir = resolved_dir
+    settings.username = "admin"
+    settings.using_password = True
+    settings.password_hash = password_hash("correctpassword")
+    return settings
+
+
+def test_check_password_correct_credentials(auth_settings: DashboardSettings) -> None:
+    """Test check_password returns True for correct username and password."""
+    assert auth_settings.check_password("admin", "correctpassword") is True
+
+
+def test_check_password_wrong_password(auth_settings: DashboardSettings) -> None:
+    """Test check_password returns False for wrong password."""
+    assert auth_settings.check_password("admin", "wrongpassword") is False
+
+
+def test_check_password_wrong_username(auth_settings: DashboardSettings) -> None:
+    """Test check_password returns False for wrong username."""
+    assert auth_settings.check_password("notadmin", "correctpassword") is False
+
+
+def test_check_password_both_wrong(auth_settings: DashboardSettings) -> None:
+    """Test check_password returns False when both are wrong."""
+    assert auth_settings.check_password("notadmin", "wrongpassword") is False
+
+
+def test_check_password_no_auth(dashboard_settings: DashboardSettings) -> None:
+    """Test check_password returns True when auth is not configured."""
+    assert dashboard_settings.check_password("anyone", "anything") is True

--- a/tests/dashboard/test_settings.py
+++ b/tests/dashboard/test_settings.py
@@ -258,6 +258,18 @@ def test_check_password_no_auth(dashboard_settings: DashboardSettings) -> None:
     assert dashboard_settings.check_password("anyone", "anything") is True
 
 
+def test_check_password_non_ascii_username(
+    dashboard_settings: DashboardSettings,
+) -> None:
+    """Test check_password handles non-ASCII usernames without TypeError."""
+    dashboard_settings.username = "\u00e9l\u00e8ve"
+    dashboard_settings.using_password = True
+    dashboard_settings.password_hash = password_hash("pass")
+    assert dashboard_settings.check_password("\u00e9l\u00e8ve", "pass") is True
+    assert dashboard_settings.check_password("\u00e9l\u00e8ve", "wrong") is False
+    assert dashboard_settings.check_password("other", "pass") is False
+
+
 def test_check_password_ha_addon_no_password(
     dashboard_settings: DashboardSettings,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# What does this implement/fix?

Use `hmac.compare_digest()` for the username comparison in dashboard authentication to match the existing constant-time password comparison. This prevents username enumeration via timing analysis.

The password comparison already correctly uses `hmac.compare_digest()`. This change applies the same approach to the username check for consistency.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Python-side change only.

## Example entry for `config.yaml`:

```yaml
# n/a - no configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).