### PR TITLE
2026.2.0b2

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.2.0b1
+PROJECT_NUMBER         = 2026.2.0b2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ FROM ghcr.io/esphome/docker-base:${BUILD_OS}-ha-addon-${BUILD_BASE_VERSION} AS b
 ARG BUILD_TYPE
 FROM base-source-${BUILD_TYPE} AS base
 
-RUN git config --system --add safe.directory "*"
+RUN git config --system --add safe.directory "*" \
+    && git config --system advice.detachedHead false
 
 # Install build tools for Python packages that require compilation
 # (e.g., ruamel.yaml.clibz used by ESP-IDF's idf-component-manager)

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -148,12 +148,16 @@ void APIServer::loop() {
   while (client_index < this->clients_.size()) {
     auto &client = this->clients_[client_index];
 
+    // Common case: process active client
+    if (!client->flags_.remove) {
+      client->loop();
+    }
+    // Handle disconnection promptly - close socket to free LWIP PCB
+    // resources and prevent retransmit crashes on ESP8266.
     if (client->flags_.remove) {
       // Rare case: handle disconnection (don't increment - swapped element needs processing)
       this->remove_client_(client_index);
     } else {
-      // Common case: process active client
-      client->loop();
       client_index++;
     }
   }

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -117,37 +117,7 @@ void APIServer::setup() {
 void APIServer::loop() {
   // Accept new clients only if the socket exists and has incoming connections
   if (this->socket_ && this->socket_->ready()) {
-    while (true) {
-      struct sockaddr_storage source_addr;
-      socklen_t addr_len = sizeof(source_addr);
-
-      auto sock = this->socket_->accept_loop_monitored((struct sockaddr *) &source_addr, &addr_len);
-      if (!sock)
-        break;
-
-      char peername[socket::SOCKADDR_STR_LEN];
-      sock->getpeername_to(peername);
-
-      // Check if we're at the connection limit
-      if (this->clients_.size() >= this->max_connections_) {
-        ESP_LOGW(TAG, "Max connections (%d), rejecting %s", this->max_connections_, peername);
-        // Immediately close - socket destructor will handle cleanup
-        sock.reset();
-        continue;
-      }
-
-      ESP_LOGD(TAG, "Accept %s", peername);
-
-      auto *conn = new APIConnection(std::move(sock), this);
-      this->clients_.emplace_back(conn);
-      conn->start();
-
-      // First client connected - clear warning and update timestamp
-      if (this->clients_.size() == 1 && this->reboot_timeout_ != 0) {
-        this->status_clear_warning();
-        this->last_connected_ = App.get_loop_component_start_time();
-      }
-    }
+    this->accept_new_connections_();
   }
 
   if (this->clients_.empty()) {
@@ -178,46 +148,84 @@ void APIServer::loop() {
   while (client_index < this->clients_.size()) {
     auto &client = this->clients_[client_index];
 
-    if (!client->flags_.remove) {
+    if (client->flags_.remove) {
+      // Rare case: handle disconnection (don't increment - swapped element needs processing)
+      this->remove_client_(client_index);
+    } else {
       // Common case: process active client
       client->loop();
       client_index++;
+    }
+  }
+}
+
+void APIServer::remove_client_(size_t client_index) {
+  auto &client = this->clients_[client_index];
+
+#ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
+  this->unregister_active_action_calls_for_connection(client.get());
+#endif
+  ESP_LOGV(TAG, "Remove connection %s", client->get_name());
+
+#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
+  // Save client info before closing socket and removal for the trigger
+  char peername_buf[socket::SOCKADDR_STR_LEN];
+  std::string client_name(client->get_name());
+  std::string client_peername(client->get_peername_to(peername_buf));
+#endif
+
+  // Close socket now (was deferred from on_fatal_error to allow getpeername)
+  client->helper_->close();
+
+  // Swap with the last element and pop (avoids expensive vector shifts)
+  if (client_index < this->clients_.size() - 1) {
+    std::swap(this->clients_[client_index], this->clients_.back());
+  }
+  this->clients_.pop_back();
+
+  // Last client disconnected - set warning and start tracking for reboot timeout
+  if (this->clients_.empty() && this->reboot_timeout_ != 0) {
+    this->status_set_warning();
+    this->last_connected_ = App.get_loop_component_start_time();
+  }
+
+#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
+  // Fire trigger after client is removed so api.connected reflects the true state
+  this->client_disconnected_trigger_.trigger(client_name, client_peername);
+#endif
+}
+
+void APIServer::accept_new_connections_() {
+  while (true) {
+    struct sockaddr_storage source_addr;
+    socklen_t addr_len = sizeof(source_addr);
+
+    auto sock = this->socket_->accept_loop_monitored((struct sockaddr *) &source_addr, &addr_len);
+    if (!sock)
+      break;
+
+    char peername[socket::SOCKADDR_STR_LEN];
+    sock->getpeername_to(peername);
+
+    // Check if we're at the connection limit
+    if (this->clients_.size() >= this->max_connections_) {
+      ESP_LOGW(TAG, "Max connections (%d), rejecting %s", this->max_connections_, peername);
+      // Immediately close - socket destructor will handle cleanup
+      sock.reset();
       continue;
     }
 
-    // Rare case: handle disconnection
-#ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-    this->unregister_active_action_calls_for_connection(client.get());
-#endif
-    ESP_LOGV(TAG, "Remove connection %s", client->get_name());
+    ESP_LOGD(TAG, "Accept %s", peername);
 
-#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
-    // Save client info before closing socket and removal for the trigger
-    char peername_buf[socket::SOCKADDR_STR_LEN];
-    std::string client_name(client->get_name());
-    std::string client_peername(client->get_peername_to(peername_buf));
-#endif
+    auto *conn = new APIConnection(std::move(sock), this);
+    this->clients_.emplace_back(conn);
+    conn->start();
 
-    // Close socket now (was deferred from on_fatal_error to allow getpeername)
-    client->helper_->close();
-
-    // Swap with the last element and pop (avoids expensive vector shifts)
-    if (client_index < this->clients_.size() - 1) {
-      std::swap(this->clients_[client_index], this->clients_.back());
-    }
-    this->clients_.pop_back();
-
-    // Last client disconnected - set warning and start tracking for reboot timeout
-    if (this->clients_.empty() && this->reboot_timeout_ != 0) {
-      this->status_set_warning();
+    // First client connected - clear warning and update timestamp
+    if (this->clients_.size() == 1 && this->reboot_timeout_ != 0) {
+      this->status_clear_warning();
       this->last_connected_ = App.get_loop_component_start_time();
     }
-
-#ifdef USE_API_CLIENT_DISCONNECTED_TRIGGER
-    // Fire trigger after client is removed so api.connected reflects the true state
-    this->client_disconnected_trigger_.trigger(client_name, client_peername);
-#endif
-    // Don't increment client_index since we need to process the swapped element
   }
 }
 

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -234,6 +234,11 @@ class APIServer : public Component,
 #endif
 
  protected:
+  // Accept incoming socket connections. Only called when socket has pending connections.
+  void __attribute__((noinline)) accept_new_connections_();
+  // Remove a disconnected client by index. Swaps with last element and pops.
+  void __attribute__((noinline)) remove_client_(size_t client_index);
+
 #ifdef USE_API_NOISE
   bool update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg, const LogString *fail_log_msg,
                          const psk_t &active_psk, bool make_active);

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -46,17 +46,16 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   uint32_t total_pulses_ = 0;
   uint32_t last_processed_edge_us_ = 0;
 
-  // This struct (and the two pointers) are used to pass data between the ISR and loop.
-  // These two pointers are exchanged each loop.
-  // Use these to send data from the ISR to the loop not the other way around (except for resetting the values).
+  // This struct and variable are used to pass data between the ISR and loop.
+  // The data from state_ is read and then count_ in state_ is reset in each loop.
+  // This must be done while guarded by an InterruptLock. Use this variable to send data
+  // from the ISR to the loop not the other way around (except for resetting count_).
   struct State {
     uint32_t last_detected_edge_us_ = 0;
     uint32_t last_rising_edge_us_ = 0;
     uint32_t count_ = 0;
   };
-  State state_[2];
-  volatile State *set_ = state_;
-  volatile State *get_ = state_ + 1;
+  volatile State state_{};
 
   // Only use the following variables in the ISR or while guarded by an InterruptLock
   ISRInternalGPIOPin isr_pin_;

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -8,6 +8,13 @@
 
 namespace esphome::uart {
 
+/// ESP-IDF UART driver wrapper.
+///
+/// Thread safety: All public methods must only be called from the main loop.
+/// The ESP-IDF UART driver API does not guarantee thread safety, and ESPHome's
+/// peek byte state (has_peek_/peek_byte_) is not synchronized. The rx_event_task
+/// (when enabled) must not call any of these methods — it communicates with the
+/// main loop exclusively via App.wake_loop_threadsafe().
 class IDFUARTComponent : public UARTComponent, public Component {
  public:
   void setup() override;
@@ -26,7 +33,9 @@ class IDFUARTComponent : public UARTComponent, public Component {
   void flush() override;
 
   uint8_t get_hw_serial_number() { return this->uart_num_; }
+#ifdef USE_UART_WAKE_LOOP_ON_RX
   QueueHandle_t *get_uart_event_queue() { return &this->uart_event_queue_; }
+#endif
 
   /**
    * Load the UART with the current settings.
@@ -46,18 +55,20 @@ class IDFUARTComponent : public UARTComponent, public Component {
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;
-  QueueHandle_t uart_event_queue_;
   uart_config_t get_config_();
-  SemaphoreHandle_t lock_;
 
   bool has_peek_{false};
   uint8_t peek_byte_;
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
-  // RX notification support
+  // RX notification support — runs on a separate FreeRTOS task.
+  // IMPORTANT: rx_event_task_func must NOT call any UART wrapper methods (read_array,
+  // write_array, etc.) or touch has_peek_/peek_byte_. It must only read from the
+  // event queue and call App.wake_loop_threadsafe().
   void start_rx_event_task_();
   static void rx_event_task_func(void *param);
 
+  QueueHandle_t uart_event_queue_;
   TaskHandle_t rx_event_task_handle_{nullptr};
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 };

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.2.0b1"
+__version__ = "2026.2.0b2"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/script/build_language_schema.py
+++ b/script/build_language_schema.py
@@ -369,7 +369,7 @@ def get_logger_tags():
         "api.service",
     ]
     for file in CORE_COMPONENTS_PATH.rglob("*.cpp"):
-        data = file.read_text()
+        data = file.read_text(encoding="utf-8")
         match = pattern.search(data)
         if match:
             tags.append(match.group(1))


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [schema-gen] fix Windows: ensure UTF-8 encoding when reading component files [esphome#13952](https://github.com/esphome/esphome/pull/13952)
- [uart] Remove redundant mutex, fix flush race, conditional event queue [esphome#13955](https://github.com/esphome/esphome/pull/13955)
- [api] Extract cold code from APIServer::loop() hot path [esphome#13902](https://github.com/esphome/esphome/pull/13902)
- [pulse_meter] Fix early edge detection [esphome#12360](https://github.com/esphome/esphome/pull/12360)
- [alarm_control_panel] Fix flaky integration test race condition [esphome#13964](https://github.com/esphome/esphome/pull/13964)
- [docker] Suppress git detached HEAD advice [esphome#13962](https://github.com/esphome/esphome/pull/13962)
- [api] Fix ESP8266 noise API handshake deadlock and prompt socket cleanup [esphome#13972](https://github.com/esphome/esphome/pull/13972)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
