### PR TITLE
[libretiny] Use direct register access for ISR GPIO on BK72XX

### DIFF
--- a/esphome/components/libretiny/gpio_arduino.cpp
+++ b/esphome/components/libretiny/gpio_arduino.cpp
@@ -3,6 +3,18 @@
 #include "gpio_arduino.h"
 #include "esphome/core/log.h"
 
+#ifdef USE_BK72XX
+// Direct GPIO register access for ISR-safe operations on Beken chips.
+// The LibreTiny Arduino GPIO abstraction has guards that silently drop
+// writes when the pin is not in OUTPUT mode, breaking timing-critical
+// protocols like 1-Wire that set the output register before switching
+// pin direction.
+extern "C" {
+#include <gpio_pub.h>       // gpio_output, gpio_input, gpio_config, GMODE_*
+#include <wiring_custom.h>  // pinInfo() for Arduino pin -> GPIO number mapping
+}
+#endif
+
 namespace esphome {
 namespace libretiny {
 
@@ -24,15 +36,39 @@ static int IRAM_ATTR flags_to_mode(gpio::Flags flags) {
   }
 }
 
+#ifdef USE_BK72XX
+static uint32_t IRAM_ATTR flags_to_bk_mode(gpio::Flags flags) {
+  if (flags == gpio::FLAG_INPUT) {
+    return GMODE_INPUT;
+  } else if (flags == gpio::FLAG_OUTPUT) {
+    return GMODE_OUTPUT;
+  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
+    return GMODE_INPUT_PULLUP;
+  } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLDOWN)) {
+    return GMODE_INPUT_PULLDOWN;
+  } else if (flags == (gpio::FLAG_OUTPUT | gpio::FLAG_OPEN_DRAIN)) {
+    return GMODE_SET_HIGH_IMPENDANCE;
+  } else {
+    return GMODE_INPUT;
+  }
+}
+#endif
+
 struct ISRPinArg {
   uint8_t pin;
   bool inverted;
+#ifdef USE_BK72XX
+  uint32_t gpio;  // Raw Beken GPIO number for direct register access
+#endif
 };
 
 ISRInternalGPIOPin ArduinoInternalGPIOPin::to_isr() const {
   auto *arg = new ISRPinArg{};  // NOLINT(cppcoreguidelines-owning-memory)
   arg->pin = pin_;
   arg->inverted = inverted_;
+#ifdef USE_BK72XX
+  arg->gpio = pinInfo(pin_)->gpio;
+#endif
   return ISRInternalGPIOPin((void *) arg);
 }
 
@@ -83,11 +119,19 @@ using namespace libretiny;
 
 bool IRAM_ATTR ISRInternalGPIOPin::digital_read() {
   auto *arg = reinterpret_cast<ISRPinArg *>(arg_);
+#ifdef USE_BK72XX
+  return bool(gpio_input(arg->gpio)) != arg->inverted;
+#else
   return bool(digitalRead(arg->pin)) ^ arg->inverted;  // NOLINT
+#endif
 }
 void IRAM_ATTR ISRInternalGPIOPin::digital_write(bool value) {
   auto *arg = reinterpret_cast<ISRPinArg *>(arg_);
-  digitalWrite(arg->pin, value ^ arg->inverted);  // NOLINT
+#ifdef USE_BK72XX
+  gpio_output(arg->gpio, value != arg->inverted);
+#else
+  digitalWrite(arg->pin, value ^ arg->inverted);       // NOLINT
+#endif
 }
 void IRAM_ATTR ISRInternalGPIOPin::clear_interrupt() {
   auto *arg = reinterpret_cast<ISRPinArg *>(arg_);
@@ -95,7 +139,11 @@ void IRAM_ATTR ISRInternalGPIOPin::clear_interrupt() {
 }
 void IRAM_ATTR ISRInternalGPIOPin::pin_mode(gpio::Flags flags) {
   auto *arg = reinterpret_cast<ISRPinArg *>(arg_);
-  pinMode(arg->pin, flags_to_mode(flags));  // NOLINT
+#ifdef USE_BK72XX
+  gpio_config(arg->gpio, flags_to_bk_mode(flags));
+#else
+  pinMode(arg->pin, flags_to_mode(flags));             // NOLINT
+#endif
 }
 
 }  // namespace esphome


### PR DESCRIPTION
# **This change is completely untested on hardware**  I don't have a BK72XX device with a Dallas sensor to verify. It compiles successfully but needs someone with the hardware to confirm.


# What does this implement/fix?

Fix Dallas 1-Wire (and other timing-critical GPIO protocols) broken on BK72XX since PR #8744.

On BK72XX, the Arduino `digitalWrite()` abstraction has a guard ([`pinSetOutputPull`](https://github.com/libretiny-eu/libretiny/blob/caf3e79ada2ef878754d539a91c223e626b3684f/cores/common/arduino/src/wiring/wiring_private.h#L48-L54) in LibreTiny's `wiring_private.h`) that **silently returns without writing** the output register when the pin is not in OUTPUT mode. Similarly, `digitalRead()` has a guard ([`pinSetInputMode`](https://github.com/libretiny-eu/libretiny/blob/caf3e79ada2ef878754d539a91c223e626b3684f/cores/common/arduino/src/wiring/wiring_private.h#L56-L60)) that implicitly changes the pin mode.

PR #8744 changed the one_wire code to call `digital_write()` before `pin_mode(OUTPUT)` — an optimization to avoid glitches that works on ESP32/ESP8266/RP2040 because their `ISRInternalGPIOPin::digital_write()` writes directly to hardware registers regardless of pin direction. On BK72XX, the write is silently dropped, so the 480µs reset pulse is never generated and DS18B20 devices are never detected.

Every other platform (ESP32, ESP8266, RP2040) implements `ISRInternalGPIOPin` as direct hardware register access. This change does the same for BK72XX by calling `gpio_output()`, `gpio_input()`, and `gpio_config()` from the Beken SDK directly, bypassing the Arduino abstraction layer entirely.

Non-Beken LibreTiny families (Realtek, Lightning) are unchanged as they have different SDK APIs and are not reported as affected.


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14085

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change - existing configs should work
bk72xx:
  board: cb3s

one_wire:
  - platform: gpio
    pin: P14

sensor:
  - platform: dallas_temp
    name: Dallas Temperature
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).