### PR TITLE
[web_server_idf] Pass std::function by rvalue reference

### DIFF
--- a/esphome/components/web_server_idf/multipart.h
+++ b/esphome/components/web_server_idf/multipart.h
@@ -33,8 +33,8 @@ class MultipartReader {
   ~MultipartReader();
 
   // Set callbacks for handling data
-  void set_data_callback(DataCallback callback) { data_callback_ = std::move(callback); }
-  void set_part_complete_callback(PartCompleteCallback callback) { part_complete_callback_ = std::move(callback); }
+  void set_data_callback(DataCallback &&callback) { data_callback_ = std::move(callback); }
+  void set_part_complete_callback(PartCompleteCallback &&callback) { part_complete_callback_ = std::move(callback); }
 
   // Parse incoming data
   size_t parse(const char *data, size_t len);

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -204,7 +204,7 @@ class AsyncWebServer {
   ~AsyncWebServer() { this->end(); }
 
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void onNotFound(std::function<void(AsyncWebServerRequest *request)> fn) { on_not_found_ = std::move(fn); }
+  void onNotFound(std::function<void(AsyncWebServerRequest *request)> &&fn) { on_not_found_ = std::move(fn); }
 
   void begin();
   void end();
@@ -327,7 +327,7 @@ class AsyncEventSource : public AsyncWebHandler {
   // NOLINTNEXTLINE(readability-identifier-naming)
   void handleRequest(AsyncWebServerRequest *request) override;
   // NOLINTNEXTLINE(readability-identifier-naming)
-  void onConnect(connect_handler_t cb) { this->on_connect_ = std::move(cb); }
+  void onConnect(connect_handler_t &&cb) { this->on_connect_ = std::move(cb); }
 
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);
   void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);


### PR DESCRIPTION
# What does this implement/fix?

Four methods in the ESP-IDF web server implementation were taking `std::function` (or typedef'd callbacks) by value despite every caller passing a lambda temporary. No caller ever reuses the callback after the call. By-value forced the compiler to emit a move constructor + destructor pair at each call site for no reason.

This changes them to rvalue reference (`&&`):
- `MultipartReader::set_data_callback(DataCallback &&)`
- `MultipartReader::set_part_complete_callback(PartCompleteCallback &&)`
- `AsyncWebServer::onNotFound(std::function<...> &&)`
- `AsyncEventSource::onConnect(connect_handler_t &&)`

### Safety analysis

Every caller already passes rvalues (lambda temporaries):

| Caller | What's passed |
|---|---|
| `web_server_idf.cpp:901` (`set_data_callback`) | lambda temporary |
| `web_server_idf.cpp:915` (`set_part_complete_callback`) | lambda temporary |
| `web_server.cpp:316` (`onConnect`) | lambda temporary |

`onNotFound` has no current callers outside its declaration.

These are all internal functions — not public API. If a future caller tries to pass an lvalue, they get a compile error (requires explicit `std::move`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).