### PR TITLE
[e131] Drain all queued packets per loop iteration

### DIFF
--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -70,27 +70,9 @@ void E131Component::loop() {
   E131Packet packet;
   int universe = 0;
   uint8_t buf[1460];
+  ssize_t len;
 
-#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
-  ssize_t len = this->socket_->read(buf, sizeof(buf));
-  if (len == -1) {
-    return;
-  }
-
-  if (!this->packet_(buf, (size_t) len, universe, packet)) {
-    ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);
-    return;
-  }
-
-  if (!this->process_(universe, packet)) {
-    ESP_LOGV(TAG, "Ignored packet for %d universe of size %d.", universe, packet.count);
-  }
-#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
-  while (auto packet_size = this->udp_.parsePacket()) {
-    auto len = this->udp_.read(buf, sizeof(buf));
-    if (len <= 0)
-      continue;
-
+  while ((len = this->read_(buf, sizeof(buf))) > 0) {
     if (!this->packet_(buf, (size_t) len, universe, packet)) {
       ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);
       continue;
@@ -100,6 +82,15 @@ void E131Component::loop() {
       ESP_LOGV(TAG, "Ignored packet for %d universe of size %d.", universe, packet.count);
     }
   }
+}
+
+ssize_t E131Component::read_(uint8_t *buf, size_t len) {
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
+  return this->socket_->read(buf, len);
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+  if (!this->udp_.parsePacket())
+    return -1;
+  return this->udp_.read(buf, len);
 #endif
 }
 

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -84,16 +84,6 @@ void E131Component::loop() {
   }
 }
 
