### PR TITLE
[bluetooth_proxy] Use constexpr for remaining compile-time constants

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -23,9 +23,9 @@
 
 namespace esphome::bluetooth_proxy {
 
-static const esp_err_t ESP_GATT_NOT_CONNECTED = -1;
-static const int DONE_SENDING_SERVICES = -2;
-static const int INIT_SENDING_SERVICES = -3;
+static constexpr esp_err_t ESP_GATT_NOT_CONNECTED = -1;
+static constexpr int DONE_SENDING_SERVICES = -2;
+static constexpr int INIT_SENDING_SERVICES = -3;
 
 using namespace esp32_ble_client;
 


### PR DESCRIPTION
# What does this implement/fix?

Followup to #14073 addressing review feedback. Convert remaining `const` to `constexpr` for compile-time constants in `bluetooth_proxy.h`:

- `ESP_GATT_NOT_CONNECTED`
- `DONE_SENDING_SERVICES`
- `INIT_SENDING_SERVICES`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Followup to #14073

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal code quality improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).