### PR TITLE
Add IP6 only network config

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -457,6 +457,8 @@ float EthernetComponent::get_setup_priority() const { return setup_priority::WIF
 
 network::IPAddresses EthernetComponent::get_ip_addresses() {
   network::IPAddresses addresses;
+  int offset = 0;
+#if USE_NETWORK_IP4
   esp_netif_ip_info_t ip;
   esp_err_t err = esp_netif_get_ip_info(this->eth_netif_, &ip);
   if (err != ESP_OK) {
@@ -464,15 +466,16 @@ network::IPAddresses EthernetComponent::get_ip_addresses() {
     // TODO: do something smarter
     // return false;
   } else {
-    addresses[0] = network::IPAddress(&ip.ip);
+    addresses[offset++] = network::IPAddress(&ip.ip);
   }
+#endif
 #if USE_NETWORK_IPV6
   struct esp_ip6_addr if_ip6s[CONFIG_LWIP_IPV6_NUM_ADDRESSES];
   uint8_t count = 0;
   count = esp_netif_get_all_ip6(this->eth_netif_, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
   for (int i = 0; i < count; i++) {
-    addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
+    addresses[i + offset] = network::IPAddress(&if_ip6s[i]);
   }
 #endif /* USE_NETWORK_IPV6 */
 

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -229,12 +229,12 @@ void MQTTClientComponent::start_dnslookup_() {
     constexpr u8_t dns_addrtype =
 #if USE_NETWORK_IPV6
 #if USE_NETWORK_IPV4
-      LWIP_DNS_ADDRTYPE_IPV6_IPV4; // Dual: IP6 first, then IP4
+        LWIP_DNS_ADDRTYPE_IPV6_IPV4;  // Dual: IP6 first, then IP4
 #else
-      LWIP_DNS_ADDRTYPE_IPV6; // IP6 only
-#endif /* USE_NETWORK_IPV4 */
-      LWIP_DNS_ADDRTYPE_IPV4; // IP4 only
-#endif /* USE_NETWORK_IPV6 */
+        LWIP_DNS_ADDRTYPE_IPV6;  // IP6 only
+#endif                       /* USE_NETWORK_IPV4 */
+    LWIP_DNS_ADDRTYPE_IPV4;  // IP4 only
+#endif                       /* USE_NETWORK_IPV6 */
 
     err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr, MQTTClientComponent::dns_found_callback,
                                      this, dns_addrtype);

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -224,13 +224,20 @@ void MQTTClientComponent::start_dnslookup_() {
   err_t err;
   {
     LwIPLock lock;
+    // Resolution type depending on IP6/IP4 build config
+    // Note there is LWIP_DNS_ADDRTYPE_DEFAULT. But latter has different order (IP46 not IP64)
+    constexpr u8_t dns_addrtype =
 #if USE_NETWORK_IPV6
-    err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr, MQTTClientComponent::dns_found_callback,
-                                     this, LWIP_DNS_ADDRTYPE_IPV6_IPV4);
+#if USE_NETWORK_IPV4
+      LWIP_DNS_ADDRTYPE_IPV6_IPV4; // Dual: IP6 first, then IP4
 #else
-    err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr, MQTTClientComponent::dns_found_callback,
-                                     this, LWIP_DNS_ADDRTYPE_IPV4);
+      LWIP_DNS_ADDRTYPE_IPV6; // IP6 only
+#endif /* USE_NETWORK_IPV4 */
+      LWIP_DNS_ADDRTYPE_IPV4; // IP4 only
 #endif /* USE_NETWORK_IPV6 */
+
+    err = dns_gethostbyname_addrtype(this->credentials_.address.c_str(), &addr, MQTTClientComponent::dns_found_callback,
+                                     this, dns_addrtype);
   }
   switch (err) {
     case ERR_OK: {

--- a/esphome/components/network/__init__.py
+++ b/esphome/components/network/__init__.py
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 # Components can request high performance networking and this configures lwip and WiFi settings
 KEY_HIGH_PERFORMANCE_NETWORKING = "high_performance_networking"
 CONF_ENABLE_HIGH_PERFORMANCE = "enable_high_performance"
+CONF_ENABLE_IPV4 = "enable_ipv4"
 
 network_ns = cg.esphome_ns.namespace("network")
 IPAddress = network_ns.class_("IPAddress")
@@ -107,6 +108,7 @@ def has_high_performance_networking() -> bool:
 
 CONFIG_SCHEMA = cv.Schema(
     {
+        cv.Optional(CONF_ENABLE_IPV4, default=True): cv.boolean,
         cv.SplitDefault(
             CONF_ENABLE_IPV6,
             esp8266=False,
@@ -202,6 +204,20 @@ async def to_code(config):
             add_idf_sdkconfig_option("CONFIG_LWIP_TCP_RECVMBOX_SIZE", 64)
             add_idf_sdkconfig_option("CONFIG_LWIP_TCPIP_RECVMBOX_SIZE", 64)
 
+    # IP4
+    enable_ipv4 = config.get(CONF_ENABLE_IPV4, True)
+    # Can only compile out for ESP32 IDF without Arduino on top (latter cannot disable IP4)
+    if CORE.is_esp32:
+        if CORE.using_arduino:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", True)
+            cg.add_define("USE_NETWORK_IPV4", True)
+        else:
+            add_idf_sdkconfig_option("CONFIG_LWIP_IPV4", enable_ipv4)
+            cg.add_define("USE_NETWORK_IPV4", enable_ipv4)
+    else:
+        cg.add_define("USE_NETWORK_IPV4", True)
+
+    # IP6
     if (enable_ipv6 := config.get(CONF_ENABLE_IPV6, None)) is not None:
         cg.add_define("USE_NETWORK_IPV6", enable_ipv6)
         if enable_ipv6:

--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -74,41 +74,55 @@ struct IPAddress {
   }
 #else
   IPAddress() { ip_addr_set_zero(&ip_addr_); }
+#if LWIP_IPV4
   IPAddress(uint8_t first, uint8_t second, uint8_t third, uint8_t fourth) {
     IP_ADDR4(&ip_addr_, first, second, third, fourth);
   }
+#endif
   IPAddress(const ip_addr_t *other_ip) { ip_addr_copy(ip_addr_, *other_ip); }
   IPAddress(const char *in_address) { ipaddr_aton(in_address, &ip_addr_); }
   IPAddress(const std::string &in_address) { ipaddr_aton(in_address.c_str(), &ip_addr_); }
+#if LWIP_IPV4
   IPAddress(ip4_addr_t *other_ip) {
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(ip4_addr_t));
 #if USE_ESP32 && LWIP_IPV6
     ip_addr_.type = IPADDR_TYPE_V4;
 #endif
   }
+#endif
 #if USE_ARDUINO
   IPAddress(const arduino_ns::IPAddress &other_ip) { ip_addr_set_ip4_u32(&ip_addr_, other_ip); }
 #endif
 #if LWIP_IPV6
   IPAddress(ip6_addr_t *other_ip) {
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(ip6_addr_t));
+#if LWIP_IPV4
     ip_addr_.type = IPADDR_TYPE_V6;
+#endif
   }
 #endif /* LWIP_IPV6 */
 
 #ifdef USE_ESP32
 #if LWIP_IPV6
   IPAddress(esp_ip6_addr_t *other_ip) {
+#if LWIP_IPV4
     memcpy((void *) &ip_addr_.u_addr.ip6, (void *) other_ip, sizeof(esp_ip6_addr_t));
+#else
+    memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(esp_ip6_addr_t));
+#endif
+#if LWIP_IPV4
     ip_addr_.type = IPADDR_TYPE_V6;
+#endif
   }
 #endif /* LWIP_IPV6 */
+#if LWIP_IPV4
   IPAddress(esp_ip4_addr_t *other_ip) {
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(esp_ip4_addr_t));
 #if LWIP_IPV6
     ip_addr_.type = IPADDR_TYPE_V4;
 #endif
   }
+#endif
   IPAddress(esp_ip_addr_t *other_ip) {
 #if LWIP_IPV6
     memcpy((void *) &ip_addr_, (void *) other_ip, sizeof(ip_addr_));
@@ -125,6 +139,7 @@ struct IPAddress {
 #endif /* LWIP_IPV6 */
     return tmp;
   }
+#if LWIP_IPV4
   operator esp_ip4_addr_t() const {
     esp_ip4_addr_t tmp;
 #if LWIP_IPV6
@@ -134,10 +149,11 @@ struct IPAddress {
 #endif /* LWIP_IPV6 */
     return tmp;
   }
+#endif
 #endif /* USE_ESP32 */
 
   operator ip_addr_t() const { return ip_addr_; }
-#if LWIP_IPV6
+#if LWIP_IPV6 && LWIP_IPV4
   operator ip4_addr_t() const { return *ip_2_ip4(&ip_addr_); }
 #endif /* LWIP_IPV6 */
 
@@ -166,6 +182,7 @@ struct IPAddress {
   bool operator==(const IPAddress &other) const { return ip_addr_cmp(&ip_addr_, &other.ip_addr_); }
   bool operator!=(const IPAddress &other) const { return !ip_addr_cmp(&ip_addr_, &other.ip_addr_); }
   IPAddress &operator+=(uint8_t increase) {
+#if LWIP_IPV4
     if (IP_IS_V4(&ip_addr_)) {
 #if LWIP_IPV6
       (((u8_t *) (&ip_addr_.u_addr.ip4))[3]) += increase;
@@ -173,6 +190,7 @@ struct IPAddress {
       (((u8_t *) (&ip_addr_.addr))[3]) += increase;
 #endif /* LWIP_IPV6 */
     }
+#endif
     return *this;
   }
 #endif

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -90,7 +90,9 @@ class LWIPRawImpl : public Socket {
     }
     ip_addr_t ip;
     in_port_t port;
-#if LWIP_IPV6
+    // Configured can be IP4 only, IP6 only, or dual IP46
+    // Check IP4 first, IP6 second, then fail if nothing matched
+#if LWIP_IPV4
     if (family_ == AF_INET) {
       if (addrlen < sizeof(sockaddr_in)) {
         errno = EINVAL;
@@ -98,32 +100,32 @@ class LWIPRawImpl : public Socket {
       }
       auto *addr4 = reinterpret_cast<const sockaddr_in *>(name);
       port = ntohs(addr4->sin_port);
-      ip.type = IPADDR_TYPE_V4;
-      ip.u_addr.ip4.addr = addr4->sin_addr.s_addr;
-      LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip4addr_ntoa(&ip.u_addr.ip4), port);
-    } else if (family_ == AF_INET6) {
-      if (addrlen < sizeof(sockaddr_in6)) {
+      IP_SET_TYPE_VAL(ip, IPADDR_TYPE_V4);
+      ip_2_ip4(&ip)->addr = addr4->sin_addr.s_addr;
+      LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip4addr_ntoa(ip_2_ip4(&ip)), port);
+    } else {
+#endif
+#if LWIP_IPV6
+      if (family_ == AF_INET6) {
+        if (addrlen < sizeof(sockaddr_in6)) {
+          errno = EINVAL;
+          return -1;
+        }
+        auto *addr6 = reinterpret_cast<const sockaddr_in6 *>(name);
+        port = ntohs(addr6->sin6_port);
+        IP_SET_TYPE_VAL(ip, IPADDR_TYPE_ANY);
+        memcpy(&ip_2_ip6(&ip)->addr, &addr6->sin6_addr.un.u8_addr, 16);
+        LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip6addr_ntoa(ip_2_ip6(&ip)), port);
+      } else {
+#endif
+        // No supported family matched
         errno = EINVAL;
         return -1;
+#if LWIP_IPV6
       }
-      auto *addr6 = reinterpret_cast<const sockaddr_in6 *>(name);
-      port = ntohs(addr6->sin6_port);
-      ip.type = IPADDR_TYPE_ANY;
-      memcpy(&ip.u_addr.ip6.addr, &addr6->sin6_addr.un.u8_addr, 16);
-      LWIP_LOG("tcp_bind(%p ip=%s port=%u)", pcb_, ip6addr_ntoa(&ip.u_addr.ip6), port);
-    } else {
-      errno = EINVAL;
-      return -1;
+#endif
+#if LWIP_IPV4
     }
-#else
-    if (family_ != AF_INET) {
-      errno = EINVAL;
-      return -1;
-    }
-    auto *addr4 = reinterpret_cast<const sockaddr_in *>(name);
-    port = ntohs(addr4->sin_port);
-    ip.addr = addr4->sin_addr.s_addr;
-    LWIP_LOG("tcp_bind(%p ip=%u port=%u)", pcb_, ip.addr, port);
 #endif
     err_t err = tcp_bind(pcb_, &ip, port);
     if (err == ERR_USE) {
@@ -514,6 +516,7 @@ class LWIPRawImpl : public Socket {
 
  protected:
   int ip2sockaddr_(ip_addr_t *ip, uint16_t port, struct sockaddr *name, socklen_t *addrlen) {
+#if LWIP_IPV4
     if (family_ == AF_INET) {
       if (*addrlen < sizeof(struct sockaddr_in)) {
         errno = EINVAL;
@@ -527,8 +530,9 @@ class LWIPRawImpl : public Socket {
       inet_addr_from_ip4addr(&addr->sin_addr, ip_2_ip4(ip));
       return 0;
     }
+#endif
 #if LWIP_IPV6
-    else if (family_ == AF_INET6) {
+    if (family_ == AF_INET6) {
       if (*addrlen < sizeof(struct sockaddr_in6)) {
         errno = EINVAL;
         return -1;
@@ -539,12 +543,15 @@ class LWIPRawImpl : public Socket {
       *addrlen = addr->sin6_len = sizeof(struct sockaddr_in6);
       addr->sin6_port = port;
 
+#if LWIP_IPV4
       // AF_INET6 sockets are bound to IPv4 as well, so we may encounter IPv4 addresses that must be converted to IPv6.
       if (IP_IS_V4(ip)) {
         ip_addr_t mapped;
         ip4_2_ipv4_mapped_ipv6(ip_2_ip6(&mapped), ip_2_ip4(ip));
         inet6_addr_from_ip6addr(&addr->sin6_addr, ip_2_ip6(&mapped));
-      } else {
+      } else
+#endif
+      {
         inet6_addr_from_ip6addr(&addr->sin6_addr, ip_2_ip6(ip));
       }
       return 0;

--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -17,10 +17,12 @@ bool Socket::ready() const { return !this->loop_monitored_ || App.is_socket_read
 // Platform-specific inet_ntop wrappers
 #if defined(USE_SOCKET_IMPL_LWIP_TCP)
 // LWIP raw TCP (ESP8266) uses inet_ntoa_r which takes struct by value
+#if USE_NETWORK_IPV4
 static inline const char *esphome_inet_ntop4(const void *addr, char *buf, size_t size) {
   inet_ntoa_r(*reinterpret_cast<const struct in_addr *>(addr), buf, size);
   return buf;
 }
+#endif
 #if USE_NETWORK_IPV6
 static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t size) {
   inet6_ntoa_r(*reinterpret_cast<const ip6_addr_t *>(addr), buf, size);
@@ -29,9 +31,11 @@ static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t
 #endif
 #elif defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
 // LWIP sockets (LibreTiny, ESP32 Arduino)
+#if USE_NETWORK_IPV4
 static inline const char *esphome_inet_ntop4(const void *addr, char *buf, size_t size) {
   return lwip_inet_ntop(AF_INET, addr, buf, size);
 }
+#endif
 #if USE_NETWORK_IPV6
 static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t size) {
   return lwip_inet_ntop(AF_INET6, addr, buf, size);
@@ -39,9 +43,11 @@ static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t
 #endif
 #else
 // BSD sockets (host, ESP32-IDF)
+#if USE_NETWORK_IPV4
 static inline const char *esphome_inet_ntop4(const void *addr, char *buf, size_t size) {
   return inet_ntop(AF_INET, addr, buf, size);
 }
+#endif
 #if USE_NETWORK_IPV6
 static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t size) {
   return inet_ntop(AF_INET6, addr, buf, size);
@@ -51,21 +57,25 @@ static inline const char *esphome_inet_ntop6(const void *addr, char *buf, size_t
 
 // Format sockaddr into caller-provided buffer, returns length written (excluding null)
 size_t format_sockaddr_to(const struct sockaddr *addr_ptr, socklen_t len, std::span<char, SOCKADDR_STR_LEN> buf) {
+#if USE_NETWORK_IPV4
   if (addr_ptr->sa_family == AF_INET && len >= sizeof(const struct sockaddr_in)) {
     const auto *addr = reinterpret_cast<const struct sockaddr_in *>(addr_ptr);
     if (esphome_inet_ntop4(&addr->sin_addr, buf.data(), buf.size()) != nullptr)
       return strlen(buf.data());
   }
+#endif
 #if USE_NETWORK_IPV6
-  else if (addr_ptr->sa_family == AF_INET6 && len >= sizeof(sockaddr_in6)) {
+  if (addr_ptr->sa_family == AF_INET6 && len >= sizeof(sockaddr_in6)) {
     const auto *addr = reinterpret_cast<const struct sockaddr_in6 *>(addr_ptr);
 #ifndef USE_SOCKET_IMPL_LWIP_TCP
+#if USE_NETWORK_IPV4
     // Format IPv4-mapped IPv6 addresses as regular IPv4 (not supported on ESP8266 raw TCP)
     if (addr->sin6_addr.un.u32_addr[0] == 0 && addr->sin6_addr.un.u32_addr[1] == 0 &&
         addr->sin6_addr.un.u32_addr[2] == htonl(0xFFFF) &&
         esphome_inet_ntop4(&addr->sin6_addr.un.u32_addr[3], buf.data(), buf.size()) != nullptr) {
       return strlen(buf.data());
     }
+#endif
 #endif
     if (esphome_inet_ntop6(&addr->sin6_addr, buf.data(), buf.size()) != nullptr)
       return strlen(buf.data());
@@ -138,6 +148,7 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const char *ip_
     return sizeof(sockaddr_in6);
   }
 #endif /* USE_NETWORK_IPV6 */
+#if USE_NETWORK_IPV4
   if (addrlen < sizeof(sockaddr_in)) {
     errno = EINVAL;
     return 0;
@@ -148,6 +159,11 @@ socklen_t set_sockaddr(struct sockaddr *addr, socklen_t addrlen, const char *ip_
   server->sin_addr.s_addr = inet_addr(ip_address);
   server->sin_port = htons(port);
   return sizeof(sockaddr_in);
+#else
+  // Only IP6 without IP4 configured, but did not find IP6 separator
+  errno = EINVAL;
+  return 0;
+#endif /* USE_NETWORK_IPV4 */
 }
 
 socklen_t set_sockaddr_any(struct sockaddr *addr, socklen_t addrlen, uint16_t port) {

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -887,11 +887,13 @@ network::IPAddresses WiFiComponent::get_ip_addresses() {
 
   return {};
 }
+#if USE_NETWORK_IPV4
 network::IPAddress WiFiComponent::get_dns_address(int num) {
   if (this->has_sta())
     return this->wifi_dns_ip_(num);
   return {};
 }
+#endif /* USE_NETWORK_IPV4 */
 // set_use_address() is guaranteed to be called during component setup by Python code generation,
 // so use_address_ will always be valid when get_use_address() is called - no fallback needed.
 const char *WiFiComponent::get_use_address() const { return this->use_address_; }

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -652,7 +652,9 @@ class WiFiComponent : public Component {
   bool wifi_sta_pre_setup_();
   bool wifi_apply_output_power_(float output_power);
   bool wifi_apply_power_save_();
+#if USE_NETWORK_IPV4
   bool wifi_sta_ip_config_(const optional<ManualIP> &manual_ip);
+#endif
   bool wifi_apply_hostname_();
   bool wifi_sta_connect_(const WiFiAP &ap);
   void wifi_pre_setup_();
@@ -666,9 +668,11 @@ class WiFiComponent : public Component {
 
   bool wifi_disconnect_();
 
+#if USE_NETWORK_IPV4
   network::IPAddress wifi_subnet_mask_();
   network::IPAddress wifi_gateway_ip_();
   network::IPAddress wifi_dns_ip_(int num);
+#endif /* USE_NETWORK_IPV4 */
 
   bool is_captive_portal_active_();
   bool is_esp32_improv_active_();
@@ -825,7 +829,9 @@ class WiFiComponent : public Component {
   bool rrm_{false};
 #endif
   bool enable_on_boot_{true};
+#if USE_NETWORK_IPV4
   bool got_ipv4_address_{false};
+#endif /* USE_NETWORK_IPV4 */
   bool keep_scan_results_{false};
   bool has_completed_scan_after_captive_portal_start_{
       false};  // Tracks if we've completed a scan after captive portal started

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -116,6 +116,8 @@ bool WiFiComponent::wifi_apply_power_save_() {
   return success;
 }
 
+#if USE_NETWORK_IPV4
+
 #if LWIP_VERSION_MAJOR != 1
 /*
   lwip v2 needs to be notified of IP changes, see also
@@ -198,6 +200,7 @@ bool WiFiComponent::wifi_sta_ip_config_(const optional<ManualIP> &manual_ip) {
 #endif
   return ret;
 }
+#endif /* USE_NETWORK_IPV4 */
 
 network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   if (!this->has_sta())
@@ -286,6 +289,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
   }
 
+#if USE_NETWORK_IPV4
 #ifdef USE_WIFI_MANUAL_IP
   if (!this->wifi_sta_ip_config_(ap.get_manual_ip())) {
     return false;
@@ -295,6 +299,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
   }
 #endif
+#endif /* USE_NETWORK_IPV4 */
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
@@ -917,6 +922,7 @@ int8_t WiFiComponent::wifi_rssi() {
   return rssi >= 31 ? WIFI_RSSI_DISCONNECTED : rssi;
 }
 int32_t WiFiComponent::get_wifi_channel() { return wifi_get_channel(); }
+#if USE_NETWORK_IPV4
 network::IPAddress WiFiComponent::wifi_subnet_mask_() {
   struct ip_info ip {};
   wifi_get_ip_info(STATION_IF, &ip);
@@ -928,6 +934,7 @@ network::IPAddress WiFiComponent::wifi_gateway_ip_() {
   return network::IPAddress(&ip.gw);
 }
 network::IPAddress WiFiComponent::wifi_dns_ip_(int num) { return network::IPAddress(dns_getserver(num)); }
+#endif /* USE_NETWORK_IPV4 */
 void WiFiComponent::wifi_loop_() { this->process_pending_callbacks_(); }
 
 void WiFiComponent::process_pending_callbacks_() {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -930,9 +930,9 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
   if (s_sta_connected
 #if USE_NETWORK_IPV4
-          && this->got_ipv4_address_
+      && this->got_ipv4_address_
 #endif /* USE_NETWORK_IPV4 */
-    ) {
+  ) {
 #if USE_NETWORK_IPV6 && (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
     if (this->num_ipv6_addresses_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT) {
       return WiFiSTAConnectStatus::CONNECTED;

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -387,6 +387,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
   }
 
+#if USE_NETWORK_IPV4
 #ifdef USE_WIFI_MANUAL_IP
   if (!this->wifi_sta_ip_config_(ap.get_manual_ip())) {
     return false;
@@ -396,6 +397,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
     return false;
   }
 #endif
+#endif /* USE_NETWORK_IPV4 */
 
   // setup enterprise authentication if required
 #ifdef USE_WIFI_WPA2_EAP
@@ -484,9 +486,11 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   s_sta_connected = false;
   s_sta_connect_error = false;
   s_sta_connect_not_found = false;
+#if USE_NETWORK_IPV4
   // Reset IP address flags - ensures we don't report connected before DHCP completes
   // (IP_EVENT_STA_LOST_IP doesn't always fire on disconnect)
   this->got_ipv4_address_ = false;
+#endif
 #if USE_NETWORK_IPV6
   this->num_ipv6_addresses_ = 0;
 #endif
@@ -500,6 +504,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
   return true;
 }
 
+#if USE_NETWORK_IPV4
 bool WiFiComponent::wifi_sta_ip_config_(const optional<ManualIP> &manual_ip) {
   // enable STA
   if (!this->wifi_mode_(true, {}))
@@ -561,11 +566,14 @@ bool WiFiComponent::wifi_sta_ip_config_(const optional<ManualIP> &manual_ip) {
 
   return true;
 }
+#endif /* USE_NETWORK_IPV4 */
 
 network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   if (!this->has_sta())
     return {};
   network::IPAddresses addresses;
+  int offset = 0;
+#if USE_NETWORK_IPV4
   esp_netif_ip_info_t ip;
   esp_err_t err = esp_netif_get_ip_info(s_sta_netif, &ip);
   if (err != ESP_OK) {
@@ -573,15 +581,16 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
     // TODO: do something smarter
     // return false;
   } else {
-    addresses[0] = network::IPAddress(&ip.ip);
+    addresses[offset++] = network::IPAddress(&ip.ip);
   }
+#endif
 #if USE_NETWORK_IPV6
   struct esp_ip6_addr if_ip6s[CONFIG_LWIP_IPV6_NUM_ADDRESSES];
   uint8_t count = 0;
   count = esp_netif_get_all_ip6(s_sta_netif, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
   for (int i = 0; i < count; i++) {
-    addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
+    addresses[i + offset] = network::IPAddress(&if_ip6s[i]);
   }
 #endif /* USE_NETWORK_IPV6 */
   return addresses;
@@ -780,6 +789,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     this->notify_disconnect_state_listeners_();
 #endif
 
+#if USE_NETWORK_IPV4
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_GOT_IP) {
     const auto &it = data->data.ip_got_ip;
 #if USE_NETWORK_IPV6
@@ -790,6 +800,7 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 #ifdef USE_WIFI_IP_STATE_LISTENERS
     this->notify_ip_state_listeners_();
 #endif
+#endif /* USE_NETWORK_IPV4 */
 
 #if USE_NETWORK_IPV6
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_GOT_IP6) {
@@ -801,9 +812,11 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 #endif
 #endif /* USE_NETWORK_IPV6 */
 
+#if USE_NETWORK_IPV4
   } else if (data->event_base == IP_EVENT && data->event_id == IP_EVENT_STA_LOST_IP) {
     ESP_LOGV(TAG, "Lost IP");
     this->got_ipv4_address_ = false;
+#endif
 
   } else if (data->event_base == WIFI_EVENT && data->event_id == WIFI_EVENT_SCAN_DONE) {
     const auto &it = data->data.sta_scan_done;
@@ -915,7 +928,11 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
 }
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() {
-  if (s_sta_connected && this->got_ipv4_address_) {
+  if (s_sta_connected
+#if USE_NETWORK_IPV4
+          && this->got_ipv4_address_
+#endif /* USE_NETWORK_IPV4 */
+    ) {
 #if USE_NETWORK_IPV6 && (USE_NETWORK_MIN_IPV6_ADDR_COUNT > 0)
     if (this->num_ipv6_addresses_ >= USE_NETWORK_MIN_IPV6_ADDR_COUNT) {
       return WiFiSTAConnectStatus::CONNECTED;
@@ -1166,6 +1183,7 @@ int32_t WiFiComponent::get_wifi_channel() {
   }
   return primary;
 }
+#if USE_NETWORK_IPV4
 network::IPAddress WiFiComponent::wifi_subnet_mask_() {
   esp_netif_ip_info_t ip;
   esp_err_t err = esp_netif_get_ip_info(s_sta_netif, &ip);
@@ -1188,6 +1206,7 @@ network::IPAddress WiFiComponent::wifi_dns_ip_(int num) {
   const ip_addr_t *dns_ip = dns_getserver(num);
   return network::IPAddress(dns_ip);
 }
+#endif /* USE_NETWORK_IPV4 */
 
 }  // namespace esphome::wifi
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

_Disclaimer: PoC: Parts missing (e.g. validation, tests, covering all potentially affected components, local longrun tests)_

Add config option for IP6 only network.

## Usecase

Thread network devices are IP6 only. Having external IP4 network built into ESPHome firmware is waste of resources if no IP4 connection even usable.

## First estimation of savings

Local YAML project using Thread network with api:

BEFORE:
```txt
RAM:   [=         ]  11.7% (used 38328 bytes from 327680 bytes)
Flash: [=         ]  11.3% (used 916660 bytes from 8126464 bytes)
```
AFTER:
```txt
RAM:   [=         ]  11.2% (used 36616 bytes from 327680 bytes)
Flash: [=         ]  10.9% (used 888136 bytes from 8126464 bytes)
```

--> Ca 1.7kB RAM savings and 28kB flash savings.

Now abovementioned usecase of Thread devices relates mostly to newer ESP32 devices, less so to RAM restricted older architectures. However, still seems worthwhile.

ESP IDF e.g. officially supports and mentions this option to save resources:
https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/performance/size.html#lwip-ipv4

## Backward compatibility

IP4 should stay enabled by default.
Only when disabled, IP6 only should be used.
Therefore no developer breaking change.

Component tests (at least compilation) likely vital to catch all components that may be possibly affected. Also regression testing to avoid regression for vital network.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
network:
  enable_ipv6: true  # E.g. needed for openthread
  enable_ipv4: false # Newly allowed
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
