### PR TITLE
[uart] Fix available() return type to size_t across components

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -16,8 +16,8 @@ void CSE7766Component::loop() {
   }
 
   // Early return prevents updating last_transmission_ when no data is available.
-  int avail = this->available();
-  if (avail <= 0) {
+  size_t avail = this->available();
+  if (avail == 0) {
     return;
   }
 
@@ -27,7 +27,7 @@ void CSE7766Component::loop() {
   // At 4800 baud (~480 bytes/sec) with ~122 Hz loop rate, typically ~4 bytes per call.
   uint8_t buf[CSE7766_RAW_DATA_SIZE];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -133,10 +133,10 @@ void DFPlayer::send_cmd_(uint8_t cmd, uint16_t argument) {
 
 void DFPlayer::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/dsmr/dsmr.cpp
+++ b/esphome/components/dsmr/dsmr.cpp
@@ -120,9 +120,9 @@ void Dsmr::stop_requesting_data_() {
 
 void Dsmr::drain_rx_buffer_() {
   uint8_t buf[64];
-  int avail;
+  size_t avail;
   while ((avail = this->available()) > 0) {
-    if (!this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)))) {
+    if (!this->read_array(buf, std::min(avail, sizeof(buf)))) {
       break;
     }
   }
@@ -140,9 +140,9 @@ void Dsmr::receive_telegram_() {
   while (this->available_within_timeout_()) {
     // Read all available bytes in batches to reduce UART call overhead.
     uint8_t buf[64];
-    int avail = this->available();
+    size_t avail = this->available();
     while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      size_t to_read = std::min(avail, sizeof(buf));
       if (!this->read_array(buf, to_read))
         return;
       avail -= to_read;
@@ -206,9 +206,9 @@ void Dsmr::receive_encrypted_telegram_() {
   while (this->available_within_timeout_()) {
     // Read all available bytes in batches to reduce UART call overhead.
     uint8_t buf[64];
-    int avail = this->available();
+    size_t avail = this->available();
     while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      size_t to_read = std::min(avail, sizeof(buf));
       if (!this->read_array(buf, to_read))
         return;
       avail -= to_read;

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -276,10 +276,10 @@ void LD2410Component::restart_and_read_all_info() {
 
 void LD2410Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -311,10 +311,10 @@ void LD2412Component::restart_and_read_all_info() {
 
 void LD2412Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -277,10 +277,10 @@ void LD2450Component::dump_config() {
 
 void LD2450Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[MAX_LINE_LENGTH];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -20,10 +20,10 @@ void Modbus::loop() {
   const uint32_t now = App.get_loop_component_start_time();
 
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -398,10 +398,10 @@ bool Nextion::remove_from_q_(bool report_empty) {
 
 void Nextion::process_serial_() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -14,9 +14,9 @@ void Pipsolar::setup() {
 
 void Pipsolar::empty_uart_buffer_() {
   uint8_t buf[64];
-  int avail;
+  size_t avail;
   while ((avail = this->available()) > 0) {
-    if (!this->read_array(buf, std::min(static_cast<size_t>(avail), sizeof(buf)))) {
+    if (!this->read_array(buf, std::min(avail, sizeof(buf)))) {
       break;
     }
   }
@@ -97,10 +97,10 @@ void Pipsolar::loop() {
   }
 
   if (this->state_ == STATE_COMMAND || this->state_ == STATE_POLL) {
-    int avail = this->available();
+    size_t avail = this->available();
     while (avail > 0) {
       uint8_t buf[64];
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      size_t to_read = std::min(avail, sizeof(buf));
       if (!this->read_array(buf, to_read)) {
         break;
       }

--- a/esphome/components/pylontech/pylontech.cpp
+++ b/esphome/components/pylontech/pylontech.cpp
@@ -56,14 +56,14 @@ void PylontechComponent::setup() {
 void PylontechComponent::update() { this->write_str("pwr\n"); }
 
 void PylontechComponent::loop() {
-  int avail = this->available();
+  size_t avail = this->available();
   if (avail > 0) {
     // pylontech sends a lot of data very suddenly
     // we need to quickly put it all into our own buffer, otherwise the uart's buffer will overflow
     int recv = 0;
     uint8_t buf[64];
     while (avail > 0) {
-      size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+      size_t to_read = std::min(avail, sizeof(buf));
       if (!this->read_array(buf, to_read)) {
         break;
       }

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -82,10 +82,10 @@ void RD03DComponent::dump_config() {
 
 void RD03DComponent::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -136,10 +136,10 @@ void RFBridgeComponent::loop() {
     this->last_bridge_byte_ = now;
   }
 
-  int avail = this->available();
+  size_t avail = this->available();
   while (avail > 0) {
     uint8_t buf[64];
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -107,10 +107,10 @@ void MR24HPC1Component::update_() {
 // main loop
 void MR24HPC1Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -31,10 +31,10 @@ void MR60BHA2Component::dump_config() {
 // main loop
 void MR60BHA2Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -50,10 +50,10 @@ void MR60FDA2Component::setup() {
 // main loop
 void MR60FDA2Component::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }

--- a/esphome/components/tuya/tuya.cpp
+++ b/esphome/components/tuya/tuya.cpp
@@ -32,10 +32,10 @@ void Tuya::setup() {
 
 void Tuya::loop() {
   // Read all available bytes in batches to reduce UART call overhead.
-  int avail = this->available();
+  size_t avail = this->available();
   uint8_t buf[64];
   while (avail > 0) {
-    size_t to_read = std::min(static_cast<size_t>(avail), sizeof(buf));
+    size_t to_read = std::min(avail, sizeof(buf));
     if (!this->read_array(buf, to_read)) {
       break;
     }


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #13893 which changed `available()` return type from `int` to `size_t`. The batch UART read PRs (#13817-#13828) that were merged around the same time still used `int avail = this->available()` with unnecessary `static_cast<size_t>(avail)` casts.

This PR fixes all 16 remaining components to use `size_t avail` directly and removes the now-redundant casts. Also fixes one `<= 0` comparison on `size_t` in cse7766 (`<= 0` is always equivalent to `== 0` for unsigned).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13893

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing changes

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Purely mechanical type change — no logic changes.

## Example entry for `config.yaml`:

N/A — no configuration changes

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).