### PR TITLE
[nextion] Add error log for failed HTTP status during TFT upload

### DIFF
--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -220,6 +220,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   }
 
   if (code != 200 and code != 206) {
+    ESP_LOGE(TAG, "HTTP request failed with status %d", code);
     return this->upload_end_(false);
   }
 

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -238,6 +238,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
            esp_get_free_heap_size());
   int status_code = esp_http_client_get_status_code(http_client);
   if (status_code != 200 && status_code != 206) {
+    ESP_LOGE(TAG, "HTTP request failed with status %d", status_code);
     return this->upload_end_(false);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Adds a clear error log message when the HTTP request during TFT upload returns an unexpected status code (not 200 or 206). This helps users diagnose upload failures without needing to inspect network traffic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
