### PR TITLE
[zigbee] Fix codegen ordering for basic/identify attribute lists

### DIFF
--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -8,7 +8,7 @@ from esphome.components.zephyr import zephyr_add_pm_static, zephyr_data
 from esphome.components.zephyr.const import KEY_BOOTLOADER
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_INTERNAL, CONF_NAME
-from esphome.core import CORE
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
 from esphome.types import ConfigType
 
 from .const_zephyr import (
@@ -96,6 +96,7 @@ FINAL_VALIDATE_SCHEMA = cv.All(
 )
 
 
+@coroutine_with_priority(CoroPriority.CORE)
 async def to_code(config: ConfigType) -> None:
     cg.add_define("USE_ZIGBEE")
     if CORE.using_zephyr:

--- a/esphome/components/zigbee/zigbee_zephyr.py
+++ b/esphome/components/zigbee/zigbee_zephyr.py
@@ -179,6 +179,7 @@ async def zephyr_to_code(config: ConfigType) -> None:
                 "USE_ZIGBEE_WIPE_ON_BOOT_MAGIC", random.randint(0x000001, 0xFFFFFF)
             )
         cg.add_define("USE_ZIGBEE_WIPE_ON_BOOT")
+
     # Generate attribute lists before any await that could yield (e.g., build_automation
     # waiting for variables from other components). If the hub's priority decays while
     # yielding, deferred entity jobs may add cluster list globals that reference these

--- a/esphome/components/zigbee/zigbee_zephyr.py
+++ b/esphome/components/zigbee/zigbee_zephyr.py
@@ -179,6 +179,12 @@ async def zephyr_to_code(config: ConfigType) -> None:
                 "USE_ZIGBEE_WIPE_ON_BOOT_MAGIC", random.randint(0x000001, 0xFFFFFF)
             )
         cg.add_define("USE_ZIGBEE_WIPE_ON_BOOT")
+    # Generate attribute lists before any await that could yield (e.g., build_automation
+    # waiting for variables from other components). If the hub's priority decays while
+    # yielding, deferred entity jobs may add cluster list globals that reference these
+    # attribute lists before they're declared.
+    await _attr_to_code(config)
+
     var = cg.new_Pvariable(config[CONF_ID])
 
     if on_join_config := config.get(CONF_ON_JOIN):
@@ -186,7 +192,6 @@ async def zephyr_to_code(config: ConfigType) -> None:
 
     await cg.register_component(var, config)
 
-    await _attr_to_code(config)
     CORE.add_job(_ctx_to_code, config)
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation failure on nRF52/Zephyr when using the zigbee component with any entity type (binary_sensor, switch, sensor, number). The generated `main.cpp` references `zigbee_basic_attrib_list` and `zigbee_identify_attrib_list` in the cluster list before they are declared.

**Root cause:** Two independent issues combine to cause the bug:

1. **Priority decay with `on_join` automations:** When zigbee hub `to_code` has `on_join` automations referencing components not yet registered (e.g., a light), `build_automation` → `get_variable` yields repeatedly. FakeEventLoop decrements the task priority by 1 each yield. Starting at `CoroPriority.CORE` (100), the zigbee task drops below priority 0 after ~101 yields. At that point, priority-0 tasks (GPIO binary_sensor platform `to_code`) start running and defer `_add_binary_sensor` jobs that add cluster list globals referencing `zigbee_basic_attrib_list` — before `_attr_to_code` has had a chance to declare it.

2. **Missing priority on hub `to_code`:** Without `CoroPriority.CORE`, the zigbee hub runs at default priority 0 alongside entity platforms, making the scheduling even more fragile.

**Fix (two changes):**

1. **`__init__.py`:** Add `@coroutine_with_priority(CoroPriority.CORE)` to `to_code` so the hub runs at the same priority tier as entity base components.

2. **`zigbee_zephyr.py`:** Move `_attr_to_code()` to the top of `zephyr_to_code`, before `build_automation` or any other `await` that could yield. Since `_attr_to_code` has no internal `await`, it completes in the zigbee task's first scheduler step — guaranteeing the attribute list globals are emitted before any priority decay can occur.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14342

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Config with on_join referencing a light triggers the scheduling race
zigbee:
  power_source: DC_SOURCE
  on_join:
    then:
      - light.turn_on:
          id: status_led
          effect: "Blink"

light:
  - platform: binary
    id: status_led
    output: led_output

binary_sensor:
  - platform: gpio
    name: "Button 1"
    pin:
      number: P0.29
      mode: { input: true, pullup: true }
      inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).