### PR TITLE
[light] Eliminate redundant clamp in LightCall::validate_()

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -270,22 +270,23 @@ LightColorValues LightCall::validate_() {
   if (this->has_state())
     v.set_state(this->state_);
 
-#define VALIDATE_AND_APPLY(field, setter, name_str, ...) \
+    // clamp_and_log_if_invalid already clamps in-place, so assign directly
+    // to avoid redundant clamp code from the setter being inlined.
+#define VALIDATE_AND_APPLY(field, name_str, ...) \
   if (this->has_##field()) { \
     clamp_and_log_if_invalid(name, this->field##_, LOG_STR(name_str), ##__VA_ARGS__); \
-    v.setter(this->field##_); \
+    v.field##_ = this->field##_; \
   }
 
-  VALIDATE_AND_APPLY(brightness, set_brightness, "Brightness")
-  VALIDATE_AND_APPLY(color_brightness, set_color_brightness, "Color brightness")
-  VALIDATE_AND_APPLY(red, set_red, "Red")
-  VALIDATE_AND_APPLY(green, set_green, "Green")
-  VALIDATE_AND_APPLY(blue, set_blue, "Blue")
-  VALIDATE_AND_APPLY(white, set_white, "White")
-  VALIDATE_AND_APPLY(cold_white, set_cold_white, "Cold white")
-  VALIDATE_AND_APPLY(warm_white, set_warm_white, "Warm white")
-  VALIDATE_AND_APPLY(color_temperature, set_color_temperature, "Color temperature", traits.get_min_mireds(),
-                     traits.get_max_mireds())
+  VALIDATE_AND_APPLY(brightness, "Brightness")
+  VALIDATE_AND_APPLY(color_brightness, "Color brightness")
+  VALIDATE_AND_APPLY(red, "Red")
+  VALIDATE_AND_APPLY(green, "Green")
+  VALIDATE_AND_APPLY(blue, "Blue")
+  VALIDATE_AND_APPLY(white, "White")
+  VALIDATE_AND_APPLY(cold_white, "Cold white")
+  VALIDATE_AND_APPLY(warm_white, "Warm white")
+  VALIDATE_AND_APPLY(color_temperature, "Color temperature", traits.get_min_mireds(), traits.get_max_mireds())
 
 #undef VALIDATE_AND_APPLY
 

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -95,15 +95,18 @@ class LightColorValues {
    */
   void normalize_color() {
     if (this->color_mode_ & ColorCapability::RGB) {
-      float max_value = fmaxf(this->get_red(), fmaxf(this->get_green(), this->get_blue()));
+      float max_value = fmaxf(this->red_, fmaxf(this->green_, this->blue_));
+      // Assign directly to avoid redundant clamp in set_red/green/blue.
+      // Values are guaranteed in [0,1]: inputs are already clamped to [0,1],
+      // and dividing by max_value (the largest) keeps results in [0,1].
       if (max_value == 0.0f) {
-        this->set_red(1.0f);
-        this->set_green(1.0f);
-        this->set_blue(1.0f);
+        this->red_ = 1.0f;
+        this->green_ = 1.0f;
+        this->blue_ = 1.0f;
       } else {
-        this->set_red(this->get_red() / max_value);
-        this->set_green(this->get_green() / max_value);
-        this->set_blue(this->get_blue() / max_value);
+        this->red_ /= max_value;
+        this->green_ /= max_value;
+        this->blue_ /= max_value;
       }
     }
   }

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -276,6 +276,8 @@ class LightColorValues {
   /// Set the warm white property of these light color values. In range 0.0 to 1.0.
   void set_warm_white(float warm_white) { this->warm_white_ = clamp(warm_white, 0.0f, 1.0f); }
 
+  friend class LightCall;
+
  protected:
   float state_;  ///< ON / OFF, float for transition
   float brightness_;


### PR DESCRIPTION
# What does this implement/fix?

In `LightCall::validate_()`, the `VALIDATE_AND_APPLY` macro calls `clamp_and_log_if_invalid()` which clamps the value in-place, then passes it to a `LightColorValues` setter (e.g. `set_brightness()`) which clamps again internally. For 5 of 9 fields (brightness, color_brightness, white, cold_white, warm_white), the compiler inlines the setter's `clamp()`, generating ~18 bytes of redundant float compare + conditional move per field.

Similarly, `normalize_color()` calls `set_red/green/blue()` with values that are guaranteed to be in [0,1] (division by the max of the three), making the setter's clamp redundant there too.

This PR:
1. Adds a `friend class LightCall` declaration to `LightColorValues`
2. Assigns directly to protected fields in `VALIDATE_AND_APPLY` after validation
3. Assigns directly in `normalize_color()` where division by max_value guarantees [0,1]

**Measured on ESP32 (xtensa):**
- `validate_()`: 1,359 → 1,283 bytes (-76 bytes)
- `set_red`/`set_green`/`set_blue` standalone function bodies eliminated
- `normalize_color()` no longer inlines redundant clamp code
- Total flash: **-476 bytes**

The changes are safe because:
- `clamp_and_log_if_invalid()` guarantees values are in `[min, max]` before returning
- In `normalize_color()`, inputs are already in [0,1] and dividing by the largest keeps results in [0,1]

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
light:
  - platform: rgbw
    name: "Test Light"
    red: output1
    green: output2
    blue: output3
    white: output4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).