### PR TITLE
[cse7766] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -3,8 +3,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace cse7766 {
+namespace esphome::cse7766 {
 
 static const char *const TAG = "cse7766";
 
@@ -258,5 +257,4 @@ void CSE7766Component::dump_config() {
   this->check_uart_settings(4800, 1, uart::UART_CONFIG_PARITY_EVEN);
 }
 
-}  // namespace cse7766
-}  // namespace esphome
+}  // namespace esphome::cse7766

--- a/esphome/components/cse7766/cse7766.h
+++ b/esphome/components/cse7766/cse7766.h
@@ -5,8 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/uart/uart.h"
 
-namespace esphome {
-namespace cse7766 {
+namespace esphome::cse7766 {
 
 static constexpr size_t CSE7766_RAW_DATA_SIZE = 24;
 
@@ -49,5 +48,4 @@ class CSE7766Component : public Component, public uart::UARTDevice {
   uint16_t cf_pulses_last_{0};
 };
 
-}  // namespace cse7766
-}  // namespace esphome
+}  // namespace esphome::cse7766


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::cse7766 {`) instead of the older nested style in the cse7766 component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).