### PR TITLE
[ota] Prefer make_unique_for_overwrite for noninit OTA buffer

### DIFF
--- a/esphome/components/ota/ota_backend_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_esp8266.cpp
@@ -98,7 +98,7 @@ OTAResponseTypes ESP8266OTABackend::begin(size_t image_size) {
 
   // ESP8266's umm_malloc guarantees 4-byte aligned allocations, which is required
   // for spi_flash_write(). This is the same pattern used by Arduino's Updater class.
-  this->buffer_ = make_unique<uint8_t[]>(this->buffer_size_);
+  this->buffer_ = std::make_unique_for_overwrite<uint8_t[]>(this->buffer_size_);
   if (!this->buffer_) {
     return OTA_RESPONSE_ERROR_UNKNOWN;
   }


### PR DESCRIPTION
# What does this implement/fix?

Use C++20 `make_unique_for_overwrite<uint8_t[]>` instead of `make_unique<uint8_t[]>` for the ESP8266 OTA write buffer. `make_unique_for_overwrite` skips zero-initialization for POD types, which is unnecessary overhead here because `buffer_len_` is initialized to 0 and the buffer is always filled by incoming OTA data (via `memcpy` in `write()`) before being read.

Follow-up to https://github.com/esphome/esphome/pull/14272 by @schdro which applied the same optimization to `esp32/preferences.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/pull/14272

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [X] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).