### PR TITLE
[scheduler] Reduce lock acquisitions in process_defer_queue_

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -421,6 +421,29 @@ void Scheduler::full_cleanup_removed_items_() {
   this->to_remove_ = 0;
 }
 
+#ifndef ESPHOME_THREAD_SINGLE
+void Scheduler::compact_defer_queue_locked_() {
+  // Rare case: new items were added during processing - compact the vector
+  // This only happens when:
+  // 1. A deferred callback calls defer() again, or
+  // 2. Another thread calls defer() while we're processing
+  //
+  // Move unprocessed items (added during this loop) to the front for next iteration
+  //
+  // SAFETY: Compacted items may include cancelled items (marked for removal via
+  // cancel_item_locked_() during execution). This is safe because should_skip_item_()
+  // checks is_item_removed_() before executing, so cancelled items will be skipped
+  // and recycled on the next loop iteration.
+  size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
+  for (size_t i = 0; i < remaining; i++) {
+    this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
+  }
+  // Use erase() instead of resize() to avoid instantiating _M_default_append
+  // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
+  this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
+}
+#endif /* not ESPHOME_THREAD_SINGLE */
+
 void HOT Scheduler::call(uint32_t now) {
 #ifndef ESPHOME_THREAD_SINGLE
   this->process_defer_queue_(now);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -384,41 +384,46 @@ class Scheduler {
     // No lock needed: single consumer (main loop), stale read just means we process less this iteration
     size_t defer_queue_end = this->defer_queue_.size();
 
+    // Fast path: nothing to process, avoid lock entirely.
+    // Safe without lock: single consumer (main loop) reads front_, and a stale size() read
+    // from a concurrent push can only make us see fewer items — they'll be processed next loop.
+    if (this->defer_queue_front_ >= defer_queue_end)
+      return;
+
+    // Merge lock acquisitions: instead of separate locks for move-out and recycle (2N+1 total),
+    // recycle each item after re-acquiring the lock for the next iteration (N+1 total).
+    // The lock is held across: recycle → loop condition → move-out, then released for execution.
+    std::unique_ptr<SchedulerItem> item;
+
+    this->lock_.lock();
     while (this->defer_queue_front_ < defer_queue_end) {
-      std::unique_ptr<SchedulerItem> item;
-      {
-        LockGuard lock(this->lock_);
-        // SAFETY: Moving out the unique_ptr leaves a nullptr in the vector at defer_queue_front_.
-        // This is intentional and safe because:
-        // 1. The vector is only cleaned up by cleanup_defer_queue_locked_() at the end of this function
-        // 2. Any code iterating defer_queue_ MUST check for nullptr items (see mark_matching_items_removed_locked_
-        //    and has_cancelled_timeout_in_container_locked_ in scheduler.h)
-        // 3. The lock protects concurrent access, but the nullptr remains until cleanup
-        item = std::move(this->defer_queue_[this->defer_queue_front_]);
-        this->defer_queue_front_++;
-      }
+      // SAFETY: Moving out the unique_ptr leaves a nullptr in the vector at defer_queue_front_.
+      // This is intentional and safe because:
+      // 1. The vector is only cleaned up by cleanup_defer_queue_locked_() at the end of this function
+      // 2. Any code iterating defer_queue_ MUST check for nullptr items (see mark_matching_items_removed_locked_
+      //    and has_cancelled_timeout_in_container_locked_ in scheduler.h)
+      // 3. The lock protects concurrent access, but the nullptr remains until cleanup
+      item = std::move(this->defer_queue_[this->defer_queue_front_]);
+      this->defer_queue_front_++;
+      this->lock_.unlock();
 
       // Execute callback without holding lock to prevent deadlocks
       // if the callback tries to call defer() again
       if (!this->should_skip_item_(item.get())) {
         now = this->execute_item_(item.get(), now);
       }
-      // Recycle the defer item after execution
-      {
-        LockGuard lock(this->lock_);
-        this->recycle_item_main_loop_(std::move(item));
-      }
-    }
 
-    // If we've consumed all items up to the snapshot point, clean up the dead space
-    // Single consumer (main loop), so no lock needed for this check
-    if (this->defer_queue_front_ >= defer_queue_end) {
-      LockGuard lock(this->lock_);
-      this->cleanup_defer_queue_locked_();
+      this->lock_.lock();
+      this->recycle_item_main_loop_(std::move(item));
     }
+    // Clean up the queue (lock already held from last recycle or initial acquisition)
+    this->cleanup_defer_queue_locked_();
+    this->lock_.unlock();
   }
 
-  // Helper to cleanup defer_queue_ after processing
+  // Helper to cleanup defer_queue_ after processing.
+  // Keeps the common clear() path inline, outlines the rare compaction to keep
+  // cold code out of the hot instruction cache lines.
   // IMPORTANT: Caller must hold the scheduler lock before calling this function.
   inline void cleanup_defer_queue_locked_() {
     // Check if new items were added by producers during processing
@@ -426,27 +431,17 @@ class Scheduler {
       // Common case: no new items - clear everything
       this->defer_queue_.clear();
     } else {
-      // Rare case: new items were added during processing - compact the vector
-      // This only happens when:
-      // 1. A deferred callback calls defer() again, or
-      // 2. Another thread calls defer() while we're processing
-      //
-      // Move unprocessed items (added during this loop) to the front for next iteration
-      //
-      // SAFETY: Compacted items may include cancelled items (marked for removal via
-      // cancel_item_locked_() during execution). This is safe because should_skip_item_()
-      // checks is_item_removed_() before executing, so cancelled items will be skipped
-      // and recycled on the next loop iteration.
-      size_t remaining = this->defer_queue_.size() - this->defer_queue_front_;
-      for (size_t i = 0; i < remaining; i++) {
-        this->defer_queue_[i] = std::move(this->defer_queue_[this->defer_queue_front_ + i]);
-      }
-      // Use erase() instead of resize() to avoid instantiating _M_default_append
-      // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
-      this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
+      // Rare case: new items were added during processing - outlined to keep cold code
+      // out of the hot instruction cache lines
+      this->compact_defer_queue_locked_();
     }
     this->defer_queue_front_ = 0;
   }
+
+  // Cold path for compacting defer_queue_ when new items were added during processing.
+  // IMPORTANT: Caller must hold the scheduler lock before calling this function.
+  // IMPORTANT: Must not be inlined - rare path, outlined to keep it out of the hot instruction cache lines.
+  void __attribute__((noinline)) compact_defer_queue_locked_();
 #endif /* not ESPHOME_THREAD_SINGLE */
 
   // Helper to check if item is marked for removal (platform-specific)


### PR DESCRIPTION
# What does this implement/fix?

Restructure the defer queue processing loop to reduce mutex lock acquisitions from 2N+1 to N+1 for N deferred items.

**Changes:**

1. **Merge lock acquisitions:** Previously each item required two separate lock/unlock pairs (one for move-out, one for recycle). By combining the recycle of each item with the move-out of the next item under a single lock hold, the total drops to N+1. The callback still executes without the lock held to prevent deadlocks.

2. **Early return on empty queue:** Avoids taking the lock at all when nothing is deferred (the common case). The lockless check is safe because the main loop is the single consumer of `defer_queue_front_`, and a stale `size()` read from a concurrent push can only cause us to see fewer items — they will be processed on the next loop iteration.

3. **Outline rare compaction path:** Moves the defer queue compaction logic (only runs when items are added during processing) into a separate `noinline` `compact_defer_queue_locked_()` to keep cold code out of the hot instruction cache lines.

**Lock count comparison (verified with isolated test):**

| Items | Before | After |
|-------|--------|-------|
| 0 | 1 | 0 |
| 1 | 3 | 2 |
| 3 | 7 | 4 |
| 10 | 21 | 11 |

**Testing:** The scheduler is one of the most tested parts of the codebase — the integration tests in `tests/integration` fully cover the defer queue processing paths.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Note: This code is compiled only on multi-threaded platforms (`#ifndef ESPHOME_THREAD_SINGLE`), so ESP8266 and RP2040 are unaffected.

## Example entry for `config.yaml`:

n/a — internal scheduler optimization, no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).