### PR TITLE
[mqtt] add missing precision in HA autodiscovery

### DIFF
--- a/esphome/components/mqtt/mqtt_const.h
+++ b/esphome/components/mqtt/mqtt_const.h
@@ -84,6 +84,7 @@
   X(MQTT_DEVICE_HW_VERSION, "hw", "hw_version") \
   X(MQTT_DIRECTION_COMMAND_TOPIC, "dir_cmd_t", "direction_command_topic") \
   X(MQTT_DIRECTION_STATE_TOPIC, "dir_stat_t", "direction_state_topic") \
+  X(MQTT_DISPLAY_PRECISION, "dsp_prc", "display_precision") \
   X(MQTT_DOCKED_TEMPLATE, "dock_tpl", "docked_template") \
   X(MQTT_DOCKED_TOPIC, "dock_t", "docked_topic") \
   X(MQTT_EFFECT_COMMAND_TOPIC, "fx_cmd_t", "effect_command_topic") \

--- a/esphome/components/mqtt/mqtt_const.h
+++ b/esphome/components/mqtt/mqtt_const.h
@@ -84,7 +84,6 @@
   X(MQTT_DEVICE_HW_VERSION, "hw", "hw_version") \
   X(MQTT_DIRECTION_COMMAND_TOPIC, "dir_cmd_t", "direction_command_topic") \
   X(MQTT_DIRECTION_STATE_TOPIC, "dir_stat_t", "direction_state_topic") \
-  X(MQTT_DISPLAY_PRECISION, "dsp_prc", "display_precision") \
   X(MQTT_DOCKED_TEMPLATE, "dock_tpl", "docked_template") \
   X(MQTT_DOCKED_TOPIC, "dock_t", "docked_topic") \
   X(MQTT_EFFECT_COMMAND_TOPIC, "fx_cmd_t", "effect_command_topic") \
@@ -244,6 +243,7 @@
   X(MQTT_STATE_VALUE_TEMPLATE, "stat_val_tpl", "state_value_template") \
   X(MQTT_STEP, "step", "step") \
   X(MQTT_SUBTYPE, "stype", "subtype") \
+  X(MQTT_SUGGESTED_DISPLAY_PRECISION, "sug_dsp_prc", "suggested_display_precision") \
   X(MQTT_SUPPORTED_COLOR_MODES, "sup_clrm", "supported_color_modes") \
   X(MQTT_SUPPORTED_FEATURES, "sup_feat", "supported_features") \
   X(MQTT_SWING_MODE_COMMAND_TEMPLATE, "swing_mode_cmd_tpl", "swing_mode_command_template") \

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -50,7 +50,7 @@ void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
   }
 
   if (this->sensor_->has_accuracy_decimals()) {
-    root[MQTT_DISPLAY_PRECISION] = this->sensor_->get_accuracy_decimals();
+    root[MQTT_SUGGESTED_DISPLAY_PRECISION] = this->sensor_->get_accuracy_decimals();
   }
 
   const auto unit_of_measurement = this->sensor_->get_unit_of_measurement_ref();

--- a/esphome/components/mqtt/mqtt_sensor.cpp
+++ b/esphome/components/mqtt/mqtt_sensor.cpp
@@ -49,6 +49,10 @@ void MQTTSensorComponent::send_discovery(JsonObject root, mqtt::SendDiscoveryCon
     root[MQTT_DEVICE_CLASS] = device_class;
   }
 
+  if (this->sensor_->has_accuracy_decimals()) {
+    root[MQTT_DISPLAY_PRECISION] = this->sensor_->get_accuracy_decimals();
+  }
+
   const auto unit_of_measurement = this->sensor_->get_unit_of_measurement_ref();
   if (!unit_of_measurement.empty()) {
     root[MQTT_UNIT_OF_MEASUREMENT] = unit_of_measurement;

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -48,6 +48,8 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
   int8_t get_accuracy_decimals();
   /// Manually set the accuracy in decimals.
   void set_accuracy_decimals(int8_t accuracy_decimals);
+  /// Check if the accuracy in decimals has been manually set.
+  bool has_accuracy_decimals() const { return this->sensor_flags_.has_accuracy_override; }
 
   /// Get the state class, using the manual override if set.
   StateClass get_state_class();


### PR DESCRIPTION
# What does this implement/fix?

Currently, `accuracy_decimals` does not have an effect in the displayed precision in HA for MQTT sensors. They were missing the `sug_dsp_prc` configuration in the HA autodiscovery topics.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
