### PR TITLE
[api] Guard varint parsing against overlong encodings

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -112,8 +112,12 @@ class ProtoVarInt {
     uint64_t result = buffer[0] & 0x7F;
     uint8_t bitpos = 7;
 
+    // A 64-bit varint is at most 10 bytes (ceil(64/7)). Reject overlong encodings
+    // to avoid undefined behavior from shifting uint64_t by >= 64 bits.
+    uint32_t max_len = std::min(len, uint32_t(10));
+
     // Start from the second byte since we've already processed the first
-    for (uint32_t i = 1; i < len; i++) {
+    for (uint32_t i = 1; i < max_len; i++) {
       uint8_t val = buffer[i];
       result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
       bitpos += 7;


### PR DESCRIPTION
# What does this implement/fix?

Limits protobuf varint parsing to a maximum of 10 bytes (`ceil(64/7)`) to prevent undefined behavior when processing malformed data.

A 64-bit protobuf varint is encoded in at most 10 bytes. Without a length guard, a malicious client could send 11+ continuation bytes, causing the bit shift position to exceed 63 bits. Shifting a `uint64_t` by >= 64 bits is undefined behavior per the C++ standard. While real compilers for ESP32 (GCC for Xtensa/RISC-V) perform modular shifts making this unexploitable in practice, the UB should still be eliminated as a defensive measure.

The fix clamps the loop iteration count to `min(len, 10)`, which matches the protobuf specification for maximum varint encoding length. Overlong varints (11+ bytes) are now correctly rejected as incomplete/invalid.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change needed - this is an internal protocol fix
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).