### PR TITLE
[api] Fix ESP8266 noise API handshake deadlock and prompt socket cleanup

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -148,12 +148,16 @@ void APIServer::loop() {
   while (client_index < this->clients_.size()) {
     auto &client = this->clients_[client_index];
 
+    // Common case: process active client
+    if (!client->flags_.remove) {
+      client->loop();
+    }
+    // Handle disconnection promptly - close socket to free LWIP PCB
+    // resources and prevent retransmit crashes on ESP8266.
     if (client->flags_.remove) {
       // Rare case: handle disconnection (don't increment - swapped element needs processing)
       this->remove_client_(client_index);
     } else {
-      // Common case: process active client
-      client->loop();
       client_index++;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes two ESP8266 regressions with noise encryption API connections:

**1. Handshake deadlock**

The noise handshake loop re-checked `socket->ready()` on each iteration. On ESP32, `ready()` is cached via `select()` and stays true until the next main loop. On ESP8266 LWIP raw TCP, `ready()` returns the live state — it becomes false as soon as the rx buffer is consumed by a read. Since the noise handshake involves both reads **and** writes, after reading the client's handshake message the rx buffer is empty, `ready()` returns false, and the loop exits before the server can write its response. This deadlocks the handshake: the server won't write because `ready()` is false, and the client won't send because it's waiting for the server's response. The client eventually times out and closes the connection.

Fix: cache `ready()` once before entering the loop so write actions aren't blocked after reads consume the rx buffer.

**2. LWIP PCB retransmit crash**

After `on_fatal_error()`, the socket close was deferred to `APIServer::loop()` on the next iteration. On ESP8266, this left the LWIP PCB alive too long, allowing retransmit timers to fire on a connection in a bad state, causing a crash in `tcp_rexmit` with a null pointer dereference (`excvaddr=0x0000000E`).

Fix: process client removal (and socket close) immediately after `client->loop()` sets the remove flag, instead of deferring to the next server loop iteration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any ESP8266 config with noise encryption
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).