### PR TITLE
[api] Extract cold code from APIConnection::loop() hot path

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -259,30 +259,31 @@ void APIConnection::loop() {
 void APIConnection::process_active_iterator_() {
   // Caller ensures active_iterator_ != NONE
   if (this->active_iterator_ == ActiveIterator::LIST_ENTITIES) {
-    if (this->iterator_storage_.list_entities.completed()) {
-      this->destroy_active_iterator_();
-      if (this->flags_.state_subscription) {
-        this->begin_iterator_(ActiveIterator::INITIAL_STATE);
-      }
-    } else {
+    if (!this->iterator_storage_.list_entities.completed()) {
       this->process_iterator_batch_(this->iterator_storage_.list_entities);
+      return;
     }
-  } else {  // INITIAL_STATE
-    if (this->iterator_storage_.initial_state.completed()) {
-      this->destroy_active_iterator_();
-      // Process any remaining batched messages immediately
-      if (!this->deferred_batch_.empty()) {
-        this->process_batch_();
-      }
-      // Now that everything is sent, enable immediate sending for future state changes
-      this->flags_.should_try_send_immediately = true;
-      // Release excess memory from buffers that grew during initial sync
-      this->deferred_batch_.release_buffer();
-      this->helper_->release_buffers();
-    } else {
-      this->process_iterator_batch_(this->iterator_storage_.initial_state);
+    this->destroy_active_iterator_();
+    if (this->flags_.state_subscription) {
+      this->begin_iterator_(ActiveIterator::INITIAL_STATE);
     }
+    return;
   }
+  // INITIAL_STATE
+  if (!this->iterator_storage_.initial_state.completed()) {
+    this->process_iterator_batch_(this->iterator_storage_.initial_state);
+    return;
+  }
+  this->destroy_active_iterator_();
+  // Process any remaining batched messages immediately
+  if (!this->deferred_batch_.empty()) {
+    this->process_batch_();
+  }
+  // Now that everything is sent, enable immediate sending for future state changes
+  this->flags_.should_try_send_immediately = true;
+  // Release excess memory from buffers that grew during initial sync
+  this->deferred_batch_.release_buffer();
+  this->helper_->release_buffers();
 }
 
 void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -257,35 +257,31 @@ void APIConnection::loop() {
 }
 
 void APIConnection::process_active_iterator_() {
-  switch (this->active_iterator_) {
-    case ActiveIterator::LIST_ENTITIES:
-      if (this->iterator_storage_.list_entities.completed()) {
-        this->destroy_active_iterator_();
-        if (this->flags_.state_subscription) {
-          this->begin_iterator_(ActiveIterator::INITIAL_STATE);
-        }
-      } else {
-        this->process_iterator_batch_(this->iterator_storage_.list_entities);
+  // Caller ensures active_iterator_ != NONE
+  if (this->active_iterator_ == ActiveIterator::LIST_ENTITIES) {
+    if (this->iterator_storage_.list_entities.completed()) {
+      this->destroy_active_iterator_();
+      if (this->flags_.state_subscription) {
+        this->begin_iterator_(ActiveIterator::INITIAL_STATE);
       }
-      break;
-    case ActiveIterator::INITIAL_STATE:
-      if (this->iterator_storage_.initial_state.completed()) {
-        this->destroy_active_iterator_();
-        // Process any remaining batched messages immediately
-        if (!this->deferred_batch_.empty()) {
-          this->process_batch_();
-        }
-        // Now that everything is sent, enable immediate sending for future state changes
-        this->flags_.should_try_send_immediately = true;
-        // Release excess memory from buffers that grew during initial sync
-        this->deferred_batch_.release_buffer();
-        this->helper_->release_buffers();
-      } else {
-        this->process_iterator_batch_(this->iterator_storage_.initial_state);
+    } else {
+      this->process_iterator_batch_(this->iterator_storage_.list_entities);
+    }
+  } else {
+    if (this->iterator_storage_.initial_state.completed()) {
+      this->destroy_active_iterator_();
+      // Process any remaining batched messages immediately
+      if (!this->deferred_batch_.empty()) {
+        this->process_batch_();
       }
-      break;
-    case ActiveIterator::NONE:
-      break;
+      // Now that everything is sent, enable immediate sending for future state changes
+      this->flags_.should_try_send_immediately = true;
+      // Release excess memory from buffers that grew during initial sync
+      this->deferred_batch_.release_buffer();
+      this->helper_->release_buffers();
+    } else {
+      this->process_iterator_batch_(this->iterator_storage_.initial_state);
+    }
   }
 }
 

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -259,31 +259,30 @@ void APIConnection::loop() {
 void APIConnection::process_active_iterator_() {
   // Caller ensures active_iterator_ != NONE
   if (this->active_iterator_ == ActiveIterator::LIST_ENTITIES) {
-    if (!this->iterator_storage_.list_entities.completed()) {
+    if (this->iterator_storage_.list_entities.completed()) {
+      this->destroy_active_iterator_();
+      if (this->flags_.state_subscription) {
+        this->begin_iterator_(ActiveIterator::INITIAL_STATE);
+      }
+    } else {
       this->process_iterator_batch_(this->iterator_storage_.list_entities);
-      return;
     }
-    this->destroy_active_iterator_();
-    if (this->flags_.state_subscription) {
-      this->begin_iterator_(ActiveIterator::INITIAL_STATE);
+  } else {  // INITIAL_STATE
+    if (this->iterator_storage_.initial_state.completed()) {
+      this->destroy_active_iterator_();
+      // Process any remaining batched messages immediately
+      if (!this->deferred_batch_.empty()) {
+        this->process_batch_();
+      }
+      // Now that everything is sent, enable immediate sending for future state changes
+      this->flags_.should_try_send_immediately = true;
+      // Release excess memory from buffers that grew during initial sync
+      this->deferred_batch_.release_buffer();
+      this->helper_->release_buffers();
+    } else {
+      this->process_iterator_batch_(this->iterator_storage_.initial_state);
     }
-    return;
   }
-  // INITIAL_STATE
-  if (!this->iterator_storage_.initial_state.completed()) {
-    this->process_iterator_batch_(this->iterator_storage_.initial_state);
-    return;
-  }
-  this->destroy_active_iterator_();
-  // Process any remaining batched messages immediately
-  if (!this->deferred_batch_.empty()) {
-    this->process_batch_();
-  }
-  // Now that everything is sent, enable immediate sending for future state changes
-  this->flags_.should_try_send_immediately = true;
-  // Release excess memory from buffers that grew during initial sync
-  this->deferred_batch_.release_buffer();
-  this->helper_->release_buffers();
 }
 
 void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -267,7 +267,7 @@ void APIConnection::process_active_iterator_() {
     } else {
       this->process_iterator_batch_(this->iterator_storage_.list_entities);
     }
-  } else {
+  } else {  // INITIAL_STATE
     if (this->iterator_storage_.initial_state.completed()) {
       this->destroy_active_iterator_();
       // Process any remaining batched messages immediately

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -283,6 +283,20 @@ void APIConnection::loop() {
 #endif
 }
 
+void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {
+  size_t initial_size = this->deferred_batch_.size();
+  size_t max_batch = this->get_max_batch_size_();
+  while (!iterator.completed() && (this->deferred_batch_.size() - initial_size) < max_batch) {
+    iterator.advance();
+  }
+
+  // If the batch is full, process it immediately
+  // Note: iterator.advance() already calls schedule_batch_() via schedule_message_()
+  if (this->deferred_batch_.size() >= max_batch) {
+    this->process_batch_();
+  }
+}
+
 bool APIConnection::send_disconnect_response_() {
   // remote initiated disconnect_client
   // don't close yet, we still need to send the disconnect response

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -219,35 +219,8 @@ void APIConnection::loop() {
     this->process_batch_();
   }
 
-  switch (this->active_iterator_) {
-    case ActiveIterator::LIST_ENTITIES:
-      if (this->iterator_storage_.list_entities.completed()) {
-        this->destroy_active_iterator_();
-        if (this->flags_.state_subscription) {
-          this->begin_iterator_(ActiveIterator::INITIAL_STATE);
-        }
-      } else {
-        this->process_iterator_batch_(this->iterator_storage_.list_entities);
-      }
-      break;
-    case ActiveIterator::INITIAL_STATE:
-      if (this->iterator_storage_.initial_state.completed()) {
-        this->destroy_active_iterator_();
-        // Process any remaining batched messages immediately
-        if (!this->deferred_batch_.empty()) {
-          this->process_batch_();
-        }
-        // Now that everything is sent, enable immediate sending for future state changes
-        this->flags_.should_try_send_immediately = true;
-        // Release excess memory from buffers that grew during initial sync
-        this->deferred_batch_.release_buffer();
-        this->helper_->release_buffers();
-      } else {
-        this->process_iterator_batch_(this->iterator_storage_.initial_state);
-      }
-      break;
-    case ActiveIterator::NONE:
-      break;
+  if (this->active_iterator_ != ActiveIterator::NONE) {
+    this->process_active_iterator_();
   }
 
   if (this->flags_.sent_ping) {
@@ -281,6 +254,39 @@ void APIConnection::loop() {
   // (missing a frame is fine, missing a state update is not)
   this->try_send_camera_image_();
 #endif
+}
+
+void APIConnection::process_active_iterator_() {
+  switch (this->active_iterator_) {
+    case ActiveIterator::LIST_ENTITIES:
+      if (this->iterator_storage_.list_entities.completed()) {
+        this->destroy_active_iterator_();
+        if (this->flags_.state_subscription) {
+          this->begin_iterator_(ActiveIterator::INITIAL_STATE);
+        }
+      } else {
+        this->process_iterator_batch_(this->iterator_storage_.list_entities);
+      }
+      break;
+    case ActiveIterator::INITIAL_STATE:
+      if (this->iterator_storage_.initial_state.completed()) {
+        this->destroy_active_iterator_();
+        // Process any remaining batched messages immediately
+        if (!this->deferred_batch_.empty()) {
+          this->process_batch_();
+        }
+        // Now that everything is sent, enable immediate sending for future state changes
+        this->flags_.should_try_send_immediately = true;
+        // Release excess memory from buffers that grew during initial sync
+        this->deferred_batch_.release_buffer();
+        this->helper_->release_buffers();
+      } else {
+        this->process_iterator_batch_(this->iterator_storage_.initial_state);
+      }
+      break;
+    case ActiveIterator::NONE:
+      break;
+  }
 }
 
 void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -364,6 +364,10 @@ class APIConnection final : public APIServerConnectionBase {
     return this->client_supports_api_version(1, 14) ? MAX_INITIAL_PER_BATCH : MAX_INITIAL_PER_BATCH_LEGACY;
   }
 
+  // Process active iterator (list_entities/initial_state) during connection setup.
+  // Extracted from loop() — only runs during initial handshake, NONE in steady state.
+  void __attribute__((noinline)) process_active_iterator_();
+
   // Helper method to process multiple entities from an iterator in a batch.
   // Takes ComponentIterator base class reference to avoid duplicate template instantiations.
   void process_iterator_batch_(ComponentIterator &iterator);

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -15,6 +15,10 @@
 #include <limits>
 #include <vector>
 
+namespace esphome {
+class ComponentIterator;
+}  // namespace esphome
+
 namespace esphome::api {
 
 // Keepalive timeout in milliseconds

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -364,20 +364,9 @@ class APIConnection final : public APIServerConnectionBase {
     return this->client_supports_api_version(1, 14) ? MAX_INITIAL_PER_BATCH : MAX_INITIAL_PER_BATCH_LEGACY;
   }
 
-  // Helper method to process multiple entities from an iterator in a batch
-  template<typename Iterator> void process_iterator_batch_(Iterator &iterator) {
-    size_t initial_size = this->deferred_batch_.size();
-    size_t max_batch = this->get_max_batch_size_();
-    while (!iterator.completed() && (this->deferred_batch_.size() - initial_size) < max_batch) {
-      iterator.advance();
-    }
-
-    // If the batch is full, process it immediately
-    // Note: iterator.advance() already calls schedule_batch_() via schedule_message_()
-    if (this->deferred_batch_.size() >= max_batch) {
-      this->process_batch_();
-    }
-  }
+  // Helper method to process multiple entities from an iterator in a batch.
+  // Takes ComponentIterator base class reference to avoid duplicate template instantiations.
+  void process_iterator_batch_(ComponentIterator &iterator);
 
 #ifdef USE_BINARY_SENSOR
   static uint16_t try_send_binary_sensor_state(EntityBase *entity, APIConnection *conn, uint32_t remaining_size);

--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -94,7 +94,6 @@ class ListEntitiesIterator : public ComponentIterator {
   bool on_update(update::UpdateEntity *entity) override;
 #endif
   bool on_end() override;
-  bool completed() { return this->state_ == IteratorState::NONE; }
 
  protected:
   APIConnection *client_;

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -88,7 +88,6 @@ class InitialStateIterator : public ComponentIterator {
 #ifdef USE_UPDATE
   bool on_update(update::UpdateEntity *entity) override;
 #endif
-  bool completed() { return this->state_ == IteratorState::NONE; }
 
  protected:
   APIConnection *client_;

--- a/esphome/core/component_iterator.h
+++ b/esphome/core/component_iterator.h
@@ -26,6 +26,7 @@ class ComponentIterator {
  public:
   void begin(bool include_internal = false);
   void advance();
+  bool completed() const { return this->state_ == IteratorState::NONE; }
   virtual bool on_begin();
 #ifdef USE_BINARY_SENSOR
   virtual bool on_binary_sensor(binary_sensor::BinarySensor *binary_sensor) = 0;


### PR DESCRIPTION
# What does this implement/fix?

Reduce `APIConnection::loop()` binary size by extracting cold code from the hot path.

**1. De-duplicate iterator batch processing:**
Replace template `process_iterator_batch_<Iterator>()` with a non-template method taking `ComponentIterator&` base class reference. This eliminates duplicate instantiations for `ListEntitiesIterator` and `InitialStateIterator`.

- Move `completed()` to `ComponentIterator` base class (was duplicated in both derived classes)
- Convert `process_iterator_batch_` from template to regular method taking `ComponentIterator&`
- Move implementation from header to .cpp file

**2. Extract iterator switch into `process_active_iterator_()`:**
The iterator switch (LIST_ENTITIES/INITIAL_STATE/NONE) only runs during initial connection handshake. In steady state `active_iterator_` is always `NONE`, so the entire switch block is cold code that wastes icache in the hot loop path. Replace with `if (active_iterator_ != NONE) process_active_iterator_();`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).