### PR TITLE
[wifi] Use direct SDK APIs for LibreTiny SSID retrieval

### DIFF
--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -13,6 +13,19 @@
 #include <FreeRTOS.h>
 #include <queue.h>
 
+#ifdef USE_BK72XX
+extern "C" {
+#include <wlan_ui_pub.h>
+}
+#endif
+
+#ifdef USE_RTL87XX
+extern "C" {
+#include <wifi_conf.h>
+#include <wifi_structures.h>
+}
+#endif
+
 #include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -760,10 +773,22 @@ bssid_t WiFiComponent::wifi_bssid() {
 }
 std::string WiFiComponent::wifi_ssid() { return WiFi.SSID().c_str(); }
 const char *WiFiComponent::wifi_ssid_to(std::span<char, SSID_BUFFER_SIZE> buffer) {
-  // TODO: Find direct LibreTiny API to avoid Arduino String allocation
+#ifdef USE_BK72XX
+  LinkStatusTypeDef link_status{};
+  bk_wlan_get_link_status(&link_status);
+  size_t len = strnlen(reinterpret_cast<const char *>(link_status.ssid), SSID_BUFFER_SIZE - 1);
+  memcpy(buffer.data(), link_status.ssid, len);
+#elif defined(USE_RTL87XX)
+  rtw_wifi_setting_t setting{};
+  wifi_get_setting("wlan0", &setting);
+  size_t len = strnlen(reinterpret_cast<const char *>(setting.ssid), SSID_BUFFER_SIZE - 1);
+  memcpy(buffer.data(), setting.ssid, len);
+#else
+  // LN882X: wifi_get_sta_conn_info() provides direct pointer access
   String ssid = WiFi.SSID();
   size_t len = std::min(static_cast<size_t>(ssid.length()), SSID_BUFFER_SIZE - 1);
   memcpy(buffer.data(), ssid.c_str(), len);
+#endif
   buffer[len] = '\0';
   return buffer.data();
 }


### PR DESCRIPTION
# What does this implement/fix?

Avoid Arduino `String` heap allocation in `wifi_ssid_to()` on BK72XX and RTL87XX by calling vendor SDK functions directly:

- **BK72XX**: `bk_wlan_get_link_status()` fills a stack-allocated `LinkStatusTypeDef` struct
- **RTL87XX**: `wifi_get_setting()` fills a stack-allocated `rtw_wifi_setting_t` struct

These are the same underlying calls that the Arduino `WiFi.SSID()` method uses internally, but without the intermediate `String` allocation.

LN882X is left unchanged as we lack hardware to test. The direct API there would be `wifi_get_sta_conn_info()` (noted in a comment for future work).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).