### PR TITLE
[web_server_idf] Remove std::string temporaries from multipart header parsing

### DIFF
--- a/esphome/components/web_server_idf/multipart.h
+++ b/esphome/components/web_server_idf/multipart.h
@@ -66,19 +66,20 @@ class MultipartReader {
 // ========== Utility Functions ==========
 
 // Case-insensitive string prefix check
-bool str_startswith_case_insensitive(const std::string &str, const std::string &prefix);
+bool str_startswith_case_insensitive(const char *str, size_t str_len, const char *prefix);
 
 // Extract a parameter value from a header line
 // Handles both quoted and unquoted values
-std::string extract_header_param(const std::string &header, const std::string &param);
+// Assigns to out if found, clears out otherwise
+void extract_header_param(const char *header, size_t header_len, const char *param, std::string &out);
 
 // Parse boundary from Content-Type header
 // Returns true if boundary found, false otherwise
 // boundary_start and boundary_len will point to the boundary value
 bool parse_multipart_boundary(const char *content_type, const char **boundary_start, size_t *boundary_len);
 
-// Trim whitespace from both ends of a string
-std::string str_trim(const std::string &str);
+// Trim whitespace from both ends, assign result to out
+void str_trim(const char *str, size_t len, std::string &out);
 
 }  // namespace esphome::web_server_idf
 #endif  // defined(USE_ESP32) && defined(USE_WEBSERVER_OTA)

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -98,8 +98,8 @@ bool str_ncmp_ci(const char *s1, const char *s2, size_t n) {
   return true;
 }
 
-// Case-insensitive string search (like strstr but case-insensitive)
-const char *stristr(const char *haystack, const char *needle) {
+// Bounded case-insensitive string search (like strcasestr but length-bounded)
+const char *strcasestr_n(const char *haystack, size_t haystack_len, const char *needle) {
   if (!haystack) {
     return nullptr;
   }
@@ -109,7 +109,12 @@ const char *stristr(const char *haystack, const char *needle) {
     return haystack;
   }
 
-  for (const char *p = haystack; *p; p++) {
+  if (haystack_len < needle_len) {
+    return nullptr;
+  }
+
+  const char *end = haystack + haystack_len - needle_len + 1;
+  for (const char *p = haystack; p < end; p++) {
     if (str_ncmp_ci(p, needle, needle_len)) {
       return p;
     }

--- a/esphome/components/web_server_idf/utils.h
+++ b/esphome/components/web_server_idf/utils.h
@@ -25,8 +25,8 @@ inline bool char_equals_ci(char a, char b) { return ::tolower(a) == ::tolower(b)
 // Helper function for case-insensitive string region comparison
 bool str_ncmp_ci(const char *s1, const char *s2, size_t n);
 
-// Case-insensitive string search (like strstr but case-insensitive)
-const char *stristr(const char *haystack, const char *needle);
+// Bounded case-insensitive string search (like strcasestr but length-bounded)
+const char *strcasestr_n(const char *haystack, size_t haystack_len, const char *needle);
 
 }  // namespace esphome::web_server_idf
 #endif  // USE_ESP32

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -171,10 +171,11 @@ esp_err_t AsyncWebServer::request_post_handler(httpd_req_t *r) {
     const char *content_type_char = content_type.value().c_str();
 
     // Check most common case first
-    if (stristr(content_type_char, "application/x-www-form-urlencoded") != nullptr) {
+    size_t content_type_len = strlen(content_type_char);
+    if (strcasestr_n(content_type_char, content_type_len, "application/x-www-form-urlencoded") != nullptr) {
       // Normal form data - proceed with regular handling
 #ifdef USE_WEBSERVER_OTA
-    } else if (stristr(content_type_char, "multipart/form-data") != nullptr) {
+    } else if (strcasestr_n(content_type_char, content_type_len, "multipart/form-data") != nullptr) {
       auto *server = static_cast<AsyncWebServer *>(r->user_ctx);
       return server->handle_multipart_upload_(r, content_type_char);
 #endif


### PR DESCRIPTION
While testing I found a stack overflow sometimes happened so we need to revert the multipart buffer to heap in https://github.com/esphome/esphome/pull/13941

# What does this implement/fix?

Refactors multipart utility functions to work with `const char*` + length instead of `std::string` to eliminate temporary heap allocations during header parsing. The original implementations used `std::string` for convenience when the OTA multipart support was first added in #9264, but these can be avoided since the multipart parser already provides raw pointers and lengths in its callbacks.

Changes:
- `extract_header_param`: takes `(const char*, size_t, const char*, std::string&)` instead of `(const std::string&, const std::string&) -> std::string`. Assigns directly to destination, avoiding intermediate string construction.
- `str_startswith_case_insensitive`: takes `(const char*, size_t, const char*)` instead of `(const std::string&, const std::string&)`
- `str_trim`: takes `(const char*, size_t, std::string&)` instead of `(const std::string&) -> std::string`
- Rename `stristr` to `strcasestr_n` with explicit haystack length parameter to make the relationship to POSIX `strcasestr` clear and fix a latent buffer over-read risk (`stristr` relied on null-termination which the multipart parser does not guarantee for its callback data)
- `process_header_` no longer creates a `std::string` copy of the raw parser buffer before calling utility functions

Saves ~350 bytes of flash on builds with OTA enabled. The CI memory impact analysis does not show these savings because `USE_WEBSERVER_OTA` is not enabled in the CI test configuration, so `multipart.cpp` is not compiled. The +16 bytes reported by CI reflects only the `strcasestr_n` bounds check (+4 bytes) and length passing in `request_post_handler` (+12 bytes).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal refactor, no user-facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).