### PR TITLE
[web_server] Switch from getParam to arg API to eliminate heap allocations

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -47,8 +47,8 @@ void CaptivePortal::handle_config(AsyncWebServerRequest *request) {
   request->send(stream);
 }
 void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
-  std::string ssid = request->arg("ssid").c_str();  // NOLINT(readability-redundant-string-cstr)
-  std::string psk = request->arg("psk").c_str();    // NOLINT(readability-redundant-string-cstr)
+  const auto &ssid = request->arg("ssid");
+  const auto &psk = request->arg("psk");
   ESP_LOGI(TAG,
            "Requested WiFi Settings Change:\n"
            "  SSID='%s'\n"
@@ -56,10 +56,12 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
            ssid.c_str(), psk.c_str());
 #ifdef USE_ESP8266
   // ESP8266 is single-threaded, call directly
-  wifi::global_wifi_component->save_wifi_sta(ssid, psk);
+  wifi::global_wifi_component->save_wifi_sta(ssid.c_str(), psk.c_str());
 #else
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
-  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid, psk); });
+  this->defer([ssid = std::string(ssid.c_str(), ssid.length()), psk = std::string(psk.c_str(), psk.length())]() {
+    wifi::global_wifi_component->save_wifi_sta(ssid, psk);
+  });
 #endif
   request->redirect(ESPHOME_F("/?save"));
 }

--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -59,9 +59,7 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   wifi::global_wifi_component->save_wifi_sta(ssid.c_str(), psk.c_str());
 #else
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
-  this->defer([ssid = std::string(ssid.c_str(), ssid.length()), psk = std::string(psk.c_str(), psk.length())]() {
-    wifi::global_wifi_component->save_wifi_sta(ssid, psk);
-  });
+  this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid.c_str(), psk.c_str()); });
 #endif
   request->redirect(ESPHOME_F("/?save"));
 }

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1179,7 +1179,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
       request->send(409);
       return;
     }
-    call.set_date(value);
+    call.set_date(value.c_str(), value.size());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1240,7 +1240,7 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
       request->send(409);
       return;
     }
-    call.set_time(value);
+    call.set_time(value.c_str(), value.size());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1300,7 +1300,7 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
       request->send(409);
       return;
     }
