### PR TITLE
[haier] Fix uninitialized HonSettings causing API connection failures

### DIFF
--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -29,10 +29,10 @@ enum class CleaningState : uint8_t {
 enum class HonControlMethod { MONITOR_ONLY = 0, SET_GROUP_PARAMETERS, SET_SINGLE_PARAMETER };
 
 struct HonSettings {
-  hon_protocol::VerticalSwingMode last_vertiacal_swing;
-  hon_protocol::HorizontalSwingMode last_horizontal_swing;
-  bool beeper_state;
-  bool quiet_mode_state;
+  hon_protocol::VerticalSwingMode last_vertiacal_swing{hon_protocol::VerticalSwingMode::CENTER};
+  hon_protocol::HorizontalSwingMode last_horizontal_swing{hon_protocol::HorizontalSwingMode::CENTER};
+  bool beeper_state{true};
+  bool quiet_mode_state{false};
 };
 
 class HonClimate : public HaierClimateBase {
@@ -189,7 +189,7 @@ class HonClimate : public HaierClimateBase {
   int big_data_sensors_{0};
   esphome::optional<hon_protocol::VerticalSwingMode> current_vertical_swing_{};
   esphome::optional<hon_protocol::HorizontalSwingMode> current_horizontal_swing_{};
-  HonSettings settings_;
+  HonSettings settings_{};
   ESPPreferenceObject hon_rtc_;
   SwitchState quiet_mode_state_{SwitchState::OFF};
 };


### PR DESCRIPTION
# What does this implement/fix?

`HonSettings settings_` was not value-initialized in `HonClimate`. The `set_beeper_switch()` and `set_quiet_mode_switch()` setters are called from generated code before `setup()` runs, so they read `settings_.beeper_state` and `settings_.quiet_mode_state` before `initialization()` loads them from NVS. The uninitialized garbage bytes (e.g. `0xa5`) propagate through `publish_state()` into `Switch::state`, and then through `encode_bool()` into the protobuf wire format. The compiler optimizes bool copies to raw `strb` instructions, trusting the value is 0 or 1, so the garbage byte reaches the wire unchanged. Home Assistant's protobuf decoder then fails with `DecodeError` on `SwitchStateResponse`, causing repeated `CONNECTION_CLOSED errno=128`.

The fix is simply `HonSettings settings_{}` which zero-initializes all fields. The setters will harmlessly publish `false`, then `setup()` loads the real values from NVS and publishes again.

Note: `set_display_switch()` and `set_health_mode_switch()` in `HaierClimateBase` are not affected because they are guarded by `valid_connection()` which is `false` before `setup()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14166

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change needed - this is a runtime fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).