### PR TITLE
[uart] Always call pin setup for UART0 default pins on ESP-IDF

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -19,6 +19,11 @@ namespace esphome::uart {
 
 static const char *const TAG = "uart.idf";
 
+/// Check if a pin number matches one of the default UART0 GPIO pins.
+/// These pins may have residual state from the boot console that requires
+/// explicit reset before UART reconfiguration (ESP-IDF issue #17459).
+static bool is_default_uart0_pin(int8_t pin_num) { return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM; }
+
 uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;
   if (this->parity_ == UART_CONFIG_PARITY_EVEN) {
@@ -150,20 +155,26 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   // Commit 9ed617fb17 removed gpio_func_sel() calls from uart_set_pin(), which breaks
   // UART on default UART0 pins that may have residual state from boot console.
   // Reset these pins before configuring UART to ensure they're in a clean state.
-  if (tx == U0TXD_GPIO_NUM || tx == U0RXD_GPIO_NUM) {
+  if (is_default_uart0_pin(tx)) {
     gpio_reset_pin(static_cast<gpio_num_t>(tx));
   }
-  if (rx == U0TXD_GPIO_NUM || rx == U0RXD_GPIO_NUM) {
+  if (is_default_uart0_pin(rx)) {
     gpio_reset_pin(static_cast<gpio_num_t>(rx));
   }
 
-  // Setup pins after reset to preserve open drain/pullup/pulldown flags
+  // Setup pins after reset to configure GPIO direction and pull resistors.
+  // For UART0 default pins, setup() must always be called because gpio_reset_pin()
+  // above sets GPIO_MODE_DISABLE which disables the input buffer. Without setup(),
+  // uart_set_pin() on ESP-IDF 5.4.2+ does not re-enable the input buffer for
+  // IOMUX-connected pins, so the RX pin cannot receive data (see issue #10132).
+  // For other pins, only call setup() if pull or open-drain flags are set to avoid
+  // disturbing the default pin state which breaks some external components (#11823).
   auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
+    if (is_default_uart0_pin(pin->get_pin()) || (pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -22,7 +22,9 @@ static const char *const TAG = "uart.idf";
 /// Check if a pin number matches one of the default UART0 GPIO pins.
 /// These pins may have residual state from the boot console that requires
 /// explicit reset before UART reconfiguration (ESP-IDF issue #17459).
-static bool is_default_uart0_pin(int8_t pin_num) { return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM; }
+static constexpr bool is_default_uart0_pin(int8_t pin_num) {
+  return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM;
+}
 
 uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;


### PR DESCRIPTION
# What does this implement/fix?

Fix UART0 communication failure on ESP-IDF 5.4.2+ that has affected LD2410 and other UART sensors on default UART0 pins across all ESP32 variants (ESP32, ESP32-C3, ESP32-S3, ESP32-C6).

**Root cause:** The `gpio_reset_pin()` workaround from PR #12519 sets `GPIO_MODE_DISABLE` which disables the input buffer. PR #11914 made `pin->setup()` conditional on pull/open-drain flags, so most users' UART0 RX pins never got their input buffer re-enabled after the reset. On ESP-IDF 5.4.2+, `uart_set_pin()` does not re-enable the input buffer for IOMUX-connected UART0 default pins (due to `gpio_func_sel()` removal in espressif/esp-idf@9ed617fb17), so the RX pin cannot receive data.

**Fix:** Always call `pin->setup()` for pins matching `U0TXD_GPIO_NUM` or `U0RXD_GPIO_NUM` to restore proper GPIO direction after `gpio_reset_pin()`. For non-UART0 pins, the conditional behavior is preserved to avoid breaking external components (#11823).

**Affected UART0 default pins per variant:**
| Chip | U0TXD | U0RXD |
|------|-------|-------|
| ESP32 | GPIO1 | GPIO3 |
| ESP32-C3 | GPIO21 | GPIO20 |
| ESP32-S3 | GPIO43 | GPIO44 |
| ESP32-C6 | GPIO16 | GPIO17 |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10132

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any UART device on UART0 default pins, e.g. LD2410:
uart:
  tx_pin: GPIO1   # U0TXD on ESP32 (or GPIO21 on C3, GPIO43 on S3, etc.)
  rx_pin: GPIO3   # U0RXD on ESP32 (or GPIO20 on C3, GPIO44 on S3, etc.)
  baud_rate: 256000
  parity: NONE
  stop_bits: 1

ld2410:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).