-    call.set_datetime(value);
+    call.set_datetime(value.c_str(), value.size());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1173,12 +1173,13 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    if (!request->hasArg(ESPHOME_F("value"))) {
+    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
+    if (value.empty()) {
       request->send(409);
       return;
     }
-
-    parse_string_param_(request, ESPHOME_F("value"), call, &decltype(call)::set_date);
+    call.set_date(value);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1233,12 +1234,13 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    if (!request->hasArg(ESPHOME_F("value"))) {
+    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
+    if (value.empty()) {
       request->send(409);
       return;
     }
-
-    parse_string_param_(request, ESPHOME_F("value"), call, &decltype(call)::set_time);
+    call.set_time(value);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1292,12 +1294,13 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
 
     auto call = obj->make_call();
 
-    if (!request->hasArg(ESPHOME_F("value"))) {
+    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
+    if (value.empty()) {
       request->send(409);
       return;
     }
-
-    parse_string_param_(request, ESPHOME_F("value"), call, &decltype(call)::set_datetime);
+    call.set_datetime(value);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1476,9 +1476,14 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     parse_string_param_(request, ESPHOME_F("swing_mode"), call, &decltype(call)::set_swing_mode);
 
     // Parse temperature parameters
-    parse_num_param_(request, ESPHOME_F("target_temperature_high"), call, &decltype(call)::set_target_temperature_high);
-    parse_num_param_(request, ESPHOME_F("target_temperature_low"), call, &decltype(call)::set_target_temperature_low);
-    parse_num_param_(request, ESPHOME_F("target_temperature"), call, &decltype(call)::set_target_temperature);
+    // static_cast needed to disambiguate overloaded setters (float vs optional<float>)
+    using ClimateCall = decltype(call);
+    parse_num_param_(request, ESPHOME_F("target_temperature_high"), call,
+                     static_cast<ClimateCall &(ClimateCall::*) (float)>(&ClimateCall::set_target_temperature_high));
+    parse_num_param_(request, ESPHOME_F("target_temperature_low"), call,
+                     static_cast<ClimateCall &(ClimateCall::*) (float)>(&ClimateCall::set_target_temperature_low));
+    parse_num_param_(request, ESPHOME_F("target_temperature"), call,
+                     static_cast<ClimateCall &(ClimateCall::*) (float)>(&ClimateCall::set_target_temperature));
 
     DEFER_ACTION(call, call.perform());
     request->send(200);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -860,7 +860,7 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
       }
       auto call = is_on ? obj->turn_on() : obj->turn_off();
 
-      parse_int_param_(request, ESPHOME_F("speed_level"), call, &decltype(call)::set_speed);
+      parse_num_param_(request, ESPHOME_F("speed_level"), call, &decltype(call)::set_speed);
 
       if (request->hasArg(ESPHOME_F("oscillation"))) {
         auto speed = request->arg(ESPHOME_F("oscillation"));
@@ -1045,8 +1045,8 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
       return;
     }
 
-    parse_float_param_(request, ESPHOME_F("position"), call, &decltype(call)::set_position);
-    parse_float_param_(request, ESPHOME_F("tilt"), call, &decltype(call)::set_tilt);
+    parse_num_param_(request, ESPHOME_F("position"), call, &decltype(call)::set_position);
+    parse_num_param_(request, ESPHOME_F("tilt"), call, &decltype(call)::set_tilt);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1105,7 +1105,7 @@ void WebServer::handle_number_request(AsyncWebServerRequest *request, const UrlM
     }
 
     auto call = obj->make_call();
-    parse_float_param_(request, ESPHOME_F("value"), call, &decltype(call)::set_value);
+    parse_num_param_(request, ESPHOME_F("value"), call, &decltype(call)::set_value);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1476,10 +1476,9 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     parse_string_param_(request, ESPHOME_F("swing_mode"), call, &decltype(call)::set_swing_mode);
 
     // Parse temperature parameters
-    parse_float_param_(request, ESPHOME_F("target_temperature_high"), call,
-                       &decltype(call)::set_target_temperature_high);
-    parse_float_param_(request, ESPHOME_F("target_temperature_low"), call, &decltype(call)::set_target_temperature_low);
-    parse_float_param_(request, ESPHOME_F("target_temperature"), call, &decltype(call)::set_target_temperature);
+    parse_num_param_(request, ESPHOME_F("target_temperature_high"), call, &decltype(call)::set_target_temperature_high);
+    parse_num_param_(request, ESPHOME_F("target_temperature_low"), call, &decltype(call)::set_target_temperature_low);
+    parse_num_param_(request, ESPHOME_F("target_temperature"), call, &decltype(call)::set_target_temperature);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1725,7 +1724,7 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
       return;
     }
 
-    parse_float_param_(request, ESPHOME_F("position"), call, &decltype(call)::set_position);
+    parse_num_param_(request, ESPHOME_F("position"), call, &decltype(call)::set_position);
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1869,12 +1868,12 @@ void WebServer::handle_water_heater_request(AsyncWebServerRequest *request, cons
     parse_string_param_(request, ESPHOME_F("mode"), base_call, &water_heater::WaterHeaterCall::set_mode);
 
     // Parse temperature parameters
-    parse_float_param_(request, ESPHOME_F("target_temperature"), base_call,
-                       &water_heater::WaterHeaterCall::set_target_temperature);
-    parse_float_param_(request, ESPHOME_F("target_temperature_low"), base_call,
-                       &water_heater::WaterHeaterCall::set_target_temperature_low);
-    parse_float_param_(request, ESPHOME_F("target_temperature_high"), base_call,
-                       &water_heater::WaterHeaterCall::set_target_temperature_high);
+    parse_num_param_(request, ESPHOME_F("target_temperature"), base_call,
+                     &water_heater::WaterHeaterCall::set_target_temperature);
+    parse_num_param_(request, ESPHOME_F("target_temperature_low"), base_call,
+                     &water_heater::WaterHeaterCall::set_target_temperature_low);
+    parse_num_param_(request, ESPHOME_F("target_temperature_high"), base_call,
+                     &water_heater::WaterHeaterCall::set_target_temperature_high);
 
     // Parse away mode parameter
     parse_bool_param_(request, ESPHOME_F("away"), base_call, &water_heater::WaterHeaterCall::set_away);
@@ -1978,7 +1977,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
     auto call = obj->make_call();
 
     // Parse carrier frequency (optional)
-    if (request->hasArg(ESPHOME_F("carrier_frequency"))) {
+    {
       auto value = parse_number<uint32_t>(request->arg(ESPHOME_F("carrier_frequency")).c_str());
       if (value.has_value()) {
         call.set_carrier_frequency(*value);
@@ -1986,7 +1985,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
     }
 
     // Parse repeat count (optional, defaults to 1)
-    if (request->hasArg(ESPHOME_F("repeat_count"))) {
+    {
       auto value = parse_number<uint32_t>(request->arg(ESPHOME_F("repeat_count")).c_str());
       if (value.has_value()) {
         call.set_repeat_count(*value);
@@ -1995,17 +1994,12 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     // Parse base64url-encoded raw timings (required)
     // Base64url is URL-safe: uses A-Za-z0-9-_ (no special characters needing escaping)
-    if (!request->hasArg(ESPHOME_F("data"))) {
-      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Missing 'data' parameter"));
-      return;
-    }
-
     // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
     std::string encoded = request->arg(ESPHOME_F("data")).c_str();  // NOLINT(readability-redundant-string-cstr)
 
-    // Validate base64url is not empty
+    // Validate base64url is not empty (also catches missing parameter since arg() returns empty string)
     if (encoded.empty()) {
-      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Empty 'data' parameter"));
+      request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Missing or empty 'data' parameter"));
       return;
     }
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -2002,11 +2002,11 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     // Parse base64url-encoded raw timings (required)
     // Base64url is URL-safe: uses A-Za-z0-9-_ (no special characters needing escaping)
-    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-    std::string encoded = request->arg(ESPHOME_F("data")).c_str();  // NOLINT(readability-redundant-string-cstr)
+    const auto &data_arg = request->arg(ESPHOME_F("data"));
 
     // Validate base64url is not empty (also catches missing parameter since arg() returns empty string)
-    if (encoded.empty()) {
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (data_arg.length() == 0) {  // NOLINT(readability-container-size-empty)
       request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Missing or empty 'data' parameter"));
       return;
     }
@@ -2015,7 +2015,7 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
     // it outlives the call - set_raw_timings_base64url stores a pointer, so the string
     // must remain valid until perform() completes.
     // ESP8266 also needs this because ESPAsyncWebServer callbacks run in "sys" context.
-    this->defer([call, encoded = std::move(encoded)]() mutable {
+    this->defer([call, encoded = std::string(data_arg.c_str(), data_arg.length())]() mutable {
       call.set_raw_timings_base64url(encoded);
       call.perform();
     });

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -583,8 +583,7 @@ static void set_json_icon_state_value(JsonObject &root, EntityBase *obj, const c
 
 // Helper to get request detail parameter
 static JsonDetail get_request_detail(AsyncWebServerRequest *request) {
-  auto *param = request->getParam(ESPHOME_F("detail"));
-  return (param && param->value() == "all") ? DETAIL_ALL : DETAIL_STATE;
+  return request->arg(ESPHOME_F("detail")) == "all" ? DETAIL_ALL : DETAIL_STATE;
 }
 
 #ifdef USE_SENSOR
@@ -863,8 +862,8 @@ void WebServer::handle_fan_request(AsyncWebServerRequest *request, const UrlMatc
 
       parse_int_param_(request, ESPHOME_F("speed_level"), call, &decltype(call)::set_speed);
 
-      if (request->hasParam(ESPHOME_F("oscillation"))) {
-        auto speed = request->getParam(ESPHOME_F("oscillation"))->value();
+      if (request->hasArg(ESPHOME_F("oscillation"))) {
+        auto speed = request->arg(ESPHOME_F("oscillation"));
         auto val = parse_on_off(speed.c_str());
         switch (val) {
           case PARSE_ON:
@@ -1040,8 +1039,8 @@ void WebServer::handle_cover_request(AsyncWebServerRequest *request, const UrlMa
     }
 
     auto traits = obj->get_traits();
-    if ((request->hasParam(ESPHOME_F("position")) && !traits.get_supports_position()) ||
-        (request->hasParam(ESPHOME_F("tilt")) && !traits.get_supports_tilt())) {
+    if ((request->hasArg(ESPHOME_F("position")) && !traits.get_supports_position()) ||
+        (request->hasArg(ESPHOME_F("tilt")) && !traits.get_supports_tilt())) {
       request->send(409);
       return;
     }
@@ -1174,7 +1173,7 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    if (!request->hasParam(ESPHOME_F("value"))) {
+    if (!request->hasArg(ESPHOME_F("value"))) {
       request->send(409);
       return;
     }
@@ -1234,7 +1233,7 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    if (!request->hasParam(ESPHOME_F("value"))) {
+    if (!request->hasArg(ESPHOME_F("value"))) {
       request->send(409);
       return;
     }
@@ -1293,7 +1292,7 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
 
     auto call = obj->make_call();
 
-    if (!request->hasParam(ESPHOME_F("value"))) {
+    if (!request->hasArg(ESPHOME_F("value"))) {
       request->send(409);
       return;
     }
@@ -1721,7 +1720,7 @@ void WebServer::handle_valve_request(AsyncWebServerRequest *request, const UrlMa
     }
 
     auto traits = obj->get_traits();
-    if (request->hasParam(ESPHOME_F("position")) && !traits.get_supports_position()) {
+    if (request->hasArg(ESPHOME_F("position")) && !traits.get_supports_position()) {
       request->send(409);
       return;
     }
@@ -1979,16 +1978,16 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
     auto call = obj->make_call();
 
     // Parse carrier frequency (optional)
-    if (request->hasParam(ESPHOME_F("carrier_frequency"))) {
-      auto value = parse_number<uint32_t>(request->getParam(ESPHOME_F("carrier_frequency"))->value().c_str());
+    if (request->hasArg(ESPHOME_F("carrier_frequency"))) {
+      auto value = parse_number<uint32_t>(request->arg(ESPHOME_F("carrier_frequency")).c_str());
       if (value.has_value()) {
         call.set_carrier_frequency(*value);
       }
     }
 
     // Parse repeat count (optional, defaults to 1)
-    if (request->hasParam(ESPHOME_F("repeat_count"))) {
-      auto value = parse_number<uint32_t>(request->getParam(ESPHOME_F("repeat_count"))->value().c_str());
+    if (request->hasArg(ESPHOME_F("repeat_count"))) {
+      auto value = parse_number<uint32_t>(request->arg(ESPHOME_F("repeat_count")).c_str());
       if (value.has_value()) {
         call.set_repeat_count(*value);
       }
@@ -1996,14 +1995,13 @@ void WebServer::handle_infrared_request(AsyncWebServerRequest *request, const Ur
 
     // Parse base64url-encoded raw timings (required)
     // Base64url is URL-safe: uses A-Za-z0-9-_ (no special characters needing escaping)
-    if (!request->hasParam(ESPHOME_F("data"))) {
+    if (!request->hasArg(ESPHOME_F("data"))) {
       request->send(400, ESPHOME_F("text/plain"), ESPHOME_F("Missing 'data' parameter"));
       return;
     }
 
-    // .c_str() is required for Arduino framework where value() returns Arduino String instead of std::string
-    std::string encoded =
-        request->getParam(ESPHOME_F("data"))->value().c_str();  // NOLINT(readability-redundant-string-cstr)
+    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+    std::string encoded = request->arg(ESPHOME_F("data")).c_str();  // NOLINT(readability-redundant-string-cstr)
 
     // Validate base64url is not empty
     if (encoded.empty()) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1173,13 +1173,13 @@ void WebServer::handle_date_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
-    if (value.empty()) {
+    const auto &value = request->arg(ESPHOME_F("value"));
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (value.length() == 0) {  // NOLINT(readability-container-size-empty)
       request->send(409);
       return;
     }
-    call.set_date(value.c_str(), value.size());
+    call.set_date(value.c_str(), value.length());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1234,13 +1234,13 @@ void WebServer::handle_time_request(AsyncWebServerRequest *request, const UrlMat
 
     auto call = obj->make_call();
 
-    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
-    if (value.empty()) {
+    const auto &value = request->arg(ESPHOME_F("value"));
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (value.length() == 0) {  // NOLINT(readability-container-size-empty)
       request->send(409);
       return;
     }
-    call.set_time(value.c_str(), value.size());
+    call.set_time(value.c_str(), value.length());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);
@@ -1294,13 +1294,13 @@ void WebServer::handle_datetime_request(AsyncWebServerRequest *request, const Ur
 
     auto call = obj->make_call();
 
-    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-    std::string value = request->arg(ESPHOME_F("value")).c_str();  // NOLINT(readability-redundant-string-cstr)
-    if (value.empty()) {
+    const auto &value = request->arg(ESPHOME_F("value"));
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (value.length() == 0) {  // NOLINT(readability-container-size-empty)
       request->send(409);
       return;
     }
-    call.set_datetime(value.c_str(), value.size());
+    call.set_datetime(value.c_str(), value.length());
 
     DEFER_ACTION(call, call.perform());
     request->send(200);

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -543,9 +543,9 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_string_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                            Ret (T::*setter)(const std::string &)) {
-    if (request->hasArg(param_name)) {
-      // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-      std::string value = request->arg(param_name).c_str();  // NOLINT(readability-redundant-string-cstr)
+    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+    std::string value = request->arg(param_name).c_str();  // NOLINT(readability-redundant-string-cstr)
+    if (!value.empty()) {
       (call.*setter)(value);
     }
   }

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -513,11 +513,9 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_light_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(float),
                           float scale = 1.0f) {
-    if (request->hasArg(param_name)) {
-      auto value = parse_number<float>(request->arg(param_name).c_str());
-      if (value.has_value()) {
-        (call.*setter)(*value / scale);
-      }
+    auto value = parse_number<float>(request->arg(param_name).c_str());
+    if (value.has_value()) {
+      (call.*setter)(*value / scale);
     }
   }
 
@@ -525,34 +523,19 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_light_param_uint_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                                Ret (T::*setter)(uint32_t), uint32_t scale = 1) {
-    if (request->hasArg(param_name)) {
-      auto value = parse_number<uint32_t>(request->arg(param_name).c_str());
-      if (value.has_value()) {
-        (call.*setter)(*value * scale);
-      }
+    auto value = parse_number<uint32_t>(request->arg(param_name).c_str());
+    if (value.has_value()) {
+      (call.*setter)(*value * scale);
     }
   }
 #endif
 
-  // Generic helper to parse and apply a float parameter
-  template<typename T, typename Ret>
-  void parse_float_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(float)) {
-    if (request->hasArg(param_name)) {
-      auto value = parse_number<float>(request->arg(param_name).c_str());
-      if (value.has_value()) {
-        (call.*setter)(*value);
-      }
-    }
-  }
-
-  // Generic helper to parse and apply an int parameter
-  template<typename T, typename Ret>
-  void parse_int_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(int)) {
-    if (request->hasArg(param_name)) {
-      auto value = parse_number<int>(request->arg(param_name).c_str());
-      if (value.has_value()) {
-        (call.*setter)(*value);
-      }
+  // Generic helper to parse and apply a numeric parameter
+  template<typename NumT, typename T, typename Ret>
+  void parse_num_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(NumT)) {
+    auto value = parse_number<NumT>(request->arg(param_name).c_str());
+    if (value.has_value()) {
+      (call.*setter)(*value);
     }
   }
 
@@ -573,8 +556,8 @@ class WebServer : public Controller,
   // Invalid values are ignored (setter not called)
   template<typename T, typename Ret>
   void parse_bool_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(bool)) {
-    if (request->hasArg(param_name)) {
-      const auto &param_value = request->arg(param_name);
+    const auto &param_value = request->arg(param_name);
+    if (!param_value.empty()) {
       // First check on/off (default), then true/false (custom)
       auto val = parse_on_off(param_value.c_str());
       if (val == PARSE_NONE) {

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -513,8 +513,8 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_light_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(float),
                           float scale = 1.0f) {
-    if (request->hasParam(param_name)) {
-      auto value = parse_number<float>(request->getParam(param_name)->value().c_str());
+    if (request->hasArg(param_name)) {
+      auto value = parse_number<float>(request->arg(param_name).c_str());
       if (value.has_value()) {
         (call.*setter)(*value / scale);
       }
@@ -525,8 +525,8 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_light_param_uint_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                                Ret (T::*setter)(uint32_t), uint32_t scale = 1) {
-    if (request->hasParam(param_name)) {
-      auto value = parse_number<uint32_t>(request->getParam(param_name)->value().c_str());
+    if (request->hasArg(param_name)) {
+      auto value = parse_number<uint32_t>(request->arg(param_name).c_str());
       if (value.has_value()) {
         (call.*setter)(*value * scale);
       }
@@ -537,8 +537,8 @@ class WebServer : public Controller,
   // Generic helper to parse and apply a float parameter
   template<typename T, typename Ret>
   void parse_float_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(float)) {
-    if (request->hasParam(param_name)) {
-      auto value = parse_number<float>(request->getParam(param_name)->value().c_str());
+    if (request->hasArg(param_name)) {
+      auto value = parse_number<float>(request->arg(param_name).c_str());
       if (value.has_value()) {
         (call.*setter)(*value);
       }
@@ -548,8 +548,8 @@ class WebServer : public Controller,
   // Generic helper to parse and apply an int parameter
   template<typename T, typename Ret>
   void parse_int_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(int)) {
-    if (request->hasParam(param_name)) {
-      auto value = parse_number<int>(request->getParam(param_name)->value().c_str());
+    if (request->hasArg(param_name)) {
+      auto value = parse_number<int>(request->arg(param_name).c_str());
       if (value.has_value()) {
         (call.*setter)(*value);
       }
@@ -560,9 +560,9 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_string_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                            Ret (T::*setter)(const std::string &)) {
-    if (request->hasParam(param_name)) {
-      // .c_str() is required for Arduino framework where value() returns Arduino String instead of std::string
-      std::string value = request->getParam(param_name)->value().c_str();  // NOLINT(readability-redundant-string-cstr)
+    if (request->hasArg(param_name)) {
+      // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
+      std::string value = request->arg(param_name).c_str();  // NOLINT(readability-redundant-string-cstr)
       (call.*setter)(value);
     }
   }
@@ -573,8 +573,8 @@ class WebServer : public Controller,
   // Invalid values are ignored (setter not called)
   template<typename T, typename Ret>
   void parse_bool_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(bool)) {
-    if (request->hasParam(param_name)) {
-      auto param_value = request->getParam(param_name)->value();
+    if (request->hasArg(param_name)) {
+      auto param_value = request->arg(param_name);
       // First check on/off (default), then true/false (custom)
       auto val = parse_on_off(param_value.c_str());
       if (val == PARSE_NONE) {

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -543,10 +543,10 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_string_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                            Ret (T::*setter)(const std::string &)) {
-    // .c_str() is required for Arduino framework where arg() returns Arduino String instead of std::string
-    std::string value = request->arg(param_name).c_str();  // NOLINT(readability-redundant-string-cstr)
-    if (!value.empty()) {
-      (call.*setter)(value);
+    const auto &value = request->arg(param_name);
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (value.length() > 0) {  // NOLINT(readability-container-size-empty)
+      (call.*setter)(std::string(value.c_str(), value.length()));
     }
   }
 

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -574,7 +574,7 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_bool_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(bool)) {
     if (request->hasArg(param_name)) {
-      auto param_value = request->arg(param_name);
+      const auto &param_value = request->arg(param_name);
       // First check on/off (default), then true/false (custom)
       auto val = parse_on_off(param_value.c_str());
       if (val == PARSE_NONE) {

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -557,7 +557,7 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_bool_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(bool)) {
     const auto &param_value = request->arg(param_name);
-    if (!param_value.empty()) {
+    if (param_value.length() > 0) {
       // First check on/off (default), then true/false (custom)
       auto val = parse_on_off(param_value.c_str());
       if (val == PARSE_NONE) {

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -543,9 +543,8 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_string_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call,
                            Ret (T::*setter)(const std::string &)) {
-    const auto &value = request->arg(param_name);
-    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
-    if (value.length() > 0) {  // NOLINT(readability-container-size-empty)
+    if (request->hasArg(param_name)) {
+      const auto &value = request->arg(param_name);
       (call.*setter)(std::string(value.c_str(), value.length()));
     }
   }

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -557,7 +557,8 @@ class WebServer : public Controller,
   template<typename T, typename Ret>
   void parse_bool_param_(AsyncWebServerRequest *request, ParamNameType param_name, T &call, Ret (T::*setter)(bool)) {
     const auto &param_value = request->arg(param_name);
-    if (param_value.length() > 0) {
+    // Arduino String has isEmpty() not empty(), use length() for cross-platform compatibility
+    if (param_value.length() > 0) {  // NOLINT(readability-container-size-empty)
       // First check on/off (default), then true/false (custom)
       auto val = parse_on_off(param_value.c_str());
       if (val == PARSE_NONE) {

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -73,9 +73,10 @@ bool query_has_key(const char *query_url, size_t query_len, const char *key) {
   }
   // Minimal buffer — we only care if the key exists, not the value
   char buf[1];
-  // httpd_query_key_value returns ESP_OK if key found (even if buffer too small for value),
-  // ESP_ERR_NOT_FOUND if key absent
-  return httpd_query_key_value(query_url, key, buf, sizeof(buf)) != ESP_ERR_NOT_FOUND;
+  // httpd_query_key_value returns ESP_OK if found, ESP_ERR_HTTPD_RESULT_TRUNC if found
+  // but value truncated (expected with 1-byte buffer), or other errors for invalid input
+  auto err = httpd_query_key_value(query_url, key, buf, sizeof(buf));
+  return err == ESP_OK || err == ESP_ERR_HTTPD_RESULT_TRUNC;
 }
 
 // Helper function for case-insensitive string region comparison

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -1,5 +1,4 @@
 #ifdef USE_ESP32
-#include <memory>
 #include <cstring>
 #include <cctype>
 #include "esphome/core/helpers.h"
@@ -56,15 +55,13 @@ optional<std::string> query_key_value(const char *query_url, size_t query_len, c
     return {};
   }
 
-  // Use stack buffer for typical query strings, heap fallback for large ones
-  SmallBufferWithHeapFallback<256, char> val(query_len);
-
-  if (httpd_query_key_value(query_url, key, val.get(), query_len) != ESP_OK) {
+  char val[CONFIG_HTTPD_MAX_URI_LEN + 1];
+  if (httpd_query_key_value(query_url, key, val, query_len) != ESP_OK) {
     return {};
   }
 
-  url_decode(val.get());
-  return {val.get()};
+  url_decode(val);
+  return {val};
 }
 
 bool query_has_key(const char *query_url, size_t query_len, const char *key) {

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -55,13 +55,16 @@ optional<std::string> query_key_value(const char *query_url, size_t query_len, c
     return {};
   }
 
-  char val[CONFIG_HTTPD_MAX_URI_LEN + 1];
-  if (httpd_query_key_value(query_url, key, val, query_len) != ESP_OK) {
+  // Value can't exceed query_len. Use small stack buffer for typical values,
+  // heap fallback for long ones (e.g. base64 IR data) to limit stack usage
+  // since callers may also have stack buffers for the query string.
+  SmallBufferWithHeapFallback<128, char> val(query_len);
+  if (httpd_query_key_value(query_url, key, val.get(), query_len) != ESP_OK) {
     return {};
   }
 
-  url_decode(val);
-  return {val};
+  url_decode(val.get());
+  return {val.get()};
 }
 
 bool query_has_key(const char *query_url, size_t query_len, const char *key) {

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -88,6 +88,17 @@ optional<std::string> query_key_value(const char *query_url, size_t query_len, c
   return {val.get()};
 }
 
+bool query_has_key(const char *query_url, size_t query_len, const char *key) {
+  if (query_url == nullptr || query_len == 0) {
+    return false;
+  }
+  // Minimal buffer — we only care if the key exists, not the value
+  char buf[1];
+  // httpd_query_key_value returns ESP_OK if key found (even if buffer too small for value),
+  // ESP_ERR_NOT_FOUND if key absent
+  return httpd_query_key_value(query_url, key, buf, sizeof(buf)) != ESP_ERR_NOT_FOUND;
+}
+
 // Helper function for case-insensitive string region comparison
 bool str_ncmp_ci(const char *s1, const char *s2, size_t n) {
   for (size_t i = 0; i < n; i++) {

--- a/esphome/components/web_server_idf/utils.cpp
+++ b/esphome/components/web_server_idf/utils.cpp
@@ -3,14 +3,11 @@
 #include <cstring>
 #include <cctype>
 #include "esphome/core/helpers.h"
-#include "esphome/core/log.h"
 #include "http_parser.h"
 
 #include "utils.h"
 
 namespace esphome::web_server_idf {
-
-static const char *const TAG = "web_server_idf_utils";
 
 size_t url_decode(char *str) {
   char *start = str;
@@ -48,24 +45,6 @@ optional<std::string> request_get_header(httpd_req_t *req, const char *name) {
 
   auto res = httpd_req_get_hdr_value_str(req, name, &str[0], len + 1);
   if (res != ESP_OK) {
-    return {};
-  }
-
-  return {str};
-}
-
-optional<std::string> request_get_url_query(httpd_req_t *req) {
-  auto len = httpd_req_get_url_query_len(req);
-  if (len == 0) {
-    return {};
-  }
-
-  std::string str;
-  str.resize(len);
-
-  auto res = httpd_req_get_url_query_str(req, &str[0], len + 1);
-  if (res != ESP_OK) {
-    ESP_LOGW(TAG, "Can't get query for request: %s", esp_err_to_name(res));
     return {};
   }
 

--- a/esphome/components/web_server_idf/utils.h
+++ b/esphome/components/web_server_idf/utils.h
@@ -18,6 +18,7 @@ optional<std::string> query_key_value(const char *query_url, size_t query_len, c
 inline optional<std::string> query_key_value(const std::string &query_url, const std::string &key) {
   return query_key_value(query_url.c_str(), query_url.size(), key.c_str());
 }
+bool query_has_key(const char *query_url, size_t query_len, const char *key);
 
 // Helper function for case-insensitive character comparison
 inline bool char_equals_ci(char a, char b) { return ::tolower(a) == ::tolower(b); }

--- a/esphome/components/web_server_idf/utils.h
+++ b/esphome/components/web_server_idf/utils.h
@@ -13,11 +13,7 @@ size_t url_decode(char *str);
 
 bool request_has_header(httpd_req_t *req, const char *name);
 optional<std::string> request_get_header(httpd_req_t *req, const char *name);
-optional<std::string> request_get_url_query(httpd_req_t *req);
 optional<std::string> query_key_value(const char *query_url, size_t query_len, const char *key);
-inline optional<std::string> query_key_value(const std::string &query_url, const std::string &key) {
-  return query_key_value(query_url.c_str(), query_url.size(), key.c_str());
-}
 bool query_has_key(const char *query_url, size_t query_len, const char *key);
 
 // Helper function for case-insensitive character comparison

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -412,7 +412,7 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
   return param;
 }
 
-optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) {
+optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {
   auto val = query_key_value(this->post_query_.c_str(), this->post_query_.size(), name);
   if (val.has_value()) {
     return val;

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -408,7 +408,7 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
 
 /// Search post_query then URL query with a callback.
 /// Returns first truthy result, or value-initialized default.
-/// Uses stack buffer for URL query to avoid heap allocation.
+/// URL query is accessed directly from req->uri to avoid stack buffer copy.
 template<typename Func>
 static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
     -> decltype(func(nullptr, size_t{0}, name)) {
@@ -418,15 +418,17 @@ static auto search_query_sources(httpd_req_t *req, const std::string &post_query
       return result;
     }
   }
-  auto len = httpd_req_get_url_query_len(req);
+  // Access query string directly from URI — no copy needed
+  const char *query = strchr(req->uri, '?');
+  if (query == nullptr) {
+    return {};
+  }
+  query++;  // skip '?'
+  size_t len = strlen(query);
   if (len == 0) {
     return {};
   }
-  char buf[AsyncWebServerRequest::URL_BUF_SIZE];
-  if (httpd_req_get_url_query_str(req, buf, len + 1) != ESP_OK) {
-    return {};
-  }
-  return func(buf, len, name);
+  return func(query, len, name);
 }
 
 optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -418,18 +418,18 @@ static auto search_query_sources(httpd_req_t *req, const std::string &post_query
       return result;
     }
   }
-  // Access query string directly from URI — no stack buffer needed.
+  // Use httpd API for query length, then access string directly from URI.
   // http_parser identifies components by offset/length without modifying the URI string.
   // This is the same pattern used by url_to().
+  auto len = httpd_req_get_url_query_len(req);
+  if (len == 0) {
+    return {};
+  }
   const char *query = strchr(req->uri, '?');
   if (query == nullptr) {
     return {};
   }
   query++;  // skip '?'
-  size_t len = strlen(query);
-  if (len == 0) {
-    return {};
-  }
   return func(query, len, name);
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -393,13 +393,7 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
   }
 
   // Look up value from query strings
-  optional<std::string> val = query_key_value(this->post_query_.c_str(), this->post_query_.size(), name);
-  if (!val.has_value()) {
-    auto url_query = request_get_url_query(*this);
-    if (url_query.has_value()) {
-      val = query_key_value(url_query.value().c_str(), url_query.value().size(), name);
-    }
-  }
+  auto val = this->find_query_value_(name);
 
   // Don't cache misses to avoid wasting memory when handlers check for
   // optional parameters that don't exist in the request
@@ -418,9 +412,11 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
 template<typename Func>
 static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
     -> decltype(func(nullptr, size_t{0}, name)) {
-  auto result = func(post_query.c_str(), post_query.size(), name);
-  if (result) {
-    return result;
+  if (!post_query.empty()) {
+    auto result = func(post_query.c_str(), post_query.size(), name);
+    if (result) {
+      return result;
+    }
   }
   auto len = httpd_req_get_url_query_len(req);
   if (len == 0) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -408,7 +408,6 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
 
 /// Search post_query then URL query with a callback.
 /// Returns first truthy result, or value-initialized default.
-/// URL query is accessed directly from req->uri to avoid stack buffer copy.
 template<typename Func>
 static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
     -> decltype(func(nullptr, size_t{0}, name)) {
@@ -418,17 +417,15 @@ static auto search_query_sources(httpd_req_t *req, const std::string &post_query
       return result;
     }
   }
-  // Access query string directly from URI — no copy needed
-  const char *query = strchr(req->uri, '?');
-  if (query == nullptr) {
-    return {};
-  }
-  query++;  // skip '?'
-  size_t len = strlen(query);
+  auto len = httpd_req_get_url_query_len(req);
   if (len == 0) {
     return {};
   }
-  return func(query, len, name);
+  char buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  if (httpd_req_get_url_query_str(req, buf, len + 1) != ESP_OK) {
+    return {};
+  }
+  return func(buf, len, name);
 }
 
 optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -414,27 +414,32 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
 
 /// Search post_query then URL query with a callback.
 /// Returns first truthy result, or value-initialized default.
+/// Uses stack buffer for URL query to avoid heap allocation.
 template<typename Func>
-static auto search_query_sources(const AsyncWebServerRequest &req, const std::string &post_query, const char *name,
-                                 Func func) -> decltype(func(nullptr, size_t{0}, name)) {
+static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
+    -> decltype(func(nullptr, size_t{0}, name)) {
   auto result = func(post_query.c_str(), post_query.size(), name);
   if (result) {
     return result;
   }
-  auto url_query = request_get_url_query(req);
-  if (url_query.has_value()) {
-    return func(url_query.value().c_str(), url_query.value().size(), name);
+  auto len = httpd_req_get_url_query_len(req);
+  if (len == 0) {
+    return {};
   }
-  return {};
+  SmallBufferWithHeapFallback<256, char> buf(len + 1);
+  if (httpd_req_get_url_query_str(req, buf.get(), len + 1) != ESP_OK) {
+    return {};
+  }
+  return func(buf.get(), len, name);
 }
 
 optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {
-  return search_query_sources(*this, this->post_query_, name,
+  return search_query_sources(this->req_, this->post_query_, name,
                               [](const char *q, size_t len, const char *k) { return query_key_value(q, len, k); });
 }
 
 bool AsyncWebServerRequest::hasArg(const char *name) {
-  return search_query_sources(*this, this->post_query_, name, query_has_key);
+  return search_query_sources(this->req_, this->post_query_, name, query_has_key);
 }
 
 std::string AsyncWebServerRequest::arg(const char *name) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -422,11 +422,11 @@ static auto search_query_sources(httpd_req_t *req, const std::string &post_query
   if (len == 0) {
     return {};
   }
-  SmallBufferWithHeapFallback<256, char> buf(len + 1);
-  if (httpd_req_get_url_query_str(req, buf.get(), len + 1) != ESP_OK) {
+  char buf[AsyncWebServerRequest::URL_BUF_SIZE];
+  if (httpd_req_get_url_query_str(req, buf, len + 1) != ESP_OK) {
     return {};
   }
-  return func(buf.get(), len, name);
+  return func(buf, len, name);
 }
 
 optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -408,6 +408,7 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
 
 /// Search post_query then URL query with a callback.
 /// Returns first truthy result, or value-initialized default.
+/// URL query is accessed directly from req->uri (same pattern as url_to()).
 template<typename Func>
 static auto search_query_sources(httpd_req_t *req, const std::string &post_query, const char *name, Func func)
     -> decltype(func(nullptr, size_t{0}, name)) {
@@ -417,15 +418,19 @@ static auto search_query_sources(httpd_req_t *req, const std::string &post_query
       return result;
     }
   }
-  auto len = httpd_req_get_url_query_len(req);
+  // Access query string directly from URI — no stack buffer needed.
+  // http_parser identifies components by offset/length without modifying the URI string.
+  // This is the same pattern used by url_to().
+  const char *query = strchr(req->uri, '?');
+  if (query == nullptr) {
+    return {};
+  }
+  query++;  // skip '?'
+  size_t len = strlen(query);
   if (len == 0) {
     return {};
   }
-  char buf[AsyncWebServerRequest::URL_BUF_SIZE];
-  if (httpd_req_get_url_query_str(req, buf, len + 1) != ESP_OK) {
-    return {};
-  }
-  return func(buf, len, name);
+  return func(query, len, name);
 }
 
 optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -412,27 +412,29 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
   return param;
 }
 
-optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {
-  auto val = query_key_value(this->post_query_.c_str(), this->post_query_.size(), name);
-  if (val.has_value()) {
-    return val;
+/// Search post_query then URL query with a callback.
+/// Returns first truthy result, or value-initialized default.
+template<typename Func>
+static auto search_query_sources(const AsyncWebServerRequest &req, const std::string &post_query, const char *name,
+                                 Func func) -> decltype(func(nullptr, size_t{0}, name)) {
+  auto result = func(post_query.c_str(), post_query.size(), name);
+  if (result) {
+    return result;
   }
-  auto url_query = request_get_url_query(*this);
+  auto url_query = request_get_url_query(req);
   if (url_query.has_value()) {
-    return query_key_value(url_query.value().c_str(), url_query.value().size(), name);
+    return func(url_query.value().c_str(), url_query.value().size(), name);
   }
   return {};
 }
 
+optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) const {
+  return search_query_sources(*this, this->post_query_, name,
+                              [](const char *q, size_t len, const char *k) { return query_key_value(q, len, k); });
+}
+
 bool AsyncWebServerRequest::hasArg(const char *name) {
-  if (query_has_key(this->post_query_.c_str(), this->post_query_.size(), name)) {
-    return true;
-  }
-  auto url_query = request_get_url_query(*this);
-  if (url_query.has_value()) {
-    return query_has_key(url_query.value().c_str(), url_query.value().size(), name);
-  }
-  return false;
+  return search_query_sources(*this, this->post_query_, name, query_has_key);
 }
 
 std::string AsyncWebServerRequest::arg(const char *name) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -424,7 +424,16 @@ optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name)
   return {};
 }
 
-bool AsyncWebServerRequest::hasArg(const char *name) { return this->find_query_value_(name).has_value(); }
+bool AsyncWebServerRequest::hasArg(const char *name) {
+  if (query_has_key(this->post_query_.c_str(), this->post_query_.size(), name)) {
+    return true;
+  }
+  auto url_query = request_get_url_query(*this);
+  if (url_query.has_value()) {
+    return query_has_key(url_query.value().c_str(), url_query.value().size(), name);
+  }
+  return false;
+}
 
 std::string AsyncWebServerRequest::arg(const char *name) {
   auto val = this->find_query_value_(name);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -411,6 +411,28 @@ AsyncWebParameter *AsyncWebServerRequest::getParam(const char *name) {
   return param;
 }
 
+optional<std::string> AsyncWebServerRequest::find_query_value_(const char *name) {
+  auto val = query_key_value(this->post_query_.c_str(), this->post_query_.size(), name);
+  if (val.has_value()) {
+    return val;
+  }
+  auto url_query = request_get_url_query(*this);
+  if (url_query.has_value()) {
+    return query_key_value(url_query.value().c_str(), url_query.value().size(), name);
+  }
+  return {};
+}
+
+bool AsyncWebServerRequest::hasArg(const char *name) { return this->find_query_value_(name).has_value(); }
+
+std::string AsyncWebServerRequest::arg(const char *name) {
+  auto val = this->find_query_value_(name);
+  if (val.has_value()) {
+    return std::move(val.value());
+  }
+  return {};
+}
+
 void AsyncWebServerResponse::addHeader(const char *name, const char *value) {
   httpd_resp_set_hdr(*this->req_, name, value);
 }

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -170,14 +170,8 @@ class AsyncWebServerRequest {
   AsyncWebParameter *getParam(const std::string &name) { return this->getParam(name.c_str()); }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
-  bool hasArg(const char *name) { return this->hasParam(name); }
-  std::string arg(const char *name) {
-    auto *param = this->getParam(name);
-    if (param) {
-      return param->value();
-    }
-    return {};
-  }
+  bool hasArg(const char *name);
+  std::string arg(const char *name);
   std::string arg(const std::string &name) { return this->arg(name.c_str()); }
 
   operator httpd_req_t *() const { return this->req_; }
@@ -192,6 +186,7 @@ class AsyncWebServerRequest {
   // is faster than tree/hash overhead. AsyncWebParameter stores both name and value to avoid
   // duplicate storage. Only successful lookups are cached to prevent cache pollution when
   // handlers check for optional parameters that don't exist.
+  optional<std::string> find_query_value_(const char *name);
   std::vector<AsyncWebParameter *> params_;
   std::string post_query_;
   AsyncWebServerRequest(httpd_req_t *req) : req_(req) {}

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -186,7 +186,7 @@ class AsyncWebServerRequest {
   // is faster than tree/hash overhead. AsyncWebParameter stores both name and value to avoid
   // duplicate storage. Only successful lookups are cached to prevent cache pollution when
   // handlers check for optional parameters that don't exist.
-  optional<std::string> find_query_value_(const char *name);
+  optional<std::string> find_query_value_(const char *name) const;
   std::vector<AsyncWebParameter *> params_;
   std::string post_query_;
   AsyncWebServerRequest(httpd_req_t *req) : req_(req) {}


### PR DESCRIPTION
## What does this implement/fix?

Switches all web_server and captive_portal callers from `getParam()`/`hasParam()` to `arg()`/`hasArg()` and eliminates unnecessary heap allocations and double query lookups.

### IDF `arg()`/`hasArg()` rewrite

On the IDF side, `getParam()` allocated a `new AsyncWebParameter` on the heap for every successful lookup, cached it in a `params_` vector, and required cleanup in the destructor. No caller ever held the returned pointer or called `getParam` twice with the same name — every use was just `getParam("x")->value()` immediately.

This PR rewrites the IDF `arg()`/`hasArg()` via a new `search_query_sources` template that searches POST body then URL query with a single callback, and a `find_query_value_()` const helper. `getParam` is refactored to use `find_query_value_()` internally, eliminating the duplicate search logic it previously contained.

### Zero-allocation query lookup

- **Direct URI access**: URL query string is accessed directly from `req->uri` via `strchr('?')` — the same pattern `url_to()` uses. This is more efficient than `httpd_req_get_url_query_str` which copies the query into a separate buffer. No stack buffer needed at all for the query string.
- `hasArg()` uses a new `query_has_key()` function with a 1-byte buffer — checks key existence without url_decode or string allocation (`httpd_query_key_value` returns `ESP_ERR_NOT_FOUND` vs `ESP_OK`/`ESP_ERR_HTTPD_RESULT_TRUNC`)
- `query_key_value()` uses `SmallBufferWithHeapFallback<128>` for the extracted value — 128 bytes on stack for typical values, heap fallback for longer ones (e.g. base64 IR data). Total stack cost for query parsing is ~128 bytes.
- Removed `request_get_url_query()` which heap-allocated a `std::string` for every query lookup
- Removed unused `std::string` overload of `query_key_value()`
- Empty `post_query_` (common for GET requests) is skipped without calling into the search function

### Double lookup elimination

Removed redundant `hasArg()` + `arg()` double lookups where possible:
- **Numeric params** (`parse_num_param_`): Dropped `hasArg()` guard — `parse_number("")` returns nullopt, so the setter is never called when the param is missing
- **Bool params** (`parse_bool_param_`): Dropped `hasArg()` guard — `parse_on_off("")` returns `PARSE_NONE` and empty string doesn't match `"1"`/`"0"`
- **Date/time/datetime**: Inlined `arg()` call with `length() == 0` check, passing `c_str()`/`length()` directly to setter's `(const char*, size_t)` overload — avoids `std::string` copy
- **IR carrier_frequency/repeat_count**: Dropped `hasArg()` guard (same as numeric params)
- **IR data**: Combined missing/empty into single `arg()` + `length() == 0` check
- **String params** (`parse_string_param_`): Kept `hasArg()` guard — empty string is a valid value (e.g. select options)
- **Oscillation**: Kept `hasArg()` guard — must distinguish missing from present (sends 404 on invalid)

### Template unification

Merged `parse_float_param_` and `parse_int_param_` into a single `parse_num_param_<NumT>` template. Climate setters need `static_cast` to disambiguate overloaded `float` vs `optional<float>` signatures.

### Cross-platform cleanup

- Use `const auto &` to bind `arg()` results directly (avoids `std::string` copy from Arduino `String`)
- Removed all `readability-redundant-string-cstr` NOLINTs from web_server and captive_portal
- Use `length() > 0` / `length() == 0` instead of `empty()` / `isEmpty()` for cross-platform compatibility (Arduino `String` vs `std::string`)

### Binary savings

~1,040 bytes flash on ESP32-IDF. Key eliminated symbols:
- `getParam` (-368 bytes) — function plus `AsyncWebParameter` cache and `vector::_M_realloc_append`
- `request_get_url_query` (-112 bytes)
- `httpd_req_get_url_query_str` (-82 bytes) — no longer referenced
- `std::string::resize` (-120 bytes)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - internal refactor, no user-facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).