### PR TITLE
[core] Added python version check in setup.bat

### DIFF
--- a/script/setup.bat
+++ b/script/setup.bat
@@ -1,9 +1,44 @@
-@echo off
+rem python 3.11.x is required to prevent platformio littlefs errors in later versions.
+
+rem Define the Python executable to use.
+rem - If Python 3.11 is in your PATH, leave as 'python'
+rem - If you need to point to a specific installation, use the full path, e.g.:
+
+rem set PYTHON_EXE="C:\Program Files\Python311\python.exe"
+set PYTHON_EXE=python
+
+
+rem Check that the defined Python exists
+%PYTHON_EXE% --version >nul 2>&1
+if errorlevel 1 (
+    echo Error: The defined Python executable was not found.
+    echo PYTHON_EXE: %PYTHON_EXE%
+	echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
+    pause
+    exit /b 1
+)
+
+rem Get the version
+for /f "tokens=2" %%v in ('%PYTHON_EXE% --version 2^>^&1') do set PYVER=%%v
+
+rem Extract major.minor (e.g., 3.11 from 3.11.9)
+set MAJOR_MINOR=%PYVER:~0,5%
+
+if not "%MAJOR_MINOR%" == "3.11." (
+    echo Error: Incorrect Python version detected.
+    echo PYTHON_EXE:     %PYTHON_EXE%
+    echo Python version: %PYVER%
+    echo .
+	echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
+    pause
+    exit /b 1
+)
 
 if defined VIRTUAL_ENV goto :install
 
 echo Starting the Virtual Environment
-python -m venv venv
+rem Use specified python version to create virtual environment
+%PYTHON_EXE% -m venv venv
 call venv/Scripts/activate
 echo Running the Virtual Environment
 
@@ -11,6 +46,7 @@ echo Running the Virtual Environment
 
 echo Installing required packages...
 
+rem At this point, we're in the virtual environment, so the python version 'should' be correct.
 python.exe -m pip install --upgrade pip
 
 pip3 install -r requirements.txt -r requirements_test.txt -r requirements_dev.txt

--- a/script/setup.bat
+++ b/script/setup.bat
@@ -13,7 +13,7 @@ rem Check that the defined Python exists
 if errorlevel 1 (
     echo Error: The defined Python executable was not found.
     echo PYTHON_EXE: %PYTHON_EXE%
-	echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
+    echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
     pause
     exit /b 1
 )
@@ -29,7 +29,7 @@ if not "%MAJOR_MINOR%" == "3.11." (
     echo PYTHON_EXE:     %PYTHON_EXE%
     echo Python version: %PYVER%
     echo .
-	echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
+    echo Please ensure Python 3.11.x is installed and either in PATH or set the full path in PYTHON_EXE.
     pause
     exit /b 1
 )


### PR DESCRIPTION
When the target device is esp32c3: platformio seems to generate a 'littlefs' error if python version 3.13 is used. 3.11.x is ok.

# What does this implement/fix?

When building for target esp32c3, platformio generates a circular dependency 'littlefs' error if python is version 3.13. There's no issue with python 3.11.7.
The issue doesn't occur when the target is esp8266.
This change to setup.bat (windows) adds a check on the version of python being used to generate the virtual environment, and allows the user to easily specify the location of the python executable, if required.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
