### PR TITLE
[core] Use constexpr for compile-time constants

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -111,7 +111,7 @@ namespace esphome {
 // For reboots, it's more important to shut down quickly than disconnect cleanly
 // since we're not entering deep sleep. The only consequence of not shutting down
 // cleanly is a warning in the log.
-static const uint32_t TEARDOWN_TIMEOUT_REBOOT_MS = 1000;  // 1 second for quick reboot
+static constexpr uint32_t TEARDOWN_TIMEOUT_REBOOT_MS = 1000;  // 1 second for quick reboot
 
 class Application {
  public:

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -846,9 +846,9 @@ void IRAM_ATTR HOT delay_microseconds_safe(uint32_t us) {
   // avoids CPU locks that could trigger WDT or affect WiFi/BT stability
   uint32_t start = micros();
 
-  const uint32_t lag = 5000;  // microseconds, specifies the maximum time for a CPU busy-loop.
-                              // it must be larger than the worst-case duration of a delay(1) call (hardware tasks)
-                              // 5ms is conservative, it could be reduced when exact BT/WiFi stack delays are known
+  constexpr uint32_t lag = 5000;  // microseconds, specifies the maximum time for a CPU busy-loop.
+                                  // it must be larger than the worst-case duration of a delay(1) call (hardware tasks)
+                                  // 5ms is conservative, it could be reduced when exact BT/WiFi stack delays are known
   if (us > lag) {
     delay((us - lag) / 1000UL);  // note: in disabled-interrupt contexts delay() won't actually sleep
     while (micros() - start < us - lag)

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -728,7 +728,7 @@ uint64_t Scheduler::millis_64_(uint32_t now) {
 
   // Define a safe window around the rollover point (10 seconds)
   // This covers any reasonable scheduler delays or thread preemption
-  static const uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
+  static constexpr uint32_t ROLLOVER_WINDOW = 10000;  // 10 seconds in milliseconds
 
   // Check if we're near the rollover boundary (close to std::numeric_limits<uint32_t>::max() or just past 0)
   bool near_rollover = (last > (std::numeric_limits<uint32_t>::max() - ROLLOVER_WINDOW)) || (now < ROLLOVER_WINDOW);


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for integer constants initialized with literal values in core files to enable compile-time evaluation.

- `application.h`: `TEARDOWN_TIMEOUT_REBOOT_MS`
- `scheduler.cpp`: `ROLLOVER_WINDOW`
- `helpers.cpp`: `lag`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).