### PR TITLE
[mqtt] increase TLS options and compatibility

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -182,14 +182,15 @@ async def to_code(config):
                     "CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True
                 )
 
-        esp32.add_idf_sdkconfig_option(
-            "CONFIG_ESP_TLS_INSECURE",
-            not config.get(CONF_VERIFY_SSL),
-        )
-        esp32.add_idf_sdkconfig_option(
-            "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
-            not config.get(CONF_VERIFY_SSL),
-        )
+        if not config.get(CONF_VERIFY_SSL):
+            esp32.add_idf_sdkconfig_option(
+                "CONFIG_ESP_TLS_INSECURE",
+                True,
+            )
+            esp32.add_idf_sdkconfig_option(
+                "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
+                True,
+            )
     if CORE.is_esp8266:
         cg.add_library("ESP8266HTTPClient", None)
     if CORE.is_rp2040 and CORE.using_arduino:

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -73,6 +73,8 @@ def AUTO_LOAD():
     return ["json"]
 
 
+CONF_TLS = "tls"
+CONF_VERIFY_SSL = "verify_ssl"
 CONF_DISCOVER_IP = "discover_ip"
 CONF_IDF_SEND_ASYNC = "idf_send_async"
 CONF_WAIT_FOR_CONNECTION = "wait_for_connection"
@@ -215,6 +217,15 @@ def validate_config(value):
             }
         else:
             out[CONF_LOG_TOPIC] = {}
+    # Enable SSL if any of the SSL-related options are set
+    ssl_related_options = [
+        CONF_VERIFY_SSL,
+        CONF_CERTIFICATE_AUTHORITY,
+        CONF_CLIENT_CERTIFICATE,
+        CONF_CLIENT_CERTIFICATE_KEY,
+    ]
+    if any(opt in value and value[opt] for opt in ssl_related_options):
+        out[CONF_TLS] = True
     return out
 
 
@@ -239,6 +250,8 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32=False): cv.All(
                 cv.boolean, cv.only_on_esp32
             ),
+            cv.Optional(CONF_TLS, default=False): cv.All(cv.boolean, cv.only_on_esp32),
+            cv.Optional(CONF_VERIFY_SSL): cv.All(cv.boolean, cv.only_on_esp32),
             cv.Optional(CONF_CERTIFICATE_AUTHORITY): cv.All(
                 cv.string, cv.only_on_esp32
             ),
@@ -436,16 +449,34 @@ async def to_code(config):
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
 
     # esp-idf only
-    if CONF_CERTIFICATE_AUTHORITY in config:
-        cg.add(var.set_ca_certificate(config[CONF_CERTIFICATE_AUTHORITY]))
-        cg.add(var.set_skip_cert_cn_check(config[CONF_SKIP_CERT_CN_CHECK]))
+    if config.get(CONF_TLS):
+        cg.add(var.set_ssl(config[CONF_TLS]))
+
+        if not config.get(CONF_VERIFY_SSL, True):
+            add_idf_sdkconfig_option(
+                "CONFIG_ESP_TLS_INSECURE",
+                True,
+            )
+            add_idf_sdkconfig_option(
+                "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
+                True,
+            )
+
+        if CONF_CERTIFICATE_AUTHORITY in config:
+            cg.add(var.set_ca_certificate(config[CONF_CERTIFICATE_AUTHORITY]))
+            cg.add(var.set_skip_cert_cn_check(config[CONF_SKIP_CERT_CN_CHECK]))
+            # prevent error -0x428e
+            # See https://github.com/espressif/esp-idf/issues/139
+            add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
+        else:
+            # Uses the certificate bundle configured in esp32 component.
+            # By default, ESPHome uses the CMN (common CAs) bundle which covers
+            # ~99% of websites including GitHub, Let's Encrypt, DigiCert, etc.
+            add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+
         if CONF_CLIENT_CERTIFICATE in config:
             cg.add(var.set_cl_certificate(config[CONF_CLIENT_CERTIFICATE]))
             cg.add(var.set_cl_key(config[CONF_CLIENT_CERTIFICATE_KEY]))
