### PR TITLE
[esp32_rmt] Handle ESP32 variants without RMT hardware

### DIFF
--- a/esphome/components/esp32_rmt/__init__.py
+++ b/esphome/components/esp32_rmt/__init__.py
@@ -1,7 +1,29 @@
 from esphome.components import esp32
 import esphome.config_validation as cv
+from esphome.core import CORE
 
 CODEOWNERS = ["@jesserockz"]
+
+VARIANTS_NO_RMT = {esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61}
+
+
+def validate_rmt_not_supported(rmt_only_keys):
+    """Validate that RMT-only config keys are not used on variants without RMT hardware."""
+    rmt_only_keys = set(rmt_only_keys)
+
+    def _validator(config):
+        if CORE.is_esp32:
+            variant = esp32.get_esp32_variant()
+            if variant in VARIANTS_NO_RMT:
+                unsupported = rmt_only_keys.intersection(config)
+                if unsupported:
+                    keys = ", ".join(sorted(f"'{k}'" for k in unsupported))
+                    raise cv.Invalid(
+                        f"{keys} not available on {variant} (no RMT hardware)"
+                    )
+        return config
+
+    return _validator
 
 
 def validate_clock_resolution():

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -71,6 +71,10 @@ CONF_RESET_LOW = "reset_low"
 
 
 CONFIG_SCHEMA = cv.All(
+    esp32.only_on_variant(
+        unsupported=[esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61],
+        msg_prefix="ESP32 RMT LED strip",
+    ),
     light.ADDRESSABLE_LIGHT_SCHEMA.extend(
         {
             cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(ESP32RMTLEDStripLightOutput),

--- a/esphome/components/esp32_rmt_led_strip/light.py
+++ b/esphome/components/esp32_rmt_led_strip/light.py
@@ -3,7 +3,7 @@ import logging
 
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components import esp32, light
+from esphome.components import esp32, esp32_rmt, light
 from esphome.components.const import CONF_USE_PSRAM
 from esphome.components.esp32 import include_builtin_idf_component
 import esphome.config_validation as cv
@@ -72,7 +72,7 @@ CONF_RESET_LOW = "reset_low"
 
 CONFIG_SCHEMA = cv.All(
     esp32.only_on_variant(
-        unsupported=[esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61],
+        unsupported=list(esp32_rmt.VARIANTS_NO_RMT),
         msg_prefix="ESP32 RMT LED strip",
     ),
     light.ADDRESSABLE_LIGHT_SCHEMA.extend(

--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -119,6 +119,8 @@ class RemoteComponentBase {
 };
 
 #ifdef USE_ESP32
+#include <soc/soc_caps.h>
+#if SOC_RMT_SUPPORTED
 class RemoteRMTChannel {
  public:
   void set_clock_resolution(uint32_t clock_resolution) { this->clock_resolution_ = clock_resolution; }
@@ -137,7 +139,8 @@ class RemoteRMTChannel {
   uint32_t clock_resolution_{1000000};
   uint32_t rmt_symbols_;
 };
-#endif
+#endif  // SOC_RMT_SUPPORTED
+#endif  // USE_ESP32
 
 class RemoteTransmitterBase : public RemoteComponentBase {
  public:

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -22,6 +22,8 @@ from esphome.const import (
 )
 from esphome.core import CORE, TimePeriod
 
+_VARIANTS_NO_RMT = [esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61]
+
 CONF_FILTER_SYMBOLS = "filter_symbols"
 CONF_RECEIVE_SYMBOLS = "receive_symbols"
 
@@ -65,6 +67,21 @@ RemoteReceiverComponent = remote_receiver_ns.class_(
 def validate_config(config):
     if CORE.is_esp32:
         variant = esp32.get_esp32_variant()
+        if variant in _VARIANTS_NO_RMT:
+            for conf in (
+                CONF_CLOCK_RESOLUTION,
+                CONF_USE_DMA,
+                CONF_RMT_SYMBOLS,
+                CONF_FILTER_SYMBOLS,
+                CONF_RECEIVE_SYMBOLS,
+                CONF_CARRIER_DUTY_PERCENT,
+                CONF_CARRIER_FREQUENCY,
+            ):
+                if conf in config:
+                    raise cv.Invalid(
+                        f"'{conf}' is not available on {variant} (no RMT hardware)"
+                    )
+            return config
         if variant in (esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S2):
             max_idle = 65535
         else:
@@ -110,6 +127,8 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.SplitDefault(
                 CONF_BUFFER_SIZE,
                 esp32="10000b",
+                esp32_c2="1000b",
+                esp32_c61="1000b",
                 esp8266="1000b",
                 bk72xx="1000b",
                 ln882x="1000b",
@@ -131,9 +150,11 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.SplitDefault(
                 CONF_RMT_SYMBOLS,
                 esp32=192,
+                esp32_c2=cv.UNDEFINED,
                 esp32_c3=96,
                 esp32_c5=96,
                 esp32_c6=96,
+                esp32_c61=cv.UNDEFINED,
                 esp32_h2=96,
                 esp32_p4=192,
                 esp32_s2=192,
@@ -145,6 +166,8 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
             cv.SplitDefault(
                 CONF_RECEIVE_SYMBOLS,
                 esp32=192,
+                esp32_c2=cv.UNDEFINED,
+                esp32_c61=cv.UNDEFINED,
             ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
             cv.Optional(CONF_USE_DMA): cv.All(
                 esp32.only_on_variant(
@@ -152,14 +175,22 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
                 ),
                 cv.boolean,
             ),
-            cv.SplitDefault(CONF_CARRIER_DUTY_PERCENT, esp32=100): cv.All(
+            cv.SplitDefault(
+                CONF_CARRIER_DUTY_PERCENT,
+                esp32=100,
+                esp32_c2=cv.UNDEFINED,
+                esp32_c61=cv.UNDEFINED,
+            ): cv.All(
                 cv.only_on_esp32,
                 cv.percentage_int,
                 cv.Range(min=1, max=100),
             ),
-            cv.SplitDefault(CONF_CARRIER_FREQUENCY, esp32="0Hz"): cv.All(
-                cv.only_on_esp32, cv.frequency, cv.int_
-            ),
+            cv.SplitDefault(
+                CONF_CARRIER_FREQUENCY,
+                esp32="0Hz",
+                esp32_c2=cv.UNDEFINED,
+                esp32_c61=cv.UNDEFINED,
+            ): cv.All(cv.only_on_esp32, cv.frequency, cv.int_),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -169,7 +200,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
 
 async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    if CORE.is_esp32:
+    if CORE.is_esp32 and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
 
@@ -213,6 +244,8 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
             PlatformFramework.ESP32_IDF,
         },
         "remote_receiver.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
             PlatformFramework.ESP8266_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -62,25 +62,10 @@ RemoteReceiverComponent = remote_receiver_ns.class_(
 )
 
 
-_RMT_ONLY_KEYS = {
-    CONF_CLOCK_RESOLUTION,
-    CONF_USE_DMA,
-    CONF_RMT_SYMBOLS,
-    CONF_FILTER_SYMBOLS,
-    CONF_RECEIVE_SYMBOLS,
-    CONF_CARRIER_DUTY_PERCENT,
-    CONF_CARRIER_FREQUENCY,
-}
-
-
 def validate_config(config):
     if CORE.is_esp32:
         variant = esp32.get_esp32_variant()
         if variant in esp32_rmt.VARIANTS_NO_RMT:
-            unsupported = _RMT_ONLY_KEYS.intersection(config)
-            if unsupported:
-                keys = ", ".join(sorted(f"'{k}'" for k in unsupported))
-                raise cv.Invalid(f"{keys} not available on {variant} (no RMT hardware)")
             return config
         if variant in (esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S2):
             max_idle = 65535
@@ -194,6 +179,19 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
+    .add_extra(
+        esp32_rmt.validate_rmt_not_supported(
+            [
+                CONF_CLOCK_RESOLUTION,
+                CONF_USE_DMA,
+                CONF_RMT_SYMBOLS,
+                CONF_FILTER_SYMBOLS,
+                CONF_RECEIVE_SYMBOLS,
+                CONF_CARRIER_DUTY_PERCENT,
+                CONF_CARRIER_FREQUENCY,
+            ]
+        )
+    )
     .add_extra(validate_config)
 )
 

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -22,8 +22,6 @@ from esphome.const import (
 )
 from esphome.core import CORE, TimePeriod
 
-_VARIANTS_NO_RMT = [esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61]
-
 CONF_FILTER_SYMBOLS = "filter_symbols"
 CONF_RECEIVE_SYMBOLS = "receive_symbols"
 
@@ -64,23 +62,25 @@ RemoteReceiverComponent = remote_receiver_ns.class_(
 )
 
 
+_RMT_ONLY_KEYS = {
+    CONF_CLOCK_RESOLUTION,
+    CONF_USE_DMA,
+    CONF_RMT_SYMBOLS,
+    CONF_FILTER_SYMBOLS,
+    CONF_RECEIVE_SYMBOLS,
+    CONF_CARRIER_DUTY_PERCENT,
+    CONF_CARRIER_FREQUENCY,
+}
+
+
 def validate_config(config):
     if CORE.is_esp32:
         variant = esp32.get_esp32_variant()
-        if variant in _VARIANTS_NO_RMT:
-            for conf in (
-                CONF_CLOCK_RESOLUTION,
-                CONF_USE_DMA,
-                CONF_RMT_SYMBOLS,
-                CONF_FILTER_SYMBOLS,
-                CONF_RECEIVE_SYMBOLS,
-                CONF_CARRIER_DUTY_PERCENT,
-                CONF_CARRIER_FREQUENCY,
-            ):
-                if conf in config:
-                    raise cv.Invalid(
-                        f"'{conf}' is not available on {variant} (no RMT hardware)"
-                    )
+        if variant in esp32_rmt.VARIANTS_NO_RMT:
+            unsupported = _RMT_ONLY_KEYS.intersection(config)
+            if unsupported:
+                keys = ", ".join(sorted(f"'{k}'" for k in unsupported))
+                raise cv.Invalid(f"{keys} not available on {variant} (no RMT hardware)")
             return config
         if variant in (esp32.VARIANT_ESP32, esp32.VARIANT_ESP32S2):
             max_idle = 65535
@@ -200,7 +200,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
 
 async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    if CORE.is_esp32 and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT:
+    if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
 

--- a/esphome/components/remote_receiver/remote_receiver.cpp
+++ b/esphome/components/remote_receiver/remote_receiver.cpp
@@ -3,7 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-#if defined(USE_LIBRETINY) || defined(USE_ESP8266) || defined(USE_RP2040)
+#if defined(USE_LIBRETINY) || defined(USE_ESP8266) || defined(USE_RP2040) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
 
 namespace esphome::remote_receiver {
 

--- a/esphome/components/remote_receiver/remote_receiver_esp32.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_esp32.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/log.h"
 
 #ifdef USE_ESP32
+#include <soc/soc_caps.h>
+#if SOC_RMT_SUPPORTED
 #include <driver/gpio.h>
 #include <esp_clk_tree.h>
 
@@ -248,4 +250,5 @@ void RemoteReceiverComponent::decode_rmt_(rmt_symbol_word_t *item, size_t item_c
 
 }  // namespace esphome::remote_receiver
 
-#endif
+#endif  // SOC_RMT_SUPPORTED
+#endif  // USE_ESP32

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -24,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["remote_base"]
 
+_VARIANTS_NO_RMT = [esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61]
+
 CONF_EOT_LEVEL = "eot_level"
 CONF_NON_BLOCKING = "non_blocking"
 CONF_ON_TRANSMIT = "on_transmit"
@@ -40,45 +42,74 @@ DigitalWriteAction = remote_transmitter_ns.class_(
     cg.Parented.template(RemoteTransmitterComponent),
 )
 
+
+def _validate_rmt(config):
+    if CORE.is_esp32:
+        variant = esp32.get_esp32_variant()
+        if variant in _VARIANTS_NO_RMT:
+            for conf in (
+                CONF_CLOCK_RESOLUTION,
+                CONF_EOT_LEVEL,
+                CONF_USE_DMA,
+                CONF_RMT_SYMBOLS,
+                CONF_NON_BLOCKING,
+            ):
+                if conf in config:
+                    raise cv.Invalid(
+                        f"'{conf}' is not available on {variant} (no RMT hardware)"
+                    )
+    return config
+
+
 MULTI_CONF = True
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(RemoteTransmitterComponent),
-        cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
-        cv.Required(CONF_CARRIER_DUTY_PERCENT): cv.All(
-            cv.percentage_int, cv.Range(min=1, max=100)
-        ),
-        cv.Optional(CONF_CLOCK_RESOLUTION): cv.All(
-            cv.only_on_esp32,
-            esp32_rmt.validate_clock_resolution(),
-        ),
-        cv.Optional(CONF_EOT_LEVEL): cv.All(cv.only_on_esp32, cv.boolean),
-        cv.Optional(CONF_USE_DMA): cv.All(
-            esp32.only_on_variant(
-                supported=[esp32.VARIANT_ESP32P4, esp32.VARIANT_ESP32S3]
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(RemoteTransmitterComponent),
+            cv.Required(CONF_PIN): pins.gpio_output_pin_schema,
+            cv.Required(CONF_CARRIER_DUTY_PERCENT): cv.All(
+                cv.percentage_int, cv.Range(min=1, max=100)
             ),
-            cv.boolean,
-        ),
-        cv.SplitDefault(
-            CONF_RMT_SYMBOLS,
-            esp32=64,
-            esp32_c3=48,
-            esp32_c5=48,
-            esp32_c6=48,
-            esp32_h2=48,
-            esp32_p4=48,
-            esp32_s2=64,
-            esp32_s3=48,
-        ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
-        cv.Optional(CONF_NON_BLOCKING): cv.All(cv.only_on_esp32, cv.boolean),
-        cv.Optional(CONF_ON_TRANSMIT): automation.validate_automation(single=True),
-        cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
-    }
-).extend(cv.COMPONENT_SCHEMA)
+            cv.Optional(CONF_CLOCK_RESOLUTION): cv.All(
+                cv.only_on_esp32,
+                esp32_rmt.validate_clock_resolution(),
+            ),
+            cv.Optional(CONF_EOT_LEVEL): cv.All(cv.only_on_esp32, cv.boolean),
+            cv.Optional(CONF_USE_DMA): cv.All(
+                esp32.only_on_variant(
+                    supported=[esp32.VARIANT_ESP32P4, esp32.VARIANT_ESP32S3]
+                ),
+                cv.boolean,
+            ),
+            cv.SplitDefault(
+                CONF_RMT_SYMBOLS,
+                esp32=64,
+                esp32_c2=cv.UNDEFINED,
+                esp32_c3=48,
+                esp32_c5=48,
+                esp32_c6=48,
+                esp32_c61=cv.UNDEFINED,
+                esp32_h2=48,
+                esp32_p4=48,
+                esp32_s2=64,
+                esp32_s3=48,
+            ): cv.All(cv.only_on_esp32, cv.int_range(min=2)),
+            cv.Optional(CONF_NON_BLOCKING): cv.All(cv.only_on_esp32, cv.boolean),
+            cv.Optional(CONF_ON_TRANSMIT): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_COMPLETE): automation.validate_automation(single=True),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .add_extra(_validate_rmt)
+)
 
 
 def _validate_non_blocking(config):
-    if CORE.is_esp32 and CONF_NON_BLOCKING not in config:
+    if (
+        CORE.is_esp32
+        and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT
+        and CONF_NON_BLOCKING not in config
+    ):
         _LOGGER.warning(
             "'non_blocking' is not set for 'remote_transmitter' and will default to 'true'.\n"
             "The default behavior changed in 2025.11.0; previously blocking mode was used.\n"
@@ -111,7 +142,7 @@ async def digital_write_action_to_code(config, action_id, template_arg, args):
 
 async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    if CORE.is_esp32:
+    if CORE.is_esp32 and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
 
@@ -155,6 +186,8 @@ FILTER_SOURCE_FILES = filter_source_files_from_platform(
             PlatformFramework.ESP32_IDF,
         },
         "remote_transmitter.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
             PlatformFramework.ESP8266_ARDUINO,
             PlatformFramework.BK72XX_ARDUINO,
             PlatformFramework.RTL87XX_ARDUINO,

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -24,8 +24,6 @@ _LOGGER = logging.getLogger(__name__)
 
 AUTO_LOAD = ["remote_base"]
 
-_VARIANTS_NO_RMT = [esp32.VARIANT_ESP32C2, esp32.VARIANT_ESP32C61]
-
 CONF_EOT_LEVEL = "eot_level"
 CONF_NON_BLOCKING = "non_blocking"
 CONF_ON_TRANSMIT = "on_transmit"
@@ -41,24 +39,6 @@ DigitalWriteAction = remote_transmitter_ns.class_(
     automation.Action,
     cg.Parented.template(RemoteTransmitterComponent),
 )
-
-
-def _validate_rmt(config):
-    if CORE.is_esp32:
-        variant = esp32.get_esp32_variant()
-        if variant in _VARIANTS_NO_RMT:
-            for conf in (
-                CONF_CLOCK_RESOLUTION,
-                CONF_EOT_LEVEL,
-                CONF_USE_DMA,
-                CONF_RMT_SYMBOLS,
-                CONF_NON_BLOCKING,
-            ):
-                if conf in config:
-                    raise cv.Invalid(
-                        f"'{conf}' is not available on {variant} (no RMT hardware)"
-                    )
-    return config
 
 
 MULTI_CONF = True
@@ -100,14 +80,24 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .add_extra(_validate_rmt)
+    .add_extra(
+        esp32_rmt.validate_rmt_not_supported(
+            [
+                CONF_CLOCK_RESOLUTION,
+                CONF_EOT_LEVEL,
+                CONF_USE_DMA,
+                CONF_RMT_SYMBOLS,
+                CONF_NON_BLOCKING,
+            ]
+        )
+    )
 )
 
 
 def _validate_non_blocking(config):
     if (
         CORE.is_esp32
-        and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT
+        and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT
         and CONF_NON_BLOCKING not in config
     ):
         _LOGGER.warning(
@@ -142,7 +132,7 @@ async def digital_write_action_to_code(config, action_id, template_arg, args):
 
 async def to_code(config):
     pin = await cg.gpio_pin_expression(config[CONF_PIN])
-    if CORE.is_esp32 and esp32.get_esp32_variant() not in _VARIANTS_NO_RMT:
+    if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
 

--- a/esphome/components/remote_transmitter/automation.h
+++ b/esphome/components/remote_transmitter/automation.h
@@ -5,8 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace remote_transmitter {
+namespace esphome::remote_transmitter {
 
 template<typename... Ts> class DigitalWriteAction : public Action<Ts...>, public Parented<RemoteTransmitterComponent> {
  public:
@@ -14,5 +13,4 @@ template<typename... Ts> class DigitalWriteAction : public Action<Ts...>, public
   void play(const Ts &...x) override { this->parent_->digital_write(this->value_.value(x...)); }
 };
 
-}  // namespace remote_transmitter
-}  // namespace esphome
+}  // namespace esphome::remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-#if defined(USE_LIBRETINY) || defined(USE_ESP8266) || defined(USE_RP2040)
+#if defined(USE_LIBRETINY) || defined(USE_ESP8266) || defined(USE_RP2040) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
 
 namespace esphome {
 namespace remote_transmitter {

--- a/esphome/components/remote_transmitter/remote_transmitter.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter.cpp
@@ -4,8 +4,7 @@
 
 #if defined(USE_LIBRETINY) || defined(USE_ESP8266) || defined(USE_RP2040) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
 
-namespace esphome {
-namespace remote_transmitter {
+namespace esphome::remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
@@ -105,7 +104,6 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
   this->complete_trigger_.trigger();
 }
 
-}  // namespace remote_transmitter
-}  // namespace esphome
+}  // namespace esphome::remote_transmitter
 
 #endif

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -6,13 +6,16 @@
 #include <vector>
 
 #if defined(USE_ESP32)
+#include <soc/soc_caps.h>
+#if SOC_RMT_SUPPORTED
 #include <driver/rmt_tx.h>
-#endif
+#endif  // SOC_RMT_SUPPORTED
+#endif  // USE_ESP32
 
 namespace esphome {
 namespace remote_transmitter {
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && SOC_RMT_SUPPORTED
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
 // IDF version 5.5.1 and above is required because of a bug in
 // the RMT encoder: https://github.com/espressif/esp-idf/issues/17244
@@ -33,7 +36,7 @@ struct RemoteTransmitterComponentStore {
 
 class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
                                    public Component
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && SOC_RMT_SUPPORTED
     ,
                                    public remote_base::RemoteRMTChannel
 #endif
@@ -51,7 +54,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
   void digital_write(bool value);
 
-#if defined(USE_ESP32)
+#if defined(USE_ESP32) && SOC_RMT_SUPPORTED
   void set_with_dma(bool with_dma) { this->with_dma_ = with_dma; }
   void set_eot_level(bool eot_level) { this->eot_level_ = eot_level; }
   void set_non_blocking(bool non_blocking) { this->non_blocking_ = non_blocking; }
@@ -62,7 +65,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
 
  protected:
   void send_internal(uint32_t send_times, uint32_t send_wait) override;
-#if defined(USE_ESP8266) || defined(USE_LIBRETINY) || defined(USE_RP2040)
+#if defined(USE_ESP8266) || defined(USE_LIBRETINY) || defined(USE_RP2040) || (defined(USE_ESP32) && !SOC_RMT_SUPPORTED)
   void calculate_on_off_time_(uint32_t carrier_frequency, uint32_t *on_time_period, uint32_t *off_time_period);
 
   void mark_(uint32_t on_time, uint32_t off_time, uint32_t usec);
@@ -73,7 +76,7 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   uint32_t target_time_;
 #endif
 
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && SOC_RMT_SUPPORTED
   void configure_rmt_();
   void wait_for_rmt_();
 

--- a/esphome/components/remote_transmitter/remote_transmitter.h
+++ b/esphome/components/remote_transmitter/remote_transmitter.h
@@ -12,8 +12,7 @@
 #endif  // SOC_RMT_SUPPORTED
 #endif  // USE_ESP32
 
-namespace esphome {
-namespace remote_transmitter {
+namespace esphome::remote_transmitter {
 
 #if defined(USE_ESP32) && SOC_RMT_SUPPORTED
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 1)
@@ -103,5 +102,4 @@ class RemoteTransmitterComponent : public remote_base::RemoteTransmitterBase,
   Trigger<> complete_trigger_;
 };
 
-}  // namespace remote_transmitter
-}  // namespace esphome
+}  // namespace esphome::remote_transmitter

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -7,8 +7,7 @@
 #if SOC_RMT_SUPPORTED
 #include <driver/gpio.h>
 
-namespace esphome {
-namespace remote_transmitter {
+namespace esphome::remote_transmitter {
 
 static const char *const TAG = "remote_transmitter";
 
@@ -360,8 +359,7 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
 }
 #endif
 
-}  // namespace remote_transmitter
-}  // namespace esphome
+}  // namespace esphome::remote_transmitter
 
 #endif  // SOC_RMT_SUPPORTED
 #endif  // USE_ESP32

--- a/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_esp32.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/application.h"
 
 #ifdef USE_ESP32
+#include <soc/soc_caps.h>
+#if SOC_RMT_SUPPORTED
 #include <driver/gpio.h>
 
 namespace esphome {
@@ -361,4 +363,5 @@ void RemoteTransmitterComponent::send_internal(uint32_t send_times, uint32_t sen
 }  // namespace remote_transmitter
 }  // namespace esphome
 
-#endif
+#endif  // SOC_RMT_SUPPORTED
+#endif  // USE_ESP32

--- a/tests/components/remote_receiver/test.esp32-c2-idf.yaml
+++ b/tests/components/remote_receiver/test.esp32-c2-idf.yaml
@@ -1,0 +1,12 @@
+remote_receiver:
+  id: rcvr
+  pin: GPIO2
+  dump: all
+  <<: !include common-actions.yaml
+
+binary_sensor:
+  - platform: remote_receiver
+    name: Panasonic Remote Input
+    panasonic:
+      address: 0x4004
+      command: 0x100BCBD

--- a/tests/components/remote_transmitter/test.esp32-c2-idf.yaml
+++ b/tests/components/remote_transmitter/test.esp32-c2-idf.yaml
@@ -1,0 +1,7 @@
+remote_transmitter:
+  id: xmitr
+  pin: GPIO2
+  carrier_duty_percent: 50%
+
+packages:
+  buttons: !include common-buttons.yaml


### PR DESCRIPTION
# What does this implement/fix?

Route ESP32-C2 and ESP32-C61 (which lack RMT hardware) to the software GPIO bitbang implementation for `remote_transmitter` and `remote_receiver`. Block `esp32_rmt_led_strip` entirely on these variants since no software fallback exists.

**Approach:**
- Python side: Check variant against `_VARIANTS_NO_RMT` list to route C2/C61 to software code path in `to_code()`. Add validators to reject RMT-specific config options on these variants. Use `cv.UNDEFINED` in `SplitDefault` to suppress RMT defaults.
- C++ side: Use `SOC_RMT_SUPPORTED` from `<soc/soc_caps.h>` in preprocessor guards. RMT code is guarded by `#if defined(USE_ESP32) && SOC_RMT_SUPPORTED`, software code extends to include `(defined(USE_ESP32) && !SOC_RMT_SUPPORTED)`.
- Both `_esp32.cpp` (RMT) and `.cpp` (software) files are included for ESP32 builds; preprocessor guards determine which compiles.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13993

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6086

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP32-C2/C61 remote_receiver (software implementation, no RMT options)
remote_receiver:
  pin: GPIO2
  dump: all

# ESP32-C2/C61 remote_transmitter (software implementation, no RMT options)
remote_transmitter:
  pin: GPIO3
  carrier_duty_percent: 50%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).