### PR TITLE
[lcd_base] Fix millis() truncation to uint8_t

### DIFF
--- a/esphome/components/lcd_base/lcd_display.cpp
+++ b/esphome/components/lcd_base/lcd_display.cpp
@@ -45,7 +45,7 @@ void LCDDisplay::setup() {
   // TODO dotsize
 
   // Commands can only be sent 40ms after boot-up, so let's wait if we're close
-  const uint8_t now = millis();
+  const uint32_t now = millis();
   if (now < 40)
     delay(40u - now);
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a type truncation bug where `millis()` (returns `uint32_t`) was stored in a `uint8_t`, silently discarding the upper 24 bits. The variable is only used during `setup()` to delay if boot time is under 40ms, so in practice this worked because `millis()` is small at boot. However it is technically incorrect and would produce wrong results if `millis()` exceeded 255 at setup time.

Changed `const uint8_t now` to `const uint32_t now`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal bug fix
display:
  - platform: lcd_pcf8574
    dimensions: 20x4
    address: 0x27
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
