### PR TITLE
[openthread] Optimize by avoiding std::vector

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -162,6 +162,8 @@ void OpenThreadSrpComponent::setup() {
   // Get mdns services and copy their data (strings are copied with strdup below)
   const auto &mdns_services = this->mdns_->get_services();
   ESP_LOGD(TAG, "Setting up SRP services. count = %d\n", mdns_services.size());
+  // Allocate pool upfront, on rare failure not all might be filled below but not fatal
+  memory_pool_ = std::make_unique<TxtEntryListPtr[]>(mdns_services.size());
   for (const auto &service : mdns_services) {
     otSrpClientBuffersServiceEntry *entry = otSrpClientBuffersAllocateService(instance);
     if (!entry) {
@@ -190,8 +192,12 @@ void OpenThreadSrpComponent::setup() {
     // Set port
     entry->mService.mPort = const_cast<TemplatableValue<uint16_t> &>(service.port).value();
 
-    otDnsTxtEntry *txt_entries =
-        reinterpret_cast<otDnsTxtEntry *>(this->pool_alloc_(sizeof(otDnsTxtEntry) * service.txt_records.size()));
+    // Make new pool entry with service array
+    const size_t list_idx = &service - &mdns_services[0];
+    auto &pool_pos = this->memory_pool_[list_idx];
+    pool_pos = std::make_unique<otDnsTxtEntry[]>(size);
+    otDnsTxtEntry *txt_entries = pool_pos.get();
+
     // Set TXT records
     entry->mService.mNumTxtEntries = service.txt_records.size();
     for (size_t i = 0; i < service.txt_records.size(); i++) {
@@ -216,12 +222,6 @@ void OpenThreadSrpComponent::setup() {
 
   otSrpClientEnableAutoStartMode(instance, OpenThreadSrpComponent::srp_start_callback, nullptr);
   ESP_LOGD(TAG, "Finished SRP setup");
-}
-
-void *OpenThreadSrpComponent::pool_alloc_(size_t size) {
-  uint8_t *ptr = new uint8_t[size];
-  this->memory_pool_.emplace_back(std::unique_ptr<uint8_t[]>(ptr));
-  return ptr;
 }
 
 void OpenThreadSrpComponent::set_mdns(esphome::mdns::MDNSComponent *mdns) { this->mdns_ = mdns; }

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -195,7 +195,7 @@ void OpenThreadSrpComponent::setup() {
     // Make new pool entry with service array
     const size_t list_idx = &service - &mdns_services[0];
     auto &pool_pos = this->memory_pool_[list_idx];
-    pool_pos = std::make_unique<otDnsTxtEntry[]>(size);
+    pool_pos = std::make_unique<otDnsTxtEntry[]>(service.txt_records.size());
     otDnsTxtEntry *txt_entries = pool_pos.get();
 
     // Set TXT records

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -195,8 +195,8 @@ void OpenThreadSrpComponent::setup() {
     // Make new pool entry with service array
     const size_t list_idx = &service - &mdns_services[0];
     auto &pool_pos = this->memory_pool_[list_idx];
-    pool_pos = std::make_unique<otDnsTxtEntry[]>(service.txt_records.size());
-    otDnsTxtEntry *txt_entries = pool_pos.get();
+    pool_pos = std::make_unique<std::byte[]>(sizeof(otDnsTxtEntry) * service.txt_records.size());
+    otDnsTxtEntry *txt_entries = reinterpret_cast<otDnsTxtEntry *>(pool_pos.get());
 
     // Set TXT records
     entry->mService.mNumTxtEntries = service.txt_records.size();

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -10,8 +10,8 @@
 #include <openthread/srp_client_buffers.h>
 #include <openthread/thread.h>
 
+#include <memory>
 #include <optional>
-#include <vector>
 
 namespace esphome::openthread {
 
@@ -70,9 +70,9 @@ class OpenThreadSrpComponent : public Component {
                                          void *context);
 
  protected:
+  typedef std::unique_ptr<otDnsTxtEntry[]> TxtEntryListPtr;
   esphome::mdns::MDNSComponent *mdns_{nullptr};
-  std::vector<std::unique_ptr<uint8_t[]>> memory_pool_;
-  void *pool_alloc_(size_t size);
+  std::unique_ptr<TxtEntryListPtr[]> memory_pool_;
 };
 
 class InstanceLock {

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -70,7 +70,7 @@ class OpenThreadSrpComponent : public Component {
                                          void *context);
 
  protected:
-  typedef std::unique_ptr<otDnsTxtEntry[]> TxtEntryListPtr;
+  typedef std::unique_ptr<std::byte[]> TxtEntryListPtr;
   esphome::mdns::MDNSComponent *mdns_{nullptr};
   std::unique_ptr<TxtEntryListPtr[]> memory_pool_;
 };


### PR DESCRIPTION
# What does this implement/fix?

`openthread` uses growing `std::vector` during `setup` once to retain lifetime of certain service data.

Qualifies for easier containers with less boilerplate code and fragmentation risk.

Also the unneeded `reinterpret_cast` from `uint8_t[]` to actual `otDnsTxtEntry` array looks little risky wrt alignment. But _likely_ it is still safe as long as `otDnsTxtEntry` does not have overalign requirements, as `new` of e.g. `char[]` should still return `max_align_t` alignment for common idiom of placing other objects (C++20 N7868 expr.new 15).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
