### PR TITLE
[platformio] Add exponential backoff and session reset to download retries

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -55,6 +55,9 @@ def patch_file_downloader():
     from platformio.package.download import FileDownloader
     from platformio.package.exception import PackageException
 
+    if getattr(FileDownloader.__init__, "_esphome_patched", False):
+        return
+
     original_init = FileDownloader.__init__
 
     def patched_init(self, *args: Any, **kwargs: Any) -> None:
@@ -62,7 +65,8 @@ def patch_file_downloader():
 
         for attempt in range(max_retries):
             try:
-                return original_init(self, *args, **kwargs)
+                original_init(self, *args, **kwargs)
+                return
             except PackageException as e:
                 if attempt < max_retries - 1:
                     # Exponential backoff: 2, 4, 8, 16 seconds
@@ -83,8 +87,8 @@ def patch_file_downloader():
                 else:
                     # Final attempt - re-raise
                     raise
-        return None
 
+    patched_init._esphome_patched = True  # type: ignore[attr-defined]
     FileDownloader.__init__ = patched_init
 
 

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -82,16 +82,18 @@ def patch_file_downloader():
                     # Close the response and session to free resources
                     # and force a new TCP connection on retry, which may
                     # route to a different CDN edge node
+                    # pylint: disable=protected-access,broad-except
                     try:
                         if (
                             hasattr(self, "_http_response")
                             and self._http_response is not None
                         ):
-                            self._http_response.close()  # pylint: disable=protected-access
+                            self._http_response.close()
                         if hasattr(self, "_http_session"):
-                            self._http_session.close()  # pylint: disable=protected-access
-                    except Exception:  # pylint: disable=broad-except
+                            self._http_session.close()
+                    except Exception:
                         pass
+                    # pylint: enable=protected-access,broad-except
                     time.sleep(delay)
                 else:
                     # Final attempt - re-raise

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -78,7 +78,7 @@ def patch_file_downloader():
                     # Close the session to force a new TCP connection,
                     # potentially routing to a different CDN edge node
                     if hasattr(self, "_http_session"):
-                        self._http_session.close()
+                        self._http_session.close()  # pylint: disable=protected-access
                     time.sleep(delay)
                 else:
                     # Final attempt - re-raise

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -79,10 +79,19 @@ def patch_file_downloader():
                         attempt + 1,
                         max_retries,
                     )
-                    # Close the session to force a new TCP connection,
-                    # potentially routing to a different CDN edge node
-                    if hasattr(self, "_http_session"):
-                        self._http_session.close()  # pylint: disable=protected-access
+                    # Close the response and session to free resources
+                    # and force a new TCP connection on retry, which may
+                    # route to a different CDN edge node
+                    try:
+                        if (
+                            hasattr(self, "_http_response")
+                            and self._http_response is not None
+                        ):
+                            self._http_response.close()  # pylint: disable=protected-access
+                        if hasattr(self, "_http_session"):
+                            self._http_session.close()  # pylint: disable=protected-access
+                    except Exception:  # pylint: disable=broad-except
+                        pass
                     time.sleep(delay)
                 else:
                     # Final attempt - re-raise

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -88,7 +88,7 @@ def patch_file_downloader():
                     # Final attempt - re-raise
                     raise
 
-    patched_init._esphome_patched = True  # type: ignore[attr-defined]
+    patched_init._esphome_patched = True  # type: ignore[attr-defined]  # pylint: disable=protected-access
     FileDownloader.__init__ = patched_init
 
 

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import re
 import subprocess
+import time
 from typing import Any
 
 from esphome.const import CONF_COMPILE_PROCESS_LIMIT, CONF_ESPHOME, KEY_CORE
@@ -44,26 +45,41 @@ def patch_structhash():
 
 
 def patch_file_downloader():
-    """Patch PlatformIO's FileDownloader to retry on PackageException errors."""
+    """Patch PlatformIO's FileDownloader to retry on PackageException errors.
+
+    PlatformIO's FileDownloader uses HTTPSession which lacks built-in retry
+    for 502/503 errors. We add retries with exponential backoff and close the
+    session between attempts to force a fresh TCP connection, which may route
+    to a different CDN edge node.
+    """
     from platformio.package.download import FileDownloader
     from platformio.package.exception import PackageException
 
     original_init = FileDownloader.__init__
 
     def patched_init(self, *args: Any, **kwargs: Any) -> None:
-        max_retries = 3
+        max_retries = 5
 
         for attempt in range(max_retries):
             try:
                 return original_init(self, *args, **kwargs)
             except PackageException as e:
                 if attempt < max_retries - 1:
