### PR TITLE
[core] more accurate check for leap year and valid day_of_month

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -7,9 +7,9 @@
 namespace esphome {
 
 uint8_t days_in_month(uint8_t month, uint16_t year) {
+  static const uint8_t DAYS_IN_MONTH[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   if (month == 2 && (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0))
     return 29;
-  static const uint8_t DAYS_IN_MONTH[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   return DAYS_IN_MONTH[month];
 }
 

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -7,9 +7,9 @@
 namespace esphome {
 
 uint8_t days_in_month(uint8_t month, uint16_t year) {
-  static const uint8_t DAYS_IN_MONTH[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-  if (month == 2 && (year % 4 == 0))
+  if (month == 2 && (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0))
     return 29;
+  static const uint8_t DAYS_IN_MONTH[] = {0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
   return DAYS_IN_MONTH[month];
 }
 

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -70,7 +70,7 @@ struct ESPTime {
   /// @copydoc strftime(const std::string &format)
   std::string strftime(const char *format);
 
-  /// Check if this ESPTime is valid (all fields in range and year is greater or equal than 2019)
+  /// Check if this ESPTime is valid (all fields in range and year is greater than or equal to 2019)
   bool is_valid() const { return this->year >= 2019 && this->fields_in_range(); }
 
   /// Check if all time fields of this ESPTime are in range.

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -70,14 +70,14 @@ struct ESPTime {
   /// @copydoc strftime(const std::string &format)
   std::string strftime(const char *format);
 
-  /// Check if this ESPTime is valid (all fields in range and year is greater than 2018)
+  /// Check if this ESPTime is valid (all fields in range and year is greater or equal than 2019)
   bool is_valid() const { return this->year >= 2019 && this->fields_in_range(); }
 
   /// Check if all time fields of this ESPTime are in range.
   bool fields_in_range() const {
     return this->second < 61 && this->minute < 60 && this->hour < 24 && this->day_of_week > 0 &&
-           this->day_of_week < 8 && this->day_of_month > 0 && this->day_of_month < 32 && this->day_of_year > 0 &&
-           this->day_of_year < 367 && this->month > 0 && this->month < 13;
+           this->day_of_week < 8 && this->day_of_year > 0 && this->day_of_year < 367 && this->month > 0 &&
+           this->month < 13 && this->day_of_month > 0 && this->day_of_month <= days_in_month(this->month, this->year);
   }
 
   /** Convert a string to ESPTime struct as specified by the format argument.


### PR DESCRIPTION
# What does this implement/fix?
- improve comment about year >= 2019
- more exact check for leap year
- more exact check for `day_of_month`
- only init `DAYS_IN_MONTH` vector if not month=2

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
