### PR TITLE
[core] Make setup_priority and component state constants constexpr

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -76,36 +76,8 @@ void store_component_error_message(const Component *component, const char *messa
 }
 }  // namespace
 
-namespace setup_priority {
-
-const float BUS = 1000.0f;
-const float IO = 900.0f;
-const float HARDWARE = 800.0f;
-const float DATA = 600.0f;
-const float PROCESSOR = 400.0;
-const float BLUETOOTH = 350.0f;
-const float AFTER_BLUETOOTH = 300.0f;
-const float WIFI = 250.0f;
-const float ETHERNET = 250.0f;
-const float BEFORE_CONNECTION = 220.0f;
-const float AFTER_WIFI = 200.0f;
-const float AFTER_CONNECTION = 100.0f;
-const float LATE = -100.0f;
-
-}  // namespace setup_priority
-
-// Component state uses bits 0-2 (8 states, 5 used)
-const uint8_t COMPONENT_STATE_MASK = 0x07;
-const uint8_t COMPONENT_STATE_CONSTRUCTION = 0x00;
-const uint8_t COMPONENT_STATE_SETUP = 0x01;
-const uint8_t COMPONENT_STATE_LOOP = 0x02;
-const uint8_t COMPONENT_STATE_FAILED = 0x03;
-const uint8_t COMPONENT_STATE_LOOP_DONE = 0x04;
-// Status LED uses bits 3-4
-const uint8_t STATUS_LED_MASK = 0x18;
-const uint8_t STATUS_LED_OK = 0x00;
-const uint8_t STATUS_LED_WARNING = 0x08;  // Bit 3
-const uint8_t STATUS_LED_ERROR = 0x10;    // Bit 4
+// setup_priority, component state, and status LED constants are now
+// constexpr in component.h
 
 const uint16_t WARN_IF_BLOCKING_OVER_MS = 50U;       ///< Initial blocking time allowed without warning
 const uint16_t WARN_IF_BLOCKING_INCREMENT_MS = 10U;  ///< How long the blocking time must be larger to warn again

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -21,33 +21,31 @@ struct LogString;
 namespace setup_priority {
 
 /// For communication buses like i2c/spi
-extern const float BUS;
+inline constexpr float BUS = 1000.0f;
 /// For components that represent GPIO pins like PCF8573
-extern const float IO;
+inline constexpr float IO = 900.0f;
 /// For components that deal with hardware and are very important like GPIO switch
-extern const float HARDWARE;
+inline constexpr float HARDWARE = 800.0f;
 /// For components that import data from directly connected sensors like DHT.
-extern const float DATA;
-/// Alias for DATA (here for compatibility reasons)
-extern const float HARDWARE_LATE;
+inline constexpr float DATA = 600.0f;
 /// For components that use data from sensors like displays
-extern const float PROCESSOR;
-extern const float BLUETOOTH;
-extern const float AFTER_BLUETOOTH;
-extern const float WIFI;
-extern const float ETHERNET;
+inline constexpr float PROCESSOR = 400.0f;
+inline constexpr float BLUETOOTH = 350.0f;
+inline constexpr float AFTER_BLUETOOTH = 300.0f;
+inline constexpr float WIFI = 250.0f;
+inline constexpr float ETHERNET = 250.0f;
 /// For components that should be initialized after WiFi and before API is connected.
-extern const float BEFORE_CONNECTION;
+inline constexpr float BEFORE_CONNECTION = 220.0f;
 /// For components that should be initialized after WiFi is connected.
-extern const float AFTER_WIFI;
+inline constexpr float AFTER_WIFI = 200.0f;
 /// For components that should be initialized after a data connection (API/MQTT) is connected.
-extern const float AFTER_CONNECTION;
+inline constexpr float AFTER_CONNECTION = 100.0f;
 /// For components that should be initialized at the very end of the setup process.
-extern const float LATE;
+inline constexpr float LATE = -100.0f;
 
 }  // namespace setup_priority
 
-static const uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
+inline constexpr uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
 
 /// Type-safe scheduler IDs for core base classes.
 /// Uses a separate NameType (NUMERIC_ID_INTERNAL) so IDs can never collide
@@ -65,16 +63,18 @@ void log_update_interval(const char *tag, PollingComponent *component);
 
 #define LOG_UPDATE_INTERVAL(this) log_update_interval(TAG, this)
 
-extern const uint8_t COMPONENT_STATE_MASK;
-extern const uint8_t COMPONENT_STATE_CONSTRUCTION;
-extern const uint8_t COMPONENT_STATE_SETUP;
-extern const uint8_t COMPONENT_STATE_LOOP;
-extern const uint8_t COMPONENT_STATE_FAILED;
-extern const uint8_t COMPONENT_STATE_LOOP_DONE;
-extern const uint8_t STATUS_LED_MASK;
-extern const uint8_t STATUS_LED_OK;
-extern const uint8_t STATUS_LED_WARNING;
-extern const uint8_t STATUS_LED_ERROR;
+// Component state uses bits 0-2 (8 states, 5 used)
+inline constexpr uint8_t COMPONENT_STATE_MASK = 0x07;
+inline constexpr uint8_t COMPONENT_STATE_CONSTRUCTION = 0x00;
+inline constexpr uint8_t COMPONENT_STATE_SETUP = 0x01;
+inline constexpr uint8_t COMPONENT_STATE_LOOP = 0x02;
+inline constexpr uint8_t COMPONENT_STATE_FAILED = 0x03;
+inline constexpr uint8_t COMPONENT_STATE_LOOP_DONE = 0x04;
+// Status LED uses bits 3-4
+inline constexpr uint8_t STATUS_LED_MASK = 0x18;
+inline constexpr uint8_t STATUS_LED_OK = 0x00;
+inline constexpr uint8_t STATUS_LED_WARNING = 0x08;
+inline constexpr uint8_t STATUS_LED_ERROR = 0x10;
 
 // Remove before 2026.8.0
 enum class RetryResult { DONE, RETRY };


### PR DESCRIPTION
# What does this implement/fix?

Converts `setup_priority` floats, component state `uint8_t` constants, and status LED constants from `extern const` (defined in `component.cpp`) to `inline constexpr` in the header.

With `extern const`, the compiler cannot see the values in other translation units and must emit memory loads (`l32r` on Xtensa) every time these constants are used. As `inline constexpr`, the compiler can use immediate values, fold comparisons at compile time, and eliminate the storage entirely.

Also removes the dead `HARDWARE_LATE` declaration — it was declared `extern const float` in the header but never defined anywhere, so any code referencing it already fails at link time.

Results (ESP32-S3 IDF):
- Flash savings: **-372 bytes**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).