### PR TITLE
[runtime_image] Remove stored RAMAllocator member

### DIFF
--- a/esphome/components/runtime_image/png_decoder.cpp
+++ b/esphome/components/runtime_image/png_decoder.cpp
@@ -50,7 +50,8 @@ static void draw_callback(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, ui
 
 PngDecoder::PngDecoder(RuntimeImage *image) : ImageDecoder(image) {
   {
-    pngle_t *pngle = this->allocator_.allocate(1, PNGLE_T_SIZE);
+    RAMAllocator<pngle_t> allocator;
+    pngle_t *pngle = allocator.allocate(1, PNGLE_T_SIZE);
     if (!pngle) {
       ESP_LOGE(TAG, "Failed to allocate memory for PNGLE engine!");
       return;
@@ -64,7 +65,8 @@ PngDecoder::PngDecoder(RuntimeImage *image) : ImageDecoder(image) {
 PngDecoder::~PngDecoder() {
   if (this->pngle_) {
     pngle_reset(this->pngle_);
-    this->allocator_.deallocate(this->pngle_, PNGLE_T_SIZE);
+    RAMAllocator<pngle_t> allocator;
+    allocator.deallocate(this->pngle_, PNGLE_T_SIZE);
   }
 }
 

--- a/esphome/components/runtime_image/png_decoder.h
+++ b/esphome/components/runtime_image/png_decoder.h
@@ -29,7 +29,6 @@ class PngDecoder : public ImageDecoder {
   uint32_t get_pixels_decoded() const { return this->pixels_decoded_; }
 
  protected:
-  RAMAllocator<pngle_t> allocator_;
   pngle_t *pngle_{nullptr};
   uint32_t pixels_decoded_{0};
 };

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -230,7 +230,8 @@ void RuntimeImage::release() {
 void RuntimeImage::release_buffer_() {
   if (this->buffer_) {
     ESP_LOGV(TAG, "Releasing buffer of size %zu", this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
-    this->allocator_.deallocate(this->buffer_, this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
+    RAMAllocator<uint8_t> allocator;
+    allocator.deallocate(this->buffer_, this->get_buffer_size_(this->buffer_width_, this->buffer_height_));
     this->buffer_ = nullptr;
     this->data_start_ = nullptr;
     this->width_ = 0;
@@ -254,11 +255,12 @@ size_t RuntimeImage::resize_buffer_(int width, int height) {
   }
 
   ESP_LOGD(TAG, "Allocating buffer: %dx%d, %zu bytes", width, height, new_size);
-  this->buffer_ = this->allocator_.allocate(new_size);
+  RAMAllocator<uint8_t> allocator;
+  this->buffer_ = allocator.allocate(new_size);
 
   if (!this->buffer_) {
     ESP_LOGE(TAG, "Failed to allocate %zu bytes. Largest free block: %zu", new_size,
-             this->allocator_.get_max_free_block_size());
+             allocator.get_max_free_block_size());
     return 0;
   }
 

--- a/esphome/components/runtime_image/runtime_image.h
+++ b/esphome/components/runtime_image/runtime_image.h
@@ -165,7 +165,6 @@ class RuntimeImage : public image::Image {
   std::unique_ptr<ImageDecoder> create_decoder_();
 
   // Memory management
-  RAMAllocator<uint8_t> allocator_{};
   uint8_t *buffer_{nullptr};
 
   // Decoder management


### PR DESCRIPTION
# What does this implement/fix?

`RAMAllocator` with default flags is stateless — it's just a thin dispatch wrapper over `heap_caps_malloc`/`heap_caps_realloc`/`free`. Storing it as a class member is unnecessary. This removes the stored `allocator_` member from `RuntimeImage` and `PngDecoder`, using stack-local instances at each call site instead.

This matches the pattern already used in `audio_transfer_buffer.cpp` and `ring_buffer.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable, internal implementation change only.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).