### PR TITLE
[http_request] Retry update check on startup until network is ready

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -31,7 +31,7 @@ void HttpRequestUpdate::setup() {
 
   // Check every 10s until network is ready (max 6 attempts)
   // Only if update interval is > 1 minute to avoid redundant checks
-  if (this->get_update_interval() > 60000) {
+  if (this->get_update_interval() != SCHEDULER_DONT_RUN && this->get_update_interval() > 60000) {
     this->initial_check_remaining_ = 6;
     this->set_interval(INITIAL_CHECK_INTERVAL_ID, 10000, [this]() {
       bool connected = network::is_connected();

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -24,8 +24,26 @@ namespace http_request {
 static const char *const TAG = "http_request.update";
 
 static const size_t MAX_READ_SIZE = 256;
+static constexpr uint32_t INITIAL_CHECK_INTERVAL_ID = 0;
 
-void HttpRequestUpdate::setup() { this->ota_parent_->add_state_listener(this); }
+void HttpRequestUpdate::setup() {
+  this->ota_parent_->add_state_listener(this);
+
+  // Check every 10s until network is ready (max 6 attempts)
+  // Only if update interval is > 1 minute to avoid redundant checks
+  if (this->get_update_interval() > 60000) {
+    this->initial_check_remaining_ = 6;
+    this->set_interval(INITIAL_CHECK_INTERVAL_ID, 10000, [this]() {
+      bool connected = network::is_connected();
+      if (--this->initial_check_remaining_ == 0 || connected) {
+        this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
+        if (connected) {
+          this->update();
+        }
+      }
+    });
+  }
+}
 
 void HttpRequestUpdate::on_ota_state(ota::OTAState state, float progress, uint8_t error) {
   if (state == ota::OTAState::OTA_IN_PROGRESS) {
@@ -45,6 +63,8 @@ void HttpRequestUpdate::update() {
     ESP_LOGD(TAG, "Network not connected, skipping update check");
     return;
   }
+  // Network is up, cancel any pending initial check to prevent duplicate update checks
+  this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
 #ifdef USE_ESP32
   xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);
 #else

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -25,15 +25,18 @@ static const char *const TAG = "http_request.update";
 
 static const size_t MAX_READ_SIZE = 256;
 static constexpr uint32_t INITIAL_CHECK_INTERVAL_ID = 0;
+static constexpr uint32_t INITIAL_CHECK_INTERVAL_MS = 10000;
+static constexpr uint8_t INITIAL_CHECK_MAX_ATTEMPTS = 6;
 
 void HttpRequestUpdate::setup() {
   this->ota_parent_->add_state_listener(this);
 
   // Check every 10s until network is ready (max 6 attempts)
-  // Only if update interval is > 1 minute to avoid redundant checks
-  if (this->get_update_interval() != SCHEDULER_DONT_RUN && this->get_update_interval() > 60000) {
-    this->initial_check_remaining_ = 6;
-    this->set_interval(INITIAL_CHECK_INTERVAL_ID, 10000, [this]() {
+  // Only if update interval is > total retry window to avoid redundant checks
+  if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
+      this->get_update_interval() > INITIAL_CHECK_INTERVAL_MS * INITIAL_CHECK_MAX_ATTEMPTS) {
+    this->initial_check_remaining_ = INITIAL_CHECK_MAX_ATTEMPTS;
+    this->set_interval(INITIAL_CHECK_INTERVAL_ID, INITIAL_CHECK_INTERVAL_MS, [this]() {
       bool connected = network::is_connected();
       if (--this->initial_check_remaining_ == 0 || connected) {
         this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -31,7 +31,7 @@ static constexpr uint8_t INITIAL_CHECK_MAX_ATTEMPTS = 6;
 void HttpRequestUpdate::setup() {
   this->ota_parent_->add_state_listener(this);
 
-  // Check every 10s until network is ready (max 6 attempts)
+  // Check periodically until network is ready
   // Only if update interval is > total retry window to avoid redundant checks
   if (this->get_update_interval() != SCHEDULER_DONT_RUN &&
       this->get_update_interval() > INITIAL_CHECK_INTERVAL_MS * INITIAL_CHECK_MAX_ATTEMPTS) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -63,7 +63,6 @@ void HttpRequestUpdate::update() {
     ESP_LOGD(TAG, "Network not connected, skipping update check");
     return;
   }
-  // Network is up, cancel any pending initial check to prevent duplicate update checks
   this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
 #ifdef USE_ESP32
   xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -40,6 +40,7 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
 #ifdef USE_ESP32
   TaskHandle_t update_task_handle_{nullptr};
 #endif
+  uint8_t initial_check_remaining_{0};
 };
 
 }  // namespace http_request


### PR DESCRIPTION
# What does this implement/fix?

When the first polling update fires before WiFi has connected, the check is skipped and wont retry for the full update interval (default 6h). This adds initial retry logic that checks every 10s for up to 60s until the network is connected, matching the pattern used by esp32_hosted update.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14227

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
update:
  - platform: http_request
    name: Firmware Update
    source: http://example.com/firmware/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).