### PR TITLE
[logger] Reduce UART driver heap waste on ESP32

### DIFF
--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -77,8 +77,10 @@ void init_uart(uart_port_t uart_num, uint32_t baud_rate, int tx_buffer_size) {
   uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
   uart_config.source_clk = UART_SCLK_DEFAULT;
   uart_param_config(uart_num, &uart_config);
-  const int uart_buffer_size = tx_buffer_size;
-  uart_driver_install(uart_num, uart_buffer_size, uart_buffer_size, 0, nullptr, 0);
+  // The logger only writes to UART, never reads, so use the minimum RX buffer.
+  // ESP-IDF requires rx_buffer_size > UART_HW_FIFO_LEN (128 bytes).
+  const int min_rx_buffer_size = UART_HW_FIFO_LEN(uart_num) + 1;
+  uart_driver_install(uart_num, min_rx_buffer_size, tx_buffer_size, 0, nullptr, 0);
 }
 
 void Logger::pre_setup() {

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -78,8 +78,7 @@ void init_uart(uart_port_t uart_num, uint32_t baud_rate, int tx_buffer_size) {
   uart_config.source_clk = UART_SCLK_DEFAULT;
   uart_param_config(uart_num, &uart_config);
   const int uart_buffer_size = tx_buffer_size;
-  // Install UART driver using an event queue here
-  uart_driver_install(uart_num, uart_buffer_size, uart_buffer_size, 10, nullptr, 0);
+  uart_driver_install(uart_num, uart_buffer_size, uart_buffer_size, 0, nullptr, 0);
 }
 
 void Logger::pre_setup() {


### PR DESCRIPTION
# What does this implement/fix?

Reduces unnecessary heap waste in the logger's UART driver initialization on ESP32:

1. **Remove unused event queue** (~212 bytes saved): `uart_driver_install()` was allocating a 10-item FreeRTOS event queue but passing `nullptr` as the queue handle, meaning nothing could ever read from it. Setting the queue size to 0 eliminates this waste.

2. **Minimize RX buffer** (~383 bytes saved): The logger only writes to UART, never reads. Previously it used `tx_buffer_size` (512 bytes) for both RX and TX buffers. Since ESP-IDF requires `rx_buffer_size > UART_HW_FIFO_LEN` (128 bytes), we now use the minimum of 129 bytes instead of 512.

**Total savings: ~595 bytes of heap on ESP32.**

## History

The unused event queue was introduced in September 2021 in PR #2303 (ESP-IDF support), likely copied from an ESP-IDF example. Before that, the logger used Arduino's `hw_serial_->begin()` which has no event queue concept. In February 2024, the code was split from `logger.cpp` into `logger_esp32.cpp` (#6167) but the waste was carried over unchanged.

The UART component had the same event queue issue and was already fixed with the `USE_UART_WAKE_LOOP_ON_RX` conditional. The logger is the last remaining instance of this pattern in the codebase. Unlike UART, the logger never needs to receive data from the UART event queue, so the fix is simply setting the queue size to 0.

The RX buffer issue stems from the same code using a single `uart_buffer_size` variable for both RX and TX arguments to `uart_driver_install()`. ESP-IDF allows TX buffer to be 0 (synchronous writes), but requires RX buffer > `UART_HW_FIFO_LEN` (128). Since the logger never reads, we use the minimum.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).