### PR TITLE
[light] Resolve effect names to indices at codegen time

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -41,7 +41,7 @@ template<typename... Ts> class LightControlAction : public Action<Ts...> {
   TEMPLATABLE_VALUE(float, color_temperature)
   TEMPLATABLE_VALUE(float, cold_white)
   TEMPLATABLE_VALUE(float, warm_white)
-  TEMPLATABLE_VALUE(std::string, effect)
+  TEMPLATABLE_VALUE(uint32_t, effect)
 
   void play(const Ts &...x) override {
     auto call = this->parent_->make_call();

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -194,6 +194,9 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 config[CONF_EFFECT], args, return_type=cg.std_string
             )
             fwd_args = ", ".join(n for _, n in args)
+            # capture="" is correct: paren is a global variable name
+            # string-interpolated into the body at codegen time, not a
+            # C++ runtime capture.
             wrapper = LambdaExpression(
                 f"auto __effect_s = ({inner_lambda})({fwd_args});\n"
                 f"return {paren}->get_effect_index("

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -28,6 +28,7 @@ from esphome.const import (
 )
 from esphome.core import CORE, Lambda
 from esphome.cpp_generator import LambdaExpression
+from esphome.types import ConfigType
 
 from .types import (
     COLOR_MODES,
@@ -114,23 +115,24 @@ LIGHT_TURN_ON_ACTION_SCHEMA = automation.maybe_simple_id(
 )
 
 
-def _resolve_effect_index(config):
+def _resolve_effect_index(config: ConfigType) -> int:
     """Resolve a static effect name to its 1-based index at codegen time.
 
     Effect index 0 means "None" (no effect). Effects are 1-indexed matching
     the C++ convention in LightState.
     """
-    effect_name = config[CONF_EFFECT]
-    if effect_name.lower() == "none":
+    original_name = config[CONF_EFFECT]
+    effect_name = original_name.lower()
+    if effect_name == "none":
         return 0
     light_id = config[CONF_ID]
     light_path = CORE.config.get_path_for_id(light_id)[:-1]
     light_config = CORE.config.get_config_for_path(light_path)
     for i, effect_conf in enumerate(light_config.get(CONF_EFFECTS, [])):
         key = next(iter(effect_conf))
-        if effect_conf[key][CONF_NAME].lower() == effect_name.lower():
+        if effect_conf[key][CONF_NAME].lower() == effect_name:
             return i + 1
-    raise ValueError(f"Effect '{effect_name}' not found in light '{light_id}'")
+    raise ValueError(f"Effect '{original_name}' not found in light '{light_id}'")
 
 
 @automation.register_action(

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -10,12 +10,14 @@ from esphome.const import (
     CONF_COLOR_MODE,
     CONF_COLOR_TEMPERATURE,
     CONF_EFFECT,
+    CONF_EFFECTS,
     CONF_FLASH_LENGTH,
     CONF_GREEN,
     CONF_ID,
     CONF_LIMIT_MODE,
     CONF_MAX_BRIGHTNESS,
     CONF_MIN_BRIGHTNESS,
+    CONF_NAME,
     CONF_RANGE_FROM,
     CONF_RANGE_TO,
     CONF_RED,
@@ -24,6 +26,8 @@ from esphome.const import (
     CONF_WARM_WHITE,
     CONF_WHITE,
 )
+from esphome.core import CORE, Lambda
+from esphome.cpp_generator import LambdaExpression
 
 from .types import (
     COLOR_MODES,
@@ -110,6 +114,25 @@ LIGHT_TURN_ON_ACTION_SCHEMA = automation.maybe_simple_id(
 )
 
 
+def _resolve_effect_index(config):
+    """Resolve a static effect name to its 1-based index at codegen time.
+
+    Effect index 0 means "None" (no effect). Effects are 1-indexed matching
+    the C++ convention in LightState.
+    """
+    effect_name = config[CONF_EFFECT]
+    if effect_name.lower() == "none":
+        return 0
+    light_id = config[CONF_ID]
+    light_path = CORE.config.get_path_for_id(light_id)[:-1]
+    light_config = CORE.config.get_config_for_path(light_path)
+    for i, effect_conf in enumerate(light_config.get(CONF_EFFECTS, [])):
+        key = next(iter(effect_conf))
+        if effect_conf[key][CONF_NAME].lower() == effect_name.lower():
+            return i + 1
+    raise ValueError(f"Effect '{effect_name}' not found in light '{light_id}'")
+
+
 @automation.register_action(
     "light.turn_off", LightControlAction, LIGHT_TURN_OFF_ACTION_SCHEMA
 )
@@ -164,8 +187,26 @@ async def light_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_WARM_WHITE], args, float)
         cg.add(var.set_warm_white(template_))
     if CONF_EFFECT in config:
-        template_ = await cg.templatable(config[CONF_EFFECT], args, cg.std_string)
-        cg.add(var.set_effect(template_))
+        if isinstance(config[CONF_EFFECT], Lambda):
+            # Lambda returns a string — wrap in a C++ lambda that resolves
+            # the effect name to its uint32_t index at runtime
+            inner_lambda = await cg.process_lambda(
+                config[CONF_EFFECT], args, return_type=cg.std_string
+            )
+            fwd_args = ", ".join(n for _, n in args)
+            wrapper = LambdaExpression(
+                f"auto __effect_s = ({inner_lambda})({fwd_args});\n"
+                f"return {paren}->get_effect_index("
+                f"__effect_s.c_str(), __effect_s.size());",
+                args,
+                capture="",
+                return_type=cg.uint32,
+            )
+            cg.add(var.set_effect(wrapper))
+        else:
+            # Static string — resolve effect name to index at codegen time
+            effect_index = _resolve_effect_index(config)
+            cg.add(var.set_effect(effect_index))
     return var
 
 

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -200,6 +200,20 @@ class LightState : public EntityBase, public Component {
     return 0;  // Effect not found
   }
 
+  /// Get effect index by name (const char* overload, avoids std::string construction).
+  uint32_t get_effect_index(const char *name, size_t len) const {
+    StringRef ref(name, len);
+    if (str_equals_case_insensitive(ref, StringRef("none", 4))) {
+      return 0;
+    }
+    for (size_t i = 0; i < this->effects_.size(); i++) {
+      if (str_equals_case_insensitive(ref, this->effects_[i]->get_name())) {
+        return i + 1;
+      }
+    }
+    return 0;
+  }
+
   /// Get effect by index. Returns nullptr if index is invalid.
   LightEffect *get_effect_by_index(uint32_t index) const {
     if (index == 0 || index > this->effects_.size()) {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -12,6 +12,7 @@
 #include "light_transformer.h"
 
 #include "esphome/core/helpers.h"
+#include "esphome/core/progmem.h"
 #include <strings.h>
 #include <vector>
 
@@ -202,10 +203,10 @@ class LightState : public EntityBase, public Component {
 
   /// Get effect index by name (const char* overload, avoids std::string construction).
   uint32_t get_effect_index(const char *name, size_t len) const {
-    StringRef ref(name, len);
-    if (str_equals_case_insensitive(ref, StringRef("none", 4))) {
+    if (len == 4 && ESPHOME_strncasecmp_P(name, ESPHOME_PSTR("none"), 4) == 0) {
       return 0;
     }
+    StringRef ref(name, len);
     for (size_t i = 0; i < this->effects_.size(); i++) {
       if (str_equals_case_insensitive(ref, this->effects_[i]->get_name())) {
         return i + 1;

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -71,6 +71,32 @@ esphome:
       - light.control:
           id: test_monochromatic_light
           state: on
+      # Test static effect name resolution at codegen time
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: Strobe
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: none
+      # Test resolving a different effect on the same light
+      - light.control:
+          id: test_monochromatic_light
+          effect: My Flicker
+      # Test effect: None (capitalized)
+      - light.control:
+          id: test_monochromatic_light
+          effect: None
+      # Test effect lambda with no args (on_boot has empty Ts...)
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: !lambda 'return "Strobe";'
+      # Test effect lambda with non-empty args (repeat passes uint32_t iteration)
+      - repeat:
+          count: 3
+          then:
+            - light.turn_on:
+                id: test_monochromatic_light
+                effect: !lambda 'return iteration > 1 ? "Strobe" : "none";'
       - light.dim_relative:
           id: test_monochromatic_light
           relative_brightness: 5%


### PR DESCRIPTION
# What does this implement/fix?

Resolves static light effect names to their integer index during Python code generation instead of passing strings through `TemplatableValue<std::string>` at C++ runtime.

`TEMPLATABLE_VALUE(std::string, effect)` in `LightControlAction` was pulling in `std::string` construction and `LightCall::set_effect(const char*, size_t)` string-matching code even when the effect name is a static string known at build time. Resolving at codegen time avoids this overhead and also catches invalid effect names at compile time instead of silently failing at runtime.

Measured savings on ESP8266: -632 bytes flash.

### Changes

- **`automation.h`**: Changed `TEMPLATABLE_VALUE(std::string, effect)` to `TEMPLATABLE_VALUE(uint32_t, effect)`
- **`automation.py`**: Static effect names are resolved to their 1-based index at codegen time using `CORE.config`. Invalid effect names now produce a clear error at build time instead of silently failing at runtime.
- **`light_state.h`**: Added `get_effect_index(const char*, size_t)` overload using `StringRef` to avoid `std::string` in the lambda wrapper path
- For the rare lambda case (`effect: !lambda '...'`), a `LambdaExpression` wrapper resolves the string to an index at runtime

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: monochromatic
    id: my_light
    name: My Light
    output: my_output
    effects:
      - strobe:

esphome:
  on_boot:
    then:
      # Static effect name — resolved to index at codegen time
      - light.turn_on:
          id: my_light
          effect: Strobe
      # Turn off effect
      - light.turn_on:
          id: my_light
          effect: none
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).