### PR TITLE
[web_server] Remove unnecessary packed attribute from DeferredEvent

### DIFF
--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -112,10 +112,10 @@ class DeferredUpdateEventSource : public AsyncEventSource {
   /*
     This class holds a pointer to the source component that wants to publish a state event, and a pointer to a function
     that will lazily generate that event.  The two pointers allow dedup in the deferred queue if multiple publishes for
-    the same component are backed up, and take up only 8 bytes of memory.  The entry in the deferred queue (a
-    std::vector) is the DeferredEvent instance itself (not a pointer to one elsewhere in heap) so still only 8 bytes per
-    entry (and no heap fragmentation).  Even 100 backed up events (you'd have to have at least 100 sensors publishing
-    because of dedup) would take up only 0.8 kB.
+    the same component are backed up, and take up only two pointers of memory.  The entry in the deferred queue (a
+    std::vector) is the DeferredEvent instance itself (not a pointer to one elsewhere in heap) so still only two
+    pointers per entry (and no heap fragmentation).  Even 100 backed up events (you'd have to have at least 100 sensors
+    publishing because of dedup) would take up only 0.8 kB.
   */
   struct DeferredEvent {
     friend class DeferredUpdateEventSource;
@@ -131,6 +131,8 @@ class DeferredUpdateEventSource : public AsyncEventSource {
       return (source_ == test.source_ && message_generator_ == test.message_generator_);
     }
   };
+  static_assert(sizeof(DeferredEvent) == sizeof(void *) + sizeof(message_generator_t *),
+                "DeferredEvent should have no padding");
 
  protected:
   // surface a couple methods from the base class

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -130,7 +130,7 @@ class DeferredUpdateEventSource : public AsyncEventSource {
     bool operator==(const DeferredEvent &test) const {
       return (source_ == test.source_ && message_generator_ == test.message_generator_);
     }
-  } __attribute__((packed));
+  };
 
  protected:
   // surface a couple methods from the base class

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -277,7 +277,7 @@ struct DeferredEvent {
   bool operator==(const DeferredEvent &test) const {
     return (source_ == test.source_ && message_generator_ == test.message_generator_);
   }
-} __attribute__((packed));
+};
 
 class AsyncEventSourceResponse {
   friend class AsyncEventSource;

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -259,9 +259,9 @@ using message_generator_t = std::string(esphome::web_server::WebServer *, void *
 /*
   This class holds a pointer to the source component that wants to publish a state event, and a pointer to a function
   that will lazily generate that event.  The two pointers allow dedup in the deferred queue if multiple publishes for
-  the same component are backed up, and take up only 8 bytes of memory.  The entry in the deferred queue (a
-  std::vector) is the DeferredEvent instance itself (not a pointer to one elsewhere in heap) so still only 8 bytes per
-  entry (and no heap fragmentation).  Even 100 backed up events (you'd have to have at least 100 sensors publishing
+  the same component are backed up, and take up only two pointers of memory.  The entry in the deferred queue (a
+  std::vector) is the DeferredEvent instance itself (not a pointer to one elsewhere in heap) so still only two pointers
+  per entry (and no heap fragmentation).  Even 100 backed up events (you'd have to have at least 100 sensors publishing
   because of dedup) would take up only 0.8 kB.
 */
 struct DeferredEvent {
@@ -278,6 +278,8 @@ struct DeferredEvent {
     return (source_ == test.source_ && message_generator_ == test.message_generator_);
   }
 };
+static_assert(sizeof(DeferredEvent) == sizeof(void *) + sizeof(message_generator_t *),
+              "DeferredEvent should have no padding");
 
 class AsyncEventSourceResponse {
   friend class AsyncEventSource;


### PR DESCRIPTION
# What does this implement/fix?

Remove `__attribute__((packed))` from the `DeferredEvent` struct in both `web_server` (Arduino) and `web_server_idf` (ESP-IDF) implementations.

`DeferredEvent` contains two pointers (`void*` + function pointer), which are already naturally 4-byte aligned on all ESPHome targets (ESP32, ESP8266, RP2040). The struct is 8 bytes with zero padding regardless of `packed`.

The `packed` attribute forces the compiler to use byte-by-byte loads/stores (`l8ui`/`s8i` + shift/mask/or) instead of word-aligned access (`l32i`/`s32i`). Disassembly of `deq_push_back_with_dedup_` on ESP32 shows this bloats the function from 163 to 317 bytes — **154 bytes (49%) of unnecessary code** for reassembling words from individual bytes.

The attribute was added in #7538, likely to guarantee the struct stayed at exactly 8 bytes. Since both fields are pointer-sized and naturally aligned, this guarantee already holds without it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).