### PR TITLE
[network] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/network/ip_address.h
+++ b/esphome/components/network/ip_address.h
@@ -37,8 +37,7 @@ using ip4_addr_t = in_addr;
 #include <esp_netif.h>
 #endif
 
-namespace esphome {
-namespace network {
+namespace esphome::network {
 
 /// Buffer size for IP address string (IPv6 max: 39 chars + null)
 static constexpr size_t IP_ADDRESS_BUFFER_SIZE = 40;
@@ -187,6 +186,5 @@ struct IPAddress {
 
 using IPAddresses = std::array<IPAddress, 5>;
 
-}  // namespace network
-}  // namespace esphome
+}  // namespace esphome::network
 #endif

--- a/esphome/components/network/util.cpp
+++ b/esphome/components/network/util.cpp
@@ -17,8 +17,7 @@
 #include "esphome/components/modem/modem_component.h"
 #endif
 
-namespace esphome {
-namespace network {
+namespace esphome::network {
 
 // The order of the components is important: WiFi should come after any possible main interfaces (it may be used as
 // an AP that use a previous interface for NAT).
@@ -109,6 +108,5 @@ const char *get_use_address() {
 #endif
 }
 
-}  // namespace network
-}  // namespace esphome
+}  // namespace esphome::network
 #endif

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -4,8 +4,7 @@
 #include <string>
 #include "ip_address.h"
 
-namespace esphome {
-namespace network {
+namespace esphome::network {
 
 /// Return whether the node is connected to the network (through wifi, eth, ...)
 bool is_connected();
@@ -15,6 +14,5 @@ bool is_disabled();
 const char *get_use_address();
 IPAddresses get_ip_addresses();
 
-}  // namespace network
-}  // namespace esphome
+}  // namespace esphome::network
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Use C++17 nested namespace syntax (`namespace esphome::network {`) instead of the older nested style in the network component.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).