### PR TITLE
[esp32_ble_server] add max_clients option for multi-client support

### DIFF
--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -42,6 +42,7 @@ CONF_FIRMWARE_VERSION = "firmware_version"
 CONF_INDICATE = "indicate"
 CONF_MANUFACTURER = "manufacturer"
 CONF_MANUFACTURER_DATA = "manufacturer_data"
+CONF_MAX_CLIENTS = "max_clients"
 CONF_ON_WRITE = "on_write"
 CONF_READ = "read"
 CONF_STRING = "string"
@@ -428,6 +429,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL): value_schema("string", templatable=False),
         cv.Optional(CONF_FIRMWARE_VERSION): value_schema("string", templatable=False),
         cv.Optional(CONF_MANUFACTURER_DATA): cv.Schema([cv.uint8_t]),
+        cv.Optional(CONF_MAX_CLIENTS, default=1): cv.int_range(min=1, max=9),
         cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA),
         cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(single=True),
@@ -552,6 +554,7 @@ async def to_code(config):
     esp32_ble.register_ble_status_event_handler(parent, var)
     cg.add(var.set_parent(parent))
     cg.add(parent.advertising_set_appearance(config[CONF_APPEARANCE]))
+    cg.add(var.set_max_clients(config[CONF_MAX_CLIENTS]))
     if CONF_MANUFACTURER_DATA in config:
         cg.add(var.set_manufacturer_data(config[CONF_MANUFACTURER_DATA]))
     for service_config in config[CONF_SERVICES]:

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -6,6 +6,7 @@ from esphome.components import esp32_ble
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components.esp32_ble import BTLoggers, bt_uuid
 import esphome.config_validation as cv
+import esphome.final_validate as fv
 from esphome.config_validation import UNDEFINED
 from esphome.const import (
     CONF_DATA,
@@ -288,6 +289,22 @@ def create_device_information_service(config):
 
 
 def final_validate_config(config):
+    # Validate max_clients does not exceed esp32_ble max_connections
+    max_clients = config.get(CONF_MAX_CLIENTS, 1)
+    if max_clients > 1:
+        full_config = fv.full_config.get()
+        ble_config = full_config.get("esp32_ble", {})
+        max_connections = ble_config.get(
+            "max_connections", esp32_ble.DEFAULT_MAX_CONNECTIONS
+        )
+        if max_clients > max_connections:
+            raise cv.Invalid(
+                f"'max_clients' ({max_clients}) cannot exceed esp32_ble "
+                f"'max_connections' ({max_connections}). "
+                f"Please set 'max_connections: {max_clients}' in the "
+                f"'esp32_ble' component."
+            )
+
     # Check if all characteristics that require notifications have the notify property set
     for char_id in CORE.data.get(DOMAIN, {}).get(KEY_NOTIFY_REQUIRED, set()):
         # Look for the characteristic in the configuration
@@ -429,7 +446,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL): value_schema("string", templatable=False),
         cv.Optional(CONF_FIRMWARE_VERSION): value_schema("string", templatable=False),
         cv.Optional(CONF_MANUFACTURER_DATA): cv.Schema([cv.uint8_t]),
-        cv.Optional(CONF_MAX_CLIENTS, default=1): cv.int_range(min=1, max=9),
+        cv.Optional(CONF_MAX_CLIENTS, default=1): cv.int_range(min=1),
         cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA),
         cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(single=True),

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -446,7 +446,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODEL): value_schema("string", templatable=False),
         cv.Optional(CONF_FIRMWARE_VERSION): value_schema("string", templatable=False),
         cv.Optional(CONF_MANUFACTURER_DATA): cv.Schema([cv.uint8_t]),
-        cv.Optional(CONF_MAX_CLIENTS, default=1): cv.int_range(min=1),
+        cv.Optional(CONF_MAX_CLIENTS, default=1): cv.int_range(min=1, max=9),
         cv.Optional(CONF_SERVICES, default=[]): cv.ensure_list(SERVICE_SCHEMA),
         cv.Optional(CONF_ON_CONNECT): automation.validate_automation(single=True),
         cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(single=True),

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -6,7 +6,6 @@ from esphome.components import esp32_ble
 from esphome.components.esp32 import add_idf_sdkconfig_option
 from esphome.components.esp32_ble import BTLoggers, bt_uuid
 import esphome.config_validation as cv
