### PR TITLE
[api] Warn when clients connect with outdated API version

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1534,11 +1534,10 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %" PRIu16 ".%" PRIu16, this->helper_->get_client_name(),
            this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);
 
+  // TODO: Remove before 2026.8.0 (one version after get_object_id backward compat removal)
   if (!this->client_supports_api_version(1, 14)) {
-    ESP_LOGW(TAG,
-             "Client '%s' is using API version %" PRIu16 ".%" PRIu16
-             " which is outdated. Update the client to a version that supports API 1.14",
-             this->helper_->get_client_name(), this->client_api_version_major_, this->client_api_version_minor_);
+    ESP_LOGW(TAG, "'%s' using outdated API %" PRIu16 ".%" PRIu16 ", update to 1.14+", this->helper_->get_client_name(),
+             this->client_api_version_major_, this->client_api_version_minor_);
   }
 
   HelloResponse resp;

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1534,6 +1534,13 @@ bool APIConnection::send_hello_response_(const HelloRequest &msg) {
   ESP_LOGV(TAG, "Hello from client: '%s' | %s | API Version %" PRIu16 ".%" PRIu16, this->helper_->get_client_name(),
            this->helper_->get_peername_to(peername), this->client_api_version_major_, this->client_api_version_minor_);
 
+  if (!this->client_supports_api_version(1, 14)) {
+    ESP_LOGW(TAG,
+             "Client '%s' is using API version %" PRIu16 ".%" PRIu16
+             " which is outdated. Update the client to a version that supports API 1.14",
+             this->helper_->get_client_name(), this->client_api_version_major_, this->client_api_version_minor_);
+  }
+
   HelloResponse resp;
   resp.api_version_major = 1;
   resp.api_version_minor = 14;


### PR DESCRIPTION
# What does this implement/fix?

Log a warning when a client connects using an API version older than 1.14. This gives users advance notice that their client needs updating before the backward-compatibility code for pre-1.14 clients is removed in 2026.7.0.

API version 1.14 introduced client-side `object_id` computation, eliminating the need for the server to send it. There is existing backward-compat code that sends larger messages with smaller batch sizes for older clients, with TODOs to remove it before 2026.7.0. Currently nothing alerts the user that their client is outdated — this warning fills that gap.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change needed — the warning is emitted automatically
# when a client with API version < 1.14 connects.
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).