### PR TITLE
[scheduler] Outline cold defer queue compaction path

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -421,6 +421,29 @@ void Scheduler::full_cleanup_removed_items_() {
   this->to_remove_ = 0;
 }
 
+#ifndef ESPHOME_THREAD_SINGLE
+void Scheduler::compact_defer_queue_locked_() {
+  // Rare case: new items were added during processing - compact the vector
+  // This only happens when:
+  // 1. A deferred callback calls defer() again, or
+  // 2. Another thread calls defer() while we're processing
+  //
+  // Move unprocessed items (added during this loop) to the front for next iteration
+  //
+  // SAFETY: Compacted items may include cancelled items (marked for removal via
+  // cancel_item_locked_() during execution). This is safe because should_skip_item_()
+  // checks is_item_removed_() before executing, so cancelled items will be skipped
+  // and recycled on the next loop iteration.
+  size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
+  for (size_t i = 0; i < remaining; i++) {
+    this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
+  }
+  // Use erase() instead of resize() to avoid instantiating _M_default_append
+  // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
+  this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
+}
+#endif /* not ESPHOME_THREAD_SINGLE */
+
 void HOT Scheduler::call(uint32_t now) {
 #ifndef ESPHOME_THREAD_SINGLE
   this->process_defer_queue_(now);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -426,27 +426,17 @@ class Scheduler {
       // Common case: no new items - clear everything
       this->defer_queue_.clear();
     } else {
-      // Rare case: new items were added during processing - compact the vector
-      // This only happens when:
-      // 1. A deferred callback calls defer() again, or
-      // 2. Another thread calls defer() while we're processing
-      //
-      // Move unprocessed items (added during this loop) to the front for next iteration
-      //
-      // SAFETY: Compacted items may include cancelled items (marked for removal via
-      // cancel_item_locked_() during execution). This is safe because should_skip_item_()
-      // checks is_item_removed_() before executing, so cancelled items will be skipped
-      // and recycled on the next loop iteration.
-      size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
-      for (size_t i = 0; i < remaining; i++) {
-        this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
-      }
-      // Use erase() instead of resize() to avoid instantiating _M_default_append
-      // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
-      this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
+      // Rare case: new items were added during processing - outlined to keep cold code
+      // out of the hot instruction cache lines
+      this->compact_defer_queue_locked_();
     }
     this->defer_queue_front_ = 0;
   }
+
+  // Cold path for compacting defer_queue_ when new items were added during processing.
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
+  // IMPORTANT: Must not be inlined - rare path, outlined to keep it out of the hot instruction cache lines.
+  void __attribute__((noinline)) compact_defer_queue_locked_();
 #endif /* not ESPHOME_THREAD_SINGLE */
 
   // Helper to check if item is marked for removal (platform-specific)


### PR DESCRIPTION
# What does this implement/fix?

Outline the rare defer queue compaction logic from the inlined `cleanup_defer_queue_locked_()` into a separate `noinline` `compact_defer_queue_locked_()` method.

The compaction only runs when new items are added to the defer queue during processing (by callbacks calling `defer()` or other threads). This is rare — the common path (`clear()` + front reset) remains inlined. Outlining the cold compaction code keeps it out of the hot instruction cache lines used by `process_defer_queue_()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Note: This code is compiled only on multi-threaded platforms (`#ifndef ESPHOME_THREAD_SINGLE`), so ESP8266 and RP2040 are unaffected.

## Example entry for `config.yaml`:

n/a — internal scheduler optimization, no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).