### PR TITLE
[usb_host] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/usb_host/usb_host.h
+++ b/esphome/components/usb_host/usb_host.h
@@ -12,8 +12,7 @@
 #include "esphome/core/event_pool.h"
 #include <atomic>
 
-namespace esphome {
-namespace usb_host {
+namespace esphome::usb_host {
 
 // THREADING MODEL:
 // This component uses a dedicated USB task for event processing to prevent data loss.
@@ -44,16 +43,16 @@ struct TransferRequest;
 class USBClient;
 
 // constants for setup packet type
-static const uint8_t USB_RECIP_DEVICE = 0;
-static const uint8_t USB_RECIP_INTERFACE = 1;
-static const uint8_t USB_RECIP_ENDPOINT = 2;
-static const uint8_t USB_TYPE_STANDARD = 0 << 5;
-static const uint8_t USB_TYPE_CLASS = 1 << 5;
-static const uint8_t USB_TYPE_VENDOR = 2 << 5;
-static const uint8_t USB_DIR_MASK = 1 << 7;
-static const uint8_t USB_DIR_IN = 1 << 7;
-static const uint8_t USB_DIR_OUT = 0;
-static const size_t SETUP_PACKET_SIZE = 8;
+static constexpr uint8_t USB_RECIP_DEVICE = 0;
+static constexpr uint8_t USB_RECIP_INTERFACE = 1;
+static constexpr uint8_t USB_RECIP_ENDPOINT = 2;
+static constexpr uint8_t USB_TYPE_STANDARD = 0 << 5;
+static constexpr uint8_t USB_TYPE_CLASS = 1 << 5;
+static constexpr uint8_t USB_TYPE_VENDOR = 2 << 5;
+static constexpr uint8_t USB_DIR_MASK = 1 << 7;
+static constexpr uint8_t USB_DIR_IN = 1 << 7;
+static constexpr uint8_t USB_DIR_OUT = 0;
+static constexpr size_t SETUP_PACKET_SIZE = 8;
 
 static constexpr size_t MAX_REQUESTS = USB_HOST_MAX_REQUESTS;  // maximum number of outstanding requests possible.
 static_assert(MAX_REQUESTS >= 1 && MAX_REQUESTS <= 32, "MAX_REQUESTS must be between 1 and 32");
@@ -189,7 +188,6 @@ class USBHost : public Component {
   std::vector<USBClient *> clients_{};
 };
 
-}  // namespace usb_host
-}  // namespace esphome
+}  // namespace esphome::usb_host
 
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -10,8 +10,7 @@
 #include <cstring>
 #include <atomic>
 #include <span>
-namespace esphome {
-namespace usb_host {
+namespace esphome::usb_host {
 
 #pragma GCC diagnostic ignored "-Wparentheses"
 
@@ -568,6 +567,5 @@ void USBClient::release_trq(TransferRequest *trq) {
   this->trq_in_use_.fetch_and(mask, std::memory_order_release);
 }
 
-}  // namespace usb_host
-}  // namespace esphome
+}  // namespace esphome::usb_host
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_host/usb_host_component.cpp
+++ b/esphome/components/usb_host/usb_host_component.cpp
@@ -4,8 +4,7 @@
 #include <cinttypes>
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace usb_host {
+namespace esphome::usb_host {
 
 void USBHost::setup() {
   usb_host_config_t config{};
@@ -28,7 +27,6 @@ void USBHost::loop() {
   }
 }
 
-}  // namespace usb_host
-}  // namespace esphome
+}  // namespace esphome::usb_host
 
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3


### PR DESCRIPTION
# What does this implement/fix?

- Use C++17 nested namespace syntax (`namespace esphome::usb_host {`) instead of the older nested style in the usb_host component.
- Use `constexpr` for USB setup packet constants.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).