### PR TITLE
[logger] Use subtraction-based line number formatting to avoid division

### DIFF
--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -77,10 +77,10 @@ struct LogBuffer {
 
     // Format line number using subtraction loops (no division - important for ESP8266 which lacks hardware divider)
     if (line > 999) [[unlikely]] {
-      LogBuffer::write_digit(p, line, 1000);
+      write_digit(p, line, 1000);
     }
-    LogBuffer::write_digit(p, line, 100);
-    LogBuffer::write_digit(p, line, 10);
+    write_digit(p, line, 100);
+    write_digit(p, line, 10);
     *p++ = '0' + line;
     *p++ = ']';
 

--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -158,7 +158,7 @@ struct LogBuffer {
   }
 #endif
   // Extract one decimal digit via subtraction (no division - important for ESP8266)
-  static inline void write_digit(char *&p, int &value, int divisor) {
+  static inline void ESPHOME_ALWAYS_INLINE write_digit(char *&p, int &value, int divisor) {
     char d = '0';
     while (value >= divisor) {
       d++;

--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -77,10 +77,10 @@ struct LogBuffer {
 
     // Format line number using subtraction loops (no division - important for ESP8266 which lacks hardware divider)
     if (line > 999) [[unlikely]] {
-      this->write_digit_(p, line, 1000);
+      LogBuffer::write_digit(p, line, 1000);
     }
-    this->write_digit_(p, line, 100);
-    this->write_digit_(p, line, 10);
+    LogBuffer::write_digit(p, line, 100);
+    LogBuffer::write_digit(p, line, 10);
     *p++ = '0' + line;
     *p++ = ']';
 
@@ -158,7 +158,7 @@ struct LogBuffer {
   }
 #endif
   // Extract one decimal digit via subtraction (no division - important for ESP8266)
-  static inline void write_digit_(char *&p, int &value, int divisor) {
+  static inline void write_digit(char *&p, int &value, int divisor) {
     char d = '0';
     while (value >= divisor) {
       d++;

--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -75,18 +75,13 @@ struct LogBuffer {
 
     *p++ = ':';
 
-    // Format line number without modulo operations
+    // Format line number using subtraction loops (no division - important for ESP8266 which lacks hardware divider)
     if (line > 999) [[unlikely]] {
-      int thousands = line / 1000;
-      *p++ = '0' + thousands;
-      line -= thousands * 1000;
+      this->write_digit_(p, line, 1000);
     }
-    int hundreds = line / 100;
-    int remainder = line - hundreds * 100;
-    int tens = remainder / 10;
-    *p++ = '0' + hundreds;
-    *p++ = '0' + tens;
-    *p++ = '0' + (remainder - tens * 10);
+    this->write_digit_(p, line, 100);
+    this->write_digit_(p, line, 10);
+    *p++ = '0' + line;
     *p++ = ']';
 
 #if defined(USE_ESP32) || defined(USE_LIBRETINY) || defined(USE_ZEPHYR) || defined(USE_HOST)
@@ -162,6 +157,15 @@ struct LogBuffer {
     this->process_vsnprintf_result_(vsnprintf_P(this->current_(), this->remaining_(), format, args));
   }
 #endif
+  // Extract one decimal digit via subtraction (no division - important for ESP8266)
+  static inline void write_digit_(char *&p, int &value, int divisor) {
+    char d = '0';
+    while (value >= divisor) {
+      d++;
+      value -= divisor;
+    }
+    *p++ = d;
+  }
   // Write ANSI color escape sequence to buffer, updates pointer in place
   // Caller is responsible for ensuring buffer has sufficient space
   void write_ansi_color_(char *&p, uint8_t level) {


### PR DESCRIPTION
# What does this implement/fix?

Replace division-based line number formatting in `LogBuffer::write_header` with subtraction loops via a `write_digit_()` helper. The ESP8266 (Xtensa lx106) lacks a hardware divider, so each division compiles to an expensive software function call (`callx0` to a divide routine). The subtraction approach eliminates all division calls.

Benchmarked on real hardware (10000 iterations x 13 test values):

| Platform | Division | Subtraction | Speedup |
|----------|----------|-------------|---------|
| ESP8266 (Xtensa lx106) | 213,029 us | 118,503 us | **1.80x** |
| ESP32-C3 (RISC-V) | 80,833 us | 56,071 us | **1.44x** |

Flash savings:
- ESP8266: **-36 bytes** (323 → 287)
- ESP32: **-23 bytes** (326 → 303)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Benchmark

Add a button to any config to compare division vs subtraction on real hardware:

```yaml
button:
  - platform: template
    name: "Line Format Benchmark"
    on_press:
      - lambda: |-
          static const char *const BTAG = "bench";
          const int ITERS = 10000;
          char buf[16];

          static const int lines[] = {1, 9, 10, 42, 99, 100, 256, 500, 999, 1000, 1234, 2500, 9999};
          static const int N = sizeof(lines) / sizeof(lines[0]);

          ESP_LOGI(BTAG, "=== Line Format Benchmark (%d iters x %d values) ===", ITERS, N);

          // OLD: division-based
          {
            uint32_t t0 = micros();
            for (int iter = 0; iter < ITERS; iter++) {
              for (int v = 0; v < N; v++) {
                char *p = buf;
                int line = lines[v];
                if (line > 999) {
                  int thousands = line / 1000;
                  *p++ = '0' + thousands;
                  line -= thousands * 1000;
                }
                int hundreds = line / 100;
                int remainder = line - hundreds * 100;
                int tens = remainder / 10;
                *p++ = '0' + hundreds;
                *p++ = '0' + tens;
                *p++ = '0' + (remainder - tens * 10);
              }
            }
            uint32_t us = micros() - t0;
            ESP_LOGI(BTAG, "Division:    %lu us", (unsigned long) us);
          }

          // NEW: subtraction-based
          {
            uint32_t t0 = micros();
            for (int iter = 0; iter < ITERS; iter++) {
              for (int v = 0; v < N; v++) {
                char *p = buf;
                int line = lines[v];
                if (line > 999) {
                  char d = '0';
                  while (line >= 1000) { d++; line -= 1000; }
                  *p++ = d;
                }
                {
                  char d = '0';
                  while (line >= 100) { d++; line -= 100; }
                  *p++ = d;
                }
                {
                  char d = '0';
                  while (line >= 10) { d++; line -= 10; }
                  *p++ = d;
                }
                *p++ = '0' + line;
              }
            }
            uint32_t us = micros() - t0;
            ESP_LOGI(BTAG, "Subtraction: %lu us", (unsigned long) us);
          }

          ESP_LOGI(BTAG, "=== Benchmark complete ===");
```

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).