### PR TITLE
[esp32] Set UV_CACHE_DIR inside data dir so Clean All clears it

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1435,6 +1435,10 @@ async def to_code(config):
         CORE.relative_internal_path(".espressif")
     )
 
+    # Set the uv cache inside the data dir so "Clean All" clears it.
+    # Avoids persistent corrupted cache from mid-stream download failures.
+    os.environ["UV_CACHE_DIR"] = str(CORE.relative_internal_path(".uv_cache"))
+
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_build_flag("-DUSE_ESP_IDF")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")


### PR DESCRIPTION
# What does this implement/fix?

Move the `uv` package cache from `/root/.cache/uv/` (default) into the ESPHome data directory by setting `UV_CACHE_DIR`. This ensures "Clean All" wipes any corrupted cache entries left by mid-stream download failures (connection resets during `uv` package downloads from PyPI).

Without this, a single failed download can leave a corrupted entry in the `uv` cache that persists indefinitely — surviving "Clean All", addon reinstalls, and ESPHome updates — blocking all ESP-IDF builds until the cache entry happens to expire or a version change bypasses it. Users report being stuck for hours or days.

The fix follows the existing pattern used for `IDF_COMPONENT_CACHE_PATH` on the line directly above.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12531

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal fix
esp32:
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).