### PR TITLE
[lightwaverf] Fix millis overflow in send timeout check

### DIFF
--- a/esphome/components/lightwaverf/lightwaverf.cpp
+++ b/esphome/components/lightwaverf/lightwaverf.cpp
@@ -31,13 +31,12 @@ void LightWaveRF::read_tx() {
 void LightWaveRF::send_rx(const std::vector<uint8_t> &msg, uint8_t repeats, bool inverted, int u_sec) {
   this->lwtx_.lwtx_setup(pin_tx_, repeats, inverted, u_sec);
 
-  uint32_t timeout = 0;
+  uint32_t timeout = millis();
   if (this->lwtx_.lwtx_free()) {
     this->lwtx_.lwtx_send(msg);
-    timeout = millis();
     ESP_LOGD(TAG, "[%i] msg start", timeout);
   }
-  while (!this->lwtx_.lwtx_free() && millis() < (timeout + 1000)) {
+  while (!this->lwtx_.lwtx_free() && millis() - timeout < 1000) {
     delay(10);
   }
   timeout = millis() - timeout;


### PR DESCRIPTION
# What does this implement/fix?

Fixes millis overflow in the LightWaveRF send timeout loop.

The code used `millis() < (timeout + 1000)` which breaks when the 32-bit millis counter wraps after ~49.7 days. Changed to the subtraction form `millis() - timeout < 1000` which handles unsigned wrap correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal bug fix
remote_transmitter:
  pin: GPIO5
  carrier_duty_percent: 50%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
