### PR TITLE
[api] Avoid modulo in send queue ring buffer operations

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -157,7 +157,12 @@ void APIFrameHelper::buffer_data_from_iov_(const struct iovec *iov, int iovcnt, 
   }
 
   // Update circular buffer tracking
+#if (API_MAX_SEND_QUEUE & (API_MAX_SEND_QUEUE - 1)) == 0
   this->tx_buf_tail_ = (this->tx_buf_tail_ + 1) % API_MAX_SEND_QUEUE;
+#else
+  if (++this->tx_buf_tail_ >= API_MAX_SEND_QUEUE)
+    this->tx_buf_tail_ = 0;
+#endif
   this->tx_buf_count_++;
 }
 
@@ -236,7 +241,12 @@ APIError APIFrameHelper::try_send_tx_buf_() {
     } else {
       // Buffer completely sent, remove it from the queue
       this->tx_buf_[this->tx_buf_head_].reset();
+#if (API_MAX_SEND_QUEUE & (API_MAX_SEND_QUEUE - 1)) == 0
       this->tx_buf_head_ = (this->tx_buf_head_ + 1) % API_MAX_SEND_QUEUE;
+#else
+      if (++this->tx_buf_head_ >= API_MAX_SEND_QUEUE)
+        this->tx_buf_head_ = 0;
+#endif
       this->tx_buf_count_--;
       // Continue loop to try sending the next buffer
     }


### PR DESCRIPTION
# What does this implement/fix?

Replace modulo-based index advancement with preprocessor-dispatched approach for the API send queue circular buffer (`tx_buf_head_` and `tx_buf_tail_`).

`API_MAX_SEND_QUEUE` is a compile-time `#define` set via `cg.add_define()` (default 5 on ESP8266/RP2040, 8 on ESP32/BK72xx, user-configurable 1-20). Uses `#if` to dispatch at compile time:
- **Power-of-2 sizes** (e.g. 8): keep `% SIZE` — compiler emits a single mask instruction
- **Non-power-of-2 sizes** (e.g. 5): use comparison+branch — avoids expensive multiply-shift sequences

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).