### PR TITLE
[web_server] Mark classes as final

### DIFF
--- a/esphome/components/web_server/list_entities.cpp
+++ b/esphome/components/web_server/list_entities.cpp
@@ -14,8 +14,6 @@ ListEntitiesIterator::ListEntitiesIterator(const WebServer *ws, AsyncEventSource
 ListEntitiesIterator::ListEntitiesIterator(const WebServer *ws, DeferredUpdateEventSource *es)
     : web_server_(ws), events_(es) {}
 #endif
-ListEntitiesIterator::~ListEntitiesIterator() {}
-
 #ifdef USE_BINARY_SENSOR
 bool ListEntitiesIterator::on_binary_sensor(binary_sensor::BinarySensor *obj) {
   this->events_->deferrable_send_state(obj, "state_detail_all", WebServer::binary_sensor_all_json_generator);

--- a/esphome/components/web_server/list_entities.h
+++ b/esphome/components/web_server/list_entities.h
@@ -17,14 +17,13 @@ class DeferredUpdateEventSource;
 #endif
 class WebServer;
 
-class ListEntitiesIterator : public ComponentIterator {
+class ListEntitiesIterator final : public ComponentIterator {
  public:
 #ifdef USE_ESP32
   ListEntitiesIterator(const WebServer *ws, esphome::web_server_idf::AsyncEventSource *es);
 #elif defined(USE_ARDUINO)
   ListEntitiesIterator(const WebServer *ws, DeferredUpdateEventSource *es);
 #endif
-  virtual ~ListEntitiesIterator();
 #ifdef USE_BINARY_SENSOR
   bool on_binary_sensor(binary_sensor::BinarySensor *obj) override;
 #endif

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -107,7 +107,7 @@ enum JsonDetail { DETAIL_ALL, DETAIL_STATE };
 using message_generator_t = json::SerializationBuffer<>(WebServer *, void *);
 
 class DeferredUpdateEventSourceList;
-class DeferredUpdateEventSource : public AsyncEventSource {
+class DeferredUpdateEventSource final : public AsyncEventSource {
   friend class DeferredUpdateEventSourceList;
 
   /*
@@ -163,7 +163,7 @@ class DeferredUpdateEventSource : public AsyncEventSource {
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);
 };
 
-class DeferredUpdateEventSourceList : public std::list<DeferredUpdateEventSource *> {
+class DeferredUpdateEventSourceList final : public std::list<DeferredUpdateEventSource *> {
  protected:
   void on_client_connect_(DeferredUpdateEventSource *source);
   void on_client_disconnect_(DeferredUpdateEventSource *source);
@@ -187,7 +187,7 @@ class DeferredUpdateEventSourceList : public std::list<DeferredUpdateEventSource
  * under the '/light/...', '/sensor/...', ... URLs. A full documentation for this API
  * can be found under https://esphome.io/web-api/.
  */
-class WebServer : public Controller, public Component, public AsyncWebHandler {
+class WebServer final : public Controller, public Component, public AsyncWebHandler {
 #if !defined(USE_ESP32) && defined(USE_ARDUINO)
   friend class DeferredUpdateEventSourceList;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Mark `WebServer`, `ListEntitiesIterator`, `DeferredUpdateEventSource`, and `DeferredUpdateEventSourceList` as `final` since none are subclassed.

This enables the compiler to devirtualize calls to the many virtual overrides from `Component`, `Controller`, `AsyncWebHandler`, and `ComponentIterator`.

Also removes the unnecessary virtual destructor from `ListEntitiesIterator` since the class is now `final` and the base class (`ComponentIterator`) has no virtual destructor.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).