### PR TITLE
[camera, camera_encoder] Remove stored RAMAllocator member

### DIFF
--- a/esphome/components/camera/buffer_impl.cpp
+++ b/esphome/components/camera/buffer_impl.cpp
@@ -3,18 +3,22 @@
 namespace esphome::camera {
 
 BufferImpl::BufferImpl(size_t size) {
-  this->data_ = this->allocator_.allocate(size);
+  RAMAllocator<uint8_t> allocator;
+  this->data_ = allocator.allocate(size);
   this->size_ = size;
 }
 
 BufferImpl::BufferImpl(CameraImageSpec *spec) {
-  this->data_ = this->allocator_.allocate(spec->bytes_per_image());
+  RAMAllocator<uint8_t> allocator;
+  this->data_ = allocator.allocate(spec->bytes_per_image());
   this->size_ = spec->bytes_per_image();
 }
 
 BufferImpl::~BufferImpl() {
-  if (this->data_ != nullptr)
-    this->allocator_.deallocate(this->data_, this->size_);
+  if (this->data_ != nullptr) {
+    RAMAllocator<uint8_t> allocator;
+    allocator.deallocate(this->data_, this->size_);
+  }
 }
 
 }  // namespace esphome::camera

--- a/esphome/components/camera/buffer_impl.h
+++ b/esphome/components/camera/buffer_impl.h
@@ -18,7 +18,6 @@ class BufferImpl : public Buffer {
   ~BufferImpl() override;
 
  protected:
-  RAMAllocator<uint8_t> allocator_;
   size_t size_{};
   uint8_t *data_{};
 };

--- a/esphome/components/camera_encoder/encoder_buffer_impl.cpp
+++ b/esphome/components/camera_encoder/encoder_buffer_impl.cpp
@@ -4,7 +4,8 @@ namespace esphome::camera_encoder {
 
 bool EncoderBufferImpl::set_buffer_size(size_t size) {
   if (size > this->capacity_) {
-    uint8_t *p = this->allocator_.reallocate(this->data_, size);
+    RAMAllocator<uint8_t> allocator;
+    uint8_t *p = allocator.reallocate(this->data_, size);
     if (p == nullptr)
       return false;
 
@@ -16,8 +17,10 @@ bool EncoderBufferImpl::set_buffer_size(size_t size) {
 }
 
 EncoderBufferImpl::~EncoderBufferImpl() {
-  if (this->data_ != nullptr)
-    this->allocator_.deallocate(this->data_, this->capacity_);
+  if (this->data_ != nullptr) {
+    RAMAllocator<uint8_t> allocator;
+    allocator.deallocate(this->data_, this->capacity_);
+  }
 }
 
 }  // namespace esphome::camera_encoder

--- a/esphome/components/camera_encoder/encoder_buffer_impl.h
+++ b/esphome/components/camera_encoder/encoder_buffer_impl.h
@@ -16,7 +16,6 @@ class EncoderBufferImpl : public camera::EncoderBuffer {
   ~EncoderBufferImpl() override;
 
  protected:
-  RAMAllocator<uint8_t> allocator_;
   size_t capacity_{};
   size_t size_{};
   uint8_t *data_{};


### PR DESCRIPTION
# What does this implement/fix?

`RAMAllocator` with default flags is stateless — it's just a thin dispatch wrapper over `heap_caps_malloc`/`heap_caps_realloc`/`free`. Storing it as a class member is unnecessary. This removes the stored `allocator_` member from `BufferImpl` and `EncoderBufferImpl`, using stack-local instances at each call site instead.

This matches the pattern already used in `audio_transfer_buffer.cpp` and `ring_buffer.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable, internal implementation change only.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).