### PR TITLE
[esp32_rmt_led_strip] Seal leaf impl class to devirtualize

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.h
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.h
@@ -31,7 +31,7 @@ struct LedParams {
   rmt_symbol_word_t reset;
 };
 
-class ESP32RMTLEDStripLightOutput : public light::AddressableLight {
+class ESP32RMTLEDStripLightOutput final : public light::AddressableLight {
  public:
   void setup() override;
   void write_state(light::LightState *state) override;


### PR DESCRIPTION
# What does this implement/fix?

Seal `esp32_fmt_led_strip` implementation class as `final` to allow devirtualizing.

Hint provided by enabling compiler flag
```yaml
esphome:
  platformio_options:
    build_flags:
      - -Wsuggest-final-types
```

```txt
src/esphome/components/esp32_rmt_led_strip/led_strip.h:34:7: warning: Declaring type 'class esphome::esp32_rmt_led_strip::ESP32RMTLEDStripLightOutput' final would enable devirtualization of 6 calls [-Wsuggest-final-types]
```

Without LTO, hint may be wrong. But here `ESP32RMTLEDStripLightOutput` was a real implementation leaf class.

Memory saving expected only in flash. See CI memory analysis.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
light:
  - platform: esp32_rmt_led_strip
    name: "LED"
    pin:
      number: GPIO08
      ignore_strapping_warning: true
    num_leds: 1
    chipset: WS2812
    restore_mode: ALWAYS_OFF
    rgb_order: RGB
    effects:
      - random
      - pulse
      - strobe
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
