### PR TITLE
[network] Improve IPAddress::str() deprecation warning with usage example

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -61,7 +61,9 @@ struct IPAddress {
   IPAddress(const std::string &in_address) { inet_aton(in_address.c_str(), &ip_addr_); }
   IPAddress(const ip_addr_t *other_ip) { ip_addr_ = *other_ip; }
   // Remove before 2026.8.0
-  ESPDEPRECATED("Use str_to() instead. Removed in 2026.8.0", "2026.2.0")
+  ESPDEPRECATED(
+      "str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0",
+      "2026.2.0")
   std::string str() const {
     char buf[IP_ADDRESS_BUFFER_SIZE];
     this->str_to(buf);
@@ -150,7 +152,9 @@ struct IPAddress {
   bool is_ip6() const { return IP_IS_V6(&ip_addr_); }
   bool is_multicast() const { return ip_addr_ismulticast(&ip_addr_); }
   // Remove before 2026.8.0
-  ESPDEPRECATED("Use str_to() instead. Removed in 2026.8.0", "2026.2.0")
+  ESPDEPRECATED(
+      "str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0",
+      "2026.2.0")
   std::string str() const {
     char buf[IP_ADDRESS_BUFFER_SIZE];
     this->str_to(buf);


### PR DESCRIPTION
# What does this implement/fix?

The deprecation warning for `IPAddress::str()` previously said only "Use str_to() instead", which left users confused because `str_to()` has a completely different API — it writes to a caller-provided buffer instead of returning a `std::string`.

This improves the deprecation message to include a concrete usage example:

```
str() is deprecated: use 'char buf[IP_ADDRESS_BUFFER_SIZE]; ip.str_to(buf);' instead. Removed in 2026.8.0
```

See https://community.home-assistant.io/t/td-string-esphome-str-const-is-deprecated/988868 for user confusion this caused.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config change, only improves compiler warning text
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).