### PR TITLE
[socket] Fix IPv6 compilation error on host platform

### DIFF
--- a/tests/components/socket/common.yaml
+++ b/tests/components/socket/common.yaml
@@ -1,0 +1,11 @@
+substitutions:
+  network_enable_ipv6: "false"
+
+socket:
+
+wifi:
+  ssid: MySSID
+  password: password1
+
+network:
+  enable_ipv6: ${network_enable_ipv6}

--- a/tests/components/socket/test-ipv6.esp32-idf.yaml
+++ b/tests/components/socket/test-ipv6.esp32-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/socket/test-ipv6.host.yaml
+++ b/tests/components/socket/test-ipv6.host.yaml
@@ -1,0 +1,4 @@
+socket:
+
+network:
+  enable_ipv6: true

--- a/tests/components/socket/test.esp32-idf.yaml
+++ b/tests/components/socket/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/socket/test.host.yaml
+++ b/tests/components/socket/test.host.yaml
@@ -1,0 +1,3 @@
+socket:
+
+network:


### PR DESCRIPTION
# What does this implement/fix?

When `network: enable_ipv6: true` is set on the `host` platform, compilation fails because `format_sockaddr_to` in `socket.cpp` accesses `sin6_addr.un.u32_addr` — an LWIP-specific struct layout — under a `#ifndef USE_SOCKET_IMPL_LWIP_TCP` guard that includes the host platform. The host platform uses POSIX `struct in6_addr` which only has `s6_addr` (no LWIP union).

ESP32-IDF is unaffected despite also using BSD sockets, because its LWIP headers provide the `un.u32_addr` union layout.

The fix narrows the preprocessor guard to `USE_HOST` and uses the standard `IN6_IS_ADDR_V4MAPPED()` macro with `s6_addr[]` for the host code path only. The existing LWIP code path for ESP32-IDF and LWIP sockets is unchanged.

Also adds socket component build tests for host and ESP32-IDF, with and without IPv6.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14097

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test-host-ipv6

host:

network:
  enable_ipv6: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).