### PR TITLE
[pmsa003i] add `set_timeout` to `setup()`

### DIFF
--- a/esphome/components/pmsa003i/pmsa003i.cpp
+++ b/esphome/components/pmsa003i/pmsa003i.cpp
@@ -19,22 +19,26 @@ static const uint8_t START_CHARACTER_2 = 0x4D;
 static const uint8_t READ_DATA_RETRY_COUNT = 3;
 
 void PMSA003IComponent::setup() {
-  PM25AQIData data;
-  bool successful_read = this->read_data_(&data);
+  // The PMSA003I needs several seconds after power-on before producing valid
+  // data frames (start bytes 0x42 0x4D), so we wait 3 seconds before trying to read the data.
+  this->set_timeout(3000, [this]() {
+    PM25AQIData data;
+    bool successful_read = this->read_data_(&data);
 
-  if (!successful_read) {
-    for (uint8_t i = 0; i < READ_DATA_RETRY_COUNT; i++) {
-      successful_read = this->read_data_(&data);
-      if (successful_read) {
-        break;
+    if (!successful_read) {
+      for (uint8_t i = 0; i < READ_DATA_RETRY_COUNT; i++) {
+        successful_read = this->read_data_(&data);
+        if (successful_read) {
+          break;
+        }
       }
     }
-  }
 
-  if (!successful_read) {
-    this->mark_failed();
-    return;
-  }
+    if (!successful_read) {
+      this->mark_failed();
+      return;
+    }
+  });
 }
 
 void PMSA003IComponent::dump_config() {


### PR DESCRIPTION
# What does this implement/fix?

On some ESP32 boards, like the [Adafruit ESP32-C6 Feather](https://www.adafruit.com/product/5933), i2c power must be explicitly turned on. This can cause issues during startup where the PMSA003i isn't ready (hasn't been powered long enough) to respond to i2c commands.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
