### PR TITLE
[switch] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/switch/automation.cpp
+++ b/esphome/components/switch/automation.cpp
@@ -1,10 +1,8 @@
 #include "automation.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 static const char *const TAG = "switch.automation";
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/automation.h
+++ b/esphome/components/switch/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/switch/switch.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 template<typename... Ts> class TurnOnAction : public Action<Ts...> {
  public:
@@ -104,5 +103,4 @@ template<typename... Ts> class SwitchPublishAction : public Action<Ts...> {
   Switch *switch_;
 };
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/binary_sensor/switch_binary_sensor.cpp
+++ b/esphome/components/switch/binary_sensor/switch_binary_sensor.cpp
@@ -1,8 +1,7 @@
 #include "switch_binary_sensor.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 static const char *const TAG = "switch.binary_sensor";
 
@@ -13,5 +12,4 @@ void SwitchBinarySensor::setup() {
 
 void SwitchBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Switch Binary Sensor", this); }
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/binary_sensor/switch_binary_sensor.h
+++ b/esphome/components/switch/binary_sensor/switch_binary_sensor.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 class SwitchBinarySensor : public binary_sensor::BinarySensor, public Component {
  public:
@@ -17,5 +16,4 @@ class SwitchBinarySensor : public binary_sensor::BinarySensor, public Component 
   Switch *source_;
 };
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 static const char *const TAG = "switch";
 
@@ -107,5 +106,4 @@ void log_switch(const char *tag, const char *prefix, const char *type, Switch *o
   }
 }
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -5,8 +5,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 
-namespace esphome {
-namespace switch_ {
+namespace esphome::switch_ {
 
 #define SUB_SWITCH(name) \
  protected: \
@@ -146,5 +145,4 @@ class Switch : public EntityBase, public EntityBase_DeviceClass {
 #define LOG_SWITCH(prefix, type, obj) log_switch((TAG), (prefix), LOG_STR_LITERAL(type), (obj))
 void log_switch(const char *tag, const char *prefix, const char *type, Switch *obj);
 
-}  // namespace switch_
-}  // namespace esphome
+}  // namespace esphome::switch_

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -15,10 +15,10 @@ namespace esphome::switch_ {
   void set_##name##_switch(switch_::Switch *s) { this->name##_switch_ = s; }
 
 // bit0: on/off. bit1: persistent. bit2: inverted. bit3: disabled
-const int RESTORE_MODE_ON_MASK = 0x01;
-const int RESTORE_MODE_PERSISTENT_MASK = 0x02;
-const int RESTORE_MODE_INVERTED_MASK = 0x04;
-const int RESTORE_MODE_DISABLED_MASK = 0x08;
+constexpr int RESTORE_MODE_ON_MASK = 0x01;
+constexpr int RESTORE_MODE_PERSISTENT_MASK = 0x02;
+constexpr int RESTORE_MODE_INVERTED_MASK = 0x04;
+constexpr int RESTORE_MODE_DISABLED_MASK = 0x08;
 
 enum SwitchRestoreMode : uint8_t {
   SWITCH_ALWAYS_OFF = !RESTORE_MODE_ON_MASK,


### PR DESCRIPTION
# What does this implement/fix?

- Use C++17 nested namespace syntax (`namespace esphome::switch_ {`) instead of the older nested style in the switch component.
- Use `constexpr` for restore mode mask constants.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).