### PR TITLE
[web_server] Flatten deq_push_back_with_dedup_ to inline vector realloc

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -198,7 +198,8 @@ EntityMatchResult UrlMatch::match_entity(EntityBase *entity) const {
 
 #if !defined(USE_ESP32) && defined(USE_ARDUINO)
 // helper for allowing only unique entries in the queue
-void DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
+void __attribute__((flatten))
+DeferredUpdateEventSource::deq_push_back_with_dedup_(void *source, message_generator_t *message_generator) {
   DeferredEvent item(source, message_generator);
 
   // Use range-based for loop instead of std::find_if to reduce template instantiation overhead and binary size


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 (GCC 10.3), `std::vector::push_back()` in `deq_push_back_with_dedup_()` emits a separate `_M_realloc_insert<DeferredEvent>` function (198 bytes) even though it's only called from one site. Adding `__attribute__((flatten))` forces the compiler to inline it, eliminating the out-of-line function's prologue/epilogue and call overhead.

This matches what GCC 14.2 (ESP-IDF/ESP32 toolchain) already does naturally for the equivalent code in `web_server_idf.cpp`.

### Binary size impact (ESP8266, `athom-rgbct-light`)

| Symbol | Before | After |
|---|---|---|
| `deq_push_back_with_dedup_` | 73 B | 207 B (+134) |
| `_M_realloc_insert<DeferredEvent>` | 198 B | 0 (inlined) |
| **Net flash** | **466,253 B** | **466,173 B (-80 B)** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).