### PR TITLE
[nfc] Replace constant std::vector with static constexpr std::array

### DIFF
--- a/esphome/components/pn532/pn532.h
+++ b/esphome/components/pn532/pn532.h
@@ -76,7 +76,7 @@ class PN532 : public PollingComponent {
 
   std::unique_ptr<nfc::NfcTag> read_mifare_classic_tag_(nfc::NfcTagUid &uid);
   bool read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
-  bool write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
+  bool write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len);
   bool auth_mifare_classic_block_(nfc::NfcTagUid &uid, uint8_t block_num, uint8_t key_num, const uint8_t *key);
   bool format_mifare_classic_mifare_(nfc::NfcTagUid &uid);
   bool format_mifare_classic_ndef_(nfc::NfcTagUid &uid);
@@ -88,7 +88,7 @@ class PN532 : public PollingComponent {
   uint16_t read_mifare_ultralight_capacity_();
   bool find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint8_t &message_length,
                                     uint8_t &message_start_index);
-  bool write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data);
+  bool write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len);
   bool write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *message);
   bool clean_mifare_ultralight_();
 

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <memory>
 
 #include "pn532.h"
@@ -106,10 +107,10 @@ bool PN532::auth_mifare_classic_block_(nfc::NfcTagUid &uid, uint8_t block_num, u
 }
 
 bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
