### PR TITLE
[version] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/progmem.h"
 
-namespace esphome {
-namespace version {
+namespace esphome::version {
 
 static const char *const TAG = "version.text_sensor";
 
@@ -35,5 +34,4 @@ void VersionTextSensor::setup() {
 void VersionTextSensor::set_hide_timestamp(bool hide_timestamp) { this->hide_timestamp_ = hide_timestamp; }
 void VersionTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Version Text Sensor", this); }
 
-}  // namespace version
-}  // namespace esphome
+}  // namespace esphome::version

--- a/esphome/components/version/version_text_sensor.h
+++ b/esphome/components/version/version_text_sensor.h
@@ -3,8 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace version {
+namespace esphome::version {
 
 class VersionTextSensor : public text_sensor::TextSensor, public Component {
  public:
@@ -16,5 +15,4 @@ class VersionTextSensor : public text_sensor::TextSensor, public Component {
   bool hide_timestamp_{false};
 };
 
-}  // namespace version
-}  // namespace esphome
+}  // namespace esphome::version


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::version {`) instead of the older nested style in the version text sensor component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).