+                    # Exponential backoff: 2, 4, 8, 16 seconds
+                    delay = 2 ** (attempt + 1)
                     _LOGGER.warning(
-                        "Package download failed: %s. Retrying... (attempt %d/%d)",
+                        "Package download failed: %s. "
+                        "Retrying in %d seconds... (attempt %d/%d)",
                         str(e),
+                        delay,
                         attempt + 1,
                         max_retries,
                     )
+                    # Close the session to force a new TCP connection,
+                    # potentially routing to a different CDN edge node
+                    if hasattr(self, "_http_session"):
+                        self._http_session.close()
+                    time.sleep(delay)
                 else:
                     # Final attempt - re-raise
                     raise

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -828,6 +828,42 @@ def test_patch_file_downloader_closes_session_between_retries() -> None:
         mock_session.close.assert_called_once()
 
 
+def test_patch_file_downloader_idempotent() -> None:
+    """Test patch_file_downloader does not stack wrappers when called multiple times."""
+    mock_exception_cls = type("PackageException", (Exception,), {})
+    call_count = 0
+
+    def counting_init(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "platformio": MagicMock(),
+            "platformio.package": MagicMock(),
+            "platformio.package.download": SimpleNamespace(
+                FileDownloader=type("FileDownloader", (), {"__init__": counting_init})
+            ),
+            "platformio.package.exception": SimpleNamespace(
+                PackageException=mock_exception_cls
+            ),
+        },
+    ):
+        # Patch multiple times
+        platformio_api.patch_file_downloader()
+        platformio_api.patch_file_downloader()
+        platformio_api.patch_file_downloader()
+
+        from platformio.package.download import FileDownloader
+
+        instance = object.__new__(FileDownloader)
+        FileDownloader.__init__(instance, "http://example.com/file.zip")
+
+        # Should only be called once, not 3 times from stacked wrappers
+        assert call_count == 1
+
+
 def test_platformio_log_filter_allows_non_platformio_messages() -> None:
     """Test that non-platformio logger messages are allowed through."""
     log_filter = platformio_api.PlatformioLogFilter()

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 import shutil
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
@@ -671,6 +671,161 @@ def test_process_stacktrace_bad_alloc(
     assert "Memory allocation of 512 bytes failed at 40201234" in caplog.text
     mock_decode_pc.assert_called_once_with(config, "40201234")
     assert state is False
+
+
+def test_patch_file_downloader_succeeds_first_try() -> None:
+    """Test patch_file_downloader succeeds on first attempt."""
+    mock_exception_cls = type("PackageException", (Exception,), {})
+    original_init = MagicMock()
+
+    with patch.dict(
+        "sys.modules",
+        {
+            "platformio": MagicMock(),
+            "platformio.package": MagicMock(),
+            "platformio.package.download": SimpleNamespace(
+                FileDownloader=type("FileDownloader", (), {"__init__": original_init})
+            ),
+            "platformio.package.exception": SimpleNamespace(
+                PackageException=mock_exception_cls
+            ),
+        },
+    ):
+        platformio_api.patch_file_downloader()
+
+        from platformio.package.download import FileDownloader
+
+        instance = object.__new__(FileDownloader)
+        FileDownloader.__init__(instance, "http://example.com/file.zip")
+
+        original_init.assert_called_once()
+
+
+def test_patch_file_downloader_retries_on_failure() -> None:
+    """Test patch_file_downloader retries with backoff on PackageException."""
+    mock_exception_cls = type("PackageException", (Exception,), {})
+    call_count = 0
+
+    def failing_init(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise mock_exception_cls(f"502 error attempt {call_count}")
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "platformio": MagicMock(),
+                "platformio.package": MagicMock(),
+                "platformio.package.download": SimpleNamespace(
+                    FileDownloader=type(
+                        "FileDownloader", (), {"__init__": failing_init}
+                    )
+                ),
+                "platformio.package.exception": SimpleNamespace(
+                    PackageException=mock_exception_cls
+                ),
+            },
+        ),
+        patch("time.sleep") as mock_sleep,
+    ):
+        platformio_api.patch_file_downloader()
+
+        from platformio.package.download import FileDownloader
+
+        instance = object.__new__(FileDownloader)
+        FileDownloader.__init__(instance, "http://example.com/file.zip")
+
+        # Should have been called 3 times (2 failures + 1 success)
+        assert call_count == 3
+
+        # Should have slept with exponential backoff: 2s, 4s
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_any_call(2)
+        mock_sleep.assert_any_call(4)
+
+
+def test_patch_file_downloader_raises_after_max_retries() -> None:
+    """Test patch_file_downloader raises after exhausting all retries."""
+    mock_exception_cls = type("PackageException", (Exception,), {})
+
+    def always_failing_init(self, *args, **kwargs):
+        raise mock_exception_cls("502 error")
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "platformio": MagicMock(),
+                "platformio.package": MagicMock(),
+                "platformio.package.download": SimpleNamespace(
+                    FileDownloader=type(
+                        "FileDownloader", (), {"__init__": always_failing_init}
+                    )
+                ),
+                "platformio.package.exception": SimpleNamespace(
+                    PackageException=mock_exception_cls
+                ),
+            },
+        ),
+        patch("time.sleep") as mock_sleep,
+    ):
+        platformio_api.patch_file_downloader()
+
+        from platformio.package.download import FileDownloader
+
+        instance = object.__new__(FileDownloader)
+        with pytest.raises(mock_exception_cls, match="502 error"):
+            FileDownloader.__init__(instance, "http://example.com/file.zip")
+
+        # Should have slept 4 times (before attempts 2-5), not on final attempt
+        assert mock_sleep.call_count == 4
+        mock_sleep.assert_has_calls([call(2), call(4), call(8), call(16)])
+
+
+def test_patch_file_downloader_closes_session_between_retries() -> None:
+    """Test patch_file_downloader closes HTTP session between retries."""
+    mock_exception_cls = type("PackageException", (Exception,), {})
+    mock_session = MagicMock()
+    call_count = 0
+
+    def failing_init_with_session(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        self._http_session = mock_session
+        if call_count < 2:
+            raise mock_exception_cls("502 error")
+
+    with (
+        patch.dict(
+            "sys.modules",
+            {
+                "platformio": MagicMock(),
+                "platformio.package": MagicMock(),
+                "platformio.package.download": SimpleNamespace(
+                    FileDownloader=type(
+                        "FileDownloader",
+                        (),
+                        {"__init__": failing_init_with_session},
+                    )
+                ),
+                "platformio.package.exception": SimpleNamespace(
+                    PackageException=mock_exception_cls
+                ),
+            },
+        ),
+        patch("time.sleep"),
+    ):
+        platformio_api.patch_file_downloader()
+
+        from platformio.package.download import FileDownloader
+
+        instance = object.__new__(FileDownloader)
+        FileDownloader.__init__(instance, "http://example.com/file.zip")
+
+        # Session should have been closed between retry 1 and 2
+        mock_session.close.assert_called_once()
 
 
 def test_platformio_log_filter_allows_non_platformio_messages() -> None:

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -784,16 +784,18 @@ def test_patch_file_downloader_raises_after_max_retries() -> None:
         mock_sleep.assert_has_calls([call(2), call(4), call(8), call(16)])
 
 
-def test_patch_file_downloader_closes_session_between_retries() -> None:
-    """Test patch_file_downloader closes HTTP session between retries."""
+def test_patch_file_downloader_closes_session_and_response_between_retries() -> None:
+    """Test patch_file_downloader closes HTTP session and response between retries."""
     mock_exception_cls = type("PackageException", (Exception,), {})
     mock_session = MagicMock()
+    mock_response = MagicMock()
     call_count = 0
 
     def failing_init_with_session(self, *args, **kwargs):
         nonlocal call_count
         call_count += 1
         self._http_session = mock_session
+        self._http_response = mock_response
         if call_count < 2:
             raise mock_exception_cls("502 error")
 
@@ -824,7 +826,8 @@ def test_patch_file_downloader_closes_session_between_retries() -> None:
         instance = object.__new__(FileDownloader)
         FileDownloader.__init__(instance, "http://example.com/file.zip")
 
-        # Session should have been closed between retry 1 and 2
+        # Both response and session should have been closed between retries
+        mock_response.close.assert_called_once()
         mock_session.close.assert_called_once()
 
 


### PR DESCRIPTION
# What does this implement/fix?

PlatformIO's `FileDownloader` uses `HTTPSession` which lacks built-in retry logic for 502/503 errors (unlike `HTTPSessionIterator` which has 5 retries with exponential backoff). Our existing patch retried 3 times with no delay, hitting the same CDN edge node immediately each time.

This change:
- Increases retries from 3 to 5
- Adds exponential backoff between retries (2s, 4s, 8s, 16s)
- Closes the HTTP session between attempts to force a fresh TCP connection, which may route to a different CDN edge node

This should significantly reduce CI flakiness caused by transient 502 errors when downloading toolchains (e.g., `riscv32-esp-elf`) from GitHub releases, which particularly affects ESP32-P4 builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - internal CI reliability improvement, no user-facing configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).