### PR TITLE
[bluetooth_proxy][esp32_ble_client][esp32_ble_server] Use constexpr for compile-time constants

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -35,8 +35,8 @@ using namespace esp32_ble_client;
 // Version 3: New connection API
 // Version 4: Pairing support
 // Version 5: Cache clear support
-static const uint32_t LEGACY_ACTIVE_CONNECTIONS_VERSION = 5;
-static const uint32_t LEGACY_PASSIVE_ONLY_VERSION = 1;
+static constexpr uint32_t LEGACY_ACTIVE_CONNECTIONS_VERSION = 5;
+static constexpr uint32_t LEGACY_PASSIVE_ONLY_VERSION = 1;
 
 enum BluetoothProxyFeature : uint32_t {
   FEATURE_PASSIVE_SCAN = 1 << 0,

--- a/esphome/components/esp32_ble_client/ble_client_base.cpp
+++ b/esphome/components/esp32_ble_client/ble_client_base.cpp
@@ -16,17 +16,17 @@ static const char *const TAG = "esp32_ble_client";
 // Intermediate connection parameters for standard operation
 // ESP-IDF defaults (12.5-15ms) are too slow for stable connections through WiFi-based BLE proxies,
 // causing disconnections. These medium parameters balance responsiveness with bandwidth usage.
-static const uint16_t MEDIUM_MIN_CONN_INTERVAL = 0x07;  // 7 * 1.25ms = 8.75ms
-static const uint16_t MEDIUM_MAX_CONN_INTERVAL = 0x09;  // 9 * 1.25ms = 11.25ms
+static constexpr uint16_t MEDIUM_MIN_CONN_INTERVAL = 0x07;  // 7 * 1.25ms = 8.75ms
+static constexpr uint16_t MEDIUM_MAX_CONN_INTERVAL = 0x09;  // 9 * 1.25ms = 11.25ms
 // The timeout value was increased from 6s to 8s to address stability issues observed
 // in certain BLE devices when operating through WiFi-based BLE proxies. The longer
 // timeout reduces the likelihood of disconnections during periods of high latency.
-static const uint16_t MEDIUM_CONN_TIMEOUT = 800;  // 800 * 10ms = 8s
+static constexpr uint16_t MEDIUM_CONN_TIMEOUT = 800;  // 800 * 10ms = 8s
 
 // Fastest connection parameters for devices with short discovery timeouts
-static const uint16_t FAST_MIN_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms (BLE minimum)
-static const uint16_t FAST_MAX_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms
-static const uint16_t FAST_CONN_TIMEOUT = 1000;       // 1000 * 10ms = 10s
+static constexpr uint16_t FAST_MIN_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms (BLE minimum)
+static constexpr uint16_t FAST_MAX_CONN_INTERVAL = 0x06;  // 6 * 1.25ms = 7.5ms
+static constexpr uint16_t FAST_CONN_TIMEOUT = 1000;       // 1000 * 10ms = 10s
 static const esp_bt_uuid_t NOTIFY_DESC_UUID = {
     .len = ESP_UUID_LEN_16,
     .uuid =

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -57,12 +57,12 @@ class BLECharacteristic {
   ESPBTUUID get_uuid() { return this->uuid_; }
   std::vector<uint8_t> &get_value() { return this->value_; }
 
-  static const uint32_t PROPERTY_READ = 1 << 0;
-  static const uint32_t PROPERTY_WRITE = 1 << 1;
-  static const uint32_t PROPERTY_NOTIFY = 1 << 2;
-  static const uint32_t PROPERTY_BROADCAST = 1 << 3;
-  static const uint32_t PROPERTY_INDICATE = 1 << 4;
-  static const uint32_t PROPERTY_WRITE_NR = 1 << 5;
+  static constexpr uint32_t PROPERTY_READ = 1 << 0;
+  static constexpr uint32_t PROPERTY_WRITE = 1 << 1;
+  static constexpr uint32_t PROPERTY_NOTIFY = 1 << 2;
+  static constexpr uint32_t PROPERTY_BROADCAST = 1 << 3;
+  static constexpr uint32_t PROPERTY_INDICATE = 1 << 4;
+  static constexpr uint32_t PROPERTY_WRITE_NR = 1 << 5;
 
   bool is_created();
   bool is_failed();


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for integer constants initialized with literal values to enable compile-time evaluation.

- `bluetooth_proxy.h`: `LEGACY_ACTIVE_CONNECTIONS_VERSION`, `LEGACY_PASSIVE_ONLY_VERSION`
- `esp32_ble_client/ble_client_base.cpp`: connection interval/timeout constants
- `esp32_ble_server/ble_characteristic.h`: `PROPERTY_*` constants

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).