### PR TITLE
[uart] Remove redundant mutex, fix flush race, conditional event queue

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -376,6 +376,13 @@ void IDFUARTComponent::start_rx_event_task_() {
   ESP_LOGV(TAG, "RX event task started");
 }
 
+// FreeRTOS task that relays UART ISR events to the main loop.
+// This task exists because wake_loop_threadsafe() is not ISR-safe (it uses a
+// UDP loopback socket), so we need a task as an ISR-to-main-loop trampoline.
+// IMPORTANT: This task must NOT call any UART wrapper methods (read_array,
+// write_array, peek_byte, etc.) or touch has_peek_/peek_byte_ — all reading
+// is done by the main loop. This task only reads from the event queue and
+// calls App.wake_loop_threadsafe().
 void IDFUARTComponent::rx_event_task_func(void *param) {
   auto *self = static_cast<IDFUARTComponent *>(param);
   uart_event_t event;

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -90,7 +90,6 @@ void IDFUARTComponent::setup() {
     return;
   }
   this->uart_num_ = static_cast<uart_port_t>(next_uart_num++);
-  this->lock_ = xSemaphoreCreateMutex();
 
 #if (SOC_UART_LP_NUM >= 1)
   size_t fifo_len = ((this->uart_num_ < SOC_UART_HP_NUM) ? SOC_UART_FIFO_LEN : SOC_LP_UART_FIFO_LEN);
@@ -102,11 +101,7 @@ void IDFUARTComponent::setup() {
     this->rx_buffer_size_ = fifo_len * 2;
   }
 
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
-
   this->load_settings(false);
-
-  xSemaphoreGive(this->lock_);
 }
 
 void IDFUARTComponent::load_settings(bool dump_config) {
@@ -126,13 +121,20 @@ void IDFUARTComponent::load_settings(bool dump_config) {
       return;
     }
   }
+#ifdef USE_UART_WAKE_LOOP_ON_RX
+  constexpr int event_queue_size = 20;
+  QueueHandle_t *event_queue_ptr = &this->uart_event_queue_;
+#else
+  constexpr int event_queue_size = 0;
+  QueueHandle_t *event_queue_ptr = nullptr;
+#endif
   err = uart_driver_install(this->uart_num_,        // UART number
                             this->rx_buffer_size_,  // RX ring buffer size
-                            0,   // TX ring buffer size. If zero, driver will not use a TX buffer and TX function will
-                                 // block task until all data has been sent out
-                            20,  // event queue size/depth
-                            &this->uart_event_queue_,  // event queue
-                            0                          // Flags used to allocate the interrupt
+                            0,  // TX ring buffer size. If zero, driver will not use a TX buffer and TX function will
+                                // block task until all data has been sent out
+                            event_queue_size,  // event queue size/depth
+                            event_queue_ptr,   // event queue
+                            0                  // Flags used to allocate the interrupt
   );
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_driver_install failed: %s", esp_err_to_name(err));
@@ -282,9 +284,7 @@ void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
 }
 
 void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
   int32_t write_len = uart_write_bytes(this->uart_num_, data, len);
-  xSemaphoreGive(this->lock_);
   if (write_len != (int32_t) len) {
     ESP_LOGW(TAG, "uart_write_bytes failed: %d != %zu", write_len, len);
     this->mark_failed();
@@ -299,7 +299,6 @@ void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
 bool IDFUARTComponent::peek_byte(uint8_t *data) {
   if (!this->check_read_timeout_())
     return false;
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
   if (this->has_peek_) {
     *data = this->peek_byte_;
   } else {
@@ -311,7 +310,6 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
       this->peek_byte_ = *data;
     }
   }
-  xSemaphoreGive(this->lock_);
   return true;
 }
 
@@ -320,7 +318,6 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   int32_t read_len = 0;
   if (!this->check_read_timeout_(len))
     return false;
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
   if (this->has_peek_) {
     length_to_read--;
     *data = this->peek_byte_;
@@ -329,7 +326,6 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   }
   if (length_to_read > 0)
     read_len = uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
