### PR TITLE
[core] Prevent inlining of mark_matching_items_removed_locked_ on Thumb-1

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -496,9 +496,9 @@ class Scheduler {
   // name_type determines matching: STATIC_STRING uses static_name, others use hash_or_id
   // Returns the number of items marked for removal
   // IMPORTANT: Must be called with scheduler lock held
-  size_t mark_matching_items_removed_locked_(std::vector<std::unique_ptr<SchedulerItem>> &container,
-                                             Component *component, NameType name_type, const char *static_name,
-                                             uint32_t hash_or_id, SchedulerItem::Type type, bool match_retry) {
+  __attribute__((noinline)) size_t mark_matching_items_removed_locked_(
+      std::vector<std::unique_ptr<SchedulerItem>> &container, Component *component, NameType name_type,
+      const char *static_name, uint32_t hash_or_id, SchedulerItem::Type type, bool match_retry) {
     size_t count = 0;
     for (auto &item : container) {
       // Skip nullptr items (can happen in defer_queue_ when items are being processed)


### PR DESCRIPTION
# What does this implement/fix?

Adds `__attribute__((noinline))` to `mark_matching_items_removed_locked_()` in the scheduler.

The BK7231N Thumb-1 compiler inlines this function 3 times into `cancel_item_locked_()`, bloating it from ~140 B to 666 B. Disassembly comparison across platforms:

| Platform | Instruction Set | `cancel_item_locked_` size |
|---|---|---|
| ESP32 (Xtensa) | Xtensa | 118 B |
| RTL8720CF | ARM Thumb-2 | 140 B |
| BK7231N | ARM Thumb-1 | 666 B → 180 B |

ESP32 and RTL8720CF compilers already outline `mark_matching_items_removed_locked_()`, so the `noinline` attribute is a no-op on those platforms and only fixes the bad inlining decision on BK7231N, saving ~486 B of flash.

This is a cold path (timer/interval cancellation), so there is no performance benefit to inlining.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32 IDF
- [x] BK72xx
- [x] RTL87xx

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).