### PR TITLE
[esp32_ble] Enable CONFIG_BT_RELEASE_IRAM on ESP32-C2

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -390,10 +390,12 @@ def final_validation(config):
 
     # ESP32-C2 has very limited RAM (~272KB). Without releasing BLE IRAM,
     # esp_bt_controller_init fails with ESP_ERR_NO_MEM.
-    # CONFIG_BT_RELEASE_IRAM frees ~21KB of IRAM by merging BT text/data/bss
-    # into heap when esp_bt_mem_release is called.
+    # CONFIG_BT_RELEASE_IRAM changes the memory layout so IRAM and DRAM share
+    # space more flexibly, giving the BT controller enough contiguous memory.
+    # This requires CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT to be disabled.
     if get_esp32_variant() == VARIANT_ESP32C2:
         add_idf_sdkconfig_option("CONFIG_BT_RELEASE_IRAM", True)
+        add_idf_sdkconfig_option("CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT", False)
 
     # Set GATT Client/Server sdkconfig options based on which components are loaded
     full_config = fv.full_config.get()

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -9,6 +9,7 @@ from esphome import automation
 import esphome.codegen as cg
 from esphome.components import socket
 from esphome.components.esp32 import add_idf_sdkconfig_option, const, get_esp32_variant
+from esphome.components.esp32.const import VARIANT_ESP32C2
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ENABLE_ON_BOOT,
@@ -386,6 +387,13 @@ def final_validation(config):
             raise cv.Invalid(
                 f"Name '{name}' is too long, maximum length is {max_length} characters"
             )
+
+    # ESP32-C2 has very limited RAM (~272KB). Without releasing BLE IRAM,
+    # esp_bt_controller_init fails with ESP_ERR_NO_MEM.
+    # CONFIG_BT_RELEASE_IRAM frees ~21KB of IRAM by merging BT text/data/bss
+    # into heap when esp_bt_mem_release is called.
+    if get_esp32_variant() == VARIANT_ESP32C2:
+        add_idf_sdkconfig_option("CONFIG_BT_RELEASE_IRAM", True)
 
     # Set GATT Client/Server sdkconfig options based on which components are loaded
     full_config = fv.full_config.get()

--- a/tests/components/esp32_ble/test.esp32-c2-idf.yaml
+++ b/tests/components/esp32_ble/test.esp32-c2-idf.yaml
@@ -1,0 +1,5 @@
+<<: !include common.yaml
+
+esp32_ble:
+  io_capability: keyboard_only
+  disable_bt_logs: false


### PR DESCRIPTION
# What does this implement/fix?

Enable `CONFIG_BT_RELEASE_IRAM` automatically when BLE is used on ESP32-C2 variants.

https://docs.espressif.com/projects/esp-idf/en/v5.2/esp32c2/api-guides/performance/ram-usage.html

The ESP32-C2 has very limited RAM (~272KB). Without this sdkconfig option, `esp_bt_controller_init` fails with `ESP_ERR_NO_MEM`, making BLE completely non-functional on C2 chips.

On ESP32-C2, enabling `CONFIG_BT_RELEASE_IRAM` disables `CONFIG_ESP_SYSTEM_PMP_IDRAM_SPLIT`, which changes the memory partitioning so IRAM and DRAM share space more flexibly. This gives the BT controller enough contiguous memory to initialize without OOM. The option also enables releasing ~21KB of BT IRAM via `esp_bt_mem_release()` after Bluetooth is no longer needed, but ESPHome keeps BLE running continuously (for proxy, improv, etc.) so that function is never called. The benefit here is purely from the compile-time memory layout change.

This is automatically applied during final validation when the ESP32-C2 variant is detected, so users no longer need to manually add it to their `sdkconfig_options`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13516

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No changes needed - CONFIG_BT_RELEASE_IRAM is now set automatically on ESP32-C2
# Previously users had to manually add:
#   esp32:
#     framework:
#       type: esp-idf
#       sdkconfig_options:
#         CONFIG_BT_RELEASE_IRAM: y
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).