### PR TITLE
[mipi_dsi] Disallow swap_xy

### DIFF
--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -50,6 +50,7 @@ from esphome.const import (
     CONF_RESET_PIN,
     CONF_SWAP_XY,
     CONF_TRANSFORM,
+    CONF_WIDTH,
 )
 from esphome.final_validate import full_config
 
@@ -102,7 +103,7 @@ def model_schema(config):
         else cv.Optional(CONF_INIT_SEQUENCE)
     )
     # Dimensions are optional if the model has a default width and the swap_xy transform is not overridden
-    cv_dimensions = cv.Optional
+    cv_dimensions = cv.Optional if model.get_default(CONF_WIDTH) else cv.Required
     pixel_modes = (PIXEL_MODE_16BIT, PIXEL_MODE_24BIT, "16", "24")
     schema = display.FULL_DISPLAY_SCHEMA.extend(
         {

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -102,7 +102,7 @@ def model_schema(config):
         if model.initsequence is None
         else cv.Optional(CONF_INIT_SEQUENCE)
     )
-    # Dimensions are optional if the model has a default width and the swap_xy transform is not overridden
+    # Dimensions are optional if the model has a default width
     cv_dimensions = cv.Optional if model.get_default(CONF_WIDTH) else cv.Required
     pixel_modes = (PIXEL_MODE_16BIT, PIXEL_MODE_24BIT, "16", "24")
     schema = display.FULL_DISPLAY_SCHEMA.extend(

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -48,10 +48,8 @@ from esphome.const import (
     CONF_MIRROR_Y,
     CONF_MODEL,
     CONF_RESET_PIN,
-    CONF_ROTATION,
     CONF_SWAP_XY,
     CONF_TRANSFORM,
-    CONF_WIDTH,
 )
 from esphome.final_validate import full_config
 
@@ -87,38 +85,24 @@ COLOR_DEPTHS = {
 
 def model_schema(config):
     model = MODELS[config[CONF_MODEL].upper()]
+    model.defaults[CONF_SWAP_XY] = cv.UNDEFINED
     transform = cv.Schema(
         {
             cv.Required(CONF_MIRROR_X): cv.boolean,
             cv.Required(CONF_MIRROR_Y): cv.boolean,
+            cv.Optional(CONF_SWAP_XY): cv.invalid(
+                "Axis swapping not supported by DSI displays"
+            ),
         }
     )
-    if model.get_default(CONF_SWAP_XY) != cv.UNDEFINED:
-        transform = transform.extend(
-            {
-                cv.Optional(CONF_SWAP_XY): cv.invalid(
-                    "Axis swapping not supported by this model"
-                )
-            }
-        )
-    else:
-        transform = transform.extend(
-            {
-                cv.Required(CONF_SWAP_XY): cv.boolean,
-            }
-        )
     # CUSTOM model will need to provide a custom init sequence
     iseqconf = (
         cv.Required(CONF_INIT_SEQUENCE)
         if model.initsequence is None
         else cv.Optional(CONF_INIT_SEQUENCE)
     )
-    swap_xy = config.get(CONF_TRANSFORM, {}).get(CONF_SWAP_XY, False)
-
     # Dimensions are optional if the model has a default width and the swap_xy transform is not overridden
-    cv_dimensions = (
-        cv.Optional if model.get_default(CONF_WIDTH) and not swap_xy else cv.Required
-    )
+    cv_dimensions = cv.Optional
     pixel_modes = (PIXEL_MODE_16BIT, PIXEL_MODE_24BIT, "16", "24")
     schema = display.FULL_DISPLAY_SCHEMA.extend(
         {
@@ -223,8 +207,6 @@ async def to_code(config):
         enable = [await cg.gpio_pin_expression(pin) for pin in enable_pin]
         cg.add(var.set_enable_pins(enable))
 
-    if model.rotation_as_transform(config):
-        config[CONF_ROTATION] = 0
     await display.register_display(var, config)
     if lamb := config.get(CONF_LAMBDA):
         lambda_ = await cg.process_lambda(

--- a/esphome/components/mipi_dsi/display.py
+++ b/esphome/components/mipi_dsi/display.py
@@ -48,6 +48,7 @@ from esphome.const import (
     CONF_MIRROR_Y,
     CONF_MODEL,
     CONF_RESET_PIN,
+    CONF_ROTATION,
     CONF_SWAP_XY,
     CONF_TRANSFORM,
     CONF_WIDTH,
@@ -208,6 +209,8 @@ async def to_code(config):
         enable = [await cg.gpio_pin_expression(pin) for pin in enable_pin]
         cg.add(var.set_enable_pins(enable))
 
+    if model.rotation_as_transform(config):
+        config[CONF_ROTATION] = 0
     await display.register_display(var, config)
     if lamb := config.get(CONF_LAMBDA):
         lambda_ = await cg.process_lambda(

--- a/tests/component_tests/mipi_dsi/fixtures/mipi_dsi.yaml
+++ b/tests/component_tests/mipi_dsi/fixtures/mipi_dsi.yaml
@@ -15,8 +15,13 @@ esp_ldo:
 
 display:
   - platform: mipi_dsi
+    id: p4_nano
     model: WAVESHARE-P4-NANO-10.1
-
+    rotation: 90
+  - platform: mipi_dsi
+    id: p4_86
+    model: "WAVESHARE-P4-86-PANEL"
+    rotation: 180
 i2c:
   sda: GPIO7
   scl: GPIO8

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -119,9 +119,11 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
-        "mipi_dsi_mipi_dsi_id = new mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"
+        "p4_nano = new mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"
         in main_cpp
     )
     assert "set_init_sequence({224, 1, 0, 225, 1, 147, 226, 1," in main_cpp
-    assert "mipi_dsi_mipi_dsi_id->set_lane_bit_rate(1500);" in main_cpp
+    assert "p4_nano->set_lane_bit_rate(1500);" in main_cpp
+    assert "p4_nano->set_rotation(display::DISPLAY_ROTATION_90_DEGREES);" in main_cpp
+    assert "p4_86->set_rotation(display::DISPLAY_ROTATION_0_DEGREES);" in main_cpp
     # assert "backlight_id = new light::LightState(mipi_dsi_dsibacklight_id);" in main_cpp


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Custom model DSI display would try to use hardware rotation. This disallows swapping x/y for all DSI models since DSI fundamentally doesn't appear to support it (could be re-enabled in the future if a use-case is demonstrated.)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1473742026204905492/1474032716679872535

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
