### PR TITLE
[http_request] Replace heavy STL containers with std::vector for headers

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -310,7 +310,7 @@ async def http_request_action_to_code(config, action_id, template_arg, args):
         cg.add(var.add_request_header(key, template_))
 
     for value in config.get(CONF_COLLECT_HEADERS, []):
-        cg.add(var.add_collect_header(value))
+        cg.add(var.add_collect_header(value.lower()))
 
     if response_conf := config.get(CONF_ON_RESPONSE):
         if capture_response:

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -22,23 +22,15 @@ void HttpRequestComponent::dump_config() {
 }
 
 std::string HttpContainer::get_response_header(const std::string &header_name) {
-  auto response_headers = this->get_response_headers();
-  auto header_name_lower_case = str_lower_case(header_name);
-  if (response_headers.count(header_name_lower_case) == 0) {
-    ESP_LOGW(TAG, "No header with name %s found", header_name_lower_case.c_str());
-    return "";
-  } else {
-    auto values = response_headers[header_name_lower_case];
-    if (values.empty()) {
-      ESP_LOGE(TAG, "header with name %s returned an empty list, this shouldn't happen",
-               header_name_lower_case.c_str());
-      return "";
-    } else {
-      auto header_value = values.front();
-      ESP_LOGD(TAG, "Header with name %s found with value %s", header_name_lower_case.c_str(), header_value.c_str());
-      return header_value;
+  auto lower = str_lower_case(header_name);
+  for (const auto &entry : this->response_headers_) {
+    if (entry.name == lower) {
+      ESP_LOGD(TAG, "Header with name %s found with value %s", lower.c_str(), entry.value.c_str());
+      return entry.value;
     }
   }
+  ESP_LOGW(TAG, "No header with name %s found", lower.c_str());
+  return "";
 }
 
 }  // namespace esphome::http_request

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -335,7 +335,7 @@ class HttpRequestComponent : public Component {
     return this->start(url, "GET", "", request_headers);
   }
   std::shared_ptr<HttpContainer> get(const std::string &url, const std::list<Header> &request_headers,
-                                     const std::set<std::string> &collect_headers) {
+                                     const std::vector<std::string> &collect_headers) {
     return this->start(url, "GET", "", request_headers, collect_headers);
   }
   std::shared_ptr<HttpContainer> post(const std::string &url, const std::string &body) {
@@ -347,7 +347,7 @@ class HttpRequestComponent : public Component {
   }
   std::shared_ptr<HttpContainer> post(const std::string &url, const std::string &body,
                                       const std::list<Header> &request_headers,
-                                      const std::set<std::string> &collect_headers) {
+                                      const std::vector<std::string> &collect_headers) {
     return this->start(url, "POST", body, request_headers, collect_headers);
   }
 
@@ -356,6 +356,9 @@ class HttpRequestComponent : public Component {
     return this->perform(url, method, body, request_headers, {});
   }
 
+  // Remove before 2027.1.0
+  ESPDEPRECATED("Pass collect_headers as std::vector<std::string> instead of std::set. Removed in 2027.1.0.",
+                "2026.7.0")
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -363,12 +363,8 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {
-    std::vector<std::string> lower_case_collect_headers;
-    lower_case_collect_headers.reserve(collect_headers.size());
-    for (const std::string &collect_header : collect_headers) {
-      lower_case_collect_headers.push_back(str_lower_case(collect_header));
-    }
-    return this->perform(url, method, body, request_headers, lower_case_collect_headers);
+    return this->start(url, method, body, request_headers,
+                       std::vector<std::string>(collect_headers.begin(), collect_headers.end()));
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -353,6 +353,7 @@ class HttpRequestComponent : public Component {
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers) {
+    // Call perform() directly to avoid ambiguity with the std::set overload
     return this->perform(url, method, body, request_headers, {});
   }
 

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -371,12 +371,12 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::vector<std::string> &collect_headers) {
-    std::vector<std::string> lower;
-    lower.reserve(collect_headers.size());
-    for (const auto &h : collect_headers) {
-      lower.push_back(str_lower_case(h));
+    std::vector<std::string> lower_case_collect_headers;
+    lower_case_collect_headers.reserve(collect_headers.size());
+    for (const auto &header : collect_headers) {
+      lower_case_collect_headers.push_back(str_lower_case(header));
     }
-    return this->perform(url, method, body, request_headers, lower);
+    return this->perform(url, method, body, request_headers, lower_case_collect_headers);
   }
 
  protected:

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -80,6 +80,15 @@ inline bool is_redirect(int const status) {
  */
 inline bool is_success(int const status) { return status >= HTTP_STATUS_OK && status < HTTP_STATUS_MULTIPLE_CHOICES; }
 
+/// Check if a header name should be collected (linear scan, fine for small lists)
+inline bool should_collect_header(const std::vector<std::string> &collect_headers, const std::string &header_name) {
+  for (const auto &h : collect_headers) {
+    if (h == header_name)
+      return true;
+  }
+  return false;
+}
+
 /*
  * HTTP Container Read Semantics
  * =============================
@@ -258,20 +267,13 @@ class HttpContainer : public Parented<HttpRequestComponent> {
     return !this->is_chunked_ && this->bytes_read_ >= this->content_length;
   }
 
-  /**
-   * @brief Get response headers.
-   *
-   * @return The key is the lower case response header name, the value is the header value.
-   */
-  std::map<std::string, std::list<std::string>> get_response_headers() { return this->response_headers_; }
-
   std::string get_response_header(const std::string &header_name);
 
  protected:
   size_t bytes_read_{0};
   bool secure_{false};
   bool is_chunked_{false};  ///< True if response uses chunked transfer encoding
-  std::map<std::string, std::list<std::string>> response_headers_{};
+  std::vector<Header> response_headers_{};
 };
 
 /// Read data from HTTP container into buffer with timeout handling
@@ -351,23 +353,30 @@ class HttpRequestComponent : public Component {
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers) {
-    return this->start(url, method, body, request_headers, {});
+    return this->perform(url, method, body, request_headers, {});
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {
-    std::set<std::string> lower_case_collect_headers;
+    std::vector<std::string> lower_case_collect_headers;
+    lower_case_collect_headers.reserve(collect_headers.size());
     for (const std::string &collect_header : collect_headers) {
-      lower_case_collect_headers.insert(str_lower_case(collect_header));
+      lower_case_collect_headers.push_back(str_lower_case(collect_header));
     }
     return this->perform(url, method, body, request_headers, lower_case_collect_headers);
+  }
+
+  std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
+                                       const std::list<Header> &request_headers,
+                                       const std::vector<std::string> &collect_headers) {
+    return this->perform(url, method, body, request_headers, collect_headers);
   }
 
  protected:
   virtual std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method,
                                                  const std::string &body, const std::list<Header> &request_headers,
-                                                 const std::set<std::string> &collect_headers) = 0;
+                                                 const std::vector<std::string> &collect_headers) = 0;
   const char *useragent_{nullptr};
   bool follow_redirects_{};
   uint16_t redirect_limit_{};
@@ -389,7 +398,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
     this->request_headers_.insert({key, value});
   }
 
