### PR TITLE
[esp32] Upgrade uv to 0.10.1 and increase HTTP retries

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ RUN if command -v apk > /dev/null; then \
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-RUN pip install --no-cache-dir -U pip uv==0.6.14
+RUN pip install --no-cache-dir -U pip uv==0.10.1
 
 COPY requirements.txt /
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1436,14 +1436,6 @@ async def to_code(config):
         CORE.relative_internal_path(".espressif")
     )
 
-    # Set the uv cache inside the data dir so "Clean All" clears it.
-    # Avoids persistent corrupted cache from mid-stream download failures.
-    os.environ["UV_CACHE_DIR"] = str(CORE.relative_internal_path(".uv_cache"))
-
-    # Set the uv cache inside the data dir so "Clean All" clears it.
-    # Avoids persistent corrupted cache from mid-stream download failures.
-    os.environ["UV_CACHE_DIR"] = str(CORE.relative_internal_path(".uv_cache"))
-
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_build_flag("-DUSE_ESP_IDF")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -133,6 +133,8 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     )
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
+    # Increase uv retry count to handle transient network errors (default is 3)
+    os.environ.setdefault("UV_HTTP_RETRIES", "10")
     cmd = ["platformio"] + list(args)
 
     if not CORE.verbose:


### PR DESCRIPTION
# What does this implement/fix?

Upgrade uv from 0.6.14 to 0.10.1 and set `UV_HTTP_RETRIES=10` to fix persistent build failures caused by transient network errors during the PlatformIO penv bootstrap.

The root cause: uv 0.6.14 has a bug where HTTP/2 connection resets during streaming downloads are not recognized as retryable errors because the `h2` library masks the underlying IO error. This was fixed in uv 0.8.16 (astral-sh/uv#15675). Users running ESPHome as a Home Assistant add-on report being stuck for hours or days with `uv installation via pip failed with exit code 1` errors that persist across "Clean All", add-on reinstalls, and ESPHome updates.

Also removes the `UV_CACHE_DIR` override added in #13888 since pioarduino now handles this upstream (pioarduino/platform-espressif32#386).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12531

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal fix
esp32:
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).