### PR TITLE
[mqtt] Use constexpr for compile-time constants

### DIFF
--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -114,11 +114,11 @@ struct QueueElement {
 
 class MQTTBackendESP32 final : public MQTTBackend {
  public:
-  static const size_t MQTT_BUFFER_SIZE = 4096;
-  static const size_t TASK_STACK_SIZE = 3072;
-  static const size_t TASK_STACK_SIZE_TLS = 4096;  // Larger stack for TLS operations
-  static const ssize_t TASK_PRIORITY = 5;
-  static const uint8_t MQTT_QUEUE_LENGTH = 30;  // 30*12 bytes = 360
+  static constexpr size_t MQTT_BUFFER_SIZE = 4096;
+  static constexpr size_t TASK_STACK_SIZE = 3072;
+  static constexpr size_t TASK_STACK_SIZE_TLS = 4096;  // Larger stack for TLS operations
+  static constexpr ssize_t TASK_PRIORITY = 5;
+  static constexpr uint8_t MQTT_QUEUE_LENGTH = 30;  // 30*12 bytes = 360
 
   void set_keep_alive(uint16_t keep_alive) final { this->keep_alive_ = keep_alive; }
   void set_client_id(const char *client_id) final { this->client_id_ = client_id; }


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for compile-time constants in `mqtt_backend_esp32.h`:

- `MQTT_BUFFER_SIZE`, `TASK_STACK_SIZE`, `TASK_STACK_SIZE_TLS`, `TASK_PRIORITY`, `MQTT_QUEUE_LENGTH`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).