### PR TITLE
[api] Pass std::function by rvalue reference in state subscriptions

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -433,8 +433,8 @@ void APIServer::handle_action_response(uint32_t call_id, bool success, StringRef
 
 #ifdef USE_API_HOMEASSISTANT_STATES
 // Helper to add subscription (reduces duplication)
-void APIServer::add_state_subscription_(const char *entity_id, const char *attribute, std::function<void(StringRef)> f,
-                                        bool once) {
+void APIServer::add_state_subscription_(const char *entity_id, const char *attribute,
+                                        std::function<void(StringRef)> &&f, bool once) {
   this->state_subs_.push_back(HomeAssistantStateSubscription{
       .entity_id = entity_id, .attribute = attribute, .callback = std::move(f), .once = once,
       // entity_id_dynamic_storage and attribute_dynamic_storage remain nullptr (no heap allocation)
@@ -443,7 +443,7 @@ void APIServer::add_state_subscription_(const char *entity_id, const char *attri
 
 // Helper to add subscription with heap-allocated strings (reduces duplication)
 void APIServer::add_state_subscription_(std::string entity_id, optional<std::string> attribute,
-                                        std::function<void(StringRef)> f, bool once) {
+                                        std::function<void(StringRef)> &&f, bool once) {
   HomeAssistantStateSubscription sub;
   // Allocate heap storage for the strings
   sub.entity_id_dynamic_storage = std::make_unique<std::string>(std::move(entity_id));
@@ -463,29 +463,29 @@ void APIServer::add_state_subscription_(std::string entity_id, optional<std::str
 
 // New const char* overload (for internal components - zero allocation)
 void APIServer::subscribe_home_assistant_state(const char *entity_id, const char *attribute,
-                                               std::function<void(StringRef)> f) {
+                                               std::function<void(StringRef)> &&f) {
   this->add_state_subscription_(entity_id, attribute, std::move(f), false);
 }
 
 void APIServer::get_home_assistant_state(const char *entity_id, const char *attribute,
-                                         std::function<void(StringRef)> f) {
+                                         std::function<void(StringRef)> &&f) {
   this->add_state_subscription_(entity_id, attribute, std::move(f), true);
 }
 
 // std::string overload with StringRef callback (zero-allocation callback)
 void APIServer::subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                               std::function<void(StringRef)> f) {
+                                               std::function<void(StringRef)> &&f) {
   this->add_state_subscription_(std::move(entity_id), std::move(attribute), std::move(f), false);
 }
 
 void APIServer::get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                         std::function<void(StringRef)> f) {
+                                         std::function<void(StringRef)> &&f) {
   this->add_state_subscription_(std::move(entity_id), std::move(attribute), std::move(f), true);
 }
 
 // Legacy helper: wraps std::string callback and delegates to StringRef version
 void APIServer::add_state_subscription_(std::string entity_id, optional<std::string> attribute,
-                                        std::function<void(const std::string &)> f, bool once) {
+                                        std::function<void(const std::string &)> &&f, bool once) {
   // Wrap callback to convert StringRef -> std::string, then delegate
   this->add_state_subscription_(std::move(entity_id), std::move(attribute),
                                 std::function<void(StringRef)>([f = std::move(f)](StringRef state) { f(state.str()); }),
@@ -494,12 +494,12 @@ void APIServer::add_state_subscription_(std::string entity_id, optional<std::str
 
 // Legacy std::string overload (for custom_api_device.h - converts StringRef to std::string)
 void APIServer::subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                               std::function<void(const std::string &)> f) {
+                                               std::function<void(const std::string &)> &&f) {
   this->add_state_subscription_(std::move(entity_id), std::move(attribute), std::move(f), false);
 }
 
 void APIServer::get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                         std::function<void(const std::string &)> f) {
+                                         std::function<void(const std::string &)> &&f) {
   this->add_state_subscription_(std::move(entity_id), std::move(attribute), std::move(f), true);
 }
 

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -201,20 +201,20 @@ class APIServer : public Component,
   };
 
   // New const char* overload (for internal components - zero allocation)
-  void subscribe_home_assistant_state(const char *entity_id, const char *attribute, std::function<void(StringRef)> f);
-  void get_home_assistant_state(const char *entity_id, const char *attribute, std::function<void(StringRef)> f);
+  void subscribe_home_assistant_state(const char *entity_id, const char *attribute, std::function<void(StringRef)> &&f);
+  void get_home_assistant_state(const char *entity_id, const char *attribute, std::function<void(StringRef)> &&f);
 
   // std::string overload with StringRef callback (for custom_api_device.h with zero-allocation callback)
   void subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                      std::function<void(StringRef)> f);
+                                      std::function<void(StringRef)> &&f);
   void get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                std::function<void(StringRef)> f);
+                                std::function<void(StringRef)> &&f);
 
   // Legacy std::string overload (for custom_api_device.h - converts StringRef to std::string for callback)
   void subscribe_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                      std::function<void(const std::string &)> f);
+                                      std::function<void(const std::string &)> &&f);
   void get_home_assistant_state(std::string entity_id, optional<std::string> attribute,
-                                std::function<void(const std::string &)> f);
+                                std::function<void(const std::string &)> &&f);
 
   const std::vector<HomeAssistantStateSubscription> &get_state_subs() const;
 #endif
