### PR TITLE
[core] Pass std::function by rvalue reference in scheduler

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -135,7 +135,7 @@ bool Scheduler::is_retry_cancelled_locked_(Component *component, NameType name_t
 // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
 void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type,
                                       const char *static_name, uint32_t hash_or_id, uint32_t delay,
-                                      std::function<void()> func, bool is_retry, bool skip_cancel) {
+                                      std::function<void()> &&func, bool is_retry, bool skip_cancel) {
   if (delay == SCHEDULER_DONT_RUN) {
     // Still need to cancel existing timer if we have a name/id
     if (!skip_cancel) {
@@ -216,17 +216,18 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   target->push_back(std::move(item));
 }
 
-void HOT Scheduler::set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func) {
+void HOT Scheduler::set_timeout(Component *component, const char *name, uint32_t timeout,
+                                std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::STATIC_STRING, name, 0, timeout,
                           std::move(func));
 }
 
 void HOT Scheduler::set_timeout(Component *component, const std::string &name, uint32_t timeout,
-                                std::function<void()> func) {
+                                std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
                           timeout, std::move(func));
 }
-void HOT Scheduler::set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func) {
+void HOT Scheduler::set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::NUMERIC_ID, nullptr, id, timeout,
                           std::move(func));
 }
@@ -240,17 +241,17 @@ bool HOT Scheduler::cancel_timeout(Component *component, uint32_t id) {
   return this->cancel_item_(component, NameType::NUMERIC_ID, nullptr, id, SchedulerItem::TIMEOUT);
 }
 void HOT Scheduler::set_interval(Component *component, const std::string &name, uint32_t interval,
-                                 std::function<void()> func) {
+                                 std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::HASHED_STRING, nullptr, fnv1a_hash(name),
                           interval, std::move(func));
 }
 
 void HOT Scheduler::set_interval(Component *component, const char *name, uint32_t interval,
-                                 std::function<void()> func) {
+                                 std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::STATIC_STRING, name, 0, interval,
                           std::move(func));
 }
-void HOT Scheduler::set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func) {
+void HOT Scheduler::set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> &&func) {
   this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::NUMERIC_ID, nullptr, id, interval,
                           std::move(func));
 }

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -33,7 +33,7 @@ class Scheduler {
   // std::string overload - deprecated, use const char* or uint32_t instead
   // Remove before 2026.7.0
   ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  void set_timeout(Component *component, const std::string &name, uint32_t timeout, std::function<void()> func);
+  void set_timeout(Component *component, const std::string &name, uint32_t timeout, std::function<void()> &&func);
 
   /** Set a timeout with a const char* name.
    *
@@ -43,11 +43,11 @@ class Scheduler {
    *   - A static const char* variable
    *   - A pointer with lifetime >= the scheduled task
    */
-  void set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> func);
+  void set_timeout(Component *component, const char *name, uint32_t timeout, std::function<void()> &&func);
   /// Set a timeout with a numeric ID (zero heap allocation)
-  void set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> func);
+  void set_timeout(Component *component, uint32_t id, uint32_t timeout, std::function<void()> &&func);
   /// Set a timeout with an internal scheduler ID (separate namespace from component NUMERIC_ID)
-  void set_timeout(Component *component, InternalSchedulerID id, uint32_t timeout, std::function<void()> func) {
+  void set_timeout(Component *component, InternalSchedulerID id, uint32_t timeout, std::function<void()> &&func) {
     this->set_timer_common_(component, SchedulerItem::TIMEOUT, NameType::NUMERIC_ID_INTERNAL, nullptr,
                             static_cast<uint32_t>(id), timeout, std::move(func));
   }
@@ -62,7 +62,7 @@ class Scheduler {
   }
 
   ESPDEPRECATED("Use const char* or uint32_t overload instead. Removed in 2026.7.0", "2026.1.0")
-  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> func);
+  void set_interval(Component *component, const std::string &name, uint32_t interval, std::function<void()> &&func);
 
   /** Set an interval with a const char* name.
    *
@@ -72,11 +72,11 @@ class Scheduler {
    *   - A static const char* variable
    *   - A pointer with lifetime >= the scheduled task
    */
-  void set_interval(Component *component, const char *name, uint32_t interval, std::function<void()> func);
+  void set_interval(Component *component, const char *name, uint32_t interval, std::function<void()> &&func);
   /// Set an interval with a numeric ID (zero heap allocation)
-  void set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> func);
+  void set_interval(Component *component, uint32_t id, uint32_t interval, std::function<void()> &&func);
   /// Set an interval with an internal scheduler ID (separate namespace from component NUMERIC_ID)