-
-        # prevent error -0x428e
-        # See https://github.com/espressif/esp-idf/issues/139
-        add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
 
     if CONF_IDF_SEND_ASYNC in config and config[CONF_IDF_SEND_ASYNC]:
         cg.add_define("USE_MQTT_IDF_ENQUEUE")

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -250,7 +250,7 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_IDF_SEND_ASYNC, esp32=False): cv.All(
                 cv.boolean, cv.only_on_esp32
             ),
-            cv.Optional(CONF_TLS, default=False): cv.All(cv.boolean, cv.only_on_esp32),
+            cv.Optional(CONF_TLS): cv.All(cv.boolean, cv.only_on_esp32),
             cv.Optional(CONF_VERIFY_SSL): cv.All(cv.boolean, cv.only_on_esp32),
             cv.Optional(CONF_CERTIFICATE_AUTHORITY): cv.All(
                 cv.string, cv.only_on_esp32
@@ -449,7 +449,7 @@ async def to_code(config):
     cg.add(var.set_reboot_timeout(config[CONF_REBOOT_TIMEOUT]))
 
     # esp-idf only
-    if config.get(CONF_TLS):
+    if config.get(CONF_TLS, False):
         cg.add(var.set_ssl(config[CONF_TLS]))
 
         if not config.get(CONF_VERIFY_SSL, True):

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -217,6 +217,14 @@ def validate_config(value):
             }
         else:
             out[CONF_LOG_TOPIC] = {}
+    # Validate that CONF_VERIFY_SSL is not False when CONF_CERTIFICATE_AUTHORITY is set
+    if (
+        CONF_CERTIFICATE_AUTHORITY in value
+        and value.get(CONF_VERIFY_SSL, True) is False
+    ):
+        raise cv.Invalid(
+            "Invalid MQTT configuration: cannot set 'verify_ssl' to false when 'certificate_authority' is set."
+        )
     # Enable SSL if any of the SSL-related options are set
     ssl_related_options = [
         CONF_VERIFY_SSL,
@@ -224,7 +232,10 @@ def validate_config(value):
         CONF_CLIENT_CERTIFICATE,
         CONF_CLIENT_CERTIFICATE_KEY,
     ]
-    if any(opt in value and value[opt] for opt in ssl_related_options):
+    if any(
+        (opt in value) if opt == CONF_VERIFY_SSL else (opt in value and value[opt])
+        for opt in ssl_related_options
+    ):
         out[CONF_TLS] = True
     return out
 
@@ -451,8 +462,25 @@ async def to_code(config):
     # esp-idf only
     if config.get(CONF_TLS, False):
         cg.add(var.set_ssl(config[CONF_TLS]))
+        cg.add(var.set_verify_ssl(config.get(CONF_VERIFY_SSL, True)))
 
-        if not config.get(CONF_VERIFY_SSL, True):
+        if config.get(CONF_VERIFY_SSL, True):
+            if CONF_CERTIFICATE_AUTHORITY in config:
+                cg.add(var.set_ca_certificate(config[CONF_CERTIFICATE_AUTHORITY]))
+                cg.add(var.set_skip_cert_cn_check(config[CONF_SKIP_CERT_CN_CHECK]))
+                # prevent error -0x428e
+                # See https://github.com/espressif/esp-idf/issues/139
+                add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
+            else:
+                # Uses the certificate bundle configured in esp32 component.
+                # By default, ESPHome uses the CMN (common CAs) bundle which covers
+                # ~99% of websites including GitHub, Let's Encrypt, DigiCert, etc.
+                add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
+
+            if CONF_CLIENT_CERTIFICATE in config:
+                cg.add(var.set_cl_certificate(config[CONF_CLIENT_CERTIFICATE]))
+                cg.add(var.set_cl_key(config[CONF_CLIENT_CERTIFICATE_KEY]))
+        else:
             add_idf_sdkconfig_option(
                 "CONFIG_ESP_TLS_INSECURE",
                 True,
@@ -461,22 +489,6 @@ async def to_code(config):
                 "CONFIG_ESP_TLS_SKIP_SERVER_CERT_VERIFY",
                 True,
             )
