### PR TITLE
[wifi] Sync output_power with PHY max TX power to prevent brownout

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 from esphome import automation
 from esphome.automation import Condition
@@ -493,6 +494,13 @@ async def to_code(config):
         cg.add(var.set_passive_scan(True))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
+        if CORE.is_esp32:
+            # Set PHY max TX power to match output_power so calibration also uses
+            # reduced power. This prevents brownout during PHY init on marginal
+            # power supplies, which is critical for OTA updates with rollback enabled.
+            # Kconfig range is 10-20, ESPHome allows 8.5-20.5
+            phy_tx_power = max(10, min(20, math.ceil(config[CONF_OUTPUT_POWER])))
+            add_idf_sdkconfig_option("CONFIG_ESP_PHY_MAX_WIFI_TX_POWER", phy_tx_power)
     # enable_on_boot defaults to true in C++ - only set if false
     if not config[CONF_ENABLE_ON_BOOT]:
         cg.add(var.set_enable_on_boot(False))


### PR DESCRIPTION
# What does this implement/fix?

When `output_power` is configured, sync the compile-time `CONFIG_ESP_PHY_MAX_WIFI_TX_POWER` sdkconfig option to match. This ensures the PHY radio calibration runs at the same reduced power level, closing a brownout window during `esp_wifi_start()`.

### Background

ESP-IDF's PHY initialization (`register_chipv7_phy()`) calibrates the radio using power levels from compile-time init data, which defaults to 20 dBm. ESPHome's `output_power` setting only takes effect *after* PHY init via `esp_wifi_set_max_tx_power()`, leaving a window where calibration can draw full TX current and trigger a brownout on devices with marginal power supplies.

With OTA rollback enabled (the default), the bootloader gives new firmware exactly **one chance** to boot. If a brownout occurs during that first boot's PHY calibration, the bootloader immediately marks the partition as `ABORTED` and rolls back — `CONFIG_ESP_PHY_REDUCE_TX_POWER` never gets to help because it only activates on the *second* boot after a brownout, which the bootloader prevents.

By setting `CONFIG_ESP_PHY_MAX_WIFI_TX_POWER` at compile time to match `output_power`, the PHY init data has reduced power levels from the start, preventing brownout during calibration and allowing OTA updates to succeed.

### How it works

The ESP32 PHY init data (`phy_init_data.c`) contains per-rate TX power entries derived from `CONFIG_ESP_PHY_MAX_TX_POWER`:
```c
LIMIT(CONFIG_ESP_PHY_MAX_TX_POWER * 4, 40, 78),  // rate 1
LIMIT(CONFIG_ESP_PHY_MAX_TX_POWER * 4, 40, 72),  // rate 2
...
```

Setting `CONFIG_ESP_PHY_MAX_WIFI_TX_POWER=13` caps all entries to 52 (13 dBm in quarter-dBm units), which is the same value `CONFIG_ESP_PHY_REDUCE_TX_POWER` would apply reactively after a brownout.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to esphome/esphome#14113 (safe_mode brownout warning)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6122 (FAQ brownout troubleshooting)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  output_power: 13dB  # Also sets CONFIG_ESP_PHY_MAX_WIFI_TX_POWER=13
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).