### PR TITLE
[core] Remove dead global_state variable

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -82,8 +82,6 @@ void store_component_error_message(const Component *component, const char *messa
 const uint16_t WARN_IF_BLOCKING_OVER_MS = 50U;       ///< Initial blocking time allowed without warning
 const uint16_t WARN_IF_BLOCKING_INCREMENT_MS = 10U;  ///< How long the blocking time must be larger to warn again
 
-uint32_t global_state = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-
 float Component::get_loop_priority() const { return 0.0f; }
 
 float Component::get_setup_priority() const { return setup_priority::DATA; }


### PR DESCRIPTION
# What does this implement/fix?

Remove the unused `uint32_t global_state` variable from `component.cpp`. It has no header declaration and zero references anywhere in the codebase.

This variable was introduced in the original esphome-core C++ repo and carried over in the April 2019 merge (abf45b11ce). It was likely intended as a device-wide state tracker using the `COMPONENT_STATE_*` / `STATUS_LED_*` bitmasks, but was never wired up — the per-component `component_state_` field handled everything instead. It shipped as dead code from day one.

The compiler/linker already eliminated it (0 bytes RAM/flash impact), so this is purely a source code cleanup.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change - internal cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).