### PR TITLE
[http_request] Improve TLS logging on ESP8266

### DIFF
--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -124,19 +124,19 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
       int last_error = secure_client->getLastSSLError();
 
       if (last_error != 0) {
-        const char *error_msg;
+        const LogString *error_msg;
         switch (last_error) {
           case ESP8266_SSL_ERR_OOM:
-            error_msg = "Unable to allocate buffer memory";
+            error_msg = LOG_STR("Unable to allocate buffer memory");
             break;
           case BR_ERR_TOO_LARGE:
-            error_msg = "Incoming TLS record does not fit in receive buffer (BR_ERR_TOO_LARGE)";
+            error_msg = LOG_STR("Incoming TLS record does not fit in receive buffer (BR_ERR_TOO_LARGE)");
             break;
           default:
-            error_msg = "Unknown SSL error";
+            error_msg = LOG_STR("Unknown SSL error");
             break;
         }
-        ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
+        ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", LOG_STR_ARG(error_msg), last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
           ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes", ESP.getFreeHeap(),
                    static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     container->end();
     return nullptr;
   }
-    ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
+  ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
   if (!is_success(container->status_code)) {
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
     this->status_momentary_error("failed", 1000);

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -138,6 +138,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
+          // Avoid ESP.getFreeHeap() here — it pulls in umm_info symbols (+128 RAM, +400 flash)
           ESP_LOGW(TAG, "Enable debug component for heap diagnostics");
         }
       } else {

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -154,9 +154,8 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     container->end();
     return nullptr;
   }