@@ -241,13 +241,13 @@ class APIServer : public Component,
 #endif  // USE_API_NOISE
 #ifdef USE_API_HOMEASSISTANT_STATES
   // Helper methods to reduce code duplication
-  void add_state_subscription_(const char *entity_id, const char *attribute, std::function<void(StringRef)> f,
+  void add_state_subscription_(const char *entity_id, const char *attribute, std::function<void(StringRef)> &&f,
                                bool once);
-  void add_state_subscription_(std::string entity_id, optional<std::string> attribute, std::function<void(StringRef)> f,
-                               bool once);
+  void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
+                               std::function<void(StringRef)> &&f, bool once);
   // Legacy helper: wraps std::string callback and delegates to StringRef version
   void add_state_subscription_(std::string entity_id, optional<std::string> attribute,
-                               std::function<void(const std::string &)> f, bool once);
+                               std::function<void(const std::string &)> &&f, bool once);
 #endif  // USE_API_HOMEASSISTANT_STATES
   // No explicit close() needed — listen sockets have no active connections on
   // failure/shutdown. Destructor handles fd cleanup (close or abort per platform).

--- a/esphome/components/api/user_services.h
+++ b/esphome/components/api/user_services.h
@@ -230,7 +230,7 @@ template<typename... Ts> class APIRespondAction : public Action<Ts...> {
   void set_is_optional_mode(bool is_optional) { this->is_optional_mode_ = is_optional; }
 
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES_JSON
-  void set_data(std::function<void(Ts..., JsonObject)> func) {
+  void set_data(std::function<void(Ts..., JsonObject)> &&func) {
     this->json_builder_ = std::move(func);
     this->has_data_ = true;
   }


### PR DESCRIPTION
# What does this implement/fix?

The API server's `subscribe_home_assistant_state`, `get_home_assistant_state`, and `add_state_subscription_` methods were taking `std::function` by value despite being internal forwarding layers where every caller passes a temporary or `std::move()`'d value. No caller ever reuses the `std::function` after the call. By-value forced the compiler to emit a move constructor + destructor pair at every forwarding call site for no reason.

This changes all `std::function` parameters in these methods (and `set_data` in `UserServiceAction`) to rvalue reference (`&&`), so callers just pass a pointer instead of materializing a copy on the stack.

The call chain is: `custom_api_device.h` / `homeassistant` components → `subscribe_home_assistant_state` / `get_home_assistant_state` → `add_state_subscription_`. Each layer was passing by value, paying move+destroy overhead at every hop. Now the entire chain passes by reference.

There are 10 forwarding functions affected. Each one compiled into a firmware pays the same overhead, so savings scale with the number of overloads used.

**Note:** The CI memory impact analysis tests a config without `homeassistant` platform components, so these functions are not compiled in and show no change. The code paths are exercised by the integration tests in `tests/integration/`.

### Safety analysis

Every caller already passes rvalues:

**`add_state_subscription_` callers:**

| Caller | What's passed |
|---|---|
| `subscribe_home_assistant_state(const char*, ...)` | `std::move(f)` |
| `get_home_assistant_state(const char*, ...)` | `std::move(f)` |
| `subscribe_home_assistant_state(std::string, ..., StringRef)` | `std::move(f)` |
| `get_home_assistant_state(std::string, ..., StringRef)` | `std::move(f)` |
| `add_state_subscription_(legacy std::string wrapper)` | lambda temporary |

**`subscribe_home_assistant_state` / `get_home_assistant_state` callers:**

| Caller | What's passed |
|---|---|
| `custom_api_device.h` (StringRef overloads) | `std::move(f)` |
| `custom_api_device.h` (legacy std::string overloads) | `std::function<...>(f)` temporary |
| `homeassistant_switch.cpp` | lambda temporary |
| `homeassistant_sensor.cpp` | lambda temporary |
| `homeassistant_binary_sensor.cpp` | lambda temporary |
| `homeassistant_text_sensor.cpp` | lambda temporary |
| `homeassistant_number.cpp` (4 calls) | `std::bind(...)` temporary |

**`set_data` caller:**

| Caller | What's passed |
|---|---|
| `__init__.py` codegen | lambda temporary |

These are all internal functions — not public API. If a future caller tries to pass an lvalue, they get a compile error (requires explicit `std::move`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).