### PR TITLE
[ethernet] Improve clk_mode deprecation warning with actionable YAML

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -218,12 +218,19 @@ def _validate(config):
                 )
     elif config[CONF_TYPE] != "OPENETH":
         if CONF_CLK_MODE in config:
+            mode, pin = CLK_MODES_DEPRECATED[config[CONF_CLK_MODE]]
             LOGGER.warning(
-                "[ethernet] The 'clk_mode' option is deprecated and will be removed in ESPHome 2026.1. "
-                "Please update your configuration to use 'clk' instead."
+                "[ethernet] The 'clk_mode' option is deprecated. "
+                "Please replace 'clk_mode: %s' with:\n"
+                "  clk:\n"
+                "    mode: %s\n"
+                "    pin: %s\n"
+                "Removal scheduled for 2026.7.0.",
+                config[CONF_CLK_MODE],
+                mode,
+                pin,
             )
-            mode = CLK_MODES_DEPRECATED[config[CONF_CLK_MODE]]
-            config[CONF_CLK] = CLK_SCHEMA({CONF_MODE: mode[0], CONF_PIN: mode[1]})
+            config[CONF_CLK] = CLK_SCHEMA({CONF_MODE: mode, CONF_PIN: pin})
             del config[CONF_CLK_MODE]
         elif CONF_CLK not in config:
             raise cv.Invalid("'clk' is a required option for [ethernet].")


### PR DESCRIPTION
# What does this implement/fix?

Improve the `clk_mode` deprecation warning to show the exact replacement YAML users need, and extend the deprecation period to 2026.7.0.

The original warning just said "use 'clk' instead" which wasn't actionable — users with e.g. `clk_mode: GPIO17_OUT` had no idea they needed:

```yaml
clk:
  mode: CLK_OUT
  pin: 17
```

The improved warning now shows the exact replacement:

```
[ethernet] The 'clk_mode' option is deprecated. Please replace 'clk_mode: GPIO17_OUT' with:
  clk:
    mode: CLK_OUT
    pin: 17
Removal scheduled for 2026.7.0.
```

The auto-migration continues to work so existing configs aren't broken.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Old (deprecated, auto-migrated with warning until 2026.7.0):
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk_mode: GPIO17_OUT
  phy_addr: 0

# New (recommended):
ethernet:
  type: LAN8720
  mdc_pin: GPIO23
  mdio_pin: GPIO18
  clk:
    mode: CLK_OUT
    pin: 17
  phy_addr: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).