### PR TITLE
[scheduler] Reduce set_timer_common_ hot path size by 25%

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -107,6 +107,24 @@ static void validate_static_string(const char *name) {
 // iterating over them from the loop task is fine; but iterating from any other context requires the lock to be held to
 // avoid the main thread modifying the list while it is being accessed.
 
+// Calculate random offset for interval timers
+// Extracted from set_timer_common_ to reduce code size - float math + random_float()
+// only needed for intervals, not timeouts
+uint32_t Scheduler::calculate_interval_offset_(uint32_t delay) {
+  return static_cast<uint32_t>(std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
+}
+
+// Check if a retry was already cancelled in items_ or to_add_
+// Extracted from set_timer_common_ to reduce code size - retry path is cold and deprecated
+// Remove before 2026.8.0 along with all retry code
+bool Scheduler::is_retry_cancelled_locked_(Component *component, NameType name_type, const char *static_name,
+                                           uint32_t hash_or_id) {
+  return has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
+                                                    /* match_retry= */ true) ||
+         has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_type, static_name, hash_or_id,
+                                                    /* match_retry= */ true);
+}
+
 // Common implementation for both timeout and interval
 // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
 void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type,
@@ -130,84 +148,66 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // Create and populate the scheduler item
   auto item = this->get_item_from_pool_locked_();
   item->component = component;
-  switch (name_type) {
-    case NameType::STATIC_STRING:
-      item->set_static_name(static_name);
-      break;
-    case NameType::HASHED_STRING:
-      item->set_hashed_name(hash_or_id);
-      break;
-    case NameType::NUMERIC_ID:
-      item->set_numeric_id(hash_or_id);
-      break;
-    case NameType::NUMERIC_ID_INTERNAL:
-      item->set_internal_id(hash_or_id);
-      break;
-  }
+  item->set_name(name_type, static_name, hash_or_id);
   item->type = type;
   item->callback = std::move(func);
   // Reset remove flag - recycled items may have been cancelled (remove=true) in previous use
   this->set_item_removed_(item.get(), false);
   item->is_retry = is_retry;
 
+  // Determine target container: defer_queue_ for deferred items, to_add_ for everything else.
+  // Using a pointer lets both paths share the cancel + push_back epilogue.
+  auto *target = &this->to_add_;
+
 #ifndef ESPHOME_THREAD_SINGLE
   // Special handling for defer() (delay = 0, type = TIMEOUT)
   // Single-core platforms don't need thread-safe defer handling
   if (delay == 0 && type == SchedulerItem::TIMEOUT) {
     // Put in defer queue for guaranteed FIFO execution
-    if (!skip_cancel) {
-      this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
-    }
-    this->defer_queue_.push_back(std::move(item));
-    return;
-  }
+    target = &this->defer_queue_;
+  } else
 #endif /* not ESPHOME_THREAD_SINGLE */
