### PR TITLE
[esp32_rmt_led_strip, remote_receiver, pulse_counter] Replace hardcoded clock frequencies with runtime queries

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -7,7 +7,7 @@
 #include "esphome/core/log.h"
 
 #include <esp_attr.h>
-#include <esp_private/esp_clk.h>
+#include <esp_clk_tree.h>
 
 namespace esphome {
 namespace esp32_rmt_led_strip {
@@ -16,9 +16,14 @@ static const char *const TAG = "esp32_rmt_led_strip";
 
 static const size_t RMT_SYMBOLS_PER_BYTE = 8;
 
-// Target ~40MHz RMT resolution to keep rmt_symbol_word_t duration fields (15-bit, max 32767)
-// from overflowing on long reset times (e.g. WS2811 300µs = 12000 ticks at 40MHz vs 24000 at 80MHz).
-static uint32_t rmt_resolution_hz() { return esp_clk_apb_freq() / (esp_clk_apb_freq() > 40000000 ? 2 : 1); }
+// Use full APB clock as RMT resolution (~80MHz on most variants, 32MHz on H2).
+// Worst-case reset time is WS2811 at 300µs = 24000 ticks at 80MHz, well within
+// the 15-bit rmt_symbol_word_t duration field max of 32767.
+static uint32_t rmt_resolution_hz() {
+  uint32_t apb_freq;
+  esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
+  return apb_freq;
+}
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size_t symbols_written, size_t symbols_free,

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -18,7 +18,6 @@ static const size_t RMT_SYMBOLS_PER_BYTE = 8;
 
 // Target ~40MHz RMT resolution to keep rmt_symbol_word_t duration fields (15-bit, max 32767)
 // from overflowing on long reset times (e.g. WS2811 300µs = 12000 ticks at 40MHz vs 24000 at 80MHz).
-// 25ns tick resolution is well within LED protocol tolerances (~100ns).
 static uint32_t rmt_resolution_hz() { return esp_clk_apb_freq() / (esp_clk_apb_freq() > 40000000 ? 2 : 1); }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -7,21 +7,19 @@
 #include "esphome/core/log.h"
 
 #include <esp_attr.h>
+#include <esp_private/esp_clk.h>
 
 namespace esphome {
 namespace esp32_rmt_led_strip {
 
 static const char *const TAG = "esp32_rmt_led_strip";
 
-#ifdef USE_ESP32_VARIANT_ESP32H2
-static const uint32_t RMT_CLK_FREQ = 32000000;
-static const uint8_t RMT_CLK_DIV = 1;
-#else
-static const uint32_t RMT_CLK_FREQ = 80000000;
-static const uint8_t RMT_CLK_DIV = 2;
-#endif
-
 static const size_t RMT_SYMBOLS_PER_BYTE = 8;
+
+// Target ~40MHz RMT resolution to keep rmt_symbol_word_t duration fields (15-bit, max 32767)
+// from overflowing on long reset times (e.g. WS2811 300µs = 12000 ticks at 40MHz vs 24000 at 80MHz).
+// 25ns tick resolution is well within LED protocol tolerances (~100ns).
+static uint32_t rmt_resolution_hz() { return esp_clk_apb_freq() / (esp_clk_apb_freq() > 40000000 ? 2 : 1); }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
 static size_t IRAM_ATTR HOT encoder_callback(const void *data, size_t size, size_t symbols_written, size_t symbols_free,
@@ -92,7 +90,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
   rmt_tx_channel_config_t channel;
   memset(&channel, 0, sizeof(channel));
   channel.clk_src = RMT_CLK_SRC_DEFAULT;
-  channel.resolution_hz = RMT_CLK_FREQ / RMT_CLK_DIV;
+  channel.resolution_hz = rmt_resolution_hz();
   channel.gpio_num = gpio_num_t(this->pin_);
   channel.mem_block_symbols = this->rmt_symbols_;
   channel.trans_queue_depth = 1;
@@ -137,7 +135,7 @@ void ESP32RMTLEDStripLightOutput::setup() {
 
 void ESP32RMTLEDStripLightOutput::set_led_params(uint32_t bit0_high, uint32_t bit0_low, uint32_t bit1_high,
                                                  uint32_t bit1_low, uint32_t reset_time_high, uint32_t reset_time_low) {
-  float ratio = (float) RMT_CLK_FREQ / RMT_CLK_DIV / 1e09f;
+  float ratio = (float) rmt_resolution_hz() / 1e09f;
 
   // 0-bit
   this->params_.bit0.duration0 = (uint32_t) (ratio * bit0_high);

--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -16,13 +16,14 @@ static const char *const TAG = "esp32_rmt_led_strip";
 
 static const size_t RMT_SYMBOLS_PER_BYTE = 8;
 
-// Use full APB clock as RMT resolution (~80MHz on most variants, 32MHz on H2).
+// Query the RMT default clock source frequency. This varies by variant:
+// APB (80MHz) on ESP32/S2/S3/C3, PLL_F80M (80MHz) on C6/P4, XTAL (32MHz) on H2.
 // Worst-case reset time is WS2811 at 300µs = 24000 ticks at 80MHz, well within
 // the 15-bit rmt_symbol_word_t duration field max of 32767.
 static uint32_t rmt_resolution_hz() {
-  uint32_t apb_freq;
-  esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
-  return apb_freq;
+  uint32_t freq;
+  esp_clk_tree_src_get_freq_hz((soc_module_clk_t) RMT_CLK_SRC_DEFAULT, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &freq);
+  return freq;
 }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 #ifdef HAS_PCNT
-#include <esp_private/esp_clk.h>
+#include <esp_clk_tree.h>
 #include <hal/pcnt_ll.h>
 #endif
 
@@ -117,7 +117,9 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / (uint32_t) esp_clk_apb_freq();
+    uint32_t apb_freq;
+    esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
+    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / apb_freq;
     pcnt_glitch_filter_config_t filter_config = {
         .max_glitch_ns = std::min(this->filter_us * 1000u, max_glitch_ns),
     };

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -94,9 +94,10 @@ void RemoteReceiverComponent::setup() {
   }
 
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
-  uint32_t apb_freq;
-  esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
-  uint32_t max_filter_ns = UINT8_MAX * 1000u / (apb_freq / 1000000);
+  uint32_t rmt_freq;
+  esp_clk_tree_src_get_freq_hz((soc_module_clk_t) RMT_CLK_SRC_DEFAULT, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED,
+                               &rmt_freq);
+  uint32_t max_filter_ns = UINT8_MAX * 1000u / (rmt_freq / 1000000);
   memset(&this->store_.config, 0, sizeof(this->store_.config));
   this->store_.config.signal_range_min_ns = std::min(this->filter_us_ * 1000, max_filter_ns);
   this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -3,15 +3,11 @@
 
 #ifdef USE_ESP32
 #include <driver/gpio.h>
+#include <esp_private/esp_clk.h>
 
 namespace esphome::remote_receiver {
 
 static const char *const TAG = "remote_receiver.esp32";
-#ifdef USE_ESP32_VARIANT_ESP32H2
-static const uint32_t RMT_CLK_FREQ = 32000000;
-#else
-static const uint32_t RMT_CLK_FREQ = 80000000;
-#endif
 
 static bool IRAM_ATTR HOT rmt_callback(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *event, void *arg) {
   RemoteReceiverComponentStore *store = (RemoteReceiverComponentStore *) arg;
@@ -98,7 +94,7 @@ void RemoteReceiverComponent::setup() {
   }
 
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
-  uint32_t max_filter_ns = 255u * 1000 / (RMT_CLK_FREQ / 1000000);
+  uint32_t max_filter_ns = UINT8_MAX * 1000u / (esp_clk_apb_freq() / 1000000);
   memset(&this->store_.config, 0, sizeof(this->store_.config));
   this->store_.config.signal_range_min_ns = std::min(this->filter_us_ * 1000, max_filter_ns);
   this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -3,7 +3,7 @@
 
 #ifdef USE_ESP32
 #include <driver/gpio.h>
-#include <esp_private/esp_clk.h>
+#include <esp_clk_tree.h>
 
 namespace esphome::remote_receiver {
 
@@ -94,7 +94,9 @@ void RemoteReceiverComponent::setup() {
   }
 
   uint32_t event_size = sizeof(rmt_rx_done_event_data_t);
-  uint32_t max_filter_ns = UINT8_MAX * 1000u / (esp_clk_apb_freq() / 1000000);
+  uint32_t apb_freq;
+  esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
+  uint32_t max_filter_ns = UINT8_MAX * 1000u / (apb_freq / 1000000);
   memset(&this->store_.config, 0, sizeof(this->store_.config));
   this->store_.config.signal_range_min_ns = std::min(this->filter_us_ * 1000, max_filter_ns);
   this->store_.config.signal_range_max_ns = this->idle_us_ * 1000;


### PR DESCRIPTION
# What does this implement/fix?

Replaces hardcoded `#ifdef` blocks for clock frequencies with runtime queries using the public `esp_clk_tree` API. This fixes incorrect assumptions about clock sources across ESP32 variants and removes the private `esp_private/esp_clk.h` header dependency.

### Changes

**esp32_rmt_led_strip/led_strip.cpp:**
- Removed `RMT_CLK_FREQ` and `RMT_CLK_DIV` `#ifdef` blocks (80MHz/2 vs 32MHz/1)
- Added `rmt_resolution_hz()` helper that queries `RMT_CLK_SRC_DEFAULT` frequency via `esp_clk_tree_src_get_freq_hz`
- Uses the full clock frequency (no divider) — worst-case reset (WS2811 300µs = 24000 ticks at 80MHz) fits within the 15-bit duration field max of 32767

**remote_receiver/remote_receiver_esp32.cpp:**
- Removed `RMT_CLK_FREQ` `#ifdef` block
- Queries `RMT_CLK_SRC_DEFAULT` frequency at runtime for filter calculation
- Replaced `255u` with `UINT8_MAX`

**pulse_counter/pulse_counter_sensor.cpp:**
- Replaced `esp_private/esp_clk.h` with public `esp_clk_tree.h` API
- Uses `esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ...)` for glitch filter calculation (PCNT always uses APB clock)

### Why `RMT_CLK_SRC_DEFAULT` instead of `SOC_MOD_CLK_APB`?

`RMT_CLK_SRC_DEFAULT` maps to different clock sources per variant:
| Variant | RMT_CLK_SRC_DEFAULT | Frequency |
|---------|-------------------|-----------|
| ESP32/S2/S3/C3 | `SOC_MOD_CLK_APB` | 80 MHz |
| ESP32-C6/P4 | `SOC_MOD_CLK_PLL_F80M` | 80 MHz |
| ESP32-H2 | `SOC_MOD_CLK_XTAL` | 32 MHz |

Using `SOC_MOD_CLK_APB` would be incorrect for C6/P4/H2 where the RMT doesn't use the APB clock.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal clock source change only, no config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).