### PR TITLE
[core] Fix Application asm label for Mach-O using __USER_LABEL_PREFIX__

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -720,16 +720,15 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 #error "Application placement new requires Itanium C++ ABI (GCC/Clang)"
 #endif
 static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
-#ifdef __APPLE__
-// Mach-O prefixes an underscore to all symbols
-// On Mach-O, external symbols get an extra leading '_' prefix.
-// The Itanium ABI mangled name is "_ZN7esphome3AppE", so the Mach-O asm label is "__ZN7esphome3AppE".
+// __USER_LABEL_PREFIX__ is "_" on Mach-O (macOS) and empty on ELF (embedded targets).
+// String literal concatenation produces the correct platform-specific mangled symbol.
+#define ESPHOME_STRINGIFY2_(x) #x
+#define ESPHOME_STRINGIFY_(x) ESPHOME_STRINGIFY2_(x)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-alignas(Application) char app_storage[sizeof(Application)] asm("__ZN7esphome3AppE");
-#else
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");
-#endif
+alignas(Application) char app_storage[sizeof(Application)] asm(
+    ESPHOME_STRINGIFY_(__USER_LABEL_PREFIX__) "_ZN7esphome3AppE");
+#undef ESPHOME_STRINGIFY_
+#undef ESPHOME_STRINGIFY2_
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -721,7 +721,12 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 #endif
 static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+#ifdef __APPLE__
+// Mach-O prefixes an underscore to all symbols
+alignas(Application) char app_storage[sizeof(Application)] asm("__ZN7esphome3AppE");
+#else
 alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");
+#endif
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -722,7 +722,8 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 #ifdef __APPLE__
-// Mach-O prefixes an underscore to all symbols
+// On Mach-O, external symbols get an extra leading '_' prefix.
+// The Itanium ABI mangled name is "_ZN7esphome3AppE", so the Mach-O asm label is "__ZN7esphome3AppE".
 alignas(Application) char app_storage[sizeof(Application)] asm("__ZN7esphome3AppE");
 #else
 alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -722,13 +722,15 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
 // __USER_LABEL_PREFIX__ is "_" on Mach-O (macOS) and empty on ELF (embedded targets).
 // String literal concatenation produces the correct platform-specific mangled symbol.
-#define ESPHOME_STRINGIFY2_(x) #x
-#define ESPHOME_STRINGIFY_(x) ESPHOME_STRINGIFY2_(x)
+// Two-level macro needed: # stringifies before expansion, so the
+// indirection forces __USER_LABEL_PREFIX__ to expand first.
+#define ESPHOME_STRINGIFY_IMPL_(x) #x
+#define ESPHOME_STRINGIFY_(x) ESPHOME_STRINGIFY_IMPL_(x)
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 alignas(Application) char app_storage[sizeof(Application)] asm(
     ESPHOME_STRINGIFY_(__USER_LABEL_PREFIX__) "_ZN7esphome3AppE");
 #undef ESPHOME_STRINGIFY_
-#undef ESPHOME_STRINGIFY2_
+#undef ESPHOME_STRINGIFY_IMPL_
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -720,11 +720,12 @@ void Application::yield_with_select_(uint32_t delay_ms) {
 #error "Application placement new requires Itanium C++ ABI (GCC/Clang)"
 #endif
 static_assert(std::is_default_constructible<Application>::value, "Application must be default-constructible");
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 #ifdef __APPLE__
 // Mach-O prefixes an underscore to all symbols
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 alignas(Application) char app_storage[sizeof(Application)] asm("__ZN7esphome3AppE");
 #else
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 alignas(Application) char app_storage[sizeof(Application)] asm("_ZN7esphome3AppE");
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

PR #14052 introduced an `asm` label on the `App` storage array using the Itanium ABI mangled name `_ZN7esphome3AppE`. This works on ELF targets (all embedded platforms) but breaks on macOS (Mach-O), where the linker prepends an underscore to all symbols. Other translation units reference `__ZN7esphome3AppE` while the `asm` label emits `_ZN7esphome3AppE`, causing an undefined symbol linker error on the host platform.

The fix uses the `__USER_LABEL_PREFIX__` predefined compiler macro, which is `_` on Mach-O and empty on ELF. String literal concatenation produces the correct platform-specific mangled symbol without any `#ifdef` guards.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes host platform build broken by #14052

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is an internal build fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).