### PR TITLE
[web_server] Add climate preset, fan mode, and humidity support

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1480,6 +1480,7 @@ void WebServer::handle_climate_request(AsyncWebServerRequest *request, const Url
     parse_string_param_(request, ESPHOME_F("mode"), call, &decltype(call)::set_mode);
     parse_string_param_(request, ESPHOME_F("fan_mode"), call, &decltype(call)::set_fan_mode);
     parse_string_param_(request, ESPHOME_F("swing_mode"), call, &decltype(call)::set_swing_mode);
+    parse_string_param_(request, ESPHOME_F("preset"), call, &decltype(call)::set_preset);
 
     // Parse temperature parameters
     // static_cast needed to disambiguate overloaded setters (float vs optional<float>)
@@ -1520,7 +1521,7 @@ std::string WebServer::climate_json_(climate::Climate *obj, JsonDetail start_con
     JsonArray opt = root[ESPHOME_F("modes")].to<JsonArray>();
     for (climate::ClimateMode m : traits.get_supported_modes())
       opt.add(PSTR_LOCAL(climate::climate_mode_to_string(m)));
-    if (!traits.get_supported_custom_fan_modes().empty()) {
+    if (traits.get_supports_fan_modes()) {
       JsonArray opt = root[ESPHOME_F("fan_modes")].to<JsonArray>();
       for (climate::ClimateFanMode m : traits.get_supported_fan_modes())
         opt.add(PSTR_LOCAL(climate::climate_fan_mode_to_string(m)));
@@ -1536,12 +1537,12 @@ std::string WebServer::climate_json_(climate::Climate *obj, JsonDetail start_con
       for (auto swing_mode : traits.get_supported_swing_modes())
         opt.add(PSTR_LOCAL(climate::climate_swing_mode_to_string(swing_mode)));
     }
-    if (traits.get_supports_presets() && obj->preset.has_value()) {
+    if (traits.get_supports_presets()) {
       JsonArray opt = root[ESPHOME_F("presets")].to<JsonArray>();
       for (climate::ClimatePreset m : traits.get_supported_presets())
         opt.add(PSTR_LOCAL(climate::climate_preset_to_string(m)));
     }
-    if (!traits.get_supported_custom_presets().empty() && obj->has_custom_preset()) {
+    if (!traits.get_supported_custom_presets().empty()) {
       JsonArray opt = root[ESPHOME_F("custom_presets")].to<JsonArray>();
       for (auto const &custom_preset : traits.get_supported_custom_presets())
         opt.add(custom_preset);
@@ -1581,6 +1582,11 @@ std::string WebServer::climate_json_(climate::Climate *obj, JsonDetail start_con
         std::isnan(obj->current_temperature)
             ? "NA"
             : (value_accuracy_to_buf(temp_buf, obj->current_temperature, current_accuracy), temp_buf);
+  }
+  if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_HUMIDITY)) {
+    root[ESPHOME_F("current_humidity")] = std::isnan(obj->current_humidity)
+                                              ? "NA"
+                                              : (value_accuracy_to_buf(temp_buf, obj->current_humidity, 0), temp_buf);
   }
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE |
                                climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE)) {


### PR DESCRIPTION
# What does this implement/fix?

The web server climate card had no way to view or change presets or fan modes, and current humidity was not displayed.

- Add preset/custom_preset dropdown support to the climate REST API
- Fix pre-existing bug where fan_modes trait list was gated on `get_supported_custom_fan_modes()` instead of `get_supports_fan_modes()`
- Always list presets/custom_presets options in detail_all regardless of current state
- Add current_humidity to climate state JSON when the device supports it

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  Tests in tests/components/web_server/ are compilation validation only