### PR TITLE
[web_server_idf] Prefer make_unique_for_overwrite for noninit recv buffer

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -921,7 +921,7 @@ esp_err_t AsyncWebServer::handle_multipart_upload_(httpd_req_t *r, const char *c
   });
 
   // Use heap buffer - 1460 bytes is too large for the httpd task stack
-  auto buffer = std::make_unique<char[]>(MULTIPART_CHUNK_SIZE);
+  auto buffer = std::make_unique_for_overwrite<char[]>(MULTIPART_CHUNK_SIZE);
   size_t bytes_since_yield = 0;
 
   for (size_t remaining = r->content_len; remaining > 0;) {


### PR DESCRIPTION
# What does this implement/fix?

Use C++20 `std::make_unique_for_overwrite<char[]>` instead of `std::make_unique<char[]>` for the multipart receive buffer. `make_unique_for_overwrite` skips zero-initialization for POD types, which is unnecessary overhead here since the buffer is written by `httpd_req_recv()` before being read, and only the bytes actually received (`recv_len`) are passed to the parser.

This component is ESP-IDF only, so GCC 14.2 is available (`make_unique_for_overwrite` requires GCC 11+ libstdc++; ESP8266's GCC 10.3 does not have it).

Follow-up to https://github.com/esphome/esphome/pull/14272 by @schdro which applied the same optimization to `esp32/preferences.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/pull/14272

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).