### PR TITLE
[uart] Revert UART0 default pin workarounds (fixed in ESP-IDF 5.5.2)

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -9,7 +9,6 @@
 #include "esphome/core/gpio.h"
 #include "driver/gpio.h"
 #include "soc/gpio_num.h"
-#include "soc/uart_pins.h"
 
 #ifdef USE_LOGGER
 #include "esphome/components/logger/logger.h"
@@ -142,22 +141,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
-  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
-  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
-
-  // Workaround for ESP-IDF issue: https://github.com/espressif/esp-idf/issues/17459
-  // Commit 9ed617fb17 removed gpio_func_sel() calls from uart_set_pin(), which breaks
-  // UART on default UART0 pins that may have residual state from boot console.
-  // Reset these pins before configuring UART to ensure they're in a clean state.
-  if (tx == U0TXD_GPIO_NUM || tx == U0RXD_GPIO_NUM) {
-    gpio_reset_pin(static_cast<gpio_num_t>(tx));
-  }
-  if (rx == U0TXD_GPIO_NUM || rx == U0RXD_GPIO_NUM) {
-    gpio_reset_pin(static_cast<gpio_num_t>(rx));
-  }
-
-  // Setup pins after reset to preserve open drain/pullup/pulldown flags
   auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
@@ -172,6 +155,10 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
+
+  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
+  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
+  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -19,13 +19,6 @@ namespace esphome::uart {
 
 static const char *const TAG = "uart.idf";
 
-/// Check if a pin number matches one of the default UART0 GPIO pins.
-/// These pins may have residual state from the boot console that requires
-/// explicit reset before UART reconfiguration (ESP-IDF issue #17459).
-static constexpr bool is_default_uart0_pin(int8_t pin_num) {
-  return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM;
-}
-
 uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;
   if (this->parity_ == UART_CONFIG_PARITY_EVEN) {
@@ -157,26 +150,20 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   // Commit 9ed617fb17 removed gpio_func_sel() calls from uart_set_pin(), which breaks
   // UART on default UART0 pins that may have residual state from boot console.
   // Reset these pins before configuring UART to ensure they're in a clean state.
-  if (is_default_uart0_pin(tx)) {
+  if (tx == U0TXD_GPIO_NUM || tx == U0RXD_GPIO_NUM) {
     gpio_reset_pin(static_cast<gpio_num_t>(tx));
   }
-  if (is_default_uart0_pin(rx)) {
+  if (rx == U0TXD_GPIO_NUM || rx == U0RXD_GPIO_NUM) {
     gpio_reset_pin(static_cast<gpio_num_t>(rx));
   }
 
-  // Setup pins after reset to configure GPIO direction and pull resistors.
-  // For UART0 default pins, setup() must always be called because gpio_reset_pin()
-  // above sets GPIO_MODE_DISABLE which disables the input buffer. Without setup(),
-  // uart_set_pin() on ESP-IDF 5.4.2+ does not re-enable the input buffer for
-  // IOMUX-connected pins, so the RX pin cannot receive data (see issue #10132).
-  // For other pins, only call setup() if pull or open-drain flags are set to avoid
-  // disturbing the default pin state which breaks some external components (#11823).
+  // Setup pins after reset to preserve open drain/pullup/pulldown flags
   auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
     }
     const auto mask = gpio::Flags::FLAG_OPEN_DRAIN | gpio::Flags::FLAG_PULLUP | gpio::Flags::FLAG_PULLDOWN;
-    if (is_default_uart0_pin(pin->get_pin()) || (pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
+    if ((pin->get_flags() & mask) != gpio::Flags::FLAG_NONE) {
       pin->setup();
     }
   };


### PR DESCRIPTION
# What does this implement/fix?

Reverts PR #14130 and PR #12519 which added `gpio_reset_pin()` and `pin->setup()` workarounds for default UART0 pins on ESP-IDF.

## Background

Issue #10132 reported that LD2410 sensors stopped working on default UART0 pins. PR #12519 attributed the root cause to [espressif/esp-idf#17459](https://github.com/espressif/esp-idf/issues/17459) (commit [espressif/esp-idf@9ed617fb17](https://github.com/espressif/esp-idf/commit/9ed617fb17) removing `gpio_func_sel()` from `uart_set_pin()`) and added `gpio_reset_pin()` calls as a workaround. However, `gpio_reset_pin()` disables the input buffer, which broke UART RX. PR #14130 then added `pin->setup()` to re-enable it — but that introduced a new regression (#14178) where `gpio_config()` removes the pullup set by `gpio_reset_pin()`, causing floating lines on RS-485/modbus devices.

## Why the workaround was misattributed

The commit [espressif/esp-idf@9ed617fb17](https://github.com/espressif/esp-idf/commit/9ed617fb17) only removed `gpio_func_sel()` from the [GPIO matrix fallback path](https://github.com/espressif/esp-idf/commit/9ed617fb179b9b0a16a2a3af6c792dc7feabc808#diff-a24b26f0de0456149be45dee354513c27e6e85e7e5f5ac67dc46b2ef98a2f4d5) — the code path for **non-default** pins. Default UART0 pins use the IOMUX path via [`uart_try_set_iomux_pin()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L686-L724), which [returns false only when the pin doesn't match the default](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L693) (`upin->default_gpio != io_num`). For default UART0 pins it returns true, so the [GPIO matrix fallback block](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L868-L880) (where `gpio_func_sel` was removed) is never entered.

The IOMUX path has handled default UART0 pins correctly since `uart_try_set_iomux_pin` was [introduced in 2021](https://github.com/espressif/esp-idf/commit/779e7400b0), including on ESP-IDF 5.4.2 where the issue was reported:

**RX path:** [`uart_set_pin()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L868) → [`uart_try_set_iomux_pin()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L704-L706) → [`gpio_iomux_in()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_gpio/src/gpio.c#L797-L800) → [`gpio_ll_iomux_in()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/hal/esp32c3/include/hal/gpio_ll.h#L258-L262) which calls `PIN_INPUT_ENABLE()` (re-enables input buffer)

**TX path:** [`uart_set_pin()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L843) → [`uart_try_set_iomux_pin()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_uart/src/uart.c#L701-L702) → [`gpio_iomux_out()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/esp_driver_gpio/src/gpio.c#L802-L806) → [`gpio_ll_iomux_out()`](https://github.com/espressif/esp-idf/blob/v5.4.2/components/hal/esp32c3/include/hal/gpio_ll.h#L275-L280) which calls `gpio_ll_func_sel()` (sets IOMUX function)

## Upstream ESP-IDF fix

The true root cause was an ESP-IDF bootloader bug: when the console was switched away from UART0 (e.g., to USB Serial JTAG or a different UART), the bootloader did not properly release the default UART0 TX pin. The TX output remained active, causing issues when user code later reconfigured those pins for a different UART purpose.

Espressif fixed this in [`bootloader_console.c`](https://github.com/espressif/esp-idf/commit/fb20e147d5bbd9247e46a668633eb65f00104f85) by adding a `release_default_console_io()` function that:
1. Disables output on the UART0 TX pin (`gpio_ll_output_disable()`)
2. Resets the pin to GPIO function (`gpio_ll_func_sel(..., PIN_FUNC_GPIO)`)
3. Disconnects the UART RX signal (`esp_rom_gpio_connect_in_signal(GPIO_MATRIX_CONST_ONE_INPUT, ...)`)

This fix closes both [espressif/esp-idf#16764](https://github.com/espressif/esp-idf/issues/16764) and [espressif/esp-idf#17459](https://github.com/espressif/esp-idf/issues/17459).

**The fix is included in ESP-IDF v5.5.2+** (not in v5.5.1). ESPHome currently uses ESP-IDF v5.5.3, so the workarounds are no longer needed.

- v5.5 branch: [`fb20e147`](https://github.com/espressif/esp-idf/commit/fb20e147d5bbd9247e46a668633eb65f00104f85) (in v5.5.2+)
- v5.4 branch: [`aef9061d`](https://github.com/espressif/esp-idf/commit/aef9061d939105451de7b8303db68732e2cacaf8) (not yet released, will be in v5.4.4)
- master: [`c4c932ad`](https://github.com/espressif/esp-idf/commit/c4c932ad2bb655a4d1c07eb7a9675530f5173b69)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14178

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP32-C3 with PZEM-003 on default UART0 pins (no explicit pullup)
uart:
  tx_pin: GPIO21
  rx_pin: GPIO20
  baud_rate: 9600

modbus:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).