### PR TITLE
[water_heater] Fix device_id missing from state responses

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1346,9 +1346,8 @@ uint16_t APIConnection::try_send_water_heater_state(EntityBase *entity, APIConne
   resp.target_temperature_low = wh->get_target_temperature_low();
   resp.target_temperature_high = wh->get_target_temperature_high();
   resp.state = wh->get_state();
-  resp.key = wh->get_object_id_hash();
 
-  return encode_message_to_buffer(resp, WaterHeaterStateResponse::MESSAGE_TYPE, conn, remaining_size);
+  return fill_and_encode_entity_state(wh, resp, WaterHeaterStateResponse::MESSAGE_TYPE, conn, remaining_size);
 }
 uint16_t APIConnection::try_send_water_heater_info(EntityBase *entity, APIConnection *conn, uint32_t remaining_size) {
   auto *wh = static_cast<water_heater::WaterHeater *>(entity);

--- a/tests/integration/fixtures/device_id_in_state.yaml
+++ b/tests/integration/fixtures/device_id_in_state.yaml
@@ -46,6 +46,7 @@ sensor:
 
 binary_sensor:
   - platform: template
+    id: motion_detected
     name: Motion Detected
     device_id: motion_sensor
     lambda: return true;
@@ -82,3 +83,117 @@ output:
     write_action:
       - lambda: |-
           ESP_LOGD("test", "Light output: %d", state);
+
+cover:
+  - platform: template
+    name: Garage Door
+    device_id: motion_sensor
+    optimistic: true
+
+fan:
+  - platform: template
+    name: Ceiling Fan
+    device_id: humidity_monitor
+    speed_count: 3
+    has_oscillating: false
+    has_direction: false
+
+lock:
+  - platform: template
+    name: Front Door Lock
+    device_id: motion_sensor
+    optimistic: true
+
+number:
+  - platform: template
+    name: Target Temperature
+    device_id: temperature_monitor
+    optimistic: true
+    min_value: 0
+    max_value: 100
+    step: 1
+
+select:
+  - platform: template
+    name: Mode Select
+    device_id: humidity_monitor
+    optimistic: true
+    options:
+      - "Auto"
+      - "Manual"
+
+text:
+  - platform: template
+    name: Device Label
+    device_id: temperature_monitor
+    optimistic: true
+    mode: text
+
+valve:
+  - platform: template
+    name: Water Valve
+    device_id: humidity_monitor
+    optimistic: true
+
+globals:
+  - id: global_away
+    type: bool
+    initial_value: "false"
+  - id: global_is_on
+    type: bool
+    initial_value: "true"
+
+water_heater:
+  - platform: template
+    name: Test Boiler
+    device_id: temperature_monitor
+    optimistic: true
+    current_temperature: !lambda "return 45.0f;"
+    target_temperature: !lambda "return 60.0f;"
+    away: !lambda "return id(global_away);"
+    is_on: !lambda "return id(global_is_on);"
+    supported_modes:
+      - "off"
+      - electric
+    visual:
+      min_temperature: 30.0
+      max_temperature: 85.0
+      target_temperature_step: 0.5
+    set_action:
+      - lambda: |-
+          ESP_LOGD("test", "Water heater set");
+
+alarm_control_panel:
+  - platform: template
+    name: House Alarm
+    device_id: motion_sensor
+    codes:
+      - "1234"
+    restore_mode: ALWAYS_DISARMED
+    binary_sensors:
+      - input: motion_detected
+
+datetime:
+  - platform: template
+    name: Schedule Date
+    device_id: temperature_monitor
+    type: date
+    optimistic: true
+  - platform: template
+    name: Schedule Time
+    device_id: humidity_monitor
+    type: time
+    optimistic: true
+  - platform: template
+    name: Schedule DateTime
+    device_id: motion_sensor
+    type: datetime
+    optimistic: true
+
+event:
+  - platform: template
+    name: Doorbell
+    device_id: motion_sensor
+    event_types:
+      - "press"
+      - "double_press"


### PR DESCRIPTION
# What does this implement/fix?

`try_send_water_heater_state()` was the only entity type that directly called `encode_message_to_buffer()` instead of `fill_and_encode_entity_state()`. This meant `device_id` was never set on `WaterHeaterStateResponse`, causing entities with `device_id` configured to show as `unknown` in Home Assistant.

The fix replaces the direct `encode_message_to_buffer()` call with `fill_and_encode_entity_state()`, matching every other entity type (sensor, climate, switch, cover, fan, light, etc.).

Also expands the `device_id` integration test from 5 entity types to 17, covering all stateful entity types that support `device_id`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14206

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
water_heater:
  - platform: template
    name: "Boiler"
    device_id: my_device  # This now works correctly
    optimistic: true
    supported_modes:
      - "OFF"
      - ELECTRIC
    visual:
      min_temperature: 30.0
      max_temperature: 85.0
      target_temperature_step: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).