### PR TITLE
[bme68x_bsec2] Fix compilation on ESP32 Arduino

### DIFF
--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -178,8 +178,11 @@ async def to_code_base(config):
     bsec2_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     cg.add(var.set_bsec2_configuration(bsec2_arr, len(rhs)))
 
-    # Although this component does not use SPI, the BSEC2 Arduino library requires the SPI library
+    # The BSEC2 and BME68x Arduino libraries unconditionally include Wire.h and
+    # SPI.h in their source files, so these libraries must be available even though
+    # ESPHome uses its own I2C/SPI abstractions instead of the Arduino ones.
     if core.CORE.using_arduino:
+        cg.add_library("Wire", None)
         cg.add_library("SPI", None)
     cg.add_library(
         "BME68x Sensor library",

--- a/tests/components/bme68x_bsec2_i2c/test.esp32-ard.yaml
+++ b/tests/components/bme68x_bsec2_i2c/test.esp32-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fix `bme68x_bsec2` compilation failure on ESP32 Arduino after the selective compilation change in 2026.2.0.

The BSEC2 and BME68x third-party Bosch libraries unconditionally include `Wire.h` and `SPI.h` in their `.cpp` source files when compiled under Arduino (`#ifdef ARDUINO`). With selective compilation now enabled, `Wire` is no longer available by default and the build fails with:

```
fatal error: Wire.h: No such file or directory
```

While ESPHome's component uses its own I2C/SPI abstractions and never calls the Arduino Wire/SPI APIs directly, PlatformIO still compiles the third-party library source files which require these headers. Unfortunately, while the component works cleanly on ESP-IDF without any Arduino dependencies, when Arduino is present the third-party libraries drag in Arduino-specific headers that we have no control over.

Also adds the missing `test.esp32-ard.yaml` test which would have caught this regression.

Reported at: https://community.home-assistant.io/t/did-esphome-2026-2-0-break-bme688-bme68x-bsec2/988435

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://community.home-assistant.io/t/did-esphome-2026-2-0-break-bme688-bme68x-bsec2/988435

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - existing configs will work again
bme68x_bsec2_i2c:
  address: 0x76
  model: bme688
  operating_age: 28d
  sample_rate: LP
  supply_voltage: 3.3V
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).