### PR TITLE
Allow Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.13"
+          - "3.14"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
     "Topic :: Home Automation",
 ]
 
-# Python 3.14 is currently not supported by IDF <= 5.5.1, see https://github.com/esphome/esphome/issues/11502
-requires-python = ">=3.11.0,<3.14"
+# Python 3.14 is not supported on Windows, see https://github.com/zephyrproject-rtos/windows-curses/issues/76
+requires-python = ">=3.11.0,<3.15"
 
 dynamic = ["dependencies", "optional-dependencies", "version"]
 


### PR DESCRIPTION
# What does this implement/fix?

Allows Python 3.14 to be used with ESPHome. Python 3.14 is not supported on Windows due to [windows-curses not supporting 3.14](https://github.com/zephyrproject-rtos/windows-curses/issues/76) but works on Linux and macOS.

Changes:
- Bump `requires-python` upper bound from `<3.14` to `<3.15`
- Add Python 3.14 to pytest CI matrix (Linux only)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

https://github.com/zephyrproject-rtos/windows-curses/issues/76

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).