-  void set_interval(Component *component, InternalSchedulerID id, uint32_t interval, std::function<void()> func) {
+  void set_interval(Component *component, InternalSchedulerID id, uint32_t interval, std::function<void()> &&func) {
     this->set_timer_common_(component, SchedulerItem::INTERVAL, NameType::NUMERIC_ID_INTERNAL, nullptr,
                             static_cast<uint32_t>(id), interval, std::move(func));
   }
@@ -255,7 +255,7 @@ class Scheduler {
   // Common implementation for both timeout and interval
   // name_type determines storage type: STATIC_STRING uses static_name, others use hash_or_id
   void set_timer_common_(Component *component, SchedulerItem::Type type, NameType name_type, const char *static_name,
-                         uint32_t hash_or_id, uint32_t delay, std::function<void()> func, bool is_retry = false,
+                         uint32_t hash_or_id, uint32_t delay, std::function<void()> &&func, bool is_retry = false,
                          bool skip_cancel = false);
 
   // Common implementation for retry - Remove before 2026.8.0


### PR DESCRIPTION
# What does this implement/fix?

The Scheduler's `set_timeout`, `set_interval`, and `set_timer_common_` methods were taking `std::function<void()>` by value despite being internal forwarding layers where every caller passes a temporary or `std::move()`'d value. No caller ever reuses the `std::function` after the call. By-value forced the compiler to emit a move constructor + destructor pair at every forwarding call site for no reason.

This changes all these parameters to `std::function<void()>&&` (rvalue reference), so callers just pass a pointer instead of materializing a copy on the stack.

The call chain is: `Component::set_timeout` → `Scheduler::set_timeout` → `set_timer_common_`. The `Component` wrappers were already `&&`, but the `Scheduler` overloads and `set_timer_common_` were by value — so every hop through the Scheduler layer paid the move overhead. Now the entire chain passes by reference.

There are 8 `set_timeout`/`set_interval` overloads plus `set_retry` variants that all forward through `set_timer_common_`. Each one compiled into a firmware pays the same overhead, so savings scale with the number of overloads used.

### Flash savings

**BK7231N (full firmware): -544 bytes** (545,594 → 545,050)

On ESP32 the by-value overhead was already mostly optimized out. On BK7231N (Thumb-1, only 8 low registers) the `std::function` move constructor was inlined at every call site, and the entire chain passing by value meant each forwarding layer paid ~86 bytes of overhead.

**ESP32-IDF: -112 bytes** — notably the `std::function` move constructor (`std::function<void()>::function(&&)`, 42 bytes) was completely eliminated since nothing instantiates it anymore.

### Stack usage

Each by-value `std::function` materialized on the stack is ~32 bytes on 32-bit platforms. Two intermediate copies meant ~64 bytes of unnecessary stack usage per `set_timeout`/`set_interval` call. With `&&`, only a 4-byte pointer is passed through each layer.

This matters for tasks with small stacks where scheduler calls have contributed to stack overflows (see #14019).

### Safety analysis

Every caller of `Scheduler::set_timeout`/`set_interval`/`set_timer_common_` already passes rvalues (`std::move(func)` or lambda temporaries). All callers verified:

**`set_timer_common_` callers (12):**

| Caller | What's passed |
|---|---|
| `Scheduler::set_timeout` (4 overloads) | `std::move(func)` |
| `Scheduler::set_interval` (4 overloads) | `std::move(func)` |
| `retry_handler` | lambda temporary |
| `set_retry_common_` | lambda temporary |
| `DelayAction` (2 call sites) | lambda temporary / `std::move(f)` |

**`Scheduler::set_timeout`/`set_interval` callers:**

| Caller | What's passed |
|---|---|
| `Component::set_timeout` (all overloads) | `std::move(f)` |
| `Component::set_interval` (all overloads) | `std::move(f)` |
| `Component::defer` (all overloads) | `std::move(f)` |
| `APIConnection::camera_image` | lambda temporary |

**No leaks:** On the early return path (`SCHEDULER_DONT_RUN`), `func` is not consumed. With by-value, the callee destroyed it; with rvalue ref, the caller's parameter destructor handles it. Either way, exactly one destruction occurs — RAII guarantees this per [unique.ptr.single.dtor].

These are all internal functions — not public API. If a future caller tries to pass an lvalue, they get a compile error (requires explicit `std::move`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #14019 (stack overflow during HTTPS requests via interval/scheduler)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).