### PR TITLE
[cc1101] Transition through IDLE in begin_tx/begin_rx for reliable state changes

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -242,6 +242,9 @@ void CC1101Component::begin_tx() {
   if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->pin_mode(gpio::FLAG_OUTPUT);
   }
+  // Transition through IDLE to bypass CCA (Clear Channel Assessment) which can
+  // block TX entry when strobing from RX, and to ensure FS_AUTOCAL calibration
+  this->enter_idle_();
   if (!this->enter_tx_()) {
     ESP_LOGW(TAG, "Failed to enter TX state!");
   }
@@ -252,6 +255,8 @@ void CC1101Component::begin_rx() {
   if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT);
   }
+  // Transition through IDLE to ensure FS_AUTOCAL calibration occurs
+  this->enter_idle_();
   if (!this->enter_rx_()) {
     ESP_LOGW(TAG, "Failed to enter RX state!");
   }


### PR DESCRIPTION
# What does this implement/fix?

`begin_tx()` and `begin_rx()` previously strobed TX/RX directly from the current state. When the CC1101 is in RX and STX is strobed, the chip performs a Clear Channel Assessment (CCA_MODE=3) which can block the transition to TX if the channel is busy. This causes `Failed to enter TX state!` when back-to-back transmissions are requested (e.g. controlling multiple RF shutters).

Additionally, `FS_AUTOCAL=1` only triggers PLL calibration when transitioning from IDLE, so direct RX↔TX transitions skip calibration entirely, which can cause frequency drift or PLL lock failures.

This fix transitions through IDLE first in both `begin_tx()` and `begin_rx()`, matching what `transmit_packet()` already does. This bypasses CCA (which only applies on RX→TX) and ensures proper PLL calibration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14315

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
cc1101:
  id: transciever
  cs_pin: GPIO22
  frequency: 433.92Mhz

remote_transmitter:
  pin: GPIO4
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - cc1101.begin_tx: transciever
  on_complete:
    then:
      - cc1101.begin_rx: transciever
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).