### PR TITLE
[stcc4] Add driver for Sensirion STCC4 CO2 sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -483,6 +483,7 @@ esphome/components/st7735/* @SenexCrenshaw
 esphome/components/st7789v/* @kbx81
 esphome/components/st7920/* @marsjan155
 esphome/components/statsd/* @Links2004
+esphome/components/stcc4/* @will-tm
 esphome/components/stts22h/* @B48D81EFCC
 esphome/components/substitutions/* @esphome/core
 esphome/components/sun/* @OttoWinter

--- a/esphome/components/stcc4/sensor.py
+++ b/esphome/components/stcc4/sensor.py
@@ -1,0 +1,118 @@
+import esphome.codegen as cg
+from esphome.components import i2c, sensirion_common, sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_AMBIENT_PRESSURE_COMPENSATION,
+    CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE,
+    CONF_CO2,
+    CONF_HUMIDITY,
+    CONF_ID,
+    CONF_MEASUREMENT_MODE,
+    CONF_TEMPERATURE,
+    CONF_TEMPERATURE_SOURCE,
+    DEVICE_CLASS_CARBON_DIOXIDE,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_MOLECULE_CO2,
+    ICON_THERMOMETER,
+    ICON_WATER_PERCENT,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_PARTS_PER_MILLION,
+    UNIT_PERCENT,
+)
+
+CODEOWNERS = ["@will-tm"]
+DEPENDENCIES = ["i2c"]
+AUTO_LOAD = ["sensirion_common"]
+
+stcc4_ns = cg.esphome_ns.namespace("stcc4")
+STCC4Component = stcc4_ns.class_(
+    "STCC4Component", cg.PollingComponent, sensirion_common.SensirionI2CDevice
+)
+
+MeasurementMode = stcc4_ns.enum("MeasurementMode")
+CONF_HUMIDITY_SOURCE = "humidity_source"
+
+MEASUREMENT_MODE_OPTIONS = {
+    "continuous": MeasurementMode.CONTINUOUS,
+    "single_shot": MeasurementMode.SINGLE_SHOT,
+}
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(STCC4Component),
+            cv.Optional(CONF_CO2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PARTS_PER_MILLION,
+                icon=ICON_MOLECULE_CO2,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_CARBON_DIOXIDE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                icon=ICON_WATER_PERCENT,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_HUMIDITY,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TEMPERATURE_SOURCE): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_HUMIDITY_SOURCE): cv.use_id(sensor.Sensor),
+            cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION): cv.pressure,
+            cv.Optional(CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE): cv.use_id(
+                sensor.Sensor
+            ),
+            cv.Optional(CONF_MEASUREMENT_MODE, default="continuous"): cv.enum(
+                MEASUREMENT_MODE_OPTIONS, lower=True
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+    .extend(i2c.i2c_device_schema(0x64))
+)
+
+SENSOR_MAP = {
+    CONF_CO2: "set_co2_sensor",
+    CONF_TEMPERATURE: "set_temperature_sensor",
+    CONF_HUMIDITY: "set_humidity_sensor",
+}
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+
+    for key, func_name in SENSOR_MAP.items():
+        if key in config:
+            sens = await sensor.new_sensor(config[key])
+            cg.add(getattr(var, func_name)(sens))
+
+    if CONF_TEMPERATURE_SOURCE in config:
+        sens = await cg.get_variable(config[CONF_TEMPERATURE_SOURCE])
+        cg.add(var.set_temperature_source(sens))
+
+    if CONF_HUMIDITY_SOURCE in config:
+        sens = await cg.get_variable(config[CONF_HUMIDITY_SOURCE])
+        cg.add(var.set_humidity_source(sens))
+
+    if CONF_AMBIENT_PRESSURE_COMPENSATION in config:
+        cg.add(
+            var.set_ambient_pressure_compensation(
+                config[CONF_AMBIENT_PRESSURE_COMPENSATION]
+            )
+        )
+
+    if CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE in config:
+        sens = await cg.get_variable(config[CONF_AMBIENT_PRESSURE_COMPENSATION_SOURCE])
+        cg.add(var.set_ambient_pressure_source(sens))
+
+    cg.add(var.set_measurement_mode(config[CONF_MEASUREMENT_MODE]))

--- a/esphome/components/stcc4/stcc4.cpp
+++ b/esphome/components/stcc4/stcc4.cpp
@@ -1,0 +1,210 @@
+#include "stcc4.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace stcc4 {
+
+static const char *const TAG = "stcc4";
+
+// I2C Commands
+static const uint16_t STCC4_CMD_START_CONTINUOUS_MEASUREMENT = 0x218b;
+static const uint16_t STCC4_CMD_READ_MEASUREMENT = 0xec05;
+static const uint16_t STCC4_CMD_STOP_CONTINUOUS_MEASUREMENT = 0x3f86;
+static const uint16_t STCC4_CMD_MEASURE_SINGLE_SHOT = 0x219d;
+static const uint16_t STCC4_CMD_GET_PRODUCT_ID = 0x365b;
+static const uint16_t STCC4_CMD_SET_RHT_COMPENSATION = 0xe000;
+static const uint16_t STCC4_CMD_SET_PRESSURE_COMPENSATION = 0xe016;
+// Exit sleep is an 8-bit command (single byte 0x00), not 16-bit
+static const uint8_t STCC4_CMD_EXIT_SLEEP_MODE = 0x00;
+
+void STCC4Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up STCC4...");
+
+  // Wake sensor from sleep mode (send single byte 0x00)
+  // The sensor needs some time after power-up
+  this->set_timeout(100, [this]() {
+    // Send exit sleep mode command (8-bit, NACK expected if already awake)
+    if (!this->write_command(STCC4_CMD_EXIT_SLEEP_MODE)) {
+      ESP_LOGW(TAG, "Failed to send exit sleep command, sensor may already be awake");
+    }
+
+    // Wait 5ms for sensor to be ready after exiting sleep
+    this->set_timeout(5, [this]() {
+      // Read product ID to verify communication (6 words: 2 for product_id + 4 for serial)
+      uint16_t raw_product_id[6];
+      if (!this->get_register(STCC4_CMD_GET_PRODUCT_ID, raw_product_id, 6, 1)) {
+        ESP_LOGE(TAG, "Failed to read product ID");
+        this->mark_failed();
+        return;
+      }
+
+      uint32_t product_id = (uint32_t(raw_product_id[0]) << 16) | raw_product_id[1];
+      uint64_t serial_number = (uint64_t(raw_product_id[2]) << 48) | (uint64_t(raw_product_id[3]) << 32) |
+                               (uint64_t(raw_product_id[4]) << 16) | raw_product_id[5];
+      ESP_LOGD(TAG, "Product ID: 0x%08" PRIX32 ", Serial: 0x%016" PRIX64, product_id, serial_number);
+
+      // Set initial pressure compensation if configured
+      if (this->ambient_pressure_ != 0) {
+        if (!this->update_ambient_pressure_compensation_(this->ambient_pressure_)) {
+          ESP_LOGE(TAG, "Failed to set ambient pressure compensation");
+          this->mark_failed();
+          return;
+        }
+      }
+
+      this->initialized_ = true;
+
+      // Start continuous measurement if in continuous mode
+      if (this->measurement_mode_ == CONTINUOUS) {
+        this->start_measurement_();
+      }
+    });
+  });
+}
+
+void STCC4Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "STCC4:");
+  LOG_I2C_DEVICE(this);
+  if (this->is_failed()) {
+    ESP_LOGW(TAG, ESP_LOG_MSG_COMM_FAIL);
+  }
+  ESP_LOGCONFIG(TAG, "  Measurement mode: %s",
+                this->measurement_mode_ == CONTINUOUS ? "Continuous (1s)" : "Single shot");
+  if (this->ambient_pressure_source_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Dynamic ambient pressure compensation using '%s'",
+                  this->ambient_pressure_source_->get_name().c_str());
+  } else if (this->ambient_pressure_ != 0) {
+    ESP_LOGCONFIG(TAG, "  Ambient pressure compensation: %" PRIu16 " hPa", this->ambient_pressure_);
+  }
+  if (this->temperature_source_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Temperature compensation using '%s'", this->temperature_source_->get_name().c_str());
+  }
+  if (this->humidity_source_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Humidity compensation using '%s'", this->humidity_source_->get_name().c_str());
+  }
+  LOG_UPDATE_INTERVAL(this);
+  LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
+}
+
+void STCC4Component::update() {
+  if (!this->initialized_) {
+    return;
+  }
+
+  // Update RHT compensation from external sensors
+  this->update_rht_compensation_();
+
+  // Update pressure compensation from external sensor
+  if (this->ambient_pressure_source_ != nullptr) {
+    float pressure = this->ambient_pressure_source_->state;
+    if (!std::isnan(pressure)) {
+      uint16_t new_pressure = static_cast<uint16_t>(pressure);
+      if (new_pressure != this->ambient_pressure_) {
+        this->update_ambient_pressure_compensation_(new_pressure);
+        this->ambient_pressure_ = new_pressure;
+      }
+    }
+  }
+
+  uint32_t wait_time = 0;
+  if (this->measurement_mode_ == SINGLE_SHOT) {
+    // Start single shot measurement
+    if (!this->write_command(STCC4_CMD_MEASURE_SINGLE_SHOT)) {
+      ESP_LOGW(TAG, "Failed to start single shot measurement");
+      this->status_set_warning();
+      return;
+    }
+    wait_time = 500;  // Single shot takes 500ms
+  }
+
+  this->set_timeout(wait_time, [this]() {
+    // Read measurement data: 4 words (CO2, temperature, humidity, status)
+    uint16_t raw_data[4];
+    if (!this->get_register(STCC4_CMD_READ_MEASUREMENT, raw_data, 4, 1)) {
+      ESP_LOGW(TAG, "Failed to read measurement data");
+      this->status_set_warning();
+      return;
+    }
+
+    // CO2 value is in ppm as int16 (can be negative during warm-up)
+    int16_t co2_raw = static_cast<int16_t>(raw_data[0]);
+
+    // Only publish valid CO2 values (non-negative)
+    if (co2_raw >= 0 && this->co2_sensor_ != nullptr) {
+      this->co2_sensor_->publish_state(co2_raw);
+    }
+
+    // Temperature: -45 + 175 * (raw / 65535)
+    if (this->temperature_sensor_ != nullptr) {
+      float temperature = -45.0f + (175.0f * raw_data[1]) / 65535.0f;
+      this->temperature_sensor_->publish_state(temperature);
+    }
+
+    // Humidity: -6 + 125 * (raw / 65535)
+    if (this->humidity_sensor_ != nullptr) {
+      float humidity = -6.0f + (125.0f * raw_data[2]) / 65535.0f;
+      this->humidity_sensor_->publish_state(humidity);
+    }
+
+    this->status_clear_warning();
+  });
+}
+
+bool STCC4Component::update_rht_compensation_() {
+  if (this->temperature_source_ == nullptr || this->humidity_source_ == nullptr) {
+    return true;  // No compensation sources configured
+  }
+
+  float temperature = this->temperature_source_->state;
+  float humidity = this->humidity_source_->state;
+
+  if (std::isnan(temperature) || std::isnan(humidity)) {
+    return false;  // No valid data yet
+  }
+
+  // Convert to ticks using SHT4x formula:
+  // temperature = -45 + 175 * (ticks / 65535)
+  // humidity = -6 + 125 * (ticks / 65535)
+  uint16_t temp_ticks = static_cast<uint16_t>(((temperature + 45.0f) / 175.0f) * 65535.0f);
+  uint16_t humidity_ticks = static_cast<uint16_t>(((humidity + 6.0f) / 125.0f) * 65535.0f);
+
+  uint16_t data[2] = {temp_ticks, humidity_ticks};
+  if (!this->write_command(STCC4_CMD_SET_RHT_COMPENSATION, data, 2)) {
+    ESP_LOGW(TAG, "Failed to set RHT compensation");
+    return false;
+  }
+
+  return true;
+}
+
+bool STCC4Component::update_ambient_pressure_compensation_(uint16_t pressure_in_hpa) {
+  // Pressure is sent as Pa / 2 (so hPa * 50)
+  uint16_t pressure_raw = pressure_in_hpa * 50;
+
+  if (!this->write_command(STCC4_CMD_SET_PRESSURE_COMPENSATION, pressure_raw)) {
+    ESP_LOGE(TAG, "Failed to set ambient pressure compensation");
+    return false;
+  }
+  ESP_LOGD(TAG, "Set ambient pressure compensation to %" PRIu16 " hPa", pressure_in_hpa);
+  return true;
+}
+
+bool STCC4Component::start_measurement_() {
+  if (!this->write_command(STCC4_CMD_START_CONTINUOUS_MEASUREMENT)) {
+    ESP_LOGE(TAG, "Failed to start continuous measurement");
+    this->status_set_warning();
+    return false;
+  }
+  ESP_LOGD(TAG, "Started continuous measurement");
+  return true;
+}
+
+void STCC4Component::set_ambient_pressure_compensation(float pressure_in_hpa) {
+  this->ambient_pressure_ = static_cast<uint16_t>(pressure_in_hpa);
+}
+
+}  // namespace stcc4
+}  // namespace esphome

--- a/esphome/components/stcc4/stcc4.h
+++ b/esphome/components/stcc4/stcc4.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/sensirion_common/i2c_sensirion.h"
+
+namespace esphome {
+namespace stcc4 {
+
+enum MeasurementMode : uint8_t {
+  CONTINUOUS,
+  SINGLE_SHOT,
+};
+
+class STCC4Component : public PollingComponent, public sensirion_common::SensirionI2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+
+  void set_co2_sensor(sensor::Sensor *co2) { this->co2_sensor_ = co2; }
+  void set_temperature_sensor(sensor::Sensor *temperature) { this->temperature_sensor_ = temperature; }
+  void set_humidity_sensor(sensor::Sensor *humidity) { this->humidity_sensor_ = humidity; }
+  void set_temperature_source(sensor::Sensor *temperature) { this->temperature_source_ = temperature; }
+  void set_humidity_source(sensor::Sensor *humidity) { this->humidity_source_ = humidity; }
+  void set_ambient_pressure_compensation(float pressure_in_hpa);
+  void set_ambient_pressure_source(sensor::Sensor *pressure) { this->ambient_pressure_source_ = pressure; }
+  void set_measurement_mode(MeasurementMode mode) { this->measurement_mode_ = mode; }
+
+ protected:
+  bool update_rht_compensation_();
+  bool update_ambient_pressure_compensation_(uint16_t pressure_in_hpa);
+  bool start_measurement_();
+
+  sensor::Sensor *co2_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
+  sensor::Sensor *temperature_source_{nullptr};
+  sensor::Sensor *humidity_source_{nullptr};
+  sensor::Sensor *ambient_pressure_source_{nullptr};
+
+  uint16_t ambient_pressure_{0};
+  bool initialized_{false};
+  MeasurementMode measurement_mode_{CONTINUOUS};
+};
+
+}  // namespace stcc4
+}  // namespace esphome

--- a/tests/components/stcc4/common.yaml
+++ b/tests/components/stcc4/common.yaml
@@ -1,0 +1,26 @@
+sensor:
+  # SHT4x for external RHT compensation (boards without onboard SHT4x)
+  - platform: sht4x
+    i2c_id: i2c_bus
+    temperature:
+      name: SHT4x Temperature
+      id: sht4x_temperature
+    humidity:
+      name: SHT4x Humidity
+      id: sht4x_humidity
+
+  # STCC4 CO2 sensor with onboard temperature/humidity and external compensation
+  - platform: stcc4
+    i2c_id: i2c_bus
+    id: stcc4_sensor
+    co2:
+      name: STCC4 CO2
+    temperature:
+      name: STCC4 Temperature
+    humidity:
+      name: STCC4 Humidity
+    temperature_source: sht4x_temperature
+    humidity_source: sht4x_humidity
+    measurement_mode: continuous
+    ambient_pressure_compensation: 1013
+    update_interval: 60s

--- a/tests/components/stcc4/test.esp32-idf.yaml
+++ b/tests/components/stcc4/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/stcc4/test.esp8266-ard.yaml
+++ b/tests/components/stcc4/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/stcc4/test.rp2040-ard.yaml
+++ b/tests/components/stcc4/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add support for the Sensirion STCC4 miniature CO₂ sensor based on thermal conductivity measurement.

The STCC4 features a dedicated I²C controller interface for an onboard SHT4x sensor, providing
automatic temperature/humidity compensation and readings alongside CO₂ concentration. For boards
without an onboard SHT4x, external RHT compensation is supported via `temperature_source` and
`humidity_source` configuration options.

Implementation details aligned with the [official Sensirion embedded driver](https://github.com/Sensirion/embedded-i2c-stcc4).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6108

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# With onboard SHT4x (typical eval kit / breakout board)
sensor:
  - platform: stcc4
    co2:
      name: "CO2 Concentration"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    ambient_pressure_compensation: 1013
    update_interval: 60s


# Without onboard SHT4x (external compensation)
sensor:
  - platform: sht4x
    temperature:
      name: "Temperature"
      id: sht4x_temp
    humidity:
      name: "Humidity"
      id: sht4x_humidity

  - platform: stcc4
    co2:
      name: "CO2 Concentration"
    temperature_source: sht4x_temp
    humidity_source: sht4x_humidity
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
