### PR TITLE
[wifi] Fix ESP8266 DHCP state corruption from premature dhcp_renew()

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -217,10 +217,9 @@ bool WiFiComponent::wifi_apply_hostname_() {
   }
 
   // Update hostname on all lwIP interfaces so DHCP packets include it.
-  // No dhcp_renew() call here — the hostname is fixed at compile time and
-  // this function is only called during setup() or wifi_sta_connect_() when
-  // the interface is always disconnected. lwIP includes the hostname in
-  // DHCP DISCOVER/REQUEST automatically via LWIP_NETIF_HOSTNAME.
+  // lwIP includes the hostname in DHCP DISCOVER/REQUEST automatically
+  // via LWIP_NETIF_HOSTNAME — no dhcp_renew() needed. The hostname is
+  // fixed at compile time and never changes at runtime.
   for (netif *intf = netif_list; intf; intf = intf->next) {
 #if LWIP_VERSION_MAJOR == 1
     intf->hostname = (char *) wifi_station_get_hostname();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -16,8 +16,7 @@ extern "C" {
 #include "lwip/err.h"
 #include "lwip/dns.h"
 #include "lwip/dhcp.h"
-#include "lwip/prot/dhcp.h"  // DHCP_STATE_BOUND
-#include "lwip/init.h"       // LWIP_VERSION_
+#include "lwip/init.h"  // LWIP_VERSION_
 #include "lwip/apps/sntp.h"
 #include "lwip/netif.h"  // struct netif
 #include <AddrList.h>
@@ -217,34 +216,17 @@ bool WiFiComponent::wifi_apply_hostname_() {
     ESP_LOGV(TAG, "Set hostname failed");
   }
 
-  // inform dhcp server of hostname change using dhcp_renew()
+  // Update hostname on all lwIP interfaces so DHCP packets include it.
+  // No dhcp_renew() call here — the hostname is fixed at compile time and
+  // this function is only called during setup() or wifi_sta_connect_() when
+  // the interface is always disconnected. lwIP includes the hostname in
+  // DHCP DISCOVER/REQUEST automatically via LWIP_NETIF_HOSTNAME.
   for (netif *intf = netif_list; intf; intf = intf->next) {
-    // unconditionally update all known interfaces
 #if LWIP_VERSION_MAJOR == 1
     intf->hostname = (char *) wifi_station_get_hostname();
 #else
     intf->hostname = wifi_station_get_hostname();
 #endif
-    struct dhcp *dhcp_data = netif_dhcp_data(intf);
-    if (dhcp_data != nullptr && dhcp_data->state == DHCP_STATE_BOUND && netif_is_link_up(intf)) {
-      // Renew already-bound DHCP leases to inform server of hostname change.
-      // Both conditions are required:
-      //  - DHCP must be BOUND (have an active lease to renew)
-      //  - Interface must have link (able to send packets)
-      // During reconnection, DHCP can remain BOUND from a previous connection
-      // while the link is down. Calling dhcp_renew() without link corrupts
-      // lwIP's DHCP state machine (it unconditionally sets state to RENEWING
-      // before attempting to send, and never rolls back on failure). This
-      // causes dhcp_network_changed() to call dhcp_reboot() instead of
-      // dhcp_discover() when WiFi later connects, sending a bogus DHCP REQUEST
-      // for IP 0.0.0.0 that can put some routers into a persistent bad state.
-      err_t lwipret = dhcp_renew(intf);
-      if (lwipret != ERR_OK) {
-        ESP_LOGW(TAG, "wifi_apply_hostname_(%s): lwIP error %d on interface %c%c (index %d)", intf->hostname,
-                 (int) lwipret, intf->name[0], intf->name[1], intf->num);
-        ret = false;
-      }
-    }
   }
 
   return ret;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -16,7 +16,8 @@ extern "C" {
 #include "lwip/err.h"
 #include "lwip/dns.h"
 #include "lwip/dhcp.h"
-#include "lwip/init.h"  // LWIP_VERSION_
+#include "lwip/prot/dhcp.h"  // DHCP_STATE_BOUND
+#include "lwip/init.h"       // LWIP_VERSION_
 #include "lwip/apps/sntp.h"
 #include "lwip/netif.h"  // struct netif
 #include <AddrList.h>
@@ -224,13 +225,14 @@ bool WiFiComponent::wifi_apply_hostname_() {
 #else
     intf->hostname = wifi_station_get_hostname();
 #endif
-    if (netif_dhcp_data(intf) != nullptr && netif_is_link_up(intf)) {
-      // Renew already started DHCP leases to inform server of hostname change.
-      // Only attempt when the interface has link — calling dhcp_renew() without
-      // an active connection corrupts lwIP's DHCP state machine (it unconditionally
-      // sets state to RENEWING before attempting to send, and never rolls back on
-      // failure). This causes dhcp_network_changed() to call dhcp_reboot() instead
-      // of dhcp_discover() when WiFi later connects, sending a bogus DHCP REQUEST
+    struct dhcp *dhcp_data = netif_dhcp_data(intf);
+    if (dhcp_data != nullptr && dhcp_data->state == DHCP_STATE_BOUND) {
+      // Renew already-bound DHCP leases to inform server of hostname change.
+      // Only attempt when DHCP is BOUND — calling dhcp_renew() in any other
+      // state corrupts lwIP's DHCP state machine (it unconditionally sets state
+      // to RENEWING before attempting to send, and never rolls back on failure).
+      // This causes dhcp_network_changed() to call dhcp_reboot() instead of
+      // dhcp_discover() when WiFi later connects, sending a bogus DHCP REQUEST
       // for IP 0.0.0.0 that can put some routers into a persistent bad state.
       err_t lwipret = dhcp_renew(intf);
       if (lwipret != ERR_OK) {

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -224,8 +224,14 @@ bool WiFiComponent::wifi_apply_hostname_() {
 #else
     intf->hostname = wifi_station_get_hostname();
 #endif
-    if (netif_dhcp_data(intf) != nullptr) {
-      // renew already started DHCP leases
+    if (netif_dhcp_data(intf) != nullptr && netif_is_link_up(intf)) {
+      // Renew already started DHCP leases to inform server of hostname change.
+      // Only attempt when the interface has link — calling dhcp_renew() without
+      // an active connection corrupts lwIP's DHCP state machine (it unconditionally
+      // sets state to RENEWING before attempting to send, and never rolls back on
+      // failure). This causes dhcp_network_changed() to call dhcp_reboot() instead
+      // of dhcp_discover() when WiFi later connects, sending a bogus DHCP REQUEST
+      // for IP 0.0.0.0 that can put some routers into a persistent bad state.
       err_t lwipret = dhcp_renew(intf);
       if (lwipret != ERR_OK) {
         ESP_LOGW(TAG, "wifi_apply_hostname_(%s): lwIP error %d on interface %c%c (index %d)", intf->hostname,

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -226,12 +226,16 @@ bool WiFiComponent::wifi_apply_hostname_() {
     intf->hostname = wifi_station_get_hostname();
 #endif
     struct dhcp *dhcp_data = netif_dhcp_data(intf);
-    if (dhcp_data != nullptr && dhcp_data->state == DHCP_STATE_BOUND) {
+    if (dhcp_data != nullptr && dhcp_data->state == DHCP_STATE_BOUND && netif_is_link_up(intf)) {
       // Renew already-bound DHCP leases to inform server of hostname change.
-      // Only attempt when DHCP is BOUND — calling dhcp_renew() in any other
-      // state corrupts lwIP's DHCP state machine (it unconditionally sets state
-      // to RENEWING before attempting to send, and never rolls back on failure).
-      // This causes dhcp_network_changed() to call dhcp_reboot() instead of
+      // Both conditions are required:
+      //  - DHCP must be BOUND (have an active lease to renew)
+      //  - Interface must have link (able to send packets)
+      // During reconnection, DHCP can remain BOUND from a previous connection
+      // while the link is down. Calling dhcp_renew() without link corrupts
+      // lwIP's DHCP state machine (it unconditionally sets state to RENEWING
+      // before attempting to send, and never rolls back on failure). This
+      // causes dhcp_network_changed() to call dhcp_reboot() instead of
       // dhcp_discover() when WiFi later connects, sending a bogus DHCP REQUEST
       // for IP 0.0.0.0 that can put some routers into a persistent bad state.
       err_t lwipret = dhcp_renew(intf);


### PR DESCRIPTION
# What does this implement/fix?

Remove a cargo-culted `dhcp_renew()` call that corrupts lwIP's DHCP state machine on every ESP8266 WiFi connection attempt.

### Origin

The `dhcp_renew()` loop in `wifi_apply_hostname_()` was copied from the ESP8266 Arduino core's [`LwipIntf::hostname()`](https://github.com/esp8266/Arduino/pull/6680) in commit 072b2c445c (Dec 2019). That function was designed for a different use case: changing the hostname on an **already-connected** system with multiple interfaces (WiFi + Ethernet), where you need to inform each interface's DHCP server of the new name.

### Why it's unnecessary in ESPHome

The hostname is fixed at compile time and never changes at runtime. Setting `intf->hostname` is sufficient — lwIP automatically includes it in DHCP DISCOVER/REQUEST packets via `LWIP_NETIF_HOSTNAME`. There is no need to call `dhcp_renew()` to propagate a hostname change that never happens.

`wifi_apply_hostname_()` is only called from:
- **`setup_()`** — during initial setup before WiFi connects
- **`wifi_sta_connect_()`** — during the connection sequence, before `wifi_station_connect()`

In neither case is a `dhcp_renew()` appropriate.

### How it causes damage

lwIP's `dhcp_renew()` unconditionally sets the DHCP state to `RENEWING` ([dhcp.c:1159](https://github.com/lwip-tcpip/lwip/blob/239918c/src/core/ipv4/dhcp.c#L1159)) **before** attempting to send, and never rolls back on failure. When called on a disconnected interface:

1. DHCP state is corrupted from INIT → RENEWING
2. When WiFi later connects, `dhcp_network_changed()` sees RENEWING and calls `dhcp_reboot()` instead of `dhcp_discover()`
3. `dhcp_reboot()` broadcasts a DHCP REQUEST for IP 0.0.0.0 (no valid lease)
4. Most routers handle this gracefully (NAK → fallback), but some routers enter a persistent bad state for the device's MAC address, requiring a router restart

### Fix

Remove the `dhcp_renew()` loop entirely. Keep the `intf->hostname` assignment which is the only part that matters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: https://github.com/ratgdo/esphome-ratgdo/issues/541
- Related: https://github.com/esphome/esphome/issues/13656

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is a bugfix in the WiFi connection internals
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).