### PR TITLE
[esp32] Fix ESP32-P4 test: replace stale esp_hosted component ref

### DIFF
--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -6,8 +6,8 @@ esp32:
     type: esp-idf
     components:
       - espressif/mdns^1.8.2
-      - name: espressif/esp_hosted
-        ref: 2.7.0
+      - name: espressif/button
+        ref: 4.1.5
     advanced:
       enable_idf_experimental_features: yes
       disable_debug_stubs: true


### PR DESCRIPTION
# What does this implement/fix?

Fix the ESP32-P4 test which fails with a version solving error. The test manually pins `espressif/esp_hosted` at 2.7.0, but `espressif/esp_wifi_remote` 1.3.2 (added by the `esp32_hosted` component) now requires `espressif/esp_hosted >=2.11`:

```
espressif/esp_wifi_remote (1.3.2) depends on espressif/esp_hosted (>=2.11)
project depends on espressif/esp_hosted (2.7.0)
```

Replace the stale manual pin with `espressif/button` 4.1.5 to keep exercising the `name:` + `ref:` component syntax without conflicting with the versions managed by the `esp32_hosted` component's `to_code`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - test fix only
esp32:
  variant: esp32p4
  framework:
    type: esp-idf
    components:
      - name: espressif/button
        ref: 4.1.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).