### PR TITLE
[esp32] Add engineering_sample option for ESP32-P4

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -863,16 +863,18 @@ def final_validate(config):
         )
     if (
         config[CONF_VARIANT] == VARIANT_ESP32P4
-        and config.get(CONF_ENGINEERING_SAMPLE)
-        and "_r3" in config[CONF_BOARD]
+        and config.get(CONF_ENGINEERING_SAMPLE) is not None
     ):
-        errs.append(
-            cv.Invalid(
-                f"'{CONF_ENGINEERING_SAMPLE}' is set to true but board "
-                f"'{config[CONF_BOARD]}' is a rev3 board",
-                path=[CONF_ENGINEERING_SAMPLE],
-            )
+        board_is_es = BOARDS.get(config[CONF_BOARD], {}).get(
+            "engineering_sample", False
         )
+        if config[CONF_ENGINEERING_SAMPLE] != board_is_es:
+            errs.append(
+                cv.Invalid(
+                    f"'{CONF_ENGINEERING_SAMPLE}' does not match board '{config[CONF_BOARD]}'",
+                    path=[CONF_ENGINEERING_SAMPLE],
+                )
+            )
     if advanced[CONF_EXECUTE_FROM_PSRAM]:
         if config[CONF_VARIANT] != VARIANT_ESP32S3:
             errs.append(
@@ -1508,14 +1510,12 @@ async def to_code(config):
     # ESP32-P4: ESP-IDF 5.5.3 changed the default of ESP32P4_SELECTS_REV_LESS_V3
     # from y to n. PlatformIO uses sections.ld.in (for rev <3) or
     # sections.rev3.ld.in (for rev >=3) based on board definition.
-    # Set the sdkconfig option to match the chip's revision.
+    # Set the sdkconfig option to match the board's chip revision.
     if variant == VARIANT_ESP32P4:
-        engineering_sample = config.get(CONF_ENGINEERING_SAMPLE)
-        if engineering_sample is not None:
-            is_pre_rev3 = engineering_sample
-        else:
-            is_pre_rev3 = "_r3" not in config[CONF_BOARD]
-        add_idf_sdkconfig_option("CONFIG_ESP32P4_SELECTS_REV_LESS_V3", is_pre_rev3)
+        is_eng_sample = BOARDS.get(config[CONF_BOARD], {}).get(
+            "engineering_sample", False
+        )
+        add_idf_sdkconfig_option("CONFIG_ESP32P4_SELECTS_REV_LESS_V3", is_eng_sample)
 
     # Set minimum chip revision for ESP32 variant
     # Setting this to 3.0 or higher reduces flash size by excluding workaround code,

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -87,6 +87,7 @@ IS_TARGET_PLATFORM = True
 CONF_ASSERTION_LEVEL = "assertion_level"
 CONF_COMPILER_OPTIMIZATION = "compiler_optimization"
 CONF_ENABLE_IDF_EXPERIMENTAL_FEATURES = "enable_idf_experimental_features"
+CONF_ENGINEERING_SAMPLE = "engineering_sample"
 CONF_INCLUDE_BUILTIN_IDF_COMPONENTS = "include_builtin_idf_components"
 CONF_ENABLE_LWIP_ASSERT = "enable_lwip_assert"
 CONF_ENABLE_OTA_ROLLBACK = "enable_ota_rollback"
@@ -778,6 +779,15 @@ def _detect_variant(value):
         # variant has already been validated against the known set
         value = value.copy()
         value[CONF_BOARD] = STANDARD_BOARDS[variant]
+        if variant == VARIANT_ESP32P4:
+            engineering_sample = value.get(CONF_ENGINEERING_SAMPLE)
+            if engineering_sample is None:
+                _LOGGER.warning(
+                    "No board specified for ESP32-P4. Defaulting to production silicon (rev3). "
+                    "If you have an early engineering sample (pre-rev3), set 'engineering_sample: true'."
+                )
+            elif engineering_sample:
+                value[CONF_BOARD] = "esp32-p4-evboard"
     elif board in BOARDS:
         variant = variant or BOARDS[board][KEY_VARIANT]
         if variant != BOARDS[board][KEY_VARIANT]:
@@ -839,6 +849,28 @@ def final_validate(config):
             cv.Invalid(
                 f"'{CONF_MINIMUM_CHIP_REVISION}' is only supported on {VARIANT_ESP32}",
                 path=[CONF_FRAMEWORK, CONF_ADVANCED, CONF_MINIMUM_CHIP_REVISION],
+            )
+        )
+    if (
+        config[CONF_VARIANT] != VARIANT_ESP32P4
+        and config.get(CONF_ENGINEERING_SAMPLE) is not None
+    ):
+        errs.append(
+            cv.Invalid(
+                f"'{CONF_ENGINEERING_SAMPLE}' is only supported on {VARIANT_ESP32P4}",
+                path=[CONF_ENGINEERING_SAMPLE],
+            )
+        )
+    if (
+        config[CONF_VARIANT] == VARIANT_ESP32P4
+        and config.get(CONF_ENGINEERING_SAMPLE)
+        and "_r3" in config[CONF_BOARD]
+    ):
+        errs.append(
+            cv.Invalid(
+                f"'{CONF_ENGINEERING_SAMPLE}' is set to true but board "
+                f"'{config[CONF_BOARD]}' is a rev3 board",
+                path=[CONF_ENGINEERING_SAMPLE],
             )
         )
     if advanced[CONF_EXECUTE_FROM_PSRAM]:
@@ -1190,6 +1222,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CPU_FREQUENCY): cv.one_of(
                 *FULL_CPU_FREQUENCIES, upper=True
             ),
