### PR TITLE
[safe_mode] Log brownout as reset reason on OTA rollback

### DIFF
--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -11,6 +11,7 @@
 
 #if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
 #include <esp_ota_ops.h>
+#include <esp_system.h>
 #endif
 
 namespace esphome::safe_mode {
@@ -54,6 +55,10 @@ void SafeModeComponent::dump_config() {
              "OTA rollback detected! Rolled back from partition '%s'\n"
              "The device reset before the boot was marked successful",
              last_invalid->label);
+    if (esp_reset_reason() == ESP_RST_BROWNOUT) {
+      ESP_LOGW(TAG, "Last reset was due to brownout - check your power supply!\n"
+                    "See https://esphome.io/guides/faq.html#brownout-detector-was-triggered");
+    }
   }
 #endif
 }


### PR DESCRIPTION
# What does this implement/fix?

When an OTA rollback is detected and the last reset reason was brownout, log a warning message directing users to check their power supply with a link to the FAQ. This helps users understand *why* their device rolled back instead of just seeing the generic "device reset before boot was marked successful" message.

### Background

Devices with marginal power supplies may brownout during WiFi TX bursts after an OTA update. On the next boot, `CONFIG_ESP_PHY_REDUCE_TX_POWER` reduces TX power to 13dBm (since `esp_reset_reason() == ESP_RST_BROWNOUT`), so the device runs fine when flashed via serial or after a manual reset. However, with OTA rollback enabled, the repeated brownout resets prevent the boot from being marked successful, causing the bootloader to roll back to the previous firmware. This means OTA updates keep failing silently with no indication of why.

Example output:
```
[W][safe_mode]: OTA rollback detected! Rolled back from partition 'ota_0'
  The device reset before the boot was marked successful
[W][safe_mode]: Last reset was due to brownout - check your power supply!
  See https://esphome.io/guides/faq.html#brownout-detector-was-triggered
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- related https://github.com/esphome/esphome/issues/14112

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6122

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is automatic logging
safe_mode:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).