### PR TITLE
[socket] Log error when UDP socket requested on LWIP TCP-only platforms

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -680,6 +680,11 @@ class LWIPRawListenImpl final : public LWIPRawImpl {
 };
 
 std::unique_ptr<Socket> socket(int domain, int type, int protocol) {
+  if (type != SOCK_STREAM) {
+    ESP_LOGE(TAG, "UDP sockets not supported on this platform, use WiFiUDP");
+    errno = EPROTOTYPE;
+    return nullptr;
+  }
   auto *pcb = tcp_new();
   if (pcb == nullptr)
     return nullptr;


### PR DESCRIPTION
# What does this implement/fix?

The LWIP raw socket factory (`lwip_raw_tcp_impl.cpp`) only supports TCP but silently ignored the `type` parameter, returning a TCP socket for `SOCK_DGRAM` requests. This caused components expecting UDP sockets to fail silently with no indication of why — the root cause of #14088 being open for 2+ years without a clear diagnosis.

Now returns `nullptr` with `EPROTOTYPE` and logs an error so the failure is immediately obvious.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/14088

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal socket factory change, no user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).