### PR TITLE
[gt911] Support for interrupt line via IO Expander (resubmit)

### DIFF
--- a/esphome/components/gt911/touchscreen/__init__.py
+++ b/esphome/components/gt911/touchscreen/__init__.py
@@ -16,7 +16,7 @@ GT911Touchscreen = gt911_ns.class_(
 CONFIG_SCHEMA = touchscreen.TOUCHSCREEN_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(GT911Touchscreen),
-        cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_INTERRUPT_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
     }
 ).extend(i2c.i2c_device_schema(0x5D))

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -2,6 +2,7 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/gpio.h"
 
 namespace esphome {
 namespace gt911 {
@@ -29,12 +30,13 @@ void GT911Touchscreen::setup() {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {
-      // temporarily set the interrupt pin to output to control address selection
+      this->interrupt_pin_->setup();
       this->interrupt_pin_->pin_mode(gpio::FLAG_OUTPUT);
       this->interrupt_pin_->digital_write(false);
     }
     delay(2);
-    this->reset_pin_->digital_write(true);  // wait at least T3+T4 ms as per the datasheet
+    this->reset_pin_->digital_write(true);
+    // wait at least T3+T4 ms as per the datasheet
     this->set_timeout(5 + 50 + 1, [this] { this->setup_internal_(); });
     return;
   }
@@ -43,11 +45,10 @@ void GT911Touchscreen::setup() {
 
 void GT911Touchscreen::setup_internal_() {
   if (this->interrupt_pin_ != nullptr) {
-    // set pre-configured input mode
-    this->interrupt_pin_->setup();
+    if (this->interrupt_pin_->is_internal())
+      this->interrupt_pin_->pin_mode(gpio::FLAG_INPUT);
   }
 
-  // check the configuration of the int line.
   uint8_t data[4];
   i2c::ErrorCode err = this->write(GET_SWITCHES, sizeof(GET_SWITCHES));
   if (err != i2c::ERROR_OK && this->address_ == PRIMARY_ADDRESS) {
@@ -58,14 +59,26 @@ void GT911Touchscreen::setup_internal_() {
     err = this->read(data, 1);
     if (err == i2c::ERROR_OK) {
       ESP_LOGD(TAG, "Switches ADDR: 0x%02X DATA: 0x%02X", this->address_, data[0]);
+
+      // data[0] & 1 == 1  =>  controller uses falling edge  =>  active-low
+      // data[0] & 1 == 0  =>  controller uses rising  edge  =>  active-high
+      bool active_high = !(data[0] & 1);
+
       if (this->interrupt_pin_ != nullptr) {
-        this->attach_interrupt_(this->interrupt_pin_,
-                                (data[0] & 1) ? gpio::INTERRUPT_FALLING_EDGE : gpio::INTERRUPT_RISING_EDGE);
+        if (this->interrupt_pin_->is_internal()) {
+          // Direct MCU pin: attach a hardware interrupt, no polling needed.
+          this->attach_interrupt_(static_cast<InternalGPIOPin *>(this->interrupt_pin_),
+                                  active_high ? gpio::INTERRUPT_RISING_EDGE : gpio::INTERRUPT_FALLING_EDGE);
+          ESP_LOGD(TAG, "Interrupt pin: hardware interrupt, active %s", active_high ? "HIGH" : "LOW");
+        } else {
+          // IO expander pin: leave as output for configuration only.
+          ESP_LOGD(TAG, "Interrupt pin: IO expander polling mode, active %s", active_high ? "HIGH" : "LOW");
+        }
       }
     }
   }
+
   if (this->x_raw_max_ == 0 || this->y_raw_max_ == 0) {
-    // no calibration? Attempt to read the max values from the touchscreen.
     if (err == i2c::ERROR_OK) {
       err = this->write(GET_MAX_VALUES, sizeof(GET_MAX_VALUES));
       if (err == i2c::ERROR_OK) {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.cpp
@@ -27,6 +27,7 @@ static const size_t MAX_BUTTONS = 4;  // max number of buttons scanned
 
 void GT911Touchscreen::setup() {
   if (this->reset_pin_ != nullptr) {
+    // temporarily set the interrupt pin to output to control address selection
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(false);
     if (this->interrupt_pin_ != nullptr) {
@@ -79,6 +80,7 @@ void GT911Touchscreen::setup_internal_() {
   }
 
   if (this->x_raw_max_ == 0 || this->y_raw_max_ == 0) {
+    // no calibration? Attempt to read the max values from the touchscreen.
     if (err == i2c::ERROR_OK) {
       err = this->write(GET_MAX_VALUES, sizeof(GET_MAX_VALUES));
       if (err == i2c::ERROR_OK) {

--- a/esphome/components/gt911/touchscreen/gt911_touchscreen.h
+++ b/esphome/components/gt911/touchscreen/gt911_touchscreen.h
@@ -30,7 +30,9 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
   void dump_config() override;
   bool can_proceed() override { return this->setup_done_; }
 
-  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+  /// Set a interrupt pin (supports hardware interrupts or expander connected).
+  void set_interrupt_pin(GPIOPin *pin) { this->interrupt_pin_ = pin; }
+
   void set_reset_pin(GPIOPin *pin) { this->reset_pin_ = pin; }
   void register_button_listener(GT911ButtonListener *listener) { this->button_listeners_.push_back(listener); }
 
@@ -49,7 +51,7 @@ class GT911Touchscreen : public touchscreen::Touchscreen, public i2c::I2CDevice 
   /// @brief True if the touchscreen setup has completed successfully.
   bool setup_done_{false};
 
-  InternalGPIOPin *interrupt_pin_{nullptr};
+  GPIOPin *interrupt_pin_{nullptr};
   GPIOPin *reset_pin_{nullptr};
   std::vector<GT911ButtonListener *> button_listeners_;
   uint8_t button_state_{0xFF};  // last button state. Initial FF guarantees first update.


### PR DESCRIPTION
# What does this implement/fix?

There exist cases where the gt911 interrupt line is connected to an IO Expander rather than directly to a mcu GPIO.

Noticed with the Waveshare esp32-S3-Touch-LCD-4 (revision 4.0) board, the interrupt line for the gt911 runs to the waveshare_io_ch32v003 IO expander (Support for this in PR https://github.com/esphome/esphome/pull/10071). This PR adds support for using this interrupt line to allow for initialization/configuration of the touch controller during startup then falling back to touch polling.

This is a re-submit of PR https://github.com/esphome/esphome/pull/14193 because I messed up my fork.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6136
## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example configuration entry for board with interrupt line run through IO Expander
touchscreen:
  platform: gt911
  id: my_touchscreen
  expander_interrupt_pin:
    waveshare_io_ch32v003: wave_io_hub
    number: 2
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
