### PR TITLE
[core] Add pow10_int helper, replace powf in normalize_accuracy and sensor filters

### DIFF
--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "sensor.h"
 
@@ -237,7 +238,7 @@ ValueListFilter::ValueListFilter(std::initializer_list<TemplatableValue<float>> 
 
 bool ValueListFilter::value_matches_any_(float sensor_value) {
   int8_t accuracy = this->parent_->get_accuracy_decimals();
-  float accuracy_mult = powf(10.0f, accuracy);
+  float accuracy_mult = pow10_int(accuracy);
   float rounded_sensor = roundf(accuracy_mult * sensor_value);
 
   for (auto &filter_value : this->values_) {
@@ -469,7 +470,7 @@ optional<float> ClampFilter::new_value(float value) {
 RoundFilter::RoundFilter(uint8_t precision) : precision_(precision) {}
 optional<float> RoundFilter::new_value(float value) {
   if (std::isfinite(value)) {
-    float accuracy_mult = powf(10.0f, this->precision_);
+    float accuracy_mult = pow10_int(this->precision_);
     return roundf(accuracy_mult * value) / accuracy_mult;
   }
   return value;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -468,20 +468,15 @@ ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
 
 static inline void normalize_accuracy_decimals(float &value, int8_t &accuracy_decimals) {
   if (accuracy_decimals < 0) {
-    // Clamp to -9 to keep divisor within uint32_t range (max 10^9 = 1,000,000,000)
-    int8_t dec = accuracy_decimals < -9 ? (int8_t) -9 : accuracy_decimals;
-    uint32_t divisor;
-    if (dec == -1) {
-      divisor = 10;
-    } else if (dec == -2) {
-      divisor = 100;
+    float divisor;
+    if (accuracy_decimals == -1) {
+      divisor = 10.0f;
+    } else if (accuracy_decimals == -2) {
+      divisor = 100.0f;
     } else {
-      divisor = 1000;
-      for (int8_t i = dec + 3; i < 0; i++)
-        divisor *= 10;
+      divisor = pow10_int(-accuracy_decimals);
     }
-    auto divisor_f = static_cast<float>(divisor);
-    value = roundf(value / divisor_f) * divisor_f;
+    value = roundf(value / divisor) * divisor;
     accuracy_decimals = 0;
   }
 }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -468,8 +468,18 @@ ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
 
 static inline void normalize_accuracy_decimals(float &value, int8_t &accuracy_decimals) {
   if (accuracy_decimals < 0) {
-    auto multiplier = powf(10.0f, accuracy_decimals);
-    value = roundf(value * multiplier) / multiplier;
+    uint32_t divisor;
+    if (accuracy_decimals == -1) {
+      divisor = 10;
+    } else if (accuracy_decimals == -2) {
+      divisor = 100;
+    } else {
+      divisor = 1000;
+      for (int8_t i = accuracy_decimals + 3; i < 0; i++)
+        divisor *= 10;
+    }
+    auto divisor_f = static_cast<float>(divisor);
+    value = roundf(value / divisor_f) * divisor_f;
     accuracy_decimals = 0;
   }
 }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -468,14 +468,16 @@ ParseOnOffState parse_on_off(const char *str, const char *on, const char *off) {
 
 static inline void normalize_accuracy_decimals(float &value, int8_t &accuracy_decimals) {
   if (accuracy_decimals < 0) {
+    // Clamp to -9 to keep divisor within uint32_t range (max 10^9 = 1,000,000,000)
+    int8_t dec = accuracy_decimals < -9 ? (int8_t) -9 : accuracy_decimals;
     uint32_t divisor;
-    if (accuracy_decimals == -1) {
+    if (dec == -1) {
       divisor = 10;
-    } else if (accuracy_decimals == -2) {
+    } else if (dec == -2) {
       divisor = 100;
     } else {
       divisor = 1000;
-      for (int8_t i = accuracy_decimals + 3; i < 0; i++)
+      for (int8_t i = dec + 3; i < 0; i++)
         divisor *= 10;
     }
     auto divisor_f = static_cast<float>(divisor);

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -439,6 +439,21 @@ template<size_t STACK_SIZE, typename T = uint8_t> class SmallBufferWithHeapFallb
 /// @name Mathematics
 ///@{
 
+/// Compute 10^exp using iterative multiplication/division.
+/// Avoids pulling in powf/__ieee754_powf (~2.3KB flash) for small integer exponents.
+/// Exact for non-negative exponents up to 10 (powers of 10 up to 10^10 are exact in float).
+inline float pow10_int(int8_t exp) {
+  float result = 1.0f;
+  if (exp >= 0) {
+    for (int8_t i = 0; i < exp; i++)
+      result *= 10.0f;
+  } else {
+    for (int8_t i = exp; i < 0; i++)
+      result /= 10.0f;
+  }
+  return result;
+}
+
 /// Remap \p value from the range (\p min, \p max) to (\p min_out, \p max_out).
 template<typename T, typename U> T remap(U value, U min, U max, T min_out, T max_out) {
   return (value - min) * (max_out - min_out) / (max - min) + min_out;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -441,7 +441,7 @@ template<size_t STACK_SIZE, typename T = uint8_t> class SmallBufferWithHeapFallb
 
 /// Compute 10^exp using iterative multiplication/division.
 /// Avoids pulling in powf/__ieee754_powf (~2.3KB flash) for small integer exponents.
-/// Exact for non-negative exponents up to 10 (powers of 10 up to 10^10 are exact in float).
+/// Matches powf(10, exp) for the int8_t exponent range used by sensor accuracy_decimals.
 inline float pow10_int(int8_t exp) {
   float result = 1.0f;
   if (exp >= 0) {


### PR DESCRIPTION
# What does this implement/fix?

Add a shared `pow10_int()` inline helper to `helpers.h` that computes `10^exp` using iterative multiplication/division, avoiding the ~2.3KB `powf`/`__ieee754_powf` pull-in for small integer exponents.

Replace all `powf(10.0f, exp)` calls in the codebase where the exponent is a small integer:

- **`helpers.cpp`** (`normalize_accuracy_decimals`): Replaced with `pow10_int()` for the general case, keeping direct `-1`/`-2` fast paths. Also fixes float precision errors in the old `powf` implementation (e.g., `powf(10.0f, -3)` does not return exactly `0.001f`).
- **`sensor/filter.cpp`** (`ValueListFilter::value_matches_any_`): `powf(10.0f, accuracy)` → `pow10_int(accuracy)`
- **`sensor/filter.cpp`** (`RoundFilter::new_value`): `powf(10.0f, precision)` → `pow10_int(precision)`

### Precision fix

The old `powf` approach had float precision errors for negative exponents:
- `1000.0` with `acc=-3`: old produced `999.9999` → new correctly produces `1000.0`
- `1e8` with `acc=-3`: old produced `99999992.0` (off by 8) → new correctly produces `100000000.0`

The `pow10_int` helper uses exact float values for positive powers (10, 100, 1000, etc. are all exactly representable in float up to 10^10) and iterative division for negative powers, which avoids the compounding errors of `powf`.

### Impact

On builds where these are the only `powf` call sites, this eliminates `powf` + `__ieee754_powf` from the binary entirely.

**Tested on ESP8266 with web_server + sensors:** -3.1KB flash, -16 bytes RAM.

### ESP8266 on-device benchmarks (1000 iterations each)

| Exponent | `powf` (µs) | `pow10_int` (µs) | Speedup |
|----------|-------------|-------------------|---------|
| +0 | 2,263 | 485 | **4.7x** |
| +1 | 2,523 | 1,706 | **1.5x** |
| +2 | 3,720 | 2,930 | **1.3x** |
| +3 | 91,245 | 4,156 | **22.0x** |
| +4 | 90,405 | 5,385 | **16.8x** |
| +6 | 91,385 | 7,835 | **11.7x** |
| -1 | 5,863 | 3,677 | **1.6x** |
| -2 | 91,005 | 6,981 | **13.0x** |
| -3 | 91,200 | 10,294 | **8.9x** |
| -5 | 91,210 | 16,831 | **5.4x** |

> [!NOTE]
> The large jumps in `powf` time (e.g., 3,720 → 91,245 between exp=+2 and exp=+3) are due to the ESP8266's software float `__ieee754_powf` implementation. Small exponents like 0, 1, 2, -1 hit a fast path in the library; larger exponents go through the full computation. `pow10_int` scales linearly with `|exp|` since it's just iterative multiplication.

<details>
<summary>ESP8266 benchmark YAML (button lambda)</summary>

```yaml
button:
  - platform: template
    name: "pow10_int Benchmark"
    on_press:
      - lambda: |-
          static const char *const BTAG = "bench";
          const int ITERS = 1000;
          volatile float vsink;
          ESP_LOGI(BTAG, "=== pow10_int vs powf(10,exp) Benchmark (%d iters) ===", ITERS);
          // Positive exponents (RoundFilter path)
          for (int8_t exp : {0, 1, 2, 3, 4, 6}) {
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) vsink = powf(10.0f, (float)exp);
            uint32_t powf_us = micros() - t0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) vsink = pow10_int(exp);
            uint32_t int_us = micros() - t0;
            ESP_LOGI(BTAG, "exp=%+d:  powf=%u us  pow10_int=%u us  (%.1fx)", exp, powf_us, int_us, (float)powf_us / int_us);
          }
          // Negative exponents (normalize_accuracy path)
          for (int8_t exp : {-1, -2, -3, -5}) {
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) vsink = powf(10.0f, (float)exp);
            uint32_t powf_us = micros() - t0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) vsink = pow10_int(exp);
            uint32_t int_us = micros() - t0;
            ESP_LOGI(BTAG, "exp=%+d:  powf=%u us  pow10_int=%u us  (%.1fx)", exp, powf_us, int_us, (float)powf_us / int_us);
          }
          // Full RoundFilter pipeline: roundf(mult * value) / mult
          {
            float value = 3.14159f;
            uint8_t precision = 2;
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) {
              float m = powf(10.0f, (float)precision);
              vsink = roundf(m * value) / m;
            }
            uint32_t powf_us = micros() - t0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) {
              float m = pow10_int(precision);
              vsink = roundf(m * value) / m;
            }
            uint32_t int_us = micros() - t0;
            ESP_LOGI(BTAG, "RoundFilter(p=2): powf=%u us  pow10_int=%u us  (%.1fx)", powf_us, int_us, (float)powf_us / int_us);
          }
          ESP_LOGI(BTAG, "=== Benchmark complete ===");
```

</details>

Verified with 144 standalone tests confirming `pow10_int` matches `powf(10, exp)` for exponents -9 through +10, and that the filter/normalize rounding behavior is equivalent or improved.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.