### PR TITLE
[e131] Fix E1.31 on ESP8266 and RP2040 by restoring WiFiUDP support

### DIFF
--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -1,7 +1,11 @@
 #pragma once
 #include "esphome/core/defines.h"
 #ifdef USE_NETWORK
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
 #include "esphome/components/socket/socket.h"
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+#include <WiFiUdp.h>
+#endif
 #include "esphome/core/component.h"
 
 #include <cinttypes>
@@ -45,7 +49,11 @@ class E131Component : public esphome::Component {
   void leave_(int universe);
 
   E131ListenMethod listen_method_{E131_MULTICAST};
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   std::unique_ptr<socket::Socket> socket_;
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+  WiFiUDP udp_;
+#endif
   std::vector<E131AddressableLightEffect *> light_effects_;
   std::map<int, int> universe_consumers_;
 };

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -62,8 +62,10 @@ const size_t E131_MIN_PACKET_SIZE = reinterpret_cast<size_t>(&((E131RawPacket *)
 bool E131Component::join_igmp_groups_() {
   if (listen_method_ != E131_MULTICAST)
     return false;
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   if (this->socket_ == nullptr)
     return false;
+#endif
 
   for (auto universe : universe_consumers_) {
     if (!universe.second)


### PR DESCRIPTION
# What does this implement/fix?

The socket abstraction layer on ESP8266/RP2040 (`USE_SOCKET_IMPL_LWIP_TCP`) only supports TCP. When E1.31 was migrated from WiFiUDP to the socket abstraction in #4832, it silently broke on these platforms — `SOCK_DGRAM` requests get TCP sockets that never receive UDP data.

This restores WiFiUDP as the UDP transport on `LWIP_TCP` platforms while keeping the socket-based implementation on BSD/LWIP socket platforms (ESP32, etc.). This follows the same dual-path pattern already used by the `udp` and `wake_on_lan` components.

Changes:
- **`e131.h`**: Conditionally include `socket/socket.h` or `WiFiUdp.h` and declare the appropriate member (`socket_` vs `udp_`)
- **`e131.cpp`**: Add `#elif` dual paths in destructor, `setup()`, and `loop()` for socket vs WiFiUDP. The WiFiUDP path uses a `while (parsePacket())` loop to drain all pending packets per loop call, matching the original pre-#4832 behavior.
- **`e131_packet.cpp`**: Guard `socket_ == nullptr` check so it only compiles on platforms that have the `socket_` member

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14088

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: e131-test

esp8266:
  board: d1_mini

wifi:
  ssid: MySSID
  password: password1

e131:
  method: multicast

light:
  - platform: neopixelbus
    id: led_strip
    type: GRB
    variant: ws2812
    pin: GPIO2
    num_leds: 50
    default_transition_length: 0s
    effects:
      - e131:
          universe: 1
          channels: RGB
```

### Test sender script

Install `sacn` (`pip install sacn`) and run to verify E1.31 reception. Sweeps red, green, blue at 50 FPS:

```python
"""Simple E1.31 (sACN) test sender for testing the ESPHome e131 component.

Usage:
    pip install sacn
    python test_e131_sender.py [--universe 1] [--unicast 192.168.1.100] [--leds 50]
"""

import argparse
import time

import sacn


def main():
    parser = argparse.ArgumentParser(description="E1.31 test sender")
    parser.add_argument("--universe", type=int, default=1)
    parser.add_argument("--unicast", type=str, default=None, help="Device IP for unicast (default: multicast)")
    parser.add_argument("--leds", type=int, default=50)
    args = parser.parse_args()

    sender = sacn.sACNsender()
    sender.start()
    sender.activate_output(args.universe)

    if args.unicast:
        sender[args.universe].destination = args.unicast
    else:
        sender[args.universe].multicast = True

    channels = args.leds * 3  # RGB
    print(f"Sending to universe {args.universe}, {args.leds} LEDs, {'unicast ' + args.unicast if args.unicast else 'multicast'}")
    print("Ctrl+C to stop")

    try:
        while True:
            # Red sweep
            for i in range(256):
                data = tuple([i, 0, 0] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
            # Green sweep
            for i in range(256):
                data = tuple([0, i, 0] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
            # Blue sweep
            for i in range(256):
                data = tuple([0, 0, i] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
    except KeyboardInterrupt:
        print("\nStopping")
    finally:
        sender.stop()


if __name__ == "__main__":
    main()
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).