### PR TITLE
[core] Use constexpr for PROGMEM arrays

### DIFF
--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -424,7 +424,7 @@ class ProgmemAssignmentExpression(AssignmentExpression):
         super().__init__(type_, "", name, rhs)
 
     def __str__(self):
-        return f"static const {self.type} {self.name}[] PROGMEM = {self.rhs}"
+        return f"static constexpr {self.type} {self.name}[] PROGMEM = {self.rhs}"
 
 
 class StaticConstAssignmentExpression(AssignmentExpression):

--- a/tests/unit_tests/test_cpp_generator.py
+++ b/tests/unit_tests/test_cpp_generator.py
@@ -325,7 +325,7 @@ class TestStatements:
             ),
             (
                 cg.ProgmemAssignmentExpression(ct.uint16, "foo", "bar"),
-                'static const uint16_t foo[] PROGMEM = "bar"',
+                'static constexpr uint16_t foo[] PROGMEM = "bar"',
             ),
         ),
     )


### PR DESCRIPTION
# What does this implement/fix?

Change `progmem_array` codegen from `static const` to `static constexpr`. This ensures the compiler evaluates PROGMEM arrays at compile time with no runtime initialization.

**Before:**
```cpp
static const uint16_t gamma_2_8_fwd[] PROGMEM = {0x00, 0x00, ...};
```

**After:**
```cpp
static constexpr uint16_t gamma_2_8_fwd[] PROGMEM = {0x00, 0x00, ...};
```

`constexpr` is the correct qualifier for constant data known at compile time. All PROGMEM arrays are initialized from literal values generated by Python codegen, so they are always valid constexpr. This is a one-line change in `cpp_generator.py`.

Affects all components using `cg.progmem_array()`: images, fonts, remote codes, gamma tables, wake word models, etc.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal codegen improvement
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - N/A - no user-facing changes.