### PR TITLE
[core] Move build_info_data.h out of application.h to fix incremental rebuilds

### DIFF
--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -152,7 +152,7 @@ void Esp32HostedUpdate::setup() {
 
 void Esp32HostedUpdate::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "ESP32 Hostedd Update:\n"
+                "ESP32 Hosted Update:\n"
                 "  Host Library Version: %s\n"
                 "  Coprocessor Version: %s\n"
                 "  Latest Version: %s",

--- a/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
+++ b/esphome/components/esp32_hosted/update/esp32_hosted_update.cpp
@@ -152,7 +152,7 @@ void Esp32HostedUpdate::setup() {
 
 void Esp32HostedUpdate::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "ESP32 Hosted Update:\n"
+                "ESP32 Hostedd Update:\n"
                 "  Host Library Version: %s\n"
                 "  Coprocessor Version: %s\n"
                 "  Latest Version: %s",

--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -1,5 +1,6 @@
 #include "version_text_sensor.h"
 #include "esphome/core/application.h"
+#include "esphome/core/build_info_data.h"
 #include "esphome/core/log.h"
 #include "esphome/core/version.h"
 #include "esphome/core/helpers.h"

--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -26,9 +26,7 @@ void VersionTextSensor::setup() {
   if (!this->hide_timestamp_) {
     size_t len = strlen(version_str);
     ESPHOME_strncat_P(version_str, BUILT_STR, sizeof(version_str) - len - 1);
-    char time_buf[esphome::Application::BUILD_TIME_STR_SIZE];
-    App.get_build_time_string(time_buf);
-    strncat(version_str, time_buf, sizeof(version_str) - strlen(version_str) - 1);
+    ESPHOME_strncat_P(version_str, ESPHOME_BUILD_TIME_STR, sizeof(version_str) - strlen(version_str) - 1);
   }
 
   strncat(version_str, ")", sizeof(version_str) - strlen(version_str) - 1);

--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -25,7 +25,9 @@ void VersionTextSensor::setup() {
   if (!this->hide_timestamp_) {
     size_t len = strlen(version_str);
     ESPHOME_strncat_P(version_str, BUILT_STR, sizeof(version_str) - len - 1);
-    ESPHOME_strncat_P(version_str, ESPHOME_BUILD_TIME_STR, sizeof(version_str) - strlen(version_str) - 1);
+    char time_buf[esphome::Application::BUILD_TIME_STR_SIZE];
+    App.get_build_time_string(time_buf);
+    strncat(version_str, time_buf, sizeof(version_str) - strlen(version_str) - 1);
   }
 
   strncat(version_str, ")", sizeof(version_str) - strlen(version_str) - 1);

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -375,9 +375,8 @@ json::SerializationBuffer<> WebServer::get_config_json() {
   JsonObject root = builder.root();
 
   root[ESPHOME_F("title")] = App.get_friendly_name().empty() ? App.get_name().c_str() : App.get_friendly_name().c_str();
-  char comment_buffer[ESPHOME_COMMENT_SIZE];
-  App.get_comment_string(comment_buffer);
-  root[ESPHOME_F("comment")] = comment_buffer;
+  auto comment = App.get_comment();
+  root[ESPHOME_F("comment")] = comment.c_str();
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
   root[ESPHOME_F("ota")] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -375,7 +375,7 @@ json::SerializationBuffer<> WebServer::get_config_json() {
   JsonObject root = builder.root();
 
   root[ESPHOME_F("title")] = App.get_friendly_name().empty() ? App.get_name().c_str() : App.get_friendly_name().c_str();
-  char comment_buffer[Application::COMMENT_MAX_SIZE];
+  char comment_buffer[Application::ESPHOME_COMMENT_SIZE_MAX];
   App.get_comment_string(comment_buffer);
   root[ESPHOME_F("comment")] = comment_buffer;
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/progmem.h"
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
+#include "esphome/core/build_info_data.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/entity_base.h"
@@ -375,8 +376,7 @@ json::SerializationBuffer<> WebServer::get_config_json() {
   JsonObject root = builder.root();
 
   root[ESPHOME_F("title")] = App.get_friendly_name().empty() ? App.get_name().c_str() : App.get_friendly_name().c_str();
-  auto comment = App.get_comment();
-  root[ESPHOME_F("comment")] = comment.c_str();
+  root[ESPHOME_F("comment")] = ESPHOME_COMMENT_STR;
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
   root[ESPHOME_F("ota")] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -4,7 +4,6 @@
 #include "esphome/core/progmem.h"
 #include "esphome/components/network/util.h"
 #include "esphome/core/application.h"
-#include "esphome/core/build_info_data.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/entity_base.h"
@@ -376,7 +375,9 @@ json::SerializationBuffer<> WebServer::get_config_json() {
   JsonObject root = builder.root();
 
   root[ESPHOME_F("title")] = App.get_friendly_name().empty() ? App.get_name().c_str() : App.get_friendly_name().c_str();
-  root[ESPHOME_F("comment")] = ESPHOME_COMMENT_STR;
+  char comment_buffer[Application::COMMENT_MAX_SIZE];
+  App.get_comment_string(comment_buffer);
+  root[ESPHOME_F("comment")] = comment_buffer;
 #if defined(USE_WEBSERVER_OTA_DISABLED) || !defined(USE_WEBSERVER_OTA)
   root[ESPHOME_F("ota")] = false;  // Note: USE_WEBSERVER_OTA_DISABLED only affects web_server, not captive_portal
 #else

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -215,8 +215,7 @@ void Application::loop() {
 void Application::process_dump_config_() {
   if (this->dump_config_at_ == 0) {
     char build_time_str[Application::BUILD_TIME_STR_SIZE];
-    ESPHOME_strncpy_P(build_time_str, ESPHOME_BUILD_TIME_STR, sizeof(build_time_str));
-    build_time_str[sizeof(build_time_str) - 1] = '\0';
+    this->get_build_time_string(build_time_str);
     ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", build_time_str);
 #ifdef ESPHOME_PROJECT_NAME
     ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
@@ -750,15 +749,9 @@ void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buf
   buffer[buffer.size() - 1] = '\0';
 }
 
-void Application::get_comment_string(std::span<char, COMMENT_MAX_SIZE> buffer) {
+void Application::get_comment_string(std::span<char, ESPHOME_COMMENT_SIZE_MAX> buffer) {
   ESPHOME_strncpy_P(buffer.data(), ESPHOME_COMMENT_STR, buffer.size());
   buffer[buffer.size() - 1] = '\0';
-}
-
-std::string Application::get_comment() {
-  char buffer[COMMENT_MAX_SIZE];
-  this->get_comment_string(buffer);
-  return std::string(buffer);
 }
 
 uint32_t Application::get_config_hash() { return ESPHOME_CONFIG_HASH; }
@@ -766,11 +759,5 @@ uint32_t Application::get_config_hash() { return ESPHOME_CONFIG_HASH; }
 uint32_t Application::get_config_version_hash() { return fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION); }
 
 time_t Application::get_build_time() { return ESPHOME_BUILD_TIME; }
-
-std::string Application::get_compilation_time() {
-  char buf[BUILD_TIME_STR_SIZE];
-  this->get_build_time_string(buf);
-  return std::string(buf);
-}
 
 }  // namespace esphome

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -749,4 +749,29 @@ void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buf
   buffer[buffer.size() - 1] = '\0';
 }
 
+size_t Application::get_comment_size() { return ESPHOME_COMMENT_SIZE; }
+
+void Application::get_comment_string(char *buffer, size_t size) {
+  ESPHOME_strncpy_P(buffer, ESPHOME_COMMENT_STR, size);
+  buffer[size - 1] = '\0';
+}
+
+std::string Application::get_comment() {
+  char buffer[ESPHOME_COMMENT_SIZE];
+  this->get_comment_string(buffer, sizeof(buffer));
+  return std::string(buffer);
+}
+
+uint32_t Application::get_config_hash() { return ESPHOME_CONFIG_HASH; }
+
+uint32_t Application::get_config_version_hash() { return fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION); }
+
+time_t Application::get_build_time() { return ESPHOME_BUILD_TIME; }
+
+std::string Application::get_compilation_time() {
+  char buf[BUILD_TIME_STR_SIZE];
+  this->get_build_time_string(buf);
+  return std::string(buf);
+}
+
 }  // namespace esphome

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -750,8 +750,8 @@ void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buf
 }
 
 void Application::get_comment_string(std::span<char, ESPHOME_COMMENT_SIZE_MAX> buffer) {
-  ESPHOME_strncpy_P(buffer.data(), ESPHOME_COMMENT_STR, buffer.size());
-  buffer[buffer.size() - 1] = '\0';
+  ESPHOME_strncpy_P(buffer.data(), ESPHOME_COMMENT_STR, ESPHOME_COMMENT_SIZE);
+  buffer[ESPHOME_COMMENT_SIZE - 1] = '\0';
 }
 
 uint32_t Application::get_config_hash() { return ESPHOME_CONFIG_HASH; }

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -215,7 +215,8 @@ void Application::loop() {
 void Application::process_dump_config_() {
   if (this->dump_config_at_ == 0) {
     char build_time_str[Application::BUILD_TIME_STR_SIZE];
-    this->get_build_time_string(build_time_str);
+    ESPHOME_strncpy_P(build_time_str, ESPHOME_BUILD_TIME_STR, sizeof(build_time_str));
+    build_time_str[sizeof(build_time_str) - 1] = '\0';
     ESP_LOGI(TAG, "ESPHome version " ESPHOME_VERSION " compiled on %s", build_time_str);
 #ifdef ESPHOME_PROJECT_NAME
     ESP_LOGI(TAG, "Project " ESPHOME_PROJECT_NAME " version " ESPHOME_PROJECT_VERSION);
@@ -749,16 +750,14 @@ void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buf
   buffer[buffer.size() - 1] = '\0';
 }
 
-size_t Application::get_comment_size() { return ESPHOME_COMMENT_SIZE; }
-
-void Application::get_comment_string(char *buffer, size_t size) {
-  ESPHOME_strncpy_P(buffer, ESPHOME_COMMENT_STR, size);
-  buffer[size - 1] = '\0';
+void Application::get_comment_string(std::span<char, COMMENT_MAX_SIZE> buffer) {
+  ESPHOME_strncpy_P(buffer.data(), ESPHOME_COMMENT_STR, buffer.size());
+  buffer[buffer.size() - 1] = '\0';
 }
 
 std::string Application::get_comment() {
-  char buffer[ESPHOME_COMMENT_SIZE];
-  this->get_comment_string(buffer, sizeof(buffer));
+  char buffer[COMMENT_MAX_SIZE];
+  this->get_comment_string(buffer);
   return std::string(buffer);
 }
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -276,11 +276,15 @@ class Application {
   /// Maximum size of the comment buffer (including null terminator)
   static constexpr size_t COMMENT_MAX_SIZE = 256;
 
-  /// Get the comment string (PROGMEM-safe, copies to buffer)
+  /// Copy the comment string into the provided buffer
   void get_comment_string(std::span<char, COMMENT_MAX_SIZE> buffer);
 
   /// Get the comment of this Application as a string
-  std::string get_comment();
+  std::string get_comment() {
+    char buffer[COMMENT_MAX_SIZE];
+    this->get_comment_string(buffer);
+    return std::string(buffer);
+  }
 
   bool is_name_add_mac_suffix_enabled() const { return this->name_add_mac_suffix_; }
 
@@ -296,13 +300,18 @@ class Application {
   /// Get the build time as a Unix timestamp
   time_t get_build_time();
 
-  /// Get the build time string (PROGMEM-safe, copies to buffer)
+  /// Copy the build time string into the provided buffer
+  /// Buffer must be BUILD_TIME_STR_SIZE bytes (compile-time enforced)
   void get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer);
 
   /// Get the build time as a string (deprecated, use get_build_time_string() instead)
   // Remove before 2026.7.0
   ESPDEPRECATED("Use get_build_time_string() instead. Removed in 2026.7.0", "2026.1.0")
-  std::string get_compilation_time();
+  std::string get_compilation_time() {
+    char buf[BUILD_TIME_STR_SIZE];
+    this->get_build_time_string(buf);
+    return std::string(buf);
+  }
 
   /// Get the cached time in milliseconds from when the current component started its loop execution
   inline uint32_t IRAM_ATTR HOT get_loop_component_start_time() const { return this->loop_component_start_time_; }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -274,14 +274,14 @@ class Application {
   }
 
   /// Maximum size of the comment buffer (including null terminator)
-  static constexpr size_t COMMENT_MAX_SIZE = 256;
+  static constexpr size_t ESPHOME_COMMENT_SIZE_MAX = 256;
 
   /// Copy the comment string into the provided buffer
-  void get_comment_string(std::span<char, COMMENT_MAX_SIZE> buffer);
+  void get_comment_string(std::span<char, ESPHOME_COMMENT_SIZE_MAX> buffer);
 
   /// Get the comment of this Application as a string
   std::string get_comment() {
-    char buffer[COMMENT_MAX_SIZE];
+    char buffer[ESPHOME_COMMENT_SIZE_MAX];
     this->get_comment_string(buffer);
     return std::string(buffer);
   }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -6,7 +6,6 @@
 #include <span>
 #include <string>
 #include <vector>
-#include "esphome/core/build_info_data.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
@@ -274,19 +273,14 @@ class Application {
     return "";
   }
 
+  /// Get the size of the comment buffer (including null terminator)
+  static size_t get_comment_size();
+
   /// Copy the comment string into the provided buffer
-  /// Buffer must be ESPHOME_COMMENT_SIZE bytes (compile-time enforced)
-  void get_comment_string(std::span<char, ESPHOME_COMMENT_SIZE> buffer) {
-    ESPHOME_strncpy_P(buffer.data(), ESPHOME_COMMENT_STR, buffer.size());
-    buffer[buffer.size() - 1] = '\0';
-  }
+  void get_comment_string(char *buffer, size_t size);
 
   /// Get the comment of this Application as a string
-  std::string get_comment() {
-    char buffer[ESPHOME_COMMENT_SIZE];
-    this->get_comment_string(buffer);
-    return std::string(buffer);
-  }
+  std::string get_comment();
 
   bool is_name_add_mac_suffix_enabled() const { return this->name_add_mac_suffix_; }
 
@@ -294,26 +288,22 @@ class Application {
   static constexpr size_t BUILD_TIME_STR_SIZE = 26;
 
   /// Get the config hash as a 32-bit integer
-  constexpr uint32_t get_config_hash() { return ESPHOME_CONFIG_HASH; }
+  uint32_t get_config_hash();
 
   /// Get the config hash extended with ESPHome version
-  constexpr uint32_t get_config_version_hash() { return fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION); }
+  uint32_t get_config_version_hash();
 
   /// Get the build time as a Unix timestamp
-  constexpr time_t get_build_time() { return ESPHOME_BUILD_TIME; }
+  time_t get_build_time();
 
   /// Copy the build time string into the provided buffer
-  /// Buffer must be BUILD_TIME_STR_SIZE bytes (compile-time enforced)
+  /// Buffer must be BUILD_TIME_STR_SIZE bytes
   void get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer);
 
   /// Get the build time as a string (deprecated, use get_build_time_string() instead)
   // Remove before 2026.7.0
   ESPDEPRECATED("Use get_build_time_string() instead. Removed in 2026.7.0", "2026.1.0")
-  std::string get_compilation_time() {
-    char buf[BUILD_TIME_STR_SIZE];
-    this->get_build_time_string(buf);
-    return std::string(buf);
-  }
+  std::string get_compilation_time();
 
   /// Get the cached time in milliseconds from when the current component started its loop execution
   inline uint32_t IRAM_ATTR HOT get_loop_component_start_time() const { return this->loop_component_start_time_; }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -273,11 +273,11 @@ class Application {
     return "";
   }
 
-  /// Get the size of the comment buffer (including null terminator)
-  static size_t get_comment_size();
+  /// Maximum size of the comment buffer (including null terminator)
+  static constexpr size_t COMMENT_MAX_SIZE = 256;
 
-  /// Copy the comment string into the provided buffer
-  void get_comment_string(char *buffer, size_t size);
+  /// Get the comment string (PROGMEM-safe, copies to buffer)
+  void get_comment_string(std::span<char, COMMENT_MAX_SIZE> buffer);
 
   /// Get the comment of this Application as a string
   std::string get_comment();
@@ -296,8 +296,7 @@ class Application {
   /// Get the build time as a Unix timestamp
   time_t get_build_time();
 
-  /// Copy the build time string into the provided buffer
-  /// Buffer must be BUILD_TIME_STR_SIZE bytes
+  /// Get the build time string (PROGMEM-safe, copies to buffer)
   void get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer);
 
   /// Get the build time as a string (deprecated, use get_build_time_string() instead)


### PR DESCRIPTION
# What does this implement/fix?

Move `build_info_data.h` out of `application.h` to fix unnecessary mass recompilation during incremental builds.

`build_info_data.h` contains `ESPHOME_BUILD_TIME` which changes every build. Since `application.h` included it, changing any source file caused `build_info_data.h` to be rewritten (via `sources_changed`), which then triggered a rebuild of every file that includes `application.h` — essentially the entire project.

### Changes

- Remove `#include "build_info_data.h"` from `application.h`
- Move `get_comment_string()`, `get_config_hash()`, `get_config_version_hash()`, and `get_build_time()` implementations to `application.cpp`
- `get_build_time_string()`, `get_comment()`, and `get_compilation_time()` remain inline in the header — they call the moved methods so they don't depend on the macros directly
- Replace `ESPHOME_COMMENT_SIZE` (from `build_info_data.h`) with a fixed `ESPHOME_COMMENT_SIZE_MAX = 256` constant on `Application`, matching the `cv.Length(max=255)` config validation
- Components that need `build_info_data.h` macros directly (`version_text_sensor`) now include it explicitly

### Performance tradeoffs

**Before:** `get_config_hash()`, `get_config_version_hash()`, and `get_build_time()` were `constexpr` inline methods, allowing the compiler to fold them into constants at call sites. However, this required every translation unit to include `build_info_data.h` transitively, causing full rebuilds on every incremental compile.

**After:** These methods are regular functions defined in `application.cpp`. This means a function call instead of a compile-time constant at each call site. In practice, these methods are called very infrequently (once at boot in `dump_config`, once in API responses, etc.), so the runtime cost is negligible. The incremental build time improvement is significant — a single `.cpp` change no longer triggers a rebuild of ~30+ files.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #12425

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal build system change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
