### PR TITLE
[core] Deduplicate base64 encode/decode logic

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -589,14 +589,25 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
   return base64_decode(reinterpret_cast<const uint8_t *>(encoded_string.data()), encoded_string.size(), buf, buf_len);
 }
 
-// Convert 4 base64 characters to 3 decoded bytes
-static inline void base64_decode_quad_(uint8_t *char_array_4, uint8_t *char_array_3) {
+// Decode 4 base64 characters to up to 'count' output bytes, returns true if truncated
+static inline bool base64_decode_quad_(uint8_t *char_array_4, int count, uint8_t *buf, size_t buf_len, size_t &out) {
   for (int i = 0; i < 4; i++)
     char_array_4[i] = base64_find_char(char_array_4[i]);
 
+  uint8_t char_array_3[3];
   char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
   char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
   char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+  bool truncated = false;
+  for (int j = 0; j < count; j++) {
+    if (out < buf_len) {
+      buf[out++] = char_array_3[j];
+    } else {
+      truncated = true;
+    }
+  }
+  return truncated;
 }
 
 size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *buf, size_t buf_len) {
@@ -604,7 +615,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
   int i = 0;
   size_t in = 0;
   size_t out = 0;
-  uint8_t char_array_4[4], char_array_3[3];
+  uint8_t char_array_4[4];
   bool truncated = false;
 
   // SAFETY: The loop condition checks is_base64() before processing each character.
@@ -614,15 +625,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
     char_array_4[i++] = encoded_data[in];
     in++;
     if (i == 4) {
-      base64_decode_quad_(char_array_4, char_array_3);
-
-      for (i = 0; i < 3; i++) {
-        if (out < buf_len) {
-          buf[out++] = char_array_3[i];
-        } else {
-          truncated = true;
-        }
-      }
+      truncated |= base64_decode_quad_(char_array_4, 3, buf, buf_len, out);
       i = 0;
     }
   }
@@ -631,15 +634,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
     for (int j = i; j < 4; j++)
       char_array_4[j] = 0;
 
