### PR TITLE
[api] Add handshake timeout to prevent connection slot exhaustion

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -60,6 +60,11 @@ static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 5;
 static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;
+// Timeout for completing the handshake (Noise transport + HelloRequest).
+// A stalled handshake from a buggy client or network glitch holds a connection
+// slot, which can prevent legitimate clients from reconnecting. Also hardens
+// against the less likely case of intentional connection slot exhaustion.
+static constexpr uint32_t HANDSHAKE_TIMEOUT_MS = 15000;
 
 static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
 
@@ -205,7 +210,12 @@ void APIConnection::loop() {
         this->fatal_error_with_log_(LOG_STR("Reading failed"), err);
         return;
       } else {
-        this->last_traffic_ = now;
+        // Only update last_traffic_ after authentication to ensure the
+        // handshake timeout is an absolute deadline from connection start.
+        // Pre-auth messages (e.g. PingRequest) must not reset the timer.
+        if (this->is_authenticated()) {
+          this->last_traffic_ = now;
+        }
         // read a packet
         this->read_message(buffer.data_len, buffer.type, buffer.data);
         if (this->flags_.remove)
@@ -221,6 +231,15 @@ void APIConnection::loop() {
 
   if (this->active_iterator_ != ActiveIterator::NONE) {
     this->process_active_iterator_();
+  }
+
+  // Disconnect clients that haven't completed the handshake in time.
+  // Stale half-open connections from buggy clients or network issues can
+  // accumulate and block legitimate clients from reconnecting.
+  if (!this->is_authenticated() && now - this->last_traffic_ > HANDSHAKE_TIMEOUT_MS) {
+    this->on_fatal_error();
+    this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("handshake timeout; disconnecting"));
+    return;
   }
 
   if (this->flags_.sent_ping) {
@@ -1484,6 +1503,8 @@ void APIConnection::complete_authentication_() {
   }
 
   this->flags_.connection_state = static_cast<uint8_t>(ConnectionState::AUTHENTICATED);
+  // Reset traffic timer so keepalive starts from authentication, not connection start
+  this->last_traffic_ = App.get_loop_component_start_time();
   this->log_client_(ESPHOME_LOG_LEVEL_DEBUG, LOG_STR("connected"));
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
   {


### PR DESCRIPTION
# What does this implement/fix?

Adds a 15-second timeout for completing the API handshake (Noise transport + HelloRequest). Previously, a client could connect and stall mid-handshake, holding a connection slot for up to 150 seconds (the keepalive disconnect timeout). With `max_connections` defaulting to 8 on ESP32 (4 on ESP8266), stale half-open connections from buggy clients or network glitches could accumulate and prevent legitimate clients from reconnecting. This also hardens against the less likely scenario of a malicious actor intentionally exhausting connection slots.

Normal clients (Home Assistant, aioesphomeapi) complete the full handshake in milliseconds, so 15 seconds is generous. The check short-circuits for authenticated connections (single bitfield compare) so there is no overhead for established sessions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - the timeout is always active.
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).