+            cv.Optional(CONF_ENGINEERING_SAMPLE): cv.boolean,
             cv.Optional(CONF_FLASH_SIZE, default="4MB"): cv.one_of(
                 *FLASH_SIZES, upper=True
             ),
@@ -1475,10 +1508,14 @@ async def to_code(config):
     # ESP32-P4: ESP-IDF 5.5.3 changed the default of ESP32P4_SELECTS_REV_LESS_V3
     # from y to n. PlatformIO uses sections.ld.in (for rev <3) or
     # sections.rev3.ld.in (for rev >=3) based on board definition.
-    # Set the sdkconfig option to match the board's revision.
+    # Set the sdkconfig option to match the chip's revision.
     if variant == VARIANT_ESP32P4:
-        is_rev3 = "_r3" in config[CONF_BOARD]
-        add_idf_sdkconfig_option("CONFIG_ESP32P4_SELECTS_REV_LESS_V3", not is_rev3)
+        engineering_sample = config.get(CONF_ENGINEERING_SAMPLE)
+        if engineering_sample is not None:
+            is_pre_rev3 = engineering_sample
+        else:
+            is_pre_rev3 = "_r3" not in config[CONF_BOARD]
+        add_idf_sdkconfig_option("CONFIG_ESP32P4_SELECTS_REV_LESS_V3", is_pre_rev3)
 
     # Set minimum chip revision for ESP32 variant
     # Setting this to 3.0 or higher reduces flash size by excluding workaround code,

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -1713,10 +1713,12 @@ BOARDS = {
     "esp32-p4": {
         "name": "Espressif ESP32-P4 ES (pre rev.300) generic",
         "variant": VARIANT_ESP32P4,
+        "engineering_sample": True,
     },
     "esp32-p4-evboard": {
         "name": "Espressif ESP32-P4 Function EV Board (ES pre rev.300)",
         "variant": VARIANT_ESP32P4,
+        "engineering_sample": True,
     },
     "esp32-p4_r3": {
         "name": "Espressif ESP32-P4 rev.300 generic",
@@ -2141,6 +2143,7 @@ BOARDS = {
     "m5stack-tab5-p4": {
         "name": "M5STACK Tab5 esp32-p4 Board (ES pre rev.300)",
         "variant": VARIANT_ESP32P4,
+        "engineering_sample": True,
     },
     "m5stack-timer-cam": {
         "name": "M5Stack Timer CAM",

--- a/esphome/components/esp32/boards.py
+++ b/esphome/components/esp32/boards.py
@@ -20,7 +20,7 @@ STANDARD_BOARDS = {
     VARIANT_ESP32C6: "esp32-c6-devkitm-1",
     VARIANT_ESP32C61: "esp32-c61-devkitc1-n8r2",
     VARIANT_ESP32H2: "esp32-h2-devkitm-1",
-    VARIANT_ESP32P4: "esp32-p4-evboard",
+    VARIANT_ESP32P4: "esp32-p4_r3-evboard",
     VARIANT_ESP32S2: "esp32-s2-kaluga-1",
     VARIANT_ESP32S3: "esp32-s3-devkitc-1",
 }

--- a/script/generate-esp32-boards.py
+++ b/script/generate-esp32-boards.py
@@ -43,16 +43,26 @@ def get_boards():
                 name = board_info["name"]
                 board = fname.stem
                 variant = mcu.upper()
-                boards[board] = {
+                chip_variant = board_info["build"].get("chip_variant", "")
+                entry = {
                     "name": name,
                     "variant": f"VARIANT_{variant}",
                 }
+                if chip_variant.endswith("_es"):
+                    entry["engineering_sample"] = True
+                boards[board] = entry
         return boards
 
 
 TEMPLATE = """    "%s": {
         "name": "%s",
         "variant": %s,
+    },"""
+
+TEMPLATE_ES = """    "%s": {
+        "name": "%s",
+        "variant": %s,
+        "engineering_sample": True,
     },"""
 
 
@@ -66,7 +76,8 @@ def main(check: bool):
         if line == "BOARDS = {":
             parts.append(line)
             parts.extend(
-                TEMPLATE % (board, info["name"], info["variant"])
+                (TEMPLATE_ES if info.get("engineering_sample") else TEMPLATE)
+                % (board, info["name"], info["variant"])
                 for board, info in sorted(boards.items())
             )
             parts.append("}")

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -1,5 +1,6 @@
 esp32:
   variant: esp32p4
+  engineering_sample: false
   flash_size: 32MB
   cpu_frequency: 400MHz
   framework:

--- a/tests/components/esp32/test.esp32-p4-idf.yaml
+++ b/tests/components/esp32/test.esp32-p4-idf.yaml
@@ -1,6 +1,6 @@
 esp32:
   variant: esp32p4
-  engineering_sample: false
+  engineering_sample: true
   flash_size: 32MB
   cpu_frequency: 400MHz
   framework:


### PR DESCRIPTION
# What does this implement/fix?

ESP32-P4 has two silicon families: pre-rev3 engineering samples (v0.0, v0.1, v1.0) and production rev3+ chips (v3.0, v3.1). These use different linker scripts and sdkconfig options (`CONFIG_ESP32P4_SELECTS_REV_LESS_V3`).

Previously, users specifying only `variant: ESP32P4` (without an explicit board) got a pre-rev3 board by default. Since most users will eventually have production silicon, this changes the default to rev3 and adds an `engineering_sample` option for users with early dev kits.

A warning is logged when neither `board` nor `engineering_sample` is explicitly set, guiding users to set the option if needed.

### Board metadata approach

The sdkconfig option `CONFIG_ESP32P4_SELECTS_REV_LESS_V3` is now derived from the board's metadata in `boards.py` rather than string-matching `_r3` in the board name. The board generator script (`script/generate-esp32-boards.py`) reads PlatformIO's `chip_variant` field (e.g. `esp32p4_es` for engineering samples) and tags boards with `"engineering_sample": True`. This means:

- Explicit board selection always gets the correct linker script automatically
- The `engineering_sample` config option only selects the default board when no `board:` is specified
- `final_validate` catches mismatches between `engineering_sample` and the board in both directions

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6123

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Production ESP32-P4 (rev3+) - default behavior
esp32:
  variant: ESP32P4
  engineering_sample: false
  framework:
    type: esp-idf

# Early engineering sample (pre-rev3)
esp32:
  variant: ESP32P4
  engineering_sample: true
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).