### PR TITLE
[ld2420] Use constexpr for compile-time constants

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -63,73 +63,73 @@ namespace esphome::ld2420 {
 static const char *const TAG = "ld2420";
 
 // Local const's
-static const uint16_t REFRESH_RATE_MS = 1000;
+static constexpr uint16_t REFRESH_RATE_MS = 1000;
 
 // Command sets
-static const uint16_t CMD_DISABLE_CONF = 0x00FE;
-static const uint16_t CMD_ENABLE_CONF = 0x00FF;
-static const uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
-static const uint16_t CMD_PARM_LOW_TRESH = 0x0021;
-static const uint16_t CMD_PROTOCOL_VER = 0x0002;
-static const uint16_t CMD_READ_ABD_PARAM = 0x0008;
-static const uint16_t CMD_READ_REG_ADDR = 0x0020;
-static const uint16_t CMD_READ_REGISTER = 0x0002;
-static const uint16_t CMD_READ_SERIAL_NUM = 0x0011;
-static const uint16_t CMD_READ_SYS_PARAM = 0x0013;
-static const uint16_t CMD_READ_VERSION = 0x0000;
-static const uint16_t CMD_RESTART = 0x0068;
-static const uint16_t CMD_SYSTEM_MODE = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
-static const uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
-static const uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
-static const uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
-static const uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
-static const uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
-static const uint16_t CMD_WRITE_REGISTER = 0x0001;
-static const uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
+static constexpr uint16_t CMD_DISABLE_CONF = 0x00FE;
+static constexpr uint16_t CMD_ENABLE_CONF = 0x00FF;
+static constexpr uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
+static constexpr uint16_t CMD_PARM_LOW_TRESH = 0x0021;
+static constexpr uint16_t CMD_PROTOCOL_VER = 0x0002;
+static constexpr uint16_t CMD_READ_ABD_PARAM = 0x0008;
+static constexpr uint16_t CMD_READ_REG_ADDR = 0x0020;
+static constexpr uint16_t CMD_READ_REGISTER = 0x0002;
+static constexpr uint16_t CMD_READ_SERIAL_NUM = 0x0011;
+static constexpr uint16_t CMD_READ_SYS_PARAM = 0x0013;
+static constexpr uint16_t CMD_READ_VERSION = 0x0000;
+static constexpr uint16_t CMD_RESTART = 0x0068;
+static constexpr uint16_t CMD_SYSTEM_MODE = 0x0000;
+static constexpr uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
+static constexpr uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
+static constexpr uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
+static constexpr uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
+static constexpr uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
+static constexpr uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
+static constexpr uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
+static constexpr uint16_t CMD_WRITE_REGISTER = 0x0001;
+static constexpr uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
 
-static const uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
-static const uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
-static const uint8_t CMD_MAX_BYTES = 0x64;
-static const uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
+static constexpr uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
+static constexpr uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
+static constexpr uint8_t CMD_MAX_BYTES = 0x64;
+static constexpr uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
 
-static const uint8_t LD2420_ERROR_NONE = 0x00;
-static const uint8_t LD2420_ERROR_TIMEOUT = 0x02;
-static const uint8_t LD2420_ERROR_UNKNOWN = 0x01;
+static constexpr uint8_t LD2420_ERROR_NONE = 0x00;
+static constexpr uint8_t LD2420_ERROR_TIMEOUT = 0x02;
+static constexpr uint8_t LD2420_ERROR_UNKNOWN = 0x01;
 
 // Register address values
-static const uint16_t CMD_MIN_GATE_REG = 0x0000;
-static const uint16_t CMD_MAX_GATE_REG = 0x0001;
-static const uint16_t CMD_TIMEOUT_REG = 0x0004;
-static const uint16_t CMD_GATE_MOVE_THRESH[TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
-                                                           0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
-                                                           0x001C, 0x001D, 0x001E, 0x001F};
-static const uint16_t CMD_GATE_STILL_THRESH[TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
-                                                            0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
-                                                            0x002C, 0x002D, 0x002E, 0x002F};
-static const uint32_t FACTORY_MOVE_THRESH[TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
-                                                          250,   250,   250, 250, 250, 250, 250, 250};
-static const uint32_t FACTORY_STILL_THRESH[TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
-                                                           150,   100,   100, 100, 100, 100, 100, 100};
-static const uint16_t FACTORY_TIMEOUT = 120;
-static const uint16_t FACTORY_MIN_GATE = 1;
-static const uint16_t FACTORY_MAX_GATE = 12;
+static constexpr uint16_t CMD_MIN_GATE_REG = 0x0000;
+static constexpr uint16_t CMD_MAX_GATE_REG = 0x0001;
+static constexpr uint16_t CMD_TIMEOUT_REG = 0x0004;
+static constexpr uint16_t CMD_GATE_MOVE_THRESH[TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
+                                                               0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
+                                                               0x001C, 0x001D, 0x001E, 0x001F};
+static constexpr uint16_t CMD_GATE_STILL_THRESH[TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
+                                                                0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
+                                                                0x002C, 0x002D, 0x002E, 0x002F};
+static constexpr uint32_t FACTORY_MOVE_THRESH[TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
+                                                              250,   250,   250, 250, 250, 250, 250, 250};
+static constexpr uint32_t FACTORY_STILL_THRESH[TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
+                                                               150,   100,   100, 100, 100, 100, 100, 100};
+static constexpr uint16_t FACTORY_TIMEOUT = 120;
+static constexpr uint16_t FACTORY_MIN_GATE = 1;
+static constexpr uint16_t FACTORY_MAX_GATE = 12;
 
 // COMMAND_BYTE Header & Footer
-static const uint32_t CMD_FRAME_FOOTER = 0x01020304;
-static const uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
-static const uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
-static const uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
-static const int CALIBRATE_VERSION_MIN = 154;
-static const uint8_t CMD_FRAME_COMMAND = 6;
-static const uint8_t CMD_FRAME_DATA_LENGTH = 4;
-static const uint8_t CMD_FRAME_STATUS = 7;
-static const uint8_t CMD_ERROR_WORD = 8;
-static const uint8_t ENERGY_SENSOR_START = 9;
-static const uint8_t CALIBRATE_REPORT_INTERVAL = 4;
+static constexpr uint32_t CMD_FRAME_FOOTER = 0x01020304;
+static constexpr uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
+static constexpr uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
+static constexpr uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
+static constexpr uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
+static constexpr uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
+static constexpr int CALIBRATE_VERSION_MIN = 154;
+static constexpr uint8_t CMD_FRAME_COMMAND = 6;
+static constexpr uint8_t CMD_FRAME_DATA_LENGTH = 4;
+static constexpr uint8_t CMD_FRAME_STATUS = 7;
+static constexpr uint8_t CMD_ERROR_WORD = 8;
+static constexpr uint8_t ENERGY_SENSOR_START = 9;
+static constexpr uint8_t CALIBRATE_REPORT_INTERVAL = 4;
 static const char *const OP_NORMAL_MODE_STRING = "Normal";
 static const char *const OP_SIMPLE_MODE_STRING = "Simple";
 

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -20,9 +20,9 @@
 
 namespace esphome::ld2420 {
 
-static const uint8_t CALIBRATE_SAMPLES = 64;
-static const uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
-static const uint8_t TOTAL_GATES = 16;
+static constexpr uint8_t CALIBRATE_SAMPLES = 64;
+static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
+static constexpr uint8_t TOTAL_GATES = 16;
 
 enum OpMode : uint8_t {
   OP_NORMAL_MODE = 1,


### PR DESCRIPTION
# What does this implement/fix?

Replace `const` with `constexpr` for compile-time constants initialized with literal values to enable compile-time evaluation.

49 constants converted across ld2420.h and ld2420.cpp.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).