### PR TITLE
[openthread_signal] Add new sensor component with RSSI + link counters

### DIFF
--- a/esphome/components/openthread_signal/openthread_signal_sensor.cpp
+++ b/esphome/components/openthread_signal/openthread_signal_sensor.cpp
@@ -1,0 +1,18 @@
+
+#include "openthread_signal_sensor.h"
+#include "esphome/core/log.h"
+
+#ifdef USE_OPENTHREAD
+
+namespace esphome::openthread_signal {
+
+static const char *const TAG = "openthread_signal";
+
+void ParentAverageRssiOpenThreadSignal::dump_config() { LOG_SENSOR("", "Parent average RSSI", this); }
+void ParentLastRssiOpenThreadSignal::dump_config() { LOG_SENSOR("", "Parent last RSSI", this); }
+void BaseLinkCounterOpenThreadSignal::dump_config() {
+  LOG_SENSOR("", this->info_name_ == nullptr ? "" : this->info_name_, this);
+}
+
+}  // namespace esphome::openthread_signal
+#endif

--- a/esphome/components/openthread_signal/openthread_signal_sensor.h
+++ b/esphome/components/openthread_signal/openthread_signal_sensor.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include <optional>
+#include "esphome/components/openthread/openthread.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
+#ifdef USE_OPENTHREAD
+
+namespace esphome::openthread_signal {
+
+using esphome::openthread::InstanceLock;
+
+class OpenThreadInstancePollingComponent : public PollingComponent {
+ public:
+  void update() override {
+    auto lock = InstanceLock::try_acquire(10);
+    if (!lock) {
+      return;
+    }
+
+    this->update_instance(lock->get_instance());
+  }
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
+ protected:
+  virtual void update_instance(otInstance *instance) = 0;
+};
+
+class ParentLastRssiOpenThreadSignal final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+ public:
+  void update_instance(otInstance *instance) override {
+    int8_t val;
+    std::optional<int8_t> parent_last_rssi;
+    if (otThreadGetParentLastRssi(instance, &val) == OT_ERROR_NONE) {
+      parent_last_rssi = val;
+    }
+    if (this->last_rssi_ != parent_last_rssi) {  // Changed?
+      this->last_rssi_ = parent_last_rssi;
+      this->publish_state(parent_last_rssi.value_or(NAN));
+    }
+  }
+  void dump_config() override;
+
+ protected:
+  std::optional<int8_t> last_rssi_;
+};
+
+class ParentAverageRssiOpenThreadSignal final : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+ public:
+  void update_instance(otInstance *instance) override {
+    int8_t val;
+    std::optional<int8_t> parent_last_rssi;
+    if (otThreadGetParentAverageRssi(instance, &val) == OT_ERROR_NONE) {
+      parent_last_rssi = val;
+    }
+    if (this->last_rssi_ != parent_last_rssi) {  // Changed?
+      this->last_rssi_ = parent_last_rssi;
+      this->publish_state(parent_last_rssi.value_or(NAN));
+    }
+  }
+  void dump_config() override;
+
+ protected:
+  std::optional<int8_t> last_rssi_;
+};
+
+/** Nontemplate base class to implement otLinkGetCounters field sensors */
+class BaseLinkCounterOpenThreadSignal : public OpenThreadInstancePollingComponent, public sensor::Sensor {
+ protected:
+  explicit BaseLinkCounterOpenThreadSignal(const char *info_name) : info_name_(info_name) {}
+
+  void check_and_publish(otInstance *instance, uint32_t otMacCounters::*member_ptr) {
+    // Fetching link counter delivers a pointer to internal instance data.
+    // Also polling of total counter only expected in larger intervals.
+    // So seems reasonable to fetch separately for sensor fields
+    const otMacCounters *val = otLinkGetCounters(instance);
+    std::optional<uint32_t> counter;
+    if (val != nullptr) {  // Returned struct pointer valid?
+      counter = val->*member_ptr;
+    }
+    if (this->last_ != counter) {  // Changed?
+      this->last_ = counter;
+      this->publish_state(counter.value_or(NAN));
+    }
+  }
+
+  void dump_config() override;
+
+ private:
+  /** Description when logging sensor (dump_config), private ownership */
+  const char *info_name_{nullptr};
+
+ protected:
+  /** Last seen value for change detection */
+  std::optional<uint32_t> last_;
+};
+
+/** Template helper to implement otLinkGetCounters field sensors
+ *
+ * Shall avoid code duplication and bloat.
+ *
+ * @internal Move nontemplate aspects into base class to avoid bloat!
+ *
+ * @internal
+ * Could be avoided if Python cg directly passes member e.g. via ctor.
+ * But to avoid that Python knows too much about C struct internals.
+ *
+ * @tparam LinkCounterMemberPtr Member pointer to field in otMacCounters
+ */
+template<auto LinkCounterMemberPtr> class LinkCounterOpenThreadSignal final : public BaseLinkCounterOpenThreadSignal {
+ public:
+  explicit LinkCounterOpenThreadSignal(const char *info_name) : BaseLinkCounterOpenThreadSignal(info_name) {}
+
+ protected:
+  void update_instance(otInstance *instance) override { check_and_publish(instance, LinkCounterMemberPtr); }
+};
+
+// Link counters
+// - Rx
+using RxAddressFilteredCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxAddressFiltered>;
+using RxErrFcsCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxErrFcs>;
+using RxErrNoFrameCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxErrNoFrame>;
+using RxErrOtherCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxErrOther>;
+using RxErrSecCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxErrSec>;
+using RxErrUnknownNeighborCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxErrUnknownNeighbor>;
+using RxTotalCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mRxTotal>;
+// - Tx
+using TxErrAbortCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mTxErrAbort>;
+using TxErrBusyChannelCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mTxErrBusyChannel>;
+using TxErrCcaCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mTxErrCca>;
+using TxRetryCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mTxRetry>;
+using TxTotalCounterOpenThreadSignal = LinkCounterOpenThreadSignal<&otMacCounters::mTxTotal>;
+
+}  // namespace esphome::openthread_signal
+#endif

