### PR TITLE
[esp32_hosted] Add configurable SDIO clock frequency

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -96,7 +96,8 @@ async def to_code(config):
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
     esp32.add_idf_sdkconfig_option(
-        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY] // 1000)
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ",
+        int(config[CONF_SDIO_FREQUENCY] // 1000),
     )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -23,6 +23,7 @@ CONF_D1_PIN = "d1_pin"
 CONF_D2_PIN = "d2_pin"
 CONF_D3_PIN = "d3_pin"
 CONF_SLOT = "slot"
+CONF_SDIO_SPEED = "sdio_speed_khz"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_D3_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_SLOT, default=1): cv.int_range(min=0, max=1),
+            cv.Optional(CONF_SDIO_SPEED, default=40000): cv.int_range(min=400, max=40000),
         }
     ),
 )
@@ -91,6 +93,7 @@ async def to_code(config):
         config[CONF_D3_PIN],
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
+    esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED])
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -38,7 +38,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_D3_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_SLOT, default=1): cv.int_range(min=0, max=1),
-            cv.Optional(CONF_SDIO_SPEED, default=40000): cv.int_range(min=400, max=40000),
+            cv.Optional(CONF_SDIO_SPEED, default=40000): cv.int_range(
+                min=400, max=40000
+            ),
         }
     ),
 )
@@ -93,7 +95,9 @@ async def to_code(config):
         config[CONF_D3_PIN],
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
-    esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED])
+    esp32.add_idf_sdkconfig_option(
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED]
+    )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -96,7 +96,7 @@ async def to_code(config):
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
     esp32.add_idf_sdkconfig_option(
-        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_FREQUENCY] // 1000
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY] // 1000)
     )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -23,7 +23,7 @@ CONF_D1_PIN = "d1_pin"
 CONF_D2_PIN = "d2_pin"
 CONF_D3_PIN = "d3_pin"
 CONF_SLOT = "slot"
-CONF_SDIO_SPEED = "sdio_speed_khz"
+CONF_SDIO_SPEED_KHZ = "sdio_speed_khz"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -38,7 +38,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_D3_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_SLOT, default=1): cv.int_range(min=0, max=1),
-            cv.Optional(CONF_SDIO_SPEED, default=40000): cv.int_range(min=400, max=40000),
+            cv.Optional(CONF_SDIO_SPEED_KHZ, default=40000): cv.int_range(min=400, max=40000),
         }
     ),
 )
@@ -93,7 +93,7 @@ async def to_code(config):
         config[CONF_D3_PIN],
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
-    esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED])
+    esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED_KHZ])
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -23,7 +23,7 @@ CONF_D1_PIN = "d1_pin"
 CONF_D2_PIN = "d2_pin"
 CONF_D3_PIN = "d3_pin"
 CONF_SLOT = "slot"
-CONF_SDIO_SPEED_KHZ = "sdio_speed_khz"
+CONF_SDIO_FREQUENCY = "sdio_frequency"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -38,8 +38,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_D3_PIN): pins.internal_gpio_output_pin_number,
             cv.Required(CONF_RESET_PIN): pins.internal_gpio_output_pin_number,
             cv.Optional(CONF_SLOT, default=1): cv.int_range(min=0, max=1),
-            cv.Optional(CONF_SDIO_SPEED_KHZ, default=40000): cv.int_range(
-                min=400, max=40000
+            cv.Optional(CONF_SDIO_FREQUENCY, default="40MHz"): cv.All(
+                cv.frequency, cv.Range(min=400e3, max=50e6)
             ),
         }
     ),
@@ -96,7 +96,7 @@ async def to_code(config):
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
     esp32.add_idf_sdkconfig_option(
-        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_SPEED_KHZ]
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY]/1000)
     )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -96,7 +96,7 @@ async def to_code(config):
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
     esp32.add_idf_sdkconfig_option(
-        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY]/1000)
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY] / 1000)
     )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -96,7 +96,7 @@ async def to_code(config):
     )
     esp32.add_idf_sdkconfig_option("CONFIG_ESP_HOSTED_CUSTOM_SDIO_PINS", True)
     esp32.add_idf_sdkconfig_option(
-        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", int(config[CONF_SDIO_FREQUENCY] / 1000)
+        "CONFIG_ESP_HOSTED_SDIO_CLOCK_FREQ_KHZ", config[CONF_SDIO_FREQUENCY] // 1000
     )
 
     framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]

--- a/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
@@ -9,7 +9,7 @@ esp32_hosted:
   d1_pin: GPIO10
   d2_pin: GPIO9
   d3_pin: GPIO8
-  sdio_frequency: 10000
+  sdio_frequency: 8MHz
 
 wifi:
   ssid: MySSID

--- a/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
@@ -9,7 +9,7 @@ esp32_hosted:
   d1_pin: GPIO10
   d2_pin: GPIO9
   d3_pin: GPIO8
-  sdio_speed_khz: 10000
+  sdio_frequency: 10000
 
 wifi:
   ssid: MySSID

--- a/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
+++ b/tests/components/esp32_hosted/test-sdio-speed.esp32-p4-idf.yaml
@@ -1,0 +1,16 @@
+esp32_hosted:
+  variant: ESP32C6
+  slot: 1
+  active_high: true
+  reset_pin: GPIO15
+  cmd_pin: GPIO13
+  clk_pin: GPIO12
+  d0_pin: GPIO11
+  d1_pin: GPIO10
+  d2_pin: GPIO9
+  d3_pin: GPIO8
+  sdio_speed_khz: 10000
+
+wifi:
+  ssid: MySSID
+  password: password1


### PR DESCRIPTION
On some products, the master processor cannot communicate with the slave at the full 40MHz. Hence there is a requirement to be able to lower the speed of communication.

# What does this implement/fix?

This enables the speed of the link between master and slave to be reduced from the default of 40MHz.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6168

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: kiosk

esp32:
  variant: esp32p4
  cpu_frequency: 360MHz
  flash_size: 16MB
  partitions: include/kiosk.csv

psram:
  speed: 200MHz

wifi: !include include/wifi.yaml

esp32_hosted:
  variant: ESP32C6
  reset_pin: GPIO32
  cmd_pin: GPIO19
  clk_pin: GPIO18
  d0_pin: GPIO14
  d1_pin: GPIO15
  d2_pin: GPIO16
  d3_pin: GPIO17
  active_high: true
  sdio_speed_khz: 10000

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
