### PR TITLE
[hmc5883l] Fix wrong gain for 88uT range

### DIFF
--- a/esphome/components/hmc5883l/hmc5883l.cpp
+++ b/esphome/components/hmc5883l/hmc5883l.cpp
@@ -95,7 +95,7 @@ void HMC5883LComponent::update() {
   float mg_per_bit;
   switch (this->range_) {
     case HMC5883L_RANGE_88_UT:
-      mg_per_bit = 0.073f;
+      mg_per_bit = 0.73f;
       break;
     case HMC5883L_RANGE_130_UT:
       mg_per_bit = 0.92f;


### PR DESCRIPTION
# What does this implement/fix?

Fix incorrect gain value for the 88µT range. The code had `0.073` mG/bit instead of `0.73` mG/bit, causing readings to be 10x too low.

The datasheet (page 14) specifies a gain of 1370 LSb/Gauss for this range: `1000 / 1370 = 0.73 mG/bit`. All other ranges were correct.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14276

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: hmc5883l
    address: 0x1E
    field_strength_x:
      name: "HMC5883L Field Strength X"
    field_strength_y:
      name: "HMC5883L Field Strength Y"
    field_strength_z:
      name: "HMC5883L Field Strength Z"
    heading:
      name: "HMC5883L Heading"
    range: 88uT
    update_interval: 1s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
