### PR TITLE
[light] Fix millis overflow in transition progress and flash timing

### DIFF
--- a/esphome/components/light/light_transformer.h
+++ b/esphome/components/light/light_transformer.h
@@ -44,12 +44,11 @@ class LightTransformer {
   /// The progress of this transition, on a scale of 0 to 1.
   float get_progress_() {
     uint32_t now = esphome::millis();
-    if (now < this->start_time_)
-      return 0.0f;
-    if (now >= this->start_time_ + this->length_)
+    uint32_t elapsed = now - this->start_time_;
+    if (elapsed >= this->length_)
       return 1.0f;
 
-    return clamp((now - this->start_time_) / float(this->length_), 0.0f, 1.0f);
+    return clamp(elapsed / float(this->length_), 0.0f, 1.0f);
   }
 
   uint32_t start_time_;

--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -78,7 +78,7 @@ class LightFlashTransformer : public LightTransformer {
   optional<LightColorValues> apply() override {
     optional<LightColorValues> result = {};
 
-    if (this->transformer_ == nullptr && millis() > this->start_time_ + this->length_ - this->transition_length_) {
+    if (this->transformer_ == nullptr && millis() - this->start_time_ > this->length_ - this->transition_length_) {
       // second transition back to start value
       this->transformer_ = this->state_.get_output()->create_default_transition();
       this->transformer_->setup(this->state_.current_values, this->get_start_values(), this->transition_length_);


### PR DESCRIPTION
# What does this implement/fix?

Fixes millis overflow in two places in the light component:

1. **`get_progress_()`** in `light_transformer.h`: Used `now < start_time_` and `now >= start_time_ + length_` which break when the 32-bit millis counter wraps after ~49.7 days. Changed to use `elapsed = now - start_time_` with unsigned subtraction which handles wrap correctly. The `now < start_time_` early return was also unnecessary with the subtraction form.

2. **`LightFlashTransformer::apply()`** in `transformers.h`: Used `millis() > start_time_ + length_ - transition_length_` which has the same overflow issue. Changed to `millis() - start_time_ > length_ - transition_length_`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal bug fix
light:
  - platform: binary
    name: "Test Light"
    output: my_output
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
