### PR TITLE
[ci] Add PR title format check

### DIFF
--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -1,5 +1,12 @@
 const fs = require('fs');
 const { DOCS_PR_PATTERNS } = require('./constants');
+const {
+  COMPONENT_REGEX,
+  detectComponents,
+  hasCoreChanges,
+  hasDashboardChanges,
+  hasGitHubActionsChanges,
+} = require('../detect-tags');
 
 // Strategy: Merge branch detection
 async function detectMergeBranch(context) {
@@ -20,15 +27,13 @@ async function detectMergeBranch(context) {
 // Strategy: Component and platform labeling
 async function detectComponentPlatforms(changedFiles, apiData) {
   const labels = new Set();
-  const componentRegex = /^esphome\/components\/([^\/]+)\//;
   const targetPlatformRegex = new RegExp(`^esphome\/components\/(${apiData.targetPlatforms.join('|')})/`);
 
-  for (const file of changedFiles) {
-    const componentMatch = file.match(componentRegex);
-    if (componentMatch) {
-      labels.add(`component: ${componentMatch[1]}`);
-    }
+  for (const comp of detectComponents(changedFiles)) {
+    labels.add(`component: ${comp}`);
+  }
 
+  for (const file of changedFiles) {
     const platformMatch = file.match(targetPlatformRegex);
     if (platformMatch) {
       labels.add(`platform: ${platformMatch[1]}`);
@@ -90,15 +95,9 @@ async function detectNewPlatforms(prFiles, apiData) {
 // Strategy: Core files detection
 async function detectCoreChanges(changedFiles) {
   const labels = new Set();
-  const coreFiles = changedFiles.filter(file =>
-    file.startsWith('esphome/core/') ||
-    (file.startsWith('esphome/') && file.split('/').length === 2)
-  );
-
-  if (coreFiles.length > 0) {
+  if (hasCoreChanges(changedFiles)) {
     labels.add('core');
   }
-
   return labels;
 }
 
@@ -131,29 +130,18 @@ async function detectPRSize(prFiles, totalAdditions, totalDeletions, totalChange
 // Strategy: Dashboard changes
 async function detectDashboardChanges(changedFiles) {
   const labels = new Set();
-  const dashboardFiles = changedFiles.filter(file =>
-    file.startsWith('esphome/dashboard/') ||
-    file.startsWith('esphome/components/dashboard_import/')
-  );
-
-  if (dashboardFiles.length > 0) {
+  if (hasDashboardChanges(changedFiles)) {
     labels.add('dashboard');
   }
-
   return labels;
 }
 
 // Strategy: GitHub Actions changes
 async function detectGitHubActionsChanges(changedFiles) {
   const labels = new Set();
-  const githubActionsFiles = changedFiles.filter(file =>
-    file.startsWith('.github/workflows/')
-  );
-
-  if (githubActionsFiles.length > 0) {
+  if (hasGitHubActionsChanges(changedFiles)) {
     labels.add('github-actions');
   }
-
   return labels;
 }
 
@@ -259,7 +247,7 @@ async function detectDeprecatedComponents(github, context, changedFiles) {
   const { owner, repo } = context.repo;
 
   // Compile regex once for better performance
-  const componentFileRegex = /^esphome\/components\/([^\/]+)\//;
+  const componentFileRegex = COMPONENT_REGEX;
 
   // Get files that are modified or added in components directory
   const componentFiles = changedFiles.filter(file => componentFileRegex.test(file));

--- a/.github/scripts/detect-tags.js
+++ b/.github/scripts/detect-tags.js
@@ -1,0 +1,66 @@
+/**
+ * Shared tag detection from changed file paths.
+ * Used by pr-title-check and auto-label-pr workflows.
+ */
+
+const COMPONENT_REGEX = /^esphome\/components\/([^\/]+)\//;
+
+/**
+ * Detect component names from changed files.
+ * @param {string[]} changedFiles - List of changed file paths
+ * @returns {Set<string>} Set of component names
+ */
+function detectComponents(changedFiles) {
+  const components = new Set();
+  for (const file of changedFiles) {
+    const match = file.match(COMPONENT_REGEX);
+    if (match) {
+      components.add(match[1]);
+    }
+  }
+  return components;
+}
+
+/**
+ * Detect if core files were changed.
+ * Core files are in esphome/core/ or top-level esphome/ directory.
+ * @param {string[]} changedFiles - List of changed file paths
+ * @returns {boolean}
+ */
+function hasCoreChanges(changedFiles) {
+  return changedFiles.some(file =>
+    file.startsWith('esphome/core/') ||
+    (file.startsWith('esphome/') && file.split('/').length === 2)
+  );
+}
+
+/**
+ * Detect if dashboard files were changed.
+ * @param {string[]} changedFiles - List of changed file paths
+ * @returns {boolean}
+ */
+function hasDashboardChanges(changedFiles) {
+  return changedFiles.some(file =>
+    file.startsWith('esphome/dashboard/') ||
+    file.startsWith('esphome/components/dashboard_import/')
+  );
+}
+
+/**
+ * Detect if GitHub Actions files were changed.
+ * @param {string[]} changedFiles - List of changed file paths
+ * @returns {boolean}
+ */
+function hasGitHubActionsChanges(changedFiles) {
+  return changedFiles.some(file =>
+    file.startsWith('.github/workflows/')
+  );
+}
+
+module.exports = {
+  COMPONENT_REGEX,
+  detectComponents,
+  hasCoreChanges,
+  hasDashboardChanges,
+  hasGitHubActionsChanges,
+};

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,76 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const {
+              detectComponents,
+              hasCoreChanges,
+              hasDashboardChanges,
+              hasGitHubActionsChanges,
+            } = require('./.github/scripts/detect-tags.js');
+
+            const title = context.payload.pull_request.title;
+
+            // Block titles starting with "word:" or "word(scope):" patterns
+            const commitStylePattern = /^\w+(\(.*?\))?[!]?\s*:/;
+            if (commitStylePattern.test(title)) {
+              core.setFailed(
+                `PR title should not start with a "prefix:" style format.\n` +
+                `Please use the format: [component] Brief description\n` +
+                `Example: [pn532] Add health checking and auto-reset`
+              );
+              return;
+            }
+
+            // Get changed files to detect tags
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const filenames = files.map(f => f.filename);
+
+            // Detect tags from changed files using shared logic
+            const tags = new Set();
+
+            for (const comp of detectComponents(filenames)) {
+              tags.add(comp);
+            }
+            if (hasCoreChanges(filenames)) tags.add('core');
+            if (hasDashboardChanges(filenames)) tags.add('dashboard');
+            if (hasGitHubActionsChanges(filenames)) tags.add('ci');
+
+            if (tags.size === 0) {
+              return;
+            }
+
+            // Check title starts with [tag] prefix
+            const bracketPattern = /^\[\w+\]/;
+            if (!bracketPattern.test(title)) {
+              const suggestion = [...tags].map(c => `[${c}]`).join('');
+              // Skip if the suggested prefix would be too long for a readable title
+              if (suggestion.length > 40) {
+                return;
+              }
+              core.setFailed(
+                `PR modifies: ${[...tags].join(', ')}\n` +
+                `Title must start with a [tag] prefix.\n` +
+                `Suggested: ${suggestion} <description>`
+              );
+            }


### PR DESCRIPTION
# What does this implement/fix?

Add a GitHub Actions workflow that validates PR titles match project conventions.

**Rules:**
1. **Always blocks** titles starting with `prefix:` patterns (e.g., `feat:`, `fix(scope):`, `components:`, `pn532:`)
2. **Requires `[tag]` prefix** when the PR modifies components, core, CI, or dashboard files — as long as the suggested prefix fits within 40 characters
3. **Skips prefix check** for PRs with no detectable tags or where the combined prefix would be too long
4. **Suggests the correct format** in error messages, including detected tag names

**Tag detection:**
| Files modified | Detected tag |
|---|---|
| `esphome/components/<name>/` | `[<name>]` |
| `esphome/core/` or `esphome/*.py` | `[core]` |
| `.github/` | `[ci]` |
| `esphome/dashboard/` | `[dashboard]` |

**Examples of blocked titles:**
- `feat: add health check` → blocked (prefix style)
- `components: pn532: resilience` → blocked (prefix style)
- `Add health check to pn532` → blocked (missing `[pn532]` when pn532 files changed)

**Examples of passing titles:**
- `[pn532] Add health checking and auto-reset` ✓
- `[pn532][spi] Fix SPI communication` ✓
- `[ci] Add PR title check` ✓
- `[core] Refactor component registration` ✓
- `Bump ruff from 0.15.2 to 0.15.3` ✓ (no tags detected)
- `2026.2.2` ✓ (no tags detected)

Note: To block merges, this check needs to be added as a required status check in branch protection settings.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).