### PR TITLE
[wifi] Deprecate wifi_ssid() in favor of wifi_ssid_to()

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -502,6 +502,8 @@ class WiFiComponent : public Component {
   }
 
   network::IPAddresses wifi_sta_ip_addresses();
+  // Remove before 2026.9.0
+  ESPDEPRECATED("Use wifi_ssid_to() instead. Removed in 2026.9.0", "2026.3.0")
   std::string wifi_ssid();
   /// Write SSID to buffer without heap allocation.
   /// Returns pointer to buffer, or empty string if not connected.


### PR DESCRIPTION
# What does this implement/fix?

Deprecates `WiFiComponent::wifi_ssid()` which returns `std::string` (heap-allocating) in favor of the existing buffer-based `wifi_ssid_to()` alternative.

All internal callers have already been migrated to `wifi_ssid_to()`. This marks the old method as deprecated with a 6-month removal window (2026.9.0) for any external components that may still use it.

**Migration:**
```cpp
// Before
std::string ssid = wifi_component->wifi_ssid();

// After
char ssid_buf[WiFiComponent::SSID_BUFFER_SIZE];
const char *ssid = wifi_component->wifi_ssid_to(ssid_buf);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a C++ API deprecation only
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).