### PR TITLE
[wled] Fix millis overflow in blank timeout

### DIFF
--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -24,7 +24,7 @@ namespace wled {
 // https://github.com/Aircoookie/WLED/wiki/UDP-Realtime-Control
 enum Protocol { WLED_NOTIFIER = 0, WARLS = 1, DRGB = 2, DRGBW = 3, DNRGB = 4 };
 
-const uint32_t DEFAULT_BLANK_TIME = 1000;
+constexpr uint32_t DEFAULT_BLANK_TIME = 1000;
 
 static const char *const TAG = "wled_light_effect";
 

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -24,7 +24,7 @@ namespace wled {
 // https://github.com/Aircoookie/WLED/wiki/UDP-Realtime-Control
 enum Protocol { WLED_NOTIFIER = 0, WARLS = 1, DRGB = 2, DRGBW = 3, DNRGB = 4 };
 
-const int DEFAULT_BLANK_TIME = 1000;
+const uint32_t DEFAULT_BLANK_TIME = 1000;
 
 static const char *const TAG = "wled_light_effect";
 
@@ -34,9 +34,10 @@ void WLEDLightEffect::start() {
   AddressableLightEffect::start();
 
   if (this->blank_on_start_) {
-    this->blank_at_ = 0;
+    this->blank_start_ = millis();
+    this->blank_timeout_ = 0;
   } else {
-    this->blank_at_ = UINT32_MAX;
+    this->blank_start_.reset();
   }
 }
 
@@ -81,10 +82,10 @@ void WLEDLightEffect::apply(light::AddressableLight &it, const Color &current_co
     }
   }
 
-  // FIXME: Use roll-over safe arithmetic
-  if (blank_at_ < millis()) {
+  if (this->blank_start_.has_value() && millis() - *this->blank_start_ >= this->blank_timeout_) {
     blank_all_leds_(it);
-    blank_at_ = millis() + DEFAULT_BLANK_TIME;
+    this->blank_start_ = millis();
+    this->blank_timeout_ = DEFAULT_BLANK_TIME;
   }
 }
 
@@ -142,11 +143,13 @@ bool WLEDLightEffect::parse_frame_(light::AddressableLight &it, const uint8_t *p
   }
 
   if (timeout == UINT8_MAX) {
-    blank_at_ = UINT32_MAX;
+    blank_start_.reset();
   } else if (timeout > 0) {
-    blank_at_ = millis() + timeout * 1000;
+    blank_start_ = millis();
+    blank_timeout_ = timeout * 1000;
   } else {
-    blank_at_ = millis() + DEFAULT_BLANK_TIME;
+    blank_start_ = millis();
+    blank_timeout_ = DEFAULT_BLANK_TIME;
   }
 
   it.schedule_show();

--- a/esphome/components/wled/wled_light_effect.cpp
+++ b/esphome/components/wled/wled_light_effect.cpp
@@ -143,13 +143,13 @@ bool WLEDLightEffect::parse_frame_(light::AddressableLight &it, const uint8_t *p
   }
 
   if (timeout == UINT8_MAX) {
-    blank_start_.reset();
+    this->blank_start_.reset();
   } else if (timeout > 0) {
-    blank_start_ = millis();
-    blank_timeout_ = timeout * 1000;
+    this->blank_start_ = millis();
+    this->blank_timeout_ = timeout * 1000;
   } else {
-    blank_start_ = millis();
-    blank_timeout_ = DEFAULT_BLANK_TIME;
+    this->blank_start_ = millis();
+    this->blank_timeout_ = DEFAULT_BLANK_TIME;
   }
 
   it.schedule_show();

--- a/esphome/components/wled/wled_light_effect.h
+++ b/esphome/components/wled/wled_light_effect.h
@@ -35,7 +35,8 @@ class WLEDLightEffect : public light::AddressableLightEffect {
 
   uint16_t port_{0};
   std::unique_ptr<UDP> udp_;
-  uint32_t blank_at_{0};
+  optional<uint32_t> blank_start_{};
+  uint32_t blank_timeout_{0};
   uint32_t dropped_{0};
   uint8_t sync_group_mask_{0};
   bool blank_on_start_{true};


### PR DESCRIPTION
# What does this implement/fix?

Fix millis overflow in WLED blank timeout handling. The code had a `// FIXME: Use roll-over safe arithmetic` comment acknowledging the issue. It used `blank_at_ = millis() + timeout` deadline then compared `blank_at_ < millis()` which breaks after ~49.7 days.

Replace the deadline-based `blank_at_` with start time + duration tracking using `optional<uint32_t>`. The optional replaces the `UINT32_MAX` sentinel that was used to mean "no blank scheduled". Use subtraction-based comparison (`millis() - start >= timeout`) which handles wrap correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