--- a/esphome/components/openthread_signal/sensor.py
+++ b/esphome/components/openthread_signal/sensor.py
@@ -1,0 +1,100 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    DEVICE_CLASS_SIGNAL_STRENGTH,
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_DECIBEL_MILLIWATT,
+)
+
+# Parent RSSI
+CONF_PARENT_AVG_RSSI = "parent_avg_rssi"
+CONF_PARENT_LAST_RSSI = "parent_last_rssi"
+
+# Link counters: Enumeration table to ease systematic generation
+# Key: Config name (public, do not change!)
+# Value: Tuple
+#   C++ Class Name sensor prefix (internal)
+#   Human readable description for logging (internal)
+CONFLIST_LC = {
+    "lc_rx_addr_filtered": ("RxAddressFiltered", "RX address filtered"),
+    "lc_rx_err_fcs": ("RxErrFcs", "RX FCS errors"),
+    "lc_rx_err_noframe": ("RxErrNoFrame", "RX No Frame errors"),
+    "lc_rx_err_other": ("RxErrOther", "RX other errors"),
+    "lc_rx_err_sec": ("RxErrSec", "RX SEC errors"),
+    "lc_rx_err_unknownneighbor": ("RxErrUnknownNeighbor", "RX unknown neighbor errors"),
+    "lc_rx_total": ("RxTotal", "RX total"),
+    "lc_tx_err_abort": ("TxErrAbort", "TX abort errors"),
+    "lc_tx_err_busychannel": ("TxErrBusyChannel", "TX busy channel errors"),
+    "lc_tx_err_cca": ("TxErrCca", "TX CCA errors"),
+    "lc_tx_retry": ("TxRetry", "TX retries"),
+    "lc_tx_total": ("TxTotal", "TX total"),
+}
+
+# Suffix for counters
+SUFFIX_COUNTER = "Counter"
+# Common C++ Class Name suffix added
+SUFFIX_OTSIGNAL = "OpenThreadSignal"
+
+
+DEPENDENCIES = ["openthread"]
+
+openthread_signal_ns = cg.esphome_ns.namespace("openthread_signal")
+
+
+# Helper to make C++ class representation object for provided prefix
+def MakeClass(class_prefix):
+    return openthread_signal_ns.class_(
+        class_prefix + SUFFIX_OTSIGNAL, sensor.Sensor, cg.PollingComponent
+    )
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        # Parent RSSI
+        cv.Optional(CONF_PARENT_AVG_RSSI): sensor.sensor_schema(
+            MakeClass("ParentAverageRssi"),
+            unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ).extend(cv.polling_component_schema("60s")),
+        cv.Optional(CONF_PARENT_LAST_RSSI): sensor.sensor_schema(
+            MakeClass("ParentLastRssi"),
+            unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ).extend(cv.polling_component_schema("60s")),
+        # Link counters
+        **{
+            cv.Optional(conf_key): sensor.sensor_schema(
+                MakeClass(conf_value[0] + SUFFIX_COUNTER),
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ).extend(cv.polling_component_schema("60s"))
+            for conf_key, conf_value in CONFLIST_LC.items()
+        },
+    }
+)
+
+
+async def setup_conf(config: dict, key: str, *initarg):
+    if conf := config.get(key):
+        var = await sensor.new_sensor(conf, *initarg)
+        await cg.register_component(var, conf)
+
+
+async def to_code(config):
+    # Parent RSSI
+    await setup_conf(config, CONF_PARENT_AVG_RSSI)
+    await setup_conf(config, CONF_PARENT_LAST_RSSI)
+
+    # Link counters
+    for conf_key, conf_value in CONFLIST_LC.items():
+        await setup_conf(config, conf_key, conf_value[1])

