### PR TITLE
[sensirion_common] Move sen5x's sensirion_convert_to_string_in_place() function to sensirion_common

### DIFF
--- a/esphome/components/sen5x/sen5x.cpp
+++ b/esphome/components/sen5x/sen5x.cpp
@@ -56,15 +56,6 @@ static const LogString *rht_accel_mode_to_string(RhtAccelerationMode mode) {
   }
 }
 
-// This function performs an in-place conversion of the provided buffer
-// from uint16_t values to big endianness
-static inline const char *sensirion_convert_to_string_in_place(uint16_t *array, size_t length) {
-  for (size_t i = 0; i < length; i++) {
-    array[i] = convert_big_endian(array[i]);
-  }
-  return reinterpret_cast<const char *>(array);
-}
-
 void SEN5XComponent::setup() {
   // the sensor needs 1000 ms to enter the idle state
   this->set_timeout(1000, [this]() {

--- a/esphome/components/sensirion_common/i2c_sensirion.h
+++ b/esphome/components/sensirion_common/i2c_sensirion.h
@@ -21,6 +21,17 @@ class SensirionI2CDevice : public i2c::I2CDevice {
  public:
   enum CommandLen : uint8_t { ADDR_8_BIT = 1, ADDR_16_BIT = 2 };
 
+  /**
+   * This function performs an in-place conversion of the provided buffer
+   * from uint16_t values to big endianness. Useful for Sensirion strings in SEN5X and SEN6X
+   */
+  static inline const char *sensirion_convert_to_string_in_place(uint16_t *array, size_t length) {
+    for (size_t i = 0; i < length; i++) {
+      array[i] = convert_big_endian(array[i]);
+    }
+    return reinterpret_cast<const char *>(array);
+  }
+
   /** Read data words from I2C device.
    * handles CRC check used by Sensirion sensors
    * @param data pointer to raw result


### PR DESCRIPTION
# What does this implement/fix?

Moves `sensirion_convert_to_string_in_place()` currently in the `sen5x` component to `sensirion_common`. Makes this function available to other components like `sen6x` in PR #12553

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
