### PR TITLE
[udp] Register socket consumption for CONFIG_LWIP_MAX_SOCKETS

### DIFF
--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -14,6 +14,7 @@ import esphome.config_validation as cv
 from esphome.const import CONF_DATA, CONF_ID, CONF_PORT, CONF_TRIGGER_ID
 from esphome.core import ID
 from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@clydebarrow"]
 DEPENDENCIES = ["network"]
@@ -66,7 +67,7 @@ RELOCATED = {
 }
 
 
-def _consume_udp_sockets(config: cv.ConfigType) -> cv.ConfigType:
+def _consume_udp_sockets(config: ConfigType) -> ConfigType:
     """Register socket needs for UDP component."""
     from esphome.components import socket
 

--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -65,33 +65,47 @@ RELOCATED = {
     )
 }
 
-CONFIG_SCHEMA = cv.COMPONENT_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(UDPComponent),
-        cv.Optional(CONF_PORT, default=18511): cv.Any(
-            cv.port,
-            cv.Schema(
+
+def _consume_udp_sockets(config: cv.ConfigType) -> cv.ConfigType:
+    """Register socket needs for UDP component."""
+    from esphome.components import socket
+
+    # UDP uses up to 2 sockets: 1 broadcast + 1 listen
+    # Whether each is used depends on code generation, so register worst case
+    socket.consume_sockets(2, "udp")(config)
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.COMPONENT_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(UDPComponent),
+            cv.Optional(CONF_PORT, default=18511): cv.Any(
+                cv.port,
+                cv.Schema(
+                    {
+                        cv.Required(CONF_LISTEN_PORT): cv.port,
+                        cv.Required(CONF_BROADCAST_PORT): cv.port,
+                    }
+                ),
+            ),
+            cv.Optional(
+                CONF_LISTEN_ADDRESS, default="255.255.255.255"
+            ): cv.ipv4address_multi_broadcast,
+            cv.Optional(CONF_ADDRESSES, default=["255.255.255.255"]): cv.ensure_list(
+                cv.ipv4address,
+            ),
+            cv.Optional(CONF_ON_RECEIVE): automation.validate_automation(
                 {
-                    cv.Required(CONF_LISTEN_PORT): cv.port,
-                    cv.Required(CONF_BROADCAST_PORT): cv.port,
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                        Trigger.template(trigger_args)
+                    ),
                 }
             ),
-        ),
-        cv.Optional(
-            CONF_LISTEN_ADDRESS, default="255.255.255.255"
-        ): cv.ipv4address_multi_broadcast,
-        cv.Optional(CONF_ADDRESSES, default=["255.255.255.255"]): cv.ensure_list(
-            cv.ipv4address,
-        ),
-        cv.Optional(CONF_ON_RECEIVE): automation.validate_automation(
-            {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                    Trigger.template(trigger_args)
-                ),
-            }
-        ),
-    }
-).extend(RELOCATED)
+        }
+    ).extend(RELOCATED),
+    _consume_udp_sockets,
+)
 
 
 async def register_udp_client(var, config):


### PR DESCRIPTION
# What does this implement/fix?

The UDP component creates up to 2 sockets (`broadcast_socket_` + `listen_socket_`) on ESP32 IDF but did not register them with the socket consumption API. This could cause `CONFIG_LWIP_MAX_SOCKETS` to be set too low, leading to socket exhaustion at runtime.

**Note on SNTP:** LWIP has two layers: raw PCBs (`udp_new()`/`udp_sendto()`, governed by `CONFIG_LWIP_MAX_UDP_PCBS`) and the BSD socket API (`socket()`/`bind()`, governed by `CONFIG_LWIP_MAX_SOCKETS`). The SNTP component calls `esp_sntp_init()` which internally uses a raw UDP PCB, not the socket API, so it does not consume from the socket pool and does not need socket registration.

**Note on syslog:** The syslog component uses its parent UDP component's socket, so it is already covered by this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14031

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - socket consumption is automatic
udp:
  port: 18511
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes