### PR TITLE
[esp32_ble] Extract state transitions from ESP32BLE::loop() hot path

### DIFF
--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -155,6 +155,10 @@ class ESP32BLE : public Component {
 #endif
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
+  // Handle non-ACTIVE state transitions (DISABLE, ENABLE, OFF, DISABLED).
+  // Extracted from loop() to keep the hot event-processing path small.
+  void __attribute__((noinline)) loop_handle_state_transition_not_active_();
+
   bool ble_setup_();
   bool ble_dismantle_();
   bool ble_pre_setup_();

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -155,8 +155,8 @@ class ESP32BLE : public Component {
 #endif
   static void gap_event_handler(esp_gap_ble_cb_event_t event, esp_ble_gap_cb_param_t *param);
 
-  // Handle non-ACTIVE state transitions (DISABLE, ENABLE, OFF, DISABLED).
-  // Extracted from loop() to keep the hot event-processing path small.
+  // Handle DISABLE and ENABLE transitions when not in the ACTIVE state.
+  // Other non-ACTIVE states (e.g. OFF, DISABLED) are currently treated as no-ops.
   void __attribute__((noinline)) loop_handle_state_transition_not_active_();
 
   bool ble_setup_();


### PR DESCRIPTION
# What does this implement/fix?

Extract the DISABLE/ENABLE state transition handling from `ESP32BLE::loop()` into a separate `loop_handle_state_transition_not_active_()` noinline helper.

In steady state, `state_` is always `BLE_COMPONENT_STATE_ACTIVE`, so the entire state machine switch (DISABLE with ble_dismantle_, ENABLE with ble_setup_, OFF, DISABLED) is cold code. It only runs during BLE enable/disable transitions. Keeping it out of the hot path reduces icache pressure for the BLE event dispatch loop which processes every BLE advertisement (~110 loops/sec).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).