### PR TITLE
[text_sensor] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/text_sensor/automation.h
+++ b/esphome/components/text_sensor/automation.h
@@ -6,8 +6,7 @@
 #include "esphome/core/automation.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
-namespace esphome {
-namespace text_sensor {
+namespace esphome::text_sensor {
 
 class TextSensorStateTrigger : public Trigger<std::string> {
  public:
@@ -46,5 +45,4 @@ template<typename... Ts> class TextSensorPublishAction : public Action<Ts...> {
   TextSensor *sensor_;
 };
 
-}  // namespace text_sensor
-}  // namespace esphome
+}  // namespace esphome::text_sensor

--- a/esphome/components/text_sensor/filter.cpp
+++ b/esphome/components/text_sensor/filter.cpp
@@ -6,8 +6,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace text_sensor {
+namespace esphome::text_sensor {
 
 static const char *const TAG = "text_sensor.filter";
 
@@ -107,7 +106,6 @@ bool MapFilter::new_value(std::string &value) {
   return true;  // Pass through if no match
 }
 
-}  // namespace text_sensor
-}  // namespace esphome
+}  // namespace esphome::text_sensor
 
 #endif  // USE_TEXT_SENSOR_FILTER

--- a/esphome/components/text_sensor/filter.h
+++ b/esphome/components/text_sensor/filter.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace text_sensor {
+namespace esphome::text_sensor {
 
 class TextSensor;
 
@@ -165,7 +164,6 @@ class MapFilter : public Filter {
   FixedVector<Substitution> mappings_;
 };
 
-}  // namespace text_sensor
-}  // namespace esphome
+}  // namespace esphome::text_sensor
 
 #endif  // USE_TEXT_SENSOR_FILTER

--- a/esphome/components/text_sensor/text_sensor.cpp
+++ b/esphome/components/text_sensor/text_sensor.cpp
@@ -4,8 +4,7 @@
 #include "esphome/core/log.h"
 #include <cstring>
 
-namespace esphome {
-namespace text_sensor {
+namespace esphome::text_sensor {
 
 static const char *const TAG = "text_sensor";
 
@@ -125,5 +124,4 @@ void TextSensor::notify_frontend_() {
 #endif
 }
 
-}  // namespace text_sensor
-}  // namespace esphome
+}  // namespace esphome::text_sensor

--- a/esphome/components/text_sensor/text_sensor.h
+++ b/esphome/components/text_sensor/text_sensor.h
@@ -10,8 +10,7 @@
 #include <initializer_list>
 #include <memory>
 
-namespace esphome {
-namespace text_sensor {
+namespace esphome::text_sensor {
 
 class TextSensor;
 
@@ -84,5 +83,4 @@ class TextSensor : public EntityBase, public EntityBase_DeviceClass {
 #endif
 };
 
-}  // namespace text_sensor
-}  // namespace esphome
+}  // namespace esphome::text_sensor


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::text_sensor {`) instead of the older nested style in the text_sensor component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).