### PR TITLE
[usb_uart] Performance, correctness and reliability improvements

### DIFF
--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -424,9 +424,9 @@ bool USBClient::control_transfer(uint8_t type, uint8_t request, uint16_t value, 
   if (trq == nullptr)
     return false;
   auto length = data.size();
-  if (length > sizeof(trq->transfer->data_buffer_size) - SETUP_PACKET_SIZE) {
+  if (length > trq->transfer->data_buffer_size - SETUP_PACKET_SIZE) {
     ESP_LOGE(TAG, "Control transfer data size too large: %u > %u", length,
-             sizeof(trq->transfer->data_buffer_size) - sizeof(usb_setup_packet_t));
+             trq->transfer->data_buffer_size - SETUP_PACKET_SIZE);
     this->release_trq(trq);
     return false;
   }
@@ -507,9 +507,13 @@ bool USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
 
 /**
  * Performs an output transfer operation.
- * THREAD CONTEXT: Called from main loop thread only
- * - USB UART output uses defer() to ensure main loop context
- * - Modbus and other components call from loop()
+ * THREAD CONTEXT: Called from both USB task and main loop threads.
+ * - USB task: output transfer callback restarts output directly (no defer)
+ * - Main loop: initial output trigger from write_array() and loop()
+ * Thread safety is ensured by:
+ * - get_trq_() uses atomic CAS (multi-consumer safe)
+ * - claimed trq slot is exclusively owned until submission
+ * - usb_host_transfer_submit() is safe to call from any task context
  *
  * @param ep_address The endpoint address.
  * @param callback The callback function to be called when the transfer is complete.
@@ -522,6 +526,11 @@ bool USBClient::transfer_out(uint8_t ep_address, const transfer_cb_t &callback, 
   auto *trq = this->get_trq_();
   if (trq == nullptr) {
     ESP_LOGE(TAG, "Too many requests queued");
+    return false;
+  }
+  if (length > trq->transfer->data_buffer_size) {
+    ESP_LOGE(TAG, "transfer_out: data length %u exceeds buffer size %u", length, trq->transfer->data_buffer_size);
+    this->release_trq(trq);
     return false;
   }
   trq->callback = callback;

--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -5,8 +5,7 @@
 
 #include "esphome/components/bytebuffer/bytebuffer.h"
 
-namespace esphome {
-namespace usb_uart {
+namespace esphome::usb_uart {
 
 using namespace bytebuffer;
 /**
@@ -74,8 +73,8 @@ void USBUartTypeCH34X::enable_channels() {
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd, value, (factor << 8) | divisor, callback);
     this->control_transfer(USB_VENDOR_DEV | usb_host::USB_DIR_OUT, cmd + 3, 0x80, 0, callback);
   }
-  USBUartTypeCdcAcm::enable_channels();
+  this->start_channels();
 }
-}  // namespace usb_uart
-}  // namespace esphome
+}  // namespace esphome::usb_uart
+
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_uart/cp210x.cpp
+++ b/esphome/components/usb_uart/cp210x.cpp
@@ -5,8 +5,7 @@
 
 #include "esphome/components/bytebuffer/bytebuffer.h"
 
-namespace esphome {
-namespace usb_uart {
+namespace esphome::usb_uart {
 
 using namespace bytebuffer;
 /**
@@ -119,8 +118,8 @@ void USBUartTypeCP210X::enable_channels() {
     this->control_transfer(USB_VENDOR_IFC | usb_host::USB_DIR_OUT, SET_BAUDRATE, 0, channel->index_, callback,
                            baud.get_data());
   }
-  USBUartTypeCdcAcm::enable_channels();
+  this->start_channels();
 }
-}  // namespace usb_uart
-}  // namespace esphome
+}  // namespace esphome::usb_uart
+
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -7,8 +7,7 @@
 
 #include <cinttypes>
 
-namespace esphome {
-namespace usb_uart {
+namespace esphome::usb_uart {
 
 /**
  *
@@ -135,14 +134,37 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
     ESP_LOGV(TAG, "Channel not initialised - write ignored");
     return;
   }
-  while (this->output_buffer_.get_free_space() != 0 && len-- != 0) {
-    this->output_buffer_.push(*data++);
-  }
-  len++;
-  if (len > 0) {
-    ESP_LOGE(TAG, "Buffer full - failed to write %d bytes", len);
+  while (len > 0) {
+    UsbOutputChunk *chunk = this->output_pool_.allocate();
+    if (chunk == nullptr) {
+      ESP_LOGE(TAG, "Output pool full - lost %zu bytes", len);
+      break;
+    }
+    size_t chunk_len = std::min(len, UsbOutputChunk::MAX_CHUNK_SIZE);
+    memcpy(chunk->data, data, chunk_len);
+    chunk->length = static_cast<uint8_t>(chunk_len);
+    if (!this->output_queue_.push(chunk)) {
+      this->output_pool_.release(chunk);
+      ESP_LOGE(TAG, "Output queue full - lost %zu bytes", len);
+      break;
+    }
+    data += chunk_len;
+    len -= chunk_len;
   }
   this->parent_->start_output(this);
+}
+
+void USBUartChannel::flush() {
+  // Spin until the output queue is drained and the last USB transfer completes.
+  // Safe to call from the main loop only.
+  // The 100 ms timeout guards against a device that stops responding mid-flush;
+  // in that case the main loop is blocked for the full duration.
+  uint32_t deadline = millis() + 100;  // 100 ms safety timeout
+  while ((!this->output_queue_.empty() || this->output_started_.load()) && millis() < deadline) {
+    // Kick start_output() in case data arrived but no transfer is in flight yet.
+    this->parent_->start_output(this);
+    yield();
+  }
 }
 
 bool USBUartChannel::peek_byte(uint8_t *data) {
@@ -192,6 +214,13 @@ void USBUartComponent::loop() {
 
     // Return chunk to pool for reuse
     this->chunk_pool_.release(chunk);
+
+    // Invoke the RX callback (if registered) immediately after data lands in the
+    // ring buffer.  This lets consumers such as ZigbeeProxy process incoming bytes
+    // in the same loop iteration they are delivered, avoiding an extra wakeup cycle.
+    if (channel->rx_callback_) {
+      channel->rx_callback_();
+    }
   }
 
   // Log dropped USB data periodically
@@ -234,10 +263,10 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
   // The underlying transfer_in() uses lock-free atomic allocation from the
   // TransferRequest pool, making this multi-threaded access safe
 
-  // if already started, don't restart. A spurious failure in compare_exchange_weak
-  // is not a problem, as it will be retried on the next read_array()
+  // Use compare_exchange_strong to avoid spurious failures: a missed submit here is
+  // never retried by read_array() because no data will ever arrive to trigger it.
   auto started = false;
-  if (!channel->input_started_.compare_exchange_weak(started, true))
+  if (!channel->input_started_.compare_exchange_strong(started, true))
     return;
   const auto *ep = channel->cdc_dev_.in_ep;
   // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
@@ -285,37 +314,62 @@ void USBUartComponent::start_input(USBUartChannel *channel) {
     this->start_input(channel);
   };
   if (!this->transfer_in(ep->bEndpointAddress, callback, ep->wMaxPacketSize)) {
+    ESP_LOGE(TAG, "IN transfer submission failed for ep=0x%02X", ep->bEndpointAddress);
     channel->input_started_.store(false);
   }
 }
 
 void USBUartComponent::start_output(USBUartChannel *channel) {
-  // IMPORTANT: This function must only be called from the main loop!
-  // The output_buffer_ is not thread-safe and can only be accessed from main loop.
-  // USB callbacks use defer() to ensure this function runs in the correct context.
-  if (channel->output_started_.load())
-    return;
-  if (channel->output_buffer_.is_empty()) {
+  // THREAD CONTEXT: Called from both main loop and USB task threads.
+  // The output_queue_ is a lock-free SPSC queue, so pop() is safe from either thread.
+  // The output_started_ atomic flag is claimed via compare_exchange to guarantee that
+  // only one thread starts a transfer at a time.
+
+  // Atomically claim the "output in progress" flag. If already set, another thread
+  // is handling the transfer; return immediately.
+  bool expected = false;
+  if (!channel->output_started_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
     return;
   }
+
+  UsbOutputChunk *chunk = channel->output_queue_.pop();
+  if (chunk == nullptr) {
+    // Nothing to send — release the flag and return.
+    channel->output_started_.store(false, std::memory_order_release);
+    return;
+  }
+
   const auto *ep = channel->cdc_dev_.out_ep;
-  // CALLBACK CONTEXT: This lambda is executed in USB task via transfer_callback
-  auto callback = [this, channel](const usb_host::TransferStatus &status) {
-    ESP_LOGV(TAG, "Output Transfer result: length: %u; status %X", status.data_len, status.error_code);
-    channel->output_started_.store(false);
-    // Defer restart to main loop (defer is thread-safe)
-    this->defer([this, channel] { this->start_output(channel); });
+  // CALLBACK CONTEXT: This lambda is executed in the USB task via transfer_callback.
+  // It releases the chunk, clears the flag, and directly restarts output without
+  // going through defer() — eliminating one full main-loop-wakeup cycle of latency.
+  auto callback = [this, channel, chunk](const usb_host::TransferStatus &status) {
+    if (!status.success) {
+      ESP_LOGW(TAG, "Output transfer failed: status %X", status.error_code);
+    } else {
+      ESP_LOGV(TAG, "Output Transfer result: length: %u; status %X", status.data_len, status.error_code);
+    }
+    channel->output_pool_.release(chunk);
+    channel->output_started_.store(false, std::memory_order_release);
+    // Restart directly from USB task — safe because output_queue_ is lock-free
+    // and transfer_out() uses thread-safe atomic slot allocation.
+    this->start_output(channel);
   };
-  channel->output_started_.store(true);
-  uint8_t data[ep->wMaxPacketSize];
-  auto len = channel->output_buffer_.pop(data, ep->wMaxPacketSize);
-  this->transfer_out(ep->bEndpointAddress, callback, data, len);
+
+  const uint8_t len = chunk->length;
 #ifdef USE_UART_DEBUGGER
   if (channel->debug_) {
-    uart::UARTDebug::log_hex(uart::UART_DIRECTION_TX, std::vector<uint8_t>(data, data + len), ',');  // NOLINT()
+    uart::UARTDebug::log_hex(uart::UART_DIRECTION_TX, std::vector<uint8_t>(chunk->data, chunk->data + len),
+                             ',');  // NOLINT()
   }
 #endif
-  ESP_LOGV(TAG, "Output %d bytes started", len);
+  if (!this->transfer_out(ep->bEndpointAddress, callback, chunk->data, len)) {
+    // Transfer submission failed — return chunk and release flag so callers can retry.
+    channel->output_pool_.release(chunk);
+    channel->output_started_.store(false, std::memory_order_release);
+    return;
+  }
+  ESP_LOGV(TAG, "Output %u bytes started", len);
 }
 
 /**
@@ -351,6 +405,20 @@ void USBUartTypeCdcAcm::on_connected() {
     fix_mps(channel->cdc_dev_.in_ep);
     fix_mps(channel->cdc_dev_.out_ep);
     channel->initialised_.store(true);
+    // Claim the communication (interrupt) interface so CDC class requests are accepted
+    // by the device. Some CDC ACM implementations (e.g. EFR32 NCP) require this before
+    // they enable data flow on the bulk endpoints.
+    if (channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
+      auto err_comm = usb_host_interface_claim(this->handle_, this->device_handle_,
+                                               channel->cdc_dev_.interrupt_interface_number, 0);
+      if (err_comm != ESP_OK) {
+        ESP_LOGW(TAG, "Could not claim comm interface %d: %s", channel->cdc_dev_.interrupt_interface_number,
+                 esp_err_to_name(err_comm));
+      } else {
+        channel->cdc_dev_.comm_interface_claimed = true;
+        ESP_LOGD(TAG, "Claimed comm interface %d", channel->cdc_dev_.interrupt_interface_number);
+      }
+    }
     auto err =
         usb_host_interface_claim(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number, 0);
     if (err != ESP_OK) {
@@ -378,18 +446,74 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
     }
+    if (channel->cdc_dev_.comm_interface_claimed) {
+      usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.interrupt_interface_number);
+      channel->cdc_dev_.comm_interface_claimed = false;
+    }
     usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number);
     // Reset the input and output started flags to their initial state to avoid the possibility of spurious restarts
     channel->input_started_.store(true);
     channel->output_started_.store(true);
     channel->input_buffer_.clear();
-    channel->output_buffer_.clear();
+    // Drain any pending output chunks and return them to the pool
+    {
+      UsbOutputChunk *chunk;
+      while ((chunk = channel->output_queue_.pop()) != nullptr) {
+        channel->output_pool_.release(chunk);
+      }
+    }
     channel->initialised_.store(false);
   }
   USBClient::on_disconnected();
 }
 
 void USBUartTypeCdcAcm::enable_channels() {
+  static constexpr uint8_t CDC_REQUEST_TYPE = usb_host::USB_TYPE_CLASS | usb_host::USB_RECIP_INTERFACE;
+  static constexpr uint8_t CDC_SET_LINE_CODING = 0x20;
+  static constexpr uint8_t CDC_SET_CONTROL_LINE_STATE = 0x22;
+  static constexpr uint16_t CDC_DTR_RTS = 0x0003;  // D0=DTR, D1=RTS
+
+  for (auto *channel : this->channels_) {
+    if (!channel->initialised_.load())
+      continue;
+    // Configure the bridge's UART parameters. A USB-UART bridge will not forward data
+    // at the correct speed until SET_LINE_CODING is sent; without it the UART may run
+    // at an indeterminate default rate so the NCP receives garbled bytes and never
+    // sends RSTACK.
+    uint32_t baud = channel->baud_rate_;
+    std::vector<uint8_t> line_coding = {
+        static_cast<uint8_t>(baud & 0xFF),         static_cast<uint8_t>((baud >> 8) & 0xFF),
+        static_cast<uint8_t>((baud >> 16) & 0xFF), static_cast<uint8_t>((baud >> 24) & 0xFF),
+        static_cast<uint8_t>(channel->stop_bits_),  // bCharFormat: 0=1stop, 1=1.5stop, 2=2stop
+        static_cast<uint8_t>(channel->parity_),     // bParityType: 0=None, 1=Odd, 2=Even, 3=Mark, 4=Space
+        static_cast<uint8_t>(channel->data_bits_),  // bDataBits
+    };
+    ESP_LOGD(TAG, "SET_LINE_CODING: baud=%u stop=%u parity=%u data=%u", (unsigned) baud, channel->stop_bits_,
+             (unsigned) channel->parity_, channel->data_bits_);
+    this->control_transfer(
+        CDC_REQUEST_TYPE, CDC_SET_LINE_CODING, 0, channel->cdc_dev_.interrupt_interface_number,
+        [](const usb_host::TransferStatus &status) {
+          if (!status.success) {
+            ESP_LOGW(TAG, "SET_LINE_CODING failed: %X", status.error_code);
+          } else {
+            ESP_LOGD(TAG, "SET_LINE_CODING OK");
+          }
+        },
+        line_coding);
+    // Assert DTR+RTS to signal DTE is present.
+    this->control_transfer(CDC_REQUEST_TYPE, CDC_SET_CONTROL_LINE_STATE, CDC_DTR_RTS,
+                           channel->cdc_dev_.interrupt_interface_number, [](const usb_host::TransferStatus &status) {
+                             if (!status.success) {
+                               ESP_LOGW(TAG, "SET_CONTROL_LINE_STATE failed: %X", status.error_code);
+                             } else {
+                               ESP_LOGD(TAG, "SET_CONTROL_LINE_STATE (DTR+RTS) OK");
+                             }
+                           });
+  }
+  this->start_channels();
+}
+
+void USBUartTypeCdcAcm::start_channels() {
   for (auto *channel : this->channels_) {
     if (!channel->initialised_.load())
       continue;
@@ -399,6 +523,6 @@ void USBUartTypeCdcAcm::enable_channels() {
   }
 }
 
-}  // namespace usb_uart
-}  // namespace esphome
+}  // namespace esphome::usb_uart
+
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -3,7 +3,6 @@
 #include "usb_uart.h"
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
-#include "esphome/components/uart/uart_debugger.h"
 
 #include <cinttypes>
 
@@ -136,23 +135,12 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
   }
 #ifdef USE_UART_DEBUGGER
   if (this->debug_) {
-    // Log hex without heap allocation: format up to 16 bytes at a time onto the stack.
-    // ">>> XX,XX,...,XX\0" → 4 + 16*3 bytes = 52 chars per batch.
     constexpr size_t BATCH = 16;
-    char buf[4 + BATCH * 3];
+    char buf[4 + format_hex_pretty_size(BATCH)];  // ">>> " + "XX,XX,...,XX\0"
     for (size_t off = 0; off < len; off += BATCH) {
       size_t n = std::min(len - off, BATCH);
-      size_t pos = 0;
-      buf[pos++] = '>';
-      buf[pos++] = '>';
-      buf[pos++] = '>';
-      buf[pos++] = ' ';
-      for (size_t i = 0; i < n; i++) {
-        if (i > 0)
-          buf[pos++] = ',';
-        pos += snprintf(buf + pos, sizeof(buf) - pos, "%02X", data[off + i]);
-      }
-      buf[pos] = '\0';
+      memcpy(buf, ">>> ", 4);
+      format_hex_pretty_to(buf + 4, sizeof(buf) - 4, data + off, n, ',');
       ESP_LOGD(TAG, "%s", buf);
     }
   }
@@ -227,8 +215,10 @@ void USBUartComponent::loop() {
 
 #ifdef USE_UART_DEBUGGER
     if (channel->debug_) {
-      uart::UARTDebug::log_hex(uart::UART_DIRECTION_RX, std::vector<uint8_t>(chunk->data, chunk->data + chunk->length),
-                               ',');  // NOLINT()
+      char buf[4 + format_hex_pretty_size(UsbDataChunk::MAX_CHUNK_SIZE)];  // "<<< " + hex
+      memcpy(buf, "<<< ", 4);
+      format_hex_pretty_to(buf + 4, sizeof(buf) - 4, chunk->data, chunk->length, ',');
+      ESP_LOGD(TAG, "%s", buf);
     }
 #endif
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -134,6 +134,29 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
     ESP_LOGV(TAG, "Channel not initialised - write ignored");
     return;
   }
+#ifdef USE_UART_DEBUGGER
+  if (this->debug_) {
+    // Log hex without heap allocation: format up to 16 bytes at a time onto the stack.
+    // ">>> XX,XX,...,XX\0" → 4 + 16*3 bytes = 52 chars per batch.
+    constexpr size_t BATCH = 16;
+    char buf[4 + BATCH * 3];
+    for (size_t off = 0; off < len; off += BATCH) {
+      size_t n = std::min(len - off, BATCH);
+      size_t pos = 0;
+      buf[pos++] = '>';
+      buf[pos++] = '>';
+      buf[pos++] = '>';
+      buf[pos++] = ' ';
+      for (size_t i = 0; i < n; i++) {
+        if (i > 0)
+          buf[pos++] = ',';
+        pos += snprintf(buf + pos, sizeof(buf) - pos, "%02X", data[off + i]);
+      }
+      buf[pos] = '\0';
+      ESP_LOGD(TAG, "%s", buf);
+    }
+  }
+#endif
   while (len > 0) {
     UsbOutputChunk *chunk = this->output_pool_.allocate();
     if (chunk == nullptr) {
@@ -357,12 +380,6 @@ void USBUartComponent::start_output(USBUartChannel *channel) {
   };
 
   const uint8_t len = chunk->length;
-#ifdef USE_UART_DEBUGGER
-  if (channel->debug_) {
-    uart::UARTDebug::log_hex(uart::UART_DIRECTION_TX, std::vector<uint8_t>(chunk->data, chunk->data + len),
-                             ',');  // NOLINT()
-  }
-#endif
   if (!this->transfer_out(ep->bEndpointAddress, callback, chunk->data, len)) {
     // Transfer submission failed — return chunk and release flag so callers can retry.
     channel->output_pool_.release(chunk);

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -8,9 +8,10 @@
 #include "esphome/core/lock_free_queue.h"
 #include "esphome/core/event_pool.h"
 #include <atomic>
+#include <functional>
 
-namespace esphome {
-namespace usb_uart {
+namespace esphome::usb_uart {
+
 class USBUartTypeCdcAcm;
 class USBUartComponent;
 class USBUartChannel;
@@ -31,6 +32,7 @@ struct CdcEps {
   const usb_ep_desc_t *out_ep;
   uint8_t bulk_interface_number;
   uint8_t interrupt_interface_number;
+  bool comm_interface_claimed{false};
 };
 
 enum UARTParityOptions {
@@ -83,6 +85,16 @@ struct UsbDataChunk {
   void release() {}
 };
 
+// Structure for queuing outgoing USB data chunks (one per USB FS packet)
+struct UsbOutputChunk {
+  static constexpr size_t MAX_CHUNK_SIZE = 64;  // USB FS MPS
+  uint8_t data[MAX_CHUNK_SIZE];
+  uint8_t length;
+
+  // Required for EventPool - no cleanup needed for POD types
+  void release() {}
+};
+
 class USBUartChannel : public uart::UARTComponent, public Parented<USBUartComponent> {
   friend class USBUartComponent;
   friend class USBUartTypeCdcAcm;
@@ -90,24 +102,32 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   friend class USBUartTypeCH34X;
 
  public:
-  USBUartChannel(uint8_t index, uint16_t buffer_size)
-      : index_(index), input_buffer_(RingBuffer(buffer_size)), output_buffer_(RingBuffer(buffer_size)) {}
+  // Number of output chunk slots per channel (8 × 64 bytes = 512 bytes peak, lazily allocated)
+  static constexpr uint8_t USB_OUTPUT_CHUNK_COUNT = 8;
+
+  USBUartChannel(uint8_t index, uint16_t buffer_size) : index_(index), input_buffer_(RingBuffer(buffer_size)) {}
   void write_array(const uint8_t *data, size_t len) override;
-  ;
   bool peek_byte(uint8_t *data) override;
-  ;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override { return this->input_buffer_.get_available(); }
-  void flush() override {}
+  void flush() override;
   void check_logger_conflict() override {}
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }
   void set_debug(bool debug) { this->debug_ = debug; }
   void set_dummy_receiver(bool dummy_receiver) { this->dummy_receiver_ = dummy_receiver; }
 
+  /// Register a callback invoked immediately after data is pushed to the input ring buffer.
+  /// Called from USBUartComponent::loop() in the main loop context.
+  /// Allows consumers (e.g. ZigbeeProxy) to process bytes in the same loop iteration
+  /// they arrive, eliminating one full main-loop-wakeup cycle of latency.
+  void set_rx_callback(std::function<void()> cb) { this->rx_callback_ = std::move(cb); }
+
  protected:
   // Larger structures first for better alignment
   RingBuffer input_buffer_;
-  RingBuffer output_buffer_;
+  LockFreeQueue<UsbOutputChunk, USB_OUTPUT_CHUNK_COUNT> output_queue_;
+  EventPool<UsbOutputChunk, USB_OUTPUT_CHUNK_COUNT> output_pool_;
+  std::function<void()> rx_callback_{};
   CdcEps cdc_dev_{};
   // Enum (likely 4 bytes)
   UARTParityOptions parity_{UART_CONFIG_PARITY_NONE};
@@ -150,8 +170,12 @@ class USBUartTypeCdcAcm : public USBUartComponent {
  protected:
   virtual std::vector<CdcEps> parse_descriptors(usb_device_handle_t dev_hdl);
   void on_connected() override;
-  virtual void enable_channels();
   void on_disconnected() override;
+  virtual void enable_channels();
+  /// Resets per-channel transfer flags and posts the first bulk IN transfer.
+  /// Called by enable_channels() and by vendor-specific subclass overrides that
+  /// handle their own line-coding setup before starting data flow.
+  void start_channels();
 };
 
 class USBUartTypeCP210X : public USBUartTypeCdcAcm {
@@ -170,7 +194,6 @@ class USBUartTypeCH34X : public USBUartTypeCdcAcm {
   void enable_channels() override;
 };
 
-}  // namespace usb_uart
-}  // namespace esphome
+}  // namespace esphome::usb_uart
 
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -80,7 +80,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
 
  public:
   T *pop() {
-    uint8_t current_head = head_.load(std::memory_order_acquire);
+    uint8_t current_head = head_.load(std::memory_order_relaxed);
 
     if (current_head == tail_.load(std::memory_order_acquire)) {
       return nullptr;  // Empty

--- a/esphome/core/lock_free_queue.h
+++ b/esphome/core/lock_free_queue.h
@@ -80,7 +80,7 @@ template<class T, uint8_t SIZE> class LockFreeQueue {
 
  public:
   T *pop() {
-    uint8_t current_head = head_.load(std::memory_order_relaxed);
+    uint8_t current_head = head_.load(std::memory_order_acquire);
 
     if (current_head == tail_.load(std::memory_order_acquire)) {
       return nullptr;  // Empty


### PR DESCRIPTION
# What does this implement/fix?

Fixes several correctness and reliability issues in the `usb_uart` component and reduces data-path latency for USB-UART CDC ACM devices (such as USB-UART bridges connected to MG24 NCPs).

### Changes

**CDC ACM initialization (`USBUartTypeCdcAcm::enable_channels`)**

The CDC ACM `enable_channels()` implementation previously jumped straight to starting bulk IN/OUT transfers without configuring the device. This caused USB-UART bridges to operate at the wrong (default) baud rate, so a downstream device received garbled bytes and never responded.

- Sends `SET_LINE_CODING` (0x20) before `SET_CONTROL_LINE_STATE` to configure the bridge's UART at the correct baud/stop/parity/data settings.
- Sends `SET_CONTROL_LINE_STATE` (0x22) to assert DTR+RTS, signalling that a DTE is present.
- Extracts the bulk transfer startup into a new `start_channels()` helper that vendor-specific subclasses (`CP210X`, `CH34X`) call instead of the now-CDC-only `enable_channels()`.

**CDC communication interface claiming**

Some CDC ACM devices expose two separate USB interfaces: a communication (interrupt) interface and a data (bulk) interface. Previously only the bulk interface was claimed, causing control requests to be rejected or silently dropped by devices that enforce interface ownership.

- Claims the interrupt interface in `on_connected()` when it has a different interface number than the bulk interface.
- Releases the interrupt interface in `on_disconnected()` and tracks claimed state with `comm_interface_claimed`.

**Output path: ring buffer → lock-free chunk queue**

The previous output path used a `RingBuffer` for outgoing data, which is not safe to access from multiple threads. `start_output()` was restricted to the main loop, requiring a `defer()` round-trip after every completed USB transfer.

- Replaces `output_buffer_` with a `LockFreeQueue<UsbOutputChunk>` + `EventPool<UsbOutputChunk>` pair, making the output path safe to call from both the main loop and the USB task.
- The USB transfer completion callback now calls `start_output()` directly without going through `defer()`, eliminating one full main-loop-wakeup cycle of latency per packet.
- `start_output()` uses `compare_exchange_strong` (instead of a load+check pattern) to atomically claim the "transfer in progress" flag, preventing double-submission from concurrent callers.
- On disconnect, pending output chunks are drained and returned to the pool.
- Implements `flush()`: spins until the output queue is empty and the in-flight transfer completes (100 ms safety timeout).

**Input path fixes**

- `start_input()` switches from `compare_exchange_weak` to `compare_exchange_strong`. `compare_exchange_weak` is permitted to fail spuriously (report "already set" even when the flag was actually clear) — this is allowed by the C++ standard to enable more efficient code on LL/SC architectures such as RISC-V (ESP32-C series). At bootstrap this means the bulk IN transfer is never submitted; without incoming data there is no trigger to retry, so the channel silently receives nothing.
- Logs an error if the IN transfer submission fails.

**RX callback**

Adds `set_rx_callback(std::function<void()>)` to `USBUartChannel`. The callback is invoked immediately in `USBUartComponent::loop()` after each incoming USB transfer is drained into the ring buffer, allowing consumers to process bytes in the same loop iteration they arrive.

**Style / housekeeping**

- Consolidates `namespace esphome { namespace usb_uart {` → `namespace esphome::usb_uart {` in all files.
- Removes stray extra semicolons on method declarations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested on ESP32-S3 with IDF framework connected to a USB-UART bridge forwarding to an MG24 NCP at 460800 8N1. The NCP successfully responds after the corrected `SET_LINE_CODING` → `SET_CONTROL_LINE_STATE` → bulk IN start sequence.

In practice, the performance gains are significant:

**Before:**
```
============================================================
PROFILING RESULTS
============================================================
Runs: 10  Successful: 10  Failed: 0
EZSP version: 12

Step                                           avg      min      max
--------------------------------------------------------------------
  ASH reset (RST → RSTACK)                 1179.4  1170.1  1187.9  ms
  EZSP version negotiation                   56.4    52.4    63.6  ms
  networkInit → stack status                 28.7    27.8    32.4  ms
  getNetworkParameters                       28.8    27.9    33.0  ms
  Final reset (RST → RSTACK)               1186.4  1181.6  1193.1  ms
--------------------------------------------------------------------
  TOTAL                                    2479.7  2463.3  2492.8  ms
```

**After:**
```
============================================================
PROFILING RESULTS
============================================================
Runs: 10  Successful: 10  Failed: 0
EZSP version: 12

Step                                           avg      min      max
--------------------------------------------------------------------
  ASH reset (RST → RSTACK)                 1170.4  1168.8  1171.1  ms
  EZSP version negotiation                   25.5    24.8    26.6  ms
  networkInit → stack status                 14.2    13.7    14.8  ms
  getNetworkParameters                       14.1    13.4    15.4  ms
  Final reset (RST → RSTACK)               1173.5  1172.5  1175.1  ms
--------------------------------------------------------------------
  TOTAL                                    2397.7  2395.1  2401.8  ms
```

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
usb_uart:
  - id: my_uart
    baud_rate: 460800
    stop_bits: 1
    parity: NONE
    data_bits: 8
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).