### PR TITLE
Enable IPv6 by default for dashboard interface

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1490,7 +1490,7 @@ def parse_args(argv):
         "--address",
         help="The address to bind to.",
         type=str,
-        default="0.0.0.0",
+        default="localhost",
     )
     parser_dashboard.add_argument(
         "--username",


### PR DESCRIPTION
# What does this implement/fix?

This is a minor change to change the default listening behaviour of the dashboard interface. This helps with the effort of getting ESPHome more ready for IPv6.

Switching the default argument passed into `args.address` from `0.0.0.0` to `localhost` changes the behaviour from listening on all IPv4 interfaces to listening on all interfaces for both IPv4 and IPv6.

This is equivalent to launching with the below command line:
```sh
esphome dashboard --address 'localhost' /config
```

Instead of the default, which is more like:
```sh
esphome dashboard --address '0.0.0.0' /config
```

As a side note, the following also works to enable dual-stack since it gets evaluated as `None`:
```sh
esphome dashboard --address '' /config
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/feature-requests#718

I'm not quite sure what wording the accompanying docs would need that isn't too long-winded.

This line would need updating to indicate that the default string is `localhost`, but it probably also needs to include the context that the `localhost` string functionally evaluates to "all IPv4 and IPv6 interfaces". Wasn't sure how to write that concisely.

https://github.com/esphome/esphome-docs/blob/f6359f11ff0cc0982d4883ef2b886ae39c8e6329/content/guides/cli.md?plain=1#L223

## Test Environment

I've tested this with a few connected devices but as far as I can tell this should only impact the Dashboard so I'm not sure how relevant this part is.

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
