### PR TITLE
[external_components] Clean up incomplete clone on failed ref fetch

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -44,9 +44,9 @@ from esphome.const import (
 from esphome.core import CORE, HexInt, TimePeriod
 from esphome.coroutine import CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
-from esphome.helpers import copy_file_if_changed, write_file_if_changed
+from esphome.helpers import copy_file_if_changed, rmtree, write_file_if_changed
 from esphome.types import ConfigType
-from esphome.writer import clean_cmake_cache, rmtree
+from esphome.writer import clean_cmake_cache
 
 from .boards import BOARDS, STANDARD_BOARDS
 from .const import (  # noqa


### PR DESCRIPTION
# What does this implement/fix?

When using `external_components` with a specific git ref (e.g. `github://pr#1234`), if the initial `git clone` succeeds but the subsequent `git fetch <ref>` fails, the clone directory is left containing only the default branch code. On subsequent runs, `clone_or_update` finds the directory already exists and skips the update if within the refresh window (default 1 day), silently using the wrong code.

This is particularly problematic with the HA addon dashboard, which calls `do_external_components_pass()` from `ImportRequestHandler` for metadata scanning. If that clone's ref fetch fails, the error is caught silently (`except vol.Invalid` at `web_server.py:1009`), but the stale clone directory persists with only the default branch. When the user then compiles, the refresh check passes and the default branch code is used instead of the PR/branch code — making it appear as if the external component wasn't loaded.

**Fix:** Wrap the clone+fetch+submodule sequence in try/except and remove the incomplete clone directory on failure, so the next attempt starts fresh rather than finding a stale clone.

**Reproduction steps:**
1. Add `external_components` with `source: github://pr#<number>` to a config on HA addon
2. Compile — the dashboard's background metadata scan may clone the repo before the compile subprocess
3. If the ref fetch fails during the dashboard's scan (network blip, etc.), the compile silently uses the default branch code
4. Even `clean-all` doesn't reliably fix it because the dashboard can re-trigger the clone before the next compile

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
external_components:
  - source: github://pr#14033
    components: [esp32_touch]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).