### PR TITLE
[config] Improve dimensions validation and fix online_image resize aspect ratio

### DIFF
--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -2,6 +2,7 @@
 #include "image_decoder.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
+#include <algorithm>
 #include <cstring>
 
 #ifdef USE_RUNTIME_IMAGE_BMP
@@ -42,6 +43,14 @@ int RuntimeImage::resize(int width, int height) {
   // Use fixed dimensions if specified (0 means auto-resize)
   int target_width = this->fixed_width_ ? this->fixed_width_ : width;
   int target_height = this->fixed_height_ ? this->fixed_height_ : height;
+
+  // When both fixed dimensions are set, scale uniformly to preserve aspect ratio
+  if (this->fixed_width_ && this->fixed_height_ && width > 0 && height > 0) {
+    float scale =
+        std::min(static_cast<float>(this->fixed_width_) / width, static_cast<float>(this->fixed_height_) / height);
+    target_width = static_cast<int>(width * scale);
+    target_height = static_cast<int>(height * scale);
+  }
 
   size_t result = this->resize_buffer_(target_width, target_height);
   if (result > 0 && this->progressive_display_) {

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1642,8 +1642,7 @@ def dimensions(value):
         return [width, height]
     if not isinstance(value, str):
         raise Invalid(
-            "Dimensions must be a string (WIDTHxHEIGHT). Got a number instead, "
-            "try quoting the value."
+            "Dimensions must be a string (WIDTHxHEIGHT). Got a number instead, try quoting the value."
         )
     match = re.match(r"\s*([0-9]+)\s*[xX]\s*([0-9]+)\s*", value)
     if not match:

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1640,7 +1640,11 @@ def dimensions(value):
         if width <= 0 or height <= 0:
             raise Invalid("Width and height must at least be 1")
         return [width, height]
-    value = string(value)
+    if not isinstance(value, str):
+        raise Invalid(
+            "Dimensions must be a string (WIDTHxHEIGHT). Got a number instead, "
+            "did YAML parse this as hex? Try quoting the value."
+        )
     match = re.match(r"\s*([0-9]+)\s*[xX]\s*([0-9]+)\s*", value)
     if not match:
         raise Invalid(

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -1643,7 +1643,7 @@ def dimensions(value):
     if not isinstance(value, str):
         raise Invalid(
             "Dimensions must be a string (WIDTHxHEIGHT). Got a number instead, "
-            "did YAML parse this as hex? Try quoting the value."
+            "try quoting the value."
         )
     match = re.match(r"\s*([0-9]+)\s*[xX]\s*([0-9]+)\s*", value)
     if not match:


### PR DESCRIPTION
# What does this implement/fix?

Two fixes:

1. **Better error for YAML hex ambiguity in `cv.dimensions`**: When a user writes `resize: 0x180`, YAML silently parses it as hex integer `384`. Previously this produced a confusing "Only WIDTHxHEIGHT is allowed" error. Now it detects non-string values and suggests quoting.

2. **Fix `online_image` resize to preserve aspect ratio**: The docs say `resize` will "resize the image to fit inside the given dimensions and preserve the aspect ratio" but the code just stretched the image to fill the exact target size. Now it scales uniformly using the smaller scale factor to fit within the bounding box.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Closes https://github.com/esphome/esphome/issues/14273

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
online_image:
  - url: http://example.com/image.jpg
    id: image
    type: RGB565
    format: JPEG
    resize: 360x180  # now preserves aspect ratio instead of stretching
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
