### PR TITLE
[pid] Fix deadband threshold conversion for Fahrenheit

### DIFF
--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -50,8 +50,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_HEAT_OUTPUT): cv.use_id(output.FloatOutput),
             cv.Optional(CONF_DEADBAND_PARAMETERS): cv.Schema(
                 {
-                    cv.Required(CONF_THRESHOLD_HIGH): cv.temperature,
-                    cv.Required(CONF_THRESHOLD_LOW): cv.temperature,
+                    cv.Required(CONF_THRESHOLD_HIGH): cv.temperature_delta,
+                    cv.Required(CONF_THRESHOLD_LOW): cv.temperature_delta,
                     cv.Optional(CONF_KP_MULTIPLIER, default=0.1): cv.float_,
                     cv.Optional(CONF_KI_MULTIPLIER, default=0.0): cv.float_,
                     cv.Optional(CONF_KD_MULTIPLIER, default=0.0): cv.float_,


### PR DESCRIPTION
# What does this implement/fix?

Fix deadband `threshold_high` and `threshold_low` using `cv.temperature` instead of `cv.temperature_delta`. These thresholds are temperature **deltas** (offsets from the setpoint), not absolute temperatures. `cv.temperature` applies the full Fahrenheit-to-Celsius conversion `(F-32)*5/9`, which introduces an incorrect -32 offset. `cv.temperature_delta` correctly converts as `F*5/9`.

For example, a 2°F deadband was being converted to `(2-32)*5/9 = -16.67°C` instead of the correct `2*5/9 = 1.11°C`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14264

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: pid
    name: "PID Climate"
    sensor: temperature_sensor
    default_target_temperature: 72°F
    heat_output: heater
    control_parameters:
      kp: 0.5
      ki: 0.01
      kd: 0.0
      deadband_parameters:
        threshold_high: 2°F
        threshold_low: -2°F
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).