### PR TITLE
[web_server] Fix water_heater JSON key names and move traits to DETAIL_ALL

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1922,6 +1922,9 @@ std::string WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDe
     JsonArray modes = root[ESPHOME_F("modes")].to<JsonArray>();
     for (auto m : traits.get_supported_modes())
       modes.add(PSTR_LOCAL(water_heater::water_heater_mode_to_string(m)));
+    root[ESPHOME_F("min_temp")] = traits.get_min_temperature();
+    root[ESPHOME_F("max_temp")] = traits.get_max_temperature();
+    root[ESPHOME_F("step")] = traits.get_target_temperature_step();
     this->add_sorting_info_(root, obj);
   }
 
@@ -1943,10 +1946,6 @@ std::string WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDe
     if (!std::isnan(target))
       root[ESPHOME_F("target_temperature")] = target;
   }
-
-  root[ESPHOME_F("min_temperature")] = traits.get_min_temperature();
-  root[ESPHOME_F("max_temperature")] = traits.get_max_temperature();
-  root[ESPHOME_F("step")] = traits.get_target_temperature_step();
 
   if (traits.get_supports_away_mode()) {
     root[ESPHOME_F("away")] = obj->is_away();


### PR DESCRIPTION
# What does this implement/fix?

Fixes two issues with the water_heater web server JSON, discovered while reviewing https://github.com/esphome/esphome/pull/14061:

1. **Wrong JSON key names**: The backend sent `min_temperature`/`max_temperature` but the [frontend expects `min_temp`/`max_temp`](https://github.com/esphome/esphome-webserver/blob/da8a30b75a5219d4e589e5da28761f60cc8be067/packages/v3/src/esp-entity-table.ts#L873-L901), so slider range limits never worked for water_heater entities.

2. **Static traits sent on every state update**: `min_temp`, `max_temp`, and `step` are static traits that never change at runtime. They were being included in every `DETAIL_STATE` SSE event instead of only in the initial `DETAIL_ALL` event. The frontend uses `Object.assign()` to merge SSE updates, so traits from the initial connection persist automatically. Other entity types (number, select, light) already correctly gate their traits behind `DETAIL_ALL`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/pull/14061

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes the web server JSON output
water_heater:
  - platform: ...
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

  Existing web_server component tests pass on all 4 platforms (esp32-ard, esp32-idf, esp8266-ard, rp2040-ard).