### PR TITLE
[dashboard] Handle malformed Basic Auth headers gracefully

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -120,8 +120,11 @@ def is_authenticated(handler: BaseHandler) -> bool:
         if auth_header := handler.request.headers.get("Authorization"):
             assert isinstance(auth_header, str)
             if auth_header.startswith("Basic "):
-                auth_decoded = base64.b64decode(auth_header[6:]).decode()
-                username, password = auth_decoded.split(":", 1)
+                try:
+                    auth_decoded = base64.b64decode(auth_header[6:]).decode()
+                    username, password = auth_decoded.split(":", 1)
+                except (ValueError, UnicodeDecodeError):
+                    return False
                 return settings.check_password(username, password)
         return handler.get_secure_cookie(AUTH_COOKIE_NAME) == COOKIE_AUTHENTICATED_YES
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -123,7 +123,7 @@ def is_authenticated(handler: BaseHandler) -> bool:
                 try:
                     auth_decoded = base64.b64decode(auth_header[6:]).decode()
                     username, password = auth_decoded.split(":", 1)
-                except (ValueError, UnicodeDecodeError):
+                except (binascii.Error, ValueError, UnicodeDecodeError):
                     return False
                 return settings.check_password(username, password)
         return handler.get_secure_cookie(AUTH_COOKIE_NAME) == COOKIE_AUTHENTICATED_YES

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from argparse import Namespace
 import asyncio
+import base64
 from collections.abc import Generator
 from contextlib import asynccontextmanager
 import gzip
@@ -1676,3 +1677,81 @@ def test_proc_on_exit_skips_when_already_closed() -> None:
 
     handler.write_message.assert_not_called()
     handler.close.assert_not_called()
+
+
+def _make_auth_handler(auth_header: str | None = None) -> Mock:
+    """Create a mock handler with the given Authorization header."""
+    handler = Mock()
+    handler.request = Mock()
+    if auth_header is not None:
+        handler.request.headers = {"Authorization": auth_header}
+    else:
+        handler.request.headers = {}
+    handler.get_secure_cookie = Mock(return_value=None)
+    return handler
+
+
+@pytest.fixture
+def mock_auth_settings(mock_dashboard_settings: MagicMock) -> MagicMock:
+    """Fixture to configure mock dashboard settings with auth enabled."""
+    mock_dashboard_settings.using_auth = True
+    mock_dashboard_settings.on_ha_addon = False
+    return mock_dashboard_settings
+
+
+def test_is_authenticated_malformed_base64(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that invalid base64 in Authorization header returns False."""
+    handler = _make_auth_handler("Basic !!!not-valid-base64!!!")
+    assert web_server.is_authenticated(handler) is False
+
+
+def test_is_authenticated_invalid_utf8(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that base64 decoding to invalid UTF-8 returns False."""
+    # \xff\xfe is invalid UTF-8
+    bad_payload = base64.b64encode(b"\xff\xfe").decode("ascii")
+    handler = _make_auth_handler(f"Basic {bad_payload}")
+    assert web_server.is_authenticated(handler) is False
+
+
+def test_is_authenticated_no_colon(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that base64 payload without ':' separator returns False."""
+    no_colon = base64.b64encode(b"nocolonhere").decode("ascii")
+    handler = _make_auth_handler(f"Basic {no_colon}")
+    assert web_server.is_authenticated(handler) is False
+
+
+def test_is_authenticated_valid_credentials(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that valid Basic auth credentials are checked."""
+    creds = base64.b64encode(b"admin:secret").decode("ascii")
+    mock_auth_settings.check_password.return_value = True
+    handler = _make_auth_handler(f"Basic {creds}")
+    assert web_server.is_authenticated(handler) is True
+    mock_auth_settings.check_password.assert_called_once_with("admin", "secret")
+
+
+def test_is_authenticated_wrong_credentials(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that valid Basic auth with wrong credentials returns False."""
+    creds = base64.b64encode(b"admin:wrong").decode("ascii")
+    mock_auth_settings.check_password.return_value = False
+    handler = _make_auth_handler(f"Basic {creds}")
+    assert web_server.is_authenticated(handler) is False
+
+
+def test_is_authenticated_no_auth_configured(
+    mock_dashboard_settings: MagicMock,
+) -> None:
+    """Test that requests pass when auth is not configured."""
+    mock_dashboard_settings.using_auth = False
+    mock_dashboard_settings.on_ha_addon = False
+    handler = _make_auth_handler()
+    assert web_server.is_authenticated(handler) is True

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1699,25 +1699,22 @@ def mock_auth_settings(mock_dashboard_settings: MagicMock) -> MagicMock:
     return mock_dashboard_settings
 
 
-def test_is_authenticated_malformed_base64(
-    mock_auth_settings: MagicMock,
-) -> None:
+@pytest.mark.usefixtures("mock_auth_settings")
+def test_is_authenticated_malformed_base64() -> None:
     """Test that invalid base64 in Authorization header returns False."""
     handler = _make_auth_handler("Basic !!!not-valid-base64!!!")
     assert web_server.is_authenticated(handler) is False
 
 
-def test_is_authenticated_bad_base64_padding(
-    mock_auth_settings: MagicMock,
-) -> None:
+@pytest.mark.usefixtures("mock_auth_settings")
+def test_is_authenticated_bad_base64_padding() -> None:
     """Test that incorrect base64 padding (binascii.Error) returns False."""
     handler = _make_auth_handler("Basic abc")
     assert web_server.is_authenticated(handler) is False
 
 
-def test_is_authenticated_invalid_utf8(
-    mock_auth_settings: MagicMock,
-) -> None:
+@pytest.mark.usefixtures("mock_auth_settings")
+def test_is_authenticated_invalid_utf8() -> None:
     """Test that base64 decoding to invalid UTF-8 returns False."""
     # \xff\xfe is invalid UTF-8
     bad_payload = base64.b64encode(b"\xff\xfe").decode("ascii")
@@ -1725,9 +1722,8 @@ def test_is_authenticated_invalid_utf8(
     assert web_server.is_authenticated(handler) is False
 
 
-def test_is_authenticated_no_colon(
-    mock_auth_settings: MagicMock,
-) -> None:
+@pytest.mark.usefixtures("mock_auth_settings")
+def test_is_authenticated_no_colon() -> None:
     """Test that base64 payload without ':' separator returns False."""
     no_colon = base64.b64encode(b"nocolonhere").decode("ascii")
     handler = _make_auth_handler(f"Basic {no_colon}")

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1707,6 +1707,14 @@ def test_is_authenticated_malformed_base64(
     assert web_server.is_authenticated(handler) is False
 
 
+def test_is_authenticated_bad_base64_padding(
+    mock_auth_settings: MagicMock,
+) -> None:
+    """Test that incorrect base64 padding (binascii.Error) returns False."""
+    handler = _make_auth_handler("Basic abc")
+    assert web_server.is_authenticated(handler) is False
+
+
 def test_is_authenticated_invalid_utf8(
     mock_auth_settings: MagicMock,
 ) -> None:


### PR DESCRIPTION
# What does this implement/fix?

Wrap base64 decode and split in try/except so malformed `Authorization: Basic` headers return a clean authentication failure instead of an unhandled exception producing a 500 response with stack trace in logs.

Catches `ValueError` (covers `binascii.Error` from `b64decode()` and unpacking failure from `split()`) and `UnicodeDecodeError` (from `.decode()`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Python-side change only.

## Example entry for `config.yaml`:

```yaml
# n/a - no configuration change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).