-  void add_collect_header(const char *value) { this->collect_headers_.insert(value); }
+  void add_collect_header(const char *value) { this->collect_headers_.push_back(str_lower_case(value)); }
 
   void add_json(const char *key, TemplatableValue<std::string, Ts...> value) { this->json_.insert({key, value}); }
 
@@ -494,7 +503,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   void encode_json_func_(Ts... x, JsonObject root) { this->json_func_(x..., root); }
   HttpRequestComponent *parent_;
   std::map<const char *, TemplatableValue<const char *, Ts...>> request_headers_{};
-  std::set<std::string> collect_headers_{"content-type", "content-length"};
+  std::vector<std::string> collect_headers_{"content-type", "content-length"};
   std::map<const char *, TemplatableValue<std::string, Ts...>> json_{};
   std::function<void(Ts..., JsonObject)> json_func_{nullptr};
 #ifdef USE_HTTP_REQUEST_RESPONSE

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -81,9 +81,10 @@ inline bool is_redirect(int const status) {
 inline bool is_success(int const status) { return status >= HTTP_STATUS_OK && status < HTTP_STATUS_MULTIPLE_CHOICES; }
 
 /// Check if a header name should be collected (linear scan, fine for small lists)
-inline bool should_collect_header(const std::vector<std::string> &collect_headers, const std::string &header_name) {
+inline bool should_collect_header(const std::vector<std::string> &collect_headers,
+                                  const std::string &lower_header_name) {
   for (const auto &h : collect_headers) {
-    if (h == header_name)
+    if (h == lower_header_name)
       return true;
   }
   return false;

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -409,7 +409,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
     this->request_headers_.insert({key, value});
   }
 
-  void add_collect_header(const char *value) { this->collect_headers_.push_back(str_lower_case(value)); }
+  void add_collect_header(const char *value) { this->collect_headers_.push_back(value); }
 
   void add_json(const char *key, TemplatableValue<std::string, Ts...> value) { this->json_.insert({key, value}); }
 

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -81,9 +81,9 @@ inline bool is_redirect(int const status) {
 inline bool is_success(int const status) { return status >= HTTP_STATUS_OK && status < HTTP_STATUS_MULTIPLE_CHOICES; }
 
 /// Check if a header name should be collected (linear scan, fine for small lists)
-inline bool should_collect_header(const std::vector<std::string> &collect_headers,
+inline bool should_collect_header(const std::vector<std::string> &lower_case_collect_headers,
                                   const std::string &lower_header_name) {
-  for (const auto &h : collect_headers) {
+  for (const auto &h : lower_case_collect_headers) {
     if (h == lower_header_name)
       return true;
   }
@@ -336,8 +336,8 @@ class HttpRequestComponent : public Component {
     return this->start(url, "GET", "", request_headers);
   }
   std::shared_ptr<HttpContainer> get(const std::string &url, const std::list<Header> &request_headers,
-                                     const std::vector<std::string> &collect_headers) {
-    return this->start(url, "GET", "", request_headers, collect_headers);
+                                     const std::vector<std::string> &lower_case_collect_headers) {
+    return this->start(url, "GET", "", request_headers, lower_case_collect_headers);
   }
   std::shared_ptr<HttpContainer> post(const std::string &url, const std::string &body) {
     return this->start(url, "POST", body, {});
@@ -348,8 +348,8 @@ class HttpRequestComponent : public Component {
   }
   std::shared_ptr<HttpContainer> post(const std::string &url, const std::string &body,
                                       const std::list<Header> &request_headers,
-                                      const std::vector<std::string> &collect_headers) {
-    return this->start(url, "POST", body, request_headers, collect_headers);
+                                      const std::vector<std::string> &lower_case_collect_headers) {
+    return this->start(url, "POST", body, request_headers, lower_case_collect_headers);
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
@@ -364,25 +364,24 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {
-    return this->start(url, method, body, request_headers,
-                       std::vector<std::string>(collect_headers.begin(), collect_headers.end()));
+    std::vector<std::string> lower;
+    lower.reserve(collect_headers.size());
+    for (const auto &h : collect_headers) {
+      lower.push_back(str_lower_case(h));
+    }
+    return this->perform(url, method, body, request_headers, lower);
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
-                                       const std::vector<std::string> &collect_headers) {
-    std::vector<std::string> lower_case_collect_headers;
-    lower_case_collect_headers.reserve(collect_headers.size());
-    for (const auto &header : collect_headers) {
-      lower_case_collect_headers.push_back(str_lower_case(header));
-    }
+                                       const std::vector<std::string> &lower_case_collect_headers) {
     return this->perform(url, method, body, request_headers, lower_case_collect_headers);
   }
 
  protected:
   virtual std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method,
                                                  const std::string &body, const std::list<Header> &request_headers,
-                                                 const std::vector<std::string> &collect_headers) = 0;
+                                                 const std::vector<std::string> &lower_case_collect_headers) = 0;
   const char *useragent_{nullptr};
   bool follow_redirects_{};
   uint16_t redirect_limit_{};
@@ -404,7 +403,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
     this->request_headers_.insert({key, value});
   }
 
-  void add_collect_header(const char *value) { this->collect_headers_.push_back(value); }
+  void add_collect_header(const char *value) { this->lower_case_collect_headers_.push_back(value); }
 
   void add_json(const char *key, TemplatableValue<std::string, Ts...> value) { this->json_.insert({key, value}); }
 
@@ -446,7 +445,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
     }
 
     auto container = this->parent_->start(this->url_.value(x...), this->method_.value(x...), body, request_headers,
-                                          this->collect_headers_);
+                                          this->lower_case_collect_headers_);
 
     auto captured_args = std::make_tuple(x...);
 
@@ -509,7 +508,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
   void encode_json_func_(Ts... x, JsonObject root) { this->json_func_(x..., root); }
   HttpRequestComponent *parent_;
   std::map<const char *, TemplatableValue<const char *, Ts...>> request_headers_{};
-  std::vector<std::string> collect_headers_{"content-type", "content-length"};
+  std::vector<std::string> lower_case_collect_headers_{"content-type", "content-length"};
   std::map<const char *, TemplatableValue<std::string, Ts...>> json_{};
   std::function<void(Ts..., JsonObject)> json_func_{nullptr};
 #ifdef USE_HTTP_REQUEST_RESPONSE

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -89,6 +89,16 @@ inline bool should_collect_header(const std::vector<std::string> &collect_header
   return false;
 }
 
+/// Lowercase a range of strings into a vector
+template<typename Iter> inline std::vector<std::string> lowercase_headers(Iter begin, Iter end) {
+  std::vector<std::string> result;
+  result.reserve(std::distance(begin, end));
+  for (auto it = begin; it != end; ++it) {
+    result.push_back(str_lower_case(*it));
+  }
+  return result;
+}
+
 /*
  * HTTP Container Read Semantics
  * =============================
@@ -363,19 +373,15 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {
-    return this->start(url, method, body, request_headers,
-                       std::vector<std::string>(collect_headers.begin(), collect_headers.end()));
+    return this->perform(url, method, body, request_headers,
+                         lowercase_headers(collect_headers.begin(), collect_headers.end()));
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::vector<std::string> &collect_headers) {
-    std::vector<std::string> lower_case_collect_headers;
-    lower_case_collect_headers.reserve(collect_headers.size());
-    for (const auto &header : collect_headers) {
-      lower_case_collect_headers.push_back(str_lower_case(header));
-    }
-    return this->perform(url, method, body, request_headers, lower_case_collect_headers);
+    return this->perform(url, method, body, request_headers,
+                         lowercase_headers(collect_headers.begin(), collect_headers.end()));
   }
 
  protected:

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -374,7 +374,12 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::vector<std::string> &collect_headers) {
-    return this->perform(url, method, body, request_headers, collect_headers);
+    std::vector<std::string> lower_case_collect_headers;
+    lower_case_collect_headers.reserve(collect_headers.size());
+    for (const auto &header : collect_headers) {
+      lower_case_collect_headers.push_back(str_lower_case(header));
+    }
+    return this->perform(url, method, body, request_headers, lower_case_collect_headers);
   }
 
  protected:

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -90,16 +90,6 @@ inline bool should_collect_header(const std::vector<std::string> &collect_header
   return false;
 }
 
-/// Lowercase a range of strings into a vector
-template<typename Iter> inline std::vector<std::string> lowercase_headers(Iter begin, Iter end) {
-  std::vector<std::string> result;
-  result.reserve(std::distance(begin, end));
-  for (auto it = begin; it != end; ++it) {
-    result.push_back(str_lower_case(*it));
-  }
-  return result;
-}
-
 /*
  * HTTP Container Read Semantics
  * =============================
@@ -374,15 +364,19 @@ class HttpRequestComponent : public Component {
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::set<std::string> &collect_headers) {
-    return this->perform(url, method, body, request_headers,
-                         lowercase_headers(collect_headers.begin(), collect_headers.end()));
+    return this->start(url, method, body, request_headers,
+                       std::vector<std::string>(collect_headers.begin(), collect_headers.end()));
   }
 
   std::shared_ptr<HttpContainer> start(const std::string &url, const std::string &method, const std::string &body,
                                        const std::list<Header> &request_headers,
                                        const std::vector<std::string> &collect_headers) {
-    return this->perform(url, method, body, request_headers,
-                         lowercase_headers(collect_headers.begin(), collect_headers.end()));
+    std::vector<std::string> lower;
+    lower.reserve(collect_headers.size());
+    for (const auto &h : collect_headers) {
+      lower.push_back(str_lower_case(h));
+    }
+    return this->perform(url, method, body, request_headers, lower);
   }
 
  protected:

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -27,7 +27,7 @@ static constexpr int ESP8266_SSL_ERR_OOM = -1000;
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
                                                            const std::string &body,
                                                            const std::list<Header> &request_headers,
-                                                           const std::set<std::string> &collect_headers) {
+                                                           const std::vector<std::string> &collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
@@ -160,14 +160,14 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     // Still return the container, so it can be used to get the status code and error message
   }
 
-  container->response_headers_ = {};
+  container->response_headers_.clear();
   auto header_count = container->client_.headers();
   for (int i = 0; i < header_count; i++) {
     const std::string header_name = str_lower_case(container->client_.headerName(i).c_str());
-    if (collect_headers.count(header_name) > 0) {
+    if (should_collect_header(collect_headers, header_name)) {
       std::string header_value = container->client_.header(i).c_str();
       ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
-      container->response_headers_[header_name].push_back(header_value);
+      container->response_headers_.push_back({header_name, header_value});
     }
   }
 

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -27,7 +27,7 @@ static constexpr int ESP8266_SSL_ERR_OOM = -1000;
 std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &url, const std::string &method,
                                                            const std::string &body,
                                                            const std::list<Header> &request_headers,
-                                                           const std::vector<std::string> &collect_headers) {
+                                                           const std::vector<std::string> &lower_case_collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
@@ -107,9 +107,9 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
   }
 
   // returned needed headers must be collected before the requests
-  const char *header_keys[collect_headers.size()];
+  const char *header_keys[lower_case_collect_headers.size()];
   int index = 0;
-  for (auto const &header_name : collect_headers) {
+  for (auto const &header_name : lower_case_collect_headers) {
     header_keys[index++] = header_name.c_str();
   }
   container->client_.collectHeaders(header_keys, index);
@@ -164,7 +164,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
   auto header_count = container->client_.headers();
   for (int i = 0; i < header_count; i++) {
     const std::string header_name = str_lower_case(container->client_.headerName(i).c_str());
-    if (should_collect_header(collect_headers, header_name)) {
+    if (should_collect_header(lower_case_collect_headers, header_name)) {
       std::string header_value = container->client_.header(i).c_str();
       ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
       container->response_headers_.push_back({header_name, header_value});

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -50,7 +50,7 @@ class HttpRequestArduino : public HttpRequestComponent {
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::vector<std::string> &collect_headers) override;
+                                         const std::vector<std::string> &lower_case_collect_headers) override;
 };
 
 }  // namespace esphome::http_request

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -50,7 +50,7 @@ class HttpRequestArduino : public HttpRequestComponent {
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::set<std::string> &collect_headers) override;
+                                         const std::vector<std::string> &collect_headers) override;
 };
 
 }  // namespace esphome::http_request

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -19,7 +19,7 @@ static const char *const TAG = "http_request.host";
 std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, const std::string &method,
                                                         const std::string &body,
                                                         const std::list<Header> &request_headers,
-                                                        const std::vector<std::string> &response_headers) {
+                                                        const std::vector<std::string> &collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
@@ -116,7 +116,7 @@ std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, 
   for (auto header : response.headers) {
     ESP_LOGD(TAG, "Header: %s: %s", header.first.c_str(), header.second.c_str());
     auto lower_name = str_lower_case(header.first);
-    if (should_collect_header(response_headers, lower_name)) {
+    if (should_collect_header(collect_headers, lower_name)) {
       container->response_headers_.push_back({lower_name, header.second});
     }
   }

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -19,7 +19,7 @@ static const char *const TAG = "http_request.host";
 std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, const std::string &method,
                                                         const std::string &body,
                                                         const std::list<Header> &request_headers,
-                                                        const std::vector<std::string> &collect_headers) {
+                                                        const std::vector<std::string> &lower_case_collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
@@ -116,7 +116,7 @@ std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, 
   for (auto header : response.headers) {
     ESP_LOGD(TAG, "Header: %s: %s", header.first.c_str(), header.second.c_str());
     auto lower_name = str_lower_case(header.first);
-    if (should_collect_header(collect_headers, lower_name)) {
+    if (should_collect_header(lower_case_collect_headers, lower_name)) {
       container->response_headers_.push_back({lower_name, header.second});
     }
   }

--- a/esphome/components/http_request/http_request_host.cpp
+++ b/esphome/components/http_request/http_request_host.cpp
@@ -19,7 +19,7 @@ static const char *const TAG = "http_request.host";
 std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, const std::string &method,
                                                         const std::string &body,
                                                         const std::list<Header> &request_headers,
-                                                        const std::set<std::string> &response_headers) {
+                                                        const std::vector<std::string> &response_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGW(TAG, "HTTP Request failed; Not connected to network");
@@ -116,8 +116,8 @@ std::shared_ptr<HttpContainer> HttpRequestHost::perform(const std::string &url, 
   for (auto header : response.headers) {
     ESP_LOGD(TAG, "Header: %s: %s", header.first.c_str(), header.second.c_str());
     auto lower_name = str_lower_case(header.first);
-    if (response_headers.find(lower_name) != response_headers.end()) {
-      container->response_headers_[lower_name].emplace_back(header.second);
+    if (should_collect_header(response_headers, lower_name)) {
+      container->response_headers_.push_back({lower_name, header.second});
     }
   }
   container->duration_ms = millis() - start;

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -20,7 +20,7 @@ class HttpRequestHost : public HttpRequestComponent {
  public:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::vector<std::string> &response_headers) override;
+                                         const std::vector<std::string> &collect_headers) override;
   void set_ca_path(const char *ca_path) { this->ca_path_ = ca_path; }
 
  protected:

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -20,7 +20,7 @@ class HttpRequestHost : public HttpRequestComponent {
  public:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::set<std::string> &response_headers) override;
+                                         const std::vector<std::string> &response_headers) override;
   void set_ca_path(const char *ca_path) { this->ca_path_ = ca_path; }
 
  protected:

--- a/esphome/components/http_request/http_request_host.h
+++ b/esphome/components/http_request/http_request_host.h
@@ -20,7 +20,7 @@ class HttpRequestHost : public HttpRequestComponent {
  public:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::vector<std::string> &collect_headers) override;
+                                         const std::vector<std::string> &lower_case_collect_headers) override;
   void set_ca_path(const char *ca_path) { this->ca_path_ = ca_path; }
 
  protected:

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -19,8 +19,8 @@ namespace esphome::http_request {
 static const char *const TAG = "http_request.idf";
 
 struct UserData {
-  const std::set<std::string> &collect_headers;
-  std::map<std::string, std::list<std::string>> response_headers;
+  const std::vector<std::string> &collect_headers;
+  std::vector<Header> &response_headers;
 };
 
 void HttpRequestIDF::dump_config() {
@@ -38,10 +38,10 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
   switch (evt->event_id) {
     case HTTP_EVENT_ON_HEADER: {
       const std::string header_name = str_lower_case(evt->header_key);
-      if (user_data->collect_headers.count(header_name)) {
+      if (should_collect_header(user_data->collect_headers, header_name)) {
         const std::string header_value = evt->header_value;
         ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
-        user_data->response_headers[header_name].push_back(header_value);
+        user_data->response_headers.push_back({header_name, header_value});
       }
       break;
     }
@@ -55,7 +55,7 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
 std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, const std::string &method,
                                                        const std::string &body,
                                                        const std::list<Header> &request_headers,
-                                                       const std::set<std::string> &collect_headers) {
+                                                       const std::vector<std::string> &collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGE(TAG, "HTTP Request failed; Not connected to network");
@@ -110,8 +110,6 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   watchdog::WatchdogManager wdm(this->get_watchdog_timeout());
 
   config.event_handler = http_event_handler;
-  auto user_data = UserData{collect_headers, {}};
-  config.user_data = static_cast<void *>(&user_data);
 
   esp_http_client_handle_t client = esp_http_client_init(&config);
 
@@ -119,6 +117,9 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   container->set_parent(this);
 
   container->set_secure(secure);
+
+  auto user_data = UserData{collect_headers, container->response_headers_};
+  esp_http_client_set_user_data(client, static_cast<void *>(&user_data));
 
   for (const auto &header : request_headers) {
     esp_http_client_set_header(client, header.name.c_str(), header.value.c_str());
@@ -164,7 +165,6 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   container->feed_wdt();
   container->status_code = esp_http_client_get_status_code(client);
   container->feed_wdt();
-  container->set_response_headers(user_data.response_headers);
   container->duration_ms = millis() - start;
   if (is_success(container->status_code)) {
     return container;

--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -19,7 +19,7 @@ namespace esphome::http_request {
 static const char *const TAG = "http_request.idf";
 
 struct UserData {
-  const std::vector<std::string> &collect_headers;
+  const std::vector<std::string> &lower_case_collect_headers;
   std::vector<Header> &response_headers;
 };
 
@@ -38,7 +38,7 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
   switch (evt->event_id) {
     case HTTP_EVENT_ON_HEADER: {
       const std::string header_name = str_lower_case(evt->header_key);
-      if (should_collect_header(user_data->collect_headers, header_name)) {
+      if (should_collect_header(user_data->lower_case_collect_headers, header_name)) {
         const std::string header_value = evt->header_value;
         ESP_LOGD(TAG, "Received response header, name: %s, value: %s", header_name.c_str(), header_value.c_str());
         user_data->response_headers.push_back({header_name, header_value});
@@ -55,7 +55,7 @@ esp_err_t HttpRequestIDF::http_event_handler(esp_http_client_event_t *evt) {
 std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, const std::string &method,
                                                        const std::string &body,
                                                        const std::list<Header> &request_headers,
-                                                       const std::vector<std::string> &collect_headers) {
+                                                       const std::vector<std::string> &lower_case_collect_headers) {
   if (!network::is_connected()) {
     this->status_momentary_error("failed", 1000);
     ESP_LOGE(TAG, "HTTP Request failed; Not connected to network");
@@ -118,7 +118,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
 
   container->set_secure(secure);
 
-  auto user_data = UserData{collect_headers, container->response_headers_};
+  auto user_data = UserData{lower_case_collect_headers, container->response_headers_};
   esp_http_client_set_user_data(client, static_cast<void *>(&user_data));
 
   for (const auto &header : request_headers) {

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -21,11 +21,8 @@ class HttpContainerIDF : public HttpContainer {
   /// @brief Feeds the watchdog timer if the executing task has one attached
   void feed_wdt();
 
-  void set_response_headers(std::map<std::string, std::list<std::string>> &response_headers) {
-    this->response_headers_ = std::move(response_headers);
-  }
-
  protected:
+  friend class HttpRequestIDF;
   esp_http_client_handle_t client_;
 };
 
@@ -41,7 +38,7 @@ class HttpRequestIDF : public HttpRequestComponent {
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::set<std::string> &collect_headers) override;
+                                         const std::vector<std::string> &collect_headers) override;
   // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
   uint16_t buffer_size_rx_{};
   uint16_t buffer_size_tx_{};

--- a/esphome/components/http_request/http_request_idf.h
+++ b/esphome/components/http_request/http_request_idf.h
@@ -38,7 +38,7 @@ class HttpRequestIDF : public HttpRequestComponent {
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::list<Header> &request_headers,
-                                         const std::vector<std::string> &collect_headers) override;
+                                         const std::vector<std::string> &lower_case_collect_headers) override;
   // if zero ESP-IDF will use DEFAULT_HTTP_BUF_SIZE
   uint16_t buffer_size_rx_{};
   uint16_t buffer_size_tx_{};


### PR DESCRIPTION
# What does this implement/fix?

#8224 added response header collection using `std::map<std::string, std::list<std::string>>` for response headers and `std::set<std::string>` for collect headers. These are reasonable container choices for desktop systems with gigabytes of RAM, but on an ESP32 with 320KB of RAM and an 8KB task stack, the red-black tree (`_Rb_tree`) and linked list template instantiations add unnecessary code size and stack overhead for the small number of headers typically collected (1-5 elements). This PR replaces them with simple `std::vector` and linear scan.

#8224 also added both `get_response_header()` (singular) and `get_response_headers()` (plural, returning the full map), but only `get_response_header()` was documented or used in the example YAML. `get_response_header()` still works — it only ever returned the first value (`values.front()`) anyway, so a linear scan over a flat vector returning the first match is functionally identical and much simpler. The undocumented `get_response_headers()` (which returned the raw `std::map`) has been removed.

Key changes:
- `response_headers_`: `std::map<string, list<string>>` -> `std::vector<Header>` (reuses existing `Header` struct)
- `collect_headers_` renamed to `lower_case_collect_headers_`: `std::set<string>` -> `std::vector<string>` with explicit lowercase invariant
- `perform()` internal signature: `std::set` -> `std::vector`, parameter renamed to `lower_case_collect_headers`
- `get()`/`post()` collect_headers parameter: `std::set` -> `std::vector` (initializer list callers like `online_image` work unchanged)
- `start()` `std::set` overload deprecated with `ESPDEPRECATED` (removal in 2027.1.0) — this overload still lowercases for backward compatibility
- `start()` with `std::vector` is now a direct passthrough to `perform()` (no per-request lowercasing or temp vector)
- Header lowercasing moved to config time: Python codegen lowercases values before calling `add_collect_header()`, eliminating per-request `str_lower_case()` calls and temporary vector allocation
- Add `should_collect_header()` inline helper for linear scan
- IDF `UserData` now holds references to the container's vector instead of owning a separate map that gets moved after the request completes (reduces stack frame in `perform()`)
- `get_response_header()` simplified from map-copy-then-lookup to direct linear scan
- All parameter and field names use `lower_case_collect_headers` to make the lowercase contract explicit throughout the chain

This reduces stack usage in the `perform()` call chain, which is relevant for HTTPS requests where the TLS handshake (mbedtls) already consumes most of the 8KB main loop task stack.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/14019
- https://github.com/esphome/esphome/issues/13927

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  verify_ssl: false
  timeout: 10s

script:
  # Test chunked transfer encoding (open-meteo API uses chunked responses)
  - id: http_test_chunked
    then:
      - logger.log: "Starting HTTP GET request (chunked - open-meteo API)"
      - http_request.get:
          url: "https://api.open-meteo.com/v1/forecast?latitude=0&longitude=0&current=uv_index"
          capture_response: true
          max_response_buffer_size: 2048
          on_response:
            then:
              - lambda: |-
                  ESP_LOGD("main", "CHUNKED - Response status: %d, Duration: %u ms, Content-Length: %zu",
                           response->status_code, response->duration_ms, response->content_length);
                  ESP_LOGD("main", "CHUNKED - Body length: %zu", body.size());
                  ESP_LOGI("main", "CHUNKED - First 100 bytes: %.100s", body.c_str());
                  if (body.find("uv_index") != std::string::npos) {
                    ESP_LOGI("main", "CHUNKED - SUCCESS: body contains 'uv_index'");
                  } else {
                    ESP_LOGE("main", "CHUNKED - FAIL: body missing 'uv_index'");
                  }

  # Test non-chunked (fixed Content-Length) for comparison
  - id: http_test_fixed_length
    then:
      - logger.log: "Starting HTTP GET request (fixed content-length)"
      - http_request.get:
          url: "http://httpbin.org/json"
          capture_response: true
          max_response_buffer_size: 2048
          on_response:
            then:
              - lambda: |-
                  ESP_LOGD("main", "FIXED - Response status: %d, Duration: %u ms, Content-Length: %zu",
                           response->status_code, response->duration_ms, response->content_length);
                  if (body.size() == response->content_length) {
                    ESP_LOGI("main", "FIXED - SUCCESS: body.size() == content_length");
                  } else {
                    ESP_LOGE("main", "FIXED - FAIL: body.size() %zu != content_length %zu",
                             body.size(), response->content_length);
                  }

button:
  - platform: template
    name: "Test HTTP Chunked"
    on_press:
      - script.execute: http_test_chunked
  - platform: template
    name: "Test HTTP Fixed Length"
    on_press:
      - script.execute: http_test_fixed_length
```

## Migration for external components

**`collect_headers` parameter contract change:** The `start()` and `perform()` methods with `std::vector<std::string>` now expect headers to be pre-lowercased. The parameter is named `lower_case_collect_headers` to make this explicit. All existing internal and known external callers (`online_image`) already pass lowercase values, so this has no practical impact.

**`std::set` to `std::vector`:** No core code was passing an explicit `std::set<std::string>` to `get()`, `post()`, or `start()` — all internal callers use initializer lists which work unchanged with `std::vector`. The `start()` overload taking `std::set<std::string>` is preserved with a deprecation warning (still lowercases for backward compatibility) and will be removed in 2027.1.0.

**`get_response_headers()` removed:** The undocumented `get_response_headers()` method (returning `std::map<std::string, std::list<std::string>>`) has been removed. Use `get_response_header(name)` instead, which returns the first matching value.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).