### PR TITLE
[libretiny] Use -Os optimization for ESPHome source on BK72xx (SDK remains at -O1)

### DIFF
--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -27,6 +27,7 @@ from esphome.storage_json import StorageJSON
 
 from . import gpio  # noqa
 from .const import (
+    COMPONENT_BK72XX,
     CONF_GPIO_RECOVER,
     CONF_LOGLEVEL,
     CONF_SDK_SILENT,
@@ -453,7 +454,14 @@ async def component_to_code(config):
     cg.add_platformio_option("lib_ldf_mode", "off")
     cg.add_platformio_option("lib_compat_mode", "soft")
     # include <Arduino.h> in every file
-    cg.add_platformio_option("build_src_flags", "-include Arduino.h")
+    build_src_flags = "-include Arduino.h"
+    if FAMILY_COMPONENT[config[CONF_FAMILY]] == COMPONENT_BK72XX:
+        # LibreTiny forces -O1 globally for BK72xx because the Beken SDK
+        # has issues with higher optimization levels. However, ESPHome code
+        # works fine with -Os (used on every other platform), so override
+        # it for project source files only. GCC uses the last -O flag.
+        build_src_flags += " -Os"
+    cg.add_platformio_option("build_src_flags", build_src_flags)
     # dummy version code
     cg.add_define("USE_ARDUINO_VERSION_CODE", cg.RawExpression("VERSION_CODE(0, 0, 0)"))
     # decrease web server stack size (16k words -> 4k words)

--- a/esphome/components/libretiny/lt_component.cpp
+++ b/esphome/components/libretiny/lt_component.cpp
@@ -15,6 +15,9 @@ void LTComponent::dump_config() {
                 "  Version: %s\n"
                 "  Loglevel: %u",
                 LT_BANNER_STR + 10, LT_LOGLEVEL);
+#if defined(__OPTIMIZE_SIZE__) && __OPTIMIZE_LEVEL__ > 0 && __OPTIMIZE_LEVEL__ <= 3
+  ESP_LOGCONFIG(TAG, "  Optimization: -Os, SDK: -O" STRINGIFY_MACRO(__OPTIMIZE_LEVEL__));
+#endif
 
 #ifdef USE_TEXT_SENSOR
   if (this->version_ != nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

LibreTiny forces `-O1` globally for BK72xx because the Beken SDK has issues with higher optimization levels when compiled with GCC 10.3.1.

**History:** The official Beken SDK (`application.mk`) was originally compiled with `-O2` using GCC 4.x. When LibreTiny upgraded to GCC 10.3.1 ([`a2de77c`](https://github.com/libretiny-eu/libretiny/commit/a2de77c), March 13, 2023) and switched to `-Os`, BK72xx devices started bootlooping. Two fixes followed on March 15, 2023:

1. [`8f338a6`](https://github.com/libretiny-eu/libretiny/commit/8f338a6) — Added `-fno-delete-null-pointer-checks` because GCC 10 aggressively optimizes away null checks that embedded code relies on (on ARM968E-S, dereferencing NULL doesn't fault — it reads from address 0, so the SDK code worked by accident with older GCC)
2. [`24832d3`](https://github.com/libretiny-eu/libretiny/commit/24832d3) — Still bootlooping, so optimization was dropped to `-O1` for the entire build with the comment: *"anything higher, like -O2 or -Os, causes random issues like bootlooping, missing (blank) strings, random lockups during boot"*

The root cause is undefined behavior in the Beken SDK C code (null pointer dereferences, likely strict aliasing violations) that GCC 10 exploits at higher optimization levels. **ESPHome code does not have these issues** — it's modern C++ compiled with `-Os` on every other platform (ESP32, ESP8266, RP2040, RTL87xx) without problems.

This PR uses PlatformIO's `build_src_flags` to add `-Os` for BK72xx project source files only. Since `build_src_flags` only applies to project source (not library code), the SDK/LibreTiny libraries continue using `-O1`. GCC uses the last `-O` flag, so the `-Os` after `-O1` effectively compiles ESPHome code with `-Os`.

The debug banner is also updated to show both optimization levels when they differ (e.g., `Optimization: -Os, SDK: -O1`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is automatic for BK72xx platforms
libretiny:
  board: cb3s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).