### PR TITLE
[ethernet, network, openthread, wifi, modem] Add support for multiple network interfaces

### DIFF
--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -224,3 +224,6 @@ async def to_code(config):
                 cg.add_build_flag("-DPIO_FRAMEWORK_ARDUINO_LWIP2_IPV6_LOW_MEMORY")
             if CORE.is_bk72xx:
                 cg.add_build_flag("-DCONFIG_IPV6")
+
+
+# PLACEHOLDER


### PR DESCRIPTION
# What does this implement/fix?

WIP. Any help would be greatly appreciated.

Discord thread: https://discord.com/channels/429907082951524364/1471429519591215136

An attempt to centralize all network interfaces (`modem`, `wifi`, `ethernet` and `openthread`). This PR comes from #6721 and will enable better integration of new network interfaces (such as the future `modem`). For this reason, I am only able to test it with `wifi` and `modem`. **Testers for `ethernet` or `openthread` are very welcomed and needed.**

The main idea behind this PR is to allow multiple network interfaces in the device configuration, but only enable one network interface at a time. All network related "stuff" should pass through the new `network` component. This way, switching between network interfaces can be avoided without creating consistency issues. In the future, this could be expanded to include "bridges" between interfaces and similar features.

This PR is being splitted into smaller PRs:
* Centralize network initialization for ESP32: #14012
* TODO: `openthread` add `enable()`, `disable()`, `is_enabled()` and `is_disabled()` methods and `enable_on_boot` configuration entry. *We need someone with access to the `openthread` component hardware to implement this PR. **Please, let me know if you are willing to help with this!***
* TODO: `ethernet` add `enable()`, `disable()`, `is_enabled()` and `is_disabled()` methods and `enable_on_boot` configuration entry. *We need someone with access to the `ethernet` component hardware to implement this PR. **Please, let me know if you are willing to help with this!***

## Example

```yaml
# Example of a configuration
network:
  enable_on_boot: True
  priority:
    - ethernet
    - wifi
```

```yaml
# Example of how it could work under the hood with multiple interfaces (with priority)
scripts:
  id: setup_network
  then:
     # Ethernet top priority
     network.set_interface:
        - ethernet # <- this internally calls network->set_active_interface(ethernet)
     wait_until:
       condition: network.is_ready # wait for ethernet to be enabled
     # Wait 30 seconds for it to be connected
     wait_until:
       condition: network.is_connected
       timeout: 30s
     # If it is not connected, try with wifi
     network.set_interface:
        - wifi # <- this internally disables the ethernet interface and calls network->set_active_interface(wifi)
     wait_until:
       condition: network.is_ready # wait for wifi to be enabled
     # Wait 30 seconds for it to be connected
     wait_until:
       condition: network.is_connected
       timeout: 30s
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [ ] The code change is tested and works locally.
 

