### PR TITLE
[preferences] Replace per-element erase with clear() in sync()

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -124,14 +124,11 @@ class ESP32Preferences : public ESPPreferences {
       return true;
 
     ESP_LOGV(TAG, "Saving %zu items...", s_pending_save.size());
-    // goal try write all pending saves even if one fails
     int cached = 0, written = 0, failed = 0;
     esp_err_t last_err = ESP_OK;
     uint32_t last_key = 0;
 
-    // go through vector from back to front (makes erase easier/more efficient)
-    for (ssize_t i = s_pending_save.size() - 1; i >= 0; i--) {
-      const auto &save = s_pending_save[i];
+    for (const auto &save : s_pending_save) {
       char key_str[KEY_BUFFER_SIZE];
       snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
       ESP_LOGVV(TAG, "Checking if NVS data %s has changed", key_str);
@@ -150,8 +147,9 @@ class ESP32Preferences : public ESPPreferences {
         ESP_LOGV(TAG, "NVS data not changed skipping %" PRIu32 "  len=%zu", save.key, save.len);
         cached++;
       }
-      s_pending_save.erase(s_pending_save.begin() + i);
     }
+    s_pending_save.clear();
+
     ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
              failed);
     if (failed > 0) {

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -114,14 +114,11 @@ class LibreTinyPreferences : public ESPPreferences {
       return true;
 
     ESP_LOGV(TAG, "Saving %zu items...", s_pending_save.size());
-    // goal try write all pending saves even if one fails
     int cached = 0, written = 0, failed = 0;
     fdb_err_t last_err = FDB_NO_ERR;
     uint32_t last_key = 0;
 
-    // go through vector from back to front (makes erase easier/more efficient)
-    for (ssize_t i = s_pending_save.size() - 1; i >= 0; i--) {
-      const auto &save = s_pending_save[i];
+    for (const auto &save : s_pending_save) {
       char key_str[KEY_BUFFER_SIZE];
       snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
       ESP_LOGVV(TAG, "Checking if FDB data %s has changed", key_str);
@@ -141,8 +138,9 @@ class LibreTinyPreferences : public ESPPreferences {
         ESP_LOGD(TAG, "FDB data not changed; skipping %" PRIu32 "  len=%zu", save.key, save.len);
         cached++;
       }
-      s_pending_save.erase(s_pending_save.begin() + i);
     }
+    s_pending_save.clear();
+
     ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
              failed);
     if (failed > 0) {


### PR DESCRIPTION
# What does this implement/fix?

Replace the reverse-iterate + per-element `vector::erase()` pattern in `sync()` with a forward range-for loop and a single `clear()` at the end.

## Background

The retry-on-failure pattern was introduced in #2119 (Configurable Flash Write Interval, 2021). When `sync()` was added to batch NVS writes, failed entries were kept in the vector with the comment "goal try write all pending saves even if one fails" — the idea being they'd be retried on the next `sync()` cycle. The same pattern was later cargo-culted into the LibreTiny platform when it was added in #3509 without questioning whether retry made sense for FlashDB either.

However, this retry logic never made sense for NVS/FDB writes:

- **`ESP_ERR_NVS_NOT_ENOUGH_SPACE`**: NVS already performs internal garbage collection (page compaction via `requestNewPage()`) during every write. By the time the error reaches the caller, all recovery is exhausted.
- **`ESP_ERR_NVS_NO_FREE_PAGES`**: Requires full partition erase + reinit — retry won't help.
- **`ESP_ERR_NVS_INVALID_STATE`**: Page marked `INVALID` in memory after flash failure — permanent until `nvs_flash_init` again.
- **`ESP_ERR_NVS_REMOVE_FAILED`**: Partial success (new value written, old not erased) — requires reinit.
- **`ESP_ERR_NVS_INVALID_HANDLE` / `READ_ONLY` / `INVALID_NAME`**: Parameter errors that will never change.

The author of #2119 even discovered during development that `nvs_commit` is a no-op and `nvs_set_blob` writes immediately to flash — confirming that failures reflect hardware/partition problems, not transient conditions.

## What this changes

Keeping failed entries in the vector:
- Leaked memory indefinitely on a constrained device
- Forced a reverse-iterate + per-element `erase()` pattern
- Generated ~130 bytes of inlined `vector::erase` move/destroy code (37% of the `sync()` function) because the compiler couldn't prove erases were always at the back (due to the `continue` on failure skipping the erase)

This PR replaces it with a forward range-for and `clear()` at the end. Failures are still logged via `ESP_LOGE`.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (N/A - no user-facing changes)