### PR TITLE
[combination] Fix 'coeffecient' typo with backward-compatible deprecation

### DIFF
--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -126,7 +126,7 @@ void LinearCombinationComponent::setup() {
 }
 
 void LinearCombinationComponent::handle_new_value(float value) {
-  // Multiplies each sensor state by a configured coeffecient and then sums
+  // Multiplies each sensor state by a configured coefficient and then sums
 
   if (!std::isfinite(value))
     return;

--- a/tests/components/combination/common.yaml
+++ b/tests/components/combination/common.yaml
@@ -27,9 +27,9 @@ sensor:
     name: Linearly combined temperatures
     sources:
       - source: template_temperature1
-        coeffecient: !lambda "return 0.4 + std::abs(x - 25) * 0.023;"
+        coefficient: !lambda "return 0.4 + std::abs(x - 25) * 0.023;"
       - source: template_temperature2
-        coeffecient: 1.5
+        coefficient: 1.5
   - platform: combination
     type: max
     name: Max of combined temperatures


### PR DESCRIPTION
# What does this implement/fix?

Fix the typo `coeffecient` (missing 'i') in the combination sensor's linear type config key. The correct spelling `coefficient` is now accepted, while the old `coeffecient` spelling continues to work with a deprecation warning. Also fixes the typo in a C++ comment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14003

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6087

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040

## Example entry for `config.yaml`:

```yaml
# New correct spelling
sensor:
  - platform: combination
    type: linear
    name: "Balance Power"
    sources:
      - source: total_power
        coefficient: 1.0
      - source: circuit_1_power
        coefficient: -1.0

# Old spelling still works (with deprecation warning, will be removed in 2026.12.0)
sensor:
  - platform: combination
    type: linear
    name: "Balance Power"
    sources:
      - source: total_power
        coeffecient: 1.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).