### PR TITLE
[display] Make COLOR_OFF and COLOR_ON inline constexpr

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -9,8 +9,7 @@ namespace esphome {
 namespace display {
 static const char *const TAG = "display";
 
-const Color COLOR_OFF(0, 0, 0, 0);
-const Color COLOR_ON(255, 255, 255, 255);
+// COLOR_OFF and COLOR_ON are now inline constexpr in display.h
 
 void Display::fill(Color color) { this->filled_rectangle(0, 0, this->get_width(), this->get_height(), color); }
 void Display::clear() { this->fill(COLOR_OFF); }

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -298,9 +298,9 @@ using display_writer_t = DisplayWriter<Display>;
   }
 
 /// Turn the pixel OFF.
-extern const Color COLOR_OFF;
+inline constexpr Color COLOR_OFF(0, 0, 0, 0);
 /// Turn the pixel ON.
-extern const Color COLOR_ON;
+inline constexpr Color COLOR_ON(255, 255, 255, 255);
 
 class BaseImage {
  public:


### PR DESCRIPTION
# What does this implement/fix?

Converts `COLOR_OFF` and `COLOR_ON` from `extern const` (defined in `display.cpp`) to `inline constexpr` in the header. The `Color` class already has `constexpr` constructors, so these can be compile-time constants.

These are used extensively as default parameters across ~30 display methods (`line()`, `rectangle()`, `print()`, `image()`, etc.), so making them constexpr allows the compiler to optimize all those default argument evaluations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).