### PR TITLE
2026.2.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.2.0
+PROJECT_NUMBER         = 2026.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/e131/e131.h
+++ b/esphome/components/e131/e131.h
@@ -1,7 +1,11 @@
 #pragma once
 #include "esphome/core/defines.h"
 #ifdef USE_NETWORK
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
 #include "esphome/components/socket/socket.h"
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+#include <WiFiUdp.h>
+#endif
 #include "esphome/core/component.h"
 
 #include <cinttypes>
@@ -45,7 +49,11 @@ class E131Component : public esphome::Component {
   void leave_(int universe);
 
   E131ListenMethod listen_method_{E131_MULTICAST};
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   std::unique_ptr<socket::Socket> socket_;
+#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
+  WiFiUDP udp_;
+#endif
   std::vector<E131AddressableLightEffect *> light_effects_;
   std::map<int, int> universe_consumers_;
 };

--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -62,8 +62,10 @@ const size_t E131_MIN_PACKET_SIZE = reinterpret_cast<size_t>(&((E131RawPacket *)
 bool E131Component::join_igmp_groups_() {
   if (listen_method_ != E131_MULTICAST)
     return false;
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   if (this->socket_ == nullptr)
     return false;
+#endif
 
   for (auto universe : universe_consumers_) {
     if (!universe.second)

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -527,7 +527,7 @@ async def to_code_characteristic(service_var, char_conf):
                 action_conf,
                 char_conf[CONF_CHAR_VALUE_ACTION_ID_],
                 cg.TemplateArguments(),
-                {},
+                [],
             )
             cg.add(value_action.play())
         else:

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -77,7 +77,6 @@ class BLECharacteristic {
   }
 
  protected:
-  bool write_event_{false};
   BLEService *service_{};
   ESPBTUUID uuid_;
   esp_gatt_char_prop_t properties_;

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -218,12 +218,19 @@ def _validate(config):
                 )
     elif config[CONF_TYPE] != "OPENETH":
         if CONF_CLK_MODE in config:
+            mode, pin = CLK_MODES_DEPRECATED[config[CONF_CLK_MODE]]
             LOGGER.warning(
-                "[ethernet] The 'clk_mode' option is deprecated and will be removed in ESPHome 2026.1. "
-                "Please update your configuration to use 'clk' instead."
+                "[ethernet] The 'clk_mode' option is deprecated. "
+                "Please replace 'clk_mode: %s' with:\n"
+                "  clk:\n"
+                "    mode: %s\n"
+                "    pin: %s\n"
+                "Removal scheduled for 2026.7.0.",
+                config[CONF_CLK_MODE],
+                mode,
+                pin,
             )
-            mode = CLK_MODES_DEPRECATED[config[CONF_CLK_MODE]]
-            config[CONF_CLK] = CLK_SCHEMA({CONF_MODE: mode[0], CONF_PIN: mode[1]})
+            config[CONF_CLK] = CLK_SCHEMA({CONF_MODE: mode, CONF_PIN: pin})
             del config[CONF_CLK_MODE]
         elif CONF_CLK not in config:
             raise cv.Invalid("'clk' is a required option for [ethernet].")

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -601,28 +601,11 @@ void LD2410Component::readline_(int readch) {
     return;  // No data available
   }
 
-  // Frame header synchronization: verify first 4 bytes match a known frame header.
-  // This prevents the parser from getting stuck in an overflow loop after losing sync
-  // (e.g. after module restart or UART noise).
-  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
-    const uint8_t byte = static_cast<uint8_t>(readch);
-    // Verify header bytes match the frame type established by byte 0
-    if (this->buffer_pos_ > 0) {
-      const uint8_t *expected = (this->buffer_data_[0] == DATA_FRAME_HEADER[0]) ? DATA_FRAME_HEADER : CMD_FRAME_HEADER;
-      if (byte != expected[this->buffer_pos_]) {
-        this->buffer_pos_ = 0;  // Reset and fall through to check if this byte starts a new frame
-      }
-    }
-    // First byte must match start of a data or command frame header
-    if (this->buffer_pos_ == 0 && byte != DATA_FRAME_HEADER[0] && byte != CMD_FRAME_HEADER[0]) {
-      return;
-    }
-  }
-
   if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
     this->buffer_data_[this->buffer_pos_++] = readch;
     this->buffer_data_[this->buffer_pos_] = 0;
   } else {
+    // We should never get here, but just in case...
     ESP_LOGW(TAG, "Max command length exceeded; ignoring");
     this->buffer_pos_ = 0;
     return;

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -601,15 +601,33 @@ void LD2410Component::readline_(int readch) {
     return;  // No data available
   }
 
+  // Frame header synchronization: verify first 4 bytes match a known frame header.
+  // This prevents the parser from getting stuck in an overflow loop after losing sync
+  // (e.g. after module restart or UART noise).
+  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
+    const uint8_t byte = static_cast<uint8_t>(readch);
+    // Verify header bytes match the frame type established by byte 0
+    if (this->buffer_pos_ > 0) {
+      const uint8_t *expected = (this->buffer_data_[0] == DATA_FRAME_HEADER[0]) ? DATA_FRAME_HEADER : CMD_FRAME_HEADER;
+      if (byte != expected[this->buffer_pos_]) {
+        this->buffer_pos_ = 0;  // Reset and fall through to check if this byte starts a new frame
+      }
+    }
+    // First byte must match start of a data or command frame header
+    if (this->buffer_pos_ == 0 && byte != DATA_FRAME_HEADER[0] && byte != CMD_FRAME_HEADER[0]) {
+      return;
+    }
+  }
+
   if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
     this->buffer_data_[this->buffer_pos_++] = readch;
     this->buffer_data_[this->buffer_pos_] = 0;
   } else {
-    // We should never get here, but just in case...
     ESP_LOGW(TAG, "Max command length exceeded; ignoring");
     this->buffer_pos_ = 0;
+    return;
   }
