### PR TITLE
[ci] Fix C++ unit tests missing time component dependency

### DIFF
--- a/script/cpp_unit_test.py
+++ b/script/cpp_unit_test.py
@@ -98,8 +98,12 @@ def run_tests(selected_components: list[str]) -> int:
 
     components = sorted(components)
 
-    # Obtain possible dependencies for the requested components:
-    components_with_dependencies = sorted(get_all_dependencies(set(components)))
+    # Obtain possible dependencies for the requested components.
+    # Always include 'time' because USE_TIME_TIMEZONE is defined as a build flag,
+    # which causes core/time.h to include components/time/posix_tz.h.
+    components_with_dependencies = sorted(
+        get_all_dependencies(set(components) | {"time"})
+    )
 
     # Build a list of include folders, one folder per component containing tests.
     # A special replacement main.cpp is located in /tests/components/main.cpp


### PR DESCRIPTION
# What does this implement/fix?

The C++ unit test build (`script/cpp_unit_test.py`) defines `-DUSE_TIME_TIMEZONE` as a build flag (line 69), which causes `core/time.h` to `#include "esphome/components/time/posix_tz.h"`. However, the `time` component is not always included in the build dependencies — it only appears if a tested component transitively depends on it.

Any component test that doesn't pull in `time` (e.g., `ld2450`, `uart`) fails to compile with:

```
esphome/core/time.h:11:10: fatal error: esphome/components/time/posix_tz.h: No such file or directory
```

The fix always includes `time` in the dependency set since the build flag requires it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).