### PR TITLE
[dsmr] Add deprecated std::string overload for set_decryption_key

### DIFF
--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -64,6 +64,9 @@ class Dsmr : public Component, public uart::UARTDevice {
   void dump_config() override;
 
   void set_decryption_key(const char *decryption_key);
+  // Remove before 2026.8.0
+  ESPDEPRECATED("Pass .c_str() - e.g. set_decryption_key(key.c_str()). Removed in 2026.8.0", "2026.2.0")
+  void set_decryption_key(const std::string &decryption_key) { this->set_decryption_key(decryption_key.c_str()); }
   void set_max_telegram_length(size_t length) { this->max_telegram_len_ = length; }
   void set_request_pin(GPIOPin *request_pin) { this->request_pin_ = request_pin; }
   void set_request_interval(uint32_t interval) { this->request_interval_ = interval; }

--- a/tests/components/dsmr/common.yaml
+++ b/tests/components/dsmr/common.yaml
@@ -1,4 +1,13 @@
+esphome:
+  on_boot:
+    then:
+      - lambda: |-
+          // Test deprecated std::string overload still compiles
+          std::string key = "00112233445566778899aabbccddeeff";
+          id(dsmr_instance).set_decryption_key(key);
+
 dsmr:
+  id: dsmr_instance
   decryption_key: 00112233445566778899aabbccddeeff
   max_telegram_length: 1000
   request_pin: ${request_pin}


### PR DESCRIPTION
# What does this implement/fix?

Adds a deprecated `std::string` overload for `set_decryption_key()` to ease the transition for users who were calling this method from lambdas with a `std::string` argument.

The `const char *` signature was introduced in #13375 to avoid heap allocation. While `set_decryption_key()` is not documented at esphome.io and therefore not public API per our [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api), adding this overload gives users a deprecation warning with a clear migration path instead of a hard compile error.

The overload will be removed in 2026.8.0.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14176

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change needed - this restores compatibility for lambda usage:
# id(dsmr_instance).set_decryption_key(key);
# Users will see a deprecation warning suggesting:
# id(dsmr_instance).set_decryption_key(key.c_str());
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).