### PR TITLE
[esp32] Remove deprecated add_idf_component() parameters and IDF component refresh option

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -25,7 +25,6 @@ from esphome.const import (
     CONF_PLATFORM_VERSION,
     CONF_PLATFORMIO_OPTIONS,
     CONF_REF,
-    CONF_REFRESH,
     CONF_SAFE_MODE,
     CONF_SOURCE,
     CONF_TYPE,
@@ -41,7 +40,7 @@ from esphome.const import (
     ThreadModel,
     __version__,
 )
-from esphome.core import CORE, HexInt, TimePeriod
+from esphome.core import CORE, HexInt
 from esphome.coroutine import CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
 from esphome.helpers import copy_file_if_changed, rmtree, write_file_if_changed
@@ -499,49 +498,24 @@ def add_idf_component(
     repo: str | None = None,
     ref: str | None = None,
     path: str | None = None,
-    refresh: TimePeriod | None = None,
-    components: list[str] | None = None,
-    submodules: list[str] | None = None,
 ):
     """Add an esp-idf component to the project."""
     if not repo and not ref and not path:
         raise ValueError("Requires at least one of repo, ref or path")
-    if refresh or submodules or components:
-        _LOGGER.warning(
-            "The refresh, components and submodules parameters in add_idf_component() are "
-            "deprecated and will be removed in ESPHome 2026.1. If you are seeing this, report "
-            "an issue to the external_component author and ask them to update it."
-        )
     components_registry = CORE.data[KEY_ESP32][KEY_COMPONENTS]
-    if components:
-        for comp in components:
-            existing = components_registry.get(comp)
-            if existing and existing.get(KEY_REF) != ref:
-                _LOGGER.warning(
-                    "IDF component %s version conflict %s replaced by %s",
-                    comp,
-                    existing.get(KEY_REF),
-                    ref,
-                )
-            components_registry[comp] = {
-                KEY_REPO: repo,
-                KEY_REF: ref,
-                KEY_PATH: f"{path}/{comp}" if path else comp,
-            }
-    else:
-        existing = components_registry.get(name)
-        if existing and existing.get(KEY_REF) != ref:
-            _LOGGER.warning(
-                "IDF component %s version conflict %s replaced by %s",
-                name,
-                existing.get(KEY_REF),
-                ref,
-            )
-        components_registry[name] = {
-            KEY_REPO: repo,
-            KEY_REF: ref,
-            KEY_PATH: path,
-        }
+    existing = components_registry.get(name)
+    if existing and existing.get(KEY_REF) != ref:
+        _LOGGER.warning(
+            "IDF component %s version conflict %s replaced by %s",
+            name,
+            existing.get(KEY_REF),
+            ref,
+        )
+    components_registry[name] = {
+        KEY_REPO: repo,
+        KEY_REF: ref,
+        KEY_PATH: path,
+    }
 
 
 def exclude_builtin_idf_component(name: str) -> None:
@@ -1037,16 +1011,6 @@ def _parse_idf_component(value: str) -> ConfigType:
     )
 
 
-def _validate_idf_component(config: ConfigType) -> ConfigType:
-    """Validate IDF component config and warn about deprecated options."""
-    if CONF_REFRESH in config:
-        _LOGGER.warning(
-            "The 'refresh' option for IDF components is deprecated and has no effect. "
-            "It will be removed in ESPHome 2026.1. Please remove it from your configuration."
-        )
-    return config
-
-
 FRAMEWORK_ESP_IDF = "esp-idf"
 FRAMEWORK_ARDUINO = "arduino"
 FRAMEWORK_SCHEMA = cv.Schema(
@@ -1135,13 +1099,9 @@ FRAMEWORK_SCHEMA = cv.Schema(
                             cv.Optional(CONF_SOURCE): cv.git_ref,
                             cv.Optional(CONF_REF): cv.string,
                             cv.Optional(CONF_PATH): cv.string,
-                            cv.Optional(CONF_REFRESH): cv.All(
-                                cv.string, cv.source_refresh
-                            ),
                         }
                     ),
                 ),
-                _validate_idf_component,
             )
         ),
     }


### PR DESCRIPTION
# What does this implement/fix?

Remove deprecated ESP32 IDF component APIs that were due for removal in 2026.1.0.

**Python API (`add_idf_component()`):**
- Remove `refresh`, `components`, and `submodules` parameters from the function signature
- Remove the deprecation warning block
- Remove the `if components:` branch that handled batch registration
- Keep only the single-component registration path (previously the `else` branch)
- Remove now-unused `TimePeriod` import

**YAML config (`esp32: framework: components:`):**
- Remove the deprecated `refresh` option from the IDF component schema
- Remove the `_validate_idf_component()` function (only existed to warn about `refresh`)
- Remove now-unused `CONF_REFRESH` import

No internal callers use the deprecated `add_idf_component()` parameters — all 12+ callers only use `name`, `repo`, `ref`, `path`. The `refresh` YAML option had no effect and was only producing a warning.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# The 'refresh' option is no longer accepted under esp-idf components:
esp32:
  framework:
    type: esp-idf
    components:
      - name: espressif/led_strip
        ref: "1.0.0"
        # refresh: 1d  <-- no longer valid, remove this line

# External components should update their add_idf_component() calls:
#   Before: add_idf_component(name="x", repo="y", ref="z", components=["a", "b"])
#   After (individual calls):
#     add_idf_component(name="a", repo="y", ref="z", path="a")
#     add_idf_component(name="b", repo="y", ref="z", path="b")
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).