### PR TITLE
[api] Prefer make_unique_for_overwrite for noninit send buffers

### DIFF
--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -134,7 +134,7 @@ void APIFrameHelper::buffer_data_from_iov_(const struct iovec *iov, int iovcnt, 
   uint16_t buffer_size = total_write_len - offset;
   auto &buffer = this->tx_buf_[this->tx_buf_tail_];
   buffer = std::make_unique<SendBuffer>(SendBuffer{
-      .data = std::make_unique<uint8_t[]>(buffer_size),
+      .data = std::make_unique_for_overwrite<uint8_t[]>(buffer_size),
       .size = buffer_size,
       .offset = 0,
   });


### PR DESCRIPTION
## What does this implement/fix?

C++20 `std::make_unique_for_overwrite` skips zero-initialization for POD types. The send buffer in `buffer_data_from_iov_` is immediately and completely filled via `memcpy` from the iov segments, so zero-initialization is unnecessary overhead.

Follow-up to https://github.com/esphome/esphome/pull/14272 by @schdro.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/pull/14272

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).