### PR TITLE
[esp32_hosted] Bump esp_wifi_remote and esp_hosted versions

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -95,9 +95,9 @@ async def to_code(config):
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"
     if framework_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.2.4")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.3.2")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.4")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.9.3")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.11.5")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
   espressif/mdns:
     version: 1.9.1
   espressif/esp_wifi_remote:
-    version: 1.2.4
+    version: 1.3.2
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/eppp_link:
@@ -18,7 +18,7 @@ dependencies:
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.9.3
+    version: 2.11.5
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:


### PR DESCRIPTION
# What does this implement/fix?

Bumps ESP component versions for ESP-IDF 5.5+:
- `esp_wifi_remote`: 1.2.4 → 1.3.2
- `esp_hosted`: 2.9.3 → 2.11.5
- `eppp_link`: stays at 1.1.4 (already latest)

Updated in both `idf_component.yml` and `esp32_hosted/__init__.py`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

Follows up on #13118

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - dependency version bump only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).