### PR TITLE
[analyze_memory] Fix mDNS packet buffer miscategorized as wifi_config

### DIFF
--- a/esphome/analyze_memory/const.py
+++ b/esphome/analyze_memory/const.py
@@ -256,7 +256,7 @@ SYMBOL_PATTERNS = {
     "ipv6_stack": ["nd6_", "ip6_", "mld6_", "icmp6_", "icmp6_input"],
     # Order matters! More specific categories must come before general ones.
     # mdns must come before bluetooth to avoid "_mdns_disable_pcb" matching "ble_" pattern
-    "mdns_lib": ["mdns"],
+    "mdns_lib": ["mdns", "packet$"],
     # memory_mgmt must come before wifi_stack to catch mmu_hal_* symbols
     "memory_mgmt": [
         "mem_",
@@ -794,7 +794,6 @@ SYMBOL_PATTERNS = {
         "s_dp",
         "s_ni",
         "s_reg_dump",
-        "packet$",
         "d_mult_table",
         "K",
         "fcstab",


### PR DESCRIPTION
# What does this implement/fix?

The `packet$` pattern in `analyze-memory` was in the `wifi_config` category, but the `packet$N` static buffer is actually the mDNS packet assembly buffer from ESP-IDF's mDNS component. This caused ~1,460 B of mDNS RAM to appear under `wifi_config` in ethernet-only builds (which don't use WiFi at all).

Moves `packet$` from `wifi_config` to `mdns_lib` where it belongs. Since `mdns_lib` is matched before `wifi_config` in the pattern order, this correctly categorizes the symbol on all builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is an analyze-memory tool fix
# Verified with: esphome analyze-memory gatetrigger.yaml (ethernet-only build)
```

Before:
```
wifi_config (1,468 B total RAM):
  packet$19  1,460 B [bss]
```

After:
```
[lib]mdns (1,908 B total RAM):
  packet$19  1,460 B [bss]
  mdns_task_buffer$14  340 B [bss]
  s_esp_netifs  48 B [data]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).