### PR TITLE
[web_server_base] Remove unnecessary Component inheritance and modernize

### DIFF
--- a/esphome/components/web_server_base/__init__.py
+++ b/esphome/components/web_server_base/__init__.py
@@ -20,7 +20,7 @@ def AUTO_LOAD():
 
 
 web_server_base_ns = cg.esphome_ns.namespace("web_server_base")
-WebServerBase = web_server_base_ns.class_("WebServerBase", cg.Component)
+WebServerBase = web_server_base_ns.class_("WebServerBase")
 
 CONF_WEB_SERVER_BASE_ID = "web_server_base_id"
 CONFIG_SCHEMA = cv.Schema(
@@ -33,7 +33,6 @@ CONFIG_SCHEMA = cv.Schema(
 @coroutine_with_priority(CoroPriority.WEB_SERVER_BASE)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await cg.register_component(var, config)
     cg.add(cg.RawExpression(f"{web_server_base_ns}::global_web_server_base = {var}"))
 
     if CORE.is_esp32:

--- a/esphome/components/web_server_base/web_server_base.cpp
+++ b/esphome/components/web_server_base/web_server_base.cpp
@@ -1,19 +1,11 @@
 #include "web_server_base.h"
 #ifdef USE_NETWORK
-#include "esphome/core/application.h"
-#include "esphome/core/helpers.h"
-#include "esphome/core/log.h"
 
-namespace esphome {
-namespace web_server_base {
-
-static const char *const TAG = "web_server_base";
+namespace esphome::web_server_base {
 
 WebServerBase *global_web_server_base = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 void WebServerBase::add_handler(AsyncWebHandler *handler) {
-  // remove all handlers
-
 #ifdef USE_WEBSERVER_AUTH
   if (!credentials_.username.empty()) {
     handler = new internal::AuthMiddlewareHandler(handler, &credentials_);
@@ -25,11 +17,5 @@ void WebServerBase::add_handler(AsyncWebHandler *handler) {
   }
 }
 
-float WebServerBase::get_setup_priority() const {
-  // Before WiFi (captive portal)
-  return setup_priority::WIFI + 2.0f;
-}
-
-}  // namespace web_server_base
-}  // namespace esphome
+}  // namespace esphome::web_server_base
 #endif

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -1,11 +1,9 @@
 #pragma once
 #include "esphome/core/defines.h"
 #ifdef USE_NETWORK
-#include <memory>
 #include <utility>
 #include <vector>
 
-#include "esphome/core/component.h"
 #include "esphome/core/progmem.h"
 
 #if USE_ESP32
@@ -21,8 +19,7 @@ using PlatformString = std::string;
 using PlatformString = String;
 #endif
 
-namespace esphome {
-namespace web_server_base {
+namespace esphome::web_server_base {
 
 class WebServerBase;
 extern WebServerBase *global_web_server_base;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -91,14 +88,14 @@ class AuthMiddlewareHandler : public MiddlewareHandler {
 
 }  // namespace internal
 
-class WebServerBase : public Component {
+class WebServerBase {
  public:
   void init() {
     if (this->initialized_) {
       this->initialized_++;
       return;
     }
-    this->server_ = std::make_unique<AsyncWebServer>(this->port_);
+    this->server_ = new AsyncWebServer(this->port_);
     // All content is controlled and created by user - so allowing all origins is fine here.
     // NOTE: Currently 1 header. If more are added, update in __init__.py:
     //   cg.add_define("WEB_SERVER_DEFAULT_HEADERS_COUNT", 1)
@@ -113,11 +110,11 @@ class WebServerBase : public Component {
   void deinit() {
     this->initialized_--;
     if (this->initialized_ == 0) {
+      delete this->server_;
       this->server_ = nullptr;
     }
   }
-  AsyncWebServer *get_server() const { return this->server_.get(); }
-  float get_setup_priority() const override;
+  AsyncWebServer *get_server() const { return this->server_; }
 
 #ifdef USE_WEBSERVER_AUTH
   void set_auth_username(std::string auth_username) { credentials_.username = std::move(auth_username); }
@@ -132,13 +129,12 @@ class WebServerBase : public Component {
  protected:
   int initialized_{0};
   uint16_t port_{80};
-  std::unique_ptr<AsyncWebServer> server_{nullptr};
+  AsyncWebServer *server_{nullptr};
   std::vector<AsyncWebHandler *> handlers_;
 #ifdef USE_WEBSERVER_AUTH
   internal::Credentials credentials_;
 #endif
 };
 
-}  // namespace web_server_base
-}  // namespace esphome
+}  // namespace esphome::web_server_base
 #endif


### PR DESCRIPTION
# What does this implement/fix?

`WebServerBase` was registered as a `Component` but never used the component lifecycle — no `setup()`, `loop()`, or `dump_config()`. The `get_setup_priority()` override was dead code since there was nothing to schedule. All consumers (`web_server`, `captive_portal`, `prometheus`) already have their own `get_setup_priority()`.

`WebServerBase` is just a shared base class that holds the `AsyncWebServer` and handler list, with `init()`/`deinit()` called manually by consumers via reference counting.

Changes:
- Remove `Component` inheritance and `register_component` call
- Use C++17 nested namespace syntax (`namespace esphome::web_server_base`)
- Replace `std::unique_ptr<AsyncWebServer>` with raw pointer — the server lifetime is already manually managed via reference counting in `init()`/`deinit()`, so `unique_ptr` provided no benefit while pulling in `<memory>` and generating extra destructor code
- Remove unused includes (`<memory>`, `component.h`, `application.h`, `helpers.h`, `log.h`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes. Any config using web_server or captive_portal works as before.
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).