### PR TITLE
[core] ESP32: massively reduce main loop socket polling overhead by replacing select()

### DIFF
--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -126,13 +126,15 @@ def require_wake_loop_threadsafe() -> None:
     """Mark that wake_loop_threadsafe support is required by a component.
 
     Call this from components that need to wake the main event loop from background threads.
-
-    On ESP32: Uses FreeRTOS task notifications (<1 us, no socket needed).
-    On other platforms: Uses a shared UDP loopback socket mechanism (~208 bytes RAM).
+    This enables the shared UDP loopback socket mechanism (~208 bytes RAM).
+    The socket is shared across all components that use this feature.
 
     This call is a no-op if networking is not enabled in the configuration.
 
-    IMPORTANT: This is for background task context only, NOT ISR context.
+    IMPORTANT: This is for background thread context only, NOT ISR context.
+    Socket operations are not safe to call from ISR handlers.
+
+    On ESP32, FreeRTOS task notifications are used instead (no socket needed).
 
     Example:
         from esphome.components import socket

--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -127,13 +127,12 @@ def require_wake_loop_threadsafe() -> None:
 
     Call this from components that need to wake the main event loop from background threads.
 
-    On ESP32: Uses FreeRTOS task notifications (<1 us, ISR-safe, no socket needed).
+    On ESP32: Uses FreeRTOS task notifications (<1 us, no socket needed).
     On other platforms: Uses a shared UDP loopback socket mechanism (~208 bytes RAM).
 
     This call is a no-op if networking is not enabled in the configuration.
 
-    On ESP32, this is safe to call from ISR context.
-    On other platforms, this is for background thread context only, NOT ISR context.
+    IMPORTANT: This is for background task context only, NOT ISR context.
 
     Example:
         from esphome.components import socket

--- a/esphome/components/socket/__init__.py
+++ b/esphome/components/socket/__init__.py
@@ -126,13 +126,14 @@ def require_wake_loop_threadsafe() -> None:
     """Mark that wake_loop_threadsafe support is required by a component.
 
     Call this from components that need to wake the main event loop from background threads.
-    This enables the shared UDP loopback socket mechanism (~208 bytes RAM).
-    The socket is shared across all components that use this feature.
+
+    On ESP32: Uses FreeRTOS task notifications (<1 us, ISR-safe, no socket needed).
+    On other platforms: Uses a shared UDP loopback socket mechanism (~208 bytes RAM).
 
     This call is a no-op if networking is not enabled in the configuration.
 
-    IMPORTANT: This is for background thread context only, NOT ISR context.
-    Socket operations are not safe to call from ISR handlers.
+    On ESP32, this is safe to call from ISR context.
+    On other platforms, this is for background thread context only, NOT ISR context.
 
     Example:
         from esphome.components import socket
@@ -147,8 +148,10 @@ def require_wake_loop_threadsafe() -> None:
     ):
         CORE.data[KEY_WAKE_LOOP_THREADSAFE_REQUIRED] = True
         cg.add_define("USE_WAKE_LOOP_THREADSAFE")
