### PR TITLE
[core] Shrink Application::dump_config_at_ from size_t to uint16_t

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -582,9 +582,6 @@ class Application {
   std::string name_;
   std::string friendly_name_;
 
-  // size_t members
-  size_t dump_config_at_{SIZE_MAX};
-
   // 4-byte members
   uint32_t last_loop_{0};
   uint32_t loop_component_start_time_{0};
@@ -594,7 +591,8 @@ class Application {
 #endif
 
   // 2-byte members (grouped together for alignment)
-  uint16_t loop_interval_{16};                 // Loop interval in ms (max 65535ms = 65.5 seconds)
+  uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress
+  uint16_t loop_interval_{16};                                     // Loop interval in ms (max 65535ms = 65.5 seconds)
   uint16_t looping_components_active_end_{0};  // Index marking end of active components in looping_components_
   uint16_t current_loop_index_{0};             // For safe reentrant modifications during iteration
 


### PR DESCRIPTION
# What does this implement/fix?

`dump_config_at_` is an index into `components_`, which is a `StaticVector<Component *, ESPHOME_COMPONENT_COUNT>` with `uint16_t`-range capacity. Using `size_t` (4 bytes on ESP32) wastes 2 bytes of storage plus introduces padding in the struct layout.

This changes it to `uint16_t` with `std::numeric_limits<uint16_t>::max()` as the "no dump pending" sentinel (matching the existing pattern used elsewhere in `application.h`), and moves it next to the other `uint16_t` members for better struct packing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

No config changes — internal struct optimization only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).