### PR TITLE
[mdns] Throttle MDNS.update() polling on ESP8266 and RP2040

### DIFF
--- a/esphome/components/mdns/mdns_esp8266.cpp
+++ b/esphome/components/mdns/mdns_esp8266.cpp
@@ -36,9 +36,14 @@ static void register_esp8266(MDNSComponent *, StaticVector<MDNSService, MDNS_SER
   }
 }
 
-void MDNSComponent::setup() { this->setup_buffers_and_register_(register_esp8266); }
-
-void MDNSComponent::loop() { MDNS.update(); }
+void MDNSComponent::setup() {
+  this->setup_buffers_and_register_(register_esp8266);
+  // Schedule MDNS.update() via set_interval() instead of overriding loop().
+  // This removes the component from the per-iteration loop list entirely,
+  // eliminating virtual dispatch overhead on every main loop cycle.
+  // See MDNS_UPDATE_INTERVAL_MS comment in mdns_component.h for safety analysis.
+  this->set_interval(MDNS_UPDATE_INTERVAL_MS, []() { MDNS.update(); });
+}
 
 void MDNSComponent::on_shutdown() {
   MDNS.close();

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -35,9 +35,14 @@ static void register_rp2040(MDNSComponent *, StaticVector<MDNSService, MDNS_SERV
   }
 }
 
-void MDNSComponent::setup() { this->setup_buffers_and_register_(register_rp2040); }
-
-void MDNSComponent::loop() { MDNS.update(); }
+void MDNSComponent::setup() {
+  this->setup_buffers_and_register_(register_rp2040);
+  // Schedule MDNS.update() via set_interval() instead of overriding loop().
+  // This removes the component from the per-iteration loop list entirely,
+  // eliminating virtual dispatch overhead on every main loop cycle.
+  // See MDNS_UPDATE_INTERVAL_MS comment in mdns_component.h for safety analysis.
+  this->set_interval(MDNS_UPDATE_INTERVAL_MS, []() { MDNS.update(); });
+}
 
 void MDNSComponent::on_shutdown() {
   MDNS.close();


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 and RP2040, `MDNS.update()` was called every main loop iteration (~120 Hz / ~7700 times per 60s). Runtime profiling showed mDNS as the single most expensive component, consuming ~360ms per 60s measurement period.

However, `MDNS.update()` only manages timer-driven probe/announce state machines and service query cache TTLs. Incoming mDNS packets are handled independently via the lwIP `onRx` UDP callback and are **not** affected by `update()` call frequency.

The shortest internal timer in the ESP8266mDNS library is the 250ms probe interval (RFC 6762 Section 8.1). Announcement intervals are 1000ms and cache TTL checks are on the order of seconds to minutes. In steady state (after the ~8 second boot probe/announce phase), `update()` checks timers that are set to never expire, making every call pure overhead.

This PR replaces the `loop()` override with `set_interval(50ms)` in `setup()`. Since `has_overridden_loop()` now returns false, the component is completely excluded from the per-iteration loop list, eliminating all overhead including virtual dispatch.

**Measured results (ESP8266):**

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Call count / 60s | 7377 | 1123 | **-85%** |
| Total CPU time / 60s | 360ms | 38ms | **-89%** |
| Rank by CPU usage | #1 most expensive | #5 | Dropped behind api, wifi, ota, web_server |

The 50ms interval:
- Provides sufficient resolution for all internal timers (5x faster than the shortest 250ms timer)
- Matches Tasmota's 50ms main loop cycle where mDNS works correctly in production

ESP32 is unaffected — it uses ESP-IDF's event-driven mDNS which runs in a background FreeRTOS task and has no `loop()` override.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed. The throttling is automatic
# for all ESP8266 and RP2040 devices using mDNS.
mdns:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).