### PR TITLE
[max7219digit] Fix typo in action names

### DIFF
--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -133,12 +133,12 @@ MAX7219_ON_ACTION_SCHEMA = automation.maybe_simple_id(
 
 
 @automation.register_action(
-    "max7129digit.invert_off", DisplayInvertAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.invert_off", DisplayInvertAction, MAX7219_OFF_ACTION_SCHEMA
 )
 @automation.register_action(
-    "max7129digit.invert_on", DisplayInvertAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.invert_on", DisplayInvertAction, MAX7219_ON_ACTION_SCHEMA
 )
-async def max7129digit_invert_to_code(config, action_id, template_arg, args):
+async def max7219digit_invert_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     cg.add(var.set_state(config[CONF_STATE]))
@@ -146,12 +146,12 @@ async def max7129digit_invert_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "max7129digit.turn_off", DisplayVisibilityAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.turn_off", DisplayVisibilityAction, MAX7219_OFF_ACTION_SCHEMA
 )
 @automation.register_action(
-    "max7129digit.turn_on", DisplayVisibilityAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.turn_on", DisplayVisibilityAction, MAX7219_ON_ACTION_SCHEMA
 )
-async def max7129digit_visible_to_code(config, action_id, template_arg, args):
+async def max7219digit_visible_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     cg.add(var.set_state(config[CONF_STATE]))
@@ -159,12 +159,12 @@ async def max7129digit_visible_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "max7129digit.reverse_off", DisplayReverseAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.reverse_off", DisplayReverseAction, MAX7219_OFF_ACTION_SCHEMA
 )
 @automation.register_action(
-    "max7129digit.reverse_on", DisplayReverseAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.reverse_on", DisplayReverseAction, MAX7219_ON_ACTION_SCHEMA
 )
-async def max7129digit_reverse_to_code(config, action_id, template_arg, args):
+async def max7219digit_reverse_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     cg.add(var.set_state(config[CONF_STATE]))
@@ -183,9 +183,9 @@ MAX7219_INTENSITY_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "max7129digit.intensity", DisplayIntensityAction, MAX7219_INTENSITY_SCHEMA
+    "max7219digit.intensity", DisplayIntensityAction, MAX7219_INTENSITY_SCHEMA
 )
-async def max7129digit_intensity_to_code(config, action_id, template_arg, args):
+async def max7219digit_intensity_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_INTENSITY], args, cg.uint8)

--- a/tests/components/max7219digit/common.yaml
+++ b/tests/components/max7219digit/common.yaml
@@ -13,10 +13,10 @@ esphome:
   on_boot:
     - priority: 100
       then:
-        - max7129digit.invert_off:
-        - max7129digit.invert_on:
-        - max7129digit.turn_on:
-        - max7129digit.turn_off:
-        - max7129digit.reverse_on:
-        - max7129digit.reverse_off:
-        - max7129digit.intensity: 10
+        - max7219digit.invert_off:
+        - max7219digit.invert_on:
+        - max7219digit.turn_on:
+        - max7219digit.turn_off:
+        - max7219digit.reverse_on:
+        - max7219digit.reverse_off:
+        - max7219digit.intensity: 10


### PR DESCRIPTION
# What does this implement/fix?

All max7219digit actions were registered with the name `max7129digit` (transposed digits `1` and `2`) instead of `max7219digit`, making the actions impossible to use with the correct component name. For example, `max7219digit.reverse_on` would fail with "Unable to find action", and only the mistyped `max7129digit.reverse_on` would work.

This is a **breaking change** for anyone who discovered and used the typo'd action names, but since the documented names never worked, this is effectively a bugfix.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14154

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6131

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  - platform: max7219digit
    cs_pin: GPIO15
    num_chips: 4
    id: my_matrix
    lambda: |-
      it.print(0, 0, id(font1), "Hello");

binary_sensor:
  - platform: gpio
    pin: GPIO16
    on_press:
      then:
        - max7219digit.reverse_on:
    on_release:
      then:
        - max7219digit.reverse_off:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).