### PR TITLE
ESPHome RFC2217 Client/Server component

### DIFF
--- a/esphome/components/network_serial/__init__.py
+++ b/esphome/components/network_serial/__init__.py
@@ -1,0 +1,165 @@
+"""RFC 2217 Network Serial component for ESPHome.
+
+Supports two modes:
+  - client: Connect to a remote RFC 2217 server
+  - server: Expose a local UART as an RFC 2217 server
+"""
+
+import esphome.codegen as cg
+from esphome.components import uart
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_MODE, CONF_PORT, CONF_UART_ID
+
+DEPENDENCIES = ["uart"]
+MULTI_CONF = True
+
+# Constants
+CONF_HOST = "host"
+CONF_BAUDRATE = "baudrate"
+CONF_DATA_BITS = "data_bits"
+CONF_PARITY = "parity"
+CONF_STOP_BITS = "stop_bits"
+CONF_FLOW_CONTROL = "flow_control"
+CONF_DTR = "dtr"
+CONF_RTS = "rts"
+CONF_DEVICE_NODE = "device_node"
+
+# Namespace
+network_serial_ns = cg.esphome_ns.namespace("network_serial")
+NetworkSerialClient = network_serial_ns.class_("NetworkSerialClient", cg.Component)
+NetworkSerialServer = network_serial_ns.class_("NetworkSerialServer", cg.Component)
+
+# Enums
+ParityMode = network_serial_ns.enum("ParityMode")
+PARITY_OPTIONS = {
+    "NONE": ParityMode.PARITY_NONE,
+    "EVEN": ParityMode.PARITY_EVEN,
+    "ODD": ParityMode.PARITY_ODD,
+    "MARK": ParityMode.PARITY_MARK,
+    "SPACE": ParityMode.PARITY_SPACE,
+}
+
+FlowControl = network_serial_ns.enum("FlowControl")
+FLOW_CONTROL_OPTIONS = {
+    "NONE": FlowControl.FLOW_NONE,
+    "SOFTWARE": FlowControl.FLOW_XONXOFF,
+    "XONXOFF": FlowControl.FLOW_XONXOFF,
+    "HARDWARE": FlowControl.FLOW_HARDWARE,
+    "RTS_CTS": FlowControl.FLOW_HARDWARE,
+}
+
+# Default values
+DEFAULT_PORT = 2217
+DEFAULT_BAUDRATE = 9600
+DEFAULT_DATA_BITS = 8
+DEFAULT_PARITY = "NONE"
+DEFAULT_STOP_BITS = 1
+DEFAULT_FLOW_CONTROL = "NONE"
+
+MODE_CLIENT = "client"
+MODE_SERVER = "server"
+
+# Client mode schema (connects to remote RFC 2217 server)
+CLIENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(NetworkSerialClient),
+        cv.Optional(CONF_MODE, default=MODE_CLIENT): cv.one_of(
+            MODE_CLIENT, MODE_SERVER, lower=True
+        ),
+        cv.Required(CONF_HOST): cv.string,
+        cv.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+        cv.Optional(CONF_BAUDRATE, default=DEFAULT_BAUDRATE): cv.int_range(
+            min=300, max=4000000
+        ),
+        cv.Optional(CONF_DATA_BITS, default=DEFAULT_DATA_BITS): cv.int_range(
+            min=5, max=8
+        ),
+        cv.Optional(CONF_PARITY, default=DEFAULT_PARITY): cv.enum(
+            PARITY_OPTIONS, upper=True
+        ),
+        cv.Optional(CONF_STOP_BITS, default=DEFAULT_STOP_BITS): cv.one_of(
+            1, 2, int=True
+        ),
+        cv.Optional(CONF_FLOW_CONTROL, default=DEFAULT_FLOW_CONTROL): cv.enum(
+            FLOW_CONTROL_OPTIONS, upper=True
+        ),
+        cv.Optional(CONF_DTR, default=False): cv.boolean,
+        cv.Optional(CONF_RTS, default=False): cv.boolean,
+        cv.Optional(CONF_DEVICE_NODE): cv.string,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+# Server mode schema (exposes local UART over RFC 2217)
+SERVER_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(NetworkSerialServer),
+        cv.Optional(CONF_MODE, default=MODE_CLIENT): cv.one_of(
+            MODE_CLIENT, MODE_SERVER, lower=True
+        ),
+        cv.Required(CONF_UART_ID): cv.use_id(uart.UARTComponent),
+        cv.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
+    }
+).extend(cv.COMPONENT_SCHEMA)
+
+
+def _validate_config(config):
+    """Route to the correct schema based on mode."""
+    mode = config.get(CONF_MODE, MODE_CLIENT)
+    if mode == MODE_SERVER:
+        return SERVER_SCHEMA(config)
+    return CLIENT_SCHEMA(config)
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_MODE, default=MODE_CLIENT): cv.one_of(
+                MODE_CLIENT, MODE_SERVER, lower=True
+            ),
+        },
+        extra=cv.ALLOW_EXTRA,
+    ),
+    _validate_config,
+)
+
+
+async def to_code(config):
+    """Generate code for network serial component."""
+    mode = config.get(CONF_MODE, "client")
+
+    # Add network dependency
+    cg.add_define("USE_NETWORK")
+
+    if mode == "server":
+        await _to_code_server(config)
+    else:
+        await _to_code_client(config)
+
+
+async def _to_code_client(config):
+    """Generate code for client mode."""
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add(var.set_host(config[CONF_HOST]))
+    cg.add(var.set_port(config[CONF_PORT]))
+    cg.add(var.set_baudrate(config[CONF_BAUDRATE]))
+    cg.add(var.set_data_bits(config[CONF_DATA_BITS]))
+    cg.add(var.set_parity(config[CONF_PARITY]))
+    cg.add(var.set_stop_bits(config[CONF_STOP_BITS]))
+    cg.add(var.set_flow_control(config[CONF_FLOW_CONTROL]))
+    cg.add(var.set_dtr(config[CONF_DTR]))
+    cg.add(var.set_rts(config[CONF_RTS]))
+
+    if CONF_DEVICE_NODE in config:
+        cg.add(var.set_device_node(config[CONF_DEVICE_NODE]))
+
+
+async def _to_code_server(config):
+    """Generate code for server mode."""
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    uart_component = await cg.get_variable(config[CONF_UART_ID])
+    cg.add(var.set_uart(uart_component))
+    cg.add(var.set_port(config[CONF_PORT]))

