### PR TITLE
[sprinkler] Fix millis overflow and underflow bugs

### DIFF
--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -84,32 +84,30 @@ SprinklerValveOperator::SprinklerValveOperator(SprinklerValve *valve, Sprinkler 
     : controller_(controller), valve_(valve) {}
 
 void SprinklerValveOperator::loop() {
+  // Use wrapping subtraction so 32-bit millis() rollover is handled correctly:
+  // (now - start) yields the true elapsed time even across the 49.7-day boundary.
   uint32_t now = App.get_loop_component_start_time();
-  if (now >= this->start_millis_) {  // dummy check
-    switch (this->state_) {
-      case STARTING:
-        if (now > (this->start_millis_ + this->start_delay_)) {
-          this->run_();  // start_delay_ has been exceeded, so ensure both valves are on and update the state
-        }
-        break;
+  switch (this->state_) {
+    case STARTING:
+      if ((now - *this->start_millis_) > this->start_delay_) {
+        this->run_();  // start_delay_ has been exceeded, so ensure both valves are on and update the state
+      }
+      break;
 
-      case ACTIVE:
-        if (now > (this->start_millis_ + this->start_delay_ + this->run_duration_)) {
-          this->stop();  // start_delay_ + run_duration_ has been exceeded, start shutting down
-        }
-        break;
+    case ACTIVE:
+      if ((now - *this->start_millis_) > (this->start_delay_ + this->run_duration_)) {
+        this->stop();  // start_delay_ + run_duration_ has been exceeded, start shutting down
+      }
+      break;
 
-      case STOPPING:
-        if (now > (this->stop_millis_ + this->stop_delay_)) {
-          this->kill_();  // stop_delay_has been exceeded, ensure all valves are off
-        }
-        break;
+    case STOPPING:
+      if ((now - *this->stop_millis_) > this->stop_delay_) {
+        this->kill_();  // stop_delay_has been exceeded, ensure all valves are off
+      }
+      break;
 
-      default:
-        break;
-    }
-  } else {         // perhaps millis() rolled over...or something else is horribly wrong!
-    this->stop();  // bail out (TODO: handle this highly unlikely situation better...)
+    default:
+      break;
   }
 }
 
@@ -126,8 +124,8 @@ void SprinklerValveOperator::set_valve(SprinklerValve *valve) {
     }
     this->state_ = IDLE;      // reset state
     this->run_duration_ = 0;  // reset to ensure the valve isn't started without updating it
-    this->start_millis_ = 0;  // reset because (new) valve has not been started yet
-    this->stop_millis_ = 0;   // reset because (new) valve has not been started yet
+    this->start_millis_.reset();  // reset because (new) valve has not been started yet
+    this->stop_millis_.reset();   // reset because (new) valve has not been started yet
     this->valve_ = valve;     // finally, set the pointer to the new valve
   }
 }
@@ -162,7 +160,7 @@ void SprinklerValveOperator::start() {
   } else {
     this->run_();  // there is no start_delay_, so just start the pump and valve
   }
-  this->stop_millis_ = 0;
+  this->stop_millis_.reset();
   this->start_millis_ = millis();  // save the time the start request was made
 }
 
