### PR TITLE
[esp32] Wrap printf/vprintf/fprintf to eliminate _vfprintf_r (~11 KB flash)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -952,6 +952,7 @@ CONF_HEAP_IN_IRAM = "heap_in_iram"
 CONF_LOOP_TASK_STACK_SIZE = "loop_task_stack_size"
 CONF_USE_FULL_CERTIFICATE_BUNDLE = "use_full_certificate_bundle"
 CONF_DISABLE_DEBUG_STUBS = "disable_debug_stubs"
+CONF_ENABLE_FULL_PRINTF = "enable_full_printf"
 CONF_DISABLE_OCD_AWARE = "disable_ocd_aware"
 CONF_DISABLE_USB_SERIAL_JTAG_SECONDARY = "disable_usb_serial_jtag_secondary"
 CONF_DISABLE_DEV_NULL_VFS = "disable_dev_null_vfs"
@@ -1126,6 +1127,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(
                     CONF_INCLUDE_BUILTIN_IDF_COMPONENTS, default=[]
                 ): cv.ensure_list(cv.string_strict),
+                cv.Optional(CONF_ENABLE_FULL_PRINTF, default=False): cv.boolean,
                 cv.Optional(CONF_DISABLE_DEBUG_STUBS, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_OCD_AWARE, default=True): cv.boolean,
                 cv.Optional(
@@ -1469,6 +1471,14 @@ async def to_code(config):
             "_ZSt25__throw_bad_function_callv",
         ]:
             cg.add_build_flag(f"-Wl,--wrap={mangled}")
+
+        # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
+        # (~11 KB). See printf_stubs.cpp for implementation.
+        if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF]:
+            cg.add_define("USE_FULL_PRINTF")
+        else:
+            for symbol in ["vprintf", "printf", "fprintf"]:
+                cg.add_build_flag(f"-Wl,--wrap={symbol}")
     else:
         cg.add_build_flag("-DUSE_ARDUINO")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ARDUINO")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1477,7 +1477,7 @@ async def to_code(config):
         if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF]:
             cg.add_define("USE_FULL_PRINTF")
         else:
-            for symbol in ["vprintf", "printf", "fprintf"]:
+            for symbol in ("vprintf", "printf", "fprintf"):
                 cg.add_build_flag(f"-Wl,--wrap={symbol}")
     else:
         cg.add_build_flag("-DUSE_ARDUINO")

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -33,15 +33,16 @@ namespace esphome::esp32 {}
 
 static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