-        # Consume 1 socket for the shared wake notification socket
-        consume_sockets(1, "socket.wake_loop_threadsafe", SocketType.UDP)({})
+        if not CORE.is_esp32:
+            # Only non-ESP32 platforms need a UDP socket for wake notifications.
+            # ESP32 uses FreeRTOS task notifications instead (no socket needed).
+            consume_sockets(1, "socket.wake_loop_threadsafe", SocketType.UDP)({})
 
 
 CONFIG_SCHEMA = cv.Schema(

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -71,7 +71,7 @@ class Socket {
   int get_fd() const { return -1; }
 #endif
 
-  /// Check if socket has data ready to read
+  /// Check if socket has data ready to read. Must only be called from the main loop thread.
   /// For select()-based sockets: non-virtual, checks Application's select() results
   /// For LWIP raw TCP sockets: virtual, checks internal buffer state
 #ifdef USE_SOCKET_SELECT_SUPPORT

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -634,16 +634,7 @@ void Application::unregister_socket_fd(int fd) {
 void Application::yield_with_select_(uint32_t delay_ms) {
   // Delay while monitoring sockets. When delay_ms is 0, always yield() to ensure other tasks run.
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
-  // ESP32 fast path: direct rcvevent reads (~858 ns for 4 sockets vs 133 us for lwip_select)
-  if (!this->socket_fds_.empty()) [[likely]] {
-    FD_ZERO(&this->read_fds_);
-    for (int fd : this->socket_fds_) {
-      if (esphome_lwip_socket_has_data(fd)) {
-        FD_SET(fd, &this->read_fds_);
-      }
-    }
-  }
-
+  // ESP32 fast path: no fd_set needed — is_socket_ready_() reads rcvevent directly (~215 ns per socket)
   if (delay_ms == 0) [[unlikely]] {
     yield();
     return;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -634,7 +634,8 @@ void Application::unregister_socket_fd(int fd) {
 void Application::yield_with_select_(uint32_t delay_ms) {
   // Delay while monitoring sockets. When delay_ms is 0, always yield() to ensure other tasks run.
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
-  // ESP32 fast path: no fd_set needed — is_socket_ready_() reads rcvevent directly (~215 ns per socket)
+  // ESP32 fast path: reads rcvevent directly via lwip_socket_dbg_get_socket() (~215 ns per socket).
+  // Safe because this runs on the main loop which owns socket lifetime (create, read, close).
   if (delay_ms == 0) [[unlikely]] {
     yield();
     return;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -611,10 +611,7 @@ void Application::unregister_socket_fd(int fd) {
     if (i < this->socket_fds_.size() - 1)
       this->socket_fds_[i] = this->socket_fds_.back();
     this->socket_fds_.pop_back();
-#ifdef USE_ESP32
-    // Unhook the socket's netconn callback
-    esphome_lwip_unhook_socket(fd);
-#else
+#ifndef USE_ESP32
     this->socket_fds_changed_ = true;
     // Only recalculate max_fd if we removed the current max
     if (fd == this->max_fd_) {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -608,7 +608,9 @@ void Application::unregister_socket_fd(int fd) {
     if (this->socket_fds_[i] != fd)
       continue;
 
-    // Swap with last element and pop - O(1) removal since order doesn't matter
+    // Swap with last element and pop - O(1) removal since order doesn't matter.
+    // No need to unhook the netconn callback on ESP32 — all LwIP sockets share
+    // the same static event_callback, and the socket will be closed by the caller.
     if (i < this->socket_fds_.size() - 1)
       this->socket_fds_[i] = this->socket_fds_.back();
     this->socket_fds_.pop_back();
@@ -640,6 +642,8 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 
   // Sleep with instant wake via FreeRTOS task notification.
   // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
+  // Without USE_WAKE_LOOP_THREADSAFE, only hooked socket callbacks wake the task —
+  // background tasks won't call wake, so this degrades to a pure timeout (same as old select path).
   ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -640,6 +640,17 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     return;
   }
 
+  // Check if any socket already has pending data before sleeping.
+  // If a socket still has unread data (rcvevent > 0) but the task notification was already
+  // consumed, ulTaskNotifyTake would block until timeout — adding up to delay_ms latency.
+  // This scan preserves select() semantics: return immediately when any fd is ready.
+  for (int fd : this->socket_fds_) {
+    if (esphome_lwip_socket_has_data(fd)) {
+      yield();
+      return;
+    }
+  }
+
   // Sleep with instant wake via FreeRTOS task notification.
   // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
   // Without USE_WAKE_LOOP_THREADSAFE, only hooked socket callbacks wake the task —

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -9,6 +9,9 @@
 #endif
 #ifdef USE_ESP32
 #include <esp_chip_info.h>
+#include "esphome/core/lwip_fast_select.h"
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 #endif
 #include "esphome/core/version.h"
 #include "esphome/core/hal.h"
@@ -145,8 +148,13 @@ void Application::setup() {
 #endif
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+#ifdef USE_ESP32
+  // Initialize fast select: saves main loop task handle for xTaskNotifyGive wake
+  esphome_lwip_fast_select_init();
+#else
   // Set up wake socket for waking main loop from tasks
   this->setup_wake_loop_threadsafe_();
+#endif
 #endif
 
   this->schedule_dump_config();
@@ -523,7 +531,7 @@ void Application::enable_pending_loops_() {
 }
 
 void Application::before_loop_tasks_(uint32_t loop_start_time) {
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
   // Drain wake notifications first to clear socket for next wake
   this->drain_wake_notifications_();
 #endif
@@ -576,11 +584,15 @@ bool Application::register_socket_fd(int fd) {
 #endif
 
   this->socket_fds_.push_back(fd);
+#ifdef USE_ESP32
+  // Hook the socket's netconn callback for instant wake on receive events
+  esphome_lwip_hook_socket(fd);
+#else
   this->socket_fds_changed_ = true;
-
   if (fd > this->max_fd_) {
     this->max_fd_ = fd;
   }
+#endif
 
   return true;
 }
@@ -599,8 +611,11 @@ void Application::unregister_socket_fd(int fd) {
     if (i < this->socket_fds_.size() - 1)
       this->socket_fds_[i] = this->socket_fds_.back();
     this->socket_fds_.pop_back();
+#ifdef USE_ESP32
+    // Unhook the socket's netconn callback
+    esphome_lwip_unhook_socket(fd);
+#else
     this->socket_fds_changed_ = true;
-
     // Only recalculate max_fd if we removed the current max
     if (fd == this->max_fd_) {
       this->max_fd_ = -1;
@@ -609,6 +624,7 @@ void Application::unregister_socket_fd(int fd) {
           this->max_fd_ = sock_fd;
       }
     }
+#endif
     return;
   }
 }
@@ -616,16 +632,34 @@ void Application::unregister_socket_fd(int fd) {
 #endif
 
 void Application::yield_with_select_(uint32_t delay_ms) {
-  // Delay while monitoring sockets. When delay_ms is 0, always yield() to ensure other tasks run
-  // since select() with 0 timeout only polls without yielding.
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  if (!this->socket_fds_.empty()) {
+  // Delay while monitoring sockets. When delay_ms is 0, always yield() to ensure other tasks run.
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
+  // ESP32 fast path: direct rcvevent reads (~858 ns for 4 sockets vs 133 us for lwip_select)
+  if (!this->socket_fds_.empty()) [[likely]] {
+    FD_ZERO(&this->read_fds_);
+    for (int fd : this->socket_fds_) {
+      if (esphome_lwip_socket_has_data(fd)) {
+        FD_SET(fd, &this->read_fds_);
+      }
+    }
+  }
+
+  if (delay_ms == 0) [[unlikely]] {
+    yield();
+    return;
+  }
+
+  // Sleep with instant wake via FreeRTOS task notification.
+  // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
+  ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
+
+#elif defined(USE_SOCKET_SELECT_SUPPORT)
+  // Non-ESP32 platforms (LibreTiny bk72xx/rtl87xx): use select()
+  if (!this->socket_fds_.empty()) [[likely]] {
     // Update fd_set if socket list has changed
-    if (this->socket_fds_changed_) {
+    if (this->socket_fds_changed_) [[unlikely]] {
       FD_ZERO(&this->base_read_fds_);
-      // fd bounds are already validated in register_socket_fd() or guaranteed by platform design:
-      // - ESP32: LwIP guarantees fd < FD_SETSIZE by design (LWIP_SOCKET_OFFSET = FD_SETSIZE - CONFIG_LWIP_MAX_SOCKETS)
-      // - Other platforms: register_socket_fd() validates fd < FD_SETSIZE
+      // fd bounds are validated in register_socket_fd()
       for (int fd : this->socket_fds_) {
         FD_SET(fd, &this->base_read_fds_);
       }
@@ -641,7 +675,7 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     tv.tv_usec = (delay_ms - tv.tv_sec * 1000) * 1000;
 
     // Call select with timeout
-#if defined(USE_SOCKET_IMPL_LWIP_SOCKETS) || (defined(USE_ESP32) && defined(USE_SOCKET_IMPL_BSD_SOCKETS))
+#ifdef USE_SOCKET_IMPL_LWIP_SOCKETS
     int ret = lwip_select(this->max_fd_ + 1, &this->read_fds_, nullptr, nullptr, &tv);
 #else
     int ret = ::select(this->max_fd_ + 1, &this->read_fds_, nullptr, nullptr, &tv);
@@ -651,19 +685,18 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     // ret < 0: error (except EINTR which is normal)
     // ret > 0: socket(s) have data ready - normal and expected
     // ret == 0: timeout occurred - normal and expected
-    if (ret < 0 && errno != EINTR) {
-      // Actual error - log and fall back to delay
-      ESP_LOGW(TAG, "select() failed with errno %d", errno);
-      delay(delay_ms);
+    if (ret >= 0 || errno == EINTR) [[likely]] {
+      // Yield if zero timeout since select(0) only polls without yielding
+      if (delay_ms == 0) [[unlikely]] {
+        yield();
+      }
+      return;
     }
-    // When delay_ms is 0, we need to yield since select(0) doesn't yield
-    if (delay_ms == 0) {
-      yield();
-    }
-  } else {
-    // No sockets registered, use regular delay
-    delay(delay_ms);
+    // select() error - log and fall through to delay()
+    ESP_LOGW(TAG, "select() failed with errno %d", errno);
   }
+  // No sockets registered or select() failed - use regular delay
+  delay(delay_ms);
 #elif defined(USE_ESP8266) && defined(USE_SOCKET_IMPL_LWIP_TCP)
   // No select support but can wake on socket activity via esp_schedule()
   socket::socket_delay(delay_ms);
@@ -676,6 +709,14 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 Application App;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+
+#ifdef USE_ESP32
+void Application::wake_loop_threadsafe() {
+  // Direct FreeRTOS task notification — ISR-safe, <1 us
+  esphome_lwip_wake_main_loop();
+}
+#else   // !USE_ESP32
+
 void Application::setup_wake_loop_threadsafe_() {
   // Create UDP socket for wake notifications
   this->wake_socket_fd_ = lwip_socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -742,6 +783,8 @@ void Application::wake_loop_threadsafe() {
     lwip_send(this->wake_socket_fd_, &dummy, 1, 0);
   }
 }
+#endif  // USE_ESP32
+
 #endif  // defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
 
 void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer) {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -647,6 +647,7 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   // This scan preserves select() semantics: return immediately when any fd is ready.
   for (int fd : this->socket_fds_) {
     if (esphome_lwip_socket_has_data(fd)) {
+      this->fast_select_skip_count_++;
       yield();
       return;
     }
@@ -656,7 +657,20 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
   // Without USE_WAKE_LOOP_THREADSAFE, only hooked socket callbacks wake the task —
   // background tasks won't call wake, so this degrades to a pure timeout (same as old select path).
-  ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
+  uint32_t notified = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
+  if (notified > 0) {
+    this->fast_select_woken_count_++;
+  } else {
+    this->fast_select_timeout_count_++;
+  }
+  if (++this->fast_select_total_count_ >= 10000) {
+    ESP_LOGD(TAG, "fast_select: woken=%" PRIu32 " timeout=%" PRIu32 " skip=%" PRIu32 " (of 10000 loops)",
+             this->fast_select_woken_count_, this->fast_select_timeout_count_, this->fast_select_skip_count_);
+    this->fast_select_total_count_ = 0;
+    this->fast_select_woken_count_ = 0;
+    this->fast_select_timeout_count_ = 0;
+    this->fast_select_skip_count_ = 0;
+  }
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)
   // Non-ESP32 select() path (LibreTiny bk72xx/rtl87xx, host platform).

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -147,14 +147,15 @@ void Application::setup() {
   clear_setup_priority_overrides();
 #endif
 
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
-#ifdef USE_ESP32
-  // Initialize fast select: saves main loop task handle for xTaskNotifyGive wake
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
+  // Initialize fast select: saves main loop task handle for xTaskNotifyGive wake.
+  // Always init on ESP32 — the fast path (rcvevent reads + ulTaskNotifyTake) is used
+  // unconditionally when USE_SOCKET_SELECT_SUPPORT is enabled.
   esphome_lwip_fast_select_init();
-#else
-  // Set up wake socket for waking main loop from tasks
-  this->setup_wake_loop_threadsafe_();
 #endif
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
+  // Set up wake socket for waking main loop from tasks (non-ESP32 only)
+  this->setup_wake_loop_threadsafe_();
 #endif
 
   this->schedule_dump_config();
@@ -642,7 +643,9 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)
-  // Non-ESP32 platforms (LibreTiny bk72xx/rtl87xx): use select()
+  // Non-ESP32 select() path (LibreTiny bk72xx/rtl87xx, host platform).
+  // ESP32 is excluded by the #if above — both BSD_SOCKETS and LWIP_SOCKETS on ESP32
+  // use LwIP under the hood, so the fast path handles all ESP32 socket implementations.
   if (!this->socket_fds_.empty()) [[likely]] {
     // Update fd_set if socket list has changed
     if (this->socket_fds_changed_) [[unlikely]] {
@@ -700,7 +703,7 @@ Application App;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 #ifdef USE_ESP32
 void Application::wake_loop_threadsafe() {
-  // Direct FreeRTOS task notification — ISR-safe, <1 us
+  // Direct FreeRTOS task notification — <1 us, task context only (NOT ISR-safe)
   esphome_lwip_wake_main_loop();
 }
 #else   // !USE_ESP32

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -647,7 +647,6 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   // This scan preserves select() semantics: return immediately when any fd is ready.
   for (int fd : this->socket_fds_) {
     if (esphome_lwip_socket_has_data(fd)) {
-      this->fast_select_skip_count_++;
       yield();
       return;
     }
@@ -657,20 +656,7 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
   // Without USE_WAKE_LOOP_THREADSAFE, only hooked socket callbacks wake the task —
   // background tasks won't call wake, so this degrades to a pure timeout (same as old select path).
-  uint32_t notified = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
-  if (notified > 0) {
-    this->fast_select_woken_count_++;
-  } else {
-    this->fast_select_timeout_count_++;
-  }
-  if (++this->fast_select_total_count_ >= 10000) {
-    ESP_LOGD(TAG, "fast_select: woken=%" PRIu32 " timeout=%" PRIu32 " skip=%" PRIu32 " (of 10000 loops)",
-             this->fast_select_woken_count_, this->fast_select_timeout_count_, this->fast_select_skip_count_);
-    this->fast_select_total_count_ = 0;
-    this->fast_select_woken_count_ = 0;
-    this->fast_select_timeout_count_ = 0;
-    this->fast_select_skip_count_ = 0;
-  }
+  ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)
   // Non-ESP32 select() path (LibreTiny bk72xx/rtl87xx, host platform).

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -511,13 +511,12 @@ class Application {
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
   /// Fast path for Socket::ready() via friendship - skips negative fd check.
-  /// Safe because: fd was validated in register_socket_fd() at registration time,
-  /// and Socket::ready() only calls this when loop_monitored_ is true (registration succeeded).
+  /// Main loop only — on ESP32, reads rcvevent via lwip_socket_dbg_get_socket()
+  /// which has no refcount; safe only because the main loop owns socket lifetime
+  /// (creates, reads, and closes sockets on the same thread).
 #ifdef USE_ESP32
-  /// ESP32: direct rcvevent read — always fresh, no fd_set snapshot needed (~215 ns)
   bool is_socket_ready_(int fd) const { return esphome_lwip_socket_has_data(fd); }
 #else
-  /// Other platforms: check fd_set populated by select()
   bool is_socket_ready_(int fd) const { return FD_ISSET(fd, &this->read_fds_); }
 #endif
 #endif

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -592,13 +592,6 @@ class Application {
 #if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_ESP32)
   int max_fd_{-1};  // Highest file descriptor number for select()
 #endif
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
-  // Diagnostic counters for fast select sleep behavior (logged every 1000 loops)
-  uint32_t fast_select_total_count_{0};
-  uint32_t fast_select_woken_count_{0};    // Woken by notification (socket data or wake_loop_threadsafe)
-  uint32_t fast_select_timeout_count_{0};  // Slept full duration (no notification)
-  uint32_t fast_select_skip_count_{0};     // Skipped sleep (socket already had data)
-#endif
 
   // 2-byte members (grouped together for alignment)
   uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -495,11 +495,6 @@ class Application {
   /// @return true if registration was successful, false if fd exceeds limits
   bool register_socket_fd(int fd);
   void unregister_socket_fd(int fd);
-  /// Check if there's data available on a socket without blocking.
-  /// Must only be called from the main loop thread — on ESP32, the underlying
-  /// lwip_socket_dbg_get_socket() has no refcount, so socket lifetime safety
-  /// depends on both reads and close happening on the same thread.
-  bool is_socket_ready(int fd) const { return fd >= 0 && this->is_socket_ready_(fd); }
 
 #ifdef USE_WAKE_LOOP_THREADSAFE
   /// Wake the main event loop from another FreeRTOS task.
@@ -715,8 +710,8 @@ static constexpr size_t WAKE_NOTIFY_DRAIN_BUFFER_SIZE = 16;
 
 inline void Application::drain_wake_notifications_() {
   // Called from main loop to drain any pending wake notifications
-  // Must check is_socket_ready() to avoid blocking on empty socket
-  if (this->wake_socket_fd_ >= 0 && this->is_socket_ready(this->wake_socket_fd_)) {
+  // Must check is_socket_ready_() to avoid blocking on empty socket
+  if (this->wake_socket_fd_ >= 0 && this->is_socket_ready_(this->wake_socket_fd_)) {
     char buffer[WAKE_NOTIFY_DRAIN_BUFFER_SIZE];
     // Drain all pending notifications with non-blocking reads
     // Multiple wake events may have triggered multiple writes, so drain until EWOULDBLOCK

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -25,7 +25,7 @@
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
 #include <sys/select.h>
-#ifdef USE_WAKE_LOOP_THREADSAFE
+#if defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
 #include <lwip/sockets.h>
 #endif
 #endif  // USE_SOCKET_SELECT_SUPPORT
@@ -497,9 +497,10 @@ class Application {
   bool is_socket_ready(int fd) const { return fd >= 0 && this->is_socket_ready_(fd); }
 
 #ifdef USE_WAKE_LOOP_THREADSAFE
-  /// Wake the main event loop from a FreeRTOS task
-  /// Thread-safe, can be called from task context to immediately wake select()
-  /// IMPORTANT: NOT safe to call from ISR context (socket operations not ISR-safe)
+  /// Wake the main event loop from a FreeRTOS task or ISR.
+  /// Thread-safe, can be called from any context to immediately wake the main loop.
+  /// On ESP32: uses xTaskNotifyGive (<1 us, ISR-safe)
+  /// On other platforms: uses UDP loopback socket (NOT ISR-safe)
   void wake_loop_threadsafe();
 #endif
 #endif
@@ -541,7 +542,7 @@ class Application {
   /// Perform a delay while also monitoring socket file descriptors for readiness
   void yield_with_select_(uint32_t delay_ms);
 
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
   void setup_wake_loop_threadsafe_();       // Create wake notification socket
   inline void drain_wake_notifications_();  // Read pending wake notifications in main loop (hot path - inlined)
 #endif
@@ -571,7 +572,7 @@ class Application {
   FixedVector<Component *> looping_components_{};
 #ifdef USE_SOCKET_SELECT_SUPPORT
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
-#ifdef USE_WAKE_LOOP_THREADSAFE
+#if defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
   int wake_socket_fd_{-1};  // Shared wake notification socket for waking main loop from tasks
 #endif
 #endif
@@ -584,7 +585,7 @@ class Application {
   uint32_t last_loop_{0};
   uint32_t loop_component_start_time_{0};
 
-#ifdef USE_SOCKET_SELECT_SUPPORT
+#if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_ESP32)
   int max_fd_{-1};  // Highest file descriptor number for select()
 #endif
 
@@ -600,14 +601,16 @@ class Application {
   bool in_loop_{false};
   volatile bool has_pending_enable_loop_requests_{false};
 
-#ifdef USE_SOCKET_SELECT_SUPPORT
+#if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_ESP32)
   bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
 #endif
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
   // Variable-sized members
-  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
-  fd_set read_fds_{};       // Working fd_set for select(), copied from base_read_fds_
+  fd_set read_fds_{};  // Working fd_set: populated by select() or direct rcvevent reads
+#ifndef USE_ESP32
+  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes (select() path)
+#endif
 #endif
 
   // StaticVectors (largest members - contain actual array data inline)
@@ -694,7 +697,7 @@ class Application {
 /// Global storage of Application pointer - only one Application can exist.
 extern Application App;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
 // Inline implementations for hot-path functions
 // drain_wake_notifications_() is called on every loop iteration
 
@@ -716,6 +719,6 @@ inline void Application::drain_wake_notifications_() {
     }
   }
 }
-#endif  // defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
+#endif  // defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
 
 }  // namespace esphome

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -24,9 +24,13 @@
 #endif
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
+#ifdef USE_ESP32
+#include "esphome/core/lwip_fast_select.h"
+#else
 #include <sys/select.h>
-#if defined(USE_WAKE_LOOP_THREADSAFE) && !defined(USE_ESP32)
+#ifdef USE_WAKE_LOOP_THREADSAFE
 #include <lwip/sockets.h>
+#endif
 #endif
 #endif  // USE_SOCKET_SELECT_SUPPORT
 
@@ -497,10 +501,10 @@ class Application {
   bool is_socket_ready(int fd) const { return fd >= 0 && this->is_socket_ready_(fd); }
 
 #ifdef USE_WAKE_LOOP_THREADSAFE
-  /// Wake the main event loop from a FreeRTOS task or ISR.
-  /// Thread-safe, can be called from any context to immediately wake the main loop.
-  /// On ESP32: uses xTaskNotifyGive (<1 us, ISR-safe)
-  /// On other platforms: uses UDP loopback socket (NOT ISR-safe)
+  /// Wake the main event loop from another FreeRTOS task.
+  /// Thread-safe, but must only be called from task context (NOT ISR-safe).
+  /// On ESP32: uses xTaskNotifyGive (<1 us)
+  /// On other platforms: uses UDP loopback socket
   void wake_loop_threadsafe();
 #endif
 #endif
@@ -513,8 +517,13 @@ class Application {
   /// Fast path for Socket::ready() via friendship - skips negative fd check.
   /// Safe because: fd was validated in register_socket_fd() at registration time,
   /// and Socket::ready() only calls this when loop_monitored_ is true (registration succeeded).
-  /// FD_ISSET may include its own upper bounds check depending on platform.
+#ifdef USE_ESP32
+  /// ESP32: direct rcvevent read — always fresh, no fd_set snapshot needed (~215 ns)
+  bool is_socket_ready_(int fd) const { return esphome_lwip_socket_has_data(fd); }
+#else
+  /// Other platforms: check fd_set populated by select()
   bool is_socket_ready_(int fd) const { return FD_ISSET(fd, &this->read_fds_); }
+#endif
 #endif
 
   void register_component_(Component *comp);
@@ -605,12 +614,10 @@ class Application {
   bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
 #endif
 
-#ifdef USE_SOCKET_SELECT_SUPPORT
-  // Variable-sized members
-  fd_set read_fds_{};  // Working fd_set: populated by select() or direct rcvevent reads
-#ifndef USE_ESP32
-  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes (select() path)
-#endif
+#if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_ESP32)
+  // Variable-sized members (not needed on ESP32 — is_socket_ready_ reads rcvevent directly)
+  fd_set read_fds_{};       // Working fd_set: populated by select()
+  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
 #endif
 
   // StaticVectors (largest members - contain actual array data inline)

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -592,6 +592,13 @@ class Application {
 #if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_ESP32)
   int max_fd_{-1};  // Highest file descriptor number for select()
 #endif
+#if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_ESP32)
+  // Diagnostic counters for fast select sleep behavior (logged every 1000 loops)
+  uint32_t fast_select_total_count_{0};
+  uint32_t fast_select_woken_count_{0};    // Woken by notification (socket data or wake_loop_threadsafe)
+  uint32_t fast_select_timeout_count_{0};  // Slept full duration (no notification)
+  uint32_t fast_select_skip_count_{0};     // Skipped sleep (socket already had data)
+#endif
 
   // 2-byte members (grouped together for alignment)
   uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -495,9 +495,10 @@ class Application {
   /// @return true if registration was successful, false if fd exceeds limits
   bool register_socket_fd(int fd);
   void unregister_socket_fd(int fd);
-  /// Check if there's data available on a socket without blocking
-  /// This function is thread-safe for reading, but should be called after select() has run
-  /// The read_fds_ is only modified by select() in the main loop
+  /// Check if there's data available on a socket without blocking.
+  /// Must only be called from the main loop thread — on ESP32, the underlying
+  /// lwip_socket_dbg_get_socket() has no refcount, so socket lifetime safety
+  /// depends on both reads and close happening on the same thread.
   bool is_socket_ready(int fd) const { return fd >= 0 && this->is_socket_ready_(fd); }
 
 #ifdef USE_WAKE_LOOP_THREADSAFE

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -6,6 +6,52 @@
 // 2. The netconn callback is a C function pointer
 //
 // defines.h is force-included by the build system (-include flag), providing USE_ESP32 etc.
+//
+// Thread safety analysis
+// ======================
+// Three threads interact with this code:
+//   1. Main loop task   — calls init, has_data, hook, unhook
+//   2. LwIP TCP/IP task — calls event_callback (which reads s_original_callback, writes rcvevent)
+//   3. Background tasks — call wake_main_loop
+//
+// Shared state and safety rationale:
+//
+//   s_main_loop_task (TaskHandle_t, 4 bytes):
+//     Written once by main loop in init(), before any hook/wake calls.
+//     Read by TCP/IP thread (in callback) and background tasks (in wake).
+//     Safe: write-once-then-read pattern. The init() call completes during setup()
+//     before any sockets are hooked, so all subsequent reads see the final value.
+//
+//   s_original_callback (netconn_callback, 4-byte function pointer):
+//     Written by main loop in hook_socket() (only when NULL — set once).
+//     Read by TCP/IP thread in esphome_socket_event_callback().
+//     Safe: set-once pattern. The first hook_socket() captures the original callback.
+//     All subsequent hooks see it already set and skip the write. The TCP/IP thread
+//     only reads this after the callback pointer has been swapped (which happens after
+//     the write), so it always sees the initialized value.
+//
+//   sock->conn->callback (netconn_callback, 4-byte function pointer):
+//     Written by main loop in hook_socket() and unhook_socket().
+//     Read by TCP/IP thread when invoking the callback.
+//     Safe: 32-bit aligned pointer writes are atomic on Xtensa and RISC-V (ESP32).
+//     The TCP/IP thread will see either the old or new pointer atomically — never a
+//     torn value. Both the wrapper and original callbacks are valid at all times
+//     (the wrapper itself calls the original), so either value is correct.
+//
+//   sock->rcvevent (s16_t, 2 bytes):
+//     Written by TCP/IP thread in event_callback (via SYS_ARCH_INC/DEC under lock).
+//     Read by main loop in has_data().
+//     Safe: aligned 16-bit reads are atomic on Xtensa/RISC-V. We use __atomic_load_n
+//     with __ATOMIC_RELAXED to prevent compiler reordering. Staleness is acceptable —
+//     a missed increment means we poll again next loop iteration (~16ms), and the
+//     task notification provides the real wake signal.
+//
+//   FreeRTOS task notification value:
+//     Written by TCP/IP thread (xTaskNotifyGive in callback) and background tasks
+//     (xTaskNotifyGive in wake_main_loop). Read by main loop (ulTaskNotifyTake).
+//     Safe: FreeRTOS notification APIs are thread-safe by design (use internal
+//     critical sections). Multiple concurrent xTaskNotifyGive calls are safe —
+//     the notification count simply increments.
 
 #ifdef USE_ESP32
 
@@ -17,10 +63,30 @@
 
 #include "esphome/core/lwip_fast_select.h"
 
-// Task handle for the main loop — set during setup, read from any thread/ISR
+#include <stddef.h>
+
+// Compile-time verification of thread safety assumptions.
+// On ESP32 (Xtensa/RISC-V), naturally-aligned reads/writes up to 32 bits are atomic.
+// These asserts ensure our cross-thread shared state meets those requirements.
+
+// Pointer types must fit in a single 32-bit store (atomic write)
+_Static_assert(sizeof(TaskHandle_t) <= 4, "TaskHandle_t must be <= 4 bytes for atomic access");
+_Static_assert(sizeof(netconn_callback) <= 4, "netconn_callback must be <= 4 bytes for atomic access");
+
+// rcvevent must fit in a single atomic read
+_Static_assert(sizeof(((struct lwip_sock *) 0)->rcvevent) <= 4, "rcvevent must be <= 4 bytes for atomic access");
+
+// Struct member alignment — natural alignment guarantees atomicity on Xtensa/RISC-V.
+// Misaligned access would not be atomic even if the size is <= 4 bytes.
+_Static_assert(offsetof(struct netconn, callback) % sizeof(netconn_callback) == 0,
+               "netconn.callback must be naturally aligned for atomic access");
+_Static_assert(offsetof(struct lwip_sock, rcvevent) % sizeof(((struct lwip_sock *) 0)->rcvevent) == 0,
+               "lwip_sock.rcvevent must be naturally aligned for atomic access");
+
+// Task handle for the main loop — written once in init(), read from TCP/IP and background tasks.
 static TaskHandle_t s_main_loop_task = NULL;
 
-// Saved original event_callback pointer (same for all LwIP sockets)
+// Saved original event_callback pointer — written once in first hook_socket(), read from TCP/IP task.
 static netconn_callback s_original_callback = NULL;
 
 // Wrapper callback: calls original event_callback + notifies main loop task.
@@ -33,7 +99,6 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
   }
   // Wake the main loop task if sleeping in ulTaskNotifyTake().
   // Only notify on receive events to avoid spurious wakeups from send-ready events.
-  // xTaskNotifyGive is safe from task context (LwIP TCP/IP thread). NOT ISR-safe.
   if (evt == NETCONN_EVT_RCVPLUS) {
     TaskHandle_t task = s_main_loop_task;
     if (task != NULL) {
@@ -48,10 +113,8 @@ bool esphome_lwip_socket_has_data(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
   if (sock == NULL || sock->conn == NULL)
     return false;
-  // rcvevent is modified by LwIP's TCP/IP thread in event_callback.
-  // Use atomic load for C11 memory model correctness. On Xtensa/RISC-V (ESP32)
-  // aligned 16-bit reads are naturally atomic, so this compiles to a plain load
-  // but prevents compiler reordering.
+  // Atomic load prevents compiler reordering. On ESP32 this compiles to a plain load
+  // since aligned 16-bit reads are naturally atomic on Xtensa/RISC-V.
   return __atomic_load_n(&sock->rcvevent, __ATOMIC_RELAXED) > 0;
 }
 
@@ -60,15 +123,13 @@ void esphome_lwip_hook_socket(int fd) {
   if (sock == NULL || sock->conn == NULL)
     return;
 
-  // Save original callback (only once — same event_callback for all LwIP sockets)
+  // Save original callback once — all LwIP sockets share the same event_callback.
   if (s_original_callback == NULL) {
     s_original_callback = sock->conn->callback;
   }
 
-  // Replace with our wrapper.
-  // Thread safety: pointer writes are atomic on ESP32 (32-bit aligned).
-  // The TCP/IP thread may read conn->callback concurrently, but it will see
-  // either the old or new pointer — both are valid (our wrapper calls the original).
+  // Replace with our wrapper. Atomic on ESP32 (32-bit aligned pointer write).
+  // TCP/IP thread sees either old or new pointer — both are valid.
   sock->conn->callback = esphome_socket_event_callback;
 }
 
@@ -77,14 +138,13 @@ void esphome_lwip_unhook_socket(int fd) {
   if (sock == NULL || sock->conn == NULL)
     return;
 
-  // Restore original callback.
-  // Thread safety: same as hook — pointer write is atomic on ESP32.
-  // TCP/IP thread sees either wrapper or original, both are safe.
+  // Restore original callback. Atomic on ESP32 (32-bit aligned pointer write).
   if (s_original_callback != NULL) {
     sock->conn->callback = s_original_callback;
   }
 }
 
+// Wake the main loop from another FreeRTOS task. NOT ISR-safe.
 void esphome_lwip_wake_main_loop(void) {
   TaskHandle_t task = s_main_loop_task;
   if (task != NULL) {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -130,10 +130,16 @@ void esphome_lwip_hook_socket(int fd) {
   if (sock == NULL || sock->conn == NULL)
     return;
 
-  // Save original callback once — all LwIP sockets share the same event_callback.
+  // Save original callback once — all LwIP sockets share the same static event_callback
+  // (DEFAULT_SOCKET_EVENTCB in sockets.c, used for SOCK_RAW, SOCK_DGRAM, and SOCK_STREAM).
   if (s_original_callback == NULL) {
     s_original_callback = sock->conn->callback;
   }
+
+  // Verify assumption: if we already have the original, this socket should have the same one.
+  // If this fires, LwIP changed to use per-socket callbacks and we need a per-fd array.
+  LWIP_ASSERT("all sockets must share the same event_callback",
+              sock->conn->callback == s_original_callback || sock->conn->callback == esphome_socket_event_callback);
 
   // Replace with our wrapper. Atomic on ESP32 (32-bit aligned pointer write).
   // TCP/IP thread sees either old or new pointer — both are valid.

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -49,6 +49,8 @@
 // is single-writer for close. ESPHome guarantees this by design: all socket
 // create/read/close happens on the main loop. fd numbers are not reused while
 // the slot remains allocated, and the slot remains allocated until lwip_close().
+// Any change in LwIP that allows free_socket() to be called outside lwip_close()
+// would invalidate this assumption.
 //
 // LwIP source references for slot lifetime:
 //   sockets.c (same commit as above):

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -127,10 +127,12 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
 
 void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTaskHandle(); }
 
-// lwip_socket_dbg_get_socket() is a direct array lookup without the refcount that
-// get_socket()/done_socket() uses. This is safe because the caller owns the socket
-// lifetime: both has_data() and socket close happen on the main loop thread, so
-// the sockets[] entry cannot be freed while we read it.
+// lwip_socket_dbg_get_socket() is a thin wrapper around the static
+// tryget_socket_unconn_nouse() — a direct array lookup without the refcount
+// that get_socket()/done_socket() uses. This is safe because the caller owns
+// the socket lifetime: both has_data() and socket close happen on the main
+// loop thread, so the sockets[] entry cannot be freed while we read it.
+// If lwip_socket_dbg_get_socket() were ever removed, we could fall back to lwip_select().
 // Returns the sock only if both the sock and its netconn are valid, NULL otherwise.
 static inline struct lwip_sock *get_sock(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -31,6 +31,31 @@
 //     - SYS_ARCH_UNPROTECT calls sys_arch_unprotect(): L506
 //     (ESP-IDF implements sys_arch_protect/unprotect as FreeRTOS mutex lock/unlock)
 //
+// Socket slot lifetime
+// ====================
+// This code reads struct lwip_sock fields without SYS_ARCH_PROTECT. The safety
+// argument requires that the slot cannot be freed while we read it.
+//
+// In LwIP, the socket table is a static array and slots are only freed via:
+//   lwip_close() -> lwip_close_internal() -> free_socket_free_elements() -> free_socket()
+// The TCP/IP thread does NOT call free_socket(). On link loss, RST, or timeout
+// it frees the TCP PCB and signals the netconn (rcvevent++ to indicate EOF), but
+// the netconn and lwip_sock slot remain allocated until the application calls
+// lwip_close(). ESPHome only calls lwip_close() from the main loop, after
+// unregister_socket_fd() has already removed the fd from the monitored set.
+//
+// Therefore lwip_socket_dbg_get_socket(fd) plus a volatile read of rcvevent is
+// safe as long as the application is single-writer for close — which ESPHome
+// guarantees by design (all socket create/read/close happens on the main loop).
+//
+// LwIP source references for slot lifetime:
+//   sockets.c (same commit as above):
+//     - alloc_socket (slot allocation): L419
+//     - free_socket (slot deallocation): L384
+//     - free_socket_free_elements (called from lwip_close_internal): L393
+//     - lwip_close_internal (only caller of free_socket_free_elements): L2355
+//     - lwip_close (only caller of lwip_close_internal): L2450
+//
 // Shared state and safety rationale:
 //
 //   s_main_loop_task (TaskHandle_t, 4 bytes):
@@ -132,9 +157,10 @@ void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTas
 
 // lwip_socket_dbg_get_socket() is a thin wrapper around the static
 // tryget_socket_unconn_nouse() — a direct array lookup without the refcount
-// that get_socket()/done_socket() uses. This is safe because the caller owns
-// the socket lifetime: both has_data() and socket close happen on the main
-// loop thread, so the sockets[] entry cannot be freed while we read it.
+// that get_socket()/done_socket() uses. This is safe because:
+// 1. The only path to free_socket() is lwip_close(), called exclusively from the main loop
+// 2. The TCP/IP thread never frees socket slots (see "Socket slot lifetime" above)
+// 3. Both has_data() reads and lwip_close() run on the main loop — no concurrent free
 // If lwip_socket_dbg_get_socket() were ever removed, we could fall back to lwip_select().
 // Returns the sock only if both the sock and its netconn are valid, NULL otherwise.
 static inline struct lwip_sock *get_sock(int fd) {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -10,7 +10,7 @@
 // Thread safety analysis
 // ======================
 // Three threads interact with this code:
-//   1. Main loop task   — calls init, has_data, hook, unhook
+//   1. Main loop task   — calls init, has_data, hook
 //   2. LwIP TCP/IP task — calls event_callback (which reads s_original_callback, writes rcvevent)
 //   3. Background tasks — call wake_main_loop
 //
@@ -31,7 +31,8 @@
 //     the write), so it always sees the initialized value.
 //
 //   sock->conn->callback (netconn_callback, 4-byte function pointer):
-//     Written by main loop in hook_socket() and unhook_socket().
+//     Written by main loop in hook_socket(). Never restored — all LwIP sockets share
+//     the same static event_callback, so the wrapper stays in place permanently.
 //     Read by TCP/IP thread when invoking the callback.
 //     Safe: 32-bit aligned pointer writes are atomic on Xtensa and RISC-V (ESP32).
 //     The TCP/IP thread will see either the old or new pointer atomically — never a
@@ -131,17 +132,6 @@ void esphome_lwip_hook_socket(int fd) {
   // Replace with our wrapper. Atomic on ESP32 (32-bit aligned pointer write).
   // TCP/IP thread sees either old or new pointer — both are valid.
   sock->conn->callback = esphome_socket_event_callback;
-}
-
-void esphome_lwip_unhook_socket(int fd) {
-  struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
-  if (sock == NULL || sock->conn == NULL)
-    return;
-
-  // Restore original callback. Atomic on ESP32 (32-bit aligned pointer write).
-  if (s_original_callback != NULL) {
-    sock->conn->callback = s_original_callback;
-  }
 }
 
 // Wake the main loop from another FreeRTOS task. NOT ISR-safe.

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -136,11 +136,6 @@ void esphome_lwip_hook_socket(int fd) {
     s_original_callback = sock->conn->callback;
   }
 
-  // Verify assumption: if we already have the original, this socket should have the same one.
-  // If this fires, LwIP changed to use per-socket callbacks and we need a per-fd array.
-  LWIP_ASSERT("all sockets must share the same event_callback",
-              sock->conn->callback == s_original_callback || sock->conn->callback == esphome_socket_event_callback);
-
   // Replace with our wrapper. Atomic on ESP32 (32-bit aligned pointer write).
   // TCP/IP thread sees either old or new pointer — both are valid.
   sock->conn->callback = esphome_socket_event_callback;

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -127,13 +127,21 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
 
 void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTaskHandle(); }
 
-bool esphome_lwip_socket_has_data(int fd) {
-  // lwip_socket_dbg_get_socket() is a direct array lookup without the refcount that
-  // get_socket()/done_socket() uses. This is safe because the caller owns the socket
-  // lifetime: both has_data() and socket close happen on the main loop thread, so
-  // the sockets[] entry cannot be freed while we read it.
+// lwip_socket_dbg_get_socket() is a direct array lookup without the refcount that
+// get_socket()/done_socket() uses. This is safe because the caller owns the socket
+// lifetime: both has_data() and socket close happen on the main loop thread, so
+// the sockets[] entry cannot be freed while we read it.
+// Returns the sock only if both the sock and its netconn are valid, NULL otherwise.
+static inline struct lwip_sock *get_sock(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
   if (sock == NULL || sock->conn == NULL)
+    return NULL;
+  return sock;
+}
+
+bool esphome_lwip_socket_has_data(int fd) {
+  struct lwip_sock *sock = get_sock(fd);
+  if (sock == NULL)
     return false;
   // volatile prevents the compiler from caching/reordering this cross-thread read.
   // The write side (TCP/IP thread) commits via SYS_ARCH_UNPROTECT which releases a
@@ -144,8 +152,8 @@ bool esphome_lwip_socket_has_data(int fd) {
 }
 
 void esphome_lwip_hook_socket(int fd) {
-  struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
-  if (sock == NULL || sock->conn == NULL)
+  struct lwip_sock *sock = get_sock(fd);
+  if (sock == NULL)
     return;
 
   // Save original callback once — all LwIP sockets share the same static event_callback

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -15,28 +15,30 @@
 //                         via the original callback under SYS_ARCH_PROTECT/UNPROTECT mutex)
 //   3. Background tasks — call wake_main_loop
 //
-// LwIP source references (STABLE-2_2_0_RELEASE):
-//   https://github.com/lwip-tcpip/lwip/blob/STABLE-2_2_0_RELEASE/src/api/sockets.c
-//     - event_callback (static, same for all sockets): line 619
-//     - DEFAULT_SOCKET_EVENTCB = event_callback: line 622
-//     - lwip_socket_dbg_get_socket (direct array lookup, no locking): line 654
-//     - tryget_socket_unconn_nouse (the array lookup helper): line 1008
-//     - All socket types use DEFAULT_SOCKET_EVENTCB: lines 3309-3325
-//     - event_callback SYS_ARCH_PROTECT before rcvevent switch: line 3685
-//     - sock->rcvevent++ (NETCONN_EVT_RCVPLUS case): line 3688
-//     - SYS_ARCH_UNPROTECT after switch: line 3720
-//   https://github.com/lwip-tcpip/lwip/blob/STABLE-2_2_0_RELEASE/src/include/lwip/sys.h
-//     - SYS_ARCH_PROTECT calls sys_arch_protect(): line 557
-//     - SYS_ARCH_UNPROTECT calls sys_arch_unprotect(): line 568
+// LwIP source references (ESP-IDF v5.5.2, commit 30aaf64524):
+//   sockets.c: https://github.com/espressif/esp-idf/blob/30aaf64524/components/lwip/lwip/src/api/sockets.c
+//     - event_callback (static, same for all sockets): L327
+//     - DEFAULT_SOCKET_EVENTCB = event_callback: L328
+//     - tryget_socket_unconn_nouse (direct array lookup): L450
+//     - lwip_socket_dbg_get_socket (thin wrapper): L461
+//     - All socket types use DEFAULT_SOCKET_EVENTCB: L1741, L1748, L1759
+//     - event_callback definition: L2538
+//     - SYS_ARCH_PROTECT before rcvevent switch: L2578
+//     - sock->rcvevent++ (NETCONN_EVT_RCVPLUS case): L2582
+//     - SYS_ARCH_UNPROTECT after switch: L2615
+//   sys.h: https://github.com/espressif/esp-idf/blob/30aaf64524/components/lwip/lwip/src/include/lwip/sys.h
+//     - SYS_ARCH_PROTECT calls sys_arch_protect(): L495
+//     - SYS_ARCH_UNPROTECT calls sys_arch_unprotect(): L506
 //     (ESP-IDF implements sys_arch_protect/unprotect as FreeRTOS mutex lock/unlock)
 //
 // Shared state and safety rationale:
 //
 //   s_main_loop_task (TaskHandle_t, 4 bytes):
-//     Written once by main loop in init(), before any hook/wake calls.
-//     Read by TCP/IP thread (in callback) and background tasks (in wake).
-//     Safe: write-once-then-read pattern. The init() call completes during setup()
-//     before any sockets are hooked, so all subsequent reads see the final value.
+//     Written once by main loop in init(). Read by TCP/IP thread (in callback)
+//     and background tasks (in wake).
+//     Safe: write-once-then-read pattern. Socket hooks may run before init(),
+//     but the NULL check on s_main_loop_task in the callback provides correct
+//     degraded behavior — notifications are simply skipped until init() completes.
 //
 //   s_original_callback (netconn_callback, 4-byte function pointer):
 //     Written by main loop in hook_socket() (only when NULL — set once).
@@ -48,7 +50,7 @@
 //
 //   sock->conn->callback (netconn_callback, 4-byte function pointer):
 //     Written by main loop in hook_socket(). Never restored — all LwIP sockets share
-//     the same static event_callback (line 619, 622), so the wrapper stays permanently.
+//     the same static event_callback (DEFAULT_SOCKET_EVENTCB), so the wrapper stays permanently.
 //     Read by TCP/IP thread when invoking the callback.
 //     Safe: 32-bit aligned pointer writes are atomic on Xtensa and RISC-V (ESP32).
 //     The TCP/IP thread will see either the old or new pointer atomically — never a
@@ -56,11 +58,12 @@
 //     (the wrapper itself calls the original), so either value is correct.
 //
 //   sock->rcvevent (s16_t, 2 bytes):
-//     Written by TCP/IP thread in event_callback under SYS_ARCH_PROTECT (line 3685).
+//     Written by TCP/IP thread in event_callback under SYS_ARCH_PROTECT.
 //     Read by main loop in has_data() via volatile cast.
-//     Safe: SYS_ARCH_UNPROTECT (line 3720) releases a FreeRTOS mutex, which internally
-//     uses a critical section with memory barrier (rsync on Xtensa), ensuring the write
-//     is committed before the mutex is released. The volatile cast prevents the compiler
+//     Safe: SYS_ARCH_UNPROTECT releases a FreeRTOS mutex, which internally
+//     uses a critical section with memory barrier (rsync on dual-core Xtensa; on
+//     single-core builds the spinlock is compiled out, but cross-core visibility is
+//     not an issue). The volatile cast prevents the compiler
 //     from caching the read. Aligned 16-bit reads are single-instruction loads on
 //     Xtensa (L16SI) and RISC-V (LH), which cannot produce torn values.
 //

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -41,11 +41,11 @@
 //
 //   sock->rcvevent (s16_t, 2 bytes):
 //     Written by TCP/IP thread in event_callback (via SYS_ARCH_INC/DEC under lock).
-//     Read by main loop in has_data().
-//     Safe: aligned 16-bit reads are atomic on Xtensa/RISC-V. We use __atomic_load_n
-//     with __ATOMIC_RELAXED to prevent compiler reordering. Staleness is acceptable —
-//     a missed increment means we poll again next loop iteration (~16ms), and the
-//     task notification provides the real wake signal.
+//     Read by main loop in has_data() via volatile cast.
+//     Safe: aligned 16-bit reads are atomic on Xtensa/RISC-V. The write side commits
+//     via SYS_ARCH_UNPROTECT (portEXIT_CRITICAL) which flushes the write buffer.
+//     ESP32 internal SRAM has no per-core data cache, so the volatile load always
+//     reads the committed value. volatile prevents compiler from caching the read.
 //
 //   FreeRTOS task notification value:
 //     Written by TCP/IP thread (xTaskNotifyGive in callback) and background tasks
@@ -114,10 +114,11 @@ bool esphome_lwip_socket_has_data(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
   if (sock == NULL || sock->conn == NULL)
     return false;
-  // Use volatile to prevent compiler from caching/reordering this read.
-  // rcvevent is written by the TCP/IP thread under SYS_ARCH_PROTECT, not C11 atomics,
-  // so we match LwIP's own access pattern. Aligned 16-bit reads are naturally atomic
-  // on Xtensa/RISC-V. Staleness is acceptable — task notifications provide the real wake.
+  // volatile prevents the compiler from caching/reordering this cross-thread read.
+  // The write side (TCP/IP thread) commits via SYS_ARCH_UNPROTECT (portEXIT_CRITICAL),
+  // which flushes the write buffer. ESP32 internal SRAM has no per-core data cache,
+  // so the volatile load always reads the committed value from SRAM.
+  // Aligned 16-bit reads are naturally atomic on Xtensa/RISC-V.
   return *(volatile s16_t *) &sock->rcvevent > 0;
 }
 

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -15,6 +15,21 @@
 //                         via the original callback under SYS_ARCH_PROTECT/UNPROTECT mutex)
 //   3. Background tasks — call wake_main_loop
 //
+// LwIP source references (STABLE-2_2_0_RELEASE):
+//   https://github.com/lwip-tcpip/lwip/blob/STABLE-2_2_0_RELEASE/src/api/sockets.c
+//     - event_callback (static, same for all sockets): line 619
+//     - DEFAULT_SOCKET_EVENTCB = event_callback: line 622
+//     - lwip_socket_dbg_get_socket (direct array lookup, no locking): line 654
+//     - tryget_socket_unconn_nouse (the array lookup helper): line 1008
+//     - All socket types use DEFAULT_SOCKET_EVENTCB: lines 3309-3325
+//     - event_callback SYS_ARCH_PROTECT before rcvevent switch: line 3685
+//     - sock->rcvevent++ (NETCONN_EVT_RCVPLUS case): line 3688
+//     - SYS_ARCH_UNPROTECT after switch: line 3720
+//   https://github.com/lwip-tcpip/lwip/blob/STABLE-2_2_0_RELEASE/src/include/lwip/sys.h
+//     - SYS_ARCH_PROTECT calls sys_arch_protect(): line 557
+//     - SYS_ARCH_UNPROTECT calls sys_arch_unprotect(): line 568
+//     (ESP-IDF implements sys_arch_protect/unprotect as FreeRTOS mutex lock/unlock)
+//
 // Shared state and safety rationale:
 //
 //   s_main_loop_task (TaskHandle_t, 4 bytes):
@@ -33,7 +48,7 @@
 //
 //   sock->conn->callback (netconn_callback, 4-byte function pointer):
 //     Written by main loop in hook_socket(). Never restored — all LwIP sockets share
-//     the same static event_callback, so the wrapper stays in place permanently.
+//     the same static event_callback (line 619, 622), so the wrapper stays permanently.
 //     Read by TCP/IP thread when invoking the callback.
 //     Safe: 32-bit aligned pointer writes are atomic on Xtensa and RISC-V (ESP32).
 //     The TCP/IP thread will see either the old or new pointer atomically — never a
@@ -41,14 +56,13 @@
 //     (the wrapper itself calls the original), so either value is correct.
 //
 //   sock->rcvevent (s16_t, 2 bytes):
-//     Written by TCP/IP thread in event_callback under SYS_ARCH_PROTECT/UNPROTECT.
+//     Written by TCP/IP thread in event_callback under SYS_ARCH_PROTECT (line 3685).
 //     Read by main loop in has_data() via volatile cast.
-//     Safe: SYS_ARCH_UNPROTECT releases a FreeRTOS mutex (sys_mutex_unlock), which
-//     internally uses a critical section with memory barrier (rsync on Xtensa),
-//     ensuring the write is committed before the mutex is released. The volatile
-//     cast prevents the compiler from caching the read. Aligned 16-bit reads are
-//     single-instruction loads on Xtensa (L16SI) and RISC-V (LH), which cannot
-//     produce torn values.
+//     Safe: SYS_ARCH_UNPROTECT (line 3720) releases a FreeRTOS mutex, which internally
+//     uses a critical section with memory barrier (rsync on Xtensa), ensuring the write
+//     is committed before the mutex is released. The volatile cast prevents the compiler
+//     from caching the read. Aligned 16-bit reads are single-instruction loads on
+//     Xtensa (L16SI) and RISC-V (LH), which cannot produce torn values.
 //
 //   FreeRTOS task notification value:
 //     Written by TCP/IP thread (xTaskNotifyGive in callback) and background tasks

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -11,7 +11,8 @@
 // ======================
 // Three threads interact with this code:
 //   1. Main loop task   — calls init, has_data, hook
-//   2. LwIP TCP/IP task — calls event_callback (which reads s_original_callback, writes rcvevent)
+//   2. LwIP TCP/IP task — calls event_callback (reads s_original_callback; writes rcvevent
+//                         via the original callback under SYS_ARCH_PROTECT/UNPROTECT mutex)
 //   3. Background tasks — call wake_main_loop
 //
 // Shared state and safety rationale:
@@ -40,12 +41,14 @@
 //     (the wrapper itself calls the original), so either value is correct.
 //
 //   sock->rcvevent (s16_t, 2 bytes):
-//     Written by TCP/IP thread in event_callback (via SYS_ARCH_INC/DEC under lock).
+//     Written by TCP/IP thread in event_callback under SYS_ARCH_PROTECT/UNPROTECT.
 //     Read by main loop in has_data() via volatile cast.
-//     Safe: aligned 16-bit reads are atomic on Xtensa/RISC-V. The write side commits
-//     via SYS_ARCH_UNPROTECT (portEXIT_CRITICAL) which flushes the write buffer.
-//     ESP32 internal SRAM has no per-core data cache, so the volatile load always
-//     reads the committed value. volatile prevents compiler from caching the read.
+//     Safe: SYS_ARCH_UNPROTECT releases a FreeRTOS mutex (sys_mutex_unlock), which
+//     internally uses a critical section with memory barrier (rsync on Xtensa),
+//     ensuring the write is committed before the mutex is released. The volatile
+//     cast prevents the compiler from caching the read. Aligned 16-bit reads are
+//     single-instruction loads on Xtensa (L16SI) and RISC-V (LH), which cannot
+//     produce torn values.
 //
 //   FreeRTOS task notification value:
 //     Written by TCP/IP thread (xTaskNotifyGive in callback) and background tasks
@@ -115,10 +118,10 @@ bool esphome_lwip_socket_has_data(int fd) {
   if (sock == NULL || sock->conn == NULL)
     return false;
   // volatile prevents the compiler from caching/reordering this cross-thread read.
-  // The write side (TCP/IP thread) commits via SYS_ARCH_UNPROTECT (portEXIT_CRITICAL),
-  // which flushes the write buffer. ESP32 internal SRAM has no per-core data cache,
-  // so the volatile load always reads the committed value from SRAM.
-  // Aligned 16-bit reads are naturally atomic on Xtensa/RISC-V.
+  // The write side (TCP/IP thread) commits via SYS_ARCH_UNPROTECT which releases a
+  // FreeRTOS mutex with a memory barrier (rsync on Xtensa), ensuring the value is
+  // visible. Aligned 16-bit reads are single-instruction loads (L16SI/LH) on
+  // Xtensa/RISC-V and cannot produce torn values.
   return *(volatile s16_t *) &sock->rcvevent > 0;
 }
 

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -149,6 +149,9 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
   s_original_callback(conn, evt, len);
   // Wake the main loop task if sleeping in ulTaskNotifyTake().
   // Only notify on receive events to avoid spurious wakeups from send-ready events.
+  // NETCONN_EVT_ERROR is deliberately omitted: LwIP signals errors via RCVPLUS
+  // (rcvevent++ with a NULL pbuf or error in recvmbox), so error conditions
+  // already wake the main loop through the RCVPLUS path.
   if (evt == NETCONN_EVT_RCVPLUS) {
     TaskHandle_t task = s_main_loop_task;
     if (task != NULL) {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -41,12 +41,14 @@
 // The TCP/IP thread does NOT call free_socket(). On link loss, RST, or timeout
 // it frees the TCP PCB and signals the netconn (rcvevent++ to indicate EOF), but
 // the netconn and lwip_sock slot remain allocated until the application calls
-// lwip_close(). ESPHome only calls lwip_close() from the main loop, after
-// unregister_socket_fd() has already removed the fd from the monitored set.
+// lwip_close(). ESPHome removes the fd from the monitored set before calling
+// lwip_close().
 //
-// Therefore lwip_socket_dbg_get_socket(fd) plus a volatile read of rcvevent is
-// safe as long as the application is single-writer for close — which ESPHome
-// guarantees by design (all socket create/read/close happens on the main loop).
+// Therefore lwip_socket_dbg_get_socket(fd) plus a volatile read of rcvevent
+// (to prevent compiler reordering or caching) is safe as long as the application
+// is single-writer for close. ESPHome guarantees this by design: all socket
+// create/read/close happens on the main loop. fd numbers are not reused while
+// the slot remains allocated, and the slot remains allocated until lwip_close().
 //
 // LwIP source references for slot lifetime:
 //   sockets.c (same commit as above):

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -24,7 +24,7 @@ static TaskHandle_t s_main_loop_task = NULL;
 static netconn_callback s_original_callback = NULL;
 
 // Wrapper callback: calls original event_callback + notifies main loop task.
-// Called from LwIP's TCP/IP thread when socket events occur.
+// Called from LwIP's TCP/IP thread when socket events occur (task context, not ISR).
 static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt evt, u16_t len) {
   // Call original LwIP event_callback first — updates rcvevent/sendevent/errevent,
   // signals any select() waiters. This preserves all LwIP behavior.
@@ -33,7 +33,7 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
   }
   // Wake the main loop task if sleeping in ulTaskNotifyTake().
   // Only notify on receive events to avoid spurious wakeups from send-ready events.
-  // xTaskNotifyGive is thread-safe and ISR-safe, costs <1 us.
+  // xTaskNotifyGive is safe from task context (LwIP TCP/IP thread). NOT ISR-safe.
   if (evt == NETCONN_EVT_RCVPLUS) {
     TaskHandle_t task = s_main_loop_task;
     if (task != NULL) {
@@ -46,7 +46,13 @@ void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTas
 
 bool esphome_lwip_socket_has_data(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
-  return sock != NULL && sock->conn != NULL && sock->rcvevent > 0;
+  if (sock == NULL || sock->conn == NULL)
+    return false;
+  // rcvevent is modified by LwIP's TCP/IP thread in event_callback.
+  // Use atomic load for C11 memory model correctness. On Xtensa/RISC-V (ESP32)
+  // aligned 16-bit reads are naturally atomic, so this compiles to a plain load
+  // but prevents compiler reordering.
+  return __atomic_load_n(&sock->rcvevent, __ATOMIC_RELAXED) > 0;
 }
 
 void esphome_lwip_hook_socket(int fd) {
@@ -59,7 +65,10 @@ void esphome_lwip_hook_socket(int fd) {
     s_original_callback = sock->conn->callback;
   }
 
-  // Replace with our wrapper
+  // Replace with our wrapper.
+  // Thread safety: pointer writes are atomic on ESP32 (32-bit aligned).
+  // The TCP/IP thread may read conn->callback concurrently, but it will see
+  // either the old or new pointer — both are valid (our wrapper calls the original).
   sock->conn->callback = esphome_socket_event_callback;
 }
 
@@ -68,7 +77,9 @@ void esphome_lwip_unhook_socket(int fd) {
   if (sock == NULL || sock->conn == NULL)
     return;
 
-  // Restore original callback
+  // Restore original callback.
+  // Thread safety: same as hook — pointer write is atomic on ESP32.
+  // TCP/IP thread sees either wrapper or original, both are safe.
   if (s_original_callback != NULL) {
     sock->conn->callback = s_original_callback;
   }

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -112,9 +112,9 @@ static netconn_callback s_original_callback = NULL;
 static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt evt, u16_t len) {
   // Call original LwIP event_callback first — updates rcvevent/sendevent/errevent,
   // signals any select() waiters. This preserves all LwIP behavior.
-  if (s_original_callback) {
-    s_original_callback(conn, evt, len);
-  }
+  // s_original_callback is always valid here: hook_socket() sets it before swapping
+  // the callback pointer, so this wrapper cannot run until it's initialized.
+  s_original_callback(conn, evt, len);
   // Wake the main loop task if sleeping in ulTaskNotifyTake().
   // Only notify on receive events to avoid spurious wakeups from send-ready events.
   if (evt == NETCONN_EVT_RCVPLUS) {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -128,6 +128,10 @@ static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt
 void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTaskHandle(); }
 
 bool esphome_lwip_socket_has_data(int fd) {
+  // lwip_socket_dbg_get_socket() is a direct array lookup without the refcount that
+  // get_socket()/done_socket() uses. This is safe because the caller owns the socket
+  // lifetime: both has_data() and socket close happen on the main loop thread, so
+  // the sockets[] entry cannot be freed while we read it.
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
   if (sock == NULL || sock->conn == NULL)
     return false;

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -114,9 +114,11 @@ bool esphome_lwip_socket_has_data(int fd) {
   struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
   if (sock == NULL || sock->conn == NULL)
     return false;
-  // Atomic load prevents compiler reordering. On ESP32 this compiles to a plain load
-  // since aligned 16-bit reads are naturally atomic on Xtensa/RISC-V.
-  return __atomic_load_n(&sock->rcvevent, __ATOMIC_RELAXED) > 0;
+  // Use volatile to prevent compiler from caching/reordering this read.
+  // rcvevent is written by the TCP/IP thread under SYS_ARCH_PROTECT, not C11 atomics,
+  // so we match LwIP's own access pattern. Aligned 16-bit reads are naturally atomic
+  // on Xtensa/RISC-V. Staleness is acceptable — task notifications provide the real wake.
+  return *(volatile s16_t *) &sock->rcvevent > 0;
 }
 
 void esphome_lwip_hook_socket(int fd) {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -1,0 +1,84 @@
+// Fast socket monitoring for ESP32 (ESP-IDF LwIP)
+// Replaces lwip_select() with direct rcvevent reads and FreeRTOS task notifications.
+//
+// This must be a .c file (not .cpp) because:
+// 1. lwip/priv/sockets_priv.h conflicts with C++ compilation units that include bootloader headers
+// 2. The netconn callback is a C function pointer
+//
+// defines.h is force-included by the build system (-include flag), providing USE_ESP32 etc.
+
+#ifdef USE_ESP32
+
+// LwIP headers must come first — they define netconn_callback, struct lwip_sock, etc.
+#include <lwip/api.h>
+#include <lwip/priv/sockets_priv.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "esphome/core/lwip_fast_select.h"
+
+// Task handle for the main loop — set during setup, read from any thread/ISR
+static TaskHandle_t s_main_loop_task = NULL;
+
+// Saved original event_callback pointer (same for all LwIP sockets)
+static netconn_callback s_original_callback = NULL;
+
+// Wrapper callback: calls original event_callback + notifies main loop task.
+// Called from LwIP's TCP/IP thread when socket events occur.
+static void esphome_socket_event_callback(struct netconn *conn, enum netconn_evt evt, u16_t len) {
+  // Call original LwIP event_callback first — updates rcvevent/sendevent/errevent,
+  // signals any select() waiters. This preserves all LwIP behavior.
+  if (s_original_callback) {
+    s_original_callback(conn, evt, len);
+  }
+  // Wake the main loop task if sleeping in ulTaskNotifyTake().
+  // Only notify on receive events to avoid spurious wakeups from send-ready events.
+  // xTaskNotifyGive is thread-safe and ISR-safe, costs <1 us.
+  if (evt == NETCONN_EVT_RCVPLUS) {
+    TaskHandle_t task = s_main_loop_task;
+    if (task != NULL) {
+      xTaskNotifyGive(task);
+    }
+  }
+}
+
+void esphome_lwip_fast_select_init(void) { s_main_loop_task = xTaskGetCurrentTaskHandle(); }
+
+bool esphome_lwip_socket_has_data(int fd) {
+  struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
+  return sock != NULL && sock->conn != NULL && sock->rcvevent > 0;
+}
+
+void esphome_lwip_hook_socket(int fd) {
+  struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
+  if (sock == NULL || sock->conn == NULL)
+    return;
+
+  // Save original callback (only once — same event_callback for all LwIP sockets)
+  if (s_original_callback == NULL) {
+    s_original_callback = sock->conn->callback;
+  }
+
+  // Replace with our wrapper
+  sock->conn->callback = esphome_socket_event_callback;
+}
+
+void esphome_lwip_unhook_socket(int fd) {
+  struct lwip_sock *sock = lwip_socket_dbg_get_socket(fd);
+  if (sock == NULL || sock->conn == NULL)
+    return;
+
+  // Restore original callback
+  if (s_original_callback != NULL) {
+    sock->conn->callback = s_original_callback;
+  }
+}
+
+void esphome_lwip_wake_main_loop(void) {
+  TaskHandle_t task = s_main_loop_task;
+  if (task != NULL) {
+    xTaskNotifyGive(task);
+  }
+}
+
+#endif  // USE_ESP32

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -14,8 +14,9 @@ extern "C" {
 void esphome_lwip_fast_select_init(void);
 
 /// Check if a LwIP socket has data ready via direct rcvevent read (~215 ns per socket).
-/// Uses lwip_socket_dbg_get_socket() which is a direct array lookup — no locking, no refcount.
-/// Safe for single-threaded polling from the main loop.
+/// Uses lwip_socket_dbg_get_socket() — a direct array lookup without the refcount that
+/// get_socket()/done_socket() uses. Safe because the caller owns the socket lifetime:
+/// both has_data reads and socket close/unregister happen on the main loop thread.
 bool esphome_lwip_socket_has_data(int fd);
 
 /// Hook a socket's netconn callback to notify the main loop task on receive events.

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -2,7 +2,6 @@
 
 // Fast socket monitoring for ESP32 (ESP-IDF LwIP)
 // Replaces lwip_select() with direct rcvevent reads and FreeRTOS task notifications.
-// See fast_select.md for design rationale and benchmarks.
 
 #include <stdbool.h>
 
@@ -28,8 +27,8 @@ void esphome_lwip_hook_socket(int fd);
 /// Must be called from the main loop before closing the socket.
 void esphome_lwip_unhook_socket(int fd);
 
-/// Wake the main loop task from any thread or ISR — costs <1 us.
-/// Replaces the UDP loopback socket wake mechanism.
+/// Wake the main loop task from another FreeRTOS task — costs <1 us.
+/// NOT ISR-safe — must only be called from task context.
 void esphome_lwip_wake_main_loop(void);
 
 #ifdef __cplusplus

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -23,10 +23,6 @@ bool esphome_lwip_socket_has_data(int fd);
 /// Must be called from the main loop after socket creation.
 void esphome_lwip_hook_socket(int fd);
 
-/// Unhook a socket's netconn callback, restoring the original event_callback.
-/// Must be called from the main loop before closing the socket.
-void esphome_lwip_unhook_socket(int fd);
-
 /// Wake the main loop task from another FreeRTOS task — costs <1 us.
 /// NOT ISR-safe — must only be called from task context.
 void esphome_lwip_wake_main_loop(void);

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -1,0 +1,37 @@
+#pragma once
+
+// Fast socket monitoring for ESP32 (ESP-IDF LwIP)
+// Replaces lwip_select() with direct rcvevent reads and FreeRTOS task notifications.
+// See fast_select.md for design rationale and benchmarks.
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Initialize fast select — must be called from the main loop task during setup().
+/// Saves the current task handle for xTaskNotifyGive() wake notifications.
+void esphome_lwip_fast_select_init(void);
+
+/// Check if a LwIP socket has data ready via direct rcvevent read (~215 ns per socket).
+/// Uses lwip_socket_dbg_get_socket() which is a direct array lookup — no locking, no refcount.
+/// Safe for single-threaded polling from the main loop.
+bool esphome_lwip_socket_has_data(int fd);
+
+/// Hook a socket's netconn callback to notify the main loop task on receive events.
+/// Wraps the original event_callback with one that also calls xTaskNotifyGive().
+/// Must be called from the main loop after socket creation.
+void esphome_lwip_hook_socket(int fd);
+
+/// Unhook a socket's netconn callback, restoring the original event_callback.
+/// Must be called from the main loop before closing the socket.
+void esphome_lwip_unhook_socket(int fd);
+
+/// Wake the main loop task from any thread or ISR — costs <1 us.
+/// Replaces the UDP loopback socket wake mechanism.
+void esphome_lwip_wake_main_loop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/components/socket/test_wake_loop_threadsafe.py
+++ b/tests/components/socket/test_wake_loop_threadsafe.py
@@ -1,9 +1,16 @@
 from esphome.components import socket
+from esphome.const import KEY_CORE, KEY_TARGET_PLATFORM, PLATFORM_ESP8266
 from esphome.core import CORE
+
+
+def _setup_non_esp32_platform() -> None:
+    """Set up CORE.data with a non-ESP32 platform for testing."""
+    CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: PLATFORM_ESP8266}
 
 
 def test_require_wake_loop_threadsafe__first_call() -> None:
     """Test that first call sets up define and consumes socket."""
+    _setup_non_esp32_platform()
     CORE.config = {"wifi": True}
     socket.require_wake_loop_threadsafe()
 
@@ -32,6 +39,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
 
 def test_require_wake_loop_threadsafe__multiple_calls() -> None:
     """Test that multiple calls only set up once."""
+    _setup_non_esp32_platform()
     # Call three times
     CORE.config = {"openthread": True}
     socket.require_wake_loop_threadsafe()

--- a/tests/components/socket/test_wake_loop_threadsafe.py
+++ b/tests/components/socket/test_wake_loop_threadsafe.py
@@ -1,16 +1,21 @@
 from esphome.components import socket
-from esphome.const import KEY_CORE, KEY_TARGET_PLATFORM, PLATFORM_ESP8266
+from esphome.const import (
+    KEY_CORE,
+    KEY_TARGET_PLATFORM,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+)
 from esphome.core import CORE
 
 
-def _setup_non_esp32_platform() -> None:
-    """Set up CORE.data with a non-ESP32 platform for testing."""
-    CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: PLATFORM_ESP8266}
+def _setup_platform(platform=PLATFORM_ESP8266) -> None:
+    """Set up CORE.data with a platform for testing."""
+    CORE.data[KEY_CORE] = {KEY_TARGET_PLATFORM: platform}
 
 
 def test_require_wake_loop_threadsafe__first_call() -> None:
     """Test that first call sets up define and consumes socket."""
-    _setup_non_esp32_platform()
+    _setup_platform()
     CORE.config = {"wifi": True}
     socket.require_wake_loop_threadsafe()
 
@@ -39,7 +44,7 @@ def test_require_wake_loop_threadsafe__idempotent() -> None:
 
 def test_require_wake_loop_threadsafe__multiple_calls() -> None:
     """Test that multiple calls only set up once."""
-    _setup_non_esp32_platform()
+    _setup_platform()
     # Call three times
     CORE.config = {"openthread": True}
     socket.require_wake_loop_threadsafe()
@@ -83,3 +88,29 @@ def test_require_wake_loop_threadsafe__no_networking_does_not_consume_socket() -
     udp_consumers = CORE.data.get(socket.KEY_SOCKET_CONSUMERS_UDP, {})
     assert "socket.wake_loop_threadsafe" not in udp_consumers
     assert udp_consumers == initial_udp
+
+
+def test_require_wake_loop_threadsafe__esp32_no_udp_socket() -> None:
+    """Test that ESP32 uses task notifications instead of UDP socket."""
+    _setup_platform(PLATFORM_ESP32)
+    CORE.config = {"wifi": True}
+    socket.require_wake_loop_threadsafe()
+
+    # Verify the define was added
+    assert CORE.data[socket.KEY_WAKE_LOOP_THREADSAFE_REQUIRED] is True
+    assert any(d.name == "USE_WAKE_LOOP_THREADSAFE" for d in CORE.defines)
+
+    # Verify no UDP socket was consumed (ESP32 uses FreeRTOS task notifications)
+    udp_consumers = CORE.data.get(socket.KEY_SOCKET_CONSUMERS_UDP, {})
+    assert "socket.wake_loop_threadsafe" not in udp_consumers
+
+
+def test_require_wake_loop_threadsafe__non_esp32_consumes_udp_socket() -> None:
+    """Test that non-ESP32 platforms consume a UDP socket for wake notifications."""
+    _setup_platform(PLATFORM_ESP8266)
+    CORE.config = {"wifi": True}
+    socket.require_wake_loop_threadsafe()
+
+    # Verify UDP socket was consumed
+    udp_consumers = CORE.data.get(socket.KEY_SOCKET_CONSUMERS_UDP, {})
+    assert udp_consumers.get("socket.wake_loop_threadsafe") == 1


### PR DESCRIPTION
# What does this implement/fix?

ESPHome 2025.11.0 introduced `wake_loop_threadsafe()` ([#11681](https://github.com/esphome/esphome/pull/11681)) which reduced event processing latency from ~8ms to ~12 us. This PR takes the next step — **eliminating `lwip_select()` entirely on ESP32**, replacing it with direct LwIP internal reads and FreeRTOS task notifications.

On ESP32, `yield_with_select_()` calls `lwip_select()` every loop iteration to check socket readiness and sleep. Benchmarks show this costs **133 us per call** even with 0ms timeout, dominated by LwIP's internal locking (`get_socket()`/`done_socket()` per fd, `SYS_ARCH_PROTECT` mutex).

This PR replaces `lwip_select()` with two faster primitives on ESP32:

1. **Direct `rcvevent` reads** via `lwip_socket_dbg_get_socket()` — a thin wrapper around the static `tryget_socket_unconn_nouse()`, which is a direct array lookup that skips the refcount overhead of `get_socket()`/`done_socket()`. (~1.4 us for 4 sockets vs 133 us for select)
2. **FreeRTOS task notifications** (`ulTaskNotifyTake`/`xTaskNotifyGive`) for sleeping with instant wake — replaces both `lwip_select()` sleep and the UDP loopback wake socket

### Why skipping refcounting is safe

`lwip_socket_dbg_get_socket()` does not increment the socket's use count, so the socket could theoretically be freed while we read it. This is safe in ESPHome because **the main loop thread owns socket lifetime end-to-end**:

- **Creation**: sockets are created on the main loop (`lwip_socket()`)
- **Registration**: `register_socket_fd()` is called from the main loop
- **Readiness checks**: all `Socket::ready()` callers run on the main loop (`api_server.loop()`, `ota.loop()`, `captive_portal.loop()`, `async_tcp.loop()`, `api_frame_helper`)
- **Close/destroy**: `unregister_socket_fd()` and `lwip_close()` are called from the main loop

Since both the readiness reads and socket destruction happen on the same thread, the socket cannot be freed between the array lookup and the `rcvevent` read. No background thread ever calls `Socket::ready()` or closes a monitored socket.

### Instant wake on socket data

To preserve instant wake when socket data arrives (which `lwip_select()` provided via its internal semaphore), we wrap each monitored socket's `netconn` callback. When LwIP's TCP/IP thread delivers data to a hooked socket, our wrapper:
1. Calls the original `event_callback` (preserves all LwIP behavior)
2. Calls `xTaskNotifyGive()` to instantly wake the main loop from `ulTaskNotifyTake()`

This is implemented in a separate `.c` file (`lwip_fast_select.c`) because `lwip/priv/sockets_priv.h` conflicts with C++ compilation units.

### Benchmark results (ESP32, 4 listen sockets)

Both paths (poll and sleep) scan sockets via `has_data()` before deciding whether to sleep.

| Method | Cost/call | vs select |
|--------|-----------|-----------|
| `select(4 fds, 0ms)` | 132,376 ns | baseline |
| **poll path** (`delay_ms=0`: 4x has_data + yield) | **7,557 ns** | **17.5x faster** |
| **pre-sleep scan** (`delay_ms>0`: 4x has_data) | **~1,336 ns** | **99x faster** |
| `wake_main_loop` | 1,806 ns | was ~130,000 ns via UDP (**72x faster**) |

The pre-sleep scan checks if any socket already has pending data (preserving `select()` semantics — return immediately when any fd is ready). When no data is pending, the main loop sleeps via `ulTaskNotifyTake` with instant wake on new data.

### Real-world CPU savings

At ~7,100 main loop iterations per minute (measured on idle ESP32):

| | Per call | Per minute |
|--|----------|-----------|
| **Old** (select overhead) | 132,376 ns | 940 ms |
| **New** (has_data scan) | 1,336 ns | 9.5 ms |
| **Saved** | | **~930 ms/min** |

That's **~1.55% of total CPU time** freed from socket polling overhead.

**Why this matters — all ESP32 variants are affected:**

- **Cross-core mutex contention on dual-core (ESP32, S3):** `lwip_select()` acquires `SYS_ARCH_PROTECT` (a FreeRTOS mutex) multiple times per call — `get_socket()` and `done_socket()` each take the lock for every fd, plus `lwip_selscan` takes it for the readiness scan. With 4 sockets that's **~9 lock/unlock operations per `select()` call**, all on the **same mutex** that the LwIP TCP/IP task on Core 0 needs to deliver incoming data via `event_callback` (where `rcvevent++` happens under `SYS_ARCH_PROTECT`). At 7,100 loops/min, that's **~64,000 cross-core mutex acquisitions per minute eliminated**. Every time Core 1 holds this mutex inside `lwip_select()`, Core 0's TCP/IP task **stalls** if it tries to deliver a packet. So the 133 us overhead isn't just wasted CPU on the main loop core — it actively blocks the network stack on the other core. The new path uses **zero locks** (direct array lookup + volatile read), eliminating this contention entirely.
- **Hidden from `runtime_stats`:** The `yield_with_select_()` overhead runs *between* component `loop()` calls, so it never appears in runtime_stats which only measures per-component time. This made the cost invisible to profiling.
- **No `epoll` on ESP32:** LwIP doesn't provide `epoll`/`kqueue` — only `select()`, which requires copying `fd_set` and acquiring per-socket refcount locks on every call. On Linux you'd use `epoll_wait` with O(1) readiness checks; here the only alternative is reading LwIP internals directly.
- **Amplified on single-core (ESP32-C3, C2, C6, H2):** On these chips the main loop, BLE stack, WiFi, and LwIP TCP/IP task all share one core. Every microsecond spent in `select()` — and every lock acquisition — is a microsecond stolen from the BLE scanner. For Bluetooth proxy devices this directly impacts scan responsiveness and connection reliability.

<details>
<summary>Benchmark button YAML (add to any ESP32 config to reproduce)</summary>

```yaml
button:
  - platform: template
    name: "Benchmark yield_with_select_"
    on_press:
      - lambda: |-
          static const char *const BTAG = "bench_select";
          const int ITERS = 10000;

          ESP_LOGI(BTAG, "=== yield_with_select_ Benchmark (%d iters) ===", ITERS);

          // Create 4 listening sockets to simulate real device (API, web_server, etc.)
          int socks[4] = {-1, -1, -1, -1};
          int max_fd = -1;
          for (int i = 0; i < 4; i++) {
            socks[i] = lwip_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
            if (socks[i] < 0) {
              ESP_LOGW(BTAG, "Failed to create socket %d: %d", i, errno);
              goto cleanup;
            }
            // Bind to loopback on ephemeral port
            struct sockaddr_in addr = {};
            addr.sin_family = AF_INET;
            addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
            addr.sin_port = 0;
            if (lwip_bind(socks[i], (struct sockaddr *) &addr, sizeof(addr)) < 0) {
              ESP_LOGW(BTAG, "Failed to bind socket %d: %d", i, errno);
              goto cleanup;
            }
            if (lwip_listen(socks[i], 1) < 0) {
              ESP_LOGW(BTAG, "Failed to listen socket %d: %d", i, errno);
              goto cleanup;
            }
            if (socks[i] > max_fd) max_fd = socks[i];
          }

          ESP_LOGI(BTAG, "Created 4 listen sockets: fd=%d,%d,%d,%d  max_fd=%d",
                   socks[0], socks[1], socks[2], socks[3], max_fd);

          {
            fd_set base_fds, work_fds;
            FD_ZERO(&base_fds);
            for (int i = 0; i < 4; i++) {
              FD_SET(socks[i], &base_fds);
            }
            struct timeval tv;

            App.feed_wdt();
            // --- Benchmark 1: fd_set copy + select(0ms) — the hot path poll ---
            {
              uint32_t t0 = micros();
              for (int i = 0; i < ITERS; i++) {
                work_fds = base_fds;
                tv.tv_sec = 0;
                tv.tv_usec = 0;
                lwip_select(max_fd + 1, &work_fds, nullptr, nullptr, &tv);
              }
              uint32_t elapsed = micros() - t0;
              ESP_LOGI(BTAG, "select(4 fds, 0ms):  %lu us total, %lu ns/call",
                       (unsigned long) elapsed, (unsigned long) (elapsed * 1000UL / ITERS));
            }

            App.feed_wdt();
            // --- Benchmark 12: direct rcvevent read via lwip_socket_dbg_get_socket ---
            {
              uint32_t t0 = micros();
              for (int i = 0; i < ITERS; i++) {
                for (int j = 0; j < 4; j++) {
                  auto *sock = lwip_socket_dbg_get_socket(socks[j]);
                  if (sock && sock->conn && sock->rcvevent > 0) {
                    // socket ready
                  }
                }
              }
              uint32_t elapsed = micros() - t0;
              ESP_LOGI(BTAG, "4x dbg rcvevent:     %lu us total, %lu ns/call",
                       (unsigned long) elapsed, (unsigned long) (elapsed * 1000UL / ITERS));
            }

            App.feed_wdt();
            // --- Benchmark 14: esphome_lwip_socket_has_data() API (our wrapper) ---
            {
              uint32_t t0 = micros();
              for (int i = 0; i < ITERS; i++) {
                for (int j = 0; j < 4; j++) {
                  if (esphome_lwip_socket_has_data(socks[j])) {
                    // socket ready
                  }
                }
              }
              uint32_t elapsed = micros() - t0;
              ESP_LOGI(BTAG, "4x has_data API:     %lu us total, %lu ns/call",
                       (unsigned long) elapsed, (unsigned long) (elapsed * 1000UL / ITERS));
            }

            App.feed_wdt();
            // --- Benchmark 15: simulated new poll path (4x has_data + yield, no fd_set) ---
            {
              volatile bool ready = false;
              uint32_t t0 = micros();
              for (int i = 0; i < ITERS; i++) {
                for (int j = 0; j < 4; j++) {
                  ready = esphome_lwip_socket_has_data(socks[j]);
                }
                esphome::yield();
              }
              uint32_t elapsed = micros() - t0;
              ESP_LOGI(BTAG, "new poll path sim:   %lu us total, %lu ns/call",
                       (unsigned long) elapsed, (unsigned long) (elapsed * 1000UL / ITERS));
              (void) ready;
            }

            App.feed_wdt();
            // --- Benchmark 16: esphome_lwip_wake_main_loop() cost ---
            {
              uint32_t t0 = micros();
              for (int i = 0; i < ITERS; i++) {
                esphome_lwip_wake_main_loop();
              }
              // Drain accumulated notifications
              ulTaskNotifyTake(pdTRUE, 0);
              uint32_t elapsed = micros() - t0;
              ESP_LOGI(BTAG, "wake_main_loop:      %lu us total, %lu ns/call",
                       (unsigned long) elapsed, (unsigned long) (elapsed * 1000UL / ITERS));
            }
          }

          cleanup:
          for (int i = 0; i < 4; i++) {
            if (socks[i] >= 0) lwip_close(socks[i]);
          }
          ESP_LOGI(BTAG, "=== Benchmark complete ===");
```

</details>

### Thread safety

The implementation includes comprehensive thread safety analysis in `lwip_fast_select.c` with [ESP-IDF LwIP source permalinks](https://github.com/espressif/esp-idf/blob/30aaf64524/components/lwip/lwip/src/api/sockets.c). Key properties verified:

- All cross-thread shared state is either write-once-then-read or uses naturally atomic aligned writes
- `rcvevent` reads use `volatile` to prevent compiler caching; writes are committed via FreeRTOS mutex barrier
- Compile-time `_Static_assert` checks verify size and alignment assumptions for atomic access
- `xTaskNotifyGive`/`ulTaskNotifyTake` provide thread-safe wake signaling

### CI-measured memory impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **RAM (static)** | 69,968 B | 69,912 B | **-56 bytes** |
| **Flash** | 1,376,478 B | 1,372,818 B | **-3,660 bytes** |
| **`yield_with_select_`** | 197 B | 47 B | **-150 bytes (76% smaller)** |

Additionally, the wake UDP loopback socket is eliminated on ESP32, saving **~200-300 bytes of runtime heap** (LwIP `netconn` + `udp_pcb` + socket slot).

Dead-code-eliminated symbols: `lwip_select` (745B), `lwip_selscan` (383B), `lwip_unlink_select_cb` (91B), `tryget_socket_unconn_locked` (82B), `lwip_select_inc_sockets_used_set` (67B), and others — totaling **1,435 bytes** from the network stack alone.

### Platform impact

| Platform | Change |
|----------|--------|
| **ESP32 (ESP-IDF & Arduino)** | Full fast path — direct rcvevent + task notifications |
| **LibreTiny bk72xx/rtl87xx** | No change (keep select) — LibreTiny's LwIP (≥2.1.3) has `sockets_priv.h` and `lwip_socket_dbg_get_socket()`, so a followup PR could extend the fast path here as well |
| **ESP8266** | No change — uses `lwip_tcp` not sockets |
| **RP2040** | No change |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Builds on #11681 which introduced `wake_loop_threadsafe()`

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A — no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes
# This is an internal optimization — all existing configs benefit automatically
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
