### PR TITLE
[web_server] Double socket allocation to prevent connection exhaustion

### DIFF
--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -144,9 +144,10 @@ def _consume_web_server_sockets(config: ConfigType) -> ConfigType:
     """Register socket needs for web_server component."""
     from esphome.components import socket
 
-    # Web server needs 1 listening socket + typically 2 concurrent client connections
-    # (browser makes 2 connections for page + event stream)
-    sockets_needed = 3
+    # Web server needs 1 listening socket + typically 5 concurrent client connections
+    # (browser opens connections for page resources, SSE event stream, and POST
+    # requests for entity control which may linger before closing)
+    sockets_needed = 6
     socket.consume_sockets(sockets_needed, "web_server")(config)
     return config
 


### PR DESCRIPTION
# What does this implement/fix?

Double the web_server socket allocation from 3 to 6 to prevent `httpd_accept_conn: error in accept (23)` errors.

Browsers open multiple concurrent connections for page resources, the SSE event stream, and POST requests for entity control (toggle, slider changes, etc.). The POST connections may linger before closing, quickly exhausting the socket pool when only 3 sockets are allocated. This causes ENFILE errors and the web server becomes unresponsive.

Changing from 3 (1 listening + 2 client) to 6 (1 listening + 5 client) provides enough headroom for concurrent SSE + POST operations.

fixes #13645

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal change, no user-facing configuration)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - automatic socket allocation
web_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes