### PR TITLE
[ld2410/ld2450] Replace header sync with buffer size increase for frame resync

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -601,28 +601,11 @@ void LD2410Component::readline_(int readch) {
     return;  // No data available
   }
 
-  // Frame header synchronization: verify first 4 bytes match a known frame header.
-  // This prevents the parser from getting stuck in an overflow loop after losing sync
-  // (e.g. after module restart or UART noise).
-  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
-    const uint8_t byte = static_cast<uint8_t>(readch);
-    // Verify header bytes match the frame type established by byte 0
-    if (this->buffer_pos_ > 0) {
-      const uint8_t *expected = (this->buffer_data_[0] == DATA_FRAME_HEADER[0]) ? DATA_FRAME_HEADER : CMD_FRAME_HEADER;
-      if (byte != expected[this->buffer_pos_]) {
-        this->buffer_pos_ = 0;  // Reset and fall through to check if this byte starts a new frame
-      }
-    }
-    // First byte must match start of a data or command frame header
-    if (this->buffer_pos_ == 0 && byte != DATA_FRAME_HEADER[0] && byte != CMD_FRAME_HEADER[0]) {
-      return;
-    }
-  }
-
   if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
     this->buffer_data_[this->buffer_pos_++] = readch;
     this->buffer_data_[this->buffer_pos_] = 0;
   } else {
+    // We should never get here, but just in case...
     ESP_LOGW(TAG, "Max command length exceeded; ignoring");
     this->buffer_pos_ = 0;
     return;

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -33,8 +33,10 @@ namespace esphome::ld2410 {
 
 using namespace ld24xx;
 
-static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
-static constexpr uint8_t TOTAL_GATES = 9;       // Total number of gates supported by the LD2410
+// Engineering data frame is 45 bytes; +1 for null terminator, +4 so that a frame footer always
+// lands inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 50;
+static constexpr uint8_t TOTAL_GATES = 9;  // Total number of gates supported by the LD2410
 
 class LD2410Component : public Component, public uart::UARTDevice {
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -769,28 +769,11 @@ void LD2450Component::readline_(int readch) {
     return;  // No data available
   }
 
-  // Frame header synchronization: verify first 4 bytes match a known frame header.
-  // This prevents the parser from accumulating mid-frame data after losing sync
-  // (e.g. after module restart or UART noise).
-  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
-    const uint8_t byte = static_cast<uint8_t>(readch);
-    // Verify header bytes match the frame type established by byte 0
-    if (this->buffer_pos_ > 0) {
-      const uint8_t *expected = (this->buffer_data_[0] == DATA_FRAME_HEADER[0]) ? DATA_FRAME_HEADER : CMD_FRAME_HEADER;
-      if (byte != expected[this->buffer_pos_]) {
-        this->buffer_pos_ = 0;  // Reset and fall through to check if this byte starts a new frame
-      }
-    }
-    // First byte must match start of a data or command frame header
-    if (this->buffer_pos_ == 0 && byte != DATA_FRAME_HEADER[0] && byte != CMD_FRAME_HEADER[0]) {
-      return;
-    }
-  }
-
   if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
     this->buffer_data_[this->buffer_pos_++] = readch;
     this->buffer_data_[this->buffer_pos_] = 0;
   } else {
+    // We should never get here, but just in case...
     ESP_LOGW(TAG, "Max command length exceeded; ignoring");
     this->buffer_pos_ = 0;
     return;

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -38,9 +38,11 @@ using namespace ld24xx;
 
 // Constants
 static constexpr uint8_t DEFAULT_PRESENCE_TIMEOUT = 5;  // Timeout to reset presense status 5 sec.
-static constexpr uint8_t MAX_LINE_LENGTH = 41;          // Max characters for serial buffer
-static constexpr uint8_t MAX_TARGETS = 3;               // Max 3 Targets in LD2450
-static constexpr uint8_t MAX_ZONES = 3;                 // Max 3 Zones in LD2450
+// Zone query response is 40 bytes; +1 for null terminator, +4 so that a frame footer always
+// lands inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 45;
+static constexpr uint8_t MAX_TARGETS = 3;  // Max 3 Targets in LD2450
+static constexpr uint8_t MAX_ZONES = 3;    // Max 3 Zones in LD2450
 
 enum Direction : uint8_t {
   DIRECTION_APPROACHING = 0,


### PR DESCRIPTION
# What does this implement/fix?

Reverts the frame header synchronization added in #14135 and #14136 in favor of a simpler fix: increasing `MAX_LINE_LENGTH` so that the existing footer-based resynchronization can recover after losing sync.

Both components already check for frame footers at every byte position, which naturally resyncs the parser after losing sync (e.g. module restart or UART noise). The problem was that the buffers were sized exactly to fit the largest frame, so a desynced parser's footer could land at the overflow boundary and get discarded, causing infinite "Max command length exceeded" log spam. Increasing the buffer by 4 bytes (footer size) ensures the footer always lands inside the buffer.

- ld2450: 41 → 45 (zone query response = 40 bytes + 1 null + 4 footer)
- ld2410: 46 → 50 (engineering data frame = 45 bytes + 1 null + 4 footer)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14131

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - this is an internal buffer size fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).