### PR TITLE
[wifi] Remove stale TODO comment for ESP8266 callback deferral

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -470,10 +470,6 @@ const LogString *get_disconnect_reason_str(uint8_t reason) {
   return LOG_STR("Unspecified");
 }
 
-// TODO: This callback runs in ESP8266 system context with limited stack (~2KB).
-// All listener notifications should be deferred to wifi_loop_() via pending_ flags
-// to avoid stack overflow. Currently only connect_state is deferred; disconnect,
-// IP, and scan listeners still run in this context and should be migrated.
 void WiFiComponent::wifi_event_callback(System_Event_t *event) {
   switch (event->event) {
     case EVENT_STAMODE_CONNECTED: {


### PR DESCRIPTION
# What does this implement/fix?

Remove a stale TODO comment in `wifi_component_esp8266.cpp`. The comment stated that disconnect, IP, and scan listener notifications should be deferred to `wifi_loop_()` via `pending_` flags. All four listener types (connect_state, disconnect, got_ip, scan_complete) have since been migrated to use `pending_` flags, making the TODO obsolete.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - comment-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).