### PR TITLE
[gp8403] Fix enum size mismatch in voltage register write

### DIFF
--- a/esphome/components/gp8403/gp8403.h
+++ b/esphome/components/gp8403/gp8403.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace gp8403 {
 
-enum GP8403Voltage {
+enum GP8403Voltage : uint8_t {
   GP8403_VOLTAGE_5V = 0x00,
   GP8403_VOLTAGE_10V = 0x11,
 };

--- a/esphome/components/gp8403/gp8403.h
+++ b/esphome/components/gp8403/gp8403.h
@@ -11,7 +11,7 @@ enum GP8403Voltage : uint8_t {
   GP8403_VOLTAGE_10V = 0x11,
 };
 
-enum GP8403Model {
+enum GP8403Model : uint8_t {
   GP8403,
   GP8413,
 };


### PR DESCRIPTION
# What does this implement/fix?

`GP8403Voltage` was an untyped enum (`sizeof(int)` = 4 bytes) but the `write_register` call only sent 1 byte via `(uint8_t *) (&this->voltage_), 1`. This worked by accident on little-endian platforms (ESP32) since the values (`0x00`, `0x11`) fit in a single byte, but is technically undefined behavior.

Fixed by typing the enum as `uint8_t` so `sizeof(GP8403Voltage)` matches the 1-byte write.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal bug fix
output:
  - platform: gp8403
    id: gp8403_output_1
    channel: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
