### PR TITLE
[wifi] Avoid .rodata RAM cost for ManualIP on ESP8266

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -439,13 +439,25 @@ def safe_ip(ip):
 def manual_ip(config):
     if config is None:
         return None
+    fields = {
+        "static_ip": CONF_STATIC_IP,
+        "gateway": CONF_GATEWAY,
+        "subnet": CONF_SUBNET,
+        "dns1": CONF_DNS1,
+        "dns2": CONF_DNS2,
+    }
+    if CORE.is_esp8266:
+        # On ESP8266, .rodata is mapped to RAM. Using StructInitializer with all
+        # compile-time constant fields causes the compiler to place a const blob
+        # in .rodata, silently consuming ~20 bytes of RAM. Field-by-field assignment
+        # encodes the values as immediate operands in flash instructions instead.
+        cg.add(cg.RawExpression("wifi::ManualIP manual_ip{}"))
+        for member, key in fields.items():
+            cg.add(cg.RawExpression(f"manual_ip.{member} = {safe_ip(config.get(key))}"))
+        return cg.RawExpression("manual_ip")
     return cg.StructInitializer(
         ManualIP,
-        ("static_ip", safe_ip(config[CONF_STATIC_IP])),
-        ("gateway", safe_ip(config[CONF_GATEWAY])),
-        ("subnet", safe_ip(config[CONF_SUBNET])),
-        ("dns1", safe_ip(config.get(CONF_DNS1))),
-        ("dns2", safe_ip(config.get(CONF_DNS2))),
+        *((member, safe_ip(config.get(key))) for member, key in fields.items()),
     )
 
 

--- a/tests/components/wifi/test.esp8266-ard.yaml
+++ b/tests/components/wifi/test.esp8266-ard.yaml
@@ -1,6 +1,12 @@
 wifi:
   min_auth_mode: WPA2
   post_connect_roaming: true
+  manual_ip:
+    static_ip: 192.168.1.100
+    gateway: 192.168.1.1
+    subnet: 255.255.255.0
+    dns1: 1.1.1.1
+    dns2: 8.8.8.8
 
 packages:
   - !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266, `.rodata` is mapped to DRAM (RAM), not flash. When `cg.StructInitializer` is used with all compile-time constant fields (like `ManualIP` with its 5 `IPAddress` fields), the C++ compiler places the entire struct as a const blob in `.rodata`, silently consuming ~20 bytes of RAM.

This PR switches to field-by-field assignment on ESP8266 so the IP address values are encoded as immediate operands in flash instructions (`.irom0.text`) instead of a `.rodata` data blob. Other platforms continue using the aggregate initializer since their `.rodata` is flash-mapped and costs no RAM.

**Before (ESP8266 generated code):**
```cpp
wifi_wifiap_id.set_manual_ip(wifi::ManualIP{
    .static_ip = network::IPAddress(192, 168, 1, 100),
    .gateway = network::IPAddress(192, 168, 1, 1),
    .subnet = network::IPAddress(255, 255, 255, 0),
    .dns1 = network::IPAddress(1, 1, 1, 1),
    .dns2 = network::IPAddress(8, 8, 8, 8),
});
```
Compiler stores the 20-byte struct in `.rodata` → RAM on ESP8266.

**After (ESP8266 generated code):**
```cpp
wifi::ManualIP manual_ip{};
manual_ip.static_ip = network::IPAddress(192, 168, 1, 100);
manual_ip.gateway = network::IPAddress(192, 168, 1, 1);
manual_ip.subnet = network::IPAddress(255, 255, 255, 0);
manual_ip.dns1 = network::IPAddress(1, 1, 1, 1);
manual_ip.dns2 = network::IPAddress(8, 8, 8, 8);
wifi_wifiap_id.set_manual_ip(manual_ip);
```
Values encoded as immediate operands in flash instructions → no `.rodata` cost.

Each `manual_ip` declaration lives inside its own `{ ... }` scope block (from `cg.with_local_variable`), so multiple networks with static IPs compile without variable name collisions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  networks:
    - ssid: MySSID
      password: password1
      manual_ip:
        static_ip: 192.168.1.100
        gateway: 192.168.1.1
        subnet: 255.255.255.0
        dns1: 1.1.1.1
        dns2: 8.8.8.8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (no user-facing changes)