@@ -189,22 +187,25 @@ void SprinklerValveOperator::stop() {
 uint32_t SprinklerValveOperator::run_duration() { return this->run_duration_ / 1000; }
 
 uint32_t SprinklerValveOperator::time_remaining() {
-  if (this->start_millis_ == 0) {
+  if (!this->start_millis_.has_value()) {
     return this->run_duration();  // hasn't been started yet
   }
 
-  if (this->stop_millis_) {
-    if (this->stop_millis_ - this->start_millis_ >= this->start_delay_ + this->run_duration_) {
+  if (this->stop_millis_.has_value()) {
+    uint32_t elapsed = *this->stop_millis_ - *this->start_millis_;
+    if (elapsed >= this->start_delay_ + this->run_duration_) {
       return 0;  // valve was active for more than its configured duration, so we are done
-    } else {
-      // we're stopped; return time remaining
-      return (this->run_duration_ - (this->stop_millis_ - this->start_millis_)) / 1000;
     }
+    if (elapsed <= this->start_delay_) {
+      return this->run_duration_ / 1000;  // stopped during start delay, full run duration remains
+    }
+    return (this->run_duration_ - (elapsed - this->start_delay_)) / 1000;
   }
 
-  auto completed_millis = this->start_millis_ + this->start_delay_ + this->run_duration_;
-  if (completed_millis > millis()) {
-    return (completed_millis - millis()) / 1000;  // running now
+  uint32_t elapsed = millis() - *this->start_millis_;
+  uint32_t total_duration = this->start_delay_ + this->run_duration_;
+  if (elapsed < total_duration) {
+    return (total_duration - elapsed) / 1000;  // running now
   }
   return 0;  // run completed
 }
@@ -593,7 +594,7 @@ void Sprinkler::set_repeat(optional<uint32_t> repeat) {
   if (this->repeat_number_ == nullptr) {
     return;
   }
-  if (this->repeat_number_->state == repeat.value()) {
+  if (this->repeat_number_->state == repeat.value_or(0)) {
     return;
   }
   auto call = this->repeat_number_->make_call();
@@ -793,7 +794,7 @@ void Sprinkler::start_single_valve(const optional<size_t> valve_number, optional
 void Sprinkler::queue_valve(optional<size_t> valve_number, optional<uint32_t> run_duration) {
   if (valve_number.has_value()) {
     if (this->is_a_valid_valve(valve_number.value()) && (this->queued_valves_.size() < this->max_queue_size_)) {
-      SprinklerQueueItem item{valve_number.value(), run_duration.value()};
+      SprinklerQueueItem item{valve_number.value(), run_duration.value_or(0)};
       this->queued_valves_.insert(this->queued_valves_.begin(), item);
       ESP_LOGD(TAG, "Valve %zu placed into queue with run duration of %" PRIu32 " seconds", valve_number.value_or(0),
                run_duration.value_or(0));
@@ -1080,7 +1081,7 @@ uint32_t Sprinkler::total_cycle_time_enabled_incomplete_valves() {
     }
   }
 
-  if (incomplete_valve_count >= enabled_valve_count) {
+  if (incomplete_valve_count > 0 && incomplete_valve_count >= enabled_valve_count) {
     incomplete_valve_count--;
   }
   if (incomplete_valve_count) {

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -122,11 +122,11 @@ void SprinklerValveOperator::set_valve(SprinklerValve *valve) {
     if (this->state_ != IDLE) {  // Only kill if not already idle
       this->kill_();             // ensure everything is off before we let go!
     }
-    this->state_ = IDLE;      // reset state
-    this->run_duration_ = 0;  // reset to ensure the valve isn't started without updating it
+    this->state_ = IDLE;          // reset state
+    this->run_duration_ = 0;      // reset to ensure the valve isn't started without updating it
     this->start_millis_.reset();  // reset because (new) valve has not been started yet
     this->stop_millis_.reset();   // reset because (new) valve has not been started yet
-    this->valve_ = valve;     // finally, set the pointer to the new valve
+    this->valve_ = valve;         // finally, set the pointer to the new valve
   }
 }
 

--- a/esphome/components/sprinkler/sprinkler.h
+++ b/esphome/components/sprinkler/sprinkler.h
@@ -141,8 +141,8 @@ class SprinklerValveOperator {
   uint32_t start_delay_{0};
   uint32_t stop_delay_{0};
   uint32_t run_duration_{0};
-  uint64_t start_millis_{0};
-  uint64_t stop_millis_{0};
+  optional<uint32_t> start_millis_{};
+  optional<uint32_t> stop_millis_{};
   Sprinkler *controller_{nullptr};
   SprinklerValve *valve_{nullptr};
   SprinklerState state_{IDLE};


### PR DESCRIPTION
# What does this implement/fix?

Fix millis overflow handling in `SprinklerValveOperator` using wrapping 32-bit subtraction instead of absolute deadline comparisons. Also fix several pre-existing bugs found during review.

### Approach

Rather than switching to 64-bit `millis_64()` (which has performance overhead in the hot `loop()` path — called ~7100 times/min), use the standard embedded pattern of wrapping subtraction: `(now - start) > delay` instead of `now > (start + delay)`. This correctly handles the 49.7-day `millis()` rollover with zero additional cost, using the already-cached `App.get_loop_component_start_time()`.

The `start_millis_` and `stop_millis_` fields are changed from `uint64_t` to `optional<uint32_t>` to eliminate the use of `0` as a sentinel value (which is a valid `millis()` timestamp that occurs every 49.7 days).

### Bugs fixed:

**`loop()` — valve stops mid-run after millis wrap:**
The code compared `uint32_t now` against `uint64_t start_millis_` deadline. After wrap, `now` (promoted to 64-bit) could never reach the 64-bit deadline, so it fell into the `else` branch which called `stop()` with a TODO comment: *"perhaps millis() rolled over...or something else is horribly wrong!"*. With wrapping subtraction, the comparisons work correctly and the bailout is removed.

**`time_remaining()` — returns ~49.7 days remaining after wrap:**
The deadline `start_millis_ + delay + duration` exceeds `UINT32_MAX` but `millis()` can never reach it as a 32-bit value, so the valve appears stuck running forever. Now uses elapsed-time subtraction which handles wrap correctly.

**`time_remaining()` — unsigned underflow when stopped during start delay:**
Pre-existing bug: if a valve was stopped during the `start_delay_` phase (before the run began), `run_duration_ - (stop - start)` would underflow since the elapsed time could exceed `run_duration_`. Now correctly detects this case and returns the full run duration.

**`time_remaining()` — millis zero sentinel unreliable:**
Pre-existing bug: `start_millis_ == 0` was used to mean "not started", but `0` is a valid `millis()` value. Changed to `optional<uint32_t>` with `.has_value()` checks, matching the pattern used in `[pn532] Replace millis zero sentinel with optional` (#14295).

**`total_cycle_time_enabled_incomplete_valves()` — unsigned underflow:**
`incomplete_valve_count--` wraps to `UINT32_MAX` when both incomplete and enabled counts are zero, producing a bogus cycle time.

**`set_repeat()` — unchecked optional dereference:**
Pre-existing bug: `repeat.value()` called without `has_value()` check. Changed to `value_or(0)` to match the usage two lines below in the same function.

**`queue_valve()` — unchecked optional dereference:**
Pre-existing bug: `run_duration.value()` called without `has_value()` check. Changed to `value_or(0)` to match the log statement in the same function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).