### PR TITLE
[fan] Fix preset_mode not restored on boot

### DIFF
--- a/esphome/components/fan/fan.h
+++ b/esphome/components/fan/fan.h
@@ -91,11 +91,13 @@ class FanCall {
 };
 
 struct FanRestoreState {
+  static constexpr uint8_t NO_PRESET = UINT8_MAX;
+
   bool state;
   int speed;
   bool oscillating;
   FanDirection direction;
-  uint8_t preset_mode;
+  uint8_t preset_mode{NO_PRESET};
 
   /// Convert this struct to a fan call that can be performed.
   FanCall to_call(Fan &fan);

--- a/esphome/components/hbridge/fan/hbridge_fan.cpp
+++ b/esphome/components/hbridge/fan/hbridge_fan.cpp
@@ -28,15 +28,15 @@ fan::FanCall HBridgeFan::brake() {
 }
 
 void HBridgeFan::setup() {
+  // Construct traits before restore so preset modes can be looked up by index
+  this->traits_ = fan::FanTraits(this->oscillating_ != nullptr, true, true, this->speed_count_);
+  this->traits_.set_supported_preset_modes(this->preset_modes_);
+
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->apply(*this);
     this->write_state_();
   }
-
-  // Construct traits
-  this->traits_ = fan::FanTraits(this->oscillating_ != nullptr, true, true, this->speed_count_);
-  this->traits_.set_supported_preset_modes(this->preset_modes_);
 }
 
 void HBridgeFan::dump_config() {

--- a/esphome/components/speed/fan/speed_fan.cpp
+++ b/esphome/components/speed/fan/speed_fan.cpp
@@ -7,15 +7,15 @@ namespace speed {
 static const char *const TAG = "speed.fan";
 
 void SpeedFan::setup() {
+  // Construct traits before restore so preset modes can be looked up by index
+  this->traits_ = fan::FanTraits(this->oscillating_ != nullptr, true, this->direction_ != nullptr, this->speed_count_);
+  this->traits_.set_supported_preset_modes(this->preset_modes_);
+
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->apply(*this);
     this->write_state_();
   }
-
-  // Construct traits
-  this->traits_ = fan::FanTraits(this->oscillating_ != nullptr, true, this->direction_ != nullptr, this->speed_count_);
-  this->traits_.set_supported_preset_modes(this->preset_modes_);
 }
 
 void SpeedFan::dump_config() { LOG_FAN("", "Speed Fan", this); }

--- a/esphome/components/template/fan/template_fan.cpp
+++ b/esphome/components/template/fan/template_fan.cpp
@@ -6,15 +6,15 @@ namespace esphome::template_ {
 static const char *const TAG = "template.fan";
 
 void TemplateFan::setup() {
+  // Construct traits before restore so preset modes can be looked up by index
+  this->traits_ =
+      fan::FanTraits(this->has_oscillating_, this->speed_count_ > 0, this->has_direction_, this->speed_count_);
+  this->traits_.set_supported_preset_modes(this->preset_modes_);
+
   auto restore = this->restore_state_();
   if (restore.has_value()) {
     restore->apply(*this);
   }
-
-  // Construct traits
-  this->traits_ =
-      fan::FanTraits(this->has_oscillating_, this->speed_count_ > 0, this->has_direction_, this->speed_count_);
-  this->traits_.set_supported_preset_modes(this->preset_modes_);
 }
 
 void TemplateFan::dump_config() { LOG_FAN("", "Template Fan", this); }


### PR DESCRIPTION
# What does this implement/fix?

Fixes `preset_mode` not being restored after reboot for speed, hbridge, and template fan components.

**Root cause:** In `setup()`, traits were constructed *after* `restore_state_().apply()` was called. But `FanRestoreState::apply()` calls `fan.get_traits()` to look up the preset mode by its stored index — at that point `traits_` had no preset modes configured, so `supports_preset_modes()` returned false and the preset mode was silently dropped.

**Fix:**
1. Move traits construction before the `restore_state_()` call in all three affected fan implementations (speed, hbridge, template).
2. Add a `NO_PRESET` sentinel value (`UINT8_MAX`) to `FanRestoreState` to distinguish "no preset saved" from "first preset index (0)". Previously, the zero-initialized `preset_mode = 0` was ambiguous — on first boot it would incorrectly match the first preset mode now that traits are available during restore. The sentinel ensures no preset is applied when none was saved.
3. Bump `RESTORE_STATE_VERSION` to invalidate old saved states (they will be treated as first boot, which is safe).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13992

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
fan:
  - platform: speed
    name: "My Fan"
    output: fan_speed_output
    restore_mode: RESTORE_DEFAULT_ON
    preset_modes:
      - half
      - full
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).