### PR TITLE
[web_server_base] Fix RP2040 compilation when Crypto-no-arduino is present

### DIFF
--- a/esphome/components/web_server_base/fix_rp2040_hash.py.script
+++ b/esphome/components/web_server_base/fix_rp2040_hash.py.script
@@ -1,0 +1,11 @@
+# ESPAsyncWebServer includes <Hash.h> expecting the Arduino-Pico framework's Hash
+# library (which provides sha1() functions). However, the Crypto-no-arduino library
+# (used by dsmr) also provides a Hash.h that can shadow the framework version when
+# PlatformIO's chain+ LDF mode auto-discovers it as a dependency.
+# Prepend the framework Hash path to CXXFLAGS so it is found first.
+import os
+
+Import("env")
+framework_dir = env.PioPlatform().get_package_dir("framework-arduinopico")
+hash_src = os.path.join(framework_dir, "libraries", "Hash", "src")
+env.Prepend(CXXFLAGS=["-I" + hash_src])


### PR DESCRIPTION
# What does this implement/fix?

Fixes RP2040 Arduino compilation failure when `web_server` and `dsmr` components are used together (or grouped in CI).

ESPAsyncWebServer includes `<Hash.h>` on RP2040 expecting the Arduino-Pico framework's Hash library (which provides `sha1()` functions). When the `dsmr` component is also present, its `Crypto-no-arduino` dependency provides a different `Hash.h` (a crypto base class, not `sha1()`) that shadows the framework version. PlatformIO's `chain+` LDF mode auto-discovers `Crypto-no-arduino` as a dependency of ESPAsyncWebServer and places it earlier in the include path, causing:

```
AsyncWebSocket.cpp: error: 'sha1' was not declared in this scope
```

This is an upstream bug in ESPAsyncWebServer (the ESP8266 codepath has a workaround for this exact conflict, but the RP2040 codepath does not).

**Fix:**
- Explicitly add the `Hash` framework library as a dependency for RP2040
- Add a PIO pre-build script that prepends the framework's `Hash/src` to `CXXFLAGS`, ensuring the correct `Hash.h` is found before `Crypto-no-arduino`'s version

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes CI failure in https://github.com/esphome/esphome/pull/13882

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes a build conflict between
# web_server and dsmr components on RP2040
web_server:

uart:
  - id: uart_dsmr
    rx_pin: GPIO1
    tx_pin: GPIO0
    baud_rate: 115200

dsmr:
  uart_id: uart_dsmr
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)