### PR TITLE
[wifi] Use memcpy-based insertion sort for scan results

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cinttypes>
 #include <cmath>
+#include <type_traits>
 
 #ifdef USE_ESP32
 #if (ESP_IDF_VERSION_MAJOR >= 5 && ESP_IDF_VERSION_MINOR >= 1)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1319,20 +1319,58 @@ void WiFiComponent::start_scanning() {
 // Using insertion sort instead of std::stable_sort saves flash memory
 // by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)
 // IMPORTANT: This sort is stable (preserves relative order of equal elements)
+//
+// Uses raw memcpy instead of copy assignment to avoid CompactString's
+// destructor/constructor overhead (heap delete[]/new[] for long SSIDs).
+// Copy assignment calls ~CompactString() then placement-new for every shift,
+// which means delete[]/new[] per shift for heap-allocated SSIDs. With 70+
+// networks (e.g., captive portal showing full scan results), this caused
+// event loop blocking from hundreds of heap operations in a tight loop.
+//
+// This is safe because we're permuting elements within the same array —
+// each slot is overwritten exactly once, so no ownership duplication occurs.
+// All members of WiFiScanResult are either trivially copyable (bssid, channel,
+// rssi, priority, flags) or CompactString, which stores either inline data or
+// a heap pointer — never a self-referential pointer (unlike std::string's SSO
+// on some implementations). This was not possible before PR#13472 replaced
+// std::string with CompactString, since std::string's internal layout is
+// implementation-defined and may use self-referential pointers.
 template<typename VectorType> static void insertion_sort_scan_results(VectorType &results) {
+  // memcpy-based sort requires no self-referential pointers or virtual dispatch.
+  // These static_asserts guard the assumptions. If any fire, the memcpy sort
+  // must be reviewed for safety before updating the expected values.
+  //
+  // No vtable pointers (memcpy would corrupt vptr)
+  static_assert(!std::is_polymorphic<WiFiScanResult>::value, "WiFiScanResult must not have vtable");
+  static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable");
+  // Standard layout ensures predictable memory layout with no virtual bases
+  // and no mixed-access-specifier reordering
+  static_assert(std::is_standard_layout<WiFiScanResult>::value, "WiFiScanResult must be standard layout");
+  static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout");
+  // Size checks catch added/removed fields that may need safety review
+  static_assert(sizeof(WiFiScanResult) == 32, "WiFiScanResult size changed - verify memcpy sort is still safe");
+  static_assert(sizeof(CompactString) == 20, "CompactString size changed - verify memcpy sort is still safe");
+  // Alignment must match for reinterpret_cast of key_buf to be valid
+  static_assert(alignof(WiFiScanResult) <= alignof(std::max_align_t), "WiFiScanResult alignment exceeds max_align_t");
   const size_t size = results.size();
+  constexpr size_t elem_size = sizeof(WiFiScanResult);
+  // Suppress warnings for intentional memcpy on non-trivially-copyable type.
+  // Safety is guaranteed by the static_asserts above and the permutation invariant.
+  // NOLINTNEXTLINE(bugprone-undefined-memory-manipulation)
+  auto *memcpy_fn = &memcpy;
   for (size_t i = 1; i < size; i++) {
-    // Make a copy to avoid issues with move semantics during comparison
-    WiFiScanResult key = results[i];
+    alignas(WiFiScanResult) uint8_t key_buf[elem_size];
+    memcpy_fn(key_buf, &results[i], elem_size);
+    const auto &key = *reinterpret_cast<const WiFiScanResult *>(key_buf);
     int32_t j = i - 1;
 
     // Move elements that are worse than key to the right
     // For stability, we only move if key is strictly better than results[j]
     while (j >= 0 && wifi_scan_result_is_better(key, results[j])) {
-      results[j + 1] = results[j];
+      memcpy_fn(&results[j + 1], &results[j], elem_size);
       j--;
     }
-    results[j + 1] = key;
+    memcpy_fn(&results[j + 1], key_buf, elem_size);
   }
 }
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1336,6 +1336,9 @@ void WiFiComponent::start_scanning() {
 // on some implementations). This was not possible before PR#13472 replaced
 // std::string with CompactString, since std::string's internal layout is
 // implementation-defined and may use self-referential pointers.
+//
+// TODO: If C++ standardizes std::trivially_relocatable, add the assertion for
+// WiFiScanResult/CompactString here to formally express the memcpy safety guarantee.
 template<typename VectorType> static void insertion_sort_scan_results(VectorType &results) {
   // memcpy-based sort requires no self-referential pointers or virtual dispatch.
   // These static_asserts guard the assumptions. If any fire, the memcpy sort

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -219,6 +219,12 @@ class CompactString {
 };
 
 static_assert(sizeof(CompactString) == 20, "CompactString must be exactly 20 bytes");
+// CompactString is safe to memcpy for permutation-based sorting (no ownership duplication).
+// Unlike libstdc++ std::string which uses a self-referential pointer (_M_p -> _M_local_buf)
+// in SSO mode, CompactString stores either inline data or an external heap pointer in
+// storage_[] — never a pointer to itself. These asserts guard that property.
+static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout for memcpy safety");
+static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable for memcpy safety");
 
 class WiFiAP {
   friend class WiFiComponent;

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -10,6 +10,7 @@
 
 #include <span>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #ifdef USE_LIBRETINY
@@ -219,12 +220,14 @@ class CompactString {
 };
 
 static_assert(sizeof(CompactString) == 20, "CompactString must be exactly 20 bytes");
-// CompactString is safe to memcpy for permutation-based sorting (no ownership duplication).
-// Unlike libstdc++ std::string which uses a self-referential pointer (_M_p -> _M_local_buf)
-// in SSO mode, CompactString stores either inline data or an external heap pointer in
-// storage_[] — never a pointer to itself. These asserts guard that property.
-static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout for memcpy safety");
-static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable for memcpy safety");
+// CompactString is not trivially copyable (non-trivial destructor/copy for heap case).
+// However, its layout has no self-referential pointers: storage_[] contains either inline
+// data or an external heap pointer — never a pointer to itself. This is unlike libstdc++
+// std::string SSO where _M_p points to _M_local_buf within the same object.
+// This property allows memcpy-based permutation sorting where each element ends up in
+// exactly one slot (no ownership duplication). These asserts document that layout property.
+static_assert(std::is_standard_layout<CompactString>::value, "CompactString must be standard layout");
+static_assert(!std::is_polymorphic<CompactString>::value, "CompactString must not have vtable");
 
 class WiFiAP {
   friend class WiFiComponent;


### PR DESCRIPTION
# What does this implement/fix?

Use raw memcpy instead of copy-assignment in the WiFi scan result insertion sort to eliminate event loop blocking during captive portal transitions and reduce pressure during post-connect roaming scans.

**The problem:** The insertion sort previously used copy-assignment to shift elements, which for any non-trivially-copyable string type means destructor + constructor calls per shift. With `std::string`, this was unavoidable since its internal layout is implementation-defined (libstdc++ SSO uses a self-referential pointer). Now that #13472 replaced `std::string` with `CompactString` — which has a known layout with no self-referential pointers — we can safely use `memcpy` instead.

With 70+ networks visible during captive portal transition (when `needs_full_scan_results_()` returns true), the copy-assignment approach caused hundreds of heap operations in a tight loop, blocking the event loop which normally runs ~7000 iterations/min on ESP8266.

Additionally, post-connect roaming scans run in the background after everything is started — the API server, web server, sensors, etc. are all active and sharing the event loop. Minimizing pressure from the sort is important to avoid disrupting these services during periodic roaming scans.

**The fix:** Use raw `memcpy` to shuffle elements during insertion sort. This is safe because:
- We're permuting elements within the same array — each slot is overwritten exactly once, no ownership duplication
- `CompactString` stores either inline data or an external heap pointer in `storage_[]` — never a self-referential pointer (unlike libstdc++ `std::string` SSO where `_M_p` points to `_M_local_buf`)
- All other fields in `WiFiScanResult` are trivially copyable

**Results:**
- **192 bytes flash saved** on ESP8266 (eliminates `CompactString` copy ctor/assignment code from sort)
- **1.6-2.6x faster** sort (benchmarked on host, ratio holds on device)
- **Event loop blocking eliminated** during captive portal transition (confirmed on real device)
- **No risk of event loop blocking** during post-connect roaming scans — zero heap operations means the sort completes in predictable time regardless of network count
- WiFi connection slightly faster

Static asserts guard all memcpy safety assumptions at compile time (`is_polymorphic`, `is_standard_layout`, `sizeof`, `alignof`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- followup to #13472

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).