-import esphome.final_validate as fv
 from esphome.config_validation import UNDEFINED
 from esphome.const import (
     CONF_DATA,
@@ -25,6 +24,7 @@ from esphome.const import (
     __version__ as ESPHOME_VERSION,
 )
 from esphome.core import CORE
+import esphome.final_validate as fv
 from esphome.schema_extractors import SCHEMA_EXTRACT
 
 AUTO_LOAD = ["esp32_ble", "bytebuffer"]

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -290,7 +290,7 @@ def create_device_information_service(config):
 
 def final_validate_config(config):
     # Validate max_clients does not exceed esp32_ble max_connections
-    max_clients = config.get(CONF_MAX_CLIENTS, 1)
+    max_clients = config[CONF_MAX_CLIENTS]
     if max_clients > 1:
         full_config = fv.full_config.get()
         ble_config = full_config.get("esp32_ble", {})

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -175,6 +175,10 @@ void BLEServer::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t ga
     case ESP_GATTS_CONNECT_EVT: {
       ESP_LOGD(TAG, "BLE Client connected");
       this->add_client_(param->connect.conn_id);
+      // Resume advertising so additional clients can discover and connect
+      if (this->client_count_ < this->max_clients_) {
+        this->parent_->advertising_start();
+      }
       this->dispatch_callbacks_(CallbackType::ON_CONNECT, param->connect.conn_id);
       break;
     }
@@ -241,7 +245,10 @@ void BLEServer::ble_before_disabled_event_handler() {
 
 float BLEServer::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH + 10; }
 
-void BLEServer::dump_config() { ESP_LOGCONFIG(TAG, "ESP32 BLE Server:"); }
+void BLEServer::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP32 BLE Server:");
+  ESP_LOGCONFIG(TAG, "  Max clients: %u", this->max_clients_);
+}
 
 BLEServer *global_ble_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -246,8 +246,10 @@ void BLEServer::ble_before_disabled_event_handler() {
 float BLEServer::get_setup_priority() const { return setup_priority::AFTER_BLUETOOTH + 10; }
 
 void BLEServer::dump_config() {
-  ESP_LOGCONFIG(TAG, "ESP32 BLE Server:");
-  ESP_LOGCONFIG(TAG, "  Max clients: %u", this->max_clients_);
+  ESP_LOGCONFIG(TAG,
+                "ESP32 BLE Server:\n"
+                "  Max clients: %u",
+                this->max_clients_);
 }
 
 BLEServer *global_ble_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -39,6 +39,9 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
     this->restart_advertising_();
   }
 
+  void set_max_clients(uint8_t max_clients) { this->max_clients_ = max_clients; }
+  uint8_t get_max_clients() const { return this->max_clients_; }
+
   BLEService *create_service(ESPBTUUID uuid, bool advertise = false, uint16_t num_handles = 15);
   void remove_service(ESPBTUUID uuid, uint8_t inst_id = 0);
   BLEService *get_service(ESPBTUUID uuid, uint8_t inst_id = 0);
@@ -95,6 +98,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
 
   uint16_t clients_[USE_ESP32_BLE_MAX_CONNECTIONS]{};
   uint8_t client_count_{0};
+  uint8_t max_clients_{1};
   std::vector<ServiceEntry> services_{};
   std::vector<BLEService *> services_to_start_{};
   BLEService *device_information_service_{};


### PR DESCRIPTION
## What does this implement/fix?

When a BLE client connects to the `esp32_ble_server`, the ESP-IDF Bluetooth stack automatically stops advertising. This means no additional clients can discover or connect to the server while the first client remains connected.

This PR adds a `max_clients` configuration option (default: `1`) that controls how many simultaneous BLE client connections the server will accept. When `max_clients > 1`, the server resumes advertising after a client connects, as long as the current client count is below the configured limit.

The default of `1` preserves the existing single-client behavior unchanged.

### Configuration

```yaml
esp32_ble_server:
  max_clients: 3
```

### Changes

- **`__init__.py`**: Added `max_clients` config key (int, 1–9, default 1) and `set_max_clients()` call in `to_code`
- **`ble_server.h`**: Added `max_clients_` member (default 1), `set_max_clients()` and `get_max_clients()` methods
- **`ble_server.cpp`**: In `ESP_GATTS_CONNECT_EVT`, restart advertising if `client_count_ < max_clients_`; added `max_clients` to `dump_config()`

## Use case

BLE proxy architectures where multiple peripheral devices (e.g., inverter proxies) need to simultaneously receive GATT notifications from a single BLE server. Without `max_clients > 1`, only one client can connect at a time.

## Types of changes

- New feature (non-breaking — default preserves current behavior)

## Related issue (if applicable)

N/A

## Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable)

- https://github.com/esphome/esphome-docs/pull/6148

## Test Environment

- ESP32-P4 (M5Stack Tab5) with ESP32-C6 coprocessor via esp32_hosted
- ESPHome 2026.2.1
- Two ESP32-S3 BLE proxy clients connecting simultaneously
- `esp32_ble: max_connections: 6` with `esp32_ble_server: max_clients: 3`

## Checklist:

  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (if appropriate).
