### PR TITLE
[epaper_spi] Add Waveshare 7.5in e-Paper (H)

### DIFF
--- a/esphome/components/epaper_spi/models/jd79660.py
+++ b/esphome/components/epaper_spi/models/jd79660.py
@@ -84,3 +84,35 @@ jd79660.extend(
         (0xA5, 0x00,),
     ),
 )
+
+# Waveshare 7.5-H
+#
+# Vendor init derived from vendor sample code
+# <https://github.com/waveshareteam/e-Paper/blob/master/E-paper_Separate_Program/7in5_e-Paper_H/ESP32/EPD_7in5h.cpp>
+# Compatible MIT license, see esphome/LICENSE file.
+#
+# Note: busy pin uses LOW=busy, HIGH=idle. Configure with inverted: true in YAML.
+#
+# fmt: off
+jd79660.extend(
+    "Waveshare-7.5in-H",
+    width=800,
+    height=480,
+
+    initsequence=(
+        (0x00, 0x0F, 0x29,),
+        (0x06, 0x0F, 0x8B, 0x93, 0xA1,),
+        (0x41, 0x00,),
+        (0x50, 0x37,),
+        (0x60, 0x02, 0x02,),
+        (0x61, 800 // 256, 800 % 256, 480 // 256, 480 % 256,),  # RES: 800x480
+        (0x62, 0x98, 0x98, 0x98, 0x75, 0xCA, 0xB2, 0x98, 0x7E,),
+        (0x65, 0x00, 0x00, 0x00, 0x00,),
+        (0xE7, 0x1C,),
+        (0xE3, 0x00,),
+        (0xE9, 0x01,),
+        (0x30, 0x08,),
+        # Power On (0x04): Must be early part of init seq = Disabled later!
+        (0x04,),
+    ),
+)

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -58,6 +58,23 @@ display:
       number: GPIO4
 
   - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-7.5in-H
+    cs_pin:
+      allow_other_uses: true
+      number: GPIO5
+    dc_pin:
+      allow_other_uses: true
+      number: GPIO17
+    reset_pin:
+      allow_other_uses: true
+      number: GPIO16
+    busy_pin:
+      allow_other_uses: true
+      number: GPIO4
+      inverted: true
+
+  - platform: epaper_spi
     model: seeed-reterminal-e1002
   - platform: epaper_spi
     model: seeed-ee04-mono-4.26


### PR DESCRIPTION
# What does this implement/fix?

Adds `epaper_spi` support for the Waveshare 7.5inch e-Paper HAT (H), a 4-color (black/white/yellow/red) 800x480 display.

Uses `jd79660.extend()` — same approach as the Waveshare 1.54-G (#13758). The display uses the same 2bpp BWYR pixel format and command set, just a different init sequence.

Init sequence derived from vendor sample code:
https://github.com/waveshareteam/e-Paper/blob/master/E-paper_Separate_Program/7in5_e-Paper_H/ESP32/EPD_7in5h.cpp
(MIT licensed)

Note: busy pin needs `inverted: true` — this display uses LOW=busy, HIGH=idle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6085

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on hardware with ESPHome 2026.1.5 + this branch via `external_components`:
- Display: [Waveshare 7.5inch e-Paper HAT (H)](https://www.waveshare.com/7.5inch-e-paper-hat-h.htm?sku=30925)
- Driver board: [Waveshare e-Paper ESP32 Driver Board](https://www.waveshare.com/product/displays/e-paper/driver-boards/e-paper-esp32-driver-board.htm)

All 4 colors render correctly (black, white, red, yellow). Text and rectangles positioned as expected. Single refresh cycle (~22s), then deep sleep.

## Example entry for `config.yaml`:

```yaml
# Load epaper_spi from fork until merged upstream
external_components:
  - source: github://corneliusludmann/esphome@add-waveshare-7.5in-h
    components: [epaper_spi]

# Waveshare ESP32 Driver Board default pins
spi:
  clk_pin: GPIO13
  mosi_pin: GPIO14

display:
  - platform: epaper_spi
    model: Waveshare-7.5in-H
    cs_pin: GPIO15
    dc_pin: GPIO27
    reset_pin: GPIO26
    busy_pin:
      number: GPIO25
      inverted: true
    update_interval: 5min
    lambda: |-
      auto BLACK = Color(0, 0, 0);
      auto WHITE = Color(255, 255, 255);
      auto RED = Color(255, 0, 0);
      auto YELLOW = Color(255, 255, 0);

      it.fill(WHITE);

      it.filled_rectangle(50, 50, 80, 80, BLACK);
      it.filled_rectangle(150, 50, 80, 80, RED);
      it.filled_rectangle(250, 50, 80, 80, YELLOW);

      it.print(400, 200, id(roboto_large), BLACK, TextAlign::CENTER, "Hello World!");
      it.print(400, 280, id(roboto_medium), RED, TextAlign::CENTER, "4-Color E-Paper");
      it.print(400, 340, id(roboto_medium), YELLOW, TextAlign::CENTER, "ESPHome + Home Assistant");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
