### PR TITLE
[nrf52,zigbee] count sleep time of zigbee thread

### DIFF
--- a/esphome/components/zigbee/zigbee_zephyr.cpp
+++ b/esphome/components/zigbee/zigbee_zephyr.cpp
@@ -61,9 +61,14 @@ void ZigbeeComponent::zboss_signal_handler_esphome(zb_bufid_t bufid) {
       break;
   }
 
+  auto before = millis();
   auto err = zigbee_default_signal_handler(bufid);
   if (err != RET_OK) {
     ESP_LOGE(TAG, "Zigbee_default_signal_handler ERROR %u [%s]", err, zb_error_to_string_get(err));
+  }
+
+  if (sig == ZB_COMMON_SIGNAL_CAN_SLEEP) {
+    this->sleep_time_ += (millis() - before) / 1000;
   }
 
   switch (sig) {
@@ -213,6 +218,7 @@ void ZigbeeComponent::dump_config() {
                 "Zigbee\n"
                 "  Wipe on boot: %s\n"
                 "  Device is joined to the network: %s\n"
+                "  Sleep time: %us\n"
                 "  Current channel: %d\n"
                 "  Current page: %d\n"
                 "  Sleep threshold: %ums\n"
@@ -221,9 +227,9 @@ void ZigbeeComponent::dump_config() {
                 "  Short addr: 0x%04X\n"
                 "  Long pan id: 0x%s\n"
                 "  Short pan id: 0x%04X",
-                get_wipe_on_boot(), YESNO(zb_zdo_joined()), zb_get_current_channel(), zb_get_current_page(),
-                zb_get_sleep_threshold(), role(), ieee_addr_buf, zb_get_short_address(), extended_pan_id_buf,
-                zb_get_pan_id());
+                get_wipe_on_boot(), YESNO(zb_zdo_joined()), this->sleep_time_, zb_get_current_channel(),
+                zb_get_current_page(), zb_get_sleep_threshold(), role(), ieee_addr_buf, zb_get_short_address(),
+                extended_pan_id_buf, zb_get_pan_id());
   dump_reporting_();
 }
 

--- a/esphome/components/zigbee/zigbee_zephyr.cpp
+++ b/esphome/components/zigbee/zigbee_zephyr.cpp
@@ -68,7 +68,10 @@ void ZigbeeComponent::zboss_signal_handler_esphome(zb_bufid_t bufid) {
   }
 
   if (sig == ZB_COMMON_SIGNAL_CAN_SLEEP) {
-    this->sleep_time_ += (millis() - before) / 1000;
+    this->sleep_remainder_ += millis() - before;
+    uint32_t seconds = this->sleep_remainder_ / 1000;
+    this->sleep_remainder_ -= seconds * 1000;
+    this->sleep_time_ += seconds;
   }
 
   switch (sig) {

--- a/esphome/components/zigbee/zigbee_zephyr.h
+++ b/esphome/components/zigbee/zigbee_zephyr.h
@@ -93,6 +93,7 @@ class ZigbeeComponent : public Component {
   Trigger<> join_trigger_;
   bool force_report_{false};
   uint32_t sleep_time_{};
+  uint32_t sleep_remainder_{};
 };
 
 class ZigbeeEntity {

--- a/esphome/components/zigbee/zigbee_zephyr.h
+++ b/esphome/components/zigbee/zigbee_zephyr.h
@@ -92,6 +92,7 @@ class ZigbeeComponent : public Component {
   CallbackManager<void()> join_cb_;
   Trigger<> join_trigger_;
   bool force_report_{false};
+  uint32_t sleep_time_{};
 };
 
 class ZigbeeEntity {


### PR DESCRIPTION
# What does this implement/fix?

Calculate zigbee sleeping time. Details in https://github.com/esphome/esphome/issues/13926#issuecomment-3884277700

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
