### PR TITLE
[component] Devirtualize call_dump_config

### DIFF
--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -405,12 +405,6 @@ void MQTTComponent::process_resend() {
     this->schedule_resend_state();
   }
 }
-void MQTTComponent::call_dump_config() {
-  if (this->is_internal())
-    return;
-
-  this->dump_config();
-}
 void MQTTComponent::schedule_resend_state() { this->resend_state_ = true; }
 bool MQTTComponent::is_connected_() const { return global_mqtt_client->is_connected(); }
 

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -98,8 +98,6 @@ class MQTTComponent : public Component {
   /// Override setup_ so that we can call send_discovery() when needed.
   void call_setup() override;
 
-  void call_dump_config() override;
-
   /// Send discovery info the Home Assistant, override this.
   virtual void send_discovery(JsonObject root, SendDiscoveryConfig &config) = 0;
 

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -256,7 +256,7 @@ void Application::process_dump_config_() {
 #endif
   }
 
-  this->components_[this->dump_config_at_]->call_dump_config();
+  this->components_[this->dump_config_at_]->call_dump_config_();
   this->dump_config_at_++;
 }
 

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -211,7 +211,7 @@ bool Component::cancel_retry(uint32_t id) {
 
 void Component::call_loop_() { this->loop(); }
 void Component::call_setup() { this->setup(); }
-void Component::call_dump_config() {
+void Component::call_dump_config_() {
   this->dump_config();
   if (this->is_failed()) {
     // Look up error message from global vector

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -291,7 +291,7 @@ class Component {
 
   void call_loop_();
   virtual void call_setup();
-  virtual void call_dump_config();
+  void call_dump_config_();
 
   /// Helper to set component state (clears state bits and sets new state)
   void set_component_state_(uint8_t state);


### PR DESCRIPTION
# What does this implement/fix?

Devirtualize `Component::call_dump_config()`. Only `MQTTComponent` overrode it, and the override incorrectly skipped `dump_config()` for internal entities — hiding useful debug info from startup logs. The `is_internal` flag means "don't expose to Home Assistant", not "don't log config".

This removes one vtable entry from every `Component` subclass and eliminates the indirect call overhead.

## Breaking change impact

A [GitHub code search for `call_dump_config`](https://github.com/search?q=call_dump_config+language%3Acpp+NOT+repo%3Aesphome%2Fesphome+NOT+repo%3Akonnected-io%2Fkonnected-esphome&type=code) shows no external components override this method. All results are forks of esphome or copies of the MQTT component — nobody uses this virtual outside of the esphome codebase itself.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).