### PR TITLE
[wifi] Allow fast_connect without preconfigured networks

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -288,11 +288,6 @@ def _validate(config):
         config = config.copy()
         config[CONF_NETWORKS] = []
 
-    if config.get(CONF_FAST_CONNECT, False):
-        networks = config.get(CONF_NETWORKS, [])
-        if not networks:
-            raise cv.Invalid("At least one network required for fast_connect!")
-
     if CONF_USE_ADDRESS not in config:
         use_address = CORE.name + config[CONF_DOMAIN]
         if CONF_MANUAL_IP in config:


### PR DESCRIPTION
# What does this implement/fix?

Allow `fast_connect` to be used with `captive_portal` (or other runtime WiFi provisioning) without requiring a preconfigured network in the YAML.

After the user configures WiFi via captive portal, the credentials are saved to flash. On subsequent boots, the `fast_connect` code path loads the saved BSSID and channel, allowing the device to reconnect without scanning — which is the whole point of `fast_connect`.

Previously, the configuration validator required at least one network to be configured when `fast_connect: true` was set. This requirement was a leftover from when `fast_connect` was a runtime option wired through a `set_fast_connect(true)` call on a station setup instance (before #11328 made it a compile-time `#define`). The requirement is no longer needed since `fast_connect` is now purely a compile-time flag.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (no issue created ATM)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [X] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] N/A