-    base64_decode_quad_(char_array_4, char_array_3);
-
-    for (int j = 0; j < i - 1; j++) {
-      if (out < buf_len) {
-        buf[out++] = char_array_3[j];
-      } else {
-        truncated = true;
-      }
-    }
+    truncated |= base64_decode_quad_(char_array_4, i - 1, buf, buf_len, out);
   }
 
   if (truncated) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -546,7 +546,7 @@ static inline bool is_base64(char c) { return (isalnum(c) || (c == '+') || (c ==
 std::string base64_encode(const std::vector<uint8_t> &buf) { return base64_encode(buf.data(), buf.size()); }
 
 // Encode 3 input bytes to 4 base64 characters, append 'count' to ret.
-static inline void base64_encode_triple_(const char *char_array_3, int count, std::string &ret) {
+static inline void base64_encode_triple(const char *char_array_3, int count, std::string &ret) {
   char char_array_4[4];
   char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
   char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
@@ -565,7 +565,7 @@ std::string base64_encode(const uint8_t *buf, size_t buf_len) {
   while (buf_len--) {
     char_array_3[i++] = *(buf++);
     if (i == 3) {
-      base64_encode_triple_(char_array_3, 4, ret);
+      base64_encode_triple(char_array_3, 4, ret);
       i = 0;
     }
   }
@@ -574,7 +574,7 @@ std::string base64_encode(const uint8_t *buf, size_t buf_len) {
     for (int j = i; j < 3; j++)
       char_array_3[j] = '\0';
 
-    base64_encode_triple_(char_array_3, i + 1, ret);
+    base64_encode_triple(char_array_3, i + 1, ret);
 
     while ((i++ < 3))
       ret += '=';
@@ -588,7 +588,7 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
 }
 
 // Decode 4 base64 characters to up to 'count' output bytes, returns true if truncated.
-static inline bool base64_decode_quad_(uint8_t *char_array_4, int count, uint8_t *buf, size_t buf_len, size_t &out) {
+static inline bool base64_decode_quad(uint8_t *char_array_4, int count, uint8_t *buf, size_t buf_len, size_t &out) {
   for (int i = 0; i < 4; i++)
     char_array_4[i] = base64_find_char(char_array_4[i]);
 
@@ -623,7 +623,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
     char_array_4[i++] = encoded_data[in];
     in++;
     if (i == 4) {
-      truncated |= base64_decode_quad_(char_array_4, 3, buf, buf_len, out);
+      truncated |= base64_decode_quad(char_array_4, 3, buf, buf_len, out);
       i = 0;
     }
   }
@@ -632,7 +632,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
     for (int j = i; j < 4; j++)
       char_array_4[j] = 0;
 
-    truncated |= base64_decode_quad_(char_array_4, i - 1, buf, buf_len, out);
+    truncated |= base64_decode_quad(char_array_4, i - 1, buf, buf_len, out);
   }
 
   if (truncated) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -545,38 +545,36 @@ static inline bool is_base64(char c) { return (isalnum(c) || (c == '+') || (c ==
 
 std::string base64_encode(const std::vector<uint8_t> &buf) { return base64_encode(buf.data(), buf.size()); }
 
+// Encode 3 input bytes to 4 base64 characters, append 'count' to ret.
+static inline void base64_encode_triple_(const char *char_array_3, int count, std::string &ret) {
+  char char_array_4[4];
+  char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
+  char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
+  char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
+  char_array_4[3] = char_array_3[2] & 0x3f;
+
+  for (int j = 0; j < count; j++)
+    ret += BASE64_CHARS[static_cast<uint8_t>(char_array_4[j])];
+}
+
 std::string base64_encode(const uint8_t *buf, size_t buf_len) {
   std::string ret;
   int i = 0;
-  int j = 0;
   char char_array_3[3];
-  char char_array_4[4];
 
   while (buf_len--) {
     char_array_3[i++] = *(buf++);
     if (i == 3) {
-      char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-      char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-      char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-      char_array_4[3] = char_array_3[2] & 0x3f;
-
-      for (i = 0; (i < 4); i++)
-        ret += BASE64_CHARS[static_cast<uint8_t>(char_array_4[i])];
+      base64_encode_triple_(char_array_3, 4, ret);
       i = 0;
     }
   }
 
   if (i) {
-    for (j = i; j < 3; j++)
+    for (int j = i; j < 3; j++)
       char_array_3[j] = '\0';
 
-    char_array_4[0] = (char_array_3[0] & 0xfc) >> 2;
-    char_array_4[1] = ((char_array_3[0] & 0x03) << 4) + ((char_array_3[1] & 0xf0) >> 4);
-    char_array_4[2] = ((char_array_3[1] & 0x0f) << 2) + ((char_array_3[2] & 0xc0) >> 6);
-    char_array_4[3] = char_array_3[2] & 0x3f;
-
-    for (j = 0; (j < i + 1); j++)
-      ret += BASE64_CHARS[static_cast<uint8_t>(char_array_4[j])];
+    base64_encode_triple_(char_array_3, i + 1, ret);
 
     while ((i++ < 3))
       ret += '=';

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -590,7 +590,6 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
 }
 
 // Decode 4 base64 characters to up to 'count' output bytes, returns true if truncated.
-// char_array_4 entries must be valid base64/base64url characters or 0 (zero-padding from tail).
 static inline bool base64_decode_quad_(uint8_t *char_array_4, int count, uint8_t *buf, size_t buf_len, size_t &out) {
   for (int i = 0; i < 4; i++)
     char_array_4[i] = base64_find_char(char_array_4[i]);

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -589,10 +589,19 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
   return base64_decode(reinterpret_cast<const uint8_t *>(encoded_string.data()), encoded_string.size(), buf, buf_len);
 }
 
+// Convert 4 base64 characters to 3 decoded bytes
+static inline void base64_decode_quad_(uint8_t *char_array_4, uint8_t *char_array_3) {
+  for (int i = 0; i < 4; i++)
+    char_array_4[i] = base64_find_char(char_array_4[i]);
+
+  char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+  char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+  char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+}
+
 size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *buf, size_t buf_len) {
   size_t in_len = encoded_len;
   int i = 0;
-  int j = 0;
   size_t in = 0;
   size_t out = 0;
   uint8_t char_array_4[4], char_array_3[3];
@@ -605,12 +614,7 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
     char_array_4[i++] = encoded_data[in];
     in++;
     if (i == 4) {
-      for (i = 0; i < 4; i++)
-        char_array_4[i] = base64_find_char(char_array_4[i]);
-
-      char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-      char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-      char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+      base64_decode_quad_(char_array_4, char_array_3);
 
       for (i = 0; i < 3; i++) {
         if (out < buf_len) {
@@ -624,17 +628,12 @@ size_t base64_decode(const uint8_t *encoded_data, size_t encoded_len, uint8_t *b
   }
 
   if (i) {
-    for (j = i; j < 4; j++)
+    for (int j = i; j < 4; j++)
       char_array_4[j] = 0;
 
-    for (j = 0; j < 4; j++)
-      char_array_4[j] = base64_find_char(char_array_4[j]);
+    base64_decode_quad_(char_array_4, char_array_3);
 
-    char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
-    char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
-    char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
-
-    for (j = 0; j < i - 1; j++) {
+    for (int j = 0; j < i - 1; j++) {
       if (out < buf_len) {
         buf[out++] = char_array_3[j];
       } else {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -589,7 +589,8 @@ size_t base64_decode(const std::string &encoded_string, uint8_t *buf, size_t buf
   return base64_decode(reinterpret_cast<const uint8_t *>(encoded_string.data()), encoded_string.size(), buf, buf_len);
 }
 
-// Decode 4 base64 characters to up to 'count' output bytes, returns true if truncated
+// Decode 4 base64 characters to up to 'count' output bytes, returns true if truncated.
+// char_array_4 entries must be valid base64/base64url characters or 0 (zero-padding from tail).
 static inline bool base64_decode_quad_(uint8_t *char_array_4, int count, uint8_t *buf, size_t buf_len, size_t &out) {
   for (int i = 0; i < 4; i++)
     char_array_4[i] = base64_find_char(char_array_4[i]);


### PR DESCRIPTION
# What does this implement/fix?

Extract duplicated logic in both `base64_decode()` and `base64_encode()` into shared static helpers:

- `base64_decode_quad_()`: Deduplicates the 4-to-3 byte decode + output copy loop (main loop and tail path)
- `base64_encode_triple_()`: Deduplicates the 3-to-4 byte encode + output append loop (main loop and tail path)

Saves 64 bytes of flash on ESP32 (decode side; encode not linked in test config).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal refactor only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).