### PR TITLE
[audio] Disable FLAC CRC validation to improve decoding effeciancy

### DIFF
--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -85,6 +85,10 @@ esp_err_t AudioDecoder::start(AudioFileType audio_file_type) {
 #ifdef USE_AUDIO_FLAC_SUPPORT
     case AudioFileType::FLAC:
       this->flac_decoder_ = make_unique<esp_audio_libs::flac::FLACDecoder>();
+      // CRC check slows down decoding by 15-20% on an ESP32-S3. FLAC sources in ESPHome are either from an http source
+      // or built into the firmware, so the data integrity is already verified by the time it gets to the decoder,
+      // making the CRC check unnecessary.
+      this->flac_decoder_->set_crc_check_enabled(false);
       this->free_buffer_required_ =
           this->output_transfer_buffer_->capacity();  // Adjusted and reallocated after reading the header
       break;


### PR DESCRIPTION
# What does this implement/fix?

Disables validating a FLAC files internal CRC measurements while decoding. The CRC validation adds a 15-20% processing overhead. Since all FLAC files decoded by ESPHome are built into the firmware from a user provided file or from an HTTP source, it is reasonable to assume there are no data integrity issues. If one somehow makes it in, which is very unlikely, it would typically just cause an audible glitch.

This was actually the original behavior for decoding FLAC in ESPHome until #10974 where the updated FLAC decoder enabled CRC validation by default.

Marked it as a developer breaking change as it is changing behavior, but I imagine it will not affect any end users or even other developers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: box_speaker
    i2s_dout_pin: GPIO15
    dac_type: external
    sample_rate: 48000
    bits_per_sample: 16bit
    channel: left
    audio_dac: es8311_dac
    buffer_duration: 100ms

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
