### PR TITLE
[core] Make LOG_ENTITY_ICON a no-op when icons are compiled out

### DIFF
--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -152,11 +152,13 @@ void EntityBase_UnitOfMeasurement::set_unit_of_measurement(const char *unit_of_m
   this->unit_of_measurement_ = unit_of_measurement;
 }
 
+#ifdef USE_ENTITY_ICON
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj) {
   if (!obj.get_icon_ref().empty()) {
     ESP_LOGCONFIG(tag, "%s  Icon: '%s'", prefix, obj.get_icon_ref().c_str());
   }
 }
+#endif
 
 void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj) {
   if (!obj.get_device_class_ref().empty()) {

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -231,8 +231,12 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
 };
 
 /// Log entity icon if set (for use in dump_config)
+#ifdef USE_ENTITY_ICON
 #define LOG_ENTITY_ICON(tag, prefix, obj) log_entity_icon(tag, prefix, obj)
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
+#else
+#define LOG_ENTITY_ICON(tag, prefix, obj)
+#endif
 /// Log entity device class if set (for use in dump_config)
 #define LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj) log_entity_device_class(tag, prefix, obj)
 void log_entity_device_class(const char *tag, const char *prefix, const EntityBase_DeviceClass &obj);

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -235,7 +235,8 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
 #define LOG_ENTITY_ICON(tag, prefix, obj) log_entity_icon(tag, prefix, obj)
 void log_entity_icon(const char *tag, const char *prefix, const EntityBase &obj);
 #else
-#define LOG_ENTITY_ICON(tag, prefix, obj)
+#define LOG_ENTITY_ICON(tag, prefix, obj) ((void) 0)
+inline void log_entity_icon(const char *, const char *, const EntityBase &) {}
 #endif
 /// Log entity device class if set (for use in dump_config)
 #define LOG_ENTITY_DEVICE_CLASS(tag, prefix, obj) log_entity_device_class(tag, prefix, obj)


### PR DESCRIPTION
# What does this implement/fix?

When `USE_ENTITY_ICON` is not defined, `LOG_ENTITY_ICON` now compiles to nothing instead of calling `log_entity_icon()` which would just check an always-empty icon reference and return.

This guards both the macro and the function definition with `#ifdef USE_ENTITY_ICON`, so all 13 call sites across components become true no-ops when icons are compiled out — eliminating dead function calls and saving code size.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).