-// Write formatted buffer to stream, aborting on overflow.
+// These stubs are essentially dead code at runtime — ESPHome replaces the
+// ESP-IDF log handler, and the SDK's printf/fprintf calls only exist in
+// debug/assert paths that are never reached in normal operation.
+// The buffer overflow check is purely defensive and should never trigger.
 static int write_printf_buffer_(FILE *stream, char *buf, int len) {
   if (len < 0) {
     return len;
   }
   size_t write_len = len;
   if (write_len >= PRINTF_BUFFER_SIZE) {
-    // Output was truncated — flush what we have before aborting
-    // so the user sees context leading up to the overflow.
     fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
     esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
   }

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -46,7 +46,7 @@ static int write_printf_buffer_(FILE *stream, char *buf, int len) {
   size_t write_len = len;
   if (write_len >= PRINTF_BUFFER_SIZE) {
     fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
-    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
+    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 framework advanced config");
   }
   if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {
     return -1;

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -11,7 +11,9 @@
  * so the SDK's vprintf() path is dead code at runtime. The fprintf()
  * and printf() calls in SDK components are only in debug/assert paths
  * (gpio_dump_io_configuration, ringbuf diagnostics) that are either
- * GC'd or never called.
+ * GC'd or never called. Crash backtraces and panic output are
+ * unaffected — they use esp_rom_printf() which is a ROM function
+ * and does not go through libc.
  *
  * These stubs redirect through vsnprintf() (which uses _svfprintf_r
  * already in the binary) and fwrite(), allowing the linker to

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -29,6 +29,8 @@
 
 #include "esp_system.h"
 
+namespace esphome::esp32 {}
+
 static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
 // NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -39,7 +39,7 @@ static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 // ESP-IDF log handler, and the SDK's printf/fprintf calls only exist in
 // debug/assert paths that are never reached in normal operation.
 // The buffer overflow check is purely defensive and should never trigger.
-static int write_printf_buffer_(FILE *stream, char *buf, int len) {
+static int write_printf_buffer(FILE *stream, char *buf, int len) {
   if (len < 0) {
     return len;
   }
@@ -59,7 +59,7 @@ extern "C" {
 
 int __wrap_vprintf(const char *fmt, va_list ap) {
   char buf[PRINTF_BUFFER_SIZE];
-  return write_printf_buffer_(stdout, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+  return write_printf_buffer(stdout, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
 
 int __wrap_printf(const char *fmt, ...) {
@@ -74,7 +74,7 @@ int __wrap_fprintf(FILE *stream, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   char buf[PRINTF_BUFFER_SIZE];
-  int len = write_printf_buffer_(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+  int len = write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
   va_end(ap);
   return len;
 }

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -33,22 +33,26 @@ namespace esphome::esp32 {}
 
 static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
+// Write formatted buffer to stream, aborting on overflow.
+static int write_printf_buffer_(FILE *stream, char *buf, int len) {
+  if (len < 0) {
+    return len;
+  }
+  if (static_cast<size_t>(len) >= PRINTF_BUFFER_SIZE) {
+    // Output was truncated — this should not happen in normal operation.
+    // Abort to make the issue visible rather than silently losing output.
+    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
+  }
+  fwrite(buf, 1, len, stream);
+  return len;
+}
+
 // NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 extern "C" {
 
 int __wrap_vprintf(const char *fmt, va_list ap) {
   char buf[PRINTF_BUFFER_SIZE];
-  int len = vsnprintf(buf, sizeof(buf), fmt, ap);
-  if (len < 0) {
-    return len;
-  }
-  if (static_cast<size_t>(len) >= sizeof(buf)) {
-    // Output was truncated — this should not happen in normal operation.
-    // Abort to make the issue visible rather than silently losing output.
-    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
-  }
-  fwrite(buf, 1, len, stdout);
-  return len;
+  return write_printf_buffer_(stdout, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
 
 int __wrap_printf(const char *fmt, ...) {
@@ -63,15 +67,8 @@ int __wrap_fprintf(FILE *stream, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
   char buf[PRINTF_BUFFER_SIZE];
-  int len = vsnprintf(buf, sizeof(buf), fmt, ap);
+  int len = write_printf_buffer_(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
   va_end(ap);
-  if (len < 0) {
-    return len;
-  }
-  if (static_cast<size_t>(len) >= sizeof(buf)) {
-    esp_system_abort("fprintf buffer overflow; set enable_full_printf: true in esp32 advanced config");
-  }
-  fwrite(buf, 1, len, stream);
   return len;
 }
 

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -38,12 +38,16 @@ static int write_printf_buffer_(FILE *stream, char *buf, int len) {
   if (len < 0) {
     return len;
   }
-  if (static_cast<size_t>(len) >= PRINTF_BUFFER_SIZE) {
-    // Output was truncated — this should not happen in normal operation.
-    // Abort to make the issue visible rather than silently losing output.
+  size_t write_len = len;
+  if (write_len >= PRINTF_BUFFER_SIZE) {
+    // Output was truncated — flush what we have before aborting
+    // so the user sees context leading up to the overflow.
+    fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
     esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
   }
-  fwrite(buf, 1, len, stream);
+  if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {
+    return -1;
+  }
   return len;
 }
 

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -1,0 +1,79 @@
+/*
+ * Linker wrap stubs for FILE*-based printf functions.
+ *
+ * ESP-IDF SDK components (gpio driver, ringbuf, log_write) reference
+ * fprintf(), printf(), and vprintf() which pull in newlib's _vfprintf_r
+ * (~11 KB). This is a separate implementation from _svfprintf_r (used by
+ * snprintf/vsnprintf) that handles FILE* stream I/O with buffering and
+ * locking.
+ *
+ * ESPHome replaces the ESP-IDF log handler via esp_log_set_vprintf_(),
+ * so the SDK's vprintf() path is dead code at runtime. The fprintf()
+ * and printf() calls in SDK components are only in debug/assert paths
+ * (gpio_dump_io_configuration, ringbuf diagnostics) that are either
+ * GC'd or never called.
+ *
+ * These stubs redirect through vsnprintf() (which uses _svfprintf_r
+ * already in the binary) and fwrite(), allowing the linker to
+ * dead-code eliminate _vfprintf_r.
+ *
+ * Saves ~11 KB of flash.
+ *
+ * To disable these wraps, set enable_full_printf: true in the esp32
+ * advanced config section.
+ */
+
+#if defined(USE_ESP_IDF) && !defined(USE_FULL_PRINTF)
+#include <cstdarg>
+#include <cstdio>
+
+#include "esp_system.h"
+
+static constexpr size_t PRINTF_BUFFER_SIZE = 512;
+
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+extern "C" {
+
+int __wrap_vprintf(const char *fmt, va_list ap) {
+  char buf[PRINTF_BUFFER_SIZE];
+  int len = vsnprintf(buf, sizeof(buf), fmt, ap);
+  if (len < 0) {
+    return len;
+  }
+  if (static_cast<size_t>(len) >= sizeof(buf)) {
+    // Output was truncated — this should not happen in normal operation.
+    // Abort to make the issue visible rather than silently losing output.
+    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 advanced config");
+  }
+  fwrite(buf, 1, len, stdout);
+  return len;
+}
+
+int __wrap_printf(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int len = __wrap_vprintf(fmt, ap);
+  va_end(ap);
+  return len;
+}
+
+int __wrap_fprintf(FILE *stream, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  char buf[PRINTF_BUFFER_SIZE];
+  int len = vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_end(ap);
+  if (len < 0) {
+    return len;
+  }
+  if (static_cast<size_t>(len) >= sizeof(buf)) {
+    esp_system_abort("fprintf buffer overflow; set enable_full_printf: true in esp32 advanced config");
+  }
+  fwrite(buf, 1, len, stream);
+  return len;
+}
+
+}  // extern "C"
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+
+#endif  // USE_ESP_IDF && !USE_FULL_PRINTF

--- a/tests/components/esp32/test.esp32-idf.yaml
+++ b/tests/components/esp32/test.esp32-idf.yaml
@@ -10,6 +10,7 @@ esp32:
       use_full_certificate_bundle: false  # Test CMN bundle (default)
       include_builtin_idf_components:
         - freertos  # Test escape hatch (freertos is always included anyway)
+      enable_full_printf: false
       disable_debug_stubs: true
       disable_ocd_aware: true
       disable_usb_serial_jtag_secondary: true


### PR DESCRIPTION
# What does this implement/fix?

Wraps `printf()`, `vprintf()`, and `fprintf()` with linker `--wrap` stubs that redirect through `vsnprintf()` + `fwrite()`, eliminating newlib's `_vfprintf_r` (~11 KB of flash).

ESP-IDF SDK components (gpio driver, ringbuf, log_write) reference these FILE*-based printf functions, which pull in `_vfprintf_r`. This is a completely separate implementation from `_svfprintf_r` (already used by `snprintf`/`vsnprintf`) that handles FILE* stream I/O with buffering and locking.

Since ESPHome replaces the ESP-IDF log handler via `esp_log_set_vprintf_()`, the SDK's `vprintf()` path is dead code at runtime. The `fprintf()` and `printf()` calls in SDK components are only in debug/assert paths that are either GC'd or never called. Crash backtraces and panic output are unaffected — they use `esp_rom_printf()` which is a ROM function and does not go through libc.

The stubs use `vsnprintf()` + `fwrite()` so `fprintf()` to any `FILE*` stream (including `fopen`'d files) still works correctly. If the 512-byte buffer overflows, the stub flushes what it has and aborts with a message directing the user to the escape hatch.

An `enable_full_printf: true` escape hatch is provided in the esp32 framework advanced config section. It will likely never be needed, but follows the project pattern of always providing an opt-out for linker wraps.

## Testing

Tested on real ESP32-S3 hardware (ESP-IDF framework) with a config that exercises all wrapped functions from a lambda:

```yaml
esphome:
  name: test-printf-wrap
  on_boot:
    then:
      - lambda: |-
          printf("printf test: hello from printf %d\n", 42);
          fprintf(stdout, "fprintf test: hello from fprintf to stdout %s\n", "works");
          fprintf(stderr, "fprintf test: hello from fprintf to stderr %s\n", "works");
          ESP_LOGI("test", "ESP_LOGI still works fine");

esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: esp-idf

logger:
api:
wifi:
  ssid: MySSID
  password: password1
```

Device boots normally, all printf/fprintf output appears correctly in the log, and `ESP_LOGI` continues to work as expected. Verified with `nm` that `_vfprintf_r` is no longer present in the final binary.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6171

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config needed - wraps are enabled by default for ESP-IDF builds.
# To disable (if an external component needs full FILE*-based fprintf):
esp32:
  framework:
    type: esp-idf
    advanced:
      enable_full_printf: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).