--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -82,6 +82,7 @@ ISOLATED_COMPONENTS = {
     "mapping": "Uses dict format for image/display sections incompatible with standard list format - ESPHome merge_config cannot handle",
     "openthread": "Conflicts with wifi: used by most components",
     "openthread_info": "Conflicts with wifi: used by most components",
+    "openthread_signal": "Conflicts with wifi: used by most components",
     "matrix_keypad": "Needs isolation due to keypad",
     "modbus_controller": "Defines multiple modbus buses for testing client/server functionality - conflicts with package modbus bus",
     "neopixelbus": "RMT type conflict with ESP32 Arduino/ESP-IDF headers (enum vs struct rmt_channel_t)",

--- a/tests/components/openthread_signal/test.esp32-c6-idf.yaml
+++ b/tests/components/openthread_signal/test.esp32-c6-idf.yaml
@@ -1,0 +1,40 @@
+network:
+  enable_ipv6: true
+
+openthread:
+  channel: 13
+  network_key: 0xdfd34f0f05cad978ec4e32b0413038ff
+  pan_id: 0x8f28
+
+sensor:
+  - platform: openthread_signal
+    parent_avg_rssi:
+      name: "Parent average RSSI"
+    parent_last_rssi:
+      name: "Parent last RSSI"
+
+    lc_rx_addr_filtered:
+      name: "# Rx address filtered"
+    lc_rx_err_fcs:
+      name: "# Rx FCS errors"
+    lc_rx_err_noframe:
+      name: "# Rx No Frame errors"
+    lc_rx_err_other:
+      name: "# Rx other errors"
+    lc_rx_err_sec:
+      name: "# Rx SEC errors"
+    lc_rx_err_unknownneighbor:
+      name: "# Rx unknown neighbor errors"
+    lc_rx_total:
+      name: "# Rx total"
+
+    lc_tx_err_abort:
+      name: "# Tx abort errors"
+    lc_tx_err_busychannel:
+      name: "# Tx busy channel errors"
+    lc_tx_err_cca:
+      name: "# Tx CCA errors"
+    lc_tx_retry:
+      name: "# Tx retries"
+    lc_tx_total:
+      name: "# Tx total"


### PR DESCRIPTION
# What does this implement/fix?

_Disclaimer: Work in progress_
_- General usefulness of new sensor data & dealing with tons of possibly available OT data_
_- Concept with separate new component `openthread_signal` (might be more reasonable to collect all possible types (text_sensor, sensor, maybe others like switch) in single platform component, even if deviating from wifi concept_

Add new `openthread_signal` component, and sensors with last RSSI of received parent and few link counters.

Helpful for optimizing ESPHome child reception (e.g. external antenna, TX power). It will provide nice timeline overview.

Excessively low update rate not recommended to keep constantly active -- if update itself triggers new communication. Instead filtering recommended.

Creates new component, so that
- new `openthread_signal` for *numeric values* mimics `wifi_signal`,
- and existing `openthread_info` for *text values* resembles `wifi_info`.

Newer Thread 1.2 "link metrics" may provide extended measurements. However, those are much more complex. They may be part of followup.

Overall, still question

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: openthread_signal
    parent_last_rssi:
      name: "Parent last RSSI"

      filters: # Example of optional local filtering to reduce frequency
        - sliding_window_moving_average:
            window_size: 100
            send_every: 100
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
