### PR TITLE
[core] Remove unnecessary IRAM_ATTR from yield(), delay(), feed_wdt(), and arch_feed_wdt()

### DIFF
--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -44,7 +44,7 @@ void arch_init() {
   esp_ota_mark_app_valid_cancel_rollback();
 #endif
 }
-void IRAM_ATTR HOT arch_feed_wdt() { esp_task_wdt_reset(); }
+void HOT arch_feed_wdt() { esp_task_wdt_reset(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
 uint32_t arch_get_cpu_cycle_count() { return esp_cpu_get_cycle_count(); }

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -21,9 +21,9 @@ extern "C" __attribute__((weak)) void initArduino() {}
 
 namespace esphome {
 
-void IRAM_ATTR HOT yield() { vPortYield(); }
+void HOT yield() { vPortYield(); }
 uint32_t IRAM_ATTR HOT millis() { return (uint32_t) (esp_timer_get_time() / 1000ULL); }
-void IRAM_ATTR HOT delay(uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
+void HOT delay(uint32_t ms) { vTaskDelay(ms / portTICK_PERIOD_MS); }
 uint32_t IRAM_ATTR HOT micros() { return (uint32_t) esp_timer_get_time(); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { delay_microseconds_safe(us); }
 void arch_restart() {

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -14,9 +14,9 @@ extern "C" {
 
 namespace esphome {
 
-void IRAM_ATTR HOT yield() { ::yield(); }
+void HOT yield() { ::yield(); }
 uint32_t IRAM_ATTR HOT millis() { return ::millis(); }
-void IRAM_ATTR HOT delay(uint32_t ms) { ::delay(ms); }
+void HOT delay(uint32_t ms) { ::delay(ms); }
 uint32_t IRAM_ATTR HOT micros() { return ::micros(); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { delay_microseconds_safe(us); }
 void arch_restart() {

--- a/esphome/components/esp8266/core.cpp
+++ b/esphome/components/esp8266/core.cpp
@@ -27,7 +27,7 @@ void arch_restart() {
   }
 }
 void arch_init() {}
-void IRAM_ATTR HOT arch_feed_wdt() { system_soft_wdt_feed(); }
+void HOT arch_feed_wdt() { system_soft_wdt_feed(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) {
   return pgm_read_byte(addr);  // NOLINT

--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -48,7 +48,7 @@ void arch_restart() { exit(0); }
 void arch_init() {
   // pass
 }
-void IRAM_ATTR HOT arch_feed_wdt() {
+void HOT arch_feed_wdt() {
   // pass
 }
 

--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -11,7 +11,7 @@
 
 namespace esphome {
 
-void IRAM_ATTR HOT yield() { ::sched_yield(); }
+void HOT yield() { ::sched_yield(); }
 uint32_t IRAM_ATTR HOT millis() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
@@ -19,7 +19,7 @@ uint32_t IRAM_ATTR HOT millis() {
   uint32_t ms = round(spec.tv_nsec / 1e6);
   return ((uint32_t) seconds) * 1000U + ms;
 }
-void IRAM_ATTR HOT delay(uint32_t ms) {
+void HOT delay(uint32_t ms) {
   struct timespec ts;
   ts.tv_sec = ms / 1000;
   ts.tv_nsec = (ms % 1000) * 1000000;

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -11,10 +11,10 @@ void loop();
 
 namespace esphome {
 
-void IRAM_ATTR HOT yield() { ::yield(); }
+void HOT yield() { ::yield(); }
 uint32_t IRAM_ATTR HOT millis() { return ::millis(); }
 uint32_t IRAM_ATTR HOT micros() { return ::micros(); }
-void IRAM_ATTR HOT delay(uint32_t ms) { ::delay(ms); }
+void HOT delay(uint32_t ms) { ::delay(ms); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { ::delayMicroseconds(us); }
 
 void arch_init() {

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -30,7 +30,7 @@ void arch_restart() {
   while (1) {
   }
 }
-void IRAM_ATTR HOT arch_feed_wdt() { lt_wdt_feed(); }
+void HOT arch_feed_wdt() { lt_wdt_feed(); }
 uint32_t arch_get_cpu_cycle_count() { return lt_cpu_get_cycle_count(); }
 uint32_t arch_get_cpu_freq_hz() { return lt_cpu_get_freq(); }
 uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }

--- a/esphome/components/rp2040/core.cpp
+++ b/esphome/components/rp2040/core.cpp
@@ -9,9 +9,9 @@
 
 namespace esphome {
 
-void IRAM_ATTR HOT yield() { ::yield(); }
+void HOT yield() { ::yield(); }
 uint32_t IRAM_ATTR HOT millis() { return ::millis(); }
-void IRAM_ATTR HOT delay(uint32_t ms) { ::delay(ms); }
+void HOT delay(uint32_t ms) { ::delay(ms); }
 uint32_t IRAM_ATTR HOT micros() { return ::micros(); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { delay_microseconds_safe(us); }
 void arch_restart() {

--- a/esphome/components/rp2040/core.cpp
+++ b/esphome/components/rp2040/core.cpp
@@ -27,7 +27,7 @@ void arch_init() {
 #endif
 }
 
-void IRAM_ATTR HOT arch_feed_wdt() { watchdog_update(); }
+void HOT arch_feed_wdt() { watchdog_update(); }
 
 uint8_t progmem_read_byte(const uint8_t *addr) {
   return pgm_read_byte(addr);  // NOLINT

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -240,7 +240,7 @@ void Application::process_dump_config_() {
   this->dump_config_at_++;
 }
 
-void IRAM_ATTR HOT Application::feed_wdt(uint32_t time) {
+void HOT Application::feed_wdt(uint32_t time) {
   static uint32_t last_feed = 0;
   // Use provided time if available, otherwise get current time
   uint32_t now = time ? time : millis();


### PR DESCRIPTION
# What does this implement/fix?

Remove `IRAM_ATTR` from `yield()`, `delay()`, `feed_wdt()`, and `arch_feed_wdt()` across all platforms (ESP32, ESP8266, RP2040, LibreTiny, Host).

**`yield()` and `delay()`:** Neither function can be called from ISR context or during flash operations:
- `yield()` calls `vPortYield()` (ESP32) / `::yield()` (ESP8266/others) — these are not ISR-safe. On ESP8266, `::yield()` explicitly calls `panic()` if invoked outside the continuation context.
- `delay()` calls `vTaskDelay()` (ESP32) / `::delay()` (ESP8266/others) — these block the calling task, which is undefined behavior in ISR context.

**`feed_wdt()` and `arch_feed_wdt()`:** The function body of `Application::feed_wdt()` calls `status_led::global_status_led->call()` which is a vtable dispatch into flash-resident code. On ESP32, `arch_feed_wdt()` calls `esp_task_wdt_reset()` which resides in `.flash.text`, not IRAM. Since the callee is in flash, placing the caller in IRAM provides no benefit — execution would crash at the callee if the flash cache were disabled.

All four functions got `IRAM_ATTR` as a blanket attribute when the HAL abstraction layer was created in 2021 (PR #2303), copying the pattern from `millis()` which does legitimately need IRAM placement.

Retains `HOT` attribute for compiler optimization hints.

**Platform-by-platform analysis:**

| Platform | `IRAM_ATTR` expands to | Impact of removal |
|----------|----------------------|-------------------|
| ESP32 | `section(".iram1")` (real IRAM) | Frees ~65 bytes of IRAM. Safe: `esp_task_wdt_reset()` is in `.flash.text`, `status_led->call()` is a vtable dispatch into flash, `vPortYield()`/`vTaskDelay()` are not ISR-safe. |
| ESP8266 | `ICACHE_RAM_ATTR` / `section(".iram.text")` | Frees ~22 bytes of IRAM. Safe: `::yield()` calls `panic()` outside continuation context, `::delay()` is in flash, `system_soft_wdt_feed()` wrapper can't help when `status_led->call()` is in flash. |
| RP2040 | `section(".time_critical")` (RAM) | Frees ~22 bytes of RAM. Safe: `::yield()`, `::delay()`, and `watchdog_update()` are Arduino core functions in flash — a `.time_critical` wrapper around a flash callee is pointless. |
| LibreTiny | Empty macro (no-op) | No effect — `IRAM_ATTR` is already a no-op on this platform (note: this means `millis()` etc. are also not in a special section on LibreTiny). |
| Host | Empty macro (no-op) | No effect — `IRAM_ATTR` is already a no-op on this platform. |

**Memory impact:**
- ESP8266: -8 bytes flash (CI measured, first commit only)
- ESP32 IDF: frees ~65 bytes of IRAM (not measured by CI since the memory impact analysis runs on ESP8266)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change - internal cleanup only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).