### PR TITLE
[hub75] add set_rotation and get_rotation methods

### DIFF
--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -203,6 +203,52 @@ void HUB75Display::set_brightness(uint8_t brightness) {
   }
 }
 
+void HUB75Display::set_rotation(display::DisplayRotation rotation) {
+  if (!driver_) [[unlikely]]
+    return;
+
+  Hub75Rotation hub75_rotation;
+  switch (rotation) {
+    case display::DisplayRotation::DISPLAY_ROTATION_0_DEGREES:
+      hub75_rotation = Hub75Rotation::ROTATE_0;
+      break;
+    case display::DisplayRotation::DISPLAY_ROTATION_90_DEGREES:
+      hub75_rotation = Hub75Rotation::ROTATE_90;
+      break;
+    case display::DisplayRotation::DISPLAY_ROTATION_180_DEGREES:
+      hub75_rotation = Hub75Rotation::ROTATE_180;
+      break;
+    case display::DisplayRotation::DISPLAY_ROTATION_270_DEGREES:
+      hub75_rotation = Hub75Rotation::ROTATE_270;
+      break;
+    default:
+      ESP_LOGE(TAG, "Unsupported rotation: %d", static_cast<int>(rotation));
+      return;
+  }
+
+  driver_->set_rotation(hub75_rotation);
+}
+
+display::DisplayRotation HUB75Display::get_rotation() {
+  if (!driver_) [[unlikely]]
+    return display::DisplayRotation::DISPLAY_ROTATION_0_DEGREES;
+
+  Hub75Rotation hub75_rotation = driver_->get_rotation();
+  switch (hub75_rotation) {
+    case Hub75Rotation::ROTATE_0:
+      return display::DisplayRotation::DISPLAY_ROTATION_0_DEGREES;
+    case Hub75Rotation::ROTATE_90:
+      return display::DisplayRotation::DISPLAY_ROTATION_90_DEGREES;
+    case Hub75Rotation::ROTATE_180:
+      return display::DisplayRotation::DISPLAY_ROTATION_180_DEGREES;
+    case Hub75Rotation::ROTATE_270:
+      return display::DisplayRotation::DISPLAY_ROTATION_270_DEGREES;
+    default:
+      ESP_LOGE(TAG, "Unsupported Hub75 rotation: %d", static_cast<int>(hub75_rotation));
+      return display::DisplayRotation::DISPLAY_ROTATION_0_DEGREES;
+  }
+}
+
 }  // namespace esphome::hub75
 
 #endif

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -229,7 +229,7 @@ void HUB75Display::set_rotation(display::DisplayRotation rotation) {
   driver_->set_rotation(hub75_rotation);
 }
 
-display::DisplayRotation HUB75Display::get_rotation() {
+display::DisplayRotation HUB75Display::get_rotation() const {
   if (!driver_) [[unlikely]]
     return display::DisplayRotation::DISPLAY_ROTATION_0_DEGREES;
 

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -38,7 +38,7 @@ class HUB75Display final : public display::Display {
   void set_brightness(uint8_t brightness);
 
   void set_rotation(display::DisplayRotation rotation);
-  display::DisplayRotation get_rotation();
+  display::DisplayRotation get_rotation() const;
 
  protected:
   // Display internal methods

--- a/esphome/components/hub75/hub75_component.h
+++ b/esphome/components/hub75/hub75_component.h
@@ -37,6 +37,9 @@ class HUB75Display final : public display::Display {
   // Brightness control (runtime mutable)
   void set_brightness(uint8_t brightness);
 
+  void set_rotation(display::DisplayRotation rotation);
+  display::DisplayRotation get_rotation();
+
  protected:
   // Display internal methods
   int get_width_internal() override { return this->driver_ != nullptr ? this->driver_->get_width() : 0; }


### PR DESCRIPTION
# What does this implement/fix?

This PR implements the standard [`set_rotation`](https://api-docs.esphome.io/classesphome_1_1display_1_1_display#a6a6069bd87fba362dbd2e6c09df289be) and [`get_rotation`](https://api-docs.esphome.io/classesphome_1_1display_1_1_display#a8f36ff79b81bd5d7985ea014f64197d8) methods to the HUB75 display component. They were there previously as part of the `Display` base implementation but had no effect on the actual display rotation.

Since the HUB75 driver handles display rotation internally, these methods effectively just forward the calls to the driver and converts between the appropriate enums.

Access to these methods is useful for drawing lambdas that need access to the display rotation, or for when display rotation changes at runtime (for example, in response to accelerometer sensors).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
