### PR TITLE
[online_image] Remove stored RAMAllocator member from DownloadBuffer

### DIFF
--- a/esphome/components/online_image/download_buffer.cpp
+++ b/esphome/components/online_image/download_buffer.cpp
@@ -7,7 +7,8 @@ namespace esphome::online_image {
 static const char *const TAG = "online_image.download_buffer";
 
 DownloadBuffer::DownloadBuffer(size_t size) : size_(size) {
-  this->buffer_ = this->allocator_.allocate(size);
+  RAMAllocator<uint8_t> allocator;
+  this->buffer_ = allocator.allocate(size);
   this->reset();
   if (!this->buffer_) {
     ESP_LOGE(TAG, "Initial allocation of download buffer failed!");
@@ -38,15 +39,16 @@ size_t DownloadBuffer::resize(size_t size) {
     // Avoid useless reallocations; if the buffer is big enough, don't reallocate.
     return this->size_;
   }
-  this->allocator_.deallocate(this->buffer_, this->size_);
-  this->buffer_ = this->allocator_.allocate(size);
+  RAMAllocator<uint8_t> allocator;
+  allocator.deallocate(this->buffer_, this->size_);
+  this->buffer_ = allocator.allocate(size);
   this->reset();
   if (this->buffer_) {
     this->size_ = size;
     return size;
   } else {
     ESP_LOGE(TAG, "allocation of %zu bytes failed. Biggest block in heap: %zu Bytes", size,
-             this->allocator_.get_max_free_block_size());
+             allocator.get_max_free_block_size());
     this->size_ = 0;
     return 0;
   }

--- a/esphome/components/online_image/download_buffer.h
+++ b/esphome/components/online_image/download_buffer.h
@@ -15,7 +15,10 @@ namespace esphome::online_image {
 class DownloadBuffer {
  public:
   DownloadBuffer(size_t size);
-  ~DownloadBuffer() { this->allocator_.deallocate(this->buffer_, this->size_); }
+  ~DownloadBuffer() {
+    RAMAllocator<uint8_t> allocator;
+    allocator.deallocate(this->buffer_, this->size_);
+  }
 
   uint8_t *data(size_t offset = 0);
   uint8_t *append() { return this->data(this->unread_); }
@@ -34,7 +37,6 @@ class DownloadBuffer {
   size_t resize(size_t size);
 
  protected:
-  RAMAllocator<uint8_t> allocator_{};
   uint8_t *buffer_;
   size_t size_;
   /** Total number of downloaded bytes not yet read. */


### PR DESCRIPTION
# What does this implement/fix?

`RAMAllocator` with default flags is stateless — it's just a thin dispatch wrapper over `heap_caps_malloc`/`heap_caps_realloc`/`free`. Storing it as a class member is unnecessary. This removes the stored `allocator_` member from `DownloadBuffer`, using stack-local instances at each call site instead.

This matches the pattern already used in `audio_transfer_buffer.cpp` and `ring_buffer.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable, internal implementation change only.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).