### PR TITLE
[pulse_counter] Fix PCNT glitch filter calculation off by 1000x

### DIFF
--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -117,7 +117,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / (uint32_t) esp_clk_apb_freq();
+    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000u / ((uint32_t) esp_clk_apb_freq() / 1000000u);
     pcnt_glitch_filter_config_t filter_config = {
         .max_glitch_ns = std::min(this->filter_us * 1000u, max_glitch_ns),
     };


### PR DESCRIPTION
# What does this implement/fix?

The `max_glitch_ns` calculation used `1000000` (10^6) instead of 10^9 when converting `PCNT_LL_MAX_GLITCH_WIDTH` ticks to nanoseconds. This made the computed maximum 1000x too small (12ns instead of 12787ns), causing `std::min` to cap the user's requested filter (e.g. 13000ns for 13µs) to just 12ns. ESP-IDF then converts that to 0 APB clock cycles — effectively disabling the glitch filter entirely.

With the filter disabled, the PCNT hardware counts electrical noise as pulses, producing wildly inflated readings (e.g. ~280,000 pulses/min instead of ~1,010 on an ESP32-C6).

This fix uses the same split-division approach as ESP-IDF's own `pulse_cnt.c:404` to stay in 32-bit arithmetic:

```c
// ESP-IDF (ns → cycles): cycles = (freq / 1000000) * ns / 1000
// ESPHome (cycles → ns): ns     = cycles * 1000 / (freq / 1000000)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14069

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pulse_counter
    pin: GPIO18
    name: "Pulse Counter"
    internal_filter: 13us
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).