-  ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
   if (!is_success(container->status_code)) {
-    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
+    ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
     this->status_momentary_error("failed", 1000);
     // Still return the container, so it can be used to get the status code and error message
   }

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -19,8 +19,10 @@ namespace esphome::http_request {
 static const char *const TAG = "http_request.arduino";
 static constexpr int RX_BUFFER_SIZE = 512;
 static constexpr int TX_BUFFER_SIZE = 512;
+#ifdef USE_ESP8266
 // ESP8266 Arduino core (WiFiClientSecureBearSSL.cpp) returns -1000 on OOM
 static constexpr int BR_ERR_OOM = -1000;
+#endif
 
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
                                                            const std::string &body,

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -17,11 +17,11 @@
 namespace esphome::http_request {
 
 static const char *const TAG = "http_request.arduino";
+#ifdef USE_ESP8266
 static constexpr int RX_BUFFER_SIZE = 512;
 static constexpr int TX_BUFFER_SIZE = 512;
-#ifdef USE_ESP8266
 // ESP8266 Arduino core (WiFiClientSecureBearSSL.cpp) returns -1000 on OOM
-static constexpr int BR_ERR_OOM = -1000;
+static constexpr int ESP8266_SSL_ERR_OOM = -1000;
 #endif
 
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
@@ -126,7 +126,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
       if (last_error != 0) {
         const char *error_msg;
         switch (last_error) {
-          case BR_ERR_OOM:
+          case ESP8266_SSL_ERR_OOM:
             error_msg = "Unable to allocate buffer memory";
             break;
           case BR_ERR_TOO_LARGE:
@@ -137,9 +137,9 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
             break;
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
-        if (last_error == BR_ERR_OOM) {
+        if (last_error == ESP8266_SSL_ERR_OOM) {
           ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes. Enable debug component for more info",
-                   ESP.getFreeHeap(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+                   ESP.getFreeHeap(), static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -9,9 +9,16 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 
+// Include BearSSL for error code constants
+#ifdef USE_ESP8266
+#include <bearssl/bearssl.h>
+#endif
+
 namespace esphome::http_request {
 
 static const char *const TAG = "http_request.arduino";
+static const int RX_BUFFER_SIZE = 512;
+static const int TX_BUFFER_SIZE = 512;
 
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
                                                            const std::string &body,
@@ -47,7 +54,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     ESP_LOGV(TAG, "ESP8266 HTTPS connection with WiFiClientSecure");
     stream_ptr = std::make_unique<WiFiClientSecure>();
     WiFiClientSecure *secure_client = static_cast<WiFiClientSecure *>(stream_ptr.get());
-    secure_client->setBufferSizes(512, 512);
+    secure_client->setBufferSizes(RX_BUFFER_SIZE, TX_BUFFER_SIZE);
     secure_client->setInsecure();
   } else {
     stream_ptr = std::make_unique<WiFiClient>();
@@ -107,15 +114,42 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
   container->status_code = container->client_.sendRequest(method.c_str(), body.c_str());
   App.feed_wdt();
   if (container->status_code < 0) {
+#if defined(USE_ESP8266) && defined(USE_HTTP_REQUEST_ESP8266_HTTPS)
+    if (secure && stream_ptr) {
+      WiFiClientSecure *secure_client = static_cast<WiFiClientSecure *>(stream_ptr.get());
+      int last_error = secure_client->getLastSSLError();
+
+      if (last_error != 0) {
+        const char *error_msg = "";
+        switch (last_error) {
+          case -1000:  // The ESP8266 Arduino core sets this error code in case of OOM
+            error_msg = "Unable to allocate buffer memory";
+            break;
+          case BR_ERR_TOO_LARGE:
+            error_msg = "Incoming TLS record does not fit in receive buffer (BR_ERR_TOO_LARGE)";
+            break;
+        }
+        ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
+        if (last_error == -1000) {
+          ESP_LOGW(TAG, "Heap free: %u bytes, max block: %u bytes, buffers needed: %u bytes", ESP.getFreeHeap(),
+                   ESP.getMaxFreeBlockSize(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+        }
+      } else {
+        ESP_LOGW(TAG, "Connection failure with no error code");
+      }
+    }
+#endif
+
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Error: %s", url.c_str(),
              HTTPClient::errorToString(container->status_code).c_str());
+
     this->status_momentary_error("failed", 1000);
     container->end();
     return nullptr;
   }
 
   if (!is_success(container->status_code)) {
-    ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
+    ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
     this->status_momentary_error("failed", 1000);
     // Still return the container, so it can be used to get the status code and error message
   }

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     container->end();
     return nullptr;
   }
-
+    ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
   if (!is_success(container->status_code)) {
     ESP_LOGW(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
     this->status_momentary_error("failed", 1000);

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -9,16 +9,18 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 
-// Include BearSSL for error code constants
+// Include BearSSL error constants for TLS failure diagnostics
 #ifdef USE_ESP8266
-#include <bearssl/bearssl.h>
+#include <bearssl/bearssl_ssl.h>
 #endif
 
 namespace esphome::http_request {
 
 static const char *const TAG = "http_request.arduino";
-static const int RX_BUFFER_SIZE = 512;
-static const int TX_BUFFER_SIZE = 512;
+static constexpr int RX_BUFFER_SIZE = 512;
+static constexpr int TX_BUFFER_SIZE = 512;
+// ESP8266 Arduino core (WiFiClientSecureBearSSL.cpp) returns -1000 on OOM
+static constexpr int BR_ERR_OOM = -1000;
 
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
                                                            const std::string &body,
@@ -115,24 +117,27 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
   App.feed_wdt();
   if (container->status_code < 0) {
 #if defined(USE_ESP8266) && defined(USE_HTTP_REQUEST_ESP8266_HTTPS)
-    if (secure && stream_ptr) {
+    if (secure) {
       WiFiClientSecure *secure_client = static_cast<WiFiClientSecure *>(stream_ptr.get());
       int last_error = secure_client->getLastSSLError();
 
       if (last_error != 0) {
-        const char *error_msg = "";
+        const char *error_msg;
         switch (last_error) {
-          case -1000:  // The ESP8266 Arduino core sets this error code in case of OOM
+          case BR_ERR_OOM:
             error_msg = "Unable to allocate buffer memory";
             break;
           case BR_ERR_TOO_LARGE:
             error_msg = "Incoming TLS record does not fit in receive buffer (BR_ERR_TOO_LARGE)";
             break;
+          default:
+            error_msg = "Unknown SSL error";
+            break;
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
-        if (last_error == -1000) {
-          ESP_LOGW(TAG, "Heap free: %u bytes, max block: %u bytes, buffers needed: %u bytes", ESP.getFreeHeap(),
-                   ESP.getMaxFreeBlockSize(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+        if (last_error == BR_ERR_OOM) {
+          ESP_LOGW(TAG, "Heap free: %u bytes, max block: %u bytes, configured buffer sizes: %u bytes",
+                   ESP.getFreeHeap(), ESP.getMaxFreeBlockSize(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -136,8 +136,8 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
         if (last_error == BR_ERR_OOM) {
-          ESP_LOGW(TAG, "Heap free: %u bytes, max block: %u bytes, configured buffer sizes: %u bytes",
-                   ESP.getFreeHeap(), ESP.getMaxFreeBlockSize(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
+          ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes. Enable debug component for more info",
+                   ESP.getFreeHeap(), RX_BUFFER_SIZE + TX_BUFFER_SIZE);
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -138,8 +138,8 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
-          // Avoid ESP.getFreeHeap() here — it pulls in umm_info symbols (+128 RAM, +400 flash)
-          ESP_LOGW(TAG, "Enable debug component for heap diagnostics");
+          ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes", ESP.getFreeHeap(),
+                   static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -138,8 +138,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
-          ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes. Enable debug component for more info",
-                   ESP.getFreeHeap(), static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));
+          ESP_LOGW(TAG, "Enable debug component for heap diagnostics");
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -138,7 +138,8 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         }
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", error_msg, last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
-          ESP_LOGW(TAG, "Enable debug component for heap diagnostics");
+          ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes. Enable debug component for more info",
+                   ESP.getFreeHeap(), static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");


### PR DESCRIPTION
# What does this implement/fix?

This improves the logged error messages in case a TLS connection fails on ESP8266.

In particular this provides error messages for the two most common failures: oversized TLS record received and out of memory when allocating the buffers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/issues/issues/3893

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
button:
  - platform: template
    name: "Test"
    on_press: 
      then:
        - http_request.get: 
            url: https://esphome.io
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