-
-        if CONF_CERTIFICATE_AUTHORITY in config:
-            cg.add(var.set_ca_certificate(config[CONF_CERTIFICATE_AUTHORITY]))
-            cg.add(var.set_skip_cert_cn_check(config[CONF_SKIP_CERT_CN_CHECK]))
-            # prevent error -0x428e
-            # See https://github.com/espressif/esp-idf/issues/139
-            add_idf_sdkconfig_option("CONFIG_MBEDTLS_HARDWARE_MPI", False)
-        else:
-            # Uses the certificate bundle configured in esp32 component.
-            # By default, ESPHome uses the CMN (common CAs) bundle which covers
-            # ~99% of websites including GitHub, Let's Encrypt, DigiCert, etc.
-            add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
-
-        if CONF_CLIENT_CERTIFICATE in config:
-            cg.add(var.set_cl_certificate(config[CONF_CLIENT_CERTIFICATE]))
-            cg.add(var.set_cl_key(config[CONF_CLIENT_CERTIFICATE_KEY]))
 
     if CONF_IDF_SEND_ASYNC in config and config[CONF_IDF_SEND_ASYNC]:
         cg.add_define("USE_MQTT_IDF_ENQUEUE")

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -223,7 +223,7 @@ def validate_config(value):
         and value.get(CONF_VERIFY_SSL, True) is False
     ):
         raise cv.Invalid(
-            "Invalid MQTT configuration: cannot set 'verify_ssl' to false when 'certificate_authority' is set."
+            "cannot set 'verify_ssl' to false when 'certificate_authority' is set."
         )
     # Enable SSL if any of the SSL-related options are set
     ssl_related_options = [
@@ -236,6 +236,8 @@ def validate_config(value):
         (opt in value) if opt == CONF_VERIFY_SSL else (opt in value and value[opt])
         for opt in ssl_related_options
     ):
+        if CONF_TLS in value and value[CONF_TLS] is False:
+            raise cv.Invalid("'tls' must be enabled when using SSL-related options.")
         out[CONF_TLS] = True
     return out
 
@@ -464,6 +466,10 @@ async def to_code(config):
         cg.add(var.set_ssl(config[CONF_TLS]))
         cg.add(var.set_verify_ssl(config.get(CONF_VERIFY_SSL, True)))
 
+        if CONF_CLIENT_CERTIFICATE in config:
+            cg.add(var.set_cl_certificate(config[CONF_CLIENT_CERTIFICATE]))
+            cg.add(var.set_cl_key(config[CONF_CLIENT_CERTIFICATE_KEY]))
+
         if config.get(CONF_VERIFY_SSL, True):
             if CONF_CERTIFICATE_AUTHORITY in config:
                 cg.add(var.set_ca_certificate(config[CONF_CERTIFICATE_AUTHORITY]))
@@ -476,10 +482,6 @@ async def to_code(config):
                 # By default, ESPHome uses the CMN (common CAs) bundle which covers
                 # ~99% of websites including GitHub, Let's Encrypt, DigiCert, etc.
                 add_idf_sdkconfig_option("CONFIG_MBEDTLS_CERTIFICATE_BUNDLE", True)
