### PR TITLE
[openthread] Add Thread version DEBUG trace

### DIFF
--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -104,6 +104,8 @@ void OpenThreadComponent::ot_main() {
   esp_cli_custom_command_init();
 #endif  // CONFIG_OPENTHREAD_CLI_ESP_EXTENSION
 
+  ESP_LOGD(TAG, "Thread Version: %" PRIu16, otThreadGetVersion());
+
   otLinkModeConfig link_mode_config{};
 #if CONFIG_OPENTHREAD_FTD
   link_mode_config.mRxOnWhenIdle = true;


### PR DESCRIPTION
# What does this implement/fix?

There is no ESPHome trace of OpenThread version.

I was surprised that internally actually still all is built for Thread version 1.3 (due to default of ESP IDFs OpenThread module within "openthread-core-config.h").

Background:
Started using Thread setup, with

- Parent:
  - [HomeAssistant OTBR app](https://www.home-assistant.io/integrations/otbr/)
    - currently 2.16.4
    - configured to beta mode = **Thread 1.4** instead of Thread 1.3)
  - Thread 1.4 capable USB device (Seeed Studio nRF54L15),
- Child:
  - ESPHome `openthread` component build for ESP32C6

Parent runs well with Thread version 1.4.

However, in child table still version of ESPHome child was printed as VER=4 (**Thread 1.3**),

```sh
docker exec -it addon_core_openthread_border_router ot-ctl child table
```

although Espressif already recertified ESP32C6 as Thread 1.4 capable in 2025-01-24 and ESP IDF `openthread` inclusion has many Thread 1.4 define extensions.

After longer analysis found that this is solely due to build settings (`openthread-core-config.h`), yet no local Thread version trace exists.

There will be followup ESP IDF versions and Thread versions (e.g. 1.5 announced).

Thread version decides on central features.

-> Seems reasonable to print Thread version at least on `DEBUG` trace level (=no effort payed on higher levels), so that others do not also need to dive into whole code base.

Debatable whether `DEBUG` trace is feature or more improvement to ease debugging. Chose for latter below.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: otversion
  platformio_options:
    build_flags:
      - -DOPENTHREAD_CONFIG_THREAD_VERSION=OT_THREAD_VERSION_1_4  # experimental/beta

esp32:
  variant: esp32c6

network:
  enable_ipv6: true

openthread:
  device_type: MTD
  tlv: ""  # Required, but irrelevant for sample

logger:
  level: DEBUG
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
    - Covered by existing compile test

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
