### PR TITLE
[text] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/text/automation.h
+++ b/esphome/components/text/automation.h
@@ -4,8 +4,7 @@
 #include "esphome/core/component.h"
 #include "text.h"
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 class TextStateTrigger : public Trigger<std::string> {
  public:
@@ -29,5 +28,4 @@ template<typename... Ts> class TextSetAction : public Action<Ts...> {
   Text *text_;
 };
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text

--- a/esphome/components/text/text.cpp
+++ b/esphome/components/text/text.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <cstring>
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 static const char *const TAG = "text";
 
@@ -34,5 +33,4 @@ void Text::add_on_state_callback(std::function<void(const std::string &)> &&call
   this->state_callback_.add(std::move(callback));
 }
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text

--- a/esphome/components/text/text.h
+++ b/esphome/components/text/text.h
@@ -6,8 +6,7 @@
 #include "text_call.h"
 #include "text_traits.h"
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 #define LOG_TEXT(prefix, type, obj) \
   if ((obj) != nullptr) { \
@@ -47,5 +46,4 @@ class Text : public EntityBase {
   LazyCallbackManager<void(const std::string &)> state_callback_;
 };
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text

--- a/esphome/components/text/text_call.cpp
+++ b/esphome/components/text/text_call.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "text.h"
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 static const char *const TAG = "text";
 
@@ -52,5 +51,4 @@ void TextCall::perform() {
   this->parent_->control(target_value);
 }
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text

--- a/esphome/components/text/text_call.h
+++ b/esphome/components/text/text_call.h
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "text_traits.h"
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 class Text;
 
@@ -21,5 +20,4 @@ class TextCall {
   void validate_();
 };
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text

--- a/esphome/components/text/text_traits.h
+++ b/esphome/components/text/text_traits.h
@@ -4,8 +4,7 @@
 
 #include "esphome/core/string_ref.h"
 
-namespace esphome {
-namespace text {
+namespace esphome::text {
 
 enum TextMode : uint8_t {
   TEXT_MODE_TEXT = 0,
@@ -37,5 +36,4 @@ class TextTraits {
   TextMode mode_{TEXT_MODE_TEXT};
 };
 
-}  // namespace text
-}  // namespace esphome
+}  // namespace esphome::text


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::text {`) instead of the older nested style in the text component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).