### PR TITLE
Make kamstrup_kmp work with a usb_uart.

### DIFF
--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -69,12 +69,11 @@ void KamstrupKMPComponent::loop() {
     case STATE_IDLE:
       if (!this->command_queue_.empty()) {
         this->current_command_ = this->command_queue_.front();
+        this->command_queue_.pop();
         this->clear_uart_rx_buffer_();
         this->send_command_(current_command_);
-        this->command_queue_.pop();
-        this->state_ = STATE_READING;
+        this->state_ = STATE_SEARCHING;
         this->last_read_time_ = millis();
-        this->rx_buffer_.clear();
       }
       break;
 

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -68,7 +68,7 @@ void KamstrupKMPComponent::loop() {
   switch (this->state_) {
     case STATE_IDLE:
       if (!this->command_queue_.empty()) {
-	this->current_command_ = this->command_queue_.front();
+        this->current_command_ = this->command_queue_.front();
         this->clear_uart_rx_buffer_();
         this->send_command_(current_command_);
         this->command_queue_.pop();
@@ -84,34 +84,34 @@ void KamstrupKMPComponent::loop() {
       // Handle RX non-blockingly
       while (this->available()) {
         uint8_t data = this->read();
-        this->last_read_time_ = millis(); // Reset timeout on new data
+        this->last_read_time_ = millis();  // Reset timeout on new data
 
-	// 0x40 always restarts the current frame.
-	if (data == 0x40) {
-	  this->rx_buffer_.clear();
-	  this->state_ = STATE_READING;
-	  continue;
-	}
-	if (this->state_ == STATE_SEARCHING) {
+        // 0x40 always restarts the current frame.
+        if (data == 0x40) {
+          this->rx_buffer_.clear();
+          this->state_ = STATE_READING;
           continue;
-	}
-        
-	if (this->state_ == STATE_READ_ESCAPE) {
+        }
+        if (this->state_ == STATE_SEARCHING) {
+          continue;
+        }
+
+        if (this->state_ == STATE_READ_ESCAPE) {
           this->rx_buffer_.push_back(data ^ 0xFF);
           this->state_ = STATE_READING;
-	} else if (data == 0x1B) { // ESCape
+        } else if (data == 0x1B) {  // ESCape
           this->state_ = STATE_READ_ESCAPE;
-	} else if (data == 0x0D) { // End of Message
+        } else if (data == 0x0D) {  // End of Message
           this->parse_command_message_(current_command_, rx_buffer_.data(), rx_buffer_.size());
           this->state_ = STATE_IDLE;
           return;
         } else if (this->rx_buffer_.size() > 32) {
-	  ESP_LOGW(TAG, "Buffer overflow, resetting.");
+          ESP_LOGW(TAG, "Buffer overflow, resetting.");
           this->rx_buffer_.clear();
           this->state_ = STATE_SEARCHING;
-	} else {
-	  this->rx_buffer_.push_back(data);
-	}
+        } else {
+          this->rx_buffer_.push_back(data);
+        }
       }
 
       // Handle Timeout

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -65,55 +65,96 @@ void KamstrupKMPComponent::update() {
 }
 
 void KamstrupKMPComponent::loop() {
-  if (!this->command_queue_.empty()) {
-    uint16_t command = this->command_queue_.front();
-    this->send_command_(command);
-    this->command_queue_.pop();
+  switch (this->state_) {
+    case STATE_IDLE:
+      if (!this->command_queue_.empty()) {
+	this->current_command_ = this->command_queue_.front();
+        this->clear_uart_rx_buffer_();
+        this->send_command_(current_command_);
+        this->command_queue_.pop();
+        this->state_ = STATE_READING;
+        this->last_read_time_ = millis();
+        this->rx_buffer_.clear();
+      }
+      break;
+
+    case STATE_SEARCHING:
+    case STATE_READING:
+    case STATE_READ_ESCAPE:
+      // Handle RX non-blockingly
+      while (this->available()) {
+        uint8_t data = this->read();
+        this->last_read_time_ = millis(); // Reset timeout on new data
+
+	// 0x40 always restarts the current frame.
+	if (data == 0x40) {
+	  this->rx_buffer_.clear();
+	  this->state_ = STATE_READING;
+	  continue;
+	}
+	if (this->state_ == STATE_SEARCHING) {
+          continue;
+	}
+        
+	if (this->state_ == STATE_READ_ESCAPE) {
+          this->rx_buffer_.push_back(data ^ 0xFF);
+          this->state_ = STATE_READING;
+	} else if (data == 0x1B) { // ESCape
+          this->state_ = STATE_READ_ESCAPE;
+	} else if (data == 0x0D) { // End of Message
+          this->parse_command_message_(current_command_, rx_buffer_.data(), rx_buffer_.size());
+          this->state_ = STATE_IDLE;
+          return;
+        } else if (this->rx_buffer_.size() > 32) {
+	  ESP_LOGW(TAG, "Buffer overflow, resetting.");
+          this->rx_buffer_.clear();
+          this->state_ = STATE_SEARCHING;
+	} else {
+	  this->rx_buffer_.push_back(data);
+	}
+      }
+
+      // Handle Timeout
+      if (millis() - this->last_read_time_ > 250) {
+        ESP_LOGE(TAG, "Timeout waiting for Kamstrup response");
+        this->state_ = STATE_IDLE;
+      }
+      break;
   }
 }
 
 void KamstrupKMPComponent::send_command_(uint16_t command) {
-  uint32_t msg_len = 5;
-  uint8_t msg[msg_len];
+  // 1. Prepare the raw frame for CRC calculation (5 bytes msg + 2 bytes for CRC padding)
+  // Total 7 bytes. We initialize the last two to 0 for the CCITT augmentation.
+  uint8_t frame[7];
 
-  msg[0] = 0x3F;
-  msg[1] = 0x10;
-  msg[2] = 0x01;
-  msg[3] = command >> 8;
-  msg[4] = command & 0xFF;
+  frame[0] = 0x3F;
+  frame[1] = 0x10;
+  frame[2] = 0x01;
+  frame[3] = command >> 8;
+  frame[4] = command & 0xFF;
+  frame[5] = 0x00;
+  frame[6] = 0x00;
 
-  this->clear_uart_rx_buffer_();
-  this->send_message_(msg, msg_len);
-  this->read_command_(command);
-}
+  // 2. Calculate CRC over the frame
+  uint16_t crc = crc16_ccitt(frame, sizeof(frame));
+  frame[5] = crc >> 8;
+  frame[6] = crc & 0xFF;
 
-void KamstrupKMPComponent::send_message_(const uint8_t *msg, int msg_len) {
-  int buffer_len = msg_len + 2;
-  uint8_t buffer[buffer_len];
-
-  // Prepare the basic message and appand CRC
-  for (int i = 0; i < msg_len; i++) {
-    buffer[i] = msg[i];
-  }
-
-  buffer[buffer_len - 2] = 0;
-  buffer[buffer_len - 1] = 0;
-
-  uint16_t crc = crc16_ccitt(buffer, buffer_len);
-  buffer[buffer_len - 2] = crc >> 8;
-  buffer[buffer_len - 1] = crc & 0xFF;
-
-  // Prepare actual TX message
-  uint8_t tx_msg[20];
+  // 3. Prepare actual TX message
+  // Max size: 1 (PREFIX) + 7 (payload+crc) * 2 (worst-case stuffing) + 1 (EOM) = 16 bytes.
+  uint8_t tx_msg[16];
   int tx_msg_len = 1;
-  tx_msg[0] = 0x80;  // prefix
 
-  for (int i = 0; i < buffer_len; i++) {
-    if (buffer[i] == 0x06 || buffer[i] == 0x0d || buffer[i] == 0x1b || buffer[i] == 0x40 || buffer[i] == 0x80) {
+  tx_msg[0] = 0x80;  // PREFIX
+
+  // 4. Single-pass stuffing: move from 'frame' to 'tx_msg'
+  for (int i = 0; i < sizeof(frame); i++) {
+    if (frame[i] == 0x06 || frame[i] == 0x0d || frame[i] == 0x1b || frame[i] == 0x40 || frame[i] == 0x80) {
       tx_msg[tx_msg_len++] = 0x1b;
-      tx_msg[tx_msg_len++] = buffer[i] ^ 0xff;
+      tx_msg[tx_msg_len++] = frame[i] ^ 0xff;
     } else {
-      tx_msg[tx_msg_len++] = buffer[i];
+      tx_msg[tx_msg_len++] = frame[i];
     }
   }
 
@@ -129,72 +170,13 @@ void KamstrupKMPComponent::clear_uart_rx_buffer_() {
   }
 }
 
-void KamstrupKMPComponent::read_command_(uint16_t command) {
-  uint8_t buffer[20] = {0};
-  int buffer_len = 0;
-  int data;
-  int timeout = 250;  // ms
-
-  // Read the data from the UART
-  while (timeout > 0) {
-    if (this->available()) {
-      data = this->read();
-      if (data > -1) {
-        if (data == 0x40) {  // start of message
-          buffer_len = 0;
-        }
-        buffer[buffer_len++] = (uint8_t) data;
-        if (data == 0x0D) {
-          break;
-        }
-      } else {
-        ESP_LOGE(TAG, "Error while reading from UART");
-      }
-    } else {
-      delay(1);
-      timeout--;
-    }
-  }
-
-  if (timeout == 0 || buffer_len == 0) {
-    ESP_LOGE(TAG, "Request timed out");
-    return;
-  }
-
-  // Validate message (prefix and suffix)
-  if (buffer[0] != 0x40) {
-    ESP_LOGE(TAG, "Received invalid message (prefix mismatch received 0x%02X, expected 0x40)", buffer[0]);
-    return;
-  }
-
-  if (buffer[buffer_len - 1] != 0x0D) {
-    ESP_LOGE(TAG, "Received invalid message (EOM mismatch received 0x%02X, expected 0x0D)", buffer[buffer_len - 1]);
-    return;
-  }
-
-  // Decode
-  uint8_t msg[20] = {0};
-  int msg_len = 0;
-  for (int i = 1; i < buffer_len - 1; i++) {
-    if (buffer[i] == 0x1B) {
-      msg[msg_len++] = buffer[i + 1] ^ 0xFF;
-      i++;
-    } else {
-      msg[msg_len++] = buffer[i];
-    }
-  }
-
+void KamstrupKMPComponent::parse_command_message_(uint16_t command, const uint8_t *msg, int msg_len) {
   // Validate CRC
   if (crc16_ccitt(msg, msg_len)) {
     ESP_LOGE(TAG, "Received invalid message (CRC mismatch)");
     return;
   }
 
-  // All seems good. Now parse the message
-  this->parse_command_message_(command, msg, msg_len);
-}
-
-void KamstrupKMPComponent::parse_command_message_(uint16_t command, const uint8_t *msg, int msg_len) {
   // Validate the message
   if (msg_len < 8) {
     ESP_LOGE(TAG, "Received invalid message (message too small)");

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -149,12 +149,12 @@ void KamstrupKMPComponent::send_command_(uint16_t command) {
   tx_msg[0] = 0x80;  // PREFIX
 
   // 4. Single-pass stuffing: move from 'frame' to 'tx_msg'
-  for (int i = 0; i < sizeof(frame); i++) {
-    if (frame[i] == 0x06 || frame[i] == 0x0d || frame[i] == 0x1b || frame[i] == 0x40 || frame[i] == 0x80) {
+  for (unsigned char ch : frame) {
+    if (ch == 0x06 || ch == 0x0d || ch == 0x1b || ch == 0x40 || ch == 0x80) {
       tx_msg[tx_msg_len++] = 0x1b;
-      tx_msg[tx_msg_len++] = frame[i] ^ 0xff;
+      tx_msg[tx_msg_len++] = ch ^ 0xff;
     } else {
-      tx_msg[tx_msg_len++] = frame[i];
+      tx_msg[tx_msg_len++] = ch;
     }
   }
 

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.h
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.h
@@ -91,6 +91,18 @@ class KamstrupKMPComponent : public PollingComponent, public uart::UARTDevice {
   }
 
  protected:
+  // State machine
+  enum State {
+    STATE_IDLE,
+    STATE_SEARCHING,
+    STATE_READING,
+    STATE_READ_ESCAPE,
+  };
+  State state_{STATE_IDLE};
+  std::vector<uint8_t> rx_buffer_;
+  uint32_t last_read_time_{0};
+  uint16_t current_command_;
+
   // Sensors
   sensor::Sensor *heat_energy_sensor_{nullptr};
   sensor::Sensor *power_sensor_{nullptr};
@@ -111,12 +123,8 @@ class KamstrupKMPComponent : public PollingComponent, public uart::UARTDevice {
 
   // Sends a command to the meter and receives its response
   void send_command_(uint16_t command);
-  // Sends a message to the meter. A prefix/suffix and CRC are added
-  void send_message_(const uint8_t *msg, int msg_len);
   // Clears and data that might be in the UART Rx buffer
   void clear_uart_rx_buffer_();
-  // Reads and validates the response to a send command
-  void read_command_(uint16_t command);
   // Parses a received message
   void parse_command_message_(uint16_t command, const uint8_t *msg, int msg_len);
   // Sets the received value to the correct sensor


### PR DESCRIPTION
# What does this implement/fix?

Rework the kamstrup_kmp serial handling for usb_uart by introducing a state machine. This allows the code to return to the main loop, giving the usb_uart a chance to process incoming/outgoing chars.

Code tested for both regular serial and usb uarts.

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
...
# 1. Enable USB Host functionality
usb_host:
  max_transfer_requests: 32  # For high-throughput devices like USB UART at 115200+ baud

# 2. Configure the USB-to-Serial adapter (ACM)
# This creates a virtual UART bus labeled 'usb_uart_bus'
usb_uart:
  - type: cp210x
    id: usb_bus
    channels:
      - id: kamstrup_uart
        baud_rate: 1200  # Standard for Kamstrup Multical
        data_bits: 8
        parity: NONE
        stop_bits: 2
        #debug: true

# 3. Use the Kamstrup KMP component on that virtual UART
sensor:
  - platform: kamstrup_kmp
    update_interval: 30min
    uart_id: kamstrup_uart
    id: kamstrup_kmp_id

    # Standard registers for Multical 403 / 603
    heat_energy:
      name: "Total Heat Energy"
    power:
      name: "Current Power"
    temp1:
      name: "Incoming Temperature"
    temp2:
      name: "Return Temperature"
    temp_diff:
      name: "Temperature Difference"
    flow:
      name: "Current Water Flow"
    volume:
      name: "Total Volume"
...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
