### PR TITLE
[packet_transport] Use constexpr for compile-time constants

### DIFF
--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -58,9 +58,9 @@ union FuData {
   float f32;
 };
 
-static const uint16_t MAGIC_NUMBER = 0x4553;
-static const uint16_t MAGIC_PING = 0x5048;
-static const uint32_t PREF_HASH = 0x45535043;
+static constexpr uint16_t MAGIC_NUMBER = 0x4553;
+static constexpr uint16_t MAGIC_PING = 0x5048;
+static constexpr uint32_t PREF_HASH = 0x45535043;
 enum DataKey {
   ZERO_FILL_KEY,
   DATA_KEY,


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for integer constants initialized with literal values to enable compile-time evaluation.

- `MAGIC_NUMBER`, `MAGIC_PING`, `PREF_HASH`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).