### PR TITLE
[ota] Mark OTA backend and component leaf classes as final

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -12,7 +12,7 @@
 namespace esphome {
 
 /// ESPHomeOTAComponent provides a simple way to integrate Over-the-Air updates into your app using ArduinoOTA.
-class ESPHomeOTAComponent : public ota::OTAComponent {
+class ESPHomeOTAComponent final : public ota::OTAComponent {
  public:
   enum class OTAState : uint8_t {
     IDLE,

--- a/esphome/components/http_request/ota/ota_http_request.h
+++ b/esphome/components/http_request/ota/ota_http_request.h
@@ -22,7 +22,7 @@ enum OtaHttpRequestError : uint8_t {
   OTA_CONNECTION_ERROR = 0x12,
 };
 
-class OtaHttpRequestComponent : public ota::OTAComponent, public Parented<HttpRequestComponent> {
+class OtaHttpRequestComponent final : public ota::OTAComponent, public Parented<HttpRequestComponent> {
  public:
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }

--- a/esphome/components/ota/ota_backend_arduino_libretiny.h
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace ota {
 
-class ArduinoLibreTinyOTABackend : public OTABackend {
+class ArduinoLibreTinyOTABackend final : public OTABackend {
  public:
   OTAResponseTypes begin(size_t image_size) override;
   void set_update_md5(const char *md5) override;

--- a/esphome/components/ota/ota_backend_arduino_rp2040.h
+++ b/esphome/components/ota/ota_backend_arduino_rp2040.h
@@ -9,7 +9,7 @@
 namespace esphome {
 namespace ota {
 
-class ArduinoRP2040OTABackend : public OTABackend {
+class ArduinoRP2040OTABackend final : public OTABackend {
  public:
   OTAResponseTypes begin(size_t image_size) override;
   void set_update_md5(const char *md5) override;

--- a/esphome/components/ota/ota_backend_esp8266.h
+++ b/esphome/components/ota/ota_backend_esp8266.h
@@ -12,7 +12,7 @@ namespace esphome::ota {
 /// OTA backend for ESP8266 using native SDK functions.
 /// This implementation bypasses the Arduino Updater library to save ~228 bytes of RAM
 /// by not having a global Update object in .bss.
-class ESP8266OTABackend : public OTABackend {
+class ESP8266OTABackend final : public OTABackend {
  public:
   OTAResponseTypes begin(size_t image_size) override;
   void set_update_md5(const char *md5) override;

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -10,7 +10,7 @@
 namespace esphome {
 namespace ota {
 
-class IDFOTABackend : public OTABackend {
+class IDFOTABackend final : public OTABackend {
  public:
   OTAResponseTypes begin(size_t image_size) override;
   void set_update_md5(const char *md5) override;

--- a/esphome/components/ota/ota_backend_host.h
+++ b/esphome/components/ota/ota_backend_host.h
@@ -7,7 +7,7 @@ namespace esphome::ota {
 /// Stub OTA backend for host platform - allows compilation but does not implement OTA.
 /// All operations return error codes immediately. This enables configurations with
 /// OTA triggers to compile for host platform during development.
-class HostOTABackend : public OTABackend {
+class HostOTABackend final : public OTABackend {
  public:
   OTAResponseTypes begin(size_t image_size) override;
   void set_update_md5(const char *md5) override;

--- a/esphome/components/web_server/ota/ota_web_server.h
+++ b/esphome/components/web_server/ota/ota_web_server.h
@@ -9,7 +9,7 @@
 
 namespace esphome::web_server {
 
-class WebServerOTAComponent : public ota::OTAComponent {
+class WebServerOTAComponent final : public ota::OTAComponent {
  public:
   void setup() override;
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

Mark all OTA leaf classes as `final` since none are subclassed. This enables the compiler to devirtualize calls to the `OTABackend` and `Component` overrides.

**Backends:** `IDFOTABackend`, `ESP8266OTABackend`, `ArduinoRP2040OTABackend`, `ArduinoLibreTinyOTABackend`, `HostOTABackend`

**Components:** `ESPHomeOTAComponent`, `WebServerOTAComponent`, `OtaHttpRequestComponent`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).