### PR TITLE
[web_server] Move climate static traits to DETAIL_ALL only

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1546,16 +1546,16 @@ std::string WebServer::climate_json_(climate::Climate *obj, JsonDetail start_con
       for (auto const &custom_preset : traits.get_supported_custom_presets())
         opt.add(custom_preset);
     }
+    root[ESPHOME_F("max_temp")] =
+        (value_accuracy_to_buf(temp_buf, traits.get_visual_max_temperature(), target_accuracy), temp_buf);
+    root[ESPHOME_F("min_temp")] =
+        (value_accuracy_to_buf(temp_buf, traits.get_visual_min_temperature(), target_accuracy), temp_buf);
+    root[ESPHOME_F("step")] = traits.get_visual_target_temperature_step();
     this->add_sorting_info_(root, obj);
   }
 
   bool has_state = false;
   root[ESPHOME_F("mode")] = PSTR_LOCAL(climate_mode_to_string(obj->mode));
-  root[ESPHOME_F("max_temp")] =
-      (value_accuracy_to_buf(temp_buf, traits.get_visual_max_temperature(), target_accuracy), temp_buf);
-  root[ESPHOME_F("min_temp")] =
-      (value_accuracy_to_buf(temp_buf, traits.get_visual_min_temperature(), target_accuracy), temp_buf);
-  root[ESPHOME_F("step")] = traits.get_visual_target_temperature_step();
   if (traits.has_feature_flags(climate::CLIMATE_SUPPORTS_ACTION)) {
     root[ESPHOME_F("action")] = PSTR_LOCAL(climate_action_to_string(obj->action));
     root[ESPHOME_F("state")] = root[ESPHOME_F("action")];


### PR DESCRIPTION
# What does this implement/fix?

Moves `max_temp`, `min_temp`, and `step` into the `DETAIL_ALL` block in `climate_json_()` so they are only sent once on initial client connection instead of on every state update.

These are static visual configuration traits that never change at runtime. The frontend preserves them via `Object.assign()` from the initial `state_detail_all` event — the same pattern already used by number, select, light, and switch entities.

This reduces the climate `DETAIL_STATE` payload by ~47 bytes, keeping it well under the 512-byte threshold for stack-first serialization (#13625).

Discovered while reviewing https://github.com/esphome/esphome/pull/14061.

Frontend reference showing `min_temp`/`max_temp`/`step` usage in the climate card: https://github.com/esphome/esphome-webserver/blob/da8a30b75a5219d4e589e5da28761f60cc8be067/packages/v3/src/esp-entity-table.ts#L771-L841

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/pull/14061
- Related to https://github.com/esphome/esphome/pull/13625

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this optimizes the web server JSON output
climate:
  - platform: ...
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

  Existing web_server component tests pass on all 4 platforms (esp32-ard, esp32-idf, esp8266-ard, rp2040-ard).