### PR TITLE
[pulse_counter] Fix build failure when use_pcnt is false

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -8,10 +8,10 @@
 
 #if defined(USE_ESP32)
 #include <soc/soc_caps.h>
-#ifdef SOC_PCNT_SUPPORTED
+#if defined(SOC_PCNT_SUPPORTED) && __has_include(<driver/pulse_cnt.h>)
 #include <driver/pulse_cnt.h>
 #define HAS_PCNT
-#endif  // SOC_PCNT_SUPPORTED
+#endif  // defined(SOC_PCNT_SUPPORTED) && __has_include(<driver/pulse_cnt.h>)
 #endif  // USE_ESP32
 
 namespace esphome {

--- a/tests/components/pulse_counter/test-no-pcnt.esp32-idf.yaml
+++ b/tests/components/pulse_counter/test-no-pcnt.esp32-idf.yaml
@@ -1,0 +1,10 @@
+sensor:
+  - platform: pulse_counter
+    name: Pulse Counter
+    pin: 4
+    use_pcnt: false
+    count_mode:
+      rising_edge: INCREMENT
+      falling_edge: DECREMENT
+    internal_filter: 13us
+    update_interval: 15s


### PR DESCRIPTION
# What does this implement/fix?

Fix a compilation error when using `pulse_counter` with `use_pcnt: false` on ESP32 with ESP-IDF framework:

```
fatal error: driver/pulse_cnt.h: No such file or directory
```

**Root cause:** The header `pulse_counter_sensor.h` unconditionally includes `<driver/pulse_cnt.h>` whenever `SOC_PCNT_SUPPORTED` is defined (a hardware capability check from `soc/soc_caps.h`). But when `use_pcnt: false`, the Python codegen doesn't call `include_builtin_idf_component("esp_driver_pcnt")`, and this IDF component is excluded by default — so the header file doesn't exist in the build.

**Fix:** Add a `__has_include(<driver/pulse_cnt.h>)` guard so the include only happens when the PCNT driver is actually available. When it's not, `HAS_PCNT` stays undefined and `BasicPulseCounterStorage` (software pulse counting) is used instead.

This also fixes the same latent issue for `hlw8012`, which includes `pulse_counter_sensor.h`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14110

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config now compiles correctly on ESP-IDF:
sensor:
  - platform: pulse_counter
    use_pcnt: false
    pin: 17
    name: "power"
    update_interval: 180s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).