--- a/esphome/components/network_serial/network_serial.cpp
+++ b/esphome/components/network_serial/network_serial.cpp
@@ -1,0 +1,751 @@
+#include "network_serial.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+#include <cstring>
+#include <algorithm>
+
+// Forward declare storage for soft dependency
+#if defined(USE_STORAGE)
+namespace storage {
+extern class StorageHost *global_storage;
+}
+#endif  // USE_STORAGE
+
+namespace esphome {
+namespace network_serial {
+
+//========================================================================
+// NetworkSerialClient Implementation
+//========================================================================
+
+NetworkSerialClient::~NetworkSerialClient() { this->disconnect(); }
+
+void NetworkSerialClient::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up Network Serial Client...");
+  ESP_LOGCONFIG(TAG, "  Host: %s:%u", this->host_.c_str(), this->port_);
+  ESP_LOGCONFIG(TAG, "  Baudrate: %u", this->config_.baudrate);
+  ESP_LOGCONFIG(TAG, "  Data bits: %u", this->config_.data_size);
+  ESP_LOGCONFIG(TAG, "  Parity: %u", this->config_.parity);
+  ESP_LOGCONFIG(TAG, "  Stop bits: %u", this->config_.stop_bits);
+  ESP_LOGCONFIG(TAG, "  Flow control: %u", this->config_.flow_control);
+
+  if (!this->device_node_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Device node: %s", this->device_node_.c_str());
+  }
+
+  // Reserve buffer space
+  this->rx_buffer_.reserve(MAX_BUFFER_SIZE);
+  this->tx_buffer_.reserve(MAX_BUFFER_SIZE);
+  this->telnet_buffer_.reserve(256);
+
+  // Register with storage if configured
+  if (!this->device_node_.empty()) {
+    this->register_with_storage();
+  }
+}
+
+void NetworkSerialClient::loop() {
+  // Try to connect if not connected
+  if (!this->connected_) {
+    uint32_t now = millis();
+    if (now - this->last_connect_attempt_ >= RECONNECT_INTERVAL_MS) {
+      this->last_connect_attempt_ = now;
+      if (this->connect()) {
+        ESP_LOGI(TAG, "Connected to %s:%u", this->host_.c_str(), this->port_);
+        for (auto &callback : this->on_connect_callbacks_) {
+          callback();
+        }
+      }
+    }
+    return;
+  }
+
+  // Receive data from network
+  uint8_t buffer[256];
+  size_t received = this->receive_raw_(buffer, sizeof(buffer));
+  if (received > 0) {
+    this->process_telnet_data_(buffer, received);
+  } else if (received == 0) {
+    // Connection closed
+    ESP_LOGW(TAG, "Connection closed by remote host");
+    this->disconnect();
+    for (auto &callback : this->on_disconnect_callbacks_) {
+      callback();
+    }
+  }
+
+  // Send pending TX data
+  if (!this->tx_buffer_.empty() && !this->flow_suspended_) {
+    size_t sent = this->send_raw_(this->tx_buffer_.data(), this->tx_buffer_.size());
+    if (sent > 0) {
+      this->tx_buffer_.erase(this->tx_buffer_.begin(), this->tx_buffer_.begin() + sent);
+    }
+  }
+
+  // Notify data callbacks if we have data
+  if (!this->rx_buffer_.empty() && !this->on_data_callbacks_.empty()) {
+    for (auto &callback : this->on_data_callbacks_) {
+      callback(this->rx_buffer_);
+    }
+  }
+}
+
+void NetworkSerialClient::dump_config() {
+  ESP_LOGCONFIG(TAG, "Network Serial Client:");
+  ESP_LOGCONFIG(TAG, "  Host: %s:%u", this->host_.c_str(), this->port_);
+  ESP_LOGCONFIG(TAG, "  Status: %s", this->connected_ ? "Connected" : "Disconnected");
+  if (!this->device_node_.empty()) {
+    ESP_LOGCONFIG(TAG, "  Device node: %s", this->device_node_.c_str());
+  }
+}
+
+void NetworkSerialClient::register_with_storage() {
+#if defined(USE_STORAGE)
+  // Check if storage is available (soft dependency)
+  if (storage::global_storage != nullptr) {
+    // Register as network_serial type device node
+    // Note: This requires storage to support network_serial devices
+    // For now, we just log the registration
+    ESP_LOGI(TAG, "Network serial device node: %s", this->device_node_.c_str());
+    // TODO: Extend storage to support network serial devices
+  } else {
+    ESP_LOGD(TAG, "storage not available, skipping device node registration");
+  }
+#else
+  ESP_LOGD(TAG, "storage component not compiled, device node registration disabled");
+#endif  // USE_STORAGE
+}
+
+//========================================================================
+// Configuration Helpers
+//========================================================================
+
+void NetworkSerialClient::set_data_bits(uint8_t data_bits) {
+  switch (data_bits) {
+    case 5:
+      this->config_.data_size = DATA_SIZE_5;
+      break;
+    case 6:
+      this->config_.data_size = DATA_SIZE_6;
+      break;
+    case 7:
+      this->config_.data_size = DATA_SIZE_7;
+      break;
+    case 8:
+      this->config_.data_size = DATA_SIZE_8;
+      break;
+    default:
+      ESP_LOGW(TAG, "Invalid data bits: %u, using 8", data_bits);
+      this->config_.data_size = DATA_SIZE_8;
+  }
+}
+
+void NetworkSerialClient::set_parity(const std::string &parity) {
+  if (parity == "NONE") {
+    this->config_.parity = PARITY_NONE;
+  } else if (parity == "EVEN") {
+    this->config_.parity = PARITY_EVEN;
+  } else if (parity == "ODD") {
+    this->config_.parity = PARITY_ODD;
+  } else if (parity == "MARK") {
+    this->config_.parity = PARITY_MARK;
+  } else if (parity == "SPACE") {
+    this->config_.parity = PARITY_SPACE;
+  } else {
+    ESP_LOGW(TAG, "Invalid parity: %s, using NONE", parity.c_str());
+    this->config_.parity = PARITY_NONE;
+  }
+}
+
+void NetworkSerialClient::set_stop_bits(uint8_t stop_bits) {
+  if (stop_bits == 1) {
+    this->config_.stop_bits = STOP_BITS_1;
+  } else if (stop_bits == 2) {
+    this->config_.stop_bits = STOP_BITS_2;
+  } else {
+    ESP_LOGW(TAG, "Invalid stop bits: %u, using 1", stop_bits);
+    this->config_.stop_bits = STOP_BITS_1;
+  }
+}
+
+void NetworkSerialClient::set_flow_control(const std::string &flow_control) {
+  if (flow_control == "NONE") {
+    this->config_.flow_control = FLOW_NONE;
+  } else if (flow_control == "SOFTWARE" || flow_control == "XONXOFF") {
+    this->config_.flow_control = FLOW_XONXOFF;
+  } else if (flow_control == "HARDWARE" || flow_control == "RTS_CTS") {
+    this->config_.flow_control = FLOW_HARDWARE;
+  } else {
+    ESP_LOGW(TAG, "Invalid flow control: %s, using NONE", flow_control.c_str());
+    this->config_.flow_control = FLOW_NONE;
+  }
+}
+
+//========================================================================
+// Connection Management
+//========================================================================
+
+bool NetworkSerialClient::connect() {
+  if (this->connected_) {
+    return true;
+  }
+
+  ESP_LOGI(TAG, "Connecting to %s:%u...", this->host_.c_str(), this->port_);
+
+  if (!this->connect_socket_()) {
+    ESP_LOGW(TAG, "Failed to connect");
+    return false;
+  }
+
+  // Negotiate Telnet protocol
+  if (!this->negotiate_telnet_()) {
+    ESP_LOGW(TAG, "Failed to negotiate Telnet protocol");
+    this->disconnect();
+    return false;
+  }
+
+  // Apply serial configuration
+  this->apply_serial_config_();
+
+  this->connected_ = true;
+  return true;
+}
+
+void NetworkSerialClient::disconnect() {
+  if (!this->connected_) {
+    return;
+  }
+
+  ESP_LOGI(TAG, "Disconnecting from %s:%u", this->host_.c_str(), this->port_);
+
+  this->close_socket_();
+  this->connected_ = false;
+  this->telnet_negotiated_ = false;
+
+  // Clear buffers
+  this->rx_buffer_.clear();
+  this->tx_buffer_.clear();
+  this->telnet_buffer_.clear();
+}
+
+bool NetworkSerialClient::connect_socket_() {
+#ifdef USE_ESP_IDF
+  // Create TCP socket
+  this->socket_ = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (this->socket_ < 0) {
+    ESP_LOGE(TAG, "Failed to create socket: errno %d", errno);
+    return false;
+  }
+
+  // Resolve host address
+  struct sockaddr_in server_addr;
+  server_addr.sin_family = AF_INET;
+  server_addr.sin_port = htons(this->port_);
+
+  struct hostent *host = gethostbyname(this->host_.c_str());
+  if (host == nullptr) {
+    ESP_LOGE(TAG, "Failed to resolve host: %s", this->host_.c_str());
+    close(this->socket_);
+    this->socket_ = -1;
+    return false;
+  }
+  memcpy(&server_addr.sin_addr, host->h_addr, sizeof(server_addr.sin_addr));
+
+  // Connect
+  if (::connect(this->socket_, (struct sockaddr *) &server_addr, sizeof(server_addr)) < 0) {
+    ESP_LOGE(TAG, "Failed to connect: errno %d", errno);
+    close(this->socket_);
+    this->socket_ = -1;
+    return false;
+  }
+
+  // Set non-blocking mode
+  int flags = fcntl(this->socket_, F_GETFL, 0);
+  fcntl(this->socket_, F_SETFL, flags | O_NONBLOCK);
+
+  // Set TCP_NODELAY for low latency
+  int nodelay = 1;
+  setsockopt(this->socket_, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+
+  return true;
+#else
+  // Arduino WiFiClient
+  this->client_ = std::make_unique<WiFiClient>();
+  if (!this->client_->connect(this->host_.c_str(), this->port_)) {
+    ESP_LOGE(TAG, "Failed to connect");
+    this->client_ = nullptr;
+    return false;
+  }
+
+  this->client_->setNoDelay(true);  // TCP_NODELAY
+  return true;
+#endif
+}
+
+void NetworkSerialClient::close_socket_() {
+#ifdef USE_ESP_IDF
+  if (this->socket_ >= 0) {
+    close(this->socket_);
+    this->socket_ = -1;
+  }
+#else
+  if (this->client_) {
+    this->client_->stop();
+    this->client_ = nullptr;
+  }
+#endif
+}
+
+bool NetworkSerialClient::send_raw_(const uint8_t *data, size_t length) {
+  if (!this->connected_) {
+    return false;
+  }
+
+#ifdef USE_ESP_IDF
+  int sent = send(this->socket_, data, length, 0);
+  if (sent < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0;  // Would block, try again later
+    }
+    ESP_LOGW(TAG, "Send error: errno %d", errno);
+    return 0;
+  }
+  return sent;
+#else
+  if (!this->client_ || !this->client_->connected()) {
+    return 0;
+  }
+  return this->client_->write(data, length);
+#endif
+}
+
+size_t NetworkSerialClient::receive_raw_(uint8_t *buffer, size_t length) {
+  if (!this->connected_) {
+    return 0;
+  }
+
+#ifdef USE_ESP_IDF
+  int received = recv(this->socket_, buffer, length, 0);
+  if (received < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0;  // No data available
+    }
+    ESP_LOGW(TAG, "Receive error: errno %d", errno);
+    return 0;
+  }
+  return received;
+#else
+  if (!this->client_ || !this->client_->connected()) {
+    return 0;
+  }
+  int available = this->client_->available();
+  if (available <= 0) {
+    return 0;
+  }
+  size_t to_read = std::min((size_t) available, length);
+  return this->client_->read(buffer, to_read);
+#endif
+}
+
+//========================================================================
+// Serial I/O Operations
+//========================================================================
+
+size_t NetworkSerialClient::write(const uint8_t *data, size_t length) {
+  if (!this->connected_ || this->flow_suspended_) {
+    return 0;
+  }
+
+  // Add to TX buffer
+  size_t space = MAX_BUFFER_SIZE - this->tx_buffer_.size();
+  size_t to_write = std::min(length, space);
+
+  // Escape IAC bytes (0xFF) by doubling them
+  for (size_t i = 0; i < to_write; i++) {
+    this->tx_buffer_.push_back(data[i]);
+    if (data[i] == TELNET_IAC) {
+      this->tx_buffer_.push_back(TELNET_IAC);  // Double IAC
+    }
+  }
+
+  return to_write;
+}
+
+size_t NetworkSerialClient::read(uint8_t *data, size_t length) {
+  size_t to_read = std::min(length, this->rx_buffer_.size());
+  if (to_read > 0) {
+    std::copy(this->rx_buffer_.begin(), this->rx_buffer_.begin() + to_read, data);
+    this->rx_buffer_.erase(this->rx_buffer_.begin(), this->rx_buffer_.begin() + to_read);
+  }
+  return to_read;
+}
+
+void NetworkSerialClient::flush() {
+  while (!this->tx_buffer_.empty() && this->connected_ && !this->flow_suspended_) {
+    size_t sent = this->send_raw_(this->tx_buffer_.data(), this->tx_buffer_.size());
+    if (sent > 0) {
+      this->tx_buffer_.erase(this->tx_buffer_.begin(), this->tx_buffer_.begin() + sent);
+    } else {
+      delay(10);
+    }
+  }
+}
+
+void NetworkSerialClient::purge(PurgeData purge_flags) {
+  if (purge_flags == PURGE_RX_BUFFER || purge_flags == PURGE_BOTH) {
+    this->rx_buffer_.clear();
+  }
+  if (purge_flags == PURGE_TX_BUFFER || purge_flags == PURGE_BOTH) {
+    this->tx_buffer_.clear();
+  }
+
+  // Send purge command to server
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t cmd_data[] = {static_cast<uint8_t>(purge_flags)};
+    this->send_com_port_command_(RFC2217_PURGE_DATA_CS, cmd_data, sizeof(cmd_data));
+  }
+}
+
+//========================================================================
+// Telnet Protocol Implementation
+//========================================================================
+
+bool NetworkSerialClient::negotiate_telnet_() {
+  ESP_LOGD(TAG, "Negotiating Telnet protocol...");
+
+  // Send: IAC WILL BINARY
+  this->send_telnet_command_(TELNET_WILL, TELNET_BINARY);
+
+  // Send: IAC WILL ECHO
+  this->send_telnet_command_(TELNET_WILL, TELNET_ECHO);
+
+  // Send: IAC WILL SUPPRESS_GO_AHEAD
+  this->send_telnet_command_(TELNET_WILL, TELNET_SUPPRESS_GO_AHEAD);
+
+  // Send: IAC DO COM_PORT (RFC 2217)
+  this->send_telnet_command_(TELNET_DO, TELNET_COM_PORT);
+
+  // Wait for server responses (simplified - in production should wait for actual responses)
+  delay(100);
+
+  this->telnet_negotiated_ = true;
+  ESP_LOGD(TAG, "Telnet negotiation complete");
+
+  return true;
+}
+
+void NetworkSerialClient::send_telnet_command_(TelnetCommand cmd, TelnetOption option) {
+  uint8_t buffer[3] = {TELNET_IAC, cmd, option};
+  this->send_raw_(buffer, sizeof(buffer));
+  ESP_LOGVV(TAG, "Sent Telnet: IAC %u %u", cmd, option);
+}
+
+void NetworkSerialClient::send_telnet_subnegotiation_(const uint8_t *data, size_t length) {
+  // Send: IAC SB <data> IAC SE
+  std::vector<uint8_t> buffer;
+  buffer.push_back(TELNET_IAC);
+  buffer.push_back(TELNET_SB);
+  buffer.insert(buffer.end(), data, data + length);
+  buffer.push_back(TELNET_IAC);
+  buffer.push_back(TELNET_SE);
+
+  this->send_raw_(buffer.data(), buffer.size());
+  ESP_LOGVV(TAG, "Sent subnegotiation: %zu bytes", length);
+}
+
+void NetworkSerialClient::process_telnet_data_(const uint8_t *data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    uint8_t byte = data[i];
+
+    // Check for IAC (Interpret As Command)
+    if (byte == TELNET_IAC) {
+      // Start of Telnet command
+      if (i + 1 < length) {
+        uint8_t cmd = data[++i];
+
+        if (cmd == TELNET_IAC) {
+          // Escaped IAC (0xFF 0xFF) -> single 0xFF data byte
+          this->rx_buffer_.push_back(TELNET_IAC);
+        } else if (cmd == TELNET_SB) {
+          // Subnegotiation begin
+          std::vector<uint8_t> subneg_data;
+          i++;
+          while (i < length) {
+            if (data[i] == TELNET_IAC && i + 1 < length && data[i + 1] == TELNET_SE) {
+              // End of subnegotiation
+              i++;  // Skip SE
+              this->handle_telnet_subnegotiation_(subneg_data.data(), subneg_data.size());
+              break;
+            }
+            subneg_data.push_back(data[i++]);
+          }
+        } else if (cmd == TELNET_WILL || cmd == TELNET_WONT || cmd == TELNET_DO || cmd == TELNET_DONT) {
+          // Option negotiation
+          if (i + 1 < length) {
+            uint8_t option = data[++i];
+            this->handle_telnet_command_(static_cast<TelnetCommand>(cmd), static_cast<TelnetOption>(option));
+          }
+        }
+        // Other commands ignored
+      }
+    } else {
+      // Regular data byte
+      if (this->rx_buffer_.size() < MAX_BUFFER_SIZE) {
+        this->rx_buffer_.push_back(byte);
+      }
+    }
+  }
+}
+
+void NetworkSerialClient::handle_telnet_command_(TelnetCommand cmd, TelnetOption option) {
+  ESP_LOGVV(TAG, "Telnet command: %u %u", cmd, option);
+
+  // Handle option negotiation
+  if (cmd == TELNET_DO && option == TELNET_COM_PORT) {
+    // Server wants us to enable COM_PORT option
+    this->send_telnet_command_(TELNET_WILL, TELNET_COM_PORT);
+  } else if (cmd == TELNET_WILL && option == TELNET_COM_PORT) {
+    // Server will enable COM_PORT option
+    this->send_telnet_command_(TELNET_DO, TELNET_COM_PORT);
+  }
+  // Other negotiations: accept or reject as needed
+}
+
+void NetworkSerialClient::handle_telnet_subnegotiation_(const uint8_t *data, size_t length) {
+  if (length < 1) {
+    return;
+  }
+
+  // Check if this is COM_PORT subnegotiation
+  if (data[0] == TELNET_COM_PORT) {
+    if (length >= 2) {
+      this->handle_com_port_control_(data + 1, length - 1);
+    }
+  }
+}
+
+//========================================================================
+// RFC 2217 Com Port Control Implementation
+//========================================================================
+
+bool NetworkSerialClient::send_com_port_command_(uint8_t command, const uint8_t *data, size_t length) {
+  std::vector<uint8_t> subneg_data;
+  subneg_data.push_back(TELNET_COM_PORT);  // Option code
+  subneg_data.push_back(command);          // Command code
+  if (data && length > 0) {
+    subneg_data.insert(subneg_data.end(), data, data + length);
+  }
+
+  this->send_telnet_subnegotiation_(subneg_data.data(), subneg_data.size());
+  return true;
+}
+
+bool NetworkSerialClient::send_com_port_command_uint32_(uint8_t command, uint32_t value) {
+  // Send value as big-endian 32-bit integer
+  uint8_t data[4];
+  data[0] = (value >> 24) & 0xFF;
+  data[1] = (value >> 16) & 0xFF;
+  data[2] = (value >> 8) & 0xFF;
+  data[3] = value & 0xFF;
+  return this->send_com_port_command_(command, data, sizeof(data));
+}
+
+void NetworkSerialClient::handle_com_port_control_(const uint8_t *data, size_t length) {
+  if (length < 1) {
+    return;
+  }
+
+  uint8_t command = data[0];
+  const uint8_t *param_data = data + 1;
+  size_t param_length = length - 1;
+
+  ESP_LOGVV(TAG, "RFC2217 command: %u, params: %zu bytes", command, param_length);
+
+  // RFC 2217: server responds with commands 101-112 (_CS values)
+  switch (command) {
+    case RFC2217_SET_BAUDRATE_CS:  // Server responds with 101
+      if (param_length >= 4) {
+        uint32_t baudrate = (param_data[0] << 24) | (param_data[1] << 16) | (param_data[2] << 8) | param_data[3];
+        ESP_LOGD(TAG, "Server confirmed baudrate: %u", baudrate);
+        this->config_.baudrate = baudrate;
+      }
+      break;
+
+    case RFC2217_SET_DATASIZE_CS:  // Server responds with 102
+      if (param_length >= 1) {
+        ESP_LOGD(TAG, "Server confirmed data size: %u", param_data[0]);
+        this->config_.data_size = static_cast<DataSize>(param_data[0]);
+      }
+      break;
+
+    case RFC2217_SET_PARITY_CS:  // Server responds with 103
+      if (param_length >= 1) {
+        ESP_LOGD(TAG, "Server confirmed parity: %u", param_data[0]);
+        this->config_.parity = static_cast<ParityMode>(param_data[0]);
+      }
+      break;
+
+    case RFC2217_SET_STOPSIZE_CS:  // Server responds with 104
+      if (param_length >= 1) {
+        ESP_LOGD(TAG, "Server confirmed stop bits: %u", param_data[0]);
+        this->config_.stop_bits = static_cast<StopBits>(param_data[0]);
+      }
+      break;
+
+    case RFC2217_SET_CONTROL_CS:  // Server responds with 105
+      if (param_length >= 1) {
+        ESP_LOGD(TAG, "Server confirmed control: 0x%02X", param_data[0]);
+      }
+      break;
+
+    case RFC2217_NOTIFY_LINESTATE_CS:  // Server sends 106
+      if (param_length >= 1) {
+        this->line_state_ = param_data[0];
+        ESP_LOGVV(TAG, "Line state: 0x%02X", this->line_state_);
+      }
+      break;
+
+    case RFC2217_NOTIFY_MODEMSTATE_CS:  // Server sends 107
+      if (param_length >= 1) {
+        this->modem_state_ = param_data[0];
+        ESP_LOGVV(TAG, "Modem state: 0x%02X (CTS=%d DSR=%d RI=%d DCD=%d)", this->modem_state_,
+                  !!(this->modem_state_ & MODEM_STATE_CTS), !!(this->modem_state_ & MODEM_STATE_DSR),
+                  !!(this->modem_state_ & MODEM_STATE_RI), !!(this->modem_state_ & MODEM_STATE_DCD));
+      }
+      break;
+
+    case RFC2217_FLOWCONTROL_SUSPEND_CS:  // Server sends 108
+      ESP_LOGD(TAG, "Flow control suspended");
+      this->flow_suspended_ = true;
+      break;
+
+    case RFC2217_FLOWCONTROL_RESUME_CS:  // Server sends 109
+      ESP_LOGD(TAG, "Flow control resumed");
+      this->flow_suspended_ = false;
+      break;
+
+    default:
+      ESP_LOGV(TAG, "Unhandled RFC2217 command: %u", command);
+      break;
+  }
+}
+
+void NetworkSerialClient::apply_serial_config_() {
+  if (!this->connected_ || !this->telnet_negotiated_) {
+    return;
+  }
+
+  // RFC 2217: client sends commands 1-12, server responds with 101-112
+  ESP_LOGD(TAG, "Applying serial configuration...");
+
+  // Set baudrate (client sends 1)
+  this->send_com_port_command_uint32_(RFC2217_SET_BAUDRATE, this->config_.baudrate);
+
+  // Set data size (client sends 2)
+  uint8_t data_size = this->config_.data_size;
+  this->send_com_port_command_(RFC2217_SET_DATASIZE, &data_size, 1);
+
+  // Set parity (client sends 3)
+  uint8_t parity = this->config_.parity;
+  this->send_com_port_command_(RFC2217_SET_PARITY, &parity, 1);
+
+  // Set stop bits (client sends 4)
+  uint8_t stop_bits = this->config_.stop_bits;
+  this->send_com_port_command_(RFC2217_SET_STOPSIZE, &stop_bits, 1);
+
+  // Set flow control (client sends 5)
+  uint8_t flow_control = this->config_.flow_control;
+  this->send_com_port_command_(RFC2217_SET_CONTROL, &flow_control, 1);
+
+  // Set DTR/RTS via SET_CONTROL (client sends 5)
+  if (this->config_.dtr) {
+    uint8_t control = 8;  // DTR ON
+    this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  } else {
+    uint8_t control = 9;  // DTR OFF
+    this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  }
+  if (this->config_.rts) {
+    uint8_t control = 11;  // RTS ON
+    this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  } else {
+    uint8_t control = 12;  // RTS OFF
+    this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  }
+
+  ESP_LOGD(TAG, "Serial configuration applied");
+}
+
+//========================================================================
+// Runtime Configuration
+//========================================================================
+
+bool NetworkSerialClient::set_baudrate_runtime(uint32_t baudrate) {
+  this->config_.baudrate = baudrate;
+  if (this->connected_ && this->telnet_negotiated_) {
+    return this->send_com_port_command_uint32_(RFC2217_SET_BAUDRATE, baudrate);
+  }
+  return false;
+}
+
+bool NetworkSerialClient::set_data_size_runtime(DataSize data_size) {
+  this->config_.data_size = data_size;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t value = data_size;
+    return this->send_com_port_command_(RFC2217_SET_DATASIZE, &value, 1);
+  }
+  return false;
+}
+
+bool NetworkSerialClient::set_parity_runtime(ParityMode parity) {
+  this->config_.parity = parity;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t value = parity;
+    return this->send_com_port_command_(RFC2217_SET_PARITY, &value, 1);
+  }
+  return false;
+}
+
+bool NetworkSerialClient::set_stop_bits_runtime(StopBits stop_bits) {
+  this->config_.stop_bits = stop_bits;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t value = stop_bits;
+    return this->send_com_port_command_(RFC2217_SET_STOPSIZE, &value, 1);
+  }
+  return false;
+}
+
+bool NetworkSerialClient::set_flow_control_runtime(FlowControl flow_control) {
+  this->config_.flow_control = flow_control;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t value = flow_control;
+    return this->send_com_port_command_(RFC2217_SET_CONTROL, &value, 1);
+  }
+  return false;
+}
+
+//========================================================================
+// Modem Control
+//========================================================================
+
+bool NetworkSerialClient::set_dtr_runtime(bool state) {
+  this->config_.dtr = state;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t control = state ? 8 : 9;  // DTR ON=8, DTR OFF=9 via SET_CONTROL
+    return this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  }
+  return false;
+}
+
+bool NetworkSerialClient::set_rts_runtime(bool state) {
+  this->config_.rts = state;
+  if (this->connected_ && this->telnet_negotiated_) {
+    uint8_t control = state ? 11 : 12;  // RTS ON=11, RTS OFF=12 via SET_CONTROL
+    return this->send_com_port_command_(RFC2217_SET_CONTROL, &control, 1);
+  }
+  return false;
+}
+
+}  // namespace network_serial
+}  // namespace esphome

