### PR TITLE
[safe_mode] Add feature to explicitly mark a boot as successful

### DIFF
--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -21,7 +21,7 @@ CONF_ON_SAFE_MODE = "on_safe_mode"
 safe_mode_ns = cg.esphome_ns.namespace("safe_mode")
 SafeModeComponent = safe_mode_ns.class_("SafeModeComponent", cg.Component)
 SafeModeTrigger = safe_mode_ns.class_("SafeModeTrigger", automation.Trigger.template())
-MarkBootOkAction = safe_mode_ns.class_("MarkBootOkAction", automation.Action)
+MarkSuccessfulAction = safe_mode_ns.class_("MarkSuccessfulAction", automation.Action)
 
 
 def _remove_id_if_disabled(value):
@@ -55,17 +55,19 @@ CONFIG_SCHEMA = cv.All(
 
 
 @automation.register_action(
-    "safe_mode.mark_boot_ok",
-    MarkBootOkAction,
+    "safe_mode.mark_successful",
+    MarkSuccessfulAction,
     cv.Schema(
         {
             cv.GenerateID(): cv.use_id(SafeModeComponent),
         }
     ),
 )
-async def safe_mode_mark_boot_ok_to_code(config, action_id, template_arg, args):
+async def safe_mode_mark_successful_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
-    return cg.new_Pvariable(action_id, template_arg, parent)
+    var = cg.new_Pvariable(action_id, template_arg)
+    cg.add(var.set_parent(parent))
+    return var
 
 
 @coroutine_with_priority(CoroPriority.APPLICATION)

--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -21,6 +21,7 @@ CONF_ON_SAFE_MODE = "on_safe_mode"
 safe_mode_ns = cg.esphome_ns.namespace("safe_mode")
 SafeModeComponent = safe_mode_ns.class_("SafeModeComponent", cg.Component)
 SafeModeTrigger = safe_mode_ns.class_("SafeModeTrigger", automation.Trigger.template())
+MarkBootOkAction = safe_mode_ns.class_("MarkBootOkAction", automation.Action)
 
 
 def _remove_id_if_disabled(value):
@@ -51,6 +52,20 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     _remove_id_if_disabled,
 )
+
+
+@automation.register_action(
+    "safe_mode.mark_boot_ok",
+    MarkBootOkAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(SafeModeComponent),
+        }
+    ),
+)
+async def safe_mode_mark_boot_ok_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)
 
 
 @coroutine_with_priority(CoroPriority.APPLICATION)

--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -1,20 +1,26 @@
 #pragma once
 #include "esphome/core/defines.h"
-
-#ifdef USE_SAFE_MODE_CALLBACK
-#include "safe_mode.h"
-
 #include "esphome/core/automation.h"
+#include "safe_mode.h"
 
 namespace esphome::safe_mode {
 
+#ifdef USE_SAFE_MODE_CALLBACK
 class SafeModeTrigger final : public Trigger<> {
  public:
   explicit SafeModeTrigger(SafeModeComponent *parent) {
     parent->add_on_safe_mode_callback([this]() { trigger(); });
   }
 };
+#endif  // USE_SAFE_MODE_CALLBACK
+
+template<typename... Ts> class MarkBootOkAction : public Action<Ts...> {
+ public:
+  explicit MarkBootOkAction(SafeModeComponent *parent) : parent_(parent) {}
+  void play(const Ts &...x) override { this->parent_->mark_boot_ok(true); }
+
+ protected:
+  SafeModeComponent *parent_;
+};
 
 }  // namespace esphome::safe_mode
-
-#endif  // USE_SAFE_MODE_CALLBACK