-  xSemaphoreGive(this->lock_);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i]);
@@ -342,9 +338,7 @@ size_t IDFUARTComponent::available() {
   size_t available = 0;
   esp_err_t err;
 
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
   err = uart_get_buffered_data_len(this->uart_num_, &available);
-  xSemaphoreGive(this->lock_);
 
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_get_buffered_data_len failed: %s", esp_err_to_name(err));
@@ -358,9 +352,7 @@ size_t IDFUARTComponent::available() {
 
 void IDFUARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
-  xSemaphoreTake(this->lock_, portMAX_DELAY);
   uart_wait_tx_done(this->uart_num_, portMAX_DELAY);
-  xSemaphoreGive(this->lock_);
 }
 
 void IDFUARTComponent::check_logger_conflict() {}
@@ -405,8 +397,11 @@ void IDFUARTComponent::rx_event_task_func(void *param) {
 
         case UART_FIFO_OVF:
         case UART_BUFFER_FULL:
-          ESP_LOGW(TAG, "FIFO overflow or ring buffer full - clearing");
-          uart_flush_input(self->uart_num_);
+          // Don't call uart_flush_input() here - it races with read_array() on the main loop
+          // and can destroy data mid-read. The driver self-heals: uart_read_bytes() internally
+          // calls uart_check_buf_full() which moves stashed FIFO bytes into the ring buffer
+          // and re-enables RX interrupts once space is freed by normal reads.
+          ESP_LOGW(TAG, "FIFO overflow or ring buffer full");
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
           App.wake_loop_threadsafe();
 #endif

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -397,10 +397,13 @@ void IDFUARTComponent::rx_event_task_func(void *param) {
 
         case UART_FIFO_OVF:
         case UART_BUFFER_FULL:
-          // Don't call uart_flush_input() here - it races with read_array() on the main loop
-          // and can destroy data mid-read. The driver self-heals: uart_read_bytes() internally
-          // calls uart_check_buf_full() which moves stashed FIFO bytes into the ring buffer
-          // and re-enables RX interrupts once space is freed by normal reads.
+          // Don't call uart_flush_input() here — this task does not own the read side.
+          // ESP-IDF examples flush on overflow because the same task handles both events
+          // and reads, so flush and read are serialized. Here, reads happen on the main
+          // loop, so flushing from this task races with read_array() and can destroy data
+          // mid-read. The driver self-heals without an explicit flush: uart_read_bytes()
+          // calls uart_check_buf_full() after each chunk, which moves stashed FIFO bytes
+          // into the ring buffer and re-enables RX interrupts once space is freed.
           ESP_LOGW(TAG, "FIFO overflow or ring buffer full");
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
           App.wake_loop_threadsafe();

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -8,6 +8,13 @@
 
 namespace esphome::uart {
 
+/// ESP-IDF UART driver wrapper.
+///
+/// Thread safety: All public methods (read_array, write_array, peek_byte, available, flush,
+/// load_settings) must only be called from the main loop. The ESP-IDF UART driver API does not
+/// guarantee thread safety, and ESPHome's peek byte state (has_peek_/peek_byte_) is not
+/// synchronized. The rx_event_task (when enabled) must not call any of these methods — it
+/// communicates with the main loop exclusively via App.wake_loop_threadsafe().
 class IDFUARTComponent : public UARTComponent, public Component {
  public:
   void setup() override;
@@ -26,7 +33,9 @@ class IDFUARTComponent : public UARTComponent, public Component {
   void flush() override;
 
   uint8_t get_hw_serial_number() { return this->uart_num_; }
+#ifdef USE_UART_WAKE_LOOP_ON_RX
   QueueHandle_t *get_uart_event_queue() { return &this->uart_event_queue_; }
+#endif
 
   /**
    * Load the UART with the current settings.
@@ -46,18 +55,20 @@ class IDFUARTComponent : public UARTComponent, public Component {
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;
-  QueueHandle_t uart_event_queue_;
   uart_config_t get_config_();
-  SemaphoreHandle_t lock_;
 
   bool has_peek_{false};
   uint8_t peek_byte_;
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
-  // RX notification support
+  // RX notification support — runs on a separate FreeRTOS task.
+  // IMPORTANT: rx_event_task_func must NOT call any UART wrapper methods (read_array,
+  // write_array, etc.) or touch has_peek_/peek_byte_. It must only read from the
+  // event queue and call App.wake_loop_threadsafe().
   void start_rx_event_task_();
   static void rx_event_task_func(void *param);
 
+  QueueHandle_t uart_event_queue_;
   TaskHandle_t rx_event_task_handle_{nullptr};
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 };

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -10,11 +10,11 @@ namespace esphome::uart {
 
 /// ESP-IDF UART driver wrapper.
 ///
-/// Thread safety: All public methods (read_array, write_array, peek_byte, available, flush,
-/// load_settings) must only be called from the main loop. The ESP-IDF UART driver API does not
-/// guarantee thread safety, and ESPHome's peek byte state (has_peek_/peek_byte_) is not
-/// synchronized. The rx_event_task (when enabled) must not call any of these methods — it
-/// communicates with the main loop exclusively via App.wake_loop_threadsafe().
+/// Thread safety: All public methods must only be called from the main loop.
+/// The ESP-IDF UART driver API does not guarantee thread safety, and ESPHome's
+/// peek byte state (has_peek_/peek_byte_) is not synchronized. The rx_event_task
+/// (when enabled) must not call any of these methods — it communicates with the
+/// main loop exclusively via App.wake_loop_threadsafe().
 class IDFUARTComponent : public UARTComponent, public Component {
  public:
   void setup() override;


### PR DESCRIPTION
# What does this implement/fix?

Three changes to the ESP-IDF UART component, motivated by disassembly analysis showing `read_array()` is the hottest function on some devices:

## 1. Remove redundant `lock_` mutex

The FreeRTOS mutex (`lock_`) wrapped every ESP-IDF UART driver call (`read_array`, `write_array`, `peek_byte`, `available`, `flush`). A full codebase audit confirmed that **all five methods are called exclusively from the cooperative main loop** — no FreeRTOS task or ISR ever calls them. The lock was protecting single-threaded code from itself.

On the hot path (`read_array`), this added **4 unnecessary semaphore operations per call**: 2 in `available()` (called via `check_read_timeout_`) and 2 in `read_array()` itself. Each `xSemaphoreTake`/`xSemaphoreGive` pair involves a critical section, queue state inspection, and potential scheduler evaluation.

The ESP-IDF UART driver docs do not guarantee thread safety, but this is irrelevant — there is no concurrent access to protect against. No other platform's UART implementation (ESP8266, RP2040, LibreTiny) uses a lock. The lock was added as defensive boilerplate in the original ESP-IDF port (#2303, 2021-09-20) and was never needed.

## 2. Fix `uart_flush_input()` race in `rx_event_task`

The `rx_event_task_func` (introduced in #12172) called `uart_flush_input()` directly on the ESP-IDF driver from a separate FreeRTOS task on `UART_BUFFER_FULL`/`UART_FIFO_OVF` events — **without taking `lock_`**. This raced with `read_array()` on the main loop: the flush could wipe the driver's ring buffer mid-read, causing data loss.

The `uart_flush_input()` pattern was copied from ESP-IDF examples ([`uart_events`](https://github.com/espressif/esp-idf/blob/v5.5.2/examples/peripherals/uart/uart_events/main/uart_events_example_main.c), [`nmea0183_parser`](https://github.com/espressif/esp-idf/blob/v5.5.2/examples/peripherals/uart/nmea0183_parser/main/nmea_parser.c)) which flush and reset the queue on overflow events. In those examples this is safe because **the same task** handles both events and reads — flush and read are serialized in the same event loop and cannot interleave. In ESPHome's architecture, the event task (`rx_event_task`) and the reader (main loop) are **separate**, so the flush races with reads on the main loop.

The flush was also unnecessary. The ESP-IDF driver self-heals the buffer-full condition: [`uart_read_bytes()`](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_driver_uart/src/uart.c#L1623) internally calls [`uart_check_buf_full()`](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_driver_uart/src/uart.c#L1605) ([line 1640](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_driver_uart/src/uart.c#L1640), [line 1657](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_driver_uart/src/uart.c#L1657)), which moves stashed FIFO bytes into the ring buffer via `xRingbufferSend`, clears `rx_buffer_full_flg`, and [re-enables RX interrupts](https://github.com/espressif/esp-idf/blob/v5.5.2/components/esp_driver_uart/src/uart.c#L1616). Normal reads from the main loop drain the buffer and restore operation without any explicit flush.

## 3. Conditionally allocate event queue (only when `USE_UART_WAKE_LOOP_ON_RX`)

The UART event queue (20 entries × 12 bytes = ~320 bytes RAM per UART instance, plus FreeRTOS queue control block) was always allocated, even when no task existed to read from it. Moved `uart_event_queue_` and `get_uart_event_queue()` behind `#ifdef USE_UART_WAKE_LOOP_ON_RX`. When disabled, `uart_driver_install` is called with `queue_size=0` and `uart_queue=NULL` — the [documented API](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/uart.html#_CPPv419uart_driver_install11uart_port_tiiiP13QueueHandle_ti) for skipping the event queue. This also reduces ISR overhead since the driver skips `xQueueSendFromISR` when no queue exists.

## 4. Add thread safety documentation

Added class-level documentation and `rx_event_task` contract comments clarifying that all UART wrapper methods must only be called from the main loop.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing configuration changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is an internal optimization.
# Any existing UART configuration continues to work unchanged.
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).