### PR TITLE
[docker] Suppress git detached HEAD advice

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ FROM ghcr.io/esphome/docker-base:${BUILD_OS}-ha-addon-${BUILD_BASE_VERSION} AS b
 ARG BUILD_TYPE
 FROM base-source-${BUILD_TYPE} AS base
 
-RUN git config --system --add safe.directory "*"
+RUN git config --system --add safe.directory "*" \
+    && git config --system advice.detachedHead false
 
 # Install build tools for Python packages that require compilation
 # (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager)


### PR DESCRIPTION
# What does this implement/fix?

Suppress the git "detached HEAD" advice message that appears repeatedly during PlatformIO dependency installation. PlatformIO clones dependencies by checking out specific tags/commits, which triggers this verbose advice for every dependency without providing useful information to the user.

Example of the noise this removes (repeated per dependency):
```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing configuration changes.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is a Docker build improvement.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).