### PR TITLE
[http_request.ota] Percent-encode credentials in URL

### DIFF
--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -1,5 +1,7 @@
 #include "ota_http_request.h"
 
+#include <cctype>
+
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
@@ -208,6 +210,26 @@ uint8_t OtaHttpRequestComponent::do_ota_() {
   ESP_LOGI(TAG, "Update complete");
   return ota::OTA_RESPONSE_OK;
 }
+
+// URL-encode characters that are not unreserved per RFC 3986 section 2.3.
+// This is needed for embedding userinfo (username/password) in URLs safely.
+static std::string url_encode(const std::string &str) {
+  std::string result;
+  result.reserve(str.size());
+  for (char c : str) {
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '-' || c == '_' || c == '.' || c == '~') {
+      result += c;
+    } else {
+      result += '%';
+      result += format_hex_pretty_char((static_cast<uint8_t>(c) >> 4) & 0x0F);
+      result += format_hex_pretty_char(static_cast<uint8_t>(c) & 0x0F);
+    }
+  }
+  return result;
+}
+
+void OtaHttpRequestComponent::set_password(const std::string &password) { this->password_ = url_encode(password); }
+void OtaHttpRequestComponent::set_username(const std::string &username) { this->username_ = url_encode(username); }
 
 std::string OtaHttpRequestComponent::get_url_with_auth_(const std::string &url) {
   if (this->username_.empty() || this->password_.empty()) {

--- a/esphome/components/http_request/ota/ota_http_request.h
+++ b/esphome/components/http_request/ota/ota_http_request.h
@@ -29,9 +29,9 @@ class OtaHttpRequestComponent : public ota::OTAComponent, public Parented<HttpRe
 
   void set_md5_url(const std::string &md5_url);
   void set_md5(const std::string &md5) { this->md5_expected_ = md5; }
-  void set_password(const std::string &password) { this->password_ = password; }
+  void set_password(const std::string &password);
   void set_url(const std::string &url);
-  void set_username(const std::string &username) { this->username_ = username; }
+  void set_username(const std::string &username);
 
   std::string md5_computed() { return this->md5_computed_; }
   std::string md5_expected() { return this->md5_expected_; }


### PR DESCRIPTION
# What does this implement/fix?

Special characters in the OTA username or password (e.g. `^`, `#`, `*`) were being embedded directly into the URL as `username:password@host`, causing ESP-IDF's HTTP client URL parser to fail and crash with a null pointer dereference in `esp_http_client_open()`.

This adds a `url_encode()` helper that percent-encodes the username and password per RFC 3986 before embedding them in the URL.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14253

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ota:
  - platform: http_request

button:
  - platform: template
    name: Firmware OTA
    on_press:
      then:
        - ota.http_request.flash:
            md5_url: https://myrepo.com/file.md5
            url: https://myrepo.com/file.bin
            username: myusername
            password: "^#^*abcde"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
