### PR TITLE
[core] Flatten single-callsite vector realloc functions

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1864,6 +1864,8 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
+void __attribute__((flatten)) APIConnection::DeferredBatch::push_item(const BatchItem &item) { items.push_back(item); }
+
 void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
                                             uint8_t aux_data_index) {
   // Check if we already have a message of this type for this entity
@@ -1880,7 +1882,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_
     }
   }
   // No existing item found (or event), add new one
-  items.push_back({entity, message_type, estimated_size, aux_data_index});
+  this->push_item({entity, message_type, estimated_size, aux_data_index});
 }
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
@@ -1888,7 +1890,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t me
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
-  items.push_back({entity, message_type, estimated_size, AUX_DATA_UNUSED});
+  this->push_item({entity, message_type, estimated_size, AUX_DATA_UNUSED});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front
     std::swap(items.front(), items.back());

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1864,7 +1864,7 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
-void __attribute__((flatten)) APIConnection::DeferredBatch::push_item_(const BatchItem &item) { items.push_back(item); }
+void __attribute__((flatten)) APIConnection::DeferredBatch::push_item(const BatchItem &item) { items.push_back(item); }
 
 void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
                                             uint8_t aux_data_index) {
@@ -1882,7 +1882,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_
     }
   }
   // No existing item found (or event), add new one
-  this->push_item_({entity, message_type, estimated_size, aux_data_index});
+  this->push_item({entity, message_type, estimated_size, aux_data_index});
 }
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
@@ -1890,7 +1890,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t me
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
-  this->push_item_({entity, message_type, estimated_size, AUX_DATA_UNUSED});
+  this->push_item({entity, message_type, estimated_size, AUX_DATA_UNUSED});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front
     std::swap(items.front(), items.back());

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1864,6 +1864,8 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
+void __attribute__((flatten)) APIConnection::DeferredBatch::push_item_(const BatchItem &item) { items.push_back(item); }
+
 void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
                                             uint8_t aux_data_index) {
   // Check if we already have a message of this type for this entity
@@ -1880,7 +1882,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_
     }
   }
   // No existing item found (or event), add new one
-  items.push_back({entity, message_type, estimated_size, aux_data_index});
+  this->push_item_({entity, message_type, estimated_size, aux_data_index});
 }
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
@@ -1888,7 +1890,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t me
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
-  items.push_back({entity, message_type, estimated_size, AUX_DATA_UNUSED});
+  this->push_item_({entity, message_type, estimated_size, AUX_DATA_UNUSED});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front
     std::swap(items.front(), items.back());

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1864,8 +1864,6 @@ void APIConnection::on_fatal_error() {
   this->flags_.remove = true;
 }
 
-void __attribute__((flatten)) APIConnection::DeferredBatch::push_item(const BatchItem &item) { items.push_back(item); }
-
 void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_type, uint8_t estimated_size,
                                             uint8_t aux_data_index) {
   // Check if we already have a message of this type for this entity
@@ -1882,7 +1880,7 @@ void APIConnection::DeferredBatch::add_item(EntityBase *entity, uint8_t message_
     }
   }
   // No existing item found (or event), add new one
