### PR TITLE
[i2c] Remove deprecated stop parameter overloads and readv/writev methods

### DIFF
--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -267,37 +267,6 @@ class I2CDevice {
 
   bool write_byte_16(uint8_t a_register, uint16_t data) const { return write_bytes_16(a_register, &data, 1); }
 
-  // Deprecated functions
-
-  ESPDEPRECATED("The stop argument is no longer used. This will be removed from ESPHome 2026.3.0", "2025.9.0")
-  ErrorCode read_register(uint8_t a_register, uint8_t *data, size_t len, bool stop) {
-    return this->read_register(a_register, data, len);
-  }
-
-  ESPDEPRECATED("The stop argument is no longer used. This will be removed from ESPHome 2026.3.0", "2025.9.0")
-  ErrorCode read_register16(uint16_t a_register, uint8_t *data, size_t len, bool stop) {
-    return this->read_register16(a_register, data, len);
-  }
-
-  ESPDEPRECATED("The stop argument is no longer used; use write_read() for consecutive write and read. This will be "
-                "removed from ESPHome 2026.3.0",
-                "2025.9.0")
-  ErrorCode write(const uint8_t *data, size_t len, bool stop) const { return this->write(data, len); }
-
-  ESPDEPRECATED("The stop argument is no longer used; use write_read() for consecutive write and read. This will be "
-                "removed from ESPHome 2026.3.0",
-                "2025.9.0")
-  ErrorCode write_register(uint8_t a_register, const uint8_t *data, size_t len, bool stop) const {
-    return this->write_register(a_register, data, len);
-  }
-
-  ESPDEPRECATED("The stop argument is no longer used; use write_read() for consecutive write and read. This will be "
-                "removed from ESPHome 2026.3.0",
-                "2025.9.0")
-  ErrorCode write_register16(uint16_t a_register, const uint8_t *data, size_t len, bool stop) const {
-    return this->write_register16(a_register, data, len);
-  }
-
  protected:
   uint8_t address_{0x00};  ///< store the address of the device on the bus
   I2CBus *bus_{nullptr};   ///< pointer to I2CBus instance

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -1,8 +1,6 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
-#include <memory>
 #include <utility>
 #include <vector>
 
@@ -22,18 +20,6 @@ enum ErrorCode {
   ERROR_TOO_LARGE = 5,         ///< requested a transfer larger than buffers can hold
   ERROR_UNKNOWN = 6,           ///< miscellaneous I2C error during execution
   ERROR_CRC = 7,               ///< bytes received with a CRC error
-};
-
-/// @brief the ReadBuffer structure stores a pointer to a read buffer and its length
-struct ReadBuffer {
-  uint8_t *data;  ///< pointer to the read buffer
-  size_t len;     ///< length of the buffer
-};
-
-/// @brief the WriteBuffer structure stores a pointer to a write buffer and its length
-struct WriteBuffer {
-  const uint8_t *data;  ///< pointer to the write buffer
-  size_t len;           ///< length of the buffer
 };
 
 /// @brief This Class provides the methods to read and write bytes from an I2CBus.
@@ -66,50 +52,6 @@ class I2CBus {
 
   ErrorCode write(uint8_t address, const uint8_t *buffer, size_t len, bool stop = true) {
     return this->write_readv(address, buffer, len, nullptr, 0);
-  }
-
-  ESPDEPRECATED("This method is deprecated and will be removed in ESPHome 2026.3.0. Use write_readv() instead.",
-                "2025.9.0")
-  ErrorCode readv(uint8_t address, ReadBuffer *read_buffers, size_t count) {
-    size_t total_len = 0;
-    for (size_t i = 0; i != count; i++) {
-      total_len += read_buffers[i].len;
-    }
-
-    SmallBufferWithHeapFallback<128> buffer_alloc(total_len);  // Most I2C reads are small
-    uint8_t *buffer = buffer_alloc.get();
-
-    auto err = this->write_readv(address, nullptr, 0, buffer, total_len);
-    if (err != ERROR_OK)
-      return err;
-    size_t pos = 0;
-    for (size_t i = 0; i != count; i++) {
-      if (read_buffers[i].len != 0) {
-        std::memcpy(read_buffers[i].data, buffer + pos, read_buffers[i].len);
-        pos += read_buffers[i].len;
-      }
-    }
-    return ERROR_OK;
-  }
-
-  ESPDEPRECATED("This method is deprecated and will be removed in ESPHome 2026.3.0. Use write_readv() instead.",
-                "2025.9.0")
-  ErrorCode writev(uint8_t address, const WriteBuffer *write_buffers, size_t count, bool stop = true) {
-    size_t total_len = 0;
-    for (size_t i = 0; i != count; i++) {
-      total_len += write_buffers[i].len;
-    }
-
-    SmallBufferWithHeapFallback<128> buffer_alloc(total_len);  // Most I2C writes are small
-    uint8_t *buffer = buffer_alloc.get();
-
-    size_t pos = 0;
-    for (size_t i = 0; i != count; i++) {
-      std::memcpy(buffer + pos, write_buffers[i].data, write_buffers[i].len);
-      pos += write_buffers[i].len;
-    }
-
-    return this->write_readv(address, buffer, total_len, nullptr, 0);
   }
 
  protected:


### PR DESCRIPTION
# What does this implement/fix?

Remove deprecated I2C APIs that were due for removal in 2026.3.0.

**I2CDevice (`i2c.h`)** — Remove the 5 deprecated method overloads that accepted a `bool stop` parameter:
- `read_register(uint8_t, uint8_t*, size_t, bool stop)`
- `read_register16(uint16_t, uint8_t*, size_t, bool stop)`
- `write(const uint8_t*, size_t, bool stop)`
- `write_register(uint8_t, const uint8_t*, size_t, bool stop)`
- `write_register16(uint16_t, const uint8_t*, size_t, bool stop)`

**I2CBus (`i2c_bus.h`)** — Remove the deprecated `readv()` and `writev()` methods (replaced by `write_readv()`), along with the now-unused `ReadBuffer` and `WriteBuffer` structs and unused `<cstring>`/`<memory>` includes.

No internal callers use any of these deprecated APIs — they existed only for external component backward compatibility. The bus-level `read()`/`write()` convenience methods and `write_readv()` are unaffected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a C++ API change, not a YAML config change.
# External components should update their calls:
#   Before: this->read_register(reg, data, len, true);
#   After:  this->read_register(reg, data, len);
#   Before: this->bus_->readv(addr, buffers, count);
#   After:  this->bus_->write_readv(addr, nullptr, 0, data, len);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).