### PR TITLE
[e131] Replace std::map with std::vector for universe tracking

### DIFF
--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -24,7 +24,7 @@ struct E131Packet {
 
 struct UniverseConsumer {
   uint16_t universe;
-  uint8_t consumers;
+  uint16_t consumers;
 };
 
 class E131Component : public esphome::Component {

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -5,7 +5,6 @@
 #include "esphome/core/component.h"
 
 #include <cinttypes>
-#include <map>
 #include <memory>
 #include <vector>
 
@@ -21,6 +20,11 @@ const int E131_MAX_PROPERTY_VALUES_COUNT = 513;
 struct E131Packet {
   uint16_t count;
   uint8_t values[E131_MAX_PROPERTY_VALUES_COUNT];
+};
+
+struct UniverseConsumer {
+  uint16_t universe;
+  uint8_t consumers;
 };
 
 class E131Component : public esphome::Component {
@@ -41,13 +45,14 @@ class E131Component : public esphome::Component {
   bool packet_(const uint8_t *data, size_t len, int &universe, E131Packet &packet);
   bool process_(int universe, const E131Packet &packet);
   bool join_igmp_groups_();
+  UniverseConsumer *find_universe_(int universe);
   void join_(int universe);
   void leave_(int universe);
 
   E131ListenMethod listen_method_{E131_MULTICAST};
   std::unique_ptr<socket::Socket> socket_;
   std::vector<E131AddressableLightEffect *> light_effects_;
-  std::map<int, int> universe_consumers_;
+  std::vector<UniverseConsumer> universe_consumers_;
 };
 
 }  // namespace e131

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -98,11 +98,12 @@ void E131Component::join_(int universe) {
   // store only latest received packet for the given universe
   auto *consumer = this->find_universe_(universe);
   if (consumer != nullptr) {
-    consumer->consumers++;
-    return;  // we already joined before
+    if (consumer->consumers++ > 0) {
+      return;  // we already joined before
+    }
+  } else {
+    this->universe_consumers_.push_back({static_cast<uint16_t>(universe), 1});
   }
-
-  this->universe_consumers_.push_back({static_cast<uint16_t>(universe), 1});
 
   if (this->join_igmp_groups_()) {
     ESP_LOGD(TAG, "Joined %d universe for E1.31.", universe);

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -60,17 +60,17 @@ union E131RawPacket {
 const size_t E131_MIN_PACKET_SIZE = reinterpret_cast<size_t>(&((E131RawPacket *) nullptr)->property_values[1]);
 
 bool E131Component::join_igmp_groups_() {
-  if (listen_method_ != E131_MULTICAST)
+  if (this->listen_method_ != E131_MULTICAST)
     return false;
   if (this->socket_ == nullptr)
     return false;
 
-  for (auto universe : universe_consumers_) {
-    if (!universe.second)
+  for (auto &entry : this->universe_consumers_) {
+    if (!entry.consumers)
       continue;
 
     ip4_addr_t multicast_addr =
-        network::IPAddress(239, 255, ((universe.first >> 8) & 0xff), ((universe.first >> 0) & 0xff));
+        network::IPAddress(239, 255, ((entry.universe >> 8) & 0xff), ((entry.universe >> 0) & 0xff));
 
     err_t err;
     {
@@ -79,34 +79,46 @@ bool E131Component::join_igmp_groups_() {
     }
 
     if (err) {
-      ESP_LOGW(TAG, "IGMP join for %d universe of E1.31 failed. Multicast might not work.", universe.first);
+      ESP_LOGW(TAG, "IGMP join for %d universe of E1.31 failed. Multicast might not work.", entry.universe);
     }
   }
 
   return true;
 }
 
+UniverseConsumer *E131Component::find_universe_(int universe) {
+  for (auto &entry : this->universe_consumers_) {
+    if (entry.universe == universe)
+      return &entry;
+  }
+  return nullptr;
+}
+
 void E131Component::join_(int universe) {
   // store only latest received packet for the given universe
-  auto consumers = ++universe_consumers_[universe];
-
-  if (consumers > 1) {
+  auto *consumer = this->find_universe_(universe);
+  if (consumer != nullptr) {
+    consumer->consumers++;
     return;  // we already joined before
   }
 
-  if (join_igmp_groups_()) {
+  this->universe_consumers_.push_back({static_cast<uint16_t>(universe), 1});
+
+  if (this->join_igmp_groups_()) {
     ESP_LOGD(TAG, "Joined %d universe for E1.31.", universe);
   }
 }
 
 void E131Component::leave_(int universe) {
-  auto consumers = --universe_consumers_[universe];
+  auto *consumer = this->find_universe_(universe);
+  if (consumer == nullptr)
+    return;
 
-  if (consumers > 0) {
+  if (--consumer->consumers > 0) {
     return;  // we have other consumers of the given universe
   }
 
-  if (listen_method_ == E131_MULTICAST) {
+  if (this->listen_method_ == E131_MULTICAST) {
     ip4_addr_t multicast_addr = network::IPAddress(239, 255, ((universe >> 8) & 0xff), ((universe >> 0) & 0xff));
 
     LwIPLock lock;


### PR DESCRIPTION
https://github.com/esphome/esphome/pull/14086 should be reviewed first since this is an optimization and that one is a bug fix and there is a risk of conflicts

# What does this implement/fix?

Replace `std::map<int, int>` with `std::vector<UniverseConsumer>` for tracking universe reference counts in the E131 component.

`std::map` uses a red-black tree with per-node heap allocation — this is unnecessary overhead for what is typically 1-10 entries. A simple struct with linear search eliminates the tree code from the binary and avoids per-node heap allocations.

Linear search is fine here, and likely faster for small data sets. Additionally `universe_consumers_` is never accessed in the hot path (`loop()`/`process_()`) so even if its > 16 its not an issue. It is only touched during:
- `join_()` / `leave_()` — called on effect start/stop (rare, user-initiated)
- `join_igmp_groups_()` — called once in `setup()` and when a new universe is joined

A `find_universe_()` helper is extracted to avoid duplicating the search in `join_()` and `leave_()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal refactor only
e131:
  method: MULTICAST

light:
  - platform: neopixelbus
    type: GRB
    variant: WS2811
    pin: GPIO13
    num_leds: 50
    name: "Light"
    effects:
      - e131:
          universe: 1
          channels: RGB
```

## Test script

To test on a real device, install the `sacn` Python library and run the following script from a machine on the same network:

```bash
pip install sacn
python test_e131_sender.py                              # multicast, universe 1, 50 LEDs
python test_e131_sender.py --unicast 192.168.1.100      # unicast to device
python test_e131_sender.py --universe 2 --leds 170      # different universe/count
```

```python
"""Simple E1.31 (sACN) test sender for testing the ESPHome e131 component.

Usage:
    pip install sacn
    python test_e131_sender.py [--universe 1] [--unicast 192.168.1.100] [--leds 50]
"""

import argparse
import time

import sacn


def main():
    parser = argparse.ArgumentParser(description="E1.31 test sender")
    parser.add_argument("--universe", type=int, default=1)
    parser.add_argument("--unicast", type=str, default=None, help="Device IP for unicast (default: multicast)")
    parser.add_argument("--leds", type=int, default=50)
    args = parser.parse_args()

    sender = sacn.sACNsender()
    sender.start()
    sender.activate_output(args.universe)

    if args.unicast:
        sender[args.universe].destination = args.unicast
    else:
        sender[args.universe].multicast = True

    channels = args.leds * 3  # RGB
    print(f"Sending to universe {args.universe}, {args.leds} LEDs, {'unicast ' + args.unicast if args.unicast else 'multicast'}")
    print("Ctrl+C to stop")

    try:
        while True:
            # Red sweep
            for i in range(256):
                data = tuple([i, 0, 0] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
            # Green sweep
            for i in range(256):
                data = tuple([0, i, 0] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
            # Blue sweep
            for i in range(256):
                data = tuple([0, 0, i] * args.leds)[:channels]
                sender[args.universe].dmx_data = data
                time.sleep(0.02)
    except KeyboardInterrupt:
        print("\nStopping")
    finally:
        sender.stop()


if __name__ == "__main__":
    main()
```

Sweeps red, green, blue in a loop. Ctrl+C to stop.

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).