### PR TITLE
[core] Avoid expensive modulo in LockFreeQueue for non-power-of-2 sizes

### DIFF
--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -38,13 +38,27 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   }
 
  protected:
+  // Advance ring buffer index by one, wrapping at SIZE.
+  // Power-of-2 sizes use modulo (compiler emits single mask instruction).
+  // Non-power-of-2 sizes use comparison to avoid expensive multiply-shift sequences.
+  static constexpr uint8_t next_index_(uint8_t index) {
+    if constexpr ((SIZE & (SIZE - 1)) == 0) {
+      return (index + 1) % SIZE;
+    } else {
+      uint8_t next = index + 1;
+      if (next >= SIZE) [[unlikely]]
+        next = 0;
+      return next;
+    }
+  }
+
   // Internal push that reports queue state - for use by derived classes
   bool push_internal_(T *element, bool &was_empty, uint8_t &old_tail) {
     if (element == nullptr)
       return false;
 
     uint8_t current_tail = tail_.load(std::memory_order_relaxed);
-    uint8_t next_tail = (current_tail + 1) % SIZE;
+    uint8_t next_tail = next_index_(current_tail);
 
     // Read head before incrementing tail
     uint8_t head_before = head_.load(std::memory_order_acquire);
@@ -73,14 +87,21 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     }
 
     T *element = buffer_[current_head];
-    head_.store((current_head + 1) % SIZE, std::memory_order_release);
+    head_.store(next_index_(current_head), std::memory_order_release);
     return element;
   }
 
   size_t size() const {
     uint8_t tail = tail_.load(std::memory_order_acquire);
     uint8_t head = head_.load(std::memory_order_acquire);
-    return (tail - head + SIZE) % SIZE;
+    if constexpr ((SIZE & (SIZE - 1)) == 0) {
+      return (tail - head + SIZE) % SIZE;
+    } else {
+      int diff = static_cast<int>(tail) - static_cast<int>(head);
+      if (diff < 0)
+        diff += SIZE;
+      return static_cast<size_t>(diff);
+    }
   }
 
   uint16_t get_and_reset_dropped_count() { return dropped_count_.exchange(0, std::memory_order_relaxed); }
@@ -90,7 +111,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   bool empty() const { return head_.load(std::memory_order_acquire) == tail_.load(std::memory_order_acquire); }
 
   bool full() const {
-    uint8_t next_tail = (tail_.load(std::memory_order_relaxed) + 1) % SIZE;
+    uint8_t next_tail = next_index_(tail_.load(std::memory_order_relaxed));
     return next_tail == head_.load(std::memory_order_acquire);
   }
 

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -41,7 +41,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   // Advance ring buffer index by one, wrapping at SIZE.
   // Power-of-2 sizes use modulo (compiler emits single mask instruction).
   // Non-power-of-2 sizes use comparison to avoid expensive multiply-shift sequences.