--- a/esphome/components/network_serial/network_serial.h
+++ b/esphome/components/network_serial/network_serial.h
@@ -1,0 +1,543 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/uart/uart_component.h"
+
+#ifdef USE_ESP_IDF
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
+#else
+#include <WiFiClient.h>
+#include <WiFiServer.h>
+#endif
+
+#include <string>
+#include <vector>
+#include <functional>
+#include <memory>
+
+namespace esphome {
+namespace network_serial {
+
+static const char *const TAG = "network_serial";
+
+//========================================================================
+// Telnet Protocol Constants (RFC 854)
+//========================================================================
+
+/// Telnet command codes
+enum TelnetCommand : uint8_t {
+  TELNET_SE = 240,    ///< End of subnegotiation parameters
+  TELNET_NOP = 241,   ///< No operation
+  TELNET_DM = 242,    ///< Data mark
+  TELNET_BRK = 243,   ///< Break
+  TELNET_IP = 244,    ///< Interrupt process
+  TELNET_AO = 245,    ///< Abort output
+  TELNET_AYT = 246,   ///< Are you there
+  TELNET_EC = 247,    ///< Erase character
+  TELNET_EL = 248,    ///< Erase line
+  TELNET_GA = 249,    ///< Go ahead
+  TELNET_SB = 250,    ///< Subnegotiation begin
+  TELNET_WILL = 251,  ///< Will (option negotiation)
+  TELNET_WONT = 252,  ///< Won't (option negotiation)
+  TELNET_DO = 253,    ///< Do (option negotiation)
+  TELNET_DONT = 254,  ///< Don't (option negotiation)
+  TELNET_IAC = 255,   ///< Interpret as command
+};
+
+/// Telnet option codes
+enum TelnetOption : uint8_t {
+  TELNET_BINARY = 0,             ///< Binary transmission
+  TELNET_ECHO = 1,               ///< Echo
+  TELNET_SUPPRESS_GO_AHEAD = 3,  ///< Suppress Go Ahead
+  TELNET_STATUS = 5,             ///< Status
+  TELNET_TIMING_MARK = 6,        ///< Timing mark
+  TELNET_COM_PORT = 44,          ///< Com Port Control (RFC 2217)
+};
+
+//========================================================================
+// RFC 2217 Com Port Control Constants
+//========================================================================
+
+/// RFC 2217 server-to-client commands
+enum RFC2217ServerCommand : uint8_t {
+  RFC2217_SET_BAUDRATE = 1,          ///< Set baud rate
+  RFC2217_SET_DATASIZE = 2,          ///< Set data size (5-8 bits)
+  RFC2217_SET_PARITY = 3,            ///< Set parity
+  RFC2217_SET_STOPSIZE = 4,          ///< Set stop bits
+  RFC2217_SET_CONTROL = 5,           ///< Set control (flow control)
+  RFC2217_NOTIFY_LINESTATE = 6,      ///< Line state notification
+  RFC2217_NOTIFY_MODEMSTATE = 7,     ///< Modem state notification
+  RFC2217_FLOWCONTROL_SUSPEND = 8,   ///< Flow control suspend
+  RFC2217_FLOWCONTROL_RESUME = 9,    ///< Flow control resume
+  RFC2217_SET_LINESTATE_MASK = 10,   ///< Set line state mask
+  RFC2217_SET_MODEMSTATE_MASK = 11,  ///< Set modem state mask
+  RFC2217_PURGE_DATA = 12,           ///< Purge data
+};
+
+/// RFC 2217 client-to-server commands (add 100 to server command)
+enum RFC2217ClientCommand : uint8_t {
+  RFC2217_SET_BAUDRATE_CS = 101,
+  RFC2217_SET_DATASIZE_CS = 102,
+  RFC2217_SET_PARITY_CS = 103,
+  RFC2217_SET_STOPSIZE_CS = 104,
+  RFC2217_SET_CONTROL_CS = 105,
+  RFC2217_NOTIFY_LINESTATE_CS = 106,
+  RFC2217_NOTIFY_MODEMSTATE_CS = 107,
+  RFC2217_FLOWCONTROL_SUSPEND_CS = 108,
+  RFC2217_FLOWCONTROL_RESUME_CS = 109,
+  RFC2217_SET_LINESTATE_MASK_CS = 110,
+  RFC2217_SET_MODEMSTATE_MASK_CS = 111,
+  RFC2217_PURGE_DATA_CS = 112,
+};
+
+/// Parity modes
+enum ParityMode : uint8_t {
+  PARITY_NONE = 1,
+  PARITY_ODD = 2,
+  PARITY_EVEN = 3,
+  PARITY_MARK = 4,
+  PARITY_SPACE = 5,
+};
+
+/// Data size (bits per character)
+enum DataSize : uint8_t {
+  DATA_SIZE_5 = 5,
+  DATA_SIZE_6 = 6,
+  DATA_SIZE_7 = 7,
+  DATA_SIZE_8 = 8,
+};
+
+/// Stop bits
+enum StopBits : uint8_t {
+  STOP_BITS_1 = 1,
+  STOP_BITS_2 = 2,
+  STOP_BITS_1_5 = 3,
+};
+
+/// Flow control modes
+enum FlowControl : uint8_t {
+  FLOW_NONE = 1,
+  FLOW_XONXOFF = 2,
+  FLOW_HARDWARE = 3,
+};
+
+/// Modem state bits
+enum ModemState : uint8_t {
+  MODEM_STATE_DELTA_CTS = (1 << 0),         ///< CTS changed
+  MODEM_STATE_DELTA_DSR = (1 << 1),         ///< DSR changed
+  MODEM_STATE_TRAILING_EDGE_RI = (1 << 2),  ///< RI trailing edge
+  MODEM_STATE_DELTA_DCD = (1 << 3),         ///< DCD changed
+  MODEM_STATE_CTS = (1 << 4),               ///< CTS state
+  MODEM_STATE_DSR = (1 << 5),               ///< DSR state
+  MODEM_STATE_RI = (1 << 6),                ///< RI state
+  MODEM_STATE_DCD = (1 << 7),               ///< DCD state
+};
+
+/// Line state bits
+enum LineState : uint8_t {
+  LINE_STATE_DATA_READY = (1 << 0),        ///< Data ready
+  LINE_STATE_OVERRUN_ERROR = (1 << 1),     ///< Overrun error
+  LINE_STATE_PARITY_ERROR = (1 << 2),      ///< Parity error
+  LINE_STATE_FRAMING_ERROR = (1 << 3),     ///< Framing error
+  LINE_STATE_BREAK_DETECT = (1 << 4),      ///< Break detected
+  LINE_STATE_TX_HOLDING_EMPTY = (1 << 5),  ///< TX holding register empty
+  LINE_STATE_TX_SHIFT_EMPTY = (1 << 6),    ///< TX shift register empty
+  LINE_STATE_TIMEOUT_ERROR = (1 << 7),     ///< Timeout error
+};
+
+/// Control signal bits
+enum ControlSignal : uint8_t {
+  CONTROL_DTR = (1 << 0),           ///< DTR (Data Terminal Ready)
+  CONTROL_RTS = (1 << 1),           ///< RTS (Request To Send)
+  CONTROL_DTR_ON = (1 << 3),        ///< DTR on
+  CONTROL_DTR_OFF = (1 << 4),       ///< DTR off
+  CONTROL_RTS_ON = (1 << 5),        ///< RTS on
+  CONTROL_RTS_OFF = (1 << 6),       ///< RTS off
+  CONTROL_FLOW_CONTROL = (1 << 7),  ///< Flow control
+};
+
+/// Purge data flags
+enum PurgeData : uint8_t {
+  PURGE_RX_BUFFER = 1,  ///< Purge receive buffer
+  PURGE_TX_BUFFER = 2,  ///< Purge transmit buffer
+  PURGE_BOTH = 3,       ///< Purge both buffers
+};
+
+//========================================================================
+// Serial Port Configuration
+//========================================================================
+
+/**
+ * @brief Serial port configuration structure
+ */
+struct SerialConfig {
+  uint32_t baudrate{9600};
+  DataSize data_size{DATA_SIZE_8};
+  ParityMode parity{PARITY_NONE};
+  StopBits stop_bits{STOP_BITS_1};
+  FlowControl flow_control{FLOW_NONE};
+  bool dtr{false};
+  bool rts{false};
+
+  SerialConfig() = default;
+};
+
+//========================================================================
+// Network Serial Client Component
+//========================================================================
+
+/**
+ * @brief RFC 2217 Network Serial Client
+ *
+ * Implements full RFC 2217 protocol for serial port control over Telnet/TCP.
+ * Provides virtual serial port accessible over network with complete control
+ * over baud rate, parity, data bits, stop bits, flow control, and modem signals.
+ *
+ * Features:
+ * - Full RFC 2217 Com Port Control implementation
+ * - Telnet protocol negotiation (RFC 854)
+ * - Configurable serial parameters (baud, parity, data bits, stop bits)
+ * - Flow control support (None, XON/XOFF, Hardware)
+ * - Modem control signals (DTR, RTS, DSR, CTS, DCD, RI)
+ * - Line state notifications (errors, break detection)
+ * - Automatic reconnection on disconnect
+ * - Buffered I/O with flow control
+ * - Storage host integration as /dev/ttyNET0
+ *
+ * Example configuration:
+ * @code
+ * network_serial:
+ *   - id: my_serial
+ *     host: 192.168.1.100
+ *     port: 2217
+ *     baudrate: 115200
+ *     data_bits: 8
+ *     parity: NONE
+ *     stop_bits: 1
+ *     device_node: /dev/ttyNET0  # Optional, for storage
+ * @endcode
+ */
+class NetworkSerialClient : public Component {
+ public:
+  NetworkSerialClient() = default;
+  ~NetworkSerialClient();
+
+  // Component lifecycle
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  //========================================================================
+  // Configuration
+  //========================================================================
+
+  void set_host(const std::string &host) { this->host_ = host; }
+  void set_port(uint16_t port) { this->port_ = port; }
+  void set_baudrate(uint32_t baudrate) { this->config_.baudrate = baudrate; }
+  void set_data_bits(uint8_t data_bits);
+  void set_parity(const std::string &parity);
+  void set_stop_bits(uint8_t stop_bits);
+  void set_flow_control(const std::string &flow_control);
+  void set_dtr(bool dtr) { this->config_.dtr = dtr; }
+  void set_rts(bool rts) { this->config_.rts = rts; }
+  void set_device_node(const std::string &device_node) { this->device_node_ = device_node; }
+
+  const std::string &get_device_node() const { return this->device_node_; }
+
+  //========================================================================
+  // Storage Host Integration (soft dependency)
+  //========================================================================
+
+  /**
+   * @brief Register this serial client with storage
+   */
+  void register_with_storage();
+
+  //========================================================================
+  // Connection Management
+  //========================================================================
+
+  bool is_connected() const { return this->connected_; }
+  bool connect();
+  void disconnect();
+
+  //========================================================================
+  // Serial I/O Operations
+  //========================================================================
+
+  /**
+   * @brief Write data to serial port
+   */
+  size_t write(const uint8_t *data, size_t length);
+
+  /**
+   * @brief Read data from serial port
+   */
+  size_t read(uint8_t *data, size_t length);
+
+  /**
+   * @brief Get number of bytes available to read
+   */
+  size_t available() const { return this->rx_buffer_.size(); }
+
+  /**
+   * @brief Flush transmit buffer
+   */
+  void flush();
+
+  /**
+   * @brief Purge buffers
+   */
+  void purge(PurgeData purge_flags);
+
+  //========================================================================
+  // Serial Configuration (Runtime)
+  //========================================================================
+
+  bool set_baudrate_runtime(uint32_t baudrate);
+  bool set_data_size_runtime(DataSize data_size);
+  bool set_parity_runtime(ParityMode parity);
+  bool set_stop_bits_runtime(StopBits stop_bits);
+  bool set_flow_control_runtime(FlowControl flow_control);
+
+  //========================================================================
+  // Modem Control
+  //========================================================================
+
+  bool set_dtr_runtime(bool state);
+  bool set_rts_runtime(bool state);
+  uint8_t get_modem_state() const { return this->modem_state_; }
+  uint8_t get_line_state() const { return this->line_state_; }
+
+  //========================================================================
+  // Callbacks
+  //========================================================================
+
+  void add_on_connect_callback(std::function<void()> callback) { this->on_connect_callbacks_.push_back(callback); }
+  void add_on_disconnect_callback(std::function<void()> callback) {
+    this->on_disconnect_callbacks_.push_back(callback);
+  }
+  void add_on_data_callback(std::function<void(const std::vector<uint8_t> &)> callback) {
+    this->on_data_callbacks_.push_back(callback);
+  }
+
+ protected:
+  //========================================================================
+  // Configuration
+  //========================================================================
+
+  std::string host_;
+  uint16_t port_{2217};
+  SerialConfig config_;
+  std::string device_node_;
+
+  //========================================================================
+  // Network State
+  //========================================================================
+
+#ifdef USE_ESP_IDF
+  int socket_{-1};
+#else
+  std::unique_ptr<WiFiClient> client_;
+#endif
+
+  bool connected_{false};
+  bool telnet_negotiated_{false};
+  uint32_t last_connect_attempt_{0};
+  static constexpr uint32_t RECONNECT_INTERVAL_MS = 5000;
+
+  //========================================================================
+  // Serial State
+  //========================================================================
+
+  uint8_t modem_state_{0};
+  uint8_t line_state_{0};
+  bool flow_suspended_{false};
+
+  //========================================================================
+  // Buffers
+  //========================================================================
+
+  std::vector<uint8_t> rx_buffer_;
+  std::vector<uint8_t> tx_buffer_;
+  std::vector<uint8_t> telnet_buffer_;  ///< For Telnet protocol parsing
+
+  static constexpr size_t MAX_BUFFER_SIZE = 2048;
+
+  //========================================================================
+  // Callbacks
+  //========================================================================
+
+  std::vector<std::function<void()>> on_connect_callbacks_;
+  std::vector<std::function<void()>> on_disconnect_callbacks_;
+  std::vector<std::function<void(const std::vector<uint8_t> &)>> on_data_callbacks_;
+
+  //========================================================================
+  // Internal Operations
+  //========================================================================
+
+  bool connect_socket_();
+  void close_socket_();
+  bool send_raw_(const uint8_t *data, size_t length);
+  size_t receive_raw_(uint8_t *buffer, size_t length);
+
+  //========================================================================
+  // Telnet Protocol
+  //========================================================================
+
+  bool negotiate_telnet_();
+  void send_telnet_command_(TelnetCommand cmd, TelnetOption option);
+  void send_telnet_subnegotiation_(const uint8_t *data, size_t length);
+  void process_telnet_data_(const uint8_t *data, size_t length);
+  void handle_telnet_command_(TelnetCommand cmd, TelnetOption option);
+  void handle_telnet_subnegotiation_(const uint8_t *data, size_t length);
+
+  //========================================================================
+  // RFC 2217 Protocol
+  //========================================================================
+
+  bool send_com_port_command_(uint8_t command, const uint8_t *data, size_t length);
+  bool send_com_port_command_uint32_(uint8_t command, uint32_t value);
+  void handle_com_port_control_(const uint8_t *data, size_t length);
+  void apply_serial_config_();
+};
+
+//========================================================================
+// Network Serial Server Component
+//========================================================================
+
+/**
+ * @brief RFC 2217 Network Serial Server
+ *
+ * Exposes a local UART as an RFC 2217 server over TCP.
+ * Remote clients (e.g. pyserial's rfc2217:// or ser2net) can connect
+ * and interact with the UART as if it were a local serial port.
+ *
+ * Features:
+ * - Listens on configurable TCP port
+ * - Full RFC 2217 Com Port Control (baud, parity, data bits, stop bits)
+ * - Telnet protocol negotiation (RFC 854)
+ * - Bidirectional UART <-> TCP bridging with IAC escaping
+ * - Flow control support
+ * - Modem signal control (DTR, RTS)
+ * - Single client at a time (rejects additional connections)
+ *
+ * Example configuration:
+ * @code
+ * network_serial:
+ *   - id: my_server
+ *     mode: server
+ *     uart_id: my_uart
+ *     port: 2217
+ * @endcode
+ */
+class NetworkSerialServer : public Component {
+ public:
+  NetworkSerialServer() = default;
+  ~NetworkSerialServer();
+
+  // Component lifecycle
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+  //========================================================================
+  // Configuration
+  //========================================================================
+
+  void set_port(uint16_t port) { this->port_ = port; }
+  void set_uart(uart::UARTComponent *uart) { this->uart_ = uart; }
+
+  //========================================================================
+  // Connection State
+  //========================================================================
+
+  bool has_client() const { return this->client_connected_; }
+
+ protected:
+  //========================================================================
+  // Configuration
+  //========================================================================
+
+  uint16_t port_{2217};
+  uart::UARTComponent *uart_{nullptr};
+
+  //========================================================================
+  // Server State
+  //========================================================================
+
+#ifdef USE_ESP_IDF
+  int listen_socket_{-1};
+  int client_socket_{-1};
+#else
+  std::unique_ptr<WiFiServer> server_;
+  std::unique_ptr<WiFiClient> client_;
+#endif
+
+  bool client_connected_{false};
+  bool telnet_negotiated_{false};
+
+  //========================================================================
+  // Serial State (tracks what client requested)
+  //========================================================================
+
+  SerialConfig client_config_;
+  uint8_t modem_state_{0};
+  uint8_t line_state_{0};
+  uint8_t modem_state_mask_{0xFF};
+  uint8_t line_state_mask_{0};
+
+  //========================================================================
+  // Buffers
+  //========================================================================
+
+  std::vector<uint8_t> telnet_parse_buf_;
+  static constexpr size_t BRIDGE_BUF_SIZE = 256;
+
+  //========================================================================
+  // Internal Operations
+  //========================================================================
+
+  bool start_listening_();
+  void stop_listening_();
+  void accept_client_();
+  void disconnect_client_();
+  bool send_to_client_(const uint8_t *data, size_t length);
+  size_t receive_from_client_(uint8_t *buffer, size_t length);
+
+  //========================================================================
+  // Telnet Protocol (server side)
+  //========================================================================
+
+  void send_telnet_negotiation_();
+  void send_telnet_command_(TelnetCommand cmd, TelnetOption option);
+  void send_telnet_subnegotiation_(const uint8_t *data, size_t length);
+  void process_client_data_(const uint8_t *data, size_t length);
+  void handle_telnet_command_(TelnetCommand cmd, TelnetOption option);
+  void handle_telnet_subnegotiation_(const uint8_t *data, size_t length);
+
+  //========================================================================
+  // RFC 2217 Protocol (server side)
+  //========================================================================
+
+  void send_com_port_response_(uint8_t command, const uint8_t *data, size_t length);
+  void send_com_port_response_uint32_(uint8_t command, uint32_t value);
+  void handle_com_port_command_(const uint8_t *data, size_t length);
+  void apply_uart_config_();
+  void send_modem_state_();
+  void send_initial_modem_state_();
+
+  //========================================================================
+  // UART Bridging
+  //========================================================================
+
+  void bridge_uart_to_client_();
+};
+
+}  // namespace network_serial
+}  // namespace esphome

