### PR TITLE
[esp32_ble_server] fix infinitely large characteristic value

### DIFF
--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -527,7 +527,7 @@ async def to_code_characteristic(service_var, char_conf):
                 action_conf,
                 char_conf[CONF_CHAR_VALUE_ACTION_ID_],
                 cg.TemplateArguments(),
-                {},
+                [],
             )
             cg.add(value_action.play())
         else:

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -277,7 +277,6 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
 
       if (!param->write.is_prep) {
         if (this->on_write_callback_) {
-          ESP_LOGE(TAG, "Sending write callback, value is %s", format_hex_pretty(this->value_).c_str());
           (*this->on_write_callback_)(this->value_, param->write.conn_id);
         }
       }
@@ -291,7 +290,6 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
       this->write_event_ = false;
       if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
         if (this->on_write_callback_) {
-          ESP_LOGE(TAG, "Sending write callback after prep, value is %s", format_hex_pretty(this->value_).c_str());
           (*this->on_write_callback_)(this->value_, param->exec_write.conn_id);
         }
       }

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -268,7 +268,6 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
           if (this->value_.size() < new_size) {
             this->value_.resize(new_size);
           }
-          ESP_LOGE(TAG, "Prepared write: offset=%zu, len=%zu, new_size=%zu", offset, write_len, new_size);
           memcpy(this->value_.data() + offset, param->write.value, write_len);
         }
       } else {

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -246,6 +246,8 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
       if (this->handle_ != param->write.handle)
         break;
 
+      esp_gatt_status_t status = ESP_GATT_OK;
+
       if (param->write.is_prep) {
         // Clean the buffer on the first prepared write event,
         // but not on subsequent ones (since they are part of the same write)
@@ -253,7 +255,22 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
           this->value_.clear();
           this->write_event_ = true;
         }
-        this->value_.insert(this->value_.end(), param->write.value, param->write.value + param->write.len);
+
+        const size_t offset = param->write.offset;
+        const size_t write_len = param->write.len;
+        const size_t new_size = offset + write_len;
+
+        if (offset > ESP_GATT_MAX_ATTR_LEN) {
+          status = ESP_GATT_INVALID_OFFSET;
+        } else if (new_size > ESP_GATT_MAX_ATTR_LEN) {
+          status = ESP_GATT_INVALID_ATTR_LEN;
+        } else {
+          if (this->value_.size() < new_size) {
+            this->value_.resize(new_size);
+          }
+          ESP_LOGE(TAG, "Prepared write: offset=%zu, len=%zu, new_size=%zu", offset, write_len, new_size);
+          memcpy(this->value_.data() + offset, param->write.value, write_len);
+        }
       } else {
         this->set_value(ByteBuffer::wrap(param->write.value, param->write.len));
       }
@@ -268,7 +285,7 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
         memcpy(response.attr_value.value, param->write.value, param->write.len);
 
         esp_err_t err =
-            esp_ble_gatts_send_response(gatts_if, param->write.conn_id, param->write.trans_id, ESP_GATT_OK, &response);
+            esp_ble_gatts_send_response(gatts_if, param->write.conn_id, param->write.trans_id, status, &response);
 
         if (err != ESP_OK) {
           ESP_LOGE(TAG, "esp_ble_gatts_send_response failed: %d", err);

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -247,8 +247,13 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
         break;
 
       if (param->write.is_prep) {
+        // Clean the buffer on the first prepared write event,
+        // but not on subsequent ones (since they are part of the same write)
+        if (!this->write_event_) {
+          this->value_.clear();
+          this->write_event_ = true;
+        }
         this->value_.insert(this->value_.end(), param->write.value, param->write.value + param->write.len);
-        this->write_event_ = true;
       } else {
         this->set_value(ByteBuffer::wrap(param->write.value, param->write.len));
       }
@@ -272,6 +277,7 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
 
       if (!param->write.is_prep) {
         if (this->on_write_callback_) {
+          ESP_LOGE(TAG, "Sending write callback, value is %s", format_hex_pretty(this->value_).c_str());
           (*this->on_write_callback_)(this->value_, param->write.conn_id);
         }
       }
@@ -285,6 +291,7 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
       this->write_event_ = false;
       if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
         if (this->on_write_callback_) {
+          ESP_LOGE(TAG, "Sending write callback after prep, value is %s", format_hex_pretty(this->value_).c_str());
           (*this->on_write_callback_)(this->value_, param->exec_write.conn_id);
         }
       }

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -249,18 +249,15 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
       esp_gatt_status_t status = ESP_GATT_OK;
 
       if (param->write.is_prep) {
-        // Clean the buffer on the first prepared write event,
-        // but not on subsequent ones (since they are part of the same write)
-        if (!this->write_event_) {
-          this->value_.clear();
-          this->write_event_ = true;
-        }
-
         const size_t offset = param->write.offset;
         const size_t write_len = param->write.len;
         const size_t new_size = offset + write_len;
+        // Clean the buffer on the first prepared write event
+        if (offset == 0) {
+          this->value_.clear();
+        }
 
-        if (offset > ESP_GATT_MAX_ATTR_LEN) {
+        if (offset != this->value_.size()) {
           status = ESP_GATT_INVALID_OFFSET;
         } else if (new_size > ESP_GATT_MAX_ATTR_LEN) {
           status = ESP_GATT_INVALID_ATTR_LEN;
@@ -301,9 +298,9 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
     }
 
     case ESP_GATTS_EXEC_WRITE_EVT: {
-      if (!this->write_event_)
+      // BLE stack will guarantee that ESP_GATTS_EXEC_WRITE_EVT is only received after prepared writes
+      if (this->value_.empty())
         break;
-      this->write_event_ = false;
       if (param->exec_write.exec_write_flag == ESP_GATT_PREP_WRITE_EXEC) {
         if (this->on_write_callback_) {
           (*this->on_write_callback_)(this->value_, param->exec_write.conn_id);

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -77,7 +77,6 @@ class BLECharacteristic {
   }
 
  protected:
-  bool write_event_{false};
   BLEService *service_{};
   ESPBTUUID uuid_;
   esp_gatt_char_prop_t properties_;


### PR DESCRIPTION
# What does this implement/fix?

Fixes the handling of BLE characteristic write events. Before, the preprepared writes just indefinitely increased the `value` buffer. The buffer for characteristic values is now cleared at the start of a prepared write sequence, preventing data from previous writes from being incorrectly retained during multi-part writes.

_This PR also includes a fix for a minor argument type for code generation. In `__init__.py`, the default argument for the value action is changed from an empty dictionary `{}` to an empty list `[]`, aligning with expected parameter types for the code generator._

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