-  std::vector<uint8_t> blank_buffer(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> trailer_buffer(
-      {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   bool error = false;
 
@@ -118,20 +119,20 @@ bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
       continue;
     }
     if (block != 0) {
-      if (!this->write_mifare_classic_block_(block, blank_buffer)) {
+      if (!this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
         error = true;
       }
     }
-    if (!this->write_mifare_classic_block_(block + 1, blank_buffer)) {
+    if (!this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 1);
       error = true;
     }
-    if (!this->write_mifare_classic_block_(block + 2, blank_buffer)) {
+    if (!this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 2);
       error = true;
     }
-    if (!this->write_mifare_classic_block_(block + 3, trailer_buffer)) {
+    if (!this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 3);
       error = true;
     }
@@ -141,28 +142,28 @@ bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
 }
 
 bool PN532::format_mifare_classic_ndef_(nfc::NfcTagUid &uid) {
-  std::vector<uint8_t> empty_ndef_message(
-      {0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> blank_block(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> block_1_data(
-      {0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_2_data(
-      {0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_3_trailer(
-      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  std::vector<uint8_t> ndef_trailer(
-      {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+      0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+      0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+      0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+      0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+      0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (!this->auth_mifare_classic_block_(uid, 0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY)) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting!");
     return false;
   }
-  if (!this->write_mifare_classic_block_(1, block_1_data))
+  if (!this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()))
     return false;
-  if (!this->write_mifare_classic_block_(2, block_2_data))
+  if (!this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()))
     return false;
-  if (!this->write_mifare_classic_block_(3, block_3_trailer))
+  if (!this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()))
     return false;
 
   ESP_LOGD(TAG, "Sector 0 formatted to NDEF");
@@ -172,36 +173,36 @@ bool PN532::format_mifare_classic_ndef_(nfc::NfcTagUid &uid) {
       return false;
     }
     if (block == 4) {
-      if (!this->write_mifare_classic_block_(block, empty_ndef_message)) {
+      if (!this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
       }
     } else {
-      if (!this->write_mifare_classic_block_(block, blank_block)) {
+      if (!this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
       }
     }
-    if (!this->write_mifare_classic_block_(block + 1, blank_block)) {
+    if (!this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 1);
     }
-    if (!this->write_mifare_classic_block_(block + 2, blank_block)) {
+    if (!this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 2);
     }
-    if (!this->write_mifare_classic_block_(block + 3, ndef_trailer)) {
+    if (!this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size())) {
       ESP_LOGE(TAG, "Unable to write trailer block %d", block + 3);
     }
   }
   return true;
 }
 
-bool PN532::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &write_data) {
-  std::vector<uint8_t> data({
+bool PN532::write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len) {
+  std::vector<uint8_t> cmd({
       PN532_COMMAND_INDATAEXCHANGE,
       0x01,  // One card
       nfc::MIFARE_CMD_WRITE,
       block_num,
   });
-  data.insert(data.end(), write_data.begin(), write_data.end());
-  if (!this->write_command_(data)) {
+  cmd.insert(cmd.end(), data, data + len);
+  if (!this->write_command_(cmd)) {
     ESP_LOGE(TAG, "Error writing block %d", block_num);
     return false;
   }
@@ -243,8 +244,7 @@ bool PN532::write_mifare_classic_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *mes
       }
     }
 
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_CLASSIC_BLOCK_SIZE);
-    if (!this->write_mifare_classic_block_(current_block, data)) {
+    if (!this->write_mifare_classic_block_(current_block, encoded.data() + index, nfc::MIFARE_CLASSIC_BLOCK_SIZE)) {
       return false;
     }
     index += nfc::MIFARE_CLASSIC_BLOCK_SIZE;

--- a/esphome/components/pn532/pn532_mifare_classic.cpp
+++ b/esphome/components/pn532/pn532_mifare_classic.cpp
@@ -107,9 +107,9 @@ bool PN532::auth_mifare_classic_block_(nfc::NfcTagUid &uid, uint8_t block_num, u
 }
 
 bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BUFFER = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> TRAILER_BUFFER = {
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   bool error = false;
@@ -119,20 +119,20 @@ bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
       continue;
     }
     if (block != 0) {
-      if (!this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size())) {
+      if (!this->write_mifare_classic_block_(block, BLANK_BUFFER.data(), BLANK_BUFFER.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
         error = true;
       }
     }
-    if (!this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size())) {
+    if (!this->write_mifare_classic_block_(block + 1, BLANK_BUFFER.data(), BLANK_BUFFER.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 1);
       error = true;
     }
-    if (!this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size())) {
+    if (!this->write_mifare_classic_block_(block + 2, BLANK_BUFFER.data(), BLANK_BUFFER.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 2);
       error = true;
     }
-    if (!this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size())) {
+    if (!this->write_mifare_classic_block_(block + 3, TRAILER_BUFFER.data(), TRAILER_BUFFER.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 3);
       error = true;
     }
@@ -142,28 +142,28 @@ bool PN532::format_mifare_classic_mifare_(nfc::NfcTagUid &uid) {
 }
 
 bool PN532::format_mifare_classic_ndef_(nfc::NfcTagUid &uid) {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> EMPTY_NDEF_MESSAGE = {
       0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BLOCK = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_1_DATA = {
       0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_2_DATA = {
       0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_3_TRAILER = {
       0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> NDEF_TRAILER = {
       0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (!this->auth_mifare_classic_block_(uid, 0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY)) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting!");
     return false;
   }
-  if (!this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()))
+  if (!this->write_mifare_classic_block_(1, BLOCK_1_DATA.data(), BLOCK_1_DATA.size()))
     return false;
-  if (!this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()))
+  if (!this->write_mifare_classic_block_(2, BLOCK_2_DATA.data(), BLOCK_2_DATA.size()))
     return false;
-  if (!this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()))
+  if (!this->write_mifare_classic_block_(3, BLOCK_3_TRAILER.data(), BLOCK_3_TRAILER.size()))
     return false;
 
   ESP_LOGD(TAG, "Sector 0 formatted to NDEF");
@@ -173,21 +173,21 @@ bool PN532::format_mifare_classic_ndef_(nfc::NfcTagUid &uid) {
       return false;
     }
     if (block == 4) {
-      if (!this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size())) {
+      if (!this->write_mifare_classic_block_(block, EMPTY_NDEF_MESSAGE.data(), EMPTY_NDEF_MESSAGE.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
       }
     } else {
-      if (!this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size())) {
+      if (!this->write_mifare_classic_block_(block, BLANK_BLOCK.data(), BLANK_BLOCK.size())) {
         ESP_LOGE(TAG, "Unable to write block %d", block);
       }
     }
-    if (!this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size())) {
+    if (!this->write_mifare_classic_block_(block + 1, BLANK_BLOCK.data(), BLANK_BLOCK.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 1);
     }
-    if (!this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size())) {
+    if (!this->write_mifare_classic_block_(block + 2, BLANK_BLOCK.data(), BLANK_BLOCK.size())) {
       ESP_LOGE(TAG, "Unable to write block %d", block + 2);
     }
-    if (!this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size())) {
+    if (!this->write_mifare_classic_block_(block + 3, NDEF_TRAILER.data(), NDEF_TRAILER.size())) {
       ESP_LOGE(TAG, "Unable to write trailer block %d", block + 3);
     }
   }

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -157,10 +157,10 @@ bool PN532::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> BLANK_DATA = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (!this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size())) {
+    if (!this->write_mifare_ultralight_page_(i, BLANK_DATA.data(), BLANK_DATA.size())) {
       return false;
     }
   }

--- a/esphome/components/pn532/pn532_mifare_ultralight.cpp
+++ b/esphome/components/pn532/pn532_mifare_ultralight.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <memory>
 
 #include "pn532.h"
@@ -143,8 +144,7 @@ bool PN532::write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, nfc::NdefMessage *
   uint8_t current_page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
   while (index < buffer_length) {
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_ULTRALIGHT_PAGE_SIZE);
-    if (!this->write_mifare_ultralight_page_(current_page, data)) {
+    if (!this->write_mifare_ultralight_page_(current_page, encoded.data() + index, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE)) {
       return false;
     }
     index += nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;
@@ -157,25 +157,25 @@ bool PN532::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  std::vector<uint8_t> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (!this->write_mifare_ultralight_page_(i, blank_data)) {
+    if (!this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size())) {
       return false;
     }
   }
   return true;
 }
 
-bool PN532::write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data) {
-  std::vector<uint8_t> data({
+bool PN532::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len) {
+  std::vector<uint8_t> cmd({
       PN532_COMMAND_INDATAEXCHANGE,
       0x01,  // One card
       nfc::MIFARE_CMD_WRITE_ULTRALIGHT,
       page_num,
   });
-  data.insert(data.end(), write_data.begin(), write_data.end());
-  if (!this->write_command_(data)) {
+  cmd.insert(cmd.end(), write_data, write_data + len);
+  if (!this->write_command_(cmd)) {
     ESP_LOGE(TAG, "Error writing page %u", page_num);
     return false;
   }

--- a/esphome/components/pn7150/pn7150.h
+++ b/esphome/components/pn7150/pn7150.h
@@ -236,7 +236,7 @@ class PN7150 : public nfc::Nfcc, public Component {
 
   uint8_t read_mifare_classic_tag_(nfc::NfcTag &tag);
   uint8_t read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
-  uint8_t write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
+  uint8_t write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len);
   uint8_t auth_mifare_classic_block_(uint8_t block_num, uint8_t key_num, const uint8_t *key);
   uint8_t sect_to_auth_(uint8_t block_num);
   uint8_t format_mifare_classic_mifare_();
@@ -250,7 +250,7 @@ class PN7150 : public nfc::Nfcc, public Component {
   uint16_t read_mifare_ultralight_capacity_();
   uint8_t find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint8_t &message_length,
                                        uint8_t &message_start_index);
-  uint8_t write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data);
+  uint8_t write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len);
   uint8_t write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, const std::shared_ptr<nfc::NdefMessage> &message);
   uint8_t clean_mifare_ultralight_();
 

--- a/esphome/components/pn7150/pn7150_mifare_classic.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_classic.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <memory>
 
 #include "pn7150.h"
@@ -139,10 +140,10 @@ uint8_t PN7150::sect_to_auth_(const uint8_t block_num) {
 }
 
 uint8_t PN7150::format_mifare_classic_mifare_() {
-  std::vector<uint8_t> blank_buffer(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> trailer_buffer(
-      {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   auto status = nfc::STATUS_OK;
 
@@ -151,20 +152,20 @@ uint8_t PN7150::format_mifare_classic_mifare_() {
       continue;
     }
     if (block != 0) {
-      if (this->write_mifare_classic_block_(block, blank_buffer) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, trailer_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -174,30 +175,30 @@ uint8_t PN7150::format_mifare_classic_mifare_() {
 }
 
 uint8_t PN7150::format_mifare_classic_ndef_() {
-  std::vector<uint8_t> empty_ndef_message(
-      {0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> blank_block(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> block_1_data(
-      {0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_2_data(
-      {0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_3_trailer(
-      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  std::vector<uint8_t> ndef_trailer(
-      {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+      0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+      0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+      0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+      0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+      0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (this->auth_mifare_classic_block_(0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY) != nfc::STATUS_OK) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting");
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(1, block_1_data) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(2, block_2_data) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(3, block_3_trailer) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
 
@@ -210,25 +211,26 @@ uint8_t PN7150::format_mifare_classic_ndef_() {
       return nfc::STATUS_FAILED;
     }
     if (block == 4) {
-      if (this->write_mifare_classic_block_(block, empty_ndef_message) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size()) !=
+          nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     } else {
-      if (this->write_mifare_classic_block_(block, blank_block) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_block) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_block) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, ndef_trailer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write trailer block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -236,7 +238,7 @@ uint8_t PN7150::format_mifare_classic_ndef_() {
   return status;
 }
 
-uint8_t PN7150::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &write_data) {
+uint8_t PN7150::write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len) {
   nfc::NciMessage rx;
   nfc::NciMessage tx(nfc::NCI_PKT_MT_DATA, {XCHG_DATA_OID, nfc::MIFARE_CMD_WRITE, block_num});
 
@@ -248,7 +250,7 @@ uint8_t PN7150::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8
   }
   // write command part two
   tx.set_payload({XCHG_DATA_OID});
-  tx.get_message().insert(tx.get_message().end(), write_data.begin(), write_data.end());
+  tx.get_message().insert(tx.get_message().end(), data, data + len);
 
   ESP_LOGVV(TAG, "Write XCHG_DATA_REQ 2: %s", nfc::format_bytes_to(buf, tx.get_message()));
   if (this->transceive_(tx, rx, NFCC_TAG_WRITE_TIMEOUT) != nfc::STATUS_OK) {
@@ -294,8 +296,8 @@ uint8_t PN7150::write_mifare_classic_tag_(const std::shared_ptr<nfc::NdefMessage
       }
     }
 
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_CLASSIC_BLOCK_SIZE);
-    if (this->write_mifare_classic_block_(current_block, data) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(current_block, encoded.data() + index, nfc::MIFARE_CLASSIC_BLOCK_SIZE) !=
+        nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
     index += nfc::MIFARE_CLASSIC_BLOCK_SIZE;

--- a/esphome/components/pn7150/pn7150_mifare_classic.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_classic.cpp
@@ -140,9 +140,9 @@ uint8_t PN7150::sect_to_auth_(const uint8_t block_num) {
 }
 
 uint8_t PN7150::format_mifare_classic_mifare_() {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BUFFER = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> TRAILER_BUFFER = {
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   auto status = nfc::STATUS_OK;
@@ -152,20 +152,20 @@ uint8_t PN7150::format_mifare_classic_mifare_() {
       continue;
     }
     if (block != 0) {
-      if (this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, TRAILER_BUFFER.data(), TRAILER_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -175,30 +175,30 @@ uint8_t PN7150::format_mifare_classic_mifare_() {
 }
 
 uint8_t PN7150::format_mifare_classic_ndef_() {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> EMPTY_NDEF_MESSAGE = {
       0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BLOCK = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_1_DATA = {
       0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_2_DATA = {
       0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_3_TRAILER = {
       0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> NDEF_TRAILER = {
       0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (this->auth_mifare_classic_block_(0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY) != nfc::STATUS_OK) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting");
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(1, BLOCK_1_DATA.data(), BLOCK_1_DATA.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(2, BLOCK_2_DATA.data(), BLOCK_2_DATA.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(3, BLOCK_3_TRAILER.data(), BLOCK_3_TRAILER.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
 
@@ -211,26 +211,26 @@ uint8_t PN7150::format_mifare_classic_ndef_() {
       return nfc::STATUS_FAILED;
     }
     if (block == 4) {
-      if (this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size()) !=
+      if (this->write_mifare_classic_block_(block, EMPTY_NDEF_MESSAGE.data(), EMPTY_NDEF_MESSAGE.size()) !=
           nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     } else {
-      if (this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, NDEF_TRAILER.data(), NDEF_TRAILER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write trailer block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }

--- a/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <cinttypes>
 #include <memory>
 
@@ -144,8 +145,8 @@ uint8_t PN7150::write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, const std::sha
   uint8_t current_page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
   while (index < buffer_length) {
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_ULTRALIGHT_PAGE_SIZE);
-    if (this->write_mifare_ultralight_page_(current_page, data) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(current_page, encoded.data() + index, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) !=
+        nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
     index += nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;
@@ -158,19 +159,19 @@ uint8_t PN7150::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  std::vector<uint8_t> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (this->write_mifare_ultralight_page_(i, blank_data) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size()) != nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
   }
   return nfc::STATUS_OK;
 }
 
-uint8_t PN7150::write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data) {
+uint8_t PN7150::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len) {
   std::vector<uint8_t> payload = {nfc::MIFARE_CMD_WRITE_ULTRALIGHT, page_num};
-  payload.insert(payload.end(), write_data.begin(), write_data.end());
+  payload.insert(payload.end(), write_data, write_data + len);
 
   nfc::NciMessage rx;
   nfc::NciMessage tx(nfc::NCI_PKT_MT_DATA, payload);

--- a/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
+++ b/esphome/components/pn7150/pn7150_mifare_ultralight.cpp
@@ -159,10 +159,10 @@ uint8_t PN7150::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> BLANK_DATA = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(i, BLANK_DATA.data(), BLANK_DATA.size()) != nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
   }

--- a/esphome/components/pn7160/pn7160.h
+++ b/esphome/components/pn7160/pn7160.h
@@ -253,7 +253,7 @@ class PN7160 : public nfc::Nfcc, public Component {
 
   uint8_t read_mifare_classic_tag_(nfc::NfcTag &tag);
   uint8_t read_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
-  uint8_t write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &data);
+  uint8_t write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len);
   uint8_t auth_mifare_classic_block_(uint8_t block_num, uint8_t key_num, const uint8_t *key);
   uint8_t sect_to_auth_(uint8_t block_num);
   uint8_t format_mifare_classic_mifare_();
@@ -267,7 +267,7 @@ class PN7160 : public nfc::Nfcc, public Component {
   uint16_t read_mifare_ultralight_capacity_();
   uint8_t find_mifare_ultralight_ndef_(const std::vector<uint8_t> &page_3_to_6, uint8_t &message_length,
                                        uint8_t &message_start_index);
-  uint8_t write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data);
+  uint8_t write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len);
   uint8_t write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, const std::shared_ptr<nfc::NdefMessage> &message);
   uint8_t clean_mifare_ultralight_();
 

--- a/esphome/components/pn7160/pn7160_mifare_classic.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_classic.cpp
@@ -140,9 +140,9 @@ uint8_t PN7160::sect_to_auth_(const uint8_t block_num) {
 }
 
 uint8_t PN7160::format_mifare_classic_mifare_() {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BUFFER = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> TRAILER_BUFFER = {
       0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   auto status = nfc::STATUS_OK;
@@ -152,20 +152,20 @@ uint8_t PN7160::format_mifare_classic_mifare_() {
       continue;
     }
     if (block != 0) {
-      if (this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, BLANK_BUFFER.data(), BLANK_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, TRAILER_BUFFER.data(), TRAILER_BUFFER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -175,30 +175,30 @@ uint8_t PN7160::format_mifare_classic_mifare_() {
 }
 
 uint8_t PN7160::format_mifare_classic_ndef_() {
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> EMPTY_NDEF_MESSAGE = {
       0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLANK_BLOCK = {
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_1_DATA = {
       0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_2_DATA = {
       0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> BLOCK_3_TRAILER = {
       0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> NDEF_TRAILER = {
       0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (this->auth_mifare_classic_block_(0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY) != nfc::STATUS_OK) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting");
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(1, BLOCK_1_DATA.data(), BLOCK_1_DATA.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(2, BLOCK_2_DATA.data(), BLOCK_2_DATA.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(3, BLOCK_3_TRAILER.data(), BLOCK_3_TRAILER.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
 
@@ -211,26 +211,26 @@ uint8_t PN7160::format_mifare_classic_ndef_() {
       return nfc::STATUS_FAILED;
     }
     if (block == 4) {
-      if (this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size()) !=
+      if (this->write_mifare_classic_block_(block, EMPTY_NDEF_MESSAGE.data(), EMPTY_NDEF_MESSAGE.size()) !=
           nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     } else {
-      if (this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, BLANK_BLOCK.data(), BLANK_BLOCK.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, NDEF_TRAILER.data(), NDEF_TRAILER.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write trailer block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }

--- a/esphome/components/pn7160/pn7160_mifare_classic.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_classic.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <memory>
 
 #include "pn7160.h"
@@ -139,10 +140,10 @@ uint8_t PN7160::sect_to_auth_(const uint8_t block_num) {
 }
 
 uint8_t PN7160::format_mifare_classic_mifare_() {
-  std::vector<uint8_t> blank_buffer(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> trailer_buffer(
-      {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_buffer = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> trailer_buffer = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x07, 0x80, 0x69, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   auto status = nfc::STATUS_OK;
 
@@ -151,20 +152,20 @@ uint8_t PN7160::format_mifare_classic_mifare_() {
       continue;
     }
     if (block != 0) {
-      if (this->write_mifare_classic_block_(block, blank_buffer) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, blank_buffer.data(), blank_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, trailer_buffer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, trailer_buffer.data(), trailer_buffer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -174,30 +175,30 @@ uint8_t PN7160::format_mifare_classic_mifare_() {
 }
 
 uint8_t PN7160::format_mifare_classic_ndef_() {
-  std::vector<uint8_t> empty_ndef_message(
-      {0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> blank_block(
-      {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00});
-  std::vector<uint8_t> block_1_data(
-      {0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_2_data(
-      {0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1});
-  std::vector<uint8_t> block_3_trailer(
-      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
-  std::vector<uint8_t> ndef_trailer(
-      {0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF});
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> empty_ndef_message = {
+      0x03, 0x03, 0xD0, 0x00, 0x00, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> blank_block = {
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_1_data = {
+      0x14, 0x01, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_2_data = {
+      0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1, 0x03, 0xE1};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> block_3_trailer = {
+      0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0x78, 0x77, 0x88, 0xC1, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+  static constexpr std::array<uint8_t, nfc::MIFARE_CLASSIC_BLOCK_SIZE> ndef_trailer = {
+      0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7, 0x7F, 0x07, 0x88, 0x40, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
   if (this->auth_mifare_classic_block_(0, nfc::MIFARE_CMD_AUTH_B, nfc::DEFAULT_KEY) != nfc::STATUS_OK) {
     ESP_LOGE(TAG, "Unable to authenticate block 0 for formatting");
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(1, block_1_data) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(1, block_1_data.data(), block_1_data.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(2, block_2_data) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(2, block_2_data.data(), block_2_data.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
-  if (this->write_mifare_classic_block_(3, block_3_trailer) != nfc::STATUS_OK) {
+  if (this->write_mifare_classic_block_(3, block_3_trailer.data(), block_3_trailer.size()) != nfc::STATUS_OK) {
     return nfc::STATUS_FAILED;
   }
 
@@ -210,25 +211,26 @@ uint8_t PN7160::format_mifare_classic_ndef_() {
       return nfc::STATUS_FAILED;
     }
     if (block == 4) {
-      if (this->write_mifare_classic_block_(block, empty_ndef_message) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, empty_ndef_message.data(), empty_ndef_message.size()) !=
+          nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     } else {
-      if (this->write_mifare_classic_block_(block, blank_block) != nfc::STATUS_OK) {
+      if (this->write_mifare_classic_block_(block, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
         ESP_LOGE(TAG, "Unable to write block %u", block);
         status = nfc::STATUS_FAILED;
       }
     }
-    if (this->write_mifare_classic_block_(block + 1, blank_block) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 1, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 1);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 2, blank_block) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 2, blank_block.data(), blank_block.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write block %u", block + 2);
       status = nfc::STATUS_FAILED;
     }
-    if (this->write_mifare_classic_block_(block + 3, ndef_trailer) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(block + 3, ndef_trailer.data(), ndef_trailer.size()) != nfc::STATUS_OK) {
       ESP_LOGE(TAG, "Unable to write trailer block %u", block + 3);
       status = nfc::STATUS_FAILED;
     }
@@ -236,7 +238,7 @@ uint8_t PN7160::format_mifare_classic_ndef_() {
   return status;
 }
 
-uint8_t PN7160::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8_t> &write_data) {
+uint8_t PN7160::write_mifare_classic_block_(uint8_t block_num, const uint8_t *data, size_t len) {
   nfc::NciMessage rx;
   nfc::NciMessage tx(nfc::NCI_PKT_MT_DATA, {XCHG_DATA_OID, nfc::MIFARE_CMD_WRITE, block_num});
   char buf[nfc::FORMAT_BYTES_BUFFER_SIZE];
@@ -248,7 +250,7 @@ uint8_t PN7160::write_mifare_classic_block_(uint8_t block_num, std::vector<uint8
   }
   // write command part two
   tx.set_payload({XCHG_DATA_OID});
-  tx.get_message().insert(tx.get_message().end(), write_data.begin(), write_data.end());
+  tx.get_message().insert(tx.get_message().end(), data, data + len);
 
   ESP_LOGVV(TAG, "Write XCHG_DATA_REQ 2: %s", nfc::format_bytes_to(buf, tx.get_message()));
   if (this->transceive_(tx, rx, NFCC_TAG_WRITE_TIMEOUT) != nfc::STATUS_OK) {
@@ -294,8 +296,8 @@ uint8_t PN7160::write_mifare_classic_tag_(const std::shared_ptr<nfc::NdefMessage
       }
     }
 
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_CLASSIC_BLOCK_SIZE);
-    if (this->write_mifare_classic_block_(current_block, data) != nfc::STATUS_OK) {
+    if (this->write_mifare_classic_block_(current_block, encoded.data() + index, nfc::MIFARE_CLASSIC_BLOCK_SIZE) !=
+        nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
     index += nfc::MIFARE_CLASSIC_BLOCK_SIZE;

--- a/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <cinttypes>
 #include <memory>
 
@@ -144,8 +145,8 @@ uint8_t PN7160::write_mifare_ultralight_tag_(nfc::NfcTagUid &uid, const std::sha
   uint8_t current_page = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
   while (index < buffer_length) {
-    std::vector<uint8_t> data(encoded.begin() + index, encoded.begin() + index + nfc::MIFARE_ULTRALIGHT_PAGE_SIZE);
-    if (this->write_mifare_ultralight_page_(current_page, data) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(current_page, encoded.data() + index, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) !=
+        nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
     index += nfc::MIFARE_ULTRALIGHT_PAGE_SIZE;
@@ -158,19 +159,19 @@ uint8_t PN7160::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  std::vector<uint8_t> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (this->write_mifare_ultralight_page_(i, blank_data) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size()) != nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
   }
   return nfc::STATUS_OK;
 }
 
-uint8_t PN7160::write_mifare_ultralight_page_(uint8_t page_num, std::vector<uint8_t> &write_data) {
+uint8_t PN7160::write_mifare_ultralight_page_(uint8_t page_num, const uint8_t *write_data, size_t len) {
   std::vector<uint8_t> payload = {nfc::MIFARE_CMD_WRITE_ULTRALIGHT, page_num};
-  payload.insert(payload.end(), write_data.begin(), write_data.end());
+  payload.insert(payload.end(), write_data, write_data + len);
 
   nfc::NciMessage rx;
   nfc::NciMessage tx(nfc::NCI_PKT_MT_DATA, payload);

--- a/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
+++ b/esphome/components/pn7160/pn7160_mifare_ultralight.cpp
@@ -159,10 +159,10 @@ uint8_t PN7160::clean_mifare_ultralight_() {
   uint32_t capacity = this->read_mifare_ultralight_capacity_();
   uint8_t pages = (capacity / nfc::MIFARE_ULTRALIGHT_PAGE_SIZE) + nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE;
 
-  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> blank_data = {0x00, 0x00, 0x00, 0x00};
+  static constexpr std::array<uint8_t, nfc::MIFARE_ULTRALIGHT_PAGE_SIZE> BLANK_DATA = {0x00, 0x00, 0x00, 0x00};
 
   for (int i = nfc::MIFARE_ULTRALIGHT_DATA_START_PAGE; i < pages; i++) {
-    if (this->write_mifare_ultralight_page_(i, blank_data.data(), blank_data.size()) != nfc::STATUS_OK) {
+    if (this->write_mifare_ultralight_page_(i, BLANK_DATA.data(), BLANK_DATA.size()) != nfc::STATUS_OK) {
       return nfc::STATUS_FAILED;
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocated `std::vector` constants with `static constexpr std::array` in MIFARE Classic and Ultralight write operations across pn532, pn7150, and pn7160 NFC components.

**What changed:**
- Convert `write_mifare_classic_block_` and `write_mifare_ultralight_page_` signatures from `std::vector<uint8_t>&` to `const uint8_t*, size_t` (they only read from the data)
- Replace 24 constant 16-byte vectors in format functions with `static constexpr std::array` (data now lives in flash/rodata instead of being heap-allocated on every call)
- Replace 3 constant 4-byte `blank_data` vectors with `static constexpr std::array`
- Eliminate per-iteration vector copies in `write_tag` loops by passing pointers directly into the encoded buffer

**Why:**
Each of these constant vectors was heap-allocating on every function call despite containing compile-time-known data. The MIFARE Classic format functions alone had 8 constant 16-byte vectors each, across 3 nearly-identical component files. The write loops were also creating a new vector copy on every iteration just to pass a 16-byte or 4-byte slice.

This is a mechanical change - the data values and logic are identical, only the container types and function signatures changed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).