### PR TITLE
[light] Replace std::lerp with lightweight lerp_fast in LightColorValues::lerp

### DIFF
--- a/esphome/components/light/light_color_values.cpp
+++ b/esphome/components/light/light_color_values.cpp
@@ -1,27 +1,30 @@
 #include "light_color_values.h"
 
-#include <cmath>
-
 namespace esphome::light {
+
+// Lightweight lerp: a + t * (b - a).
+// Avoids std::lerp's NaN/infinity handling which Clang doesn't optimize out,
+// adding ~200 bytes per call. Safe because all values are finite floats.
+static float __attribute__((noinline)) lerp_fast(float a, float b, float t) { return a + t * (b - a); }
 
 LightColorValues LightColorValues::lerp(const LightColorValues &start, const LightColorValues &end, float completion) {
   // Directly interpolate the raw values to avoid getter/setter overhead.
   // This is safe because:
-  // - All LightColorValues have their values clamped when set via the setters
-  // - std::lerp guarantees output is in the same range as inputs
+  // - All LightColorValues except color_temperature_ have their values clamped when set via the setters
+  // - lerp_fast output stays in range when inputs are in range and 0 <= completion <= 1
   // - Therefore the output doesn't need clamping, so we can skip the setters
   LightColorValues v;
   v.color_mode_ = end.color_mode_;
-  v.state_ = std::lerp(start.state_, end.state_, completion);
-  v.brightness_ = std::lerp(start.brightness_, end.brightness_, completion);
-  v.color_brightness_ = std::lerp(start.color_brightness_, end.color_brightness_, completion);
-  v.red_ = std::lerp(start.red_, end.red_, completion);
-  v.green_ = std::lerp(start.green_, end.green_, completion);
-  v.blue_ = std::lerp(start.blue_, end.blue_, completion);
-  v.white_ = std::lerp(start.white_, end.white_, completion);
-  v.color_temperature_ = std::lerp(start.color_temperature_, end.color_temperature_, completion);
-  v.cold_white_ = std::lerp(start.cold_white_, end.cold_white_, completion);
-  v.warm_white_ = std::lerp(start.warm_white_, end.warm_white_, completion);
+  v.state_ = lerp_fast(start.state_, end.state_, completion);
+  v.brightness_ = lerp_fast(start.brightness_, end.brightness_, completion);
+  v.color_brightness_ = lerp_fast(start.color_brightness_, end.color_brightness_, completion);
+  v.red_ = lerp_fast(start.red_, end.red_, completion);
+  v.green_ = lerp_fast(start.green_, end.green_, completion);
+  v.blue_ = lerp_fast(start.blue_, end.blue_, completion);
+  v.white_ = lerp_fast(start.white_, end.white_, completion);
+  v.color_temperature_ = lerp_fast(start.color_temperature_, end.color_temperature_, completion);
+  v.cold_white_ = lerp_fast(start.cold_white_, end.cold_white_, completion);
+  v.warm_white_ = lerp_fast(start.warm_white_, end.warm_white_, completion);
   return v;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

`std::lerp` includes NaN/infinity edge-case handling per the C++20 spec, generating significant overhead per call. `LightColorValues::lerp` calls it 10 times (one per field).

Since all light color values are finite floats, the special-value handling is unnecessary. This replaces `std::lerp` with a simple outlined `a + t * (b - a)` function. Using `noinline` keeps a single small function called 10 times instead of 10 inlined copies.

**Firmware size:**
| Platform | Before | After | Delta |
|----------|--------|-------|-------|
| BK72xx (Clang) | 545,866 | 543,994 | **-1,872 B** |
| ESP8266 (GCC) | 496,405 | 496,213 | **-192 B** |
| ESP32-S3 (GCC) | 816,923 | 816,823 | **-100 B** |

The maximum floating-point difference vs `std::lerp` is < 1.5e-08 for [0,1] ranged fields — well below 1 ULP and completely invisible in light output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only.
# Any light component using transitions exercises this code path.
light:
  - platform: rgb
    name: "Test Light"
    red: output_r
    green: output_g
    blue: output_b
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (n/a — no user-facing changes)