-  static constexpr uint8_t next_index_(uint8_t index) {
+  static constexpr uint8_t next_index(uint8_t index) {
     if constexpr ((SIZE & (SIZE - 1)) == 0) {
       return (index + 1) % SIZE;
     } else {
@@ -58,7 +58,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
       return false;
 
     uint8_t current_tail = tail_.load(std::memory_order_relaxed);
-    uint8_t next_tail = next_index_(current_tail);
+    uint8_t next_tail = next_index(current_tail);
 
     // Read head before incrementing tail
     uint8_t head_before = head_.load(std::memory_order_acquire);
@@ -87,7 +87,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
     }
 
     T *element = buffer_[current_head];
-    head_.store(next_index_(current_head), std::memory_order_release);
+    head_.store(next_index(current_head), std::memory_order_release);
     return element;
   }
 
@@ -111,7 +111,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
   bool empty() const { return head_.load(std::memory_order_acquire) == tail_.load(std::memory_order_acquire); }
 
   bool full() const {
-    uint8_t next_tail = next_index_(tail_.load(std::memory_order_relaxed));
+    uint8_t next_tail = next_index(tail_.load(std::memory_order_relaxed));
     return next_tail == head_.load(std::memory_order_acquire);
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Replace modulo-based ring buffer index advancement in `LockFreeQueue` with a `constexpr`-dispatched approach:
- **Power-of-2 sizes** keep `% SIZE` (compiler emits a single mask instruction)
- **Non-power-of-2 sizes** use comparison+branch instead of expensive multiply-shift sequences (7 instructions on Xtensa, hardware `div` on RISC-V)

The BLE queue (SIZE=88), MQTT queue (SIZE=30), and USB CDC queue (SIZE=12) all use non-power-of-2 sizes and benefit from this change. Every `push()` and `pop()` call on these queues pays the modulo cost.

This matters most on single-core RISC-V chips (ESP32-C3, C6, H2) where every cycle in BLE queue operations directly competes with the main loop. On these chips the BLE task and main loop share a single CPU, so reducing queue overhead is critical for BLE proxy stability.

### Benchmark results (100k iterations)

**ESP32-C3 (RISC-V, single-core):**

| Size | Old (modulo) | New (constexpr) | Speedup |
|------|-------------|-----------------|---------|
| 88 (BLE) | 24,120 us | 6,493 us | **3.7x faster** |
| 30 (MQTT) | 22,816 us | 6,879 us | **3.3x faster** |
| 32 (pow2) | 4,408 us | 4,408 us | identical |
| 16 (pow2) | 4,402 us | 4,402 us | identical |

**ESP32 (Xtensa LX6, dual-core):**

| Size | Old (modulo) | New (constexpr) | Speedup |
|------|-------------|-----------------|---------|
| 88 (BLE) | 7,641 us | 5,036 us | **1.5x faster** |
| 30 (MQTT) | 7,668 us | 4,996 us | **1.5x faster** |
| 32 (pow2) | 3,771 us | 3,783 us | identical |
| 16 (pow2) | 3,772 us | 3,773 us | identical |

The ESP32 classic gains less because its `muluh` instruction is faster than RISC-V's multi-cycle `mulhu`, making the multiply-shift sequence cheaper. The dual-core ESP32 also has a dedicated BLE task core, so the impact is less critical than on single-core chips.

### Flash impact (ESP32 Xtensa, BLE proxy build)

- `push()`: 149 → 133 bytes (-16 B)
- `pop()`:  78 →  67 bytes (-11 B)
- Net binary: +4 bytes (alignment/inlining differences offset per-function savings)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Benchmark

Add a button to any ESP32 config to compare old vs new on real hardware:

```yaml
button:
  - platform: template
    name: "Ring Buffer Benchmark"
    on_press:
      - lambda: |-
          static const char *const BTAG = "bench";
          const int ITERS = 100000;

          auto constexpr_dispatch = [](uint8_t index, auto size_tag) -> uint8_t {
            constexpr uint8_t S = decltype(size_tag)::value;
            if constexpr ((S & (S - 1)) == 0) {
              return (index + 1) % S;
            } else {
              uint8_t next = index + 1;
              if (next >= S) [[unlikely]] next = 0;
              return next;
            }
          };

          ESP_LOGI(BTAG, "=== Ring Buffer Index Benchmark (%d iters) ===", ITERS);

          // SIZE=88 (BLE queue, non-power-of-2)
          {
            volatile uint8_t sink;
            uint8_t idx = 0;
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = (idx + 1) % 88; sink = idx; }
            uint32_t us_old = micros() - t0;
            idx = 0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = constexpr_dispatch(idx, std::integral_constant<uint8_t, 88>{}); sink = idx; }
            uint32_t us_new = micros() - t0;
            ESP_LOGI(BTAG, "SIZE=88:  old=%lu us  new=%lu us  (%.1fx)", (unsigned long) us_old, (unsigned long) us_new, (float) us_old / us_new);
          }

          // SIZE=30 (MQTT queue, non-power-of-2)
          {
            volatile uint8_t sink;
            uint8_t idx = 0;
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = (idx + 1) % 30; sink = idx; }
            uint32_t us_old = micros() - t0;
            idx = 0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = constexpr_dispatch(idx, std::integral_constant<uint8_t, 30>{}); sink = idx; }
            uint32_t us_new = micros() - t0;
            ESP_LOGI(BTAG, "SIZE=30:  old=%lu us  new=%lu us  (%.1fx)", (unsigned long) us_old, (unsigned long) us_new, (float) us_old / us_new);
          }

          // SIZE=32 (power-of-2 baseline)
          {
            volatile uint8_t sink;
            uint8_t idx = 0;
            uint32_t t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = (idx + 1) % 32; sink = idx; }
            uint32_t us_old = micros() - t0;
            idx = 0;
            t0 = micros();
            for (int i = 0; i < ITERS; i++) { idx = constexpr_dispatch(idx, std::integral_constant<uint8_t, 32>{}); sink = idx; }
            uint32_t us_new = micros() - t0;
            ESP_LOGI(BTAG, "SIZE=32:  old=%lu us  new=%lu us  (%.1fx)", (unsigned long) us_old, (unsigned long) us_new, (float) us_old / us_new);
          }

          ESP_LOGI(BTAG, "=== Benchmark complete ===");
```

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).