### PR TITLE
[audio] Add support for sinking via an arbitrary callback

### DIFF
--- a/esphome/components/audio/audio_transfer_buffer.cpp
+++ b/esphome/components/audio/audio_transfer_buffer.cpp
@@ -165,6 +165,8 @@ size_t AudioSinkTransferBuffer::transfer_data_to_sink(TickType_t ticks_to_wait, 
         if (this->ring_buffer_.use_count() > 0) {
       bytes_written =
           this->ring_buffer_->write_without_replacement((void *) this->data_start_, this->available(), ticks_to_wait);
+    } else if (this->sink_callback_ != nullptr) {
+      bytes_written = this->sink_callback_->audio_sink_write(this->data_start_, this->available(), ticks_to_wait);
     }
 
     this->decrease_buffer_length(bytes_written);

--- a/esphome/components/audio/audio_transfer_buffer.h
+++ b/esphome/components/audio/audio_transfer_buffer.h
@@ -15,6 +15,12 @@
 namespace esphome {
 namespace audio {
 
+/// @brief Abstract interface for writing decoded audio data to a sink.
+class AudioSinkCallback {
+ public:
+  virtual size_t audio_sink_write(uint8_t *data, size_t length, TickType_t ticks_to_wait) = 0;
+};
+
 class AudioTransferBuffer {
   /*
    * @brief Class that facilitates tranferring data between a buffer and an audio source or sink.
@@ -108,6 +114,10 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
   void set_sink(speaker::Speaker *speaker) { this->speaker_ = speaker; }
 #endif
 
+  /// @brief Adds a callback as the transfer buffer's sink.
+  /// @param callback Pointer to the AudioSinkCallback implementation
+  void set_sink(AudioSinkCallback *callback) { this->sink_callback_ = callback; }
+
   void clear_buffered_data() override;
 
   bool has_buffered_data() const override;
@@ -116,6 +126,7 @@ class AudioSinkTransferBuffer : public AudioTransferBuffer {
 #ifdef USE_SPEAKER
   speaker::Speaker *speaker_{nullptr};
 #endif
+  AudioSinkCallback *sink_callback_{nullptr};
 };
 
 class AudioSourceTransferBuffer : public AudioTransferBuffer {


### PR DESCRIPTION
# What does this implement/fix?

Adds a new ``AudioSinkCallback`` class to allow the ``AudioSinkTransferBuffer`` class handle arbitrary outputs instead of only supporting sinking to a ring buffer or speaker.

Example code usage to sink to a specific speaker component:

```
// A component that receives decoded audio via the AudioSinkCallback interface                                                                                                                     
class MyAudioProcessor : public Component, public audio::AudioSinkCallback {
 public:                                                                                                                                                                                           
  size_t audio_sink_write(uint8_t *data, size_t length, TickType_t ticks_to_wait) override {                                                                                                       
    // Process or forward the decoded audio data
    return this->speaker_->play(data, length, ticks_to_wait);
  }

  void set_speaker(speaker::Speaker *speaker) { this->speaker_ = speaker; }

 protected:
  speaker::Speaker *speaker_{nullptr};
};
```

A possible future improvement is to fully flesh out the minimum requirements for an ``AudioSink`` class and then make the speaker class inherit from it as well as creating an adapter for ring buffers. Then, the ``AudioSinkTransferBuffer``class wouldn't need to check for three possible different sinks.

This will be used in the upcoming ``media_source`` platform component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable as this just modifies a helper class.

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