-
-  // Type-specific setup
-  if (type == SchedulerItem::INTERVAL) {
-    item->interval = delay;
-    // first execution happens immediately after a random smallish offset
-    // Calculate random offset (0 to min(interval/2, 5s))
-    uint32_t offset = (uint32_t) (std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
-    item->set_next_execution(now + offset);
+  {
+    // Type-specific setup
+    if (type == SchedulerItem::INTERVAL) {
+      item->interval = delay;
+      // first execution happens immediately after a random smallish offset
+      uint32_t offset = this->calculate_interval_offset_(delay);
+      item->set_next_execution(now + offset);
 #ifdef ESPHOME_LOG_HAS_VERBOSE
-    SchedulerNameLog name_log;
-    ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms",
-             name_log.format(name_type, static_name, hash_or_id), delay, offset);
+      SchedulerNameLog name_log;
+      ESP_LOGV(TAG, "Scheduler interval for %s is %" PRIu32 "ms, offset %" PRIu32 "ms",
+               name_log.format(name_type, static_name, hash_or_id), delay, offset);
 #endif
-  } else {
-    item->interval = 0;
-    item->set_next_execution(now + delay);
-  }
+    } else {
+      item->interval = 0;
+      item->set_next_execution(now + delay);
+    }
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
-  this->debug_log_timer_(item.get(), name_type, static_name, hash_or_id, type, delay, now);
+    this->debug_log_timer_(item.get(), name_type, static_name, hash_or_id, type, delay, now);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // For retries, check if there's a cancelled timeout first
-  // Skip check for anonymous retries (STATIC_STRING with nullptr) - they can't be cancelled by name
-  if (is_retry && (name_type != NameType::STATIC_STRING || static_name != nullptr) && type == SchedulerItem::TIMEOUT &&
-      (has_cancelled_timeout_in_container_locked_(this->items_, component, name_type, static_name, hash_or_id,
-                                                  /* match_retry= */ true) ||
-       has_cancelled_timeout_in_container_locked_(this->to_add_, component, name_type, static_name, hash_or_id,
-                                                  /* match_retry= */ true))) {
-    // Skip scheduling - the retry was cancelled
+    // For retries, check if there's a cancelled timeout first
+    // Skip check for anonymous retries (STATIC_STRING with nullptr) - they can't be cancelled by name
+    if (is_retry && (name_type != NameType::STATIC_STRING || static_name != nullptr) &&
+        type == SchedulerItem::TIMEOUT &&
+        this->is_retry_cancelled_locked_(component, name_type, static_name, hash_or_id)) {
+      // Skip scheduling - the retry was cancelled
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    SchedulerNameLog skip_name_log;
-    ESP_LOGD(TAG, "Skipping retry '%s' - found cancelled item",
-             skip_name_log.format(name_type, static_name, hash_or_id));
+      SchedulerNameLog skip_name_log;
+      ESP_LOGD(TAG, "Skipping retry '%s' - found cancelled item",
+               skip_name_log.format(name_type, static_name, hash_or_id));
 #endif
-    return;
+      return;
+    }
   }
 
-  // If name is provided, do atomic cancel-and-add (unless skip_cancel is true)
-  // Cancel existing items
+  // Common epilogue: atomic cancel-and-add (unless skip_cancel is true)
   if (!skip_cancel) {
     this->cancel_item_locked_(component, name_type, static_name, hash_or_id, type);
   }
-  // Add new item directly to to_add_
-  // since we have the lock held
-  this->to_add_.push_back(std::move(item));
+  target->push_back(std::move(item));
 }
 
 void HOT Scheduler::set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func) {


### PR DESCRIPTION
# What does this implement/fix?

Restructure `set_timer_common_` to reduce icache pressure on the hot path (538 → 405 bytes on ESP32, 25% reduction).

Changes:
- **Extract `calculate_interval_offset_` as `noinline` helper** — the float math (`random_float()`, multiply, float-to-int conversion) is only used for interval offset calculation. Extracting it avoids pulling FPU code into the main function body.
- **Extract `is_retry_cancelled_locked_` as `noinline` helper** — the retry path is cold and deprecated (removal planned for 2026.8.0). When retry code is removed, this helper and ~20-30 bytes of conditional logic in `set_timer_common_` will also be deleted.
- **Merge duplicated cancel+push_back epilogue** — both the defer queue path and the normal path ended with `cancel_item_locked_()` + `vector::push_back()`. By computing a target vector pointer (`defer_queue_` vs `to_add_`) before the branch, both paths converge at a single cancel+push sequence, eliminating ~30 bytes of duplicated code.
- **Replace 4-way `switch(name_type)` with unified `set_name()` method** — the switch generated 4 separate bitfield read-modify-write sequences (~84 bytes). The new `set_name()` does a single `if/else` on the union write plus one store to `name_type_` (~16 bytes).
- **Remove now-unused individual name setters** (`set_static_name`, `set_hashed_name`, `set_numeric_id`, `set_internal_id`) — these had no callers outside the now-replaced switch.

Size measurements (ESP32 IDF, xtensa):

| Function | Before | After |
|----------|--------|-------|
| `set_timer_common_` | 538 B | 405 B (-133 B) |
| `calculate_interval_offset_` (new) | — | 48 B |
| `is_retry_cancelled_locked_` (new, cold) | — | 50 B |
| **Net** | **538 B** | **503 B (-35 B)** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).