-  if (this->buffer_pos_ < 4) {
+  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
     return;  // Not enough data to process yet
   }
   if (ld2410::validate_header_footer(DATA_FRAME_FOOTER, &this->buffer_data_[this->buffer_pos_ - 4])) {

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -33,8 +33,10 @@ namespace esphome::ld2410 {
 
 using namespace ld24xx;
 
-static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
-static constexpr uint8_t TOTAL_GATES = 9;       // Total number of gates supported by the LD2410
+// Engineering data frame is 45 bytes; +1 for null terminator, +4 so that a frame footer always
+// lands inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 50;
+static constexpr uint8_t TOTAL_GATES = 9;  // Total number of gates supported by the LD2410
 
 class LD2410Component : public Component, public uart::UARTDevice {
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -63,73 +63,73 @@ namespace esphome::ld2420 {
 static const char *const TAG = "ld2420";
 
 // Local const's
-static const uint16_t REFRESH_RATE_MS = 1000;
+static constexpr uint16_t REFRESH_RATE_MS = 1000;
 
 // Command sets
-static const uint16_t CMD_DISABLE_CONF = 0x00FE;
-static const uint16_t CMD_ENABLE_CONF = 0x00FF;
-static const uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
-static const uint16_t CMD_PARM_LOW_TRESH = 0x0021;
-static const uint16_t CMD_PROTOCOL_VER = 0x0002;
-static const uint16_t CMD_READ_ABD_PARAM = 0x0008;
-static const uint16_t CMD_READ_REG_ADDR = 0x0020;
-static const uint16_t CMD_READ_REGISTER = 0x0002;
-static const uint16_t CMD_READ_SERIAL_NUM = 0x0011;
-static const uint16_t CMD_READ_SYS_PARAM = 0x0013;
-static const uint16_t CMD_READ_VERSION = 0x0000;
-static const uint16_t CMD_RESTART = 0x0068;
-static const uint16_t CMD_SYSTEM_MODE = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
-static const uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
-static const uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
-static const uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
-static const uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
-static const uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
-static const uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
-static const uint16_t CMD_WRITE_REGISTER = 0x0001;
-static const uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
+static constexpr uint16_t CMD_DISABLE_CONF = 0x00FE;
+static constexpr uint16_t CMD_ENABLE_CONF = 0x00FF;
+static constexpr uint16_t CMD_PARM_HIGH_TRESH = 0x0012;
+static constexpr uint16_t CMD_PARM_LOW_TRESH = 0x0021;
+static constexpr uint16_t CMD_PROTOCOL_VER = 0x0002;
+static constexpr uint16_t CMD_READ_ABD_PARAM = 0x0008;
+static constexpr uint16_t CMD_READ_REG_ADDR = 0x0020;
+static constexpr uint16_t CMD_READ_REGISTER = 0x0002;
+static constexpr uint16_t CMD_READ_SERIAL_NUM = 0x0011;
+static constexpr uint16_t CMD_READ_SYS_PARAM = 0x0013;
+static constexpr uint16_t CMD_READ_VERSION = 0x0000;
+static constexpr uint16_t CMD_RESTART = 0x0068;
+static constexpr uint16_t CMD_SYSTEM_MODE = 0x0000;
+static constexpr uint16_t CMD_SYSTEM_MODE_GR = 0x0003;
+static constexpr uint16_t CMD_SYSTEM_MODE_MTT = 0x0001;
+static constexpr uint16_t CMD_SYSTEM_MODE_SIMPLE = 0x0064;
+static constexpr uint16_t CMD_SYSTEM_MODE_DEBUG = 0x0000;
+static constexpr uint16_t CMD_SYSTEM_MODE_ENERGY = 0x0004;
+static constexpr uint16_t CMD_SYSTEM_MODE_VS = 0x0002;
+static constexpr uint16_t CMD_WRITE_ABD_PARAM = 0x0007;
+static constexpr uint16_t CMD_WRITE_REGISTER = 0x0001;
+static constexpr uint16_t CMD_WRITE_SYS_PARAM = 0x0012;
 
-static const uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
-static const uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
-static const uint8_t CMD_MAX_BYTES = 0x64;
-static const uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
+static constexpr uint8_t CMD_ABD_DATA_REPLY_SIZE = 0x04;
+static constexpr uint8_t CMD_ABD_DATA_REPLY_START = 0x0A;
+static constexpr uint8_t CMD_MAX_BYTES = 0x64;
+static constexpr uint8_t CMD_REG_DATA_REPLY_SIZE = 0x02;
 
-static const uint8_t LD2420_ERROR_NONE = 0x00;
-static const uint8_t LD2420_ERROR_TIMEOUT = 0x02;
-static const uint8_t LD2420_ERROR_UNKNOWN = 0x01;
+static constexpr uint8_t LD2420_ERROR_NONE = 0x00;
+static constexpr uint8_t LD2420_ERROR_TIMEOUT = 0x02;
+static constexpr uint8_t LD2420_ERROR_UNKNOWN = 0x01;
 
 // Register address values
-static const uint16_t CMD_MIN_GATE_REG = 0x0000;
-static const uint16_t CMD_MAX_GATE_REG = 0x0001;
-static const uint16_t CMD_TIMEOUT_REG = 0x0004;
-static const uint16_t CMD_GATE_MOVE_THRESH[TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
-                                                           0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
-                                                           0x001C, 0x001D, 0x001E, 0x001F};
-static const uint16_t CMD_GATE_STILL_THRESH[TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
-                                                            0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
-                                                            0x002C, 0x002D, 0x002E, 0x002F};
-static const uint32_t FACTORY_MOVE_THRESH[TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
-                                                          250,   250,   250, 250, 250, 250, 250, 250};
-static const uint32_t FACTORY_STILL_THRESH[TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
-                                                           150,   100,   100, 100, 100, 100, 100, 100};
-static const uint16_t FACTORY_TIMEOUT = 120;
-static const uint16_t FACTORY_MIN_GATE = 1;
-static const uint16_t FACTORY_MAX_GATE = 12;
+static constexpr uint16_t CMD_MIN_GATE_REG = 0x0000;
+static constexpr uint16_t CMD_MAX_GATE_REG = 0x0001;
+static constexpr uint16_t CMD_TIMEOUT_REG = 0x0004;
+static constexpr uint16_t CMD_GATE_MOVE_THRESH[TOTAL_GATES] = {0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015,
+                                                               0x0016, 0x0017, 0x0018, 0x0019, 0x001A, 0x001B,
+                                                               0x001C, 0x001D, 0x001E, 0x001F};
+static constexpr uint16_t CMD_GATE_STILL_THRESH[TOTAL_GATES] = {0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025,
+                                                                0x0026, 0x0027, 0x0028, 0x0029, 0x002A, 0x002B,
+                                                                0x002C, 0x002D, 0x002E, 0x002F};
+static constexpr uint32_t FACTORY_MOVE_THRESH[TOTAL_GATES] = {60000, 30000, 400, 250, 250, 250, 250, 250,
+                                                              250,   250,   250, 250, 250, 250, 250, 250};
+static constexpr uint32_t FACTORY_STILL_THRESH[TOTAL_GATES] = {40000, 20000, 200, 200, 200, 200, 200, 150,
+                                                               150,   100,   100, 100, 100, 100, 100, 100};
+static constexpr uint16_t FACTORY_TIMEOUT = 120;
+static constexpr uint16_t FACTORY_MIN_GATE = 1;
+static constexpr uint16_t FACTORY_MAX_GATE = 12;
 
 // COMMAND_BYTE Header & Footer
-static const uint32_t CMD_FRAME_FOOTER = 0x01020304;
-static const uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
-static const uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
-static const uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
-static const uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
-static const int CALIBRATE_VERSION_MIN = 154;
-static const uint8_t CMD_FRAME_COMMAND = 6;
-static const uint8_t CMD_FRAME_DATA_LENGTH = 4;
-static const uint8_t CMD_FRAME_STATUS = 7;
-static const uint8_t CMD_ERROR_WORD = 8;
-static const uint8_t ENERGY_SENSOR_START = 9;
-static const uint8_t CALIBRATE_REPORT_INTERVAL = 4;
+static constexpr uint32_t CMD_FRAME_FOOTER = 0x01020304;
+static constexpr uint32_t CMD_FRAME_HEADER = 0xFAFBFCFD;
+static constexpr uint32_t DEBUG_FRAME_FOOTER = 0xFAFBFCFD;
+static constexpr uint32_t DEBUG_FRAME_HEADER = 0x1410BFAA;
+static constexpr uint32_t ENERGY_FRAME_FOOTER = 0xF5F6F7F8;
+static constexpr uint32_t ENERGY_FRAME_HEADER = 0xF1F2F3F4;
+static constexpr int CALIBRATE_VERSION_MIN = 154;
+static constexpr uint8_t CMD_FRAME_COMMAND = 6;
+static constexpr uint8_t CMD_FRAME_DATA_LENGTH = 4;
+static constexpr uint8_t CMD_FRAME_STATUS = 7;
+static constexpr uint8_t CMD_ERROR_WORD = 8;
+static constexpr uint8_t ENERGY_SENSOR_START = 9;
+static constexpr uint8_t CALIBRATE_REPORT_INTERVAL = 4;
 static const char *const OP_NORMAL_MODE_STRING = "Normal";
 static const char *const OP_SIMPLE_MODE_STRING = "Simple";
 

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -20,9 +20,9 @@
 
 namespace esphome::ld2420 {
 
-static const uint8_t CALIBRATE_SAMPLES = 64;
-static const uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
-static const uint8_t TOTAL_GATES = 16;
+static constexpr uint8_t CALIBRATE_SAMPLES = 64;
+static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
+static constexpr uint8_t TOTAL_GATES = 16;
 
 enum OpMode : uint8_t {
   OP_NORMAL_MODE = 1,

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -21,7 +21,9 @@
 namespace esphome::ld2420 {
 
 static constexpr uint8_t CALIBRATE_SAMPLES = 64;
-static constexpr uint8_t MAX_LINE_LENGTH = 46;  // Max characters for serial buffer
+// Energy frame is 45 bytes; +1 for null terminator, +4 so that a frame footer always lands
+// inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 50;
 static constexpr uint8_t TOTAL_GATES = 16;
 
 enum OpMode : uint8_t {

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -769,28 +769,11 @@ void LD2450Component::readline_(int readch) {
     return;  // No data available
   }
 
-  // Frame header synchronization: verify first 4 bytes match a known frame header.
-  // This prevents the parser from accumulating mid-frame data after losing sync
-  // (e.g. after module restart or UART noise).
-  if (this->buffer_pos_ < HEADER_FOOTER_SIZE) {
-    const uint8_t byte = static_cast<uint8_t>(readch);
-    // Verify header bytes match the frame type established by byte 0
-    if (this->buffer_pos_ > 0) {
-      const uint8_t *expected = (this->buffer_data_[0] == DATA_FRAME_HEADER[0]) ? DATA_FRAME_HEADER : CMD_FRAME_HEADER;
-      if (byte != expected[this->buffer_pos_]) {
-        this->buffer_pos_ = 0;  // Reset and fall through to check if this byte starts a new frame
-      }
-    }
-    // First byte must match start of a data or command frame header
-    if (this->buffer_pos_ == 0 && byte != DATA_FRAME_HEADER[0] && byte != CMD_FRAME_HEADER[0]) {
-      return;
-    }
-  }
-
   if (this->buffer_pos_ < MAX_LINE_LENGTH - 1) {
     this->buffer_data_[this->buffer_pos_++] = readch;
     this->buffer_data_[this->buffer_pos_] = 0;
   } else {
+    // We should never get here, but just in case...
     ESP_LOGW(TAG, "Max command length exceeded; ignoring");
     this->buffer_pos_ = 0;
     return;

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -38,9 +38,11 @@ using namespace ld24xx;
 
 // Constants
 static constexpr uint8_t DEFAULT_PRESENCE_TIMEOUT = 5;  // Timeout to reset presense status 5 sec.
-static constexpr uint8_t MAX_LINE_LENGTH = 41;          // Max characters for serial buffer
-static constexpr uint8_t MAX_TARGETS = 3;               // Max 3 Targets in LD2450
-static constexpr uint8_t MAX_ZONES = 3;                 // Max 3 Zones in LD2450
+// Zone query response is 40 bytes; +1 for null terminator, +4 so that a frame footer always
+// lands inside the buffer during footer-based resynchronization after losing sync.
+static constexpr uint8_t MAX_LINE_LENGTH = 45;
+static constexpr uint8_t MAX_TARGETS = 3;  // Max 3 Targets in LD2450
+static constexpr uint8_t MAX_ZONES = 3;    // Max 3 Zones in LD2450
 
 enum Direction : uint8_t {
   DIRECTION_APPROACHING = 0,

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/component.h"
 #ifdef USE_SENSOR

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 #ifdef HAS_PCNT
-#include <esp_clk_tree.h>
+#include <esp_private/esp_clk.h>
 #include <hal/pcnt_ll.h>
 #endif
 
@@ -117,9 +117,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint32_t apb_freq;
-    esp_clk_tree_src_get_freq_hz(SOC_MOD_CLK_APB, ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED, &apb_freq);
-    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / apb_freq;
+    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / (uint32_t) esp_clk_apb_freq();
     pcnt_glitch_filter_config_t filter_config = {
         .max_glitch_ns = std::min(this->filter_us * 1000u, max_glitch_ns),
     };

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -117,7 +117,7 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   if (this->filter_us != 0) {
-    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000000u / (uint32_t) esp_clk_apb_freq();
+    uint32_t max_glitch_ns = PCNT_LL_MAX_GLITCH_WIDTH * 1000u / ((uint32_t) esp_clk_apb_freq() / 1000000u);
     pcnt_glitch_filter_config_t filter_config = {
         .max_glitch_ns = std::min(this->filter_us * 1000u, max_glitch_ns),
     };

--- a/esphome/components/pulse_counter/pulse_counter_sensor.h
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.h
@@ -8,10 +8,10 @@
 
 #if defined(USE_ESP32)
 #include <soc/soc_caps.h>
-#ifdef SOC_PCNT_SUPPORTED
+#if defined(SOC_PCNT_SUPPORTED) && __has_include(<driver/pulse_cnt.h>)
 #include <driver/pulse_cnt.h>
 #define HAS_PCNT
-#endif  // SOC_PCNT_SUPPORTED
+#endif  // defined(SOC_PCNT_SUPPORTED) && __has_include(<driver/pulse_cnt.h>)
 #endif  // USE_ESP32
 
 namespace esphome {

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -11,6 +11,7 @@
 
 #if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
 #include <esp_ota_ops.h>
+#include <esp_system.h>
 #endif
 
 namespace esphome::safe_mode {
@@ -54,6 +55,10 @@ void SafeModeComponent::dump_config() {
              "OTA rollback detected! Rolled back from partition '%s'\n"
              "The device reset before the boot was marked successful",
              last_invalid->label);
+    if (esp_reset_reason() == ESP_RST_BROWNOUT) {
+      ESP_LOGW(TAG, "Last reset was due to brownout - check your power supply!\n"
+                    "See https://esphome.io/guides/faq.html#brownout-detector-was-triggered");
+    }
   }
 #endif
 }

--- a/esphome/components/web_server/__init__.py
+++ b/esphome/components/web_server/__init__.py
@@ -144,9 +144,10 @@ def _consume_web_server_sockets(config: ConfigType) -> ConfigType:
     """Register socket needs for web_server component."""
     from esphome.components import socket
 
-    # Web server needs 1 listening socket + typically 2 concurrent client connections
-    # (browser makes 2 connections for page + event stream)
-    sockets_needed = 3
+    # Web server needs 1 listening socket + typically 5 concurrent client connections
+    # (browser opens connections for page resources, SSE event stream, and POST
+    # requests for entity control which may linger before closing)
+    sockets_needed = 6
     socket.consume_sockets(sockets_needed, "web_server")(config)
     return config
 

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -1913,6 +1913,9 @@ std::string WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDe
     JsonArray modes = root[ESPHOME_F("modes")].to<JsonArray>();
     for (auto m : traits.get_supported_modes())
       modes.add(PSTR_LOCAL(water_heater::water_heater_mode_to_string(m)));
+    root[ESPHOME_F("min_temp")] = traits.get_min_temperature();
+    root[ESPHOME_F("max_temp")] = traits.get_max_temperature();
+    root[ESPHOME_F("step")] = traits.get_target_temperature_step();
     this->add_sorting_info_(root, obj);
   }
 
@@ -1934,10 +1937,6 @@ std::string WebServer::water_heater_json_(water_heater::WaterHeater *obj, JsonDe
     if (!std::isnan(target))
       root[ESPHOME_F("target_temperature")] = target;
   }
-
-  root[ESPHOME_F("min_temperature")] = traits.get_min_temperature();
-  root[ESPHOME_F("max_temperature")] = traits.get_max_temperature();
-  root[ESPHOME_F("step")] = traits.get_target_temperature_step();
 
   if (traits.get_supports_away_mode()) {
     root[ESPHOME_F("away")] = obj->is_away();

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import math
 
 from esphome import automation
 from esphome.automation import Condition
@@ -493,6 +494,13 @@ async def to_code(config):
         cg.add(var.set_passive_scan(True))
     if CONF_OUTPUT_POWER in config:
         cg.add(var.set_output_power(config[CONF_OUTPUT_POWER]))
+        if CORE.is_esp32:
+            # Set PHY max TX power to match output_power so calibration also uses
+            # reduced power. This prevents brownout during PHY init on marginal
+            # power supplies, which is critical for OTA updates with rollback enabled.
+            # Kconfig range is 10-20, ESPHome allows 8.5-20.5
+            phy_tx_power = max(10, min(20, math.ceil(config[CONF_OUTPUT_POWER])))
+            add_idf_sdkconfig_option("CONFIG_ESP_PHY_MAX_WIFI_TX_POWER", phy_tx_power)
     # enable_on_boot defaults to true in C++ - only set if false
     if not config[CONF_ENABLE_ON_BOOT]:
         cg.add(var.set_enable_on_boot(False))

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.2.0"
+__version__ = "2026.2.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/tests/components/esp32_ble/test.esp32-c2-idf.yaml
+++ b/tests/components/esp32_ble/test.esp32-c2-idf.yaml
@@ -1,0 +1,5 @@
+<<: !include common.yaml
+
+esp32_ble:
+  io_capability: keyboard_only
+  disable_bt_logs: false

--- a/tests/components/ld2450/common.h
+++ b/tests/components/ld2450/common.h
@@ -1,0 +1,61 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+#include <vector>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "esphome/components/ld2450/ld2450.h"
+#include "esphome/components/uart/uart_component.h"
+
+namespace esphome::ld2450::testing {
+
+// Mock UART component to satisfy UARTDevice parent requirement.
+class MockUARTComponent : public uart::UARTComponent {
+ public:
+  void write_array(const uint8_t *data, size_t len) override {}
+  MOCK_METHOD(bool, read_array, (uint8_t * data, size_t len), (override));
+  MOCK_METHOD(bool, peek_byte, (uint8_t * data), (override));
+  MOCK_METHOD(size_t, available, (), (override));
+  MOCK_METHOD(void, flush, (), (override));
+  MOCK_METHOD(void, check_logger_conflict, (), (override));
+};
+
+// Expose protected members for testing.
+class TestableLD2450 : public LD2450Component {
+ public:
+  using LD2450Component::buffer_data_;
+  using LD2450Component::buffer_pos_;
+  using LD2450Component::readline_;
+
+  void feed(const std::vector<uint8_t> &data) {
+    for (uint8_t byte : data) {
+      this->readline_(byte);
+    }
+  }
+};
+
+// LD2450 periodic data frame: header (4) + 3 targets * 8 bytes + footer (2) = 30 bytes
+// All-zero targets means no presence detected.
+inline std::vector<uint8_t> make_periodic_frame(uint8_t fill = 0x00) {
+  std::vector<uint8_t> frame = {0xAA, 0xFF, 0x03, 0x00};  // DATA_FRAME_HEADER
+  for (int i = 0; i < 24; i++) {
+    frame.push_back(fill);  // 3 targets * 8 bytes
+  }
+  frame.push_back(0x55);  // DATA_FRAME_FOOTER
+  frame.push_back(0xCC);
+  return frame;
+}
+
+// LD2450 command ACK frame for CMD_ENABLE_CONF (0xFF), successful.
+// header (4) + length (2) + command (2) + result (2) + footer (4) = 14 bytes
+inline std::vector<uint8_t> make_ack_frame() {
+  return {
+      0xFD, 0xFC, 0xFB, 0xFA,  // CMD_FRAME_HEADER
+      0x04, 0x00,              // length = 4
+      0xFF, 0x01,              // command = enable_conf, status = success
+      0x00, 0x00,              // result = ok
+      0x04, 0x03, 0x02, 0x01   // CMD_FRAME_FOOTER
+  };
+}
+
+}  // namespace esphome::ld2450::testing

--- a/tests/components/ld2450/ld2450_readline.cpp
+++ b/tests/components/ld2450/ld2450_readline.cpp
@@ -1,0 +1,181 @@
+#include "common.h"
+
+namespace esphome::ld2450::testing {
+
+class LD2450ReadlineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    this->ld2450_.set_uart_parent(&this->mock_uart_);
+    // Ensure clean state
+    ASSERT_EQ(this->ld2450_.buffer_pos_, 0);
+  }
+
+  MockUARTComponent mock_uart_;
+  TestableLD2450 ld2450_;
+};
+
+// --- Good data tests ---
+
+TEST_F(LD2450ReadlineTest, ValidPeriodicFrame) {
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  // After a complete valid frame, buffer should be reset
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, ValidCommandAckFrame) {
+  auto frame = make_ack_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, BackToBackPeriodicFrames) {
+  auto frame = make_periodic_frame();
+  for (int i = 0; i < 5; i++) {
+    this->ld2450_.feed(frame);
+    EXPECT_EQ(this->ld2450_.buffer_pos_, 0) << "Frame " << i << " not processed";
+  }
+}
+
+TEST_F(LD2450ReadlineTest, BackToBackMixedFrames) {
+  auto periodic = make_periodic_frame();
+  auto ack = make_ack_frame();
+  this->ld2450_.feed(periodic);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+  this->ld2450_.feed(ack);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+  this->ld2450_.feed(periodic);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+// --- Garbage rejection tests ---
+
+TEST_F(LD2450ReadlineTest, GarbageDiscarded) {
+  // Feed bytes that don't match any header start byte
+  std::vector<uint8_t> garbage = {0x01, 0x02, 0x03, 0x42, 0x99, 0x00, 0xFF, 0x7F};
+  this->ld2450_.feed(garbage);
+  // Header sync should discard all of these
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, GarbageThenValidFrame) {
+  std::vector<uint8_t> garbage = {0x01, 0x02, 0x03, 0x42, 0x99};
+  this->ld2450_.feed(garbage);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+// --- Header synchronization tests ---
+
+TEST_F(LD2450ReadlineTest, PartialDataHeaderThenMismatch) {
+  // Start of a data frame header, then invalid byte
+  this->ld2450_.feed({0xAA, 0xFF, 0x42});  // 0x42 doesn't match DATA_FRAME_HEADER[2] (0x03)
+  // Parser should have reset
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, PartialCmdHeaderThenMismatch) {
+  // Start of a command frame header, then invalid byte
+  this->ld2450_.feed({0xFD, 0xFC, 0xFB, 0x42});  // 0x42 doesn't match CMD_FRAME_HEADER[3] (0xFA)
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, PartialHeaderThenValidFrame) {
+  // Partial header that fails, then a complete valid frame
+  this->ld2450_.feed({0xAA, 0xFF, 0x42});  // Fails at byte 3
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, HeaderMismatchRecoveryOnNewHeaderByte) {
+  // Start data header, mismatch at byte 2, but mismatch byte is start of command header
+  this->ld2450_.feed({0xAA, 0xFF});
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 2);  // Accumulating header
+
+  this->ld2450_.feed({0xFD});  // Doesn't match DATA_FRAME_HEADER[2]=0x03, but IS CMD_FRAME_HEADER[0]
+  // Parser should reset and start new frame with 0xFD
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 1);
+  EXPECT_EQ(this->ld2450_.buffer_data_[0], 0xFD);
+}
+
+// --- Mid-frame / overflow recovery tests ---
+
+TEST_F(LD2450ReadlineTest, MidFrameDataRecovery) {
+  // Simulate starting mid-frame: feed the tail end of a periodic frame (no valid header)
+  // These bytes would be part of target data in a real frame
+  std::vector<uint8_t> mid_frame = {0x10, 0x20, 0x30, 0x40, 0x55, 0xCC};
+  this->ld2450_.feed(mid_frame);
+  // All discarded (none match header start bytes)
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  // Now feed a valid frame
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, OverflowRecovery) {
+  // Feed a valid data frame header followed by enough filler to cause overflow.
+  // Header (4) + 36 filler = 40 bytes in buffer. The 41st byte triggers overflow.
+  std::vector<uint8_t> overflow_data = {0xAA, 0xFF, 0x03, 0x00};  // Valid header
+  for (int i = 0; i < 37; i++) {
+    overflow_data.push_back(0x11);  // Filler that won't match any footer
+  }
+  // 41 bytes total: 40 stored, 41st triggers overflow and resets buffer_pos_ to 0
+  this->ld2450_.feed(overflow_data);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  // Feed a valid frame and verify recovery
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, RepeatedOverflowDoesNotLoop) {
+  // Simulate the bug scenario: repeated overflows should not prevent recovery.
+  // Feed 3 rounds of overflow-inducing data.
+  for (int round = 0; round < 3; round++) {
+    std::vector<uint8_t> overflow_data = {0xAA, 0xFF, 0x03, 0x00};
+    for (int i = 0; i < 37; i++) {
+      overflow_data.push_back(0x22);
+    }
+    this->ld2450_.feed(overflow_data);
+    EXPECT_EQ(this->ld2450_.buffer_pos_, 0) << "Overflow round " << round;
+  }
+
+  // Parser should still recover and process a valid frame
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+TEST_F(LD2450ReadlineTest, SimulatedRestartGarbageThenFrames) {
+  // Simulate LD2450 restart: burst of garbage bytes (partial frames, noise)
+  // followed by normal periodic data.
+  // Partial periodic frame (as if we started reading mid-frame), a stale footer, and more garbage
+  std::vector<uint8_t> restart_noise = {
+      0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E,  // mid-frame data
+      0x55, 0xCC,                                                                                // stale footer bytes
+      0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88, 0x89,                                // more garbage
+  };
+
+  this->ld2450_.feed(restart_noise);
+  // All garbage should be discarded
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  // Now the LD2450 starts sending valid frames
+  auto frame = make_periodic_frame();
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+
+  this->ld2450_.feed(frame);
+  EXPECT_EQ(this->ld2450_.buffer_pos_, 0);
+}
+
+}  // namespace esphome::ld2450::testing

--- a/tests/components/pulse_counter/test-no-pcnt.esp32-idf.yaml
+++ b/tests/components/pulse_counter/test-no-pcnt.esp32-idf.yaml
@@ -1,0 +1,10 @@
+sensor:
+  - platform: pulse_counter
+    name: Pulse Counter
+    pin: 4
+    use_pcnt: false
+    count_mode:
+      rising_edge: INCREMENT
+      falling_edge: DECREMENT
+    internal_filter: 13us
+    update_interval: 15s

--- a/tests/components/socket/common.yaml
+++ b/tests/components/socket/common.yaml
@@ -1,0 +1,11 @@
+substitutions:
+  network_enable_ipv6: "false"
+
+socket:
+
+wifi:
+  ssid: MySSID
+  password: password1
+
+network:
+  enable_ipv6: ${network_enable_ipv6}

--- a/tests/components/socket/test-ipv6.esp32-idf.yaml
+++ b/tests/components/socket/test-ipv6.esp32-idf.yaml
@@ -1,0 +1,4 @@
+substitutions:
+  network_enable_ipv6: "true"
+
+<<: !include common.yaml

--- a/tests/components/socket/test-ipv6.host.yaml
+++ b/tests/components/socket/test-ipv6.host.yaml
@@ -1,0 +1,4 @@
+socket:
+
+network:
+  enable_ipv6: true

--- a/tests/components/socket/test.esp32-idf.yaml
+++ b/tests/components/socket/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/socket/test.host.yaml
+++ b/tests/components/socket/test.host.yaml
@@ -1,0 +1,3 @@
+socket:
+
+network:


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [esp32_ble_server] fix infinitely large characteristic value [esphome#14011](https://github.com/esphome/esphome/pull/14011)
- [udp] Register socket consumption for CONFIG_LWIP_MAX_SOCKETS [esphome#14068](https://github.com/esphome/esphome/pull/14068)
- [web_server] Double socket allocation to prevent connection exhaustion [esphome#14067](https://github.com/esphome/esphome/pull/14067)
- [pulse_counter] Fix compilation on ESP32-C6/C5/H2/P4 [esphome#14070](https://github.com/esphome/esphome/pull/14070)
- [web_server] Fix water_heater JSON key names and move traits to DETAIL_ALL [esphome#14064](https://github.com/esphome/esphome/pull/14064)
- [ld2420] Use constexpr for compile-time constants [esphome#14079](https://github.com/esphome/esphome/pull/14079)
- [e131] Fix E1.31 on ESP8266 and RP2040 by restoring WiFiUDP support [esphome#14086](https://github.com/esphome/esphome/pull/14086)
- [socket] Fix IPv6 compilation error on host platform [esphome#14101](https://github.com/esphome/esphome/pull/14101)
- [ethernet] Improve clk_mode deprecation warning with actionable YAML [esphome#14104](https://github.com/esphome/esphome/pull/14104)
- [pulse_counter] Fix build failure when use_pcnt is false [esphome#14111](https://github.com/esphome/esphome/pull/14111)
- [esp32_ble] Enable CONFIG_BT_RELEASE_IRAM on ESP32-C2 [esphome#14109](https://github.com/esphome/esphome/pull/14109)
- [safe_mode] Log brownout as reset reason on OTA rollback [esphome#14113](https://github.com/esphome/esphome/pull/14113)
- [wifi] Sync output_power with PHY max TX power to prevent brownout [esphome#14118](https://github.com/esphome/esphome/pull/14118)
- [uart] Always call pin setup for UART0 default pins on ESP-IDF [esphome#14130](https://github.com/esphome/esphome/pull/14130)
- [pulse_counter] Fix PCNT glitch filter calculation off by 1000x [esphome#14132](https://github.com/esphome/esphome/pull/14132)
- [ld2450] Add frame header synchronization to readline_() [esphome#14135](https://github.com/esphome/esphome/pull/14135)
- [ld2410] Add frame header synchronization to readline_() [esphome#14136](https://github.com/esphome/esphome/pull/14136)
- [ld2420] Increase MAX_LINE_LENGTH to allow footer-based resync [esphome#14137](https://github.com/esphome/esphome/pull/14137)
- [ld2410/ld2450] Replace header sync with buffer size increase for frame resync [esphome#14138](https://github.com/esphome/esphome/pull/14138)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