--- a/esphome/components/network_serial/network_serial_server.cpp
+++ b/esphome/components/network_serial/network_serial_server.cpp
@@ -1,0 +1,649 @@
+#include "network_serial.h"
+#include "esphome/core/log.h"
+#include "esphome/core/application.h"
+
+#include <cstring>
+#include <algorithm>
+
+namespace esphome {
+namespace network_serial {
+
+static const char *const TAG_SERVER = "network_serial.server";
+
+//========================================================================
+// NetworkSerialServer Lifecycle
+//========================================================================
+
+NetworkSerialServer::~NetworkSerialServer() {
+  this->disconnect_client_();
+  this->stop_listening_();
+}
+
+void NetworkSerialServer::setup() {
+  ESP_LOGCONFIG(TAG_SERVER, "Setting up Network Serial Server...");
+  ESP_LOGCONFIG(TAG_SERVER, "  Port: %u", this->port_);
+
+  this->telnet_parse_buf_.reserve(128);
+
+  if (!this->start_listening_()) {
+    ESP_LOGE(TAG_SERVER, "Failed to start listening on port %u", this->port_);
+    this->mark_failed();
+    return;
+  }
+
+  ESP_LOGI(TAG_SERVER, "Listening on port %u", this->port_);
+}
+
+void NetworkSerialServer::loop() {
+  // Accept new connections
+  if (!this->client_connected_) {
+    this->accept_client_();
+  }
+
+  if (!this->client_connected_) {
+    return;
+  }
+
+  // Read data from client
+  uint8_t buffer[BRIDGE_BUF_SIZE];
+  size_t received = this->receive_from_client_(buffer, sizeof(buffer));
+  if (received > 0) {
+    this->process_client_data_(buffer, received);
+  }
+
+  // Bridge UART -> client
+  this->bridge_uart_to_client_();
+}
+
+void NetworkSerialServer::dump_config() {
+  ESP_LOGCONFIG(TAG_SERVER, "Network Serial Server:");
+  ESP_LOGCONFIG(TAG_SERVER, "  Port: %u", this->port_);
+  ESP_LOGCONFIG(TAG_SERVER, "  Client: %s", this->client_connected_ ? "Connected" : "None");
+}
+
+//========================================================================
+// Server Socket Operations
+//========================================================================
+
+bool NetworkSerialServer::start_listening_() {
+#ifdef USE_ESP_IDF
+  this->listen_socket_ = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  if (this->listen_socket_ < 0) {
+    ESP_LOGE(TAG_SERVER, "Failed to create socket: errno %d", errno);
+    return false;
+  }
+
+  // Allow address reuse
+  int reuse = 1;
+  setsockopt(this->listen_socket_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(this->port_);
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+  if (bind(this->listen_socket_, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+    ESP_LOGE(TAG_SERVER, "Failed to bind: errno %d", errno);
+    close(this->listen_socket_);
+    this->listen_socket_ = -1;
+    return false;
+  }
+
+  if (listen(this->listen_socket_, 1) < 0) {
+    ESP_LOGE(TAG_SERVER, "Failed to listen: errno %d", errno);
+    close(this->listen_socket_);
+    this->listen_socket_ = -1;
+    return false;
+  }
+
+  // Set non-blocking
+  int flags = fcntl(this->listen_socket_, F_GETFL, 0);
+  fcntl(this->listen_socket_, F_SETFL, flags | O_NONBLOCK);
+
+  return true;
+#else
+  this->server_ = std::make_unique<WiFiServer>(this->port_);
+  this->server_->begin();
+  this->server_->setNoDelay(true);
+  return true;
+#endif
+}
+
+void NetworkSerialServer::stop_listening_() {
+#ifdef USE_ESP_IDF
+  if (this->listen_socket_ >= 0) {
+    close(this->listen_socket_);
+    this->listen_socket_ = -1;
+  }
+#else
+  if (this->server_) {
+    this->server_->stop();
+    this->server_ = nullptr;
+  }
+#endif
+}
+
+void NetworkSerialServer::accept_client_() {
+#ifdef USE_ESP_IDF
+  struct sockaddr_in client_addr;
+  socklen_t addr_len = sizeof(client_addr);
+  int new_socket = accept(this->listen_socket_, (struct sockaddr *) &client_addr, &addr_len);
+  if (new_socket < 0) {
+    return;  // No pending connection (non-blocking)
+  }
+
+  // Set non-blocking and TCP_NODELAY on client socket
+  int flags = fcntl(new_socket, F_GETFL, 0);
+  fcntl(new_socket, F_SETFL, flags | O_NONBLOCK);
+  int nodelay = 1;
+  setsockopt(new_socket, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+
+  this->client_socket_ = new_socket;
+  this->client_connected_ = true;
+  this->telnet_negotiated_ = false;
+
+  char addr_str[INET_ADDRSTRLEN];
+  inet_ntoa_r(client_addr.sin_addr, addr_str, sizeof(addr_str));
+  ESP_LOGI(TAG_SERVER, "Client connected from %s:%u", addr_str, ntohs(client_addr.sin_port));
+
+  // Send telnet negotiation
+  this->send_telnet_negotiation_();
+#else
+  if (!this->server_->hasClient()) {
+    return;
+  }
+
+  this->client_ = std::make_unique<WiFiClient>(this->server_->accept());
+  if (!this->client_ || !this->client_->connected()) {
+    this->client_ = nullptr;
+    return;
+  }
+
+  this->client_->setNoDelay(true);
+  this->client_connected_ = true;
+  this->telnet_negotiated_ = false;
+
+  ESP_LOGI(TAG_SERVER, "Client connected");
+
+  this->send_telnet_negotiation_();
+#endif
+}
+
+void NetworkSerialServer::disconnect_client_() {
+  if (!this->client_connected_) {
+    return;
+  }
+
+  ESP_LOGI(TAG_SERVER, "Client disconnected");
+
+#ifdef USE_ESP_IDF
+  if (this->client_socket_ >= 0) {
+    close(this->client_socket_);
+    this->client_socket_ = -1;
+  }
+#else
+  if (this->client_) {
+    this->client_->stop();
+    this->client_ = nullptr;
+  }
+#endif
+
+  this->client_connected_ = false;
+  this->telnet_negotiated_ = false;
+  this->telnet_parse_buf_.clear();
+}
+
+bool NetworkSerialServer::send_to_client_(const uint8_t *data, size_t length) {
+  if (!this->client_connected_) {
+    return false;
+  }
+
+#ifdef USE_ESP_IDF
+  int sent = send(this->client_socket_, data, length, 0);
+  if (sent < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return false;
+    }
+    ESP_LOGW(TAG_SERVER, "Send error: errno %d", errno);
+    this->disconnect_client_();
+    return false;
+  }
+  return sent > 0;
+#else
+  if (!this->client_ || !this->client_->connected()) {
+    this->disconnect_client_();
+    return false;
+  }
+  return this->client_->write(data, length) > 0;
+#endif
+}
+
+size_t NetworkSerialServer::receive_from_client_(uint8_t *buffer, size_t length) {
+  if (!this->client_connected_) {
+    return 0;
+  }
+
+#ifdef USE_ESP_IDF
+  int received = recv(this->client_socket_, buffer, length, 0);
+  if (received < 0) {
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0;
+    }
+    ESP_LOGW(TAG_SERVER, "Receive error: errno %d", errno);
+    this->disconnect_client_();
+    return 0;
+  }
+  if (received == 0) {
+    // Connection closed
+    this->disconnect_client_();
+    return 0;
+  }
+  return received;
+#else
+  if (!this->client_ || !this->client_->connected()) {
+    this->disconnect_client_();
+    return 0;
+  }
+  int avail = this->client_->available();
+  if (avail <= 0) {
+    return 0;
+  }
+  size_t to_read = std::min(static_cast<size_t>(avail), length);
+  return this->client_->read(buffer, to_read);
+#endif
+}
+
+//========================================================================
+// Telnet Protocol (Server Side)
+//========================================================================
+
+void NetworkSerialServer::send_telnet_negotiation_() {
+  ESP_LOGD(TAG_SERVER, "Sending Telnet negotiation...");
+
+  // Server announces capabilities
+  // WILL BINARY - we will transmit in binary
+  this->send_telnet_command_(TELNET_WILL, TELNET_BINARY);
+  // DO BINARY - client should transmit in binary
+  this->send_telnet_command_(TELNET_DO, TELNET_BINARY);
+  // WILL SUPPRESS_GO_AHEAD
+  this->send_telnet_command_(TELNET_WILL, TELNET_SUPPRESS_GO_AHEAD);
+  // DO SUPPRESS_GO_AHEAD
+  this->send_telnet_command_(TELNET_DO, TELNET_SUPPRESS_GO_AHEAD);
+  // WILL COM_PORT (RFC 2217) - we support com port control
+  this->send_telnet_command_(TELNET_WILL, TELNET_COM_PORT);
+
+  this->telnet_negotiated_ = true;
+  ESP_LOGD(TAG_SERVER, "Telnet negotiation sent");
+
+  // Send initial modem state
+  this->send_initial_modem_state_();
+}
+
+void NetworkSerialServer::send_telnet_command_(TelnetCommand cmd, TelnetOption option) {
+  uint8_t buffer[3] = {TELNET_IAC, cmd, option};
+  this->send_to_client_(buffer, sizeof(buffer));
+}
+
+void NetworkSerialServer::send_telnet_subnegotiation_(const uint8_t *data, size_t length) {
+  // IAC SB <data> IAC SE
+  std::vector<uint8_t> buffer;
+  buffer.reserve(length + 4);
+  buffer.push_back(TELNET_IAC);
+  buffer.push_back(TELNET_SB);
+  buffer.insert(buffer.end(), data, data + length);
+  buffer.push_back(TELNET_IAC);
+  buffer.push_back(TELNET_SE);
+
+  this->send_to_client_(buffer.data(), buffer.size());
+}
+
+void NetworkSerialServer::process_client_data_(const uint8_t *data, size_t length) {
+  for (size_t i = 0; i < length; i++) {
+    uint8_t byte = data[i];
+
+    if (byte == TELNET_IAC) {
+      if (i + 1 < length) {
+        uint8_t cmd = data[++i];
+
+        if (cmd == TELNET_IAC) {
+          // Escaped IAC -> forward single 0xFF to UART
+          this->uart_->write_byte(0xFF);
+        } else if (cmd == TELNET_SB) {
+          // Subnegotiation begin — collect until IAC SE
+          this->telnet_parse_buf_.clear();
+          i++;
+          while (i < length) {
+            if (data[i] == TELNET_IAC && i + 1 < length && data[i + 1] == TELNET_SE) {
+              i++;  // skip SE
+              this->handle_telnet_subnegotiation_(this->telnet_parse_buf_.data(), this->telnet_parse_buf_.size());
+              break;
+            }
+            this->telnet_parse_buf_.push_back(data[i++]);
+          }
+        } else if (cmd == TELNET_WILL || cmd == TELNET_WONT || cmd == TELNET_DO || cmd == TELNET_DONT) {
+          if (i + 1 < length) {
+            uint8_t option = data[++i];
+            this->handle_telnet_command_(static_cast<TelnetCommand>(cmd), static_cast<TelnetOption>(option));
+          }
+        }
+        // Other telnet commands (NOP, BRK, etc.) ignored
+      }
+    } else {
+      // Regular data byte -> forward to UART
+      this->uart_->write_byte(byte);
+    }
+  }
+}
+
+void NetworkSerialServer::handle_telnet_command_(TelnetCommand cmd, TelnetOption option) {
+  ESP_LOGVV(TAG_SERVER, "Client Telnet: %u %u", cmd, option);
+
+  switch (cmd) {
+    case TELNET_DO:
+      if (option == TELNET_COM_PORT || option == TELNET_BINARY || option == TELNET_SUPPRESS_GO_AHEAD) {
+        // Confirm options we support
+        this->send_telnet_command_(TELNET_WILL, option);
+      } else {
+        // Refuse options we don't support
+        this->send_telnet_command_(TELNET_WONT, option);
+      }
+      break;
+
+    case TELNET_WILL:
+      if (option == TELNET_BINARY || option == TELNET_SUPPRESS_GO_AHEAD) {
+        this->send_telnet_command_(TELNET_DO, option);
+      } else if (option == TELNET_COM_PORT) {
+        // Client supports COM_PORT too - acknowledge
+        this->send_telnet_command_(TELNET_DO, option);
+      } else {
+        this->send_telnet_command_(TELNET_DONT, option);
+      }
+      break;
+
+    case TELNET_WONT:
+    case TELNET_DONT:
+      // Client refuses — nothing to do
+      break;
+
+    default:
+      break;
+  }
+}
+
+void NetworkSerialServer::handle_telnet_subnegotiation_(const uint8_t *data, size_t length) {
+  if (length < 1) {
+    return;
+  }
+
+  if (data[0] == TELNET_COM_PORT) {
+    if (length >= 2) {
+      this->handle_com_port_command_(data + 1, length - 1);
+    }
+  }
+}
+
+//========================================================================
+// RFC 2217 Com Port Control (Server Side)
+//========================================================================
+
+void NetworkSerialServer::send_com_port_response_(uint8_t command, const uint8_t *data, size_t length) {
+  std::vector<uint8_t> subneg_data;
+  subneg_data.reserve(2 + length);
+  subneg_data.push_back(TELNET_COM_PORT);
+  subneg_data.push_back(command);  // Server response (101-112)
+  if (data && length > 0) {
+    subneg_data.insert(subneg_data.end(), data, data + length);
+  }
+  this->send_telnet_subnegotiation_(subneg_data.data(), subneg_data.size());
+}
+
+void NetworkSerialServer::send_com_port_response_uint32_(uint8_t command, uint32_t value) {
+  uint8_t data[4];
+  data[0] = (value >> 24) & 0xFF;
+  data[1] = (value >> 16) & 0xFF;
+  data[2] = (value >> 8) & 0xFF;
+  data[3] = value & 0xFF;
+  this->send_com_port_response_(command, data, sizeof(data));
+}
+
+void NetworkSerialServer::handle_com_port_command_(const uint8_t *data, size_t length) {
+  if (length < 1) {
+    return;
+  }
+
+  uint8_t command = data[0];
+  const uint8_t *param_data = data + 1;
+  size_t param_length = length - 1;
+
+  ESP_LOGD(TAG_SERVER, "RFC2217 client command: %u, params: %zu bytes", command, param_length);
+
+  // RFC 2217 command numbering:
+  //   Client sends commands 1-12 (RFC2217ServerCommand values)
+  //   Server responds with commands 101-112 (RFC2217ClientCommand values)
+  // The naming in our enums is misleading but the values are correct.
+
+  switch (command) {
+    case RFC2217_SET_BAUDRATE:  // Client sends 1
+      if (param_length >= 4) {
+        uint32_t baudrate = (param_data[0] << 24) | (param_data[1] << 16) | (param_data[2] << 8) | param_data[3];
+        if (baudrate == 0) {
+          // Request: report current baud rate
+          baudrate = this->uart_->get_baud_rate();
+        } else {
+          ESP_LOGI(TAG_SERVER, "Client set baudrate: %u", baudrate);
+          this->uart_->set_baud_rate(baudrate);
+          this->apply_uart_config_();
+        }
+        // Respond with 101 + actual baud rate
+        this->send_com_port_response_uint32_(RFC2217_SET_BAUDRATE_CS, this->uart_->get_baud_rate());
+      }
+      break;
+
+    case RFC2217_SET_DATASIZE:  // Client sends 2
+      if (param_length >= 1) {
+        uint8_t data_size = param_data[0];
+        if (data_size == 0) {
+          data_size = this->uart_->get_data_bits();
+        } else {
+          ESP_LOGI(TAG_SERVER, "Client set data size: %u", data_size);
+          this->uart_->set_data_bits(data_size);
+          this->apply_uart_config_();
+        }
+        uint8_t resp = this->uart_->get_data_bits();
+        this->send_com_port_response_(RFC2217_SET_DATASIZE_CS, &resp, 1);  // Respond with 102
+      }
+      break;
+
+    case RFC2217_SET_PARITY:  // Client sends 3
+      if (param_length >= 1) {
+        uint8_t parity = param_data[0];
+        if (parity == 0) {
+          // Request current
+        } else {
+          ESP_LOGI(TAG_SERVER, "Client set parity: %u", parity);
+          switch (parity) {
+            case PARITY_NONE:
+              this->uart_->set_parity(uart::UART_CONFIG_PARITY_NONE);
+              break;
+            case PARITY_ODD:
+              this->uart_->set_parity(uart::UART_CONFIG_PARITY_ODD);
+              break;
+            case PARITY_EVEN:
+              this->uart_->set_parity(uart::UART_CONFIG_PARITY_EVEN);
+              break;
+            default:
+              ESP_LOGW(TAG_SERVER, "Unsupported parity mode: %u, using NONE", parity);
+              this->uart_->set_parity(uart::UART_CONFIG_PARITY_NONE);
+              break;
+          }
+          this->apply_uart_config_();
+        }
+        uint8_t resp;
+        switch (this->uart_->get_parity()) {
+          case uart::UART_CONFIG_PARITY_NONE:
+            resp = PARITY_NONE;
+            break;
+          case uart::UART_CONFIG_PARITY_ODD:
+            resp = PARITY_ODD;
+            break;
+          case uart::UART_CONFIG_PARITY_EVEN:
+            resp = PARITY_EVEN;
+            break;
+          default:
+            resp = PARITY_NONE;
+            break;
+        }
+        this->send_com_port_response_(RFC2217_SET_PARITY_CS, &resp, 1);  // Respond with 103
+      }
+      break;
+
+    case RFC2217_SET_STOPSIZE:  // Client sends 4
+      if (param_length >= 1) {
+        uint8_t stop_bits = param_data[0];
+        if (stop_bits == 0) {
+          stop_bits = this->uart_->get_stop_bits();
+        } else {
+          ESP_LOGI(TAG_SERVER, "Client set stop bits: %u", stop_bits);
+          this->uart_->set_stop_bits(stop_bits);
+          this->apply_uart_config_();
+        }
+        uint8_t resp = this->uart_->get_stop_bits();
+        this->send_com_port_response_(RFC2217_SET_STOPSIZE_CS, &resp, 1);  // Respond with 104
+      }
+      break;
+
+    case RFC2217_SET_CONTROL:  // Client sends 5
+      if (param_length >= 1) {
+        uint8_t control = param_data[0];
+        ESP_LOGD(TAG_SERVER, "Client set control: %u", control);
+        uint8_t resp = control;
+        switch (control) {
+          case 0:
+            resp = FLOW_NONE;
+            break;
+          case 1:  // No flow control
+          case 2:  // XON/XOFF
+          case 3:  // Hardware
+            resp = control;
+            break;
+          case 8:  // DTR ON
+            this->modem_state_ |= MODEM_STATE_DSR;
+            this->send_modem_state_();
+            resp = 8;
+            break;
+          case 9:  // DTR OFF
+            this->modem_state_ &= ~MODEM_STATE_DSR;
+            this->send_modem_state_();
+            resp = 9;
+            break;
+          case 11:  // RTS ON
+            this->modem_state_ |= MODEM_STATE_CTS;
+            this->send_modem_state_();
+            resp = 11;
+            break;
+          case 12:  // RTS OFF
+            this->modem_state_ &= ~MODEM_STATE_CTS;
+            this->send_modem_state_();
+            resp = 12;
+            break;
+          default:
+            break;
+        }
+        this->send_com_port_response_(RFC2217_SET_CONTROL_CS, &resp, 1);  // Respond with 105
+      }
+      break;
+
+    case RFC2217_SET_LINESTATE_MASK:  // Client sends 10
+      if (param_length >= 1) {
+        this->line_state_mask_ = param_data[0];
+        ESP_LOGD(TAG_SERVER, "Client set line state mask: 0x%02X", this->line_state_mask_);
+        this->send_com_port_response_(RFC2217_SET_LINESTATE_MASK_CS, &this->line_state_mask_, 1);
+      }
+      break;
+
+    case RFC2217_SET_MODEMSTATE_MASK:  // Client sends 11
+      if (param_length >= 1) {
+        this->modem_state_mask_ = param_data[0];
+        ESP_LOGD(TAG_SERVER, "Client set modem state mask: 0x%02X", this->modem_state_mask_);
+        this->send_com_port_response_(RFC2217_SET_MODEMSTATE_MASK_CS, &this->modem_state_mask_, 1);
+      }
+      break;
+
+    case RFC2217_PURGE_DATA:  // Client sends 12
+      if (param_length >= 1) {
+        ESP_LOGD(TAG_SERVER, "Client purge: %u", param_data[0]);
+        this->send_com_port_response_(RFC2217_PURGE_DATA_CS, param_data, 1);
+      }
+      break;
+
+    case RFC2217_FLOWCONTROL_SUSPEND:  // Client sends 8
+      ESP_LOGD(TAG_SERVER, "Client flow control suspend");
+      this->send_com_port_response_(RFC2217_FLOWCONTROL_SUSPEND_CS, nullptr, 0);
+      break;
+
+    case RFC2217_FLOWCONTROL_RESUME:  // Client sends 9
+      ESP_LOGD(TAG_SERVER, "Client flow control resume");
+      this->send_com_port_response_(RFC2217_FLOWCONTROL_RESUME_CS, nullptr, 0);
+      break;
+
+    default:
+      ESP_LOGV(TAG_SERVER, "Unhandled RFC2217 client command: %u", command);
+      break;
+  }
+}
+
+void NetworkSerialServer::apply_uart_config_() {
+#if defined(USE_ESP8266) || defined(USE_ESP32)
+  ESP_LOGD(TAG_SERVER, "Applying UART configuration...");
+  this->uart_->load_settings(true);
+#else
+  ESP_LOGW(TAG_SERVER, "Runtime UART reconfiguration not supported on this platform");
+#endif
+}
+
+void NetworkSerialServer::send_modem_state_() {
+  uint8_t masked = this->modem_state_ & this->modem_state_mask_;
+  this->send_com_port_response_(RFC2217_NOTIFY_MODEMSTATE_CS, &masked, 1);
+}
+
+void NetworkSerialServer::send_initial_modem_state_() {
+  // Send initial modem state: DSR active, CTS active (typical for local UART)
+  this->modem_state_ = MODEM_STATE_DSR | MODEM_STATE_CTS;
+  this->send_modem_state_();
+}
+
+//========================================================================
+// UART Bridging
+//========================================================================
+
+void NetworkSerialServer::bridge_uart_to_client_() {
+  size_t avail = this->uart_->available();
+  if (avail == 0) {
+    return;
+  }
+
+  // Read from UART and send to client, escaping IAC bytes
+  uint8_t uart_buf[BRIDGE_BUF_SIZE];
+  size_t to_read = std::min(avail, sizeof(uart_buf));
+
+  if (!this->uart_->read_array(uart_buf, to_read)) {
+    return;
+  }
+
+  // Build output buffer with IAC escaping
+  uint8_t out_buf[BRIDGE_BUF_SIZE * 2];  // Worst case: every byte is 0xFF
+  size_t out_len = 0;
+
+  for (size_t i = 0; i < to_read && out_len < sizeof(out_buf) - 1; i++) {
+    out_buf[out_len++] = uart_buf[i];
+    if (uart_buf[i] == TELNET_IAC) {
+      out_buf[out_len++] = TELNET_IAC;  // Escape by doubling
+    }
+  }
+
+  this->send_to_client_(out_buf, out_len);
+}
+
+}  // namespace network_serial
+}  // namespace esphome


### PR DESCRIPTION
Initial draft for RFC2217 client/server component, tested with pyserial

# What does this implement/fix?

Add rfc2217 ("network - serial") client and server component

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
network_serial:
  - id: serial_server
    mode: server
    uart_id: uart_tool0
    port: 2217
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
