### PR TITLE
[api,ota,captive_portal] Fix fd leaks and clean up socket_ip_loop_monitored setup paths

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -30,6 +30,12 @@ APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-c
 
 APIServer::APIServer() { global_api_server = this; }
 
+void APIServer::socket_failed_(const LogString *msg) {
+  ESP_LOGW(TAG, "Socket %s: errno %d", LOG_STR_ARG(msg), errno);
+  this->close_socket_();
+  this->mark_failed();
+}
+
 void APIServer::setup() {
   ControllerRegistry::register_controller(this);
 
@@ -48,22 +54,20 @@ void APIServer::setup() {
 #endif
 #endif
 
-  this->socket_ = socket::socket_ip_loop_monitored(SOCK_STREAM, 0);  // monitored for incoming connections
+  this->socket_ = socket::socket_ip_loop_monitored(SOCK_STREAM, 0).release();  // monitored for incoming connections
   if (this->socket_ == nullptr) {
-    ESP_LOGW(TAG, "Could not create socket");
-    this->mark_failed();
+    this->socket_failed_(LOG_STR("creation"));
     return;
   }
   int enable = 1;
   int err = this->socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
   if (err != 0) {
-    ESP_LOGW(TAG, "Socket unable to set reuseaddr: errno %d", err);
+    ESP_LOGW(TAG, "Socket reuseaddr: errno %d", errno);
     // we can still continue
   }
   err = this->socket_->setblocking(false);
   if (err != 0) {
-    ESP_LOGW(TAG, "Socket unable to set nonblocking mode: errno %d", err);
-    this->mark_failed();
+    this->socket_failed_(LOG_STR("nonblocking"));
     return;
   }
 
@@ -71,22 +75,19 @@ void APIServer::setup() {
 
   socklen_t sl = socket::set_sockaddr_any((struct sockaddr *) &server, sizeof(server), this->port_);
   if (sl == 0) {
-    ESP_LOGW(TAG, "Socket unable to set sockaddr: errno %d", errno);
-    this->mark_failed();
+    this->socket_failed_(LOG_STR("set sockaddr"));
     return;
   }
 
   err = this->socket_->bind((struct sockaddr *) &server, sl);
   if (err != 0) {
-    ESP_LOGW(TAG, "Socket unable to bind: errno %d", errno);
-    this->mark_failed();
+    this->socket_failed_(LOG_STR("bind"));
     return;
   }
 
   err = this->socket_->listen(this->listen_backlog_);
   if (err != 0) {
-    ESP_LOGW(TAG, "Socket unable to listen: errno %d", errno);
-    this->mark_failed();
+    this->socket_failed_(LOG_STR("listen"));
     return;
   }
 
@@ -622,10 +623,7 @@ void APIServer::on_shutdown() {
   this->shutting_down_ = true;
 
   // Close the listening socket to prevent new connections
-  if (this->socket_) {
-    this->socket_->close();
-    this->socket_ = nullptr;
-  }
+  this->close_socket_();
 
   // Change batch delay to 5ms for quick flushing during shutdown
   this->batch_delay_ = 5;

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -32,7 +32,7 @@ APIServer::APIServer() { global_api_server = this; }
 
 void APIServer::socket_failed_(const LogString *msg) {
   ESP_LOGW(TAG, "Socket %s: errno %d", LOG_STR_ARG(msg), errno);
-  this->close_socket_();
+  this->destroy_socket_();
   this->mark_failed();
 }
 
@@ -623,7 +623,7 @@ void APIServer::on_shutdown() {
   this->shutting_down_ = true;
 
   // Close the listening socket to prevent new connections
-  this->close_socket_();
+  this->destroy_socket_();
 
   // Change batch delay to 5ms for quick flushing during shutdown
   this->batch_delay_ = 5;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -249,7 +249,7 @@ class APIServer : public Component,
   void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
                                std::function<void(const std::string &)> f, bool once);
 #endif  // USE_API_HOMEASSISTANT_STATES
-  // Socket destructor calls close() if not already closed
+  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
   inline void close_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -249,7 +249,8 @@ class APIServer : public Component,
   void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
                                std::function<void(const std::string &)> f, bool once);
 #endif  // USE_API_HOMEASSISTANT_STATES
-  // Socket destructor will close or abort depending on platform
+  // No explicit close() needed — listen sockets have no active connections on
+  // failure/shutdown. Destructor handles fd cleanup (close or abort per platform).
   inline void destroy_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -249,8 +249,8 @@ class APIServer : public Component,
   void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
                                std::function<void(const std::string &)> f, bool once);
 #endif  // USE_API_HOMEASSISTANT_STATES
-  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
-  inline void close_socket_() {
+  // Socket destructor will close or abort depending on platform
+  inline void destroy_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;
   }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -249,8 +249,14 @@ class APIServer : public Component,
   void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
                                std::function<void(const std::string &)> f, bool once);
 #endif  // USE_API_HOMEASSISTANT_STATES
+  // Socket destructor calls close() if not already closed
+  inline void close_socket_() {
+    delete this->socket_;
+    this->socket_ = nullptr;
+  }
+  void socket_failed_(const LogString *msg);
   // Pointers and pointer-like types first (4 bytes each)
-  std::unique_ptr<socket::Socket> socket_ = nullptr;
+  socket::Socket *socket_{nullptr};
 #ifdef USE_API_CLIENT_CONNECTED_TRIGGER
   Trigger<std::string, std::string> client_connected_trigger_;
 #endif

--- a/esphome/components/captive_portal/dns_server_esp32_idf.cpp
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.cpp
@@ -53,7 +53,7 @@ void DNSServer::start(const network::IPAddress &ip) {
 #endif
 
   // Create loop-monitored UDP socket
-  this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+  this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP).release();
   if (this->socket_ == nullptr) {
     ESP_LOGE(TAG, "Socket create failed");
     return;
@@ -70,17 +70,14 @@ void DNSServer::start(const network::IPAddress &ip) {
   int err = this->socket_->bind((struct sockaddr *) &server_addr, addr_len);
   if (err != 0) {
     ESP_LOGE(TAG, "Bind failed: %d", errno);
-    this->socket_ = nullptr;
+    this->close_socket_();
     return;
   }
   ESP_LOGV(TAG, "Bound to port %d", DNS_PORT);
 }
 
 void DNSServer::stop() {
-  if (this->socket_ != nullptr) {
-    this->socket_->close();
-    this->socket_ = nullptr;
-  }
+  this->close_socket_();
   ESP_LOGV(TAG, "Stopped");
 }
 

--- a/esphome/components/captive_portal/dns_server_esp32_idf.cpp
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.cpp
@@ -70,14 +70,14 @@ void DNSServer::start(const network::IPAddress &ip) {
   int err = this->socket_->bind((struct sockaddr *) &server_addr, addr_len);
   if (err != 0) {
     ESP_LOGE(TAG, "Bind failed: %d", errno);
-    this->close_socket_();
+    this->destroy_socket_();
     return;
   }
   ESP_LOGV(TAG, "Bound to port %d", DNS_PORT);
 }
 
 void DNSServer::stop() {
-  this->close_socket_();
+  this->destroy_socket_();
   ESP_LOGV(TAG, "Stopped");
 }
 

--- a/esphome/components/captive_portal/dns_server_esp32_idf.h
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.h
@@ -14,7 +14,7 @@ class DNSServer {
   void process_next_request();
 
  protected:
-  // Socket destructor calls close() if not already closed
+  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
   inline void close_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;

--- a/esphome/components/captive_portal/dns_server_esp32_idf.h
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.h
@@ -1,7 +1,6 @@
 #pragma once
 #ifdef USE_ESP32
 
-#include <memory>
 #include "esphome/core/helpers.h"
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/socket/socket.h"
@@ -15,9 +14,14 @@ class DNSServer {
   void process_next_request();
 
  protected:
+  // Socket destructor calls close() if not already closed
+  inline void close_socket_() {
+    delete this->socket_;
+    this->socket_ = nullptr;
+  }
   static constexpr size_t DNS_BUFFER_SIZE = 192;
 
-  std::unique_ptr<socket::Socket> socket_{nullptr};
+  socket::Socket *socket_{nullptr};
   network::IPAddress server_ip_;
   uint8_t buffer_[DNS_BUFFER_SIZE];
 };

--- a/esphome/components/captive_portal/dns_server_esp32_idf.h
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.h
@@ -14,8 +14,8 @@ class DNSServer {
   void process_next_request();
 
  protected:
-  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
-  inline void close_socket_() {
+  // Socket destructor will close or abort depending on platform
+  inline void destroy_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;
   }

--- a/esphome/components/captive_portal/dns_server_esp32_idf.h
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.h
@@ -14,7 +14,8 @@ class DNSServer {
   void process_next_request();
 
  protected:
-  // Socket destructor will close or abort depending on platform
+  // No explicit close() needed — listen sockets have no active connections on
+  // failure/shutdown. Destructor handles fd cleanup (close or abort per platform).
   inline void destroy_socket_() {
     delete this->socket_;
     this->socket_ = nullptr;

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -452,7 +452,8 @@ void ESPHomeOTAComponent::log_remote_closed_(const LogString *during) {
 
 void ESPHomeOTAComponent::server_failed_(const LogString *msg) {
   this->log_socket_error_(msg);
-  // Socket destructor will close or abort depending on platform
+  // No explicit close() needed — listen sockets have no active connections on
+  // failure/shutdown. Destructor handles fd cleanup (close or abort per platform).
   delete this->server_;
   this->server_ = nullptr;
   this->mark_failed();

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -452,7 +452,7 @@ void ESPHomeOTAComponent::log_remote_closed_(const LogString *during) {
 
 void ESPHomeOTAComponent::server_failed_(const LogString *msg) {
   this->log_socket_error_(msg);
-  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
+  // Socket destructor will close or abort depending on platform
   delete this->server_;
   this->server_ = nullptr;
   this->mark_failed();

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -36,7 +36,7 @@ void ESPHomeOTAComponent::setup() {
   int enable = 1;
   int err = this->server_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
   if (err != 0) {
-    ESP_LOGW(TAG, "Socket reuseaddr: errno %d", errno);
+    this->log_socket_error_(LOG_STR("reuseaddr"));
     // we can still continue
   }
   err = this->server_->setblocking(false);
@@ -452,7 +452,7 @@ void ESPHomeOTAComponent::log_remote_closed_(const LogString *during) {
 
 void ESPHomeOTAComponent::server_failed_(const LogString *msg) {
   this->log_socket_error_(msg);
-  // Socket destructor calls close() if not already closed
+  // Listen sockets use LwIPSocketImpl/BSDSocketImpl whose destructors call close()
   delete this->server_;
   this->server_ = nullptr;
   this->mark_failed();

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -28,22 +28,20 @@ static constexpr uint32_t OTA_SOCKET_TIMEOUT_HANDSHAKE = 20000;  // milliseconds
 static constexpr uint32_t OTA_SOCKET_TIMEOUT_DATA = 90000;       // milliseconds for data transfer
 
 void ESPHomeOTAComponent::setup() {
-  this->server_ = socket::socket_ip_loop_monitored(SOCK_STREAM, 0);  // monitored for incoming connections
+  this->server_ = socket::socket_ip_loop_monitored(SOCK_STREAM, 0).release();  // monitored for incoming connections
   if (this->server_ == nullptr) {
-    this->log_socket_error_(LOG_STR("creation"));
-    this->mark_failed();
+    this->server_failed_(LOG_STR("creation"));
     return;
   }
   int enable = 1;
   int err = this->server_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(int));
   if (err != 0) {
-    this->log_socket_error_(LOG_STR("reuseaddr"));
+    ESP_LOGW(TAG, "Socket reuseaddr: errno %d", errno);
     // we can still continue
   }
   err = this->server_->setblocking(false);
   if (err != 0) {
-    this->log_socket_error_(LOG_STR("non-blocking"));
-    this->mark_failed();
+    this->server_failed_(LOG_STR("nonblocking"));
     return;
   }
 
@@ -51,22 +49,19 @@ void ESPHomeOTAComponent::setup() {
 
   socklen_t sl = socket::set_sockaddr_any((struct sockaddr *) &server, sizeof(server), this->port_);
   if (sl == 0) {
-    this->log_socket_error_(LOG_STR("set sockaddr"));
-    this->mark_failed();
+    this->server_failed_(LOG_STR("set sockaddr"));
     return;
   }
 
   err = this->server_->bind((struct sockaddr *) &server, sizeof(server));
   if (err != 0) {
-    this->log_socket_error_(LOG_STR("bind"));
-    this->mark_failed();
+    this->server_failed_(LOG_STR("bind"));
     return;
   }
 
   err = this->server_->listen(1);  // Only one client at a time
   if (err != 0) {
-    this->log_socket_error_(LOG_STR("listen"));
-    this->mark_failed();
+    this->server_failed_(LOG_STR("listen"));
     return;
   }
 }
@@ -453,6 +448,14 @@ void ESPHomeOTAComponent::log_start_(const LogString *phase) {
 
 void ESPHomeOTAComponent::log_remote_closed_(const LogString *during) {
   ESP_LOGW(TAG, "Remote closed at %s", LOG_STR_ARG(during));
+}
+
+void ESPHomeOTAComponent::server_failed_(const LogString *msg) {
+  this->log_socket_error_(msg);
+  // Socket destructor calls close() if not already closed
+  delete this->server_;
+  this->server_ = nullptr;
+  this->mark_failed();
 }
 
 bool ESPHomeOTAComponent::handle_read_error_(ssize_t read, const LogString *desc) {

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -66,6 +66,7 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
     this->handshake_buf_pos_ = 0;  // Reset buffer position for next state
   }
 
+  void server_failed_(const LogString *msg);
   void log_socket_error_(const LogString *msg);
   void log_read_error_(const LogString *what);
   void log_start_(const LogString *phase);
@@ -83,7 +84,7 @@ class ESPHomeOTAComponent : public ota::OTAComponent {
   std::unique_ptr<uint8_t[]> auth_buf_;
 #endif  // USE_OTA_PASSWORD
 
-  std::unique_ptr<socket::Socket> server_;
+  socket::Socket *server_{nullptr};
   std::unique_ptr<socket::Socket> client_;
   std::unique_ptr<ota::OTABackend> backend_;
 


### PR DESCRIPTION
# What does this implement/fix?

Clean up and normalize socket setup error handling across API server, OTA, and captive portal DNS components, while reducing flash usage.

**Fix: error path socket fd leaks:**
Error paths after socket creation leaked the socket fd for the rest of runtime. Since these components are never destroyed on embedded (they live until chip reset), the `unique_ptr` destructor never ran to free them. The `unique_ptr` was no safer than a raw pointer — it leaked in practice. Error paths now explicitly clean up via `destroy_socket_()`/`server_failed_()` helpers.

**Error handling cleanup:**
All three components had duplicated inline error handling at each socket setup step — repeated `ESP_LOGW` + `mark_failed()` + `return` sequences. This PR consolidates them into single-call helpers (`socket_failed_`/`server_failed_`) that handle logging, cleanup, and failure marking in one place. The setup functions are now much easier to read and maintain.

**Flash savings:**
Listen sockets are created once in `setup()` and have program lifetime — they are never reassigned. The `std::unique_ptr` move-assign from `socket_ip_loop_monitored()` generates dead code to destroy the previous value (always `nullptr`), including a virtual destructor call that the compiler cannot eliminate. Using `.release()` to extract the raw pointer skips this entirely.

Additionally:
- Convert API server and OTA error messages to `LOG_STR` for flash storage on ESP8266
- Socket destructor behavior is platform-specific (close or abort) — commented accordingly

Saves 20 bytes on ESP32-IDF, 180 bytes on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).