### PR TITLE
[wifi] Add LibreTiny component test configs

### DIFF
--- a/tests/components/wifi/test.bk72xx-ard.yaml
+++ b/tests/components/wifi/test.bk72xx-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/wifi/test.ln882x-ard.yaml
+++ b/tests/components/wifi/test.ln882x-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml

--- a/tests/components/wifi/test.rtl87xx-ard.yaml
+++ b/tests/components/wifi/test.rtl87xx-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Add component test configurations for the WiFi component on all three LibreTiny platforms (BK72XX, RTL87XX, LN882X). These were missing, which meant CI could not run compilation tests or memory impact analysis for LibreTiny-specific WiFi changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - test infrastructure only
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).