### PR TITLE
[mcp2515] Fix millis overflow in set_mode_ timeout

### DIFF
--- a/esphome/components/mcp2515/mcp2515.cpp
+++ b/esphome/components/mcp2515/mcp2515.cpp
@@ -133,8 +133,8 @@ uint8_t MCP2515::get_status_() {
 canbus::Error MCP2515::set_mode_(const CanctrlReqopMode mode) {
   modify_register_(MCP_CANCTRL, CANCTRL_REQOP, mode);
 
-  uint32_t end_time = millis() + 10;
-  while (millis() < end_time) {
+  uint32_t start_time = millis();
+  while (millis() - start_time < 10) {
     if ((read_register_(MCP_CANSTAT) & CANSTAT_OPMOD) == mode)
       return canbus::ERROR_OK;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fix millis overflow in `set_mode_()`. Uses `millis() < end_time` where `end_time = millis() + 10`, which breaks when the 32-bit counter wraps after ~49.7 days. Use subtraction-based comparison instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
