### PR TITLE
[uart] Restore gpio_func_sel for RX pins removed in ESP-IDF 5.5+

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -8,6 +8,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/gpio.h"
 #include "driver/gpio.h"
+#include "esp_private/gpio.h"
 #include "soc/gpio_num.h"
 #include "soc/uart_pins.h"
 
@@ -199,6 +200,14 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     ESP_LOGW(TAG, "uart_set_line_inverse failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
+  }
+
+  // Workaround for ESP-IDF 5.5+ removing gpio_func_sel() from uart_set_pin() for RX pins
+  // (https://github.com/espressif/esp-idf/commit/1d6bcb86ba474990f5e9b7c62913ee15fbca0212).
+  // Without this, pins like GPIO4 on ESP32-C3 remain in their default IOMUX function
+  // (e.g. MTMS/JTAG) after cold boot, preventing UART RX from working via GPIO matrix.
+  if (rx >= 0) {
+    gpio_func_sel(static_cast<gpio_num_t>(rx), PIN_FUNC_GPIO);
   }
 
   err = uart_set_pin(this->uart_num_, tx, rx, flow_control, UART_PIN_NO_CHANGE);


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 5.5 removed the `gpio_func_sel(PIN_FUNC_GPIO)` call for RX pins in `uart_set_pin()` ([espressif/esp-idf@1d6bcb86ba](https://github.com/espressif/esp-idf/commit/1d6bcb86ba474990f5e9b7c62913ee15fbca0212)), considering it unnecessary for GPIO matrix input routing. However, without this call, pins remain in their default IOMUX function after cold boot (e.g. GPIO4 on ESP32-C3 defaults to MTMS/JTAG function), which prevents UART RX from working via the GPIO matrix.

This was masked until ESPHome 2025.11.0 because `pin->setup()` (which calls `gpio_config()` → `gpio_func_sel()`) was always called. When #11914 made `pin->setup()` conditional to fix #11823, both paths that set `PIN_FUNC_GPIO` were eliminated simultaneously.

This restores the `gpio_func_sel(PIN_FUNC_GPIO)` call for the RX pin in ESPHome's UART setup, without calling the full `gpio_config()` (which would regress #11823 / https://github.com/pedobry/esphome_toshiba_suzumi/issues/33).

**Why `esp_private/gpio.h`:** `gpio_func_sel` is not in the public `driver/gpio.h` API. The public alternative `gpio_config()` is too invasive — it sets GPIO direction, pull resistors, and interrupt config in addition to the IOMUX function, which is what broke the Toshiba Suzumi component (#11823). The raw `PIN_FUNC_SELECT` macro would require manually computing IO_MUX register addresses per chip variant. ESP-IDF's own `uart_set_pin()` still uses `gpio_func_sel` for TX pins on the same GPIO matrix code path, so this is a stable internal API that won't be removed.

**Note:** I don't have the MR24HPC1 / XIAO ESP32-C3 hardware to test this on, and it's currently out of stock so I can't order it. Would appreciate if someone from the issue thread could test this branch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13310
- fixes https://github.com/esphome/esphome/issues/13137

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  id: uart_mmw
  baud_rate: 115200
  tx_pin: 5
  rx_pin: 4
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).