### PR TITLE
[water_heater] Add state masking to distinguish explicit commands from no-change

### DIFF
--- a/esphome/components/water_heater/water_heater.h
+++ b/esphome/components/water_heater/water_heater.h
@@ -91,6 +91,8 @@ class WaterHeaterCall {
   float get_target_temperature_high() const { return this->target_temperature_high_; }
   /// Get state flags value
   uint32_t get_state() const { return this->state_; }
+  /// Get mask of state flags that are being changed
+  uint32_t get_state_mask() const { return this->state_mask_; }
 
  protected:
   void validate_();
@@ -100,6 +102,7 @@ class WaterHeaterCall {
   float target_temperature_low_{NAN};
   float target_temperature_high_{NAN};
   uint32_t state_{0};
+  uint32_t state_mask_{0};
 };
 
 struct WaterHeaterCallInternal : public WaterHeaterCall {
@@ -111,6 +114,7 @@ struct WaterHeaterCallInternal : public WaterHeaterCall {
     this->target_temperature_low_ = restore.target_temperature_low_;
     this->target_temperature_high_ = restore.target_temperature_high_;
     this->state_ = restore.state_;
+    this->state_mask_ = restore.state_mask_;
     return *this;
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

**Description:**
This PR introduces a `state_mask_` to the `WaterHeaterCall` object.

**The Problem:**
Currently, state flags are stored in a single bitmask. However, when a command is received via the API or a lambda call, there was no way to distinguish between "The user explicitly wants to turn this bit OFF" and "The user didn't provide a value for this bit, so leave it as is."

**The Solution:**
By adding a `state_mask_`, we track which bits in the `state` bitmask were actually intended to be changed.

**Changes:**
- Added `state_mask_` to `WaterHeaterCall` and `WaterHeaterCallInternal`.
- Updated `set_on()` and `set_away()` to update the `state_mask_`.
- Updated `perform()` logging to show "NO" status when a state is explicitly turned off (previously, turning a state off resulted in no log entry).
- Updated `validate()` to consistently clear both the state bit and the mask bit if a feature (Away or On/Off) is not supported by the specific water heater implementation.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
