### PR TITLE
[api] Fix build error when lambda returns StringRef in homeassistant.event data

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -36,6 +36,8 @@ template<typename... X> class TemplatableStringValue : public TemplatableValue<s
   static std::string value_to_string(const char *val) { return std::string(val); }  // For lambdas returning .c_str()
   static std::string value_to_string(const std::string &val) { return val; }
   static std::string value_to_string(std::string &&val) { return std::move(val); }
+  static std::string value_to_string(const StringRef &val) { return val.str(); }
+  static std::string value_to_string(StringRef &&val) { return val.str(); }
 
  public:
   TemplatableStringValue() : TemplatableValue<std::string, X...>() {}

--- a/tests/components/homeassistant/common.yaml
+++ b/tests/components/homeassistant/common.yaml
@@ -90,6 +90,19 @@ text_sensor:
     id: ha_hello_world_text2
     attribute: some_attribute
 
+event:
+  - platform: template
+    name: Test Event
+    id: test_event
+    event_types:
+      - test_event_type
+    on_event:
+      - homeassistant.event:
+          event: esphome.test_event
+          data:
+            event_name: !lambda |-
+              return event_type;
+
 time:
   - platform: homeassistant
     on_time:


### PR DESCRIPTION
# What does this implement/fix?

Stop-gap fix for the build error introduced by #13328. #13974 will fix this properly without the heap allocation, but it didn't make it into 2026.2.x in time.

When using `homeassistant.event` inside an `on_event` trigger with a lambda that returns `event_type`, compilation fails because `TemplatableStringValue::value_to_string` has no overload for `StringRef`.

Since #13328 changed `EventTrigger` from `Trigger<std::string>` to `Trigger<StringRef>`, the `event_type` variable in `on_event` lambdas is now a `StringRef`. When this value is returned from a lambda used in `homeassistant.event`'s `data` field, the generic `value_to_string(T&&)` template tries to call `to_string(StringRef)`, which doesn't exist.

The fix adds a `value_to_string(const StringRef &)` overload alongside the existing overloads for `char*`, `const char*`, `std::string&`, and `std::string&&`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14185

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
api:

event:
  - platform: template
    name: Test Event
    id: test_event
    event_types:
      - test_event_type
    on_event:
      - homeassistant.event:
          event: esphome.test_event
          data:
            event_name: !lambda |-
              return event_type;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).