### PR TITLE
[pulse_counter] Fix compilation on ESP32-C6/C5/H2/P4

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 #ifdef HAS_PCNT
-#include <esp_clk_tree.h>
+#include <esp_private/esp_clk.h>
 #include <hal/pcnt_ll.h>
 #endif
 
@@ -117,9 +117,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint32_t apb_freq;
-    esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
-    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / apb_freq;
+    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / (uint32_t) esp_clk_apb_freq();
     pcnt_glitch_filter_config_t filter_config = {
         .max_glitch_ns = std::min(this->filter_us * 1000u, max_glitch_ns),
     };


### PR DESCRIPTION
# What does this implement/fix?

Fixes compilation error on ESP32-C6 (and C5, H2, P4) where `SOC_MOD_CLK_APB` does not exist in the `soc_module_clk_t` enum. These newer variants removed the APB clock enum entry — C6 has `SOC_MOD_CLK_PLL_F80M` instead.

#13908 replaced `esp_clk_apb_freq()` with `esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ...)` for the PCNT glitch filter calculation. While the `esp_clk_tree` migration was correct for the RMT components (using `RMT_CLK_SRC_DEFAULT`), PCNT has no equivalent portable clock source enum.

This reverts the pulse_counter portion back to `esp_clk_apb_freq()` from `esp_private/esp_clk.h`, which is the approach introduced in #13904. Sorry @swoboda1337 — I shouldn't have pushed back on the private API usage in #13908. It turns out `esp_clk_apb_freq()` is what the ESP-IDF PCNT driver itself uses internally for glitch filter calculation (`pulse_cnt.c:404`), it works correctly on all ESP32 variants, and there's simply no public API equivalent. It's what we're stuck with until Espressif provides one.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14069

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pulse_counter
    pin: GPIO18
    name: "Pulse Counter"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).