### PR TITLE
[web_server] Guard icon JSON field with USE_ENTITY_ICON

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -557,7 +557,9 @@ static void set_json_id(JsonObject &root, EntityBase *obj, const char *prefix, J
       root[ESPHOME_F("device")] = device_name;
     }
 #endif
+#ifdef USE_ENTITY_ICON
     root[ESPHOME_F("icon")] = obj->get_icon_ref();
+#endif
     root[ESPHOME_F("entity_category")] = obj->get_entity_category();
     bool is_disabled = obj->is_disabled_by_default();
     if (is_disabled)


### PR DESCRIPTION
# What does this implement/fix?

Adds a missing `#ifdef USE_ENTITY_ICON` guard around the `root["icon"]` assignment in `set_json_id()`. When `USE_ENTITY_ICON` is not defined (i.e., no entities have icons configured), this avoids:

- The ArduinoJson `.set()` call overhead
- Sending an empty `"icon":""` key in every JSON entity response

This is safe for the frontend — in [esphome-webserver](https://github.com/esphome/esphome-webserver), the `icon` field is declared as optional (`icon?: string`) in the `entityConfig` TypeScript interface (both v2 and v3), and rendering uses `component.icon ? html`...` : nothing`, so a missing key (`undefined`) is handled identically to an empty string.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - no user-facing changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a compile-time optimization.
# Builds without entity icons will no longer emit empty "icon":"" in JSON.
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).