-
-            if CONF_CLIENT_CERTIFICATE in config:
-                cg.add(var.set_cl_certificate(config[CONF_CLIENT_CERTIFICATE]))
-                cg.add(var.set_cl_key(config[CONF_CLIENT_CERTIFICATE_KEY]))
         else:
             add_idf_sdkconfig_option(
                 "CONFIG_ESP_TLS_INSECURE",

--- a/esphome/components/mqtt/mqtt_backend_esp32.cpp
+++ b/esphome/components/mqtt/mqtt_backend_esp32.cpp
@@ -46,10 +46,10 @@ bool MQTTBackendESP32::initialize_() {
   // SSL/TLS configuration
   if (this->use_ssl_) {
     mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_SSL;
-    mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
     if (this->verify_ssl_) {
       if (ca_certificate_.has_value()) {
         mqtt_cfg_.broker.verification.certificate = ca_certificate_.value().c_str();
+        mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
       } else {
 #if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
         mqtt_cfg_.broker.verification.crt_bundle_attach = esp_crt_bundle_attach;

--- a/esphome/components/mqtt/mqtt_backend_esp32.cpp
+++ b/esphome/components/mqtt/mqtt_backend_esp32.cpp
@@ -8,6 +8,10 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+#include "esp_crt_bundle.h"
+#endif
+
 namespace esphome::mqtt {
 
 static const char *const TAG = "mqtt.idf";
@@ -39,10 +43,19 @@ bool MQTTBackendESP32::initialize_() {
   if (!this->client_id_.empty()) {
     mqtt_cfg_.credentials.client_id = this->client_id_.c_str();
   }
-  if (ca_certificate_.has_value()) {
-    mqtt_cfg_.broker.verification.certificate = ca_certificate_.value().c_str();
-    mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
+  // SSL/TLS configuration
+  if (this->use_ssl_) {
     mqtt_cfg_.broker.address.transport = MQTT_TRANSPORT_OVER_SSL;
+    mqtt_cfg_.broker.verification.skip_cert_common_name_check = skip_cert_cn_check_;
+    if (this->verify_ssl_) {
+      if (ca_certificate_.has_value()) {
+        mqtt_cfg_.broker.verification.certificate = ca_certificate_.value().c_str();
+      } else {
+#if CONFIG_MBEDTLS_CERTIFICATE_BUNDLE
+        mqtt_cfg_.broker.verification.crt_bundle_attach = esp_crt_bundle_attach;
+#endif
+      }
+    }
 
     if (this->cl_certificate_.has_value() && this->cl_key_.has_value()) {
       mqtt_cfg_.credentials.authentication.certificate = this->cl_certificate_.value().c_str();

--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -207,6 +207,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
 
   void loop() final;
 
+  void set_verify_ssl(bool verify_ssl) { this->verify_ssl_ = verify_ssl; }
+  void set_ssl(bool use_ssl) { this->use_ssl_ = use_ssl; }
   void set_ca_certificate(const std::string &cert) { ca_certificate_ = cert; }
   void set_cl_certificate(const std::string &cert) { cl_certificate_ = cert; }
   void set_cl_key(const std::string &key) { cl_key_ = key; }
@@ -234,6 +236,8 @@ class MQTTBackendESP32 final : public MQTTBackend {
 
   esp_mqtt_client_config_t mqtt_cfg_{};
 
+  bool use_ssl_{false};
+  bool verify_ssl_{true};
   std::string host_;
   uint16_t port_;
   std::string username_;

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -138,6 +138,8 @@ class MQTTClientComponent : public Component {
   bool is_discovery_ip_enabled() const;
 
 #ifdef USE_ESP32
+  void set_ssl(bool use_ssl) { this->mqtt_backend_.set_ssl(use_ssl); }
+  void set_verify_ssl(bool verify_ssl) { this->mqtt_backend_.set_verify_ssl(verify_ssl); }
   void set_ca_certificate(const char *cert) { this->mqtt_backend_.set_ca_certificate(cert); }
   void set_cl_certificate(const char *cert) { this->mqtt_backend_.set_cl_certificate(cert); }
   void set_cl_key(const char *key) { this->mqtt_backend_.set_cl_key(key); }

--- a/tests/components/mqtt/test.esp32-idf.yaml
+++ b/tests/components/mqtt/test.esp32-idf.yaml
@@ -1,3 +1,8 @@
 packages:
   common: !include common.yaml
   update: !include common-update.yaml
+
+mqtt:
+  broker: "test.mosquitto.org"
+  port: 8886
+  tls: true


### PR DESCRIPTION
# What does this implement/fix?

Add support for both unsafe TLS and for using the certificate bundle instead of forcing users to always hardcode a `certificate_authority`. The implementation is inspired by `http_request`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other


**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6161

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Different configurations for testing

# Basic non-TLS
mqtt:
  broker: "test.mosquitto.org"
  port: 1883

# Basic TLS (Let's Encrypt)
mqtt:
  broker: "test.mosquitto.org"
  port: 8886
  tls: true

# Basic TLS (custom CA)
mqtt:
  broker: "test.mosquitto.org"
  port: 8883
  certificate_authority: |
    -----BEGIN CERTIFICATE-----
    MIIEAzCCAuugAwIBAgIUBY1hlCGvdj4NhBXkZ/uLUZNILAwwDQYJKoZIhvcNAQEL
    BQAwgZAxCzAJBgNVBAYTAkdCMRcwFQYDVQQIDA5Vbml0ZWQgS2luZ2RvbTEOMAwG
    A1UEBwwFRGVyYnkxEjAQBgNVBAoMCU1vc3F1aXR0bzELMAkGA1UECwwCQ0ExFjAU
    BgNVBAMMDW1vc3F1aXR0by5vcmcxHzAdBgkqhkiG9w0BCQEWEHJvZ2VyQGF0Y2hv
    by5vcmcwHhcNMjAwNjA5MTEwNjM5WhcNMzAwNjA3MTEwNjM5WjCBkDELMAkGA1UE
    BhMCR0IxFzAVBgNVBAgMDlVuaXRlZCBLaW5nZG9tMQ4wDAYDVQQHDAVEZXJieTES
    MBAGA1UECgwJTW9zcXVpdHRvMQswCQYDVQQLDAJDQTEWMBQGA1UEAwwNbW9zcXVp
    dHRvLm9yZzEfMB0GCSqGSIb3DQEJARYQcm9nZXJAYXRjaG9vLm9yZzCCASIwDQYJ
    KoZIhvcNAQEBBQADggEPADCCAQoCggEBAME0HKmIzfTOwkKLT3THHe+ObdizamPg
    UZmD64Tf3zJdNeYGYn4CEXbyP6fy3tWc8S2boW6dzrH8SdFf9uo320GJA9B7U1FW
    Te3xda/Lm3JFfaHjkWw7jBwcauQZjpGINHapHRlpiCZsquAthOgxW9SgDgYlGzEA
    s06pkEFiMw+qDfLo/sxFKB6vQlFekMeCymjLCbNwPJyqyhFmPWwio/PDMruBTzPH
    3cioBnrJWKXc3OjXdLGFJOfj7pP0j/dr2LH72eSvv3PQQFl90CZPFhrCUcRHSSxo
    E6yjGOdnz7f6PveLIB574kQORwt8ePn0yidrTC1ictikED3nHYhMUOUCAwEAAaNT
    MFEwHQYDVR0OBBYEFPVV6xBUFPiGKDyo5V3+Hbh4N9YSMB8GA1UdIwQYMBaAFPVV
    6xBUFPiGKDyo5V3+Hbh4N9YSMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
    BQADggEBAGa9kS21N70ThM6/Hj9D7mbVxKLBjVWe2TPsGfbl3rEDfZ+OKRZ2j6AC
    6r7jb4TZO3dzF2p6dgbrlU71Y/4K0TdzIjRj3cQ3KSm41JvUQ0hZ/c04iGDg/xWf
    +pp58nfPAYwuerruPNWmlStWAXf0UTqRtg4hQDWBuUFDJTuWuuBvEXudz74eh/wK
    sMwfu1HFvjy5Z0iMDU8PUDepjVolOCue9ashlS4EB5IECdSR2TItnAIiIwimx839
    LdUdRudafMu5T5Xma182OC0/u/xRlEm+tvKGGmfFcN0piqVl8OrSPBgIlb+1IKJE
    m/XriWr/Cq4h/JfB7NTsezVslgkBaoU=
    -----END CERTIFICATE-----

# Basic TLS (custom CA) but not check it
mqtt:
  broker: "test.mosquitto.org"
  port: 8883
  tls: true
  verify_ssl: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
