### PR TITLE
[esp32] Enable `execute_from_psram` for P4

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1633,7 +1633,7 @@ async def to_code(config):
         elif variant == VARIANT_ESP32P4:
             add_idf_sdkconfig_option("CONFIG_SPIRAM_XIP_FROM_PSRAM", True)
         else:
-            raise ValueError("Unhandled ESP32P4 variant")
+            raise ValueError("Unhandled ESP32 variant")
 
     # Apply LWIP core locking for better socket performance
     # This is already enabled by default in Arduino framework, where it provides

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -890,10 +890,10 @@ def final_validate(config):
                 )
             )
     if advanced[CONF_EXECUTE_FROM_PSRAM]:
-        if config[CONF_VARIANT] != VARIANT_ESP32S3:
+        if config[CONF_VARIANT] not in {VARIANT_ESP32S3, VARIANT_ESP32P4}:
             errs.append(
                 cv.Invalid(
-                    f"'{CONF_EXECUTE_FROM_PSRAM}' is only supported on {VARIANT_ESP32S3} variant",
+                    f"'{CONF_EXECUTE_FROM_PSRAM}' is not available on this esp32 variant",
                     path=[CONF_FRAMEWORK, CONF_ADVANCED, CONF_EXECUTE_FROM_PSRAM],
                 )
             )
@@ -1627,8 +1627,13 @@ async def to_code(config):
     _configure_lwip_max_sockets(conf)
 
     if advanced[CONF_EXECUTE_FROM_PSRAM]:
-        add_idf_sdkconfig_option("CONFIG_SPIRAM_FETCH_INSTRUCTIONS", True)
-        add_idf_sdkconfig_option("CONFIG_SPIRAM_RODATA", True)
+        if variant == VARIANT_ESP32S3:
+            add_idf_sdkconfig_option("CONFIG_SPIRAM_FETCH_INSTRUCTIONS", True)
+            add_idf_sdkconfig_option("CONFIG_SPIRAM_RODATA", True)
+        elif variant == VARIANT_ESP32P4:
+            add_idf_sdkconfig_option("CONFIG_SPIRAM_XIP_FROM_PSRAM", True)
+        else:
+            raise ValueError("Unhandled ESP32P4 variant")
 
     # Apply LWIP core locking for better socket performance
     # This is already enabled by default in Arduino framework, where it provides

--- a/tests/component_tests/esp32/config/execute_from_psram_disabled.yaml
+++ b/tests/component_tests/esp32/config/execute_from_psram_disabled.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal

--- a/tests/component_tests/esp32/config/execute_from_psram_p4.yaml
+++ b/tests/component_tests/esp32/config/execute_from_psram_p4.yaml
@@ -1,0 +1,11 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32p4
+  framework:
+    type: esp-idf
+    advanced:
+      execute_from_psram: true
+
+psram:

--- a/tests/component_tests/esp32/config/execute_from_psram_s3.yaml
+++ b/tests/component_tests/esp32/config/execute_from_psram_s3.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test
+
+esp32:
+  variant: esp32s3
+  framework:
+    type: esp-idf
+    advanced:
+      execute_from_psram: true
+
+psram:
+  mode: octal

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -2,13 +2,17 @@
 Test ESP32 configuration
 """
 
+from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from esphome.components.esp32 import VARIANTS
+from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS
 import esphome.config_validation as cv
 from esphome.const import CONF_ESPHOME, PlatformFramework
+from esphome.core import CORE
 from tests.component_tests.types import SetCoreConfigCallable
 
 
@@ -70,7 +74,7 @@ def test_esp32_config(
                     "advanced": {"execute_from_psram": True},
                 },
             },
-            r"'execute_from_psram' is only supported on ESP32S3 variant @ data\['framework'\]\['advanced'\]\['execute_from_psram'\]",
+            r"'execute_from_psram' is not available on this esp32 variant @ data\['framework'\]\['advanced'\]\['execute_from_psram'\]",
             id="execute_from_psram_invalid_for_variant_config",
         ),
         pytest.param(
@@ -82,7 +86,18 @@ def test_esp32_config(
                 },
             },
             r"'execute_from_psram' requires PSRAM to be configured @ data\['framework'\]\['advanced'\]\['execute_from_psram'\]",
-            id="execute_from_psram_requires_psram_config",
+            id="execute_from_psram_requires_psram_s3_config",
+        ),
+        pytest.param(
+            {
+                "variant": "esp32p4",
+                "framework": {
+                    "type": "esp-idf",
+                    "advanced": {"execute_from_psram": True},
+                },
+            },
+            r"'execute_from_psram' requires PSRAM to be configured @ data\['framework'\]\['advanced'\]\['execute_from_psram'\]",
+            id="execute_from_psram_requires_psram_p4_config",
         ),
         pytest.param(
             {
@@ -108,3 +123,39 @@ def test_esp32_configuration_errors(
 
     with pytest.raises(cv.Invalid, match=error_match):
         FINAL_VALIDATE_SCHEMA(CONFIG_SCHEMA(config))
+
+
+def test_execute_from_psram_s3_sdkconfig(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that execute_from_psram on ESP32-S3 sets the correct sdkconfig options."""
+    generate_main(component_config_path("execute_from_psram_s3.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_SPIRAM_FETCH_INSTRUCTIONS") is True
+    assert sdkconfig.get("CONFIG_SPIRAM_RODATA") is True
+    assert "CONFIG_SPIRAM_XIP_FROM_PSRAM" not in sdkconfig
+
+
+def test_execute_from_psram_p4_sdkconfig(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that execute_from_psram on ESP32-P4 sets the correct sdkconfig options."""
+    generate_main(component_config_path("execute_from_psram_p4.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_SPIRAM_XIP_FROM_PSRAM") is True
+    assert "CONFIG_SPIRAM_FETCH_INSTRUCTIONS" not in sdkconfig
+    assert "CONFIG_SPIRAM_RODATA" not in sdkconfig
+
+
+def test_execute_from_psram_disabled_sdkconfig(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that without execute_from_psram, no XIP sdkconfig options are set."""
+    generate_main(component_config_path("execute_from_psram_disabled.yaml"))
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert "CONFIG_SPIRAM_FETCH_INSTRUCTIONS" not in sdkconfig
+    assert "CONFIG_SPIRAM_RODATA" not in sdkconfig
+    assert "CONFIG_SPIRAM_XIP_FROM_PSRAM" not in sdkconfig


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1270223320989831178/1476524738665906226

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6164

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
