### PR TITLE
[libretiny] Use C++17 nested namespace syntax

### DIFF
--- a/esphome/components/libretiny/core.h
+++ b/esphome/components/libretiny/core.h
@@ -4,8 +4,6 @@
 
 #include <Arduino.h>
 
-namespace esphome {
-namespace libretiny {}  // namespace libretiny
-}  // namespace esphome
+namespace esphome::libretiny {}  // namespace esphome::libretiny
 
 #endif  // USE_LIBRETINY

--- a/esphome/components/libretiny/gpio_arduino.cpp
+++ b/esphome/components/libretiny/gpio_arduino.cpp
@@ -3,8 +3,7 @@
 #include "gpio_arduino.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 static const char *const TAG = "lt.gpio";
 
@@ -77,7 +76,9 @@ void ArduinoInternalGPIOPin::detach_interrupt() const {
   detachInterrupt(pin_);  // NOLINT
 }
 
-}  // namespace libretiny
+}  // namespace esphome::libretiny
+
+namespace esphome {
 
 using namespace libretiny;
 

--- a/esphome/components/libretiny/gpio_arduino.h
+++ b/esphome/components/libretiny/gpio_arduino.h
@@ -3,8 +3,7 @@
 #ifdef USE_LIBRETINY
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 class ArduinoInternalGPIOPin : public InternalGPIOPin {
  public:
@@ -31,7 +30,6 @@ class ArduinoInternalGPIOPin : public InternalGPIOPin {
   gpio::Flags flags_{};
 };
 
-}  // namespace libretiny
-}  // namespace esphome
+}  // namespace esphome::libretiny
 
 #endif  // USE_LIBRETINY

--- a/esphome/components/libretiny/lt_component.cpp
+++ b/esphome/components/libretiny/lt_component.cpp
@@ -4,8 +4,7 @@
 
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 static const char *const TAG = "lt.component";
 
@@ -25,7 +24,6 @@ void LTComponent::dump_config() {
 
 float LTComponent::get_setup_priority() const { return setup_priority::LATE; }
 
-}  // namespace libretiny
-}  // namespace esphome
+}  // namespace esphome::libretiny
 
 #endif  // USE_LIBRETINY

--- a/esphome/components/libretiny/lt_component.h
+++ b/esphome/components/libretiny/lt_component.h
@@ -12,8 +12,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #endif
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 class LTComponent : public Component {
  public:
@@ -30,7 +29,6 @@ class LTComponent : public Component {
 #endif  // USE_TEXT_SENSOR
 };
 
-}  // namespace libretiny
-}  // namespace esphome
+}  // namespace esphome::libretiny
 
 #endif  // USE_LIBRETINY

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -8,8 +8,7 @@
 #include <cstring>
 #include <memory>
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 static const char *const TAG = "lt.preferences";
 
@@ -194,7 +193,9 @@ void setup_preferences() {
   global_preferences = &s_preferences;
 }
 
-}  // namespace libretiny
+}  // namespace esphome::libretiny
+
+namespace esphome {
 
 ESPPreferences *global_preferences;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 

--- a/esphome/components/libretiny/preferences.h
+++ b/esphome/components/libretiny/preferences.h
@@ -2,12 +2,10 @@
 
 #ifdef USE_LIBRETINY
 
-namespace esphome {
-namespace libretiny {
+namespace esphome::libretiny {
 
 void setup_preferences();
 
-}  // namespace libretiny
-}  // namespace esphome
+}  // namespace esphome::libretiny
 
 #endif  // USE_LIBRETINY


### PR DESCRIPTION
# What does this implement/fix?

Migrate the libretiny component from the old two-level namespace syntax (`namespace esphome { namespace libretiny {`) to the C++17 nested namespace syntax (`namespace esphome::libretiny {`).

This is a style-only change with no functional impact, bringing libretiny in line with other components that already use the modern syntax.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - style-only C++ refactor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).