### PR TITLE
[rtttl] Fix speaker playback bugs

### DIFF
--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -139,9 +139,10 @@ void Rtttl::loop() {
         x++;
       }
       if (x > 0) {
-        int send = this->speaker_->play((uint8_t *) (&sample), x * 2);
-        if (send != x * 4) {
-          this->samples_sent_ -= (x - (send / 2));
+        size_t bytes_to_send = x * sizeof(SpeakerSample);
+        size_t send = this->speaker_->play((uint8_t *) (&sample), bytes_to_send);
+        if (send != bytes_to_send) {
+          this->samples_sent_ -= (x - (send / sizeof(SpeakerSample)));
         }
         return;
       }
@@ -201,9 +202,9 @@ void Rtttl::loop() {
   bool need_note_gap = false;
   if (note) {
     auto note_index = (scale - 4) * 12 + note;
-    if (note_index < 0 || note_index >= (int) sizeof(NOTES)) {
+    if (note_index < 0 || note_index >= (int) (sizeof(NOTES) / sizeof(NOTES[0]))) {
       ESP_LOGE(TAG, "Note out of range (note: %d, scale: %d, index: %d, max: %d)", note, scale, note_index,
-               (int) sizeof(NOTES));
+               (int) (sizeof(NOTES) / sizeof(NOTES[0])));
       this->finish_();
       return;
     }
@@ -240,9 +241,9 @@ void Rtttl::loop() {
     this->samples_sent_ = 0;
     this->samples_gap_ = 0;
     this->samples_per_wave_ = 0;
-    this->samples_count_ = (this->sample_rate_ * this->note_duration_) / 1600;  //(ms);
+    this->samples_count_ = (this->sample_rate_ * this->note_duration_) / 1000;
     if (need_note_gap) {
-      this->samples_gap_ = (this->sample_rate_ * DOUBLE_NOTE_GAP_MS) / 1600;  //(ms);
+      this->samples_gap_ = (this->sample_rate_ * DOUBLE_NOTE_GAP_MS) / 1000;
     }
     if (this->output_freq_ != 0) {
       // make sure there is enough samples to add a full last sinus.
@@ -279,7 +280,7 @@ void Rtttl::play(std::string rtttl) {
   this->note_duration_ = 0;
 
   int bpm = 63;
-  uint8_t num;
+  uint16_t num;
 
   // Get name
   this->position_ = this->rtttl_.find(':');
@@ -395,7 +396,7 @@ void Rtttl::finish_() {
     sample[0].right = 0;
     sample[1].left = 0;
     sample[1].right = 0;
-    this->speaker_->play((uint8_t *) (&sample), 8);
+    this->speaker_->play((uint8_t *) (&sample), sizeof(sample));
     this->speaker_->finish();
     this->set_state_(State::STOPPING);
   }

--- a/esphome/components/rtttl/rtttl.cpp
+++ b/esphome/components/rtttl/rtttl.cpp
@@ -222,7 +222,7 @@ void Rtttl::loop() {
 
 #ifdef USE_OUTPUT
   if (this->output_ != nullptr) {
-    if (need_note_gap) {
+    if (need_note_gap && this->note_duration_ > DOUBLE_NOTE_GAP_MS) {
       this->output_->set_level(0.0);
       delay(DOUBLE_NOTE_GAP_MS);
       this->note_duration_ -= DOUBLE_NOTE_GAP_MS;

--- a/esphome/components/rtttl/rtttl.h
+++ b/esphome/components/rtttl/rtttl.h
@@ -46,8 +46,8 @@ class Rtttl : public Component {
   }
 
  protected:
-  inline uint8_t get_integer_() {
-    uint8_t ret = 0;
+  inline uint16_t get_integer_() {
+    uint16_t ret = 0;
     while (isdigit(this->rtttl_[this->position_])) {
       ret = (ret * 10) + (this->rtttl_[this->position_++] - '0');
     }
@@ -87,7 +87,7 @@ class Rtttl : public Component {
 
 #ifdef USE_OUTPUT
   /// The output to write the sound to.
-  output::FloatOutput *output_;
+  output::FloatOutput *output_{nullptr};
 #endif  // USE_OUTPUT
 
 #ifdef USE_SPEAKER


### PR DESCRIPTION
# What does this implement/fix?

Fixes multiple bugs in the RTTTL speaker playback path:

1. **finish_() buffer overread**: passed 8 bytes to `speaker_->play()` but `sample` array is only `sizeof(SpeakerSample) * 2 = 4` bytes, reading past the array (UB). Fixed to use `sizeof(sample)`.

2. **play() size mismatch**: `play()` was called with `x * 2` bytes but the completion check compared against `x * 4`. Fixed both to use `x * sizeof(SpeakerSample)`.

3. **Note timing divisor**: `samples_count_` and `samples_gap_` were calculated with `/1600` instead of `/1000`, causing notes to play at 62.5% of their intended duration. `sample_rate_` is in samples/sec and `note_duration_` is in milliseconds, so dividing by 1000 converts ms to seconds:
   ```
   samples = (samples/sec × ms) / 1000 = (samples/sec × sec) = samples
   ```
   With `/1600`, a 300ms note at 16kHz produces 3000 samples (187.5ms) instead of the correct 4800 samples (300ms).

4. **NOTES array bounds check**: used `sizeof(NOTES)` (98 bytes for 49 uint16_t elements) instead of element count. Fixed to `sizeof(NOTES) / sizeof(NOTES[0])`.

5. **get_integer_() overflow**: returned `uint8_t`, so BPM values > 255 would silently wrap. RTTTL spec allows BPM up to 900. Changed to `uint16_t`.

6. **Uninitialized output_ pointer**: `output::FloatOutput *output_` was not initialized, could cause UB if `USE_OUTPUT` is defined but no output is set. Initialized to `nullptr`.

7. **Note gap underflow guard**: the output path subtracts `DOUBLE_NOTE_GAP_MS` from `note_duration_` without checking the duration is large enough. With the `uint16_t` fix (#5) allowing higher BPMs and short note durations (e.g. 32nd note at BPM 900 = 8.3ms < 10ms gap), this could underflow the `uint16_t`. Added a guard to skip the gap when the note is too short.

## Testing

Tested on Waveshare ESP32-P4 Nano with ES8311 codec and I2S speaker output.

**Mario theme (`mario:d=4,o=5,b=100:16e6,16e6,32p,8e6,...`):**
- Calculated duration: 6.9s (30 notes at BPM 100)
- Before fix (`/1600`): **4.72s** — notes played at 62.5% of intended duration
- After fix (`/1000`): **7.53s** — correct duration (6.9s + speaker start/stop overhead)

```
Before:
[12:03:52.518][D][rtttl:293]: Playing song mario
[12:03:52.518][D][i2s_audio.speaker:102]: Starting
[12:03:57.240][D][i2s_audio.speaker:111]: Stopping
[12:03:57.245][D][rtttl:419]: Playback finished
Duration: ~4.72s

After:
[12:07:59.465][D][rtttl:293]: Playing song mario
[12:07:59.466][D][i2s_audio.speaker:102]: Starting
[12:08:07.005][D][i2s_audio.speaker:111]: Stopping
[12:08:07.007][D][rtttl:420]: Playback finished
Duration: ~7.53s
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2s_audio:
  - id: i2s_output
    i2s_lrclk_pin: GPIO10
    i2s_bclk_pin: GPIO12
    i2s_mclk_pin: GPIO13

speaker:
  - platform: i2s_audio
    i2s_audio_id: i2s_output
    id: speaker_id
    i2s_dout_pin: GPIO09
    dac_type: external
    sample_rate: 16000
    bits_per_sample: 16bit
    channel: mono

rtttl:
  speaker: speaker_id
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
