### PR TITLE
[openthread] Fix compiler format warning

### DIFF
--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -115,7 +115,7 @@ void OpenThreadComponent::ot_main() {
       ESP_LOGE(TAG, "Failed to set OpenThread pollperiod.");
     }
     uint32_t link_polling_period = otLinkGetPollPeriod(esp_openthread_get_instance());
-    ESP_LOGD(TAG, "Link Polling Period: %d", link_polling_period);
+    ESP_LOGD(TAG, "Link Polling Period: %" PRIu32, link_polling_period);
   }
   link_mode_config.mRxOnWhenIdle = this->poll_period == 0;
   link_mode_config.mDeviceType = false;


### PR DESCRIPTION
# What does this implement/fix?

ESPHome Version: e.g. 2026.2.0b3

`openthread` module raises gcc format warning (or error if enforced via `-Werror`) if configured as MTD with DEBUG logging.

--> Try to compile provided yaml below

```txt
In file included from src/esphome/core/component.h:9,
                 from src/esphome/core/automation.h:3,
                 from src/esphome/components/mdns/mdns_component.h:5,
                 from src/esphome/components/openthread/openthread.h:5,
                 from src/esphome/components/openthread/openthread_esp.cpp:4:
src/esphome/components/openthread/openthread_esp.cpp: In member function 'void esphome::openthread::OpenThreadComponent::ot_main()':
src/esphome/components/openthread/openthread_esp.cpp:118:19: error: format '%d' expects argument of type 'int', but argument 5 has type 'uint32_t' {aka 'long unsigned int'} [-Werror=format=]
  118 |     ESP_LOGD(TAG, "Link Polling Period: %d", link_polling_period);
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~
```

End user impact: Likely none on wrong arg interpretation, in worst case bad output. Here only signed vs unsigned.

Developer impact: Slightly annoying if to compile tree with strict warnings for enforcing QA.

Format fix is obvious.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: compileerror
  platformio_options:
    build_flags:
      - -Wall -Werror

esp32:
  variant: esp32c6

network:
  enable_ipv6: true

openthread:
  device_type: MTD
  tlv: ""  # Required, but irrelevant

logger:
  level: DEBUG
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
