### PR TITLE
[light] Add additional light effect test cases

### DIFF
--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -71,6 +71,32 @@ esphome:
       - light.control:
           id: test_monochromatic_light
           state: on
+      # Test static effect name resolution at codegen time
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: Strobe
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: none
+      # Test resolving a different effect on the same light
+      - light.control:
+          id: test_monochromatic_light
+          effect: My Flicker
+      # Test effect: None (capitalized)
+      - light.control:
+          id: test_monochromatic_light
+          effect: None
+      # Test effect lambda with no args (on_boot has empty Ts...)
+      - light.turn_on:
+          id: test_monochromatic_light
+          effect: !lambda 'return "Strobe";'
+      # Test effect lambda with non-empty args (repeat passes uint32_t iteration)
+      - repeat:
+          count: 3
+          then:
+            - light.turn_on:
+                id: test_monochromatic_light
+                effect: !lambda 'return iteration > 1 ? "Strobe" : "none";'
       - light.dim_relative:
           id: test_monochromatic_light
           relative_brightness: 5%


### PR DESCRIPTION

# What does this implement/fix?

for https://github.com/esphome/esphome/pull/14265

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
