### PR TITLE
[ld2420] Increase MAX_LINE_LENGTH to allow footer-based resync

### DIFF
--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -21,7 +21,9 @@
 namespace esphome::ld2420 {
 
 static constexpr uint8_t CALIBRATE_SAMPLES = 64;
-static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
+// Energy frame is 45 bytes; +1 for null terminator, +4 so that a frame footer always lands
+// inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 50;
 static constexpr uint8_t TOTAL_GATES = 16;
 
 enum OpMode : uint8_t {


### PR DESCRIPTION
# What does this implement/fix?

Increases `MAX_LINE_LENGTH` from 46 to 50 bytes to fix a potential parser desync issue.

The LD2420 parser uses footer-based frame detection — it checks the last 4 bytes of the buffer against known footers at every byte received. This naturally resyncs the parser after losing sync (e.g. module restart or UART noise). However, the energy frame is 45 bytes and `MAX_LINE_LENGTH` was 46 (45 + 1 null terminator), leaving zero headroom. When desynced, the frame footer can land exactly at the overflow boundary and get discarded, preventing the footer-based resynchronization from ever recovering. This results in infinite "Max command length exceeded; ignoring" log spam and prevents initialization.

Increasing the buffer to 50 bytes (45 frame + 1 null + 4 footer) ensures the footer always lands inside the buffer during resync.

Related to the same class of latent UART parser desync bugs fixed in LD2450 (#14135) and LD2410 (#14136).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to https://github.com/esphome/esphome/issues/14131 (LD2450 variant, same class of bug)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is an internal buffer size fix
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 115200

ld2420:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).