### PR TITLE
[e131] Remove dead LWIP TCP code path from loop()

### DIFF
--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -75,6 +75,7 @@ void E131Component::loop() {
   // Drain all queued packets so multi-universe frames are applied
   // atomically before the light writes. Without this, each universe
   // packet would trigger a separate full-strip write causing tearing.
+#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   while ((len = this->read_(buf, sizeof(buf))) > 0) {
     if (!this->packet_(buf, (size_t) len, universe, packet)) {
       ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);

--- a/esphome/components/e131/e131.cpp
+++ b/esphome/components/e131/e131.cpp
@@ -75,7 +75,6 @@ void E131Component::loop() {
   // Drain all queued packets so multi-universe frames are applied
   // atomically before the light writes. Without this, each universe
   // packet would trigger a separate full-strip write causing tearing.
-#if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
   while ((len = this->read_(buf, sizeof(buf))) > 0) {
     if (!this->packet_(buf, (size_t) len, universe, packet)) {
       ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);
@@ -86,22 +85,6 @@ void E131Component::loop() {
       ESP_LOGV(TAG, "Ignored packet for %d universe of size %d.", universe, packet.count);
     }
   }
-#elif defined(USE_SOCKET_IMPL_LWIP_TCP)
-  while (auto packet_size = this->udp_.parsePacket()) {
-    auto len = this->udp_.read(buf, sizeof(buf));
-    if (len <= 0)
-      continue;
-
-    if (!this->packet_(buf, (size_t) len, universe, packet)) {
-      ESP_LOGV(TAG, "Invalid packet received of size %d.", (int) len);
-      continue;
-    }
-
-    if (!this->process_(universe, packet)) {
-      ESP_LOGV(TAG, "Ignored packet for %d universe of size %d.", universe, packet.count);
-    }
-  }
-#endif
 }
 
 void E131Component::add_effect(E131AddressableLightEffect *light_effect) {


### PR DESCRIPTION
# What does this implement/fix?

Fix a `#endif without #if` compile error in `e131.cpp` caused by a merge conflict between #14086 and #14133.

#14086 added `#if`/`#elif`/`#endif` guards for LWIP TCP support in `loop()`. #14133 then unified both paths using `read_()` (which handles both socket types internally) and removed the `#if` and `#endif`, but the merge left the `#elif` LWIP TCP block and its `#endif` dangling.

The correct fix is to remove the dead `#elif` block rather than restore the `#if`, since `read_()` already abstracts over both BSD sockets and LWIP TCP.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - bugfix only, no config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).