--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -17,7 +17,7 @@ class SafeModeTrigger final : public Trigger<> {
 template<typename... Ts> class MarkBootOkAction : public Action<Ts...> {
  public:
   explicit MarkBootOkAction(SafeModeComponent *parent) : parent_(parent) {}
-  void play(const Ts &...x) override { this->parent_->mark_boot_ok(true); }
+  void play(const Ts &...x) override { this->parent_->mark_boot_ok(); }
 
  protected:
   SafeModeComponent *parent_;

--- a/esphome/components/safe_mode/automation.h
+++ b/esphome/components/safe_mode/automation.h
@@ -14,13 +14,9 @@ class SafeModeTrigger final : public Trigger<> {
 };
 #endif  // USE_SAFE_MODE_CALLBACK
 
-template<typename... Ts> class MarkBootOkAction : public Action<Ts...> {
+template<typename... Ts> class MarkSuccessfulAction : public Action<Ts...>, public Parented<SafeModeComponent> {
  public:
-  explicit MarkBootOkAction(SafeModeComponent *parent) : parent_(parent) {}
-  void play(const Ts &...x) override { this->parent_->mark_boot_ok(); }
-
- protected:
-  SafeModeComponent *parent_;
+  void play(const Ts &...x) override { this->parent_->mark_successful(); }
 };
 
 }  // namespace esphome::safe_mode

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -63,11 +63,7 @@ void SafeModeComponent::dump_config() {
 
 float SafeModeComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 
-void SafeModeComponent::mark_boot_ok(bool explicitly) {
-  if (explicitly) {
-    ESP_LOGD(TAG, "Explicitly marking boot as successful");
-  }
-
+void SafeModeComponent::mark_boot_ok() {
   this->clean_rtc();
   this->boot_successful_ = true;
 #if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -63,7 +63,7 @@ void SafeModeComponent::dump_config() {
 
 float SafeModeComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 
-void SafeModeComponent::mark_boot_ok() {
+void SafeModeComponent::mark_successful() {
   this->clean_rtc();
   this->boot_successful_ = true;
 #if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
@@ -78,7 +78,7 @@ void SafeModeComponent::loop() {
   if (!this->boot_successful_ && (millis() - this->safe_mode_start_time_) > this->safe_mode_boot_is_good_after_) {
     // successful boot, reset counter
     ESP_LOGI(TAG, "Boot seems successful; resetting boot loop counter");
-    this->mark_boot_ok(false);
+    this->mark_successful();
   }
 }
 

--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -63,18 +63,26 @@ void SafeModeComponent::dump_config() {
 
 float SafeModeComponent::get_setup_priority() const { return setup_priority::AFTER_WIFI; }
 
+void SafeModeComponent::mark_boot_ok(bool explicitly) {
+  if (explicitly) {
+    ESP_LOGD(TAG, "Explicitly marking boot as successful");
+  }
+
+  this->clean_rtc();
+  this->boot_successful_ = true;
+#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
+  // Mark OTA partition as valid to prevent rollback
+  esp_ota_mark_app_valid_cancel_rollback();
+#endif
+  // Disable loop since we no longer need to check
+  this->disable_loop();
+}
+
 void SafeModeComponent::loop() {
   if (!this->boot_successful_ && (millis() - this->safe_mode_start_time_) > this->safe_mode_boot_is_good_after_) {
     // successful boot, reset counter
     ESP_LOGI(TAG, "Boot seems successful; resetting boot loop counter");
-    this->clean_rtc();
-    this->boot_successful_ = true;
-#if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
-    // Mark OTA partition as valid to prevent rollback
-    esp_ota_mark_app_valid_cancel_rollback();
-#endif
-    // Disable loop since we no longer need to check
-    this->disable_loop();
+    this->mark_boot_ok(false);
   }
 }
 

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -31,7 +31,7 @@ class SafeModeComponent final : public Component {
 
   void on_safe_shutdown() override;
 
-  void mark_boot_ok(bool explicitly);
+  void mark_boot_ok();
 
 #ifdef USE_SAFE_MODE_CALLBACK
   void add_on_safe_mode_callback(std::function<void()> &&callback) {

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -31,7 +31,7 @@ class SafeModeComponent final : public Component {
 
   void on_safe_shutdown() override;
 
-  void mark_boot_ok();
+  void mark_successful();
 
 #ifdef USE_SAFE_MODE_CALLBACK
   void add_on_safe_mode_callback(std::function<void()> &&callback) {

--- a/esphome/components/safe_mode/safe_mode.h
+++ b/esphome/components/safe_mode/safe_mode.h
@@ -31,6 +31,8 @@ class SafeModeComponent final : public Component {
 
   void on_safe_shutdown() override;
 
+  void mark_boot_ok(bool explicitly);
+
 #ifdef USE_SAFE_MODE_CALLBACK
   void add_on_safe_mode_callback(std::function<void()> &&callback) {
     this->safe_mode_callback_.add(std::move(callback));

--- a/tests/components/safe_mode/common-enabled.yaml
+++ b/tests/components/safe_mode/common-enabled.yaml
@@ -19,4 +19,4 @@ switch:
 
 esphome:
   on_boot:
-    - safe_mode.mark_boot_ok
+    - safe_mode.mark_successful

--- a/tests/components/safe_mode/common-enabled.yaml
+++ b/tests/components/safe_mode/common-enabled.yaml
@@ -16,3 +16,7 @@ button:
 switch:
   - platform: safe_mode
     name: Safe Mode Switch
+
+esphome:
+  on_boot:
+    - safe_mode.mark_boot_ok


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

This feature allows a user to explicitly notify safe_mode that a boot is successful. The primary use case is for devices using deep sleep that boot, collect data, send the data and sleep within a short period, before the safe mode timeout. The alternative is to disable safe mode.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Feature request: https://github.com/orgs/esphome/discussions/3538
- Documentation PR: https://github.com/esphome/esphome-docs/pull/6157
- esphome/esphome-docs#6157

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml` (straight from the documentation):

```yaml
# Example mark_boot_ok usage
api:
   encryption:
      key: $api_key
   on_api_connected:
      - component.update: my_sensor
      # Wait for the sensor data to send over the network
      - delay: 2s
      - safe_mode.mark_boot_ok
      - deep_sleep.enter

```

## Checklist:

  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Additional:

This is my first PR. Mistakes have likely been made. I'm unsure how to write a reasonable test for this change, but the maintainers are more then welcome to make modifications as they see fit.
