### PR TITLE
[core] Use placement new for global Application instance

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -669,7 +669,14 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 #endif
 }
 
-Application App;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+// App storage — asm label shares the linker symbol with "extern Application App".
+// char[] is trivially destructible, so no __cxa_atexit or destructor chain is emitted.
+// Constructed via placement new in the generated setup().
+#ifndef __GXX_ABI_VERSION
+#error "Application placement new requires Itanium C++ ABI (GCC/Clang)"
+#endif
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
 void Application::setup_wake_loop_threadsafe_() {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -675,6 +675,7 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 #ifndef __GXX_ABI_VERSION
 #error "Application placement new requires Itanium C++ ABI (GCC/Clang)"
 #endif
+static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");
 

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -512,6 +512,9 @@ async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.RawExpression("using std::min"))
     cg.add_global(cg.RawExpression("using std::max"))
 
+    # Construct App via placement new — see application.cpp for storage details
+    cg.add_global(cg.RawExpression("#include <new>"))
+    cg.add(cg.RawExpression("new (&App) Application()"))
     cg.add(
         cg.App.pre_setup(
             config[CONF_NAME],

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -513,7 +513,7 @@ async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.RawExpression("using std::max"))
 
     # Construct App via placement new — see application.cpp for storage details
-    cg.add_global(cg.RawExpression("#include <new>"))
+    cg.add_global(cg.RawStatement("#include <new>"))
     cg.add(cg.RawExpression("new (&App) Application()"))
     cg.add(
         cg.App.pre_setup(


### PR DESCRIPTION
# What does this implement/fix?

Eliminates the global constructor and destructor chain for `esphome::App` by deferring construction to the generated `setup()` function.

The previous `Application App;` global generated:

**A `_GLOBAL__sub_I_` constructor** that:
- Called `xSemaphoreCreateMutex()` at static init time (via `Scheduler::lock_`) before `app_main()` runs
- Redundantly zero-initialized all members that `.bss` already handles

**A `__cxa_atexit` destructor registration** that pulled in the full destructor chain:
- `~Application()`, `~vector()` (scheduler items), `~Mutex()`, etc.
- None of this code ever runs — embedded devices never exit — but the linker couldn't eliminate it because `__cxa_atexit` referenced it

**How it works:**

1. The storage for `App` is now a `char[]` in `application.cpp` with a GCC `asm` label matching the Itanium ABI mangled name of `esphome::App`. Other translation units see a typed `extern Application App` (identical codegen, zero indirection), while the defining TU sees a trivially-destructible char array — so the compiler never emits `__cxa_atexit` or the destructor chain.

2. The generated `setup()` function emits `new (&App) Application()` before `App.pre_setup(...)`, constructing the object via placement new at the right time. This keeps `pre_setup()` small enough to inline into `setup()`, avoiding any code size increase from de-inlining.

3. A compile-time `#error` guard on `__GXX_ABI_VERSION` ensures this only compiles under the Itanium C++ ABI (all GCC/Clang targets).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).