### PR TITLE
[shelly_dimmer] Fix millis overflow in ACK timeout check

### DIFF
--- a/esphome/components/shelly_dimmer/stm32flash.cpp
+++ b/esphome/components/shelly_dimmer/stm32flash.cpp
@@ -149,7 +149,7 @@ stm32_err_t stm32_get_ack_timeout(const stm32_unique_ptr &stm, uint32_t timeout)
   do {
     yield();
     if (!stream->available()) {
-      if (millis() < start_time + timeout)
+      if (millis() - start_time < timeout)
         continue;
       ESP_LOGD(TAG, "Failed to read ACK timeout=%i", timeout);
       return STM32_ERR_UNKNOWN;
@@ -212,7 +212,7 @@ stm32_err_t stm32_resync(const stm32_unique_ptr &stm) {
   static_assert(sizeof(buf) == BUFFER_SIZE, "Buf expected to be 2 bytes");
 
   uint8_t ack;
-  while (t1 < t0 + STM32_RESYNC_TIMEOUT) {
+  while (t1 - t0 < STM32_RESYNC_TIMEOUT) {
     stream->write_array(buf, BUFFER_SIZE);
     stream->flush();
     if (!stream->read_array(&ack, 1)) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a millis overflow bug in the STM32 flash ACK timeout check.

The code used `millis() < start_time + timeout` which breaks when the 32-bit millis counter wraps after ~49.7 days. Changed to the subtraction form `millis() - start_time < timeout` which handles unsigned wrap correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal bug fix
light:
  - platform: shelly_dimmer
    name: "Shelly Dimmer"
    power:
      name: "Power"
    voltage:
      name: "Voltage"
    current:
      name: "Current"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
