### PR TITLE
[api] Fix debug asserts in production code, encode_bool bug, and reduce flash overhead

### DIFF
--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -295,9 +295,8 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
     buf_start[header_offset] = 0x00;  // indicator
 
     // Encode varints directly into buffer
-    ProtoVarInt(msg.payload_size).encode_to_buffer_unchecked(buf_start + header_offset + 1, size_varint_len);
-    ProtoVarInt(msg.message_type)
-        .encode_to_buffer_unchecked(buf_start + header_offset + 1 + size_varint_len, type_varint_len);
+    encode_varint_to_buffer(msg.payload_size, buf_start + header_offset + 1);
+    encode_varint_to_buffer(msg.message_type, buf_start + header_offset + 1 + size_varint_len);
 
     // Add iovec for this message (header + payload)
     size_t msg_len = static_cast<size_t>(total_header_len + msg.payload_size);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -105,6 +105,7 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. consumed must be a valid pointer (not null).
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
+    assert(consumed != nullptr);
     if (len == 0)
       return {};
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -221,11 +221,11 @@ class ProtoWriteBuffer {
       this->buffer_->push_back(static_cast<uint8_t>(value));
       return;
     }
-    while (value) {
-      uint8_t temp = value & 0x7F;
+    while (value > 0x7F) {
+      this->buffer_->push_back(static_cast<uint8_t>(value | 0x80));
       value >>= 7;
-      this->buffer_->push_back(value ? (temp | 0x80) : temp);
     }
+    this->buffer_->push_back(static_cast<uint8_t>(value));
   }
   void encode_varint_raw_64(uint64_t value) {
     while (value > 0x7F) {
@@ -289,7 +289,7 @@ class ProtoWriteBuffer {
     if (!value && !force)
       return;
     this->encode_field_raw(field_id, 0);  // type 0: Varint - bool
-    this->write(0x01);
+    this->buffer_->push_back(0x01);
   }
   void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
     if (value == 0 && !force)

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -292,7 +292,7 @@ class ProtoWriteBuffer {
     if (!value && !force)
       return;
     this->encode_field_raw(field_id, 0);  // type 0: Varint - bool
-    this->buffer_->push_back(0x01);
+    this->buffer_->push_back(value ? 0x01 : 0x00);
   }
   void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
     if (value == 0 && !force)

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -220,10 +220,6 @@ class ProtoWriteBuffer {
   ProtoWriteBuffer(std::vector<uint8_t> *buffer) : buffer_(buffer) {}
   void write(uint8_t value) { this->buffer_->push_back(value); }
   void encode_varint_raw(uint32_t value) {
-    if (value <= 0x7F) {
-      this->buffer_->push_back(static_cast<uint8_t>(value));
-      return;
-    }
     while (value > 0x7F) {
       this->buffer_->push_back(static_cast<uint8_t>(value | 0x80));
       value >>= 7;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -105,7 +105,9 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. consumed must be a valid pointer (not null).
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
+#ifdef ESPHOME_DEBUG_API
     assert(consumed != nullptr);
+#endif
     if (len == 0)
       return {};
 
@@ -920,8 +922,10 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   // Now encode the message content - it will append to the buffer
   value.encode(*this);
 
+#ifdef ESPHOME_DEBUG_API
   // Verify that the encoded size matches what we calculated
   assert(this->buffer_->size() == begin + varint_length_bytes + msg_length_bytes);
+#endif
 }
 
 // Implementation of decode_to_message - must be after ProtoDecodableMessage is defined

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -105,7 +105,7 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. consumed must be a valid pointer (not null).
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
-#ifdef DEBUG
+#ifdef ESPHOME_DEBUG_API
     assert(consumed != nullptr);
 #endif
     if (len == 0)
@@ -922,7 +922,7 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   // Now encode the message content - it will append to the buffer
   value.encode(*this);
 
-#ifdef DEBUG
+#ifdef ESPHOME_DEBUG_API
   // Verify that the encoded size matches what we calculated
   assert(this->buffer_->size() == begin + varint_length_bytes + msg_length_bytes);
 #endif

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -105,7 +105,7 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. consumed must be a valid pointer (not null).
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
-#ifdef ESPHOME_DEBUG_API
+#ifdef DEBUG
     assert(consumed != nullptr);
 #endif
     if (len == 0)
@@ -922,7 +922,7 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   // Now encode the message content - it will append to the buffer
   value.encode(*this);
 
-#ifdef ESPHOME_DEBUG_API
+#ifdef DEBUG
   // Verify that the encoded size matches what we calculated
   assert(this->buffer_->size() == begin + varint_length_bytes + msg_length_bytes);
 #endif

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -57,6 +57,16 @@ inline uint16_t count_packed_varints(const uint8_t *data, size_t len) {
   return count;
 }
 
+/// Encode a varint directly into a pre-allocated buffer.
+/// Caller must ensure buffer has space (use ProtoSize::varint() to calculate).
+inline void encode_varint_to_buffer(uint32_t val, uint8_t *buffer) {
+  while (val > 0x7F) {
+    *buffer++ = static_cast<uint8_t>(val | 0x80);
+    val >>= 7;
+  }
+  *buffer = static_cast<uint8_t>(val);
+}
+
 /*
  * StringRef Ownership Model for API Protocol Messages
  * ===================================================
@@ -93,17 +103,14 @@ class ProtoVarInt {
   ProtoVarInt() : value_(0) {}
   explicit ProtoVarInt(uint64_t value) : value_(value) {}
 
+  /// Parse a varint from buffer. consumed must be a valid pointer (not null).
   static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
-    if (len == 0) {
-      if (consumed != nullptr)
-        *consumed = 0;
+    if (len == 0)
       return {};
-    }
 
     // Most common case: single-byte varint (values 0-127)
     if ((buffer[0] & 0x80) == 0) {
-      if (consumed != nullptr)
-        *consumed = 1;
+      *consumed = 1;
       return ProtoVarInt(buffer[0]);
     }
 
@@ -122,14 +129,11 @@ class ProtoVarInt {
       result |= uint64_t(val & 0x7F) << uint64_t(bitpos);
       bitpos += 7;
       if ((val & 0x80) == 0) {
-        if (consumed != nullptr)
-          *consumed = i + 1;
+        *consumed = i + 1;
         return ProtoVarInt(result);
       }
     }
 
-    if (consumed != nullptr)
-      *consumed = 0;
     return {};  // Incomplete or invalid varint
   }
 
@@ -152,50 +156,6 @@ class ProtoVarInt {
   constexpr int64_t as_sint64() const {
     // with ZigZag encoding
     return decode_zigzag64(this->value_);
-  }
-  /**
-   * Encode the varint value to a pre-allocated buffer without bounds checking.
-   *
-   * @param buffer The pre-allocated buffer to write the encoded varint to
-   * @param len The size of the buffer in bytes
-   *
-   * @note The caller is responsible for ensuring the buffer is large enough
-   *       to hold the encoded value. Use ProtoSize::varint() to calculate
-   *       the exact size needed before calling this method.
-   * @note No bounds checking is performed for performance reasons.
-   */
-  void encode_to_buffer_unchecked(uint8_t *buffer, size_t len) {
-    uint64_t val = this->value_;
-    if (val <= 0x7F) {
-      buffer[0] = val;
-      return;
-    }
-    size_t i = 0;
-    while (val && i < len) {
-      uint8_t temp = val & 0x7F;
-      val >>= 7;
-      if (val) {
-        buffer[i++] = temp | 0x80;
-      } else {
-        buffer[i++] = temp;
-      }
-    }
-  }
-  void encode(std::vector<uint8_t> &out) {
-    uint64_t val = this->value_;
-    if (val <= 0x7F) {
-      out.push_back(val);
-      return;
-    }
-    while (val) {
-      uint8_t temp = val & 0x7F;
-      val >>= 7;
-      if (val) {
-        out.push_back(temp | 0x80);
-      } else {
-        out.push_back(temp);
-      }
-    }
   }
 
  protected:
@@ -256,8 +216,24 @@ class ProtoWriteBuffer {
  public:
   ProtoWriteBuffer(std::vector<uint8_t> *buffer) : buffer_(buffer) {}
   void write(uint8_t value) { this->buffer_->push_back(value); }
-  void encode_varint_raw(ProtoVarInt value) { value.encode(*this->buffer_); }
-  void encode_varint_raw(uint32_t value) { this->encode_varint_raw(ProtoVarInt(value)); }
+  void encode_varint_raw(uint32_t value) {
+    if (value <= 0x7F) {
+      this->buffer_->push_back(static_cast<uint8_t>(value));
+      return;
+    }
+    while (value) {
+      uint8_t temp = value & 0x7F;
+      value >>= 7;
+      this->buffer_->push_back(value ? (temp | 0x80) : temp);
+    }
+  }
+  void encode_varint_raw_64(uint64_t value) {
+    while (value > 0x7F) {
+      this->buffer_->push_back(static_cast<uint8_t>(value | 0x80));
+      value >>= 7;
+    }
+    this->buffer_->push_back(static_cast<uint8_t>(value));
+  }
   /**
    * Encode a field key (tag/wire type combination).
    *
@@ -307,7 +283,7 @@ class ProtoWriteBuffer {
     if (value == 0 && !force)
       return;
     this->encode_field_raw(field_id, 0);  // type 0: Varint - uint64
-    this->encode_varint_raw(ProtoVarInt(value));
+    this->encode_varint_raw_64(value);
   }
   void encode_bool(uint32_t field_id, bool value, bool force = false) {
     if (!value && !force)
@@ -938,7 +914,7 @@ inline void ProtoWriteBuffer::encode_message(uint32_t field_id, const ProtoMessa
   this->buffer_->resize(this->buffer_->size() + varint_length_bytes);
 
   // Write the length varint directly
-  ProtoVarInt(msg_length_bytes).encode_to_buffer_unchecked(this->buffer_->data() + begin, varint_length_bytes);
+  encode_varint_to_buffer(msg_length_bytes, this->buffer_->data() + begin);
 
   // Now encode the message content - it will append to the buffer
   value.encode(*this);

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -14,6 +14,7 @@
 #define ESPHOME_PROJECT_VERSION_30 "v2"
 #define ESPHOME_VARIANT "ESP32"
 #define ESPHOME_DEBUG_SCHEDULER
+#define ESPHOME_DEBUG_API
 
 // Default threading model for static analysis (ESP32 is multi-threaded with atomics)
 #define ESPHOME_THREAD_MULTI_ATOMICS

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -14,7 +14,6 @@
 #define ESPHOME_PROJECT_VERSION_30 "v2"
 #define ESPHOME_VARIANT "ESP32"
 #define ESPHOME_DEBUG_SCHEDULER
-#define ESPHOME_DEBUG_API
 
 // Default threading model for static analysis (ESP32 is multi-threaded with atomics)
 #define ESPHOME_THREAD_MULTI_ATOMICS

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -1,7 +1,4 @@
 esphome:
-  platformio_options:
-    build_flags:
-      - -DESPHOME_DEBUG_API
   on_boot:
     then:
       - wait_until:

--- a/tests/components/api/common-base.yaml
+++ b/tests/components/api/common-base.yaml
@@ -1,4 +1,7 @@
 esphome:
+  platformio_options:
+    build_flags:
+      - -DESPHOME_DEBUG_API
   on_boot:
     then:
       - wait_until:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -197,6 +197,7 @@ async def yaml_config(request: pytest.FixtureRequest, unused_tcp_port: int) -> s
             "  platformio_options:\n"
             "    build_flags:\n"
             '      - "-DDEBUG"  # Enable assert() statements\n'
+            '      - "-DESPHOME_DEBUG_API"  # Enable API protocol asserts\n'
             '      - "-g"       # Add debug symbols',
         )
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes debug asserts left active in production code, a bug in `encode_bool`, and reduces flash overhead from the varint encoding path.

**Bug fixes:**
- **Debug asserts in production code:** `assert()` calls in `proto.h` were always active in production builds. On ESP8266, each `assert()` pulls in `__PRETTY_FUNCTION__` strings costing ~200 bytes of flash. These asserts are only intended for testing — they are now guarded behind `#ifdef ESPHOME_DEBUG_API`, which is enabled only in integration tests via conftest.py.
- **`encode_bool` encodes wrong value:** Hardcoded `0x01` instead of encoding the actual value, producing incorrect output when `force=true` and `value=false`.

**Flash reduction:**
Eliminates unnecessary `uint64_t` widening through `ProtoVarInt` temporaries in the encoding path. On 32-bit architectures, every `uint64_t` operation uses register pairs and extra instructions. Replaces those paths with direct `uint32_t` encoding functions and removes dead code.

**Changes:**
- Guard debug asserts with `#ifdef ESPHOME_DEBUG_API` and enable in integration tests
- Fix `encode_bool` to encode the actual value instead of hardcoding `0x01`
- Add `encode_varint_to_buffer()` free function for direct `uint32_t` buffer encoding
- Replace `encode_varint_raw(ProtoVarInt)` with native `uint32_t` implementation
- Simplify `encode_varint_raw` loop to avoid conditional per iteration
- Add `encode_varint_raw_64()` for the few call sites needing 64-bit support (BLE addresses)
- Remove unused `ProtoVarInt::encode()` and `encode_to_buffer_unchecked()` methods
- Remove dead null checks from `ProtoVarInt::parse()` (all callers pass valid pointers)
- Use direct `push_back` in `encode_bool` instead of going through `write()`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No configuration changes required. This is an internal fix.

```yaml
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).