### PR TITLE
[core] Extract dump_config from Application::loop() hot path

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -204,36 +204,40 @@ void Application::loop() {
   this->last_loop_ = last_op_end_time;
 
   if (this->dump_config_at_ < this->components_.size()) {
-    if (this->dump_config_at_ == 0) {
-      char build_time_str[Application::BUILD_TIME_STR_SIZE];
-      this->get_build_time_string(build_time_str);
-      ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", build_time_str);
+    this->process_dump_config_();
+  }
+}
+
+void Application::process_dump_config_() {
+  if (this->dump_config_at_ == 0) {
+    char build_time_str[Application::BUILD_TIME_STR_SIZE];
+    this->get_build_time_string(build_time_str);
+    ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", build_time_str);
 #ifdef ESPHOME_PROJECT_NAME
-      ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
+    ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
 #endif
 #ifdef USE_ESP32
-      esp_chip_info_t chip_info;
-      esp_chip_info(&chip_info);
-      ESP_LOGI(TAG, "ESP32 Chip: %s rev%d.%d, %d core(s)", ESPHOME_VARIANT, chip_info.revision / 100,
-               chip_info.revision % 100, chip_info.cores);
+    esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+    ESP_LOGI(TAG, "ESP32 Chip: %s rev%d.%d, %d core(s)", ESPHOME_VARIANT, chip_info.revision / 100,
+             chip_info.revision % 100, chip_info.cores);
 #if defined(USE_ESP32_VARIANT_ESP32) && !defined(USE_ESP32_MIN_CHIP_REVISION_SET)
-      // Suggest optimization for chips that don't need the PSRAM cache workaround
-      if (chip_info.revision >= 300) {
+    // Suggest optimization for chips that don't need the PSRAM cache workaround
+    if (chip_info.revision >= 300) {
 #ifdef USE_PSRAM
-        ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to save ~10KB IRAM", chip_info.revision / 100,
-                 chip_info.revision % 100);
+      ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to save ~10KB IRAM", chip_info.revision / 100,
+               chip_info.revision % 100);
 #else
-        ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to reduce binary size", chip_info.revision / 100,
-                 chip_info.revision % 100);
-#endif
-      }
-#endif
+      ESP_LOGW(TAG, "Set minimum_chip_revision: \"%d.%d\" to reduce binary size", chip_info.revision / 100,
+               chip_info.revision % 100);
 #endif
     }
-
-    this->components_[this->dump_config_at_]->call_dump_config();
-    this->dump_config_at_++;
+#endif
+#endif
   }
+
+  this->components_[this->dump_config_at_]->call_dump_config();
+  this->dump_config_at_++;
 }
 
 void IRAM_ATTR HOT Application::feed_wdt(uint32_t time) {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,6 +521,7 @@ class Application {
 
   /// Process dump_config output one component per loop iteration.
   /// Extracted from loop() to keep cold startup/reconnect logging out of the hot path.
+  /// Caller must ensure dump_config_at_ < components_.size().
   void __attribute__((noinline)) process_dump_config_();
 
   void feed_wdt_arch_();

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -519,6 +519,10 @@ class Application {
   void before_loop_tasks_(uint32_t loop_start_time);
   void after_loop_tasks_();
 
+  /// Process dump_config output one component per loop iteration.
+  /// Extracted from loop() to keep cold startup/reconnect logging out of the hot path.
+  void __attribute__((noinline)) process_dump_config_();
+
   void feed_wdt_arch_();
 
   /// Perform a delay while also monitoring socket file descriptors for readiness


### PR DESCRIPTION
# What does this implement/fix?

Extract the dump_config block from `Application::loop()` into a separate `noinline` `process_dump_config_()` method.

`loop()` runs ~7000 times/minute, but the dump_config code only executes once at startup and once on API reconnect. On ESP32, the dump_config block compiled to ~140 bytes (38% of `loop()`'s 368 bytes), including `esp_chip_info()`, integer division for revision formatting, and multiple `ESP_LOG` calls. This cold code occupied ~2 icache lines that were loaded on every `loop()` call but never executed during normal operation.

Extracting it into a `noinline` helper frees those cache lines for the actual hot path (component iteration, scheduler, sleep calculation).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).