-ssize_t E131Component::read_(uint8_t *buf, size_t len) {
-#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
-  return this->socket_->read(buf, len);
-#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
-  if (!this->udp_.parsePacket())
-    return -1;
-  return this->udp_.read(buf, len);
-#endif
-}
-
 void E131Component::add_effect(E131AddressableLightEffect *light_effect) {
   if (std::find(light_effects_.begin(), light_effects_.end(), light_effect) != light_effects_.end()) {
     return;

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -72,6 +72,9 @@ void E131Component::loop() {
   uint8_t buf[1460];
   ssize_t len;
 
+  // Drain all queued packets so multi-universe frames are applied
+  // atomically before the light writes. Without this, each universe
+  // packet would trigger a separate full-strip write causing tearing.
   while ((len = this->read_(buf, sizeof(buf))) > 0) {
     if (!this->packet_(buf, (size_t) len, universe, packet)) {
       ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -46,7 +46,15 @@ class E131Component : public esphome::Component {
   void set_method(E131ListenMethod listen_method) { this->listen_method_ = listen_method; }
 
  protected:
-  ssize_t read_(uint8_t *buf, size_t len);
+  inline ssize_t read_(uint8_t *buf, size_t len) {
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
+    return this->socket_->read(buf, len);
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+    if (!this->udp_.parsePacket())
+      return -1;
+    return this->udp_.read(buf, len);
+#endif
+  }
   bool packet_(const uint8_t *data, size_t len, int &universe, E131Packet &packet);
   bool process_(int universe, const E131Packet &packet);
   bool join_igmp_groups_();

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -46,6 +46,7 @@ class E131Component : public esphome::Component {
   void set_method(E131ListenMethod listen_method) { this->listen_method_ = listen_method; }
 
  protected:
+  ssize_t read_(uint8_t *buf, size_t len);
   bool packet_(const uint8_t *data, size_t len, int &universe, E131Packet &packet);
   bool process_(int universe, const E131Packet &packet);
   bool join_igmp_groups_();


### PR DESCRIPTION
# What does this implement/fix?

The original WiFiUDP implementation (before #4832) drained all queued packets per `loop()` call using `while (udp_->parsePacket())`. When #4832 migrated ESP32 to BSD sockets, this was replaced with a single `socket_->read()` per loop — losing the drain behavior. ESP8266 was unaffected since it kept using WiFiUDP with the while loop (restored in #14086).

This meant ESP8266 always performed better than ESP32 for multi-universe E1.31 setups because it processed all universe packets in a single loop iteration, while ESP32 processed only one packet per loop, triggering a separate full-strip RMT write for each universe.

This PR restores the drain-all-packets behavior for the BSD socket path to match what WiFiUDP always did. The duplicated packet processing logic between the two backends is consolidated into a shared loop with a platform-specific `read_()` helper.

### Before (ESP32: 1 packet per loop, 3 universes = 3 separate writes):
```
light: count=4691, avg=1.24ms, max=14ms, total=5820ms
e131:  count=6306, avg=0.18ms, max=1ms,  total=1124ms
                                          combined=6944ms
```

### After (all packets drained, 1 write per frame):
```
e131:  count=6640, avg=0.56ms, max=12ms, total=3703ms
light: count=6640, avg=0.17ms, max=14ms, total=1108ms
                                          combined=4811ms
```

Light CPU dropped from 5820ms to 1108ms per 60s (~5x reduction). Visible tearing eliminated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
e131:

light:
  - platform: esp32_rmt_led_strip
    rgb_order: GRB
    chipset: SK6812
    is_rgbw: true
    pin: GPIO16
    num_leds: 380
    name: "LED Strip"
    effects:
      - e131:
          universe: 1
          channels: RGBW
```

## Test script

To test on a real device with multi-universe support, install the `sacn` Python library and run the following script from a machine on the same network:

```bash
pip install sacn
python test_e131_sender.py --leds 380 --rgbw                          # multicast, RGBW, 3 universes
python test_e131_sender.py --leds 170                                  # single universe RGB
python test_e131_sender.py --unicast 192.168.1.100 --leds 380 --rgbw  # unicast to device
```

```python
"""Simple E1.31 (sACN) test sender for testing multi-universe support.

Usage:
    pip install sacn
    python test_e131_sender.py [--universe 1] [--unicast 192.168.1.100] [--leds 350] [--rgbw]
"""

import argparse
import math
import time

import sacn

DMX_MAX = 512


def main():
    parser = argparse.ArgumentParser(description="E1.31 test sender")
    parser.add_argument("--universe", type=int, default=1)
    parser.add_argument("--unicast", type=str, default=None, help="Device IP for unicast (default: multicast)")
    parser.add_argument("--leds", type=int, default=350)
    parser.add_argument("--rgbw", action="store_true", help="Use RGBW (4 bytes/LED) instead of RGB (3 bytes/LED)")
    args = parser.parse_args()

    bpp = 4 if args.rgbw else 3  # bytes per LED
    leds_per_universe = DMX_MAX // bpp
    num_universes = math.ceil(args.leds / leds_per_universe)

    sender = sacn.sACNsender()
    sender.start()

    for u in range(num_universes):
        uni = args.universe + u
        sender.activate_output(uni)
        if args.unicast:
            sender[uni].destination = args.unicast
        else:
            sender[uni].multicast = True

    mode = "RGBW" if args.rgbw else "RGB"
    print(f"Sending {args.leds} LEDs ({mode}), universes {args.universe}-{args.universe + num_universes - 1}, "
          f"{'unicast ' + args.unicast if args.unicast else 'multicast'}")
    print("Ctrl+C to stop")

    def send_color(r, g, b, w=0):
        """Send a solid color across all universes."""
        if args.rgbw:
            pixel = [r, g, b, w]
        else:
            pixel = [r, g, b]
        remaining = args.leds
        for u in range(num_universes):
            uni = args.universe + u
            count = min(remaining, leds_per_universe)
            data = tuple((pixel * count)[:count * bpp])
            sender[uni].dmx_data = data
            remaining -= count

    try:
        while True:
            # Red sweep
            for i in range(256):
                send_color(i, 0, 0)
                time.sleep(0.02)
            # Green sweep
            for i in range(256):
                send_color(0, i, 0)
                time.sleep(0.02)
            # Blue sweep
            for i in range(256):
                send_color(0, 0, i)
                time.sleep(0.02)
            if args.rgbw:
                # White sweep
                for i in range(256):
                    send_color(0, 0, 0, i)
                    time.sleep(0.02)
    except KeyboardInterrupt:
        print("\nStopping")
    finally:
        sender.stop()


if __name__ == "__main__":
    main()
```

Sweeps red, green, blue (and white if `--rgbw`) across all universes. Ctrl+C to stop.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).