### PR TITLE
[core] Devirtualize call_loop() and mark_failed() in Component

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -492,16 +492,14 @@ void Component::set_setup_priority(float priority) {
 
 bool Component::has_overridden_loop() const {
 #if defined(USE_HOST) || defined(CLANG_TIDY)
-  bool loop_overridden = true;
-  bool call_loop_overridden = true;
+  return true;
 #else
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpmf-conversions"
   bool loop_overridden = (void *) (this->*(&Component::loop)) != (void *) (&Component::loop);
-  bool call_loop_overridden = (void *) (this->*(&Component::call_loop)) != (void *) (&Component::call_loop);
 #pragma GCC diagnostic pop
+  return loop_overridden;
 #endif
-  return loop_overridden || call_loop_overridden;
 }
 
 PollingComponent::PollingComponent(uint32_t update_interval) : update_interval_(update_interval) {}

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -204,7 +204,7 @@ bool Component::cancel_retry(uint32_t id) {
 #pragma GCC diagnostic pop
 }
 
-void Component::call_loop() { this->loop(); }
+void Component::call_loop_() { this->loop(); }
 void Component::call_setup() { this->setup(); }
 void Component::call_dump_config() {
   this->dump_config();
@@ -255,11 +255,11 @@ void Component::call() {
     case COMPONENT_STATE_SETUP:
       // State setup: Call first loop and set state to loop
       this->set_component_state_(COMPONENT_STATE_LOOP);
-      this->call_loop();
+      this->call_loop_();
       break;
     case COMPONENT_STATE_LOOP:
       // State loop: Call loop
-      this->call_loop();
+      this->call_loop_();
       break;
     case COMPONENT_STATE_FAILED:
       // State failed: Do nothing

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -165,7 +165,7 @@ class Component {
    * For example, i2c based components can check if the remote device is responding and otherwise
    * mark the component as failed. Eventually this will also enable smart status LEDs.
    */
-  virtual void mark_failed();
+  void mark_failed();
 
   // Remove before 2026.6.0
   ESPDEPRECATED("Use mark_failed(LOG_STR(\"static string literal\")) instead. Do NOT use .c_str() from temporary "
@@ -286,7 +286,7 @@ class Component {
  protected:
   friend class Application;
 
-  virtual void call_loop();
+  void call_loop();
   virtual void call_setup();
   virtual void call_dump_config();
 

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -286,7 +286,7 @@ class Component {
  protected:
   friend class Application;
 
-  void call_loop();
+  void call_loop_();
   virtual void call_setup();
   virtual void call_dump_config();
 


### PR DESCRIPTION
## What does this implement/fix?

Removes `virtual` from `Component::call_loop()` and `Component::mark_failed()`, and removes the now-dead `call_loop` override check from `has_overridden_loop()`.

Neither method is overridden anywhere in the codebase (confirmed via full search for `call_loop() override` and `mark_failed() override` — zero hits). Making them non-virtual eliminates one vtable slot per method from every `Component`-derived class.

With ~100+ component vtables in a typical build, this saves **~800+ bytes of flash** globally (8 bytes per vtable × ~100 vtables).

### Historical context

Both methods were virtual from the very first commit (Otto Winter, April 2019). The original comment in `component.h` explains the design intent:

> `call_loop()` / `call_setup()` are basically to make creating custom components easier. For example the SensorComponent can override these methods to not have the user call some super methods within their custom sensors.

The idea was that intermediate base classes could inject behavior between the framework's `loop_internal_()` and the user's `loop()` without users needing to remember to call `super.loop()`.

**Two components actually used these overrides over the years:**

1. **`MQTTComponent::call_loop()` override** — present from the original 2019 codebase merge (#504). It injected MQTT-specific logic (resending state/discovery) between `loop_internal_()` and `loop()`. Removed in #13356 (Jan 2026) which restructured MQTT to eliminate per-entity loop overhead.

2. **`ESP32BLE::mark_failed()` override** — added in #1807 (June 2021, Jesse Hills) for Improv BLE provisioning. When `ESP32BLE` failed, it cascaded the failure to its child BLE server. Removed in #4173 (Jan 2023) when BLE was refactored to use event handler registration instead of direct parent-child coupling.

Both overrides were removed through architectural improvements, leaving zero overrides today.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Migration guide for external components

If your external component overrides `call_loop()` or `mark_failed()`, remove the `override` keyword. These methods are no longer virtual. Note: no known components override either method — they were virtual with zero overrides.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).