-  this->push_item({entity, message_type, estimated_size, aux_data_index});
+  items.push_back({entity, message_type, estimated_size, aux_data_index});
 }
 
 void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size) {
@@ -1890,7 +1888,7 @@ void APIConnection::DeferredBatch::add_item_front(EntityBase *entity, uint8_t me
   // This avoids expensive vector::insert which shifts all elements
   // Note: We only ever have one high-priority message at a time (ping OR disconnect)
   // If we're disconnecting, pings are blocked, so this simple swap is sufficient
-  this->push_item({entity, message_type, estimated_size, AUX_DATA_UNUSED});
+  items.push_back({entity, message_type, estimated_size, AUX_DATA_UNUSED});
   if (items.size() > 1) {
     // Swap the new high-priority item to the front
     std::swap(items.front(), items.back());

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -541,6 +541,8 @@ class APIConnection final : public APIServerConnectionBase {
                   uint8_t aux_data_index = AUX_DATA_UNUSED);
     // Add item to the front of the batch (for high priority messages like ping)
     void add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size);
+    // Single push_back site to avoid duplicate _M_realloc_insert instantiation
+    void push_item(const BatchItem &item);
 
     // Clear all items
     void clear() {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -542,7 +542,7 @@ class APIConnection final : public APIServerConnectionBase {
     // Add item to the front of the batch (for high priority messages like ping)
     void add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size);
     // Single push_back site to avoid duplicate _M_realloc_insert instantiation
-    void push_item_(const BatchItem &item);
+    void push_item(const BatchItem &item);
 
     // Clear all items
     void clear() {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -541,8 +541,6 @@ class APIConnection final : public APIServerConnectionBase {
                   uint8_t aux_data_index = AUX_DATA_UNUSED);
     // Add item to the front of the batch (for high priority messages like ping)
     void add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size);
-    // Single push_back site to avoid duplicate _M_realloc_insert instantiation
-    void push_item(const BatchItem &item);
 
     // Clear all items
     void clear() {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -541,6 +541,8 @@ class APIConnection final : public APIServerConnectionBase {
                   uint8_t aux_data_index = AUX_DATA_UNUSED);
     // Add item to the front of the batch (for high priority messages like ping)
     void add_item_front(EntityBase *entity, uint8_t message_type, uint8_t estimated_size);
+    // Single push_back site to avoid duplicate _M_realloc_insert instantiation
+    void push_item_(const BatchItem &item);
 
     // Clear all items
     void clear() {

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -195,7 +195,7 @@ void APIServer::remove_client_(size_t client_index) {
 #endif
 }
 
-void APIServer::accept_new_connections_() {
+void __attribute__((flatten)) APIServer::accept_new_connections_() {
   while (true) {
     struct sockaddr_storage source_addr;
     socklen_t addr_len = sizeof(source_addr);

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -195,7 +195,7 @@ void APIServer::remove_client_(size_t client_index) {
 #endif
 }
 
-void __attribute__((flatten)) APIServer::accept_new_connections_() {
+void APIServer::accept_new_connections_() {
   while (true) {
     struct sockaddr_storage source_addr;
     socklen_t addr_len = sizeof(source_addr);

--- a/esphome/components/web_server_base/web_server_base.cpp
+++ b/esphome/components/web_server_base/web_server_base.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "web_server_base";
 
 WebServerBase *global_web_server_base = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-void WebServerBase::add_handler(AsyncWebHandler *handler) {
+void __attribute__((flatten)) WebServerBase::add_handler(AsyncWebHandler *handler) {
   // remove all handlers
 
 #ifdef USE_WEBSERVER_AUTH

--- a/esphome/components/web_server_base/web_server_base.cpp
+++ b/esphome/components/web_server_base/web_server_base.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "web_server_base";
 
 WebServerBase *global_web_server_base = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-void __attribute__((flatten)) WebServerBase::add_handler(AsyncWebHandler *handler) {
+void WebServerBase::add_handler(AsyncWebHandler *handler) {
   // remove all handlers
 
 #ifdef USE_WEBSERVER_AUTH

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -487,6 +487,19 @@ bool WiFiComponent::matches_configured_network_(const char *ssid, const uint8_t 
   return false;
 }
 
+void __attribute__((flatten)) WiFiComponent::set_sta_priority(bssid_t bssid, int8_t priority) {
+  for (auto &it : this->sta_priorities_) {
+    if (it.bssid == bssid) {
+      it.priority = priority;
+      return;
+    }
+  }
+  this->sta_priorities_.push_back(WiFiSTAPriority{
+      .bssid = bssid,
+      .priority = priority,
+  });
+}
+
 void WiFiComponent::log_discarded_scan_result_(const char *ssid, const uint8_t *bssid, int8_t rssi, uint8_t channel) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   // Skip logging during roaming scans to avoid log buffer overflow

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -487,7 +487,7 @@ bool WiFiComponent::matches_configured_network_(const char *ssid, const uint8_t 
   return false;
 }
 
-void __attribute__((flatten)) WiFiComponent::set_sta_priority(const bssid_t bssid, int8_t priority) {
+void __attribute__((flatten)) WiFiComponent::set_sta_priority(bssid_t bssid, int8_t priority) {
   for (auto &it : this->sta_priorities_) {
     if (it.bssid == bssid) {
       it.priority = priority;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -487,6 +487,19 @@ bool WiFiComponent::matches_configured_network_(const char *ssid, const uint8_t 
   return false;
 }
 
+void __attribute__((flatten)) WiFiComponent::set_sta_priority(const bssid_t bssid, int8_t priority) {
+  for (auto &it : this->sta_priorities_) {
+    if (it.bssid == bssid) {
+      it.priority = priority;
+      return;
+    }
+  }
+  this->sta_priorities_.push_back(WiFiSTAPriority{
+      .bssid = bssid,
+      .priority = priority,
+  });
+}
+
 void WiFiComponent::log_discarded_scan_result_(const char *ssid, const uint8_t *bssid, int8_t rssi, uint8_t channel) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   // Skip logging during roaming scans to avoid log buffer overflow

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -487,19 +487,6 @@ bool WiFiComponent::matches_configured_network_(const char *ssid, const uint8_t 
   return false;
 }
 
-void __attribute__((flatten)) WiFiComponent::set_sta_priority(bssid_t bssid, int8_t priority) {
-  for (auto &it : this->sta_priorities_) {
-    if (it.bssid == bssid) {
-      it.priority = priority;
-      return;
-    }
-  }
-  this->sta_priorities_.push_back(WiFiSTAPriority{
-      .bssid = bssid,
-      .priority = priority,
-  });
-}
-
 void WiFiComponent::log_discarded_scan_result_(const char *ssid, const uint8_t *bssid, int8_t rssi, uint8_t channel) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   // Skip logging during roaming scans to avoid log buffer overflow

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -488,7 +488,18 @@ class WiFiComponent : public Component {
     }
     return 0;
   }
-  void set_sta_priority(bssid_t bssid, int8_t priority);
+  void set_sta_priority(const bssid_t &bssid, int8_t priority) {
+    for (auto &it : this->sta_priorities_) {
+      if (it.bssid == bssid) {
+        it.priority = priority;
+        return;
+      }
+    }
+    this->sta_priorities_.push_back(WiFiSTAPriority{
+        .bssid = bssid,
+        .priority = priority,
+    });
+  }
 
   network::IPAddresses wifi_sta_ip_addresses();
   // Remove before 2026.9.0

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -488,18 +488,7 @@ class WiFiComponent : public Component {
     }
     return 0;
   }
-  void set_sta_priority(const bssid_t bssid, int8_t priority) {
-    for (auto &it : this->sta_priorities_) {
-      if (it.bssid == bssid) {
-        it.priority = priority;
-        return;
-      }
-    }
-    this->sta_priorities_.push_back(WiFiSTAPriority{
-        .bssid = bssid,
-        .priority = priority,
-    });
-  }
+  void set_sta_priority(const bssid_t bssid, int8_t priority);
 
   network::IPAddresses wifi_sta_ip_addresses();
   // Remove before 2026.9.0

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -488,7 +488,7 @@ class WiFiComponent : public Component {
     }
     return 0;
   }
-  void set_sta_priority(const bssid_t bssid, int8_t priority);
+  void set_sta_priority(bssid_t bssid, int8_t priority);
 
   network::IPAddresses wifi_sta_ip_addresses();
   // Remove before 2026.9.0

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -488,18 +488,7 @@ class WiFiComponent : public Component {
     }
     return 0;
   }
-  void set_sta_priority(const bssid_t &bssid, int8_t priority) {
-    for (auto &it : this->sta_priorities_) {
-      if (it.bssid == bssid) {
-        it.priority = priority;
-        return;
-      }
-    }
-    this->sta_priorities_.push_back(WiFiSTAPriority{
-        .bssid = bssid,
-        .priority = priority,
-    });
-  }
+  void set_sta_priority(bssid_t bssid, int8_t priority);
 
   network::IPAddresses wifi_sta_ip_addresses();
   // Remove before 2026.9.0


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266 (GCC 10.3), `std::vector::push_back()`/`emplace_back()` emit separate `_M_realloc_insert` template functions even when called from only one site. Adding `__attribute__((flatten))` forces the compiler to inline the realloc path into the caller, saving the out-of-line function overhead (prologue/epilogue, call glue, intermediate `$isra` clones).

This is the same technique as #13968, applied to additional vectors:

- **`wifi`**: Move `set_sta_priority()` from header to `.cpp` (eliminates duplicate template instantiation at 2 inline call sites) and add `flatten` — saves `_M_realloc_insert<WiFiSTAPriority>` (195 B) indirection
- **`api`**: Flatten `accept_new_connections_()` — saves `_M_realloc_insert<unique_ptr<APIConnection>>` (186 B) indirection
- **`api`**: Extract `DeferredBatch::push_item_()` as single flattened `push_back` site — was 2 call sites in `add_item`/`add_item_front`, saves `_M_realloc_insert<BatchItem>` (198 B) indirection

### Binary size impact

**ESP8266** (`athom-rgbct-light`):

| | Flash |
|---|---|
| Before | 466,173 B |
| After | 465,949 B |
| **Saved** | **~224 B** |

**ESP32 IDF** (`gatetrigger`):

| | Flash |
|---|---|
| Before | 450,455 B |
| After | 450,415 B |
| **Saved** | **~40 B** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #13968

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).