### PR TITLE
[tlc59208f] Make mode constants inline constexpr

### DIFF
--- a/esphome/components/tlc59208f/tlc59208f_output.cpp
+++ b/esphome/components/tlc59208f/tlc59208f_output.cpp
@@ -26,17 +26,7 @@ const uint8_t TLC59208F_MODE1_SUB3 = (1 << 1);
 // 0: device doesn't respond to i2c all-call 3, 1*: responds to all-call
 const uint8_t TLC59208F_MODE1_ALLCALL = (1 << 0);
 
-// 0*: Group dimming, 1: Group blinking
-const uint8_t TLC59208F_MODE2_DMBLNK = (1 << 5);
-// 0*: Output change on Stop command, 1: Output change on ACK
-const uint8_t TLC59208F_MODE2_OCH = (1 << 3);
-// 0*: WDT disabled, 1: WDT enabled
-const uint8_t TLC59208F_MODE2_WDTEN = (1 << 2);
-// WDT timeouts
-const uint8_t TLC59208F_MODE2_WDT_5MS = (0 << 0);
-const uint8_t TLC59208F_MODE2_WDT_15MS = (1 << 0);
-const uint8_t TLC59208F_MODE2_WDT_25MS = (2 << 0);
-const uint8_t TLC59208F_MODE2_WDT_35MS = (3 << 0);
+// TLC59208F MODE2 constants are now inline constexpr in tlc59208f_output.h
 
 // --- Special function ---
 // Call address to perform software reset, no devices will ACK

--- a/esphome/components/tlc59208f/tlc59208f_output.h
+++ b/esphome/components/tlc59208f/tlc59208f_output.h
@@ -9,16 +9,16 @@ namespace esphome {
 namespace tlc59208f {
 
 // 0*: Group dimming, 1: Group blinking
-extern const uint8_t TLC59208F_MODE2_DMBLNK;
+inline constexpr uint8_t TLC59208F_MODE2_DMBLNK = (1 << 5);
 // 0*: Output change on Stop command, 1: Output change on ACK
-extern const uint8_t TLC59208F_MODE2_OCH;
+inline constexpr uint8_t TLC59208F_MODE2_OCH = (1 << 3);
 // 0*: WDT disabled, 1: WDT enabled
-extern const uint8_t TLC59208F_MODE2_WDTEN;
+inline constexpr uint8_t TLC59208F_MODE2_WDTEN = (1 << 2);
 // WDT timeouts
-extern const uint8_t TLC59208F_MODE2_WDT_5MS;
-extern const uint8_t TLC59208F_MODE2_WDT_15MS;
-extern const uint8_t TLC59208F_MODE2_WDT_25MS;
-extern const uint8_t TLC59208F_MODE2_WDT_35MS;
+inline constexpr uint8_t TLC59208F_MODE2_WDT_5MS = (0 << 0);
+inline constexpr uint8_t TLC59208F_MODE2_WDT_15MS = (1 << 0);
+inline constexpr uint8_t TLC59208F_MODE2_WDT_25MS = (2 << 0);
+inline constexpr uint8_t TLC59208F_MODE2_WDT_35MS = (3 << 0);
 
 class TLC59208FOutput;
 


### PR DESCRIPTION
# What does this implement/fix?

Converts `TLC59208F_MODE2_*` constants from `extern const` (defined in `.cpp`) to `inline constexpr` in the header. This lets the compiler use immediate values instead of memory loads. These constants are also used as default constructor arguments, so making them constexpr avoids unnecessary runtime initialization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).