### PR TITLE
[opentherm] Remove deprecated opentherm_version config option

### DIFF
--- a/esphome/components/opentherm/__init__.py
+++ b/esphome/components/opentherm/__init__.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Any
 
 from esphome import automation, pins
@@ -24,7 +23,6 @@ CONF_CH2_ACTIVE = "ch2_active"
 CONF_SUMMER_MODE_ACTIVE = "summer_mode_active"
 CONF_DHW_BLOCK = "dhw_block"
 CONF_SYNC_MODE = "sync_mode"
-CONF_OPENTHERM_VERSION = "opentherm_version"  # Deprecated, will be removed
 CONF_BEFORE_SEND = "before_send"
 CONF_BEFORE_PROCESS_RESPONSE = "before_process_response"
 
@@ -37,8 +35,6 @@ BeforeProcessResponseTrigger = generate.opentherm_ns.class_(
     "BeforeProcessResponseTrigger",
     automation.Trigger.template(generate.OpenthermData.operator("ref")),
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -54,7 +50,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SUMMER_MODE_ACTIVE, False): cv.boolean,
             cv.Optional(CONF_DHW_BLOCK, False): cv.boolean,
             cv.Optional(CONF_SYNC_MODE, False): cv.boolean,
-            cv.Optional(CONF_OPENTHERM_VERSION): cv.positive_float,  # Deprecated
             cv.Optional(CONF_BEFORE_SEND): automation.validate_automation(
                 {
                     cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(BeforeSendTrigger),
@@ -123,11 +118,6 @@ async def to_code(config: dict[str, Any]) -> None:
             cg.add(getattr(var, f"set_{key}_{const.SETTING}")(value))
             settings.append(key)
         else:
-            if key == CONF_OPENTHERM_VERSION:
-                _LOGGER.warning(
-                    "opentherm_version is deprecated and will be removed in esphome 2025.2.0\n"
-                    "Please change to 'opentherm_version_controller'."
-                )
             cg.add(getattr(var, f"set_{key}")(value))
 
     if len(input_sensors) > 0:


### PR DESCRIPTION
# What does this implement/fix?

Remove the deprecated `opentherm_version` config option which was due for removal in 2025.2.0. The replacement `opentherm_version_controller` is a proper SETTING in `schema.py` and has been fully functional since the deprecation.

Changes:
- Remove `CONF_OPENTHERM_VERSION` constant
- Remove `cv.Optional(CONF_OPENTHERM_VERSION)` schema entry
- Remove deprecation warning block and `set_{key}()` fallback in `to_code()`
- Remove now-unused `logging` import and `_LOGGER`

No C++ changes needed — there is no `set_opentherm_version()` method in the hub class. Tests already use `opentherm_version_controller`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Use opentherm_version_controller (a SETTING) instead of the removed opentherm_version:
opentherm:
  in_pin: GPIO21
  out_pin: GPIO22
  opentherm_version_controller: 2.2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).