### PR TITLE
[i2c] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/i2c/i2c.cpp
+++ b/esphome/components/i2c/i2c.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include <memory>
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 static const char *const TAG = "i2c";
 
@@ -109,5 +108,4 @@ uint8_t I2CRegister16::get() const {
   return value;
 }
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c

--- a/esphome/components/i2c/i2c.h
+++ b/esphome/components/i2c/i2c.h
@@ -6,8 +6,7 @@
 #include "esphome/core/optional.h"
 #include "i2c_bus.h"
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 #define LOG_I2C_DEVICE(this) ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
 
@@ -272,5 +271,4 @@ class I2CDevice {
   I2CBus *bus_{nullptr};   ///< pointer to I2CBus instance
 };
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c

--- a/esphome/components/i2c/i2c_bus.h
+++ b/esphome/components/i2c/i2c_bus.h
@@ -6,8 +6,7 @@
 
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 /// @brief Error codes returned by I2CBus and I2CDevice methods
 enum ErrorCode {
@@ -69,5 +68,4 @@ class InternalI2CBus : public I2CBus {
   virtual int get_port() const = 0;
 };
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -7,8 +7,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 static const char *const TAG = "i2c.arduino";
 
@@ -262,7 +261,6 @@ void ArduinoI2CBus::recover_() {
 
   recovery_result_ = RECOVERY_COMPLETED;
 }
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c
 
 #endif  // defined(USE_ARDUINO) && !defined(USE_ESP32)

--- a/esphome/components/i2c/i2c_bus_arduino.h
+++ b/esphome/components/i2c/i2c_bus_arduino.h
@@ -6,8 +6,7 @@
 #include "esphome/core/component.h"
 #include "i2c_bus.h"
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 enum RecoveryCode {
   RECOVERY_FAILED_SCL_LOW,
@@ -45,7 +44,6 @@ class ArduinoI2CBus : public InternalI2CBus, public Component {
   bool initialized_ = false;
 };
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c
 
 #endif  // defined(USE_ARDUINO) && !defined(USE_ESP32)

--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -10,8 +10,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 static const char *const TAG = "i2c.idf";
 
@@ -312,6 +311,5 @@ void IDFI2CBus::recover_() {
   recovery_result_ = RECOVERY_COMPLETED;
 }
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c
 #endif  // USE_ESP32

--- a/esphome/components/i2c/i2c_bus_esp_idf.h
+++ b/esphome/components/i2c/i2c_bus_esp_idf.h
@@ -6,8 +6,7 @@
 #include "i2c_bus.h"
 #include <driver/i2c_master.h>
 
-namespace esphome {
-namespace i2c {
+namespace esphome::i2c {
 
 enum RecoveryCode {
   RECOVERY_FAILED_SCL_LOW,
@@ -56,7 +55,6 @@ class IDFI2CBus : public InternalI2CBus, public Component {
 #endif
 };
 
-}  // namespace i2c
-}  // namespace esphome
+}  // namespace esphome::i2c
 
 #endif  // USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::i2c {`) instead of the older nested style in the i2c component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).