### PR TITLE
[gps] Fix codegen deadlock when automations reference sibling sensors

### DIFF
--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -98,33 +98,25 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if latitude_config := config.get(CONF_LATITUDE):
-        sens = await sensor.new_sensor(latitude_config)
-        cg.add(var.set_latitude_sensor(sens))
+    # Pre-create all sensor variables so automations that reference
+    # sibling sensors don't deadlock waiting for unregistered IDs.
+    sensors = [
+        (cg.new_Pvariable(conf[CONF_ID]), conf, setter)
+        for key, setter in (
+            (CONF_LATITUDE, "set_latitude_sensor"),
+            (CONF_LONGITUDE, "set_longitude_sensor"),
+            (CONF_SPEED, "set_speed_sensor"),
+            (CONF_COURSE, "set_course_sensor"),
+            (CONF_ALTITUDE, "set_altitude_sensor"),
+            (CONF_SATELLITES, "set_satellites_sensor"),
+            (CONF_HDOP, "set_hdop_sensor"),
+        )
+        if (conf := config.get(key))
+    ]
 
-    if longitude_config := config.get(CONF_LONGITUDE):
-        sens = await sensor.new_sensor(longitude_config)
-        cg.add(var.set_longitude_sensor(sens))
-
-    if speed_config := config.get(CONF_SPEED):
-        sens = await sensor.new_sensor(speed_config)
-        cg.add(var.set_speed_sensor(sens))
-
-    if course_config := config.get(CONF_COURSE):
-        sens = await sensor.new_sensor(course_config)
-        cg.add(var.set_course_sensor(sens))
-
-    if altitude_config := config.get(CONF_ALTITUDE):
-        sens = await sensor.new_sensor(altitude_config)
-        cg.add(var.set_altitude_sensor(sens))
-
-    if satellites_config := config.get(CONF_SATELLITES):
-        sens = await sensor.new_sensor(satellites_config)
-        cg.add(var.set_satellites_sensor(sens))
-
-    if hdop_config := config.get(CONF_HDOP):
-        sens = await sensor.new_sensor(hdop_config)
-        cg.add(var.set_hdop_sensor(sens))
+    for sens, conf, setter in sensors:
+        await sensor.register_sensor(sens, conf)
+        cg.add(getattr(var, setter)(sens))
 
     # https://platformio.org/lib/show/1655/TinyGPSPlus
     # Using fork of TinyGPSPlus patched to build on ESP-IDF

--- a/tests/components/gps/common.yaml
+++ b/tests/components/gps/common.yaml
@@ -1,8 +1,15 @@
 gps:
   latitude:
     name: "Latitude"
+    id: gps_lat
+    on_value:
+      then:
+        - logger.log:
+            format: "%.6f, %.6f"
+            args: [id(gps_lat).state, id(gps_long).state]
   longitude:
     name: "Longitude"
+    id: gps_long
   altitude:
     name: "Altitude"
   speed:


### PR DESCRIPTION
# What does this implement/fix?

Fix codegen deadlock when a GPS sensor automation references a sibling sensor by ID. For example, an `on_value` on `latitude` that uses `id(gps_long)` would deadlock because `sensor.new_sensor()` processes automations before returning, and the longitude sensor has not been created yet.

The fix pre-creates all sensor variables with `cg.new_Pvariable()` first (which registers IDs in the variable map), then processes automations via `sensor.register_sensor()` in a second pass. By that point all sibling IDs are resolvable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14348

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  rx_pin: GPIO16
  tx_pin: GPIO15
  baud_rate: 9600

gps:
  latitude:
    id: gps_lat
    name: "Latitude"
    on_value:
      then:
        - logger.log:
            format: "%.2f, %.2f"
            args: [id(gps_lat).state, id(gps_long).state]
  longitude:
    id: gps_long
    name: "Longitude"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).