### PR TITLE
[pca9685] Make mode constants inline constexpr

### DIFF
--- a/esphome/components/pca9685/pca9685_output.cpp
+++ b/esphome/components/pca9685/pca9685_output.cpp
@@ -8,11 +8,7 @@ namespace pca9685 {
 
 static const char *const TAG = "pca9685";
 
-const uint8_t PCA9685_MODE_INVERTED = 0x10;
-const uint8_t PCA9685_MODE_OUTPUT_ONACK = 0x08;
-const uint8_t PCA9685_MODE_OUTPUT_TOTEM_POLE = 0x04;
-const uint8_t PCA9685_MODE_OUTNE_HIGHZ = 0x02;
-const uint8_t PCA9685_MODE_OUTNE_LOW = 0x01;
+// PCA9685 mode constants are now inline constexpr in pca9685_output.h
 
 static const uint8_t PCA9685_REGISTER_SOFTWARE_RESET = 0x06;
 static const uint8_t PCA9685_REGISTER_MODE1 = 0x00;

--- a/esphome/components/pca9685/pca9685_output.h
+++ b/esphome/components/pca9685/pca9685_output.h
@@ -13,15 +13,15 @@ enum class PhaseBalancer {
 };
 
 /// Inverts polarity of channel output signal
-extern const uint8_t PCA9685_MODE_INVERTED;
+inline constexpr uint8_t PCA9685_MODE_INVERTED = 0x10;
 /// Channel update happens upon ACK (post-set) rather than on STOP (endTransmission)
-extern const uint8_t PCA9685_MODE_OUTPUT_ONACK;
+inline constexpr uint8_t PCA9685_MODE_OUTPUT_ONACK = 0x08;
 /// Use a totem-pole (push-pull) style output rather than an open-drain structure.
-extern const uint8_t PCA9685_MODE_OUTPUT_TOTEM_POLE;
+inline constexpr uint8_t PCA9685_MODE_OUTPUT_TOTEM_POLE = 0x04;
 /// For active low output enable, sets channel output to high-impedance state
-extern const uint8_t PCA9685_MODE_OUTNE_HIGHZ;
+inline constexpr uint8_t PCA9685_MODE_OUTNE_HIGHZ = 0x02;
 /// Similarly, sets channel output to high if in totem-pole mode, otherwise
-extern const uint8_t PCA9685_MODE_OUTNE_LOW;
+inline constexpr uint8_t PCA9685_MODE_OUTNE_LOW = 0x01;
 
 class PCA9685Output;
 


### PR DESCRIPTION
# What does this implement/fix?

Converts `PCA9685_MODE_*` constants from `extern const` (defined in `.cpp`) to `inline constexpr` in the header. This lets the compiler use immediate values instead of memory loads. These constants are also used as default constructor arguments, so making them constexpr avoids unnecessary runtime initialization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).