### PR TITLE
[nfc] Fix logging tag for nfc helpers

### DIFF
--- a/esphome/components/nfc/nfc_helpers.cpp
+++ b/esphome/components/nfc/nfc_helpers.cpp
@@ -39,7 +39,7 @@ std::string get_random_ha_tag_ndef() {
   for (int i = 0; i < 12; i++) {
     uri += ALPHANUM[random_uint32() % (sizeof(ALPHANUM) - 1)];
   }
-  ESP_LOGD("pn7160", "Payload to be written: %s", uri.c_str());
+  ESP_LOGD(TAG, "Payload to be written: %s", uri.c_str());
   return uri;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Function uses incorrect tag for logging.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes NA

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

NA

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).  -- NA

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).  -- NA
