### PR TITLE
[sen6x] Fix test sensor ID collisions with sen5x

### DIFF
--- a/tests/components/sen6x/common.yaml
+++ b/tests/components/sen6x/common.yaml
@@ -12,19 +12,19 @@ sensor:
       accuracy_decimals: 0
     pm_1_0:
       name: PM <1µm Weight concentration
-      id: pm_1_0
+      id: sen6x_pm_1_0
       accuracy_decimals: 1
     pm_2_5:
       name: PM <2.5µm Weight concentration
-      id: pm_2_5
+      id: sen6x_pm_2_5
       accuracy_decimals: 1
     pm_4_0:
       name: PM <4µm Weight concentration
-      id: pm_4_0
+      id: sen6x_pm_4_0
       accuracy_decimals: 1
     pm_10_0:
       name: PM <10µm Weight concentration
-      id: pm_10_0
+      id: sen6x_pm_10_0
       accuracy_decimals: 1
     nox:
       name: NOx


### PR DESCRIPTION
# What does this implement/fix?

The sen6x test YAML (`tests/components/sen6x/common.yaml`) used identical sensor IDs (`pm_1_0`, `pm_2_5`, `pm_4_0`, `pm_10_0`) as the sen5x test YAML, causing "ID redefined" errors when both components are tested together in grouped builds. This prefixes the sen6x sensor IDs with `sen6x_` to make them unique.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes — test-only fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).