### PR TITLE
[json, core] Remove stored RAMAllocator, make constructors constexpr

### DIFF
--- a/esphome/components/json/json_util.h
+++ b/esphome/components/json/json_util.h
@@ -18,7 +18,10 @@ namespace json {
 // Build an allocator for the JSON Library using the RAMAllocator class
 // This is only compiled when PSRAM is enabled
 struct SpiRamAllocator : ArduinoJson::Allocator {
-  void *allocate(size_t size) override { return allocator_.allocate(size); }
+  void *allocate(size_t size) override {
+    RAMAllocator<uint8_t> allocator;
+    return allocator.allocate(size);
+  }
 
   void deallocate(void *ptr) override {
     // ArduinoJson's Allocator interface doesn't provide the size parameter in deallocate.
@@ -31,11 +34,9 @@ struct SpiRamAllocator : ArduinoJson::Allocator {
   }
 
   void *reallocate(void *ptr, size_t new_size) override {
-    return allocator_.reallocate(static_cast<uint8_t *>(ptr), new_size);
+    RAMAllocator<uint8_t> allocator;
+    return allocator.reallocate(static_cast<uint8_t *>(ptr), new_size);
   }
-
- protected:
-  RAMAllocator<uint8_t> allocator_{RAMAllocator<uint8_t>::NONE};
 };
 #endif
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1673,13 +1673,10 @@ template<class T> class RAMAllocator {
     ALLOW_FAILURE = 1 << 2,   // Does nothing. Kept for compatibility.
   };
 
-  RAMAllocator() = default;
-  RAMAllocator(uint8_t flags) {
-    // default is both external and internal
-    flags &= ALLOC_INTERNAL | ALLOC_EXTERNAL;
-    if (flags != 0)
-      this->flags_ = flags;
-  }
+  constexpr RAMAllocator() = default;
+  constexpr RAMAllocator(uint8_t flags)
+      : flags_((flags & (ALLOC_INTERNAL | ALLOC_EXTERNAL)) != 0 ? (flags & (ALLOC_INTERNAL | ALLOC_EXTERNAL))
+                                                                : (ALLOC_INTERNAL | ALLOC_EXTERNAL)) {}
   template<class U> constexpr RAMAllocator(const RAMAllocator<U> &other) : flags_{other.flags_} {}
 
   T *allocate(size_t n) { return this->allocate(n, sizeof(T)); }


### PR DESCRIPTION
# What does this implement/fix?

Two related improvements:

1. **Remove stored `RAMAllocator` from `SpiRamAllocator`:** `RAMAllocator` with default flags is stateless — it's just a thin dispatch wrapper over `heap_caps_malloc`/`heap_caps_realloc`/`free`. The stored member was initialized with `RAMAllocator::NONE` (0), which is equivalent to default construction since the constructor preserves the default `ALLOC_INTERNAL | ALLOC_EXTERNAL` flags when no valid allocation flags are provided. Stack-local instances are used at each call site instead.

2. **Make `RAMAllocator` constructors `constexpr`:** This allows the compiler to fully evaluate flag logic at compile time, enabling better optimization when the allocator is constructed with known flags.

This matches the pattern already used in `audio_transfer_buffer.cpp` and `ring_buffer.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable, internal implementation change only.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).