### PR TITLE
[safe_mode] Mark SafeModeComponent and SafeModeTrigger as final

### DIFF
--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -8,7 +8,7 @@
 
 namespace esphome::safe_mode {
 
-class SafeModeTrigger : public Trigger<> {
+class SafeModeTrigger final : public Trigger<> {
  public:
   explicit SafeModeTrigger(SafeModeComponent *parent) {
     parent->add_on_safe_mode_callback([this]() { trigger(); });

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -15,7 +15,7 @@ namespace esphome::safe_mode {
 constexpr uint32_t RTC_KEY = 233825507UL;
 
 /// SafeModeComponent provides a safe way to recover from repeated boot failures
-class SafeModeComponent : public Component {
+class SafeModeComponent final : public Component {
  public:
   bool should_enter_safe_mode(uint8_t num_attempts, uint32_t enable_time, uint32_t boot_is_good_after);
 


### PR DESCRIPTION
# What does this implement/fix?

Mark `SafeModeComponent` and `SafeModeTrigger` as `final` since neither class is subclassed. This enables the compiler to devirtualize calls to the `Component` overrides (`loop`, `dump_config`, `get_setup_priority`, `on_safe_shutdown`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).