### PR TITLE
[uart] Change available() return type from int to size_t

### DIFF
--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -46,16 +46,16 @@ static const uint32_t PKT_TIMEOUT_MS = 200;
 
 void BL0942::loop() {
   DataPacket buffer;
-  int avail = this->available();
+  size_t avail = this->available();
 
   if (!avail) {
     return;
   }
-  if (static_cast<size_t>(avail) < sizeof(buffer)) {
+  if (avail < sizeof(buffer)) {
     if (!this->rx_start_) {
       this->rx_start_ = millis();
     } else if (millis() > this->rx_start_ + PKT_TIMEOUT_MS) {
-      ESP_LOGW(TAG, "Junk on wire. Throwing away partial message (%d bytes)", avail);
+      ESP_LOGW(TAG, "Junk on wire. Throwing away partial message (%zu bytes)", avail);
       this->read_array((uint8_t *) &buffer, avail);
       this->rx_start_ = 0;
     }

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -251,7 +251,7 @@ void Tormatic::stop_at_target_() {
 // Read a GateStatus from the unit. The unit only sends messages in response to
 // status requests or commands, so a message needs to be sent first.
 optional<GateStatus> Tormatic::read_gate_status_() {
-  if (this->available() < static_cast<int>(sizeof(MessageHeader))) {
+  if (this->available() < sizeof(MessageHeader)) {
     return {};
   }
 

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -43,7 +43,7 @@ class UARTDevice {
     return res;
   }
 
-  int available() { return this->parent_->available(); }
+  size_t available() { return this->parent_->available(); }
 
   void flush() { this->parent_->flush(); }
 

--- a/esphome/components/uart/uart_component.cpp
+++ b/esphome/components/uart/uart_component.cpp
@@ -5,13 +5,13 @@ namespace esphome::uart {
 static const char *const TAG = "uart";
 
 bool UARTComponent::check_read_timeout_(size_t len) {
-  if (this->available() >= int(len))
+  if (this->available() >= len)
     return true;
 
   uint32_t start_time = millis();
-  while (this->available() < int(len)) {
+  while (this->available() < len) {
     if (millis() - start_time > 100) {
-      ESP_LOGE(TAG, "Reading from UART timed out at byte %u!", this->available());
+      ESP_LOGE(TAG, "Reading from UART timed out at byte %zu!", this->available());
       return false;
     }
     yield();

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -69,7 +69,7 @@ class UARTComponent {
 
   // Pure virtual method to return the number of bytes available for reading.
   // @return Number of available bytes.
-  virtual int available() = 0;
+  virtual size_t available() = 0;
 
   // Pure virtual method to block until all bytes have been written to the UART bus.
   virtual void flush() = 0;

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -330,6 +330,9 @@ void ESP8266SoftwareSerial::flush() {
   // Flush is a NO-OP with software serial, all bytes are written immediately.
 }
 size_t ESP8266SoftwareSerial::available() {
+  // Read volatile rx_in_pos_ once to avoid TOCTOU race with ISR.
+  // When in >= out, data is contiguous: [out..in).
+  // When in < out, data wraps: [out..buf_size) + [0..in).
   size_t in = this->rx_in_pos_;
   if (in >= this->rx_out_pos_)
     return in - this->rx_out_pos_;

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -206,7 +206,7 @@ bool ESP8266UartComponent::read_array(uint8_t *data, size_t len) {
 #endif
   return true;
 }
-int ESP8266UartComponent::available() {
+size_t ESP8266UartComponent::available() {
   if (this->hw_serial_ != nullptr) {
     return this->hw_serial_->available();
   } else {
@@ -329,11 +329,11 @@ uint8_t ESP8266SoftwareSerial::peek_byte() {
 void ESP8266SoftwareSerial::flush() {
   // Flush is a NO-OP with software serial, all bytes are written immediately.
 }
-int ESP8266SoftwareSerial::available() {
-  int avail = int(this->rx_in_pos_) - int(this->rx_out_pos_);
-  if (avail < 0)
-    return avail + this->rx_buffer_size_;
-  return avail;
+size_t ESP8266SoftwareSerial::available() {
+  size_t in = this->rx_in_pos_;
+  if (in >= this->rx_out_pos_)
+    return in - this->rx_out_pos_;
+  return this->rx_buffer_size_ - this->rx_out_pos_ + in;
 }
 
 }  // namespace esphome::uart

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -23,7 +23,7 @@ class ESP8266SoftwareSerial {
 
   void write_byte(uint8_t data);
 
-  int available();
+  size_t available();
 
  protected:
   static void gpio_intr(ESP8266SoftwareSerial *arg);
@@ -57,7 +57,7 @@ class ESP8266UartComponent : public UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
 
-  int available() override;
+  size_t available() override;
   void flush() override;
 
   uint32_t get_config();

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -338,7 +338,7 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   return read_len == (int32_t) length_to_read;
 }
 
-int IDFUARTComponent::available() {
+size_t IDFUARTComponent::available() {
   size_t available = 0;
   esp_err_t err;
 

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -22,7 +22,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
 
-  int available() override;
+  size_t available() override;
   void flush() override;
 
   uint8_t get_hw_serial_number() { return this->uart_num_; }

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -265,7 +265,7 @@ bool HostUartComponent::read_array(uint8_t *data, size_t len) {
   return true;
 }
 
-int HostUartComponent::available() {
+size_t HostUartComponent::available() {
   if (this->file_descriptor_ == -1) {
     return 0;
   }
@@ -275,9 +275,10 @@ int HostUartComponent::available() {
     this->update_error_(strerror(errno));
     return 0;
   }
+  size_t result = available;
   if (this->has_peek_)
-    available++;
-  return available;
+    result++;
+  return result;
 };
 
 void HostUartComponent::flush() {

--- a/esphome/components/uart/uart_component_host.h
+++ b/esphome/components/uart/uart_component_host.h
@@ -17,7 +17,7 @@ class HostUartComponent : public UARTComponent, public Component {
   void write_array(const uint8_t *data, size_t len) override;
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
-  int available() override;
+  size_t available() override;
   void flush() override;
   void set_name(std::string port_name) { port_name_ = port_name; };
 

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -169,7 +169,7 @@ bool LibreTinyUARTComponent::read_array(uint8_t *data, size_t len) {
   return true;
 }
 
-int LibreTinyUARTComponent::available() { return this->serial_->available(); }
+size_t LibreTinyUARTComponent::available() { return this->serial_->available(); }
 void LibreTinyUARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   this->serial_->flush();

--- a/esphome/components/uart/uart_component_libretiny.h
+++ b/esphome/components/uart/uart_component_libretiny.h
@@ -21,7 +21,7 @@ class LibreTinyUARTComponent : public UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
 
-  int available() override;
+  size_t available() override;
   void flush() override;
 
   uint16_t get_config();

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -186,7 +186,7 @@ bool RP2040UartComponent::read_array(uint8_t *data, size_t len) {
 #endif
   return true;
 }
-int RP2040UartComponent::available() { return this->serial_->available(); }
+size_t RP2040UartComponent::available() { return this->serial_->available(); }
 void RP2040UartComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   this->serial_->flush();

--- a/esphome/components/uart/uart_component_rp2040.h
+++ b/esphome/components/uart/uart_component_rp2040.h
@@ -24,7 +24,7 @@ class RP2040UartComponent : public UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
 
-  int available() override;
+  size_t available() override;
   void flush() override;
 
   uint16_t get_config();

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.h
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.h
@@ -81,7 +81,7 @@ class USBCDCACMInstance : public uart::UARTComponent, public Parented<USBCDCACMC
   void write_array(const uint8_t *data, size_t len) override;
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
-  int available() override;
+  size_t available() override;
   void flush() override;
 
  protected:

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -318,12 +318,12 @@ bool USBCDCACMInstance::read_array(uint8_t *data, size_t len) {
   return bytes_read == original_len;
 }
 
-int USBCDCACMInstance::available() {
+size_t USBCDCACMInstance::available() {
   UBaseType_t waiting = 0;
   if (this->usb_rx_ringbuf_ != nullptr) {
     vRingbufferGetInfo(this->usb_rx_ringbuf_, nullptr, nullptr, nullptr, nullptr, &waiting);
   }
-  return static_cast<int>(waiting) + (this->has_peek_ ? 1 : 0);
+  return waiting + (this->has_peek_ ? 1 : 0);
 }
 
 void USBCDCACMInstance::flush() {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -97,7 +97,7 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   bool peek_byte(uint8_t *data) override;
   ;
   bool read_array(uint8_t *data, size_t len) override;
-  int available() override { return static_cast<int>(this->input_buffer_.get_available()); }
+  size_t available() override { return this->input_buffer_.get_available(); }
   void flush() override {}
   void check_logger_conflict() override {}
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -401,7 +401,7 @@ bool WeikaiChannel::peek_byte(uint8_t *buffer) {
   return this->receive_buffer_.peek(*buffer);
 }
 
-int WeikaiChannel::available() {
+size_t WeikaiChannel::available() {
   size_t available = this->receive_buffer_.count();
   if (!available)
     available = xfer_fifo_to_buffer_();

--- a/esphome/components/weikai/weikai.h
+++ b/esphome/components/weikai/weikai.h
@@ -374,7 +374,7 @@ class WeikaiChannel : public uart::UARTComponent {
 
   /// @brief Returns the number of bytes in the receive buffer
   /// @return the number of bytes available in the receiver fifo
-  int available() override;
+  size_t available() override;
 
   /// @brief Flush the output fifo.
   /// @details If we refer to Serial.flush() in Arduino it says: ** Waits for the transmission of outgoing serial data

--- a/tests/components/uart/common.h
+++ b/tests/components/uart/common.h
@@ -29,7 +29,7 @@ class MockUARTComponent : public UARTComponent {
 
   MOCK_METHOD(bool, read_array, (uint8_t * data, size_t len), (override));
   MOCK_METHOD(bool, peek_byte, (uint8_t * data), (override));
-  MOCK_METHOD(int, available, (), (override));
+  MOCK_METHOD(size_t, available, (), (override));
   MOCK_METHOD(void, flush, (), (override));
   MOCK_METHOD(void, check_logger_conflict, (), (override));
 };


### PR DESCRIPTION
# What does this implement/fix?

Change `UARTComponent::available()` return type from `int` to `size_t` across all platforms. The byte count is never negative, so `size_t` makes the API honest about its semantics and prevents a class of bug where a hypothetical negative return would cause `while (this->available())` loops to spin forever.

Updates all platform implementations (ESP-IDF, ESP8266 hardware + software serial, RP2040, LibreTiny, Host) and internal callers (`usb_uart`, `bl0942`, `tormatic`) to use `size_t` consistently, removing unnecessary casts.

The ESP8266 software serial ring buffer arithmetic is rewritten to use unsigned math with a local copy of the volatile `rx_in_pos_` to avoid TOCTOU races with the ISR.

### Migration for external components

If you override `available()`, update the signature:

```cpp
// Before:
int available() override;

// After:
size_t available() override;
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is a C++ API change only.
# Existing UART configurations continue to work unchanged.
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).