### PR TITLE
[remote_base] Use constexpr for compile-time constants

### DIFF
--- a/esphome/components/remote_base/abbwelcome_protocol.cpp
+++ b/esphome/components/remote_base/abbwelcome_protocol.cpp
@@ -6,10 +6,10 @@ namespace remote_base {
 
 static const char *const TAG = "remote.abbwelcome";
 
-static const uint32_t BIT_ONE_SPACE_US = 102;
-static const uint32_t BIT_ZERO_MARK_US = 32;  // 18-44
-static const uint32_t BIT_ZERO_SPACE_US = BIT_ONE_SPACE_US - BIT_ZERO_MARK_US;
-static const uint16_t BYTE_SPACE_US = 210;
+static constexpr uint32_t BIT_ONE_SPACE_US = 102;
+static constexpr uint32_t BIT_ZERO_MARK_US = 32;  // 18-44
+static constexpr uint32_t BIT_ZERO_SPACE_US = BIT_ONE_SPACE_US - BIT_ZERO_MARK_US;
+static constexpr uint16_t BYTE_SPACE_US = 210;
 
 uint8_t ABBWelcomeData::calc_cs_() const {
   uint8_t checksum = 0;

--- a/esphome/components/remote_base/abbwelcome_protocol.h
+++ b/esphome/components/remote_base/abbwelcome_protocol.h
@@ -11,8 +11,8 @@
 namespace esphome {
 namespace remote_base {
 
-static const uint8_t MAX_DATA_LENGTH = 15;
-static const uint8_t DATA_LENGTH_MASK = 0x3f;
+static constexpr uint8_t MAX_DATA_LENGTH = 15;
+static constexpr uint8_t DATA_LENGTH_MASK = 0x3f;
 
 /*
 Message Format:

--- a/esphome/components/remote_base/aeha_protocol.cpp
+++ b/esphome/components/remote_base/aeha_protocol.cpp
@@ -7,13 +7,13 @@ namespace remote_base {
 
 static const char *const TAG = "remote.aeha";
 
-static const uint16_t BITWISE = 425;
-static const uint16_t HEADER_HIGH_US = BITWISE * 8;
-static const uint16_t HEADER_LOW_US = BITWISE * 4;
-static const uint16_t BIT_HIGH_US = BITWISE;
-static const uint16_t BIT_ONE_LOW_US = BITWISE * 3;
-static const uint16_t BIT_ZERO_LOW_US = BITWISE;
-static const uint16_t TRAILER = BITWISE;
+static constexpr uint16_t BITWISE = 425;
+static constexpr uint16_t HEADER_HIGH_US = BITWISE * 8;
+static constexpr uint16_t HEADER_LOW_US = BITWISE * 4;
+static constexpr uint16_t BIT_HIGH_US = BITWISE;
+static constexpr uint16_t BIT_ONE_LOW_US = BITWISE * 3;
+static constexpr uint16_t BIT_ZERO_LOW_US = BITWISE;
+static constexpr uint16_t TRAILER = BITWISE;
 
 void AEHAProtocol::encode(RemoteTransmitData *dst, const AEHAData &data) {
   dst->reserve(2 + 32 + (data.data.size() * 2) + 1);

--- a/esphome/components/remote_base/byronsx_protocol.cpp
+++ b/esphome/components/remote_base/byronsx_protocol.cpp
@@ -8,11 +8,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.byronsx";
 
-static const uint32_t BIT_TIME_US = 333;
-static const uint8_t NBITS_ADDRESS = 8;
-static const uint8_t NBITS_COMMAND = 4;
-static const uint8_t NBITS_START_BIT = 1;
-static const uint8_t NBITS_DATA = NBITS_ADDRESS + NBITS_COMMAND /*+ NBITS_COMMAND*/;
+static constexpr uint32_t BIT_TIME_US = 333;
+static constexpr uint8_t NBITS_ADDRESS = 8;
+static constexpr uint8_t NBITS_COMMAND = 4;
+static constexpr uint8_t NBITS_START_BIT = 1;
+static constexpr uint8_t NBITS_DATA = NBITS_ADDRESS + NBITS_COMMAND /*+ NBITS_COMMAND*/;
 
 /*
 ByronSX Protocol

--- a/esphome/components/remote_base/canalsat_protocol.cpp
+++ b/esphome/components/remote_base/canalsat_protocol.cpp
@@ -7,10 +7,10 @@ namespace remote_base {
 static const char *const CANALSAT_TAG = "remote.canalsat";
 static const char *const CANALSATLD_TAG = "remote.canalsatld";
 
-static const uint16_t CANALSAT_FREQ = 55500;
-static const uint16_t CANALSATLD_FREQ = 56000;
-static const uint16_t CANALSAT_UNIT = 250;
-static const uint16_t CANALSATLD_UNIT = 320;
+static constexpr uint16_t CANALSAT_FREQ = 55500;
+static constexpr uint16_t CANALSATLD_FREQ = 56000;
+static constexpr uint16_t CANALSAT_UNIT = 250;
+static constexpr uint16_t CANALSATLD_UNIT = 320;
 
 CanalSatProtocol::CanalSatProtocol() {
   this->frequency_ = CANALSAT_FREQ;

--- a/esphome/components/remote_base/dish_protocol.cpp
+++ b/esphome/components/remote_base/dish_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.dish";
 
-static const uint32_t HEADER_HIGH_US = 400;
-static const uint32_t HEADER_LOW_US = 6100;
-static const uint32_t BIT_HIGH_US = 400;
-static const uint32_t BIT_ONE_LOW_US = 1700;
-static const uint32_t BIT_ZERO_LOW_US = 2800;
+static constexpr uint32_t HEADER_HIGH_US = 400;
+static constexpr uint32_t HEADER_LOW_US = 6100;
+static constexpr uint32_t BIT_HIGH_US = 400;
+static constexpr uint32_t BIT_ONE_LOW_US = 1700;
+static constexpr uint32_t BIT_ZERO_LOW_US = 2800;
 
 void DishProtocol::encode(RemoteTransmitData *dst, const DishData &data) {
   dst->reserve(138);

--- a/esphome/components/remote_base/dooya_protocol.cpp
+++ b/esphome/components/remote_base/dooya_protocol.cpp
@@ -6,12 +6,12 @@ namespace remote_base {
 
 static const char *const TAG = "remote.dooya";
 
-static const uint32_t HEADER_HIGH_US = 5000;
-static const uint32_t HEADER_LOW_US = 1500;
-static const uint32_t BIT_ZERO_HIGH_US = 350;
-static const uint32_t BIT_ZERO_LOW_US = 750;
-static const uint32_t BIT_ONE_HIGH_US = 750;
-static const uint32_t BIT_ONE_LOW_US = 350;
+static constexpr uint32_t HEADER_HIGH_US = 5000;
+static constexpr uint32_t HEADER_LOW_US = 1500;
+static constexpr uint32_t BIT_ZERO_HIGH_US = 350;
+static constexpr uint32_t BIT_ZERO_LOW_US = 750;
+static constexpr uint32_t BIT_ONE_HIGH_US = 750;
+static constexpr uint32_t BIT_ONE_LOW_US = 350;
 
 void DooyaProtocol::encode(RemoteTransmitData *dst, const DooyaData &data) {
   dst->set_carrier_frequency(0);

--- a/esphome/components/remote_base/drayton_protocol.cpp
+++ b/esphome/components/remote_base/drayton_protocol.cpp
@@ -8,18 +8,18 @@ namespace remote_base {
 
 static const char *const TAG = "remote.drayton";
 
-static const uint32_t BIT_TIME_US = 500;
-static const uint8_t CARRIER_KHZ = 2;
-static const uint8_t NBITS_PREAMBLE = 12;
-static const uint8_t NBITS_SYNC = 4;
-static const uint8_t NBITS_ADDRESS = 16;
-static const uint8_t NBITS_CHANNEL = 5;
-static const uint8_t NBITS_COMMAND = 7;
-static const uint8_t NDATABITS = NBITS_ADDRESS + NBITS_CHANNEL + NBITS_COMMAND;
-static const uint8_t MIN_RX_SRC = (NDATABITS + NBITS_SYNC / 2);
+static constexpr uint32_t BIT_TIME_US = 500;
+static constexpr uint8_t CARRIER_KHZ = 2;
+static constexpr uint8_t NBITS_PREAMBLE = 12;
+static constexpr uint8_t NBITS_SYNC = 4;
+static constexpr uint8_t NBITS_ADDRESS = 16;
+static constexpr uint8_t NBITS_CHANNEL = 5;
+static constexpr uint8_t NBITS_COMMAND = 7;
+static constexpr uint8_t NDATABITS = NBITS_ADDRESS + NBITS_CHANNEL + NBITS_COMMAND;
+static constexpr uint8_t MIN_RX_SRC = (NDATABITS + NBITS_SYNC / 2);
 
-static const uint8_t CMD_ON = 0x41;
-static const uint8_t CMD_OFF = 0x02;
+static constexpr uint8_t CMD_ON = 0x41;
+static constexpr uint8_t CMD_OFF = 0x02;
 
 /*
 Drayton Protocol

--- a/esphome/components/remote_base/jvc_protocol.cpp
+++ b/esphome/components/remote_base/jvc_protocol.cpp
@@ -6,12 +6,12 @@ namespace remote_base {
 
 static const char *const TAG = "remote.jvc";
 
-static const uint8_t NBITS = 16;
-static const uint32_t HEADER_HIGH_US = 8400;
-static const uint32_t HEADER_LOW_US = 4200;
-static const uint32_t BIT_ONE_LOW_US = 1725;
-static const uint32_t BIT_ZERO_LOW_US = 525;
-static const uint32_t BIT_HIGH_US = 525;
+static constexpr uint8_t NBITS = 16;
+static constexpr uint32_t HEADER_HIGH_US = 8400;
+static constexpr uint32_t HEADER_LOW_US = 4200;
+static constexpr uint32_t BIT_ONE_LOW_US = 1725;
+static constexpr uint32_t BIT_ZERO_LOW_US = 525;
+static constexpr uint32_t BIT_HIGH_US = 525;
 
 void JVCProtocol::encode(RemoteTransmitData *dst, const JVCData &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/keeloq_protocol.cpp
+++ b/esphome/components/remote_base/keeloq_protocol.cpp
@@ -8,18 +8,18 @@ namespace remote_base {
 
 static const char *const TAG = "remote.keeloq";
 
-static const uint32_t BIT_TIME_US = 380;
-static const uint8_t NBITS_PREAMBLE = 12;
-static const uint8_t NBITS_REPEAT = 1;
-static const uint8_t NBITS_VLOW = 1;
-static const uint8_t NBITS_SERIAL = 28;
-static const uint8_t NBITS_BUTTONS = 4;
-static const uint8_t NBITS_DISC = 12;
-static const uint8_t NBITS_SYNC_CNT = 16;
+static constexpr uint32_t BIT_TIME_US = 380;
+static constexpr uint8_t NBITS_PREAMBLE = 12;
+static constexpr uint8_t NBITS_REPEAT = 1;
+static constexpr uint8_t NBITS_VLOW = 1;
+static constexpr uint8_t NBITS_SERIAL = 28;
+static constexpr uint8_t NBITS_BUTTONS = 4;
+static constexpr uint8_t NBITS_DISC = 12;
+static constexpr uint8_t NBITS_SYNC_CNT = 16;
 
-static const uint8_t NBITS_FIXED_DATA = NBITS_REPEAT + NBITS_VLOW + NBITS_BUTTONS + NBITS_SERIAL;
-static const uint8_t NBITS_ENCRYPTED_DATA = NBITS_BUTTONS + NBITS_DISC + NBITS_SYNC_CNT;
-static const uint8_t NBITS_DATA = NBITS_FIXED_DATA + NBITS_ENCRYPTED_DATA;
+static constexpr uint8_t NBITS_FIXED_DATA = NBITS_REPEAT + NBITS_VLOW + NBITS_BUTTONS + NBITS_SERIAL;
+static constexpr uint8_t NBITS_ENCRYPTED_DATA = NBITS_BUTTONS + NBITS_DISC + NBITS_SYNC_CNT;
+static constexpr uint8_t NBITS_DATA = NBITS_FIXED_DATA + NBITS_ENCRYPTED_DATA;
 
 /*
 KeeLoq Protocol

--- a/esphome/components/remote_base/lg_protocol.cpp
+++ b/esphome/components/remote_base/lg_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.lg";
 
-static const uint32_t HEADER_HIGH_US = 8000;
-static const uint32_t HEADER_LOW_US = 4000;
-static const uint32_t BIT_HIGH_US = 600;
-static const uint32_t BIT_ONE_LOW_US = 1600;
-static const uint32_t BIT_ZERO_LOW_US = 550;
+static constexpr uint32_t HEADER_HIGH_US = 8000;
+static constexpr uint32_t HEADER_LOW_US = 4000;
+static constexpr uint32_t BIT_HIGH_US = 600;
+static constexpr uint32_t BIT_ONE_LOW_US = 1600;
+static constexpr uint32_t BIT_ZERO_LOW_US = 550;
 
 void LGProtocol::encode(RemoteTransmitData *dst, const LGData &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/magiquest_protocol.cpp
+++ b/esphome/components/remote_base/magiquest_protocol.cpp
@@ -10,11 +10,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.magiquest";
 
-static const uint32_t MAGIQUEST_UNIT = 288;  // us
-static const uint32_t MAGIQUEST_ONE_MARK = 2 * MAGIQUEST_UNIT;
-static const uint32_t MAGIQUEST_ONE_SPACE = 2 * MAGIQUEST_UNIT;
-static const uint32_t MAGIQUEST_ZERO_MARK = MAGIQUEST_UNIT;
-static const uint32_t MAGIQUEST_ZERO_SPACE = 3 * MAGIQUEST_UNIT;
+static constexpr uint32_t MAGIQUEST_UNIT = 288;  // us
+static constexpr uint32_t MAGIQUEST_ONE_MARK = 2 * MAGIQUEST_UNIT;
+static constexpr uint32_t MAGIQUEST_ONE_SPACE = 2 * MAGIQUEST_UNIT;
+static constexpr uint32_t MAGIQUEST_ZERO_MARK = MAGIQUEST_UNIT;
+static constexpr uint32_t MAGIQUEST_ZERO_SPACE = 3 * MAGIQUEST_UNIT;
 
 void MagiQuestProtocol::encode(RemoteTransmitData *dst, const MagiQuestData &data) {
   dst->reserve(101);  // 2 start bits, 48 data bits, 1 stop bit

--- a/esphome/components/remote_base/midea_protocol.h
+++ b/esphome/components/remote_base/midea_protocol.h
@@ -62,7 +62,7 @@ class MideaData {
     this->data_[idx] |= (value << shift);
   }
   void set_mask_(uint8_t idx, bool state, uint8_t mask = 255) { this->set_value_(idx, state ? mask : 0, mask); }
-  static const uint8_t OFFSET_CS = 5;
+  static constexpr uint8_t OFFSET_CS = 5;
   // 48-bits data
   std::array<uint8_t, 6> data_;
   // Calculate checksum

--- a/esphome/components/remote_base/nec_protocol.cpp
+++ b/esphome/components/remote_base/nec_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.nec";
 
-static const uint32_t HEADER_HIGH_US = 9000;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 560;
-static const uint32_t BIT_ONE_LOW_US = 1690;
-static const uint32_t BIT_ZERO_LOW_US = 560;
+static constexpr uint32_t HEADER_HIGH_US = 9000;
+static constexpr uint32_t HEADER_LOW_US = 4500;
+static constexpr uint32_t BIT_HIGH_US = 560;
+static constexpr uint32_t BIT_ONE_LOW_US = 1690;
+static constexpr uint32_t BIT_ZERO_LOW_US = 560;
 
 void NECProtocol::encode(RemoteTransmitData *dst, const NECData &data) {
   ESP_LOGD(TAG, "Sending NEC: address=0x%04X, command=0x%04X command_repeats=%d", data.address, data.command,

--- a/esphome/components/remote_base/nexa_protocol.cpp
+++ b/esphome/components/remote_base/nexa_protocol.cpp
@@ -6,18 +6,18 @@ namespace remote_base {
 
 static const char *const TAG = "remote.nexa";
 
-static const uint8_t NBITS = 32;
-static const uint32_t HEADER_HIGH_US = 319;
-static const uint32_t HEADER_LOW_US = 2610;
-static const uint32_t BIT_HIGH_US = 319;
-static const uint32_t BIT_ONE_LOW_US = 1000;
-static const uint32_t BIT_ZERO_LOW_US = 140;
+static constexpr uint8_t NBITS = 32;
+static constexpr uint32_t HEADER_HIGH_US = 319;
+static constexpr uint32_t HEADER_LOW_US = 2610;
+static constexpr uint32_t BIT_HIGH_US = 319;
+static constexpr uint32_t BIT_ONE_LOW_US = 1000;
+static constexpr uint32_t BIT_ZERO_LOW_US = 140;
 
-static const uint32_t TX_HEADER_HIGH_US = 250;
-static const uint32_t TX_HEADER_LOW_US = TX_HEADER_HIGH_US * 10;
-static const uint32_t TX_BIT_HIGH_US = 250;
-static const uint32_t TX_BIT_ONE_LOW_US = TX_BIT_HIGH_US * 5;
-static const uint32_t TX_BIT_ZERO_LOW_US = TX_BIT_HIGH_US * 1;
+static constexpr uint32_t TX_HEADER_HIGH_US = 250;
+static constexpr uint32_t TX_HEADER_LOW_US = TX_HEADER_HIGH_US * 10;
+static constexpr uint32_t TX_BIT_HIGH_US = 250;
+static constexpr uint32_t TX_BIT_ONE_LOW_US = TX_BIT_HIGH_US * 5;
+static constexpr uint32_t TX_BIT_ZERO_LOW_US = TX_BIT_HIGH_US * 1;
 
 void NexaProtocol::one(RemoteTransmitData *dst) const {
   // '1' => '10'

--- a/esphome/components/remote_base/panasonic_protocol.cpp
+++ b/esphome/components/remote_base/panasonic_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.panasonic";
 
-static const uint32_t HEADER_HIGH_US = 3502;
-static const uint32_t HEADER_LOW_US = 1750;
-static const uint32_t BIT_HIGH_US = 502;
-static const uint32_t BIT_ZERO_LOW_US = 400;
-static const uint32_t BIT_ONE_LOW_US = 1244;
+static constexpr uint32_t HEADER_HIGH_US = 3502;
+static constexpr uint32_t HEADER_LOW_US = 1750;
+static constexpr uint32_t BIT_HIGH_US = 502;
+static constexpr uint32_t BIT_ZERO_LOW_US = 400;
+static constexpr uint32_t BIT_ONE_LOW_US = 1244;
 
 void PanasonicProtocol::encode(RemoteTransmitData *dst, const PanasonicData &data) {
   dst->reserve(100);

--- a/esphome/components/remote_base/pioneer_protocol.cpp
+++ b/esphome/components/remote_base/pioneer_protocol.cpp
@@ -6,12 +6,12 @@ namespace remote_base {
 
 static const char *const TAG = "remote.pioneer";
 
-static const uint32_t HEADER_HIGH_US = 9000;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 560;
-static const uint32_t BIT_ONE_LOW_US = 1690;
-static const uint32_t BIT_ZERO_LOW_US = 560;
-static const uint32_t TRAILER_SPACE_US = 25500;
+static constexpr uint32_t HEADER_HIGH_US = 9000;
+static constexpr uint32_t HEADER_LOW_US = 4500;
+static constexpr uint32_t BIT_HIGH_US = 560;
+static constexpr uint32_t BIT_ONE_LOW_US = 1690;
+static constexpr uint32_t BIT_ZERO_LOW_US = 560;
+static constexpr uint32_t TRAILER_SPACE_US = 25500;
 
 void PioneerProtocol::encode(RemoteTransmitData *dst, const PioneerData &data) {
   uint32_t address1 = ((data.rc_code_1 & 0xff00) | (~(data.rc_code_1 >> 8) & 0xff));

--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -59,18 +59,18 @@ bool ProntoData::operator==(const ProntoData &rhs) const {
 }
 
 // DO NOT EXPORT from this file
-static const uint16_t MICROSECONDS_T_MAX = 0xFFFFU;
-static const uint16_t LEARNED_TOKEN = 0x0000U;
-static const uint16_t LEARNED_NON_MODULATED_TOKEN = 0x0100U;
-static const uint16_t BITS_IN_HEXADECIMAL = 4U;
-static const uint16_t DIGITS_IN_PRONTO_NUMBER = 4U;
-static const uint16_t NUMBERS_IN_PREAMBLE = 4U;
-static const uint16_t HEX_MASK = 0xFU;
-static const uint32_t REFERENCE_FREQUENCY = 4145146UL;
-static const uint16_t FALLBACK_FREQUENCY = 64767U;  // To use with frequency = 0;
-static const uint32_t MICROSECONDS_IN_SECONDS = 1000000UL;
-static const uint16_t PRONTO_DEFAULT_GAP = 45000;
-static const uint16_t MARK_EXCESS_MICROS = 20;
+static constexpr uint16_t MICROSECONDS_T_MAX = 0xFFFFU;
+static constexpr uint16_t LEARNED_TOKEN = 0x0000U;
+static constexpr uint16_t LEARNED_NON_MODULATED_TOKEN = 0x0100U;
+static constexpr uint16_t BITS_IN_HEXADECIMAL = 4U;
+static constexpr uint16_t DIGITS_IN_PRONTO_NUMBER = 4U;
+static constexpr uint16_t NUMBERS_IN_PREAMBLE = 4U;
+static constexpr uint16_t HEX_MASK = 0xFU;
+static constexpr uint32_t REFERENCE_FREQUENCY = 4145146UL;
+static constexpr uint16_t FALLBACK_FREQUENCY = 64767U;  // To use with frequency = 0;
+static constexpr uint32_t MICROSECONDS_IN_SECONDS = 1000000UL;
+static constexpr uint16_t PRONTO_DEFAULT_GAP = 45000;
+static constexpr uint16_t MARK_EXCESS_MICROS = 20;
 static constexpr size_t PRONTO_LOG_CHUNK_SIZE = 230;
 
 static uint16_t to_frequency_k_hz(uint16_t code) {

--- a/esphome/components/remote_base/rc5_protocol.cpp
+++ b/esphome/components/remote_base/rc5_protocol.cpp
@@ -6,8 +6,8 @@ namespace remote_base {
 
 static const char *const TAG = "remote.rc5";
 
-static const uint32_t BIT_TIME_US = 889;
-static const uint8_t NBITS = 14;
+static constexpr uint32_t BIT_TIME_US = 889;
+static constexpr uint8_t NBITS = 14;
 
 void RC5Protocol::encode(RemoteTransmitData *dst, const RC5Data &data) {
   static bool toggle = false;

--- a/esphome/components/remote_base/rc6_protocol.cpp
+++ b/esphome/components/remote_base/rc6_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const RC6_TAG = "remote.rc6";
 
-static const uint16_t RC6_FREQ = 36000;
-static const uint16_t RC6_UNIT = 444;
-static const uint16_t RC6_HEADER_MARK = (6 * RC6_UNIT);
-static const uint16_t RC6_HEADER_SPACE = (2 * RC6_UNIT);
-static const uint16_t RC6_MODE_MASK = 0x07;
+static constexpr uint16_t RC6_FREQ = 36000;
+static constexpr uint16_t RC6_UNIT = 444;
+static constexpr uint16_t RC6_HEADER_MARK = (6 * RC6_UNIT);
+static constexpr uint16_t RC6_HEADER_SPACE = (2 * RC6_UNIT);
+static constexpr uint16_t RC6_MODE_MASK = 0x07;
 
 void RC6Protocol::encode(RemoteTransmitData *dst, const RC6Data &data) {
   dst->reserve(44);

--- a/esphome/components/remote_base/roomba_protocol.cpp
+++ b/esphome/components/remote_base/roomba_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.roomba";
 
-static const uint8_t NBITS = 8;
-static const uint32_t BIT_ONE_HIGH_US = 3000;
-static const uint32_t BIT_ONE_LOW_US = 1000;
-static const uint32_t BIT_ZERO_HIGH_US = BIT_ONE_LOW_US;
-static const uint32_t BIT_ZERO_LOW_US = BIT_ONE_HIGH_US;
+static constexpr uint8_t NBITS = 8;
+static constexpr uint32_t BIT_ONE_HIGH_US = 3000;
+static constexpr uint32_t BIT_ONE_LOW_US = 1000;
+static constexpr uint32_t BIT_ZERO_HIGH_US = BIT_ONE_LOW_US;
+static constexpr uint32_t BIT_ZERO_LOW_US = BIT_ONE_HIGH_US;
 
 void RoombaProtocol::encode(RemoteTransmitData *dst, const RoombaData &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/samsung36_protocol.cpp
+++ b/esphome/components/remote_base/samsung36_protocol.cpp
@@ -6,17 +6,17 @@ namespace remote_base {
 
 static const char *const TAG = "remote.samsung36";
 
-static const uint8_t NBITS = 78;
+static constexpr uint8_t NBITS = 78;
 
-static const uint32_t HEADER_HIGH_US = 4500;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 500;
-static const uint32_t BIT_ONE_LOW_US = 1500;
-static const uint32_t BIT_ZERO_LOW_US = 500;
-static const uint32_t MIDDLE_HIGH_US = 500;
-static const uint32_t MIDDLE_LOW_US = 4500;
-static const uint32_t FOOTER_HIGH_US = 500;
-static const uint32_t FOOTER_LOW_US = 59000;
+static constexpr uint32_t HEADER_HIGH_US = 4500;
+static constexpr uint32_t HEADER_LOW_US = 4500;
+static constexpr uint32_t BIT_HIGH_US = 500;
+static constexpr uint32_t BIT_ONE_LOW_US = 1500;
+static constexpr uint32_t BIT_ZERO_LOW_US = 500;
+static constexpr uint32_t MIDDLE_HIGH_US = 500;
+static constexpr uint32_t MIDDLE_LOW_US = 4500;
+static constexpr uint32_t FOOTER_HIGH_US = 500;
+static constexpr uint32_t FOOTER_LOW_US = 59000;
 
 void Samsung36Protocol::encode(RemoteTransmitData *dst, const Samsung36Data &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/samsung_protocol.cpp
+++ b/esphome/components/remote_base/samsung_protocol.cpp
@@ -7,13 +7,13 @@ namespace remote_base {
 
 static const char *const TAG = "remote.samsung";
 
-static const uint32_t HEADER_HIGH_US = 4500;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 560;
-static const uint32_t BIT_ONE_LOW_US = 1690;
-static const uint32_t BIT_ZERO_LOW_US = 560;
-static const uint32_t FOOTER_HIGH_US = 560;
-static const uint32_t FOOTER_LOW_US = 560;
+static constexpr uint32_t HEADER_HIGH_US = 4500;
+static constexpr uint32_t HEADER_LOW_US = 4500;
+static constexpr uint32_t BIT_HIGH_US = 560;
+static constexpr uint32_t BIT_ONE_LOW_US = 1690;
+static constexpr uint32_t BIT_ZERO_LOW_US = 560;
+static constexpr uint32_t FOOTER_HIGH_US = 560;
+static constexpr uint32_t FOOTER_LOW_US = 560;
 
 void SamsungProtocol::encode(RemoteTransmitData *dst, const SamsungData &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/sony_protocol.cpp
+++ b/esphome/components/remote_base/sony_protocol.cpp
@@ -6,11 +6,11 @@ namespace remote_base {
 
 static const char *const TAG = "remote.sony";
 
-static const uint32_t HEADER_HIGH_US = 2400;
-static const uint32_t HEADER_LOW_US = 600;
-static const uint32_t BIT_ONE_HIGH_US = 1200;
-static const uint32_t BIT_ZERO_HIGH_US = 600;
-static const uint32_t BIT_LOW_US = 600;
+static constexpr uint32_t HEADER_HIGH_US = 2400;
+static constexpr uint32_t HEADER_LOW_US = 600;
+static constexpr uint32_t BIT_ONE_HIGH_US = 1200;
+static constexpr uint32_t BIT_ZERO_HIGH_US = 600;
+static constexpr uint32_t BIT_LOW_US = 600;
 
 void SonyProtocol::encode(RemoteTransmitData *dst, const SonyData &data) {
   dst->set_carrier_frequency(40000);

--- a/esphome/components/remote_base/symphony_protocol.cpp
+++ b/esphome/components/remote_base/symphony_protocol.cpp
@@ -13,16 +13,16 @@ static const char *const TAG = "remote.symphony";
 // footer-gap handling used there.
 
 // Symphony protocol timing specifications (tuned to handset captures)
-static const uint32_t BIT_ZERO_HIGH_US = 460;  // short
-static const uint32_t BIT_ZERO_LOW_US = 1260;  // long
-static const uint32_t BIT_ONE_HIGH_US = 1260;  // long
-static const uint32_t BIT_ONE_LOW_US = 460;    // short
-static const uint32_t CARRIER_FREQUENCY = 38000;
+static constexpr uint32_t BIT_ZERO_HIGH_US = 460;  // short
+static constexpr uint32_t BIT_ZERO_LOW_US = 1260;  // long
+static constexpr uint32_t BIT_ONE_HIGH_US = 1260;  // long
+static constexpr uint32_t BIT_ONE_LOW_US = 460;    // short
+static constexpr uint32_t CARRIER_FREQUENCY = 38000;
 
 // IRremoteESP8266 reference: kSymphonyFooterGap = 4 * (mark + space)
-static const uint32_t FOOTER_GAP_US = 4 * (BIT_ZERO_HIGH_US + BIT_ZERO_LOW_US);
+static constexpr uint32_t FOOTER_GAP_US = 4 * (BIT_ZERO_HIGH_US + BIT_ZERO_LOW_US);
 // Typical inter-frame gap (~34.8 ms observed)
-static const uint32_t INTER_FRAME_GAP_US = 34760;
+static constexpr uint32_t INTER_FRAME_GAP_US = 34760;
 
 void SymphonyProtocol::encode(RemoteTransmitData *dst, const SymphonyData &data) {
   dst->set_carrier_frequency(CARRIER_FREQUENCY);

--- a/esphome/components/remote_base/toshiba_ac_protocol.cpp
+++ b/esphome/components/remote_base/toshiba_ac_protocol.cpp
@@ -7,14 +7,14 @@ namespace remote_base {
 
 static const char *const TAG = "remote.toshibaac";
 
-static const uint32_t HEADER_HIGH_US = 4500;
-static const uint32_t HEADER_LOW_US = 4500;
-static const uint32_t BIT_HIGH_US = 560;
-static const uint32_t BIT_ONE_LOW_US = 1690;
-static const uint32_t BIT_ZERO_LOW_US = 560;
-static const uint32_t FOOTER_HIGH_US = 560;
-static const uint32_t FOOTER_LOW_US = 4500;
-static const uint16_t PACKET_SPACE = 5500;
+static constexpr uint32_t HEADER_HIGH_US = 4500;
+static constexpr uint32_t HEADER_LOW_US = 4500;
+static constexpr uint32_t BIT_HIGH_US = 560;
+static constexpr uint32_t BIT_ONE_LOW_US = 1690;
+static constexpr uint32_t BIT_ZERO_LOW_US = 560;
+static constexpr uint32_t FOOTER_HIGH_US = 560;
+static constexpr uint32_t FOOTER_LOW_US = 4500;
+static constexpr uint16_t PACKET_SPACE = 5500;
 
 void ToshibaAcProtocol::encode(RemoteTransmitData *dst, const ToshibaAcData &data) {
   dst->set_carrier_frequency(38000);

--- a/esphome/components/remote_base/toto_protocol.cpp
+++ b/esphome/components/remote_base/toto_protocol.cpp
@@ -6,12 +6,12 @@ namespace remote_base {
 
 static const char *const TAG = "remote.toto";
 
-static const uint32_t PREAMBLE_HIGH_US = 6200;
-static const uint32_t PREAMBLE_LOW_US = 2800;
-static const uint32_t BIT_HIGH_US = 550;
-static const uint32_t BIT_ONE_LOW_US = 1700;
-static const uint32_t BIT_ZERO_LOW_US = 550;
-static const uint32_t TOTO_HEADER = 0x2008;
+static constexpr uint32_t PREAMBLE_HIGH_US = 6200;
+static constexpr uint32_t PREAMBLE_LOW_US = 2800;
+static constexpr uint32_t BIT_HIGH_US = 550;
+static constexpr uint32_t BIT_ONE_LOW_US = 1700;
+static constexpr uint32_t BIT_ZERO_LOW_US = 550;
+static constexpr uint32_t TOTO_HEADER = 0x2008;
 
 void TotoProtocol::encode(RemoteTransmitData *dst, const TotoData &data) {
   uint32_t payload = 0;


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for integer constants initialized with literal values across all remote_base protocol implementations to enable compile-time evaluation.

27 files, 170 constants converted.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).