### PR TITLE
[core] Inline set_component_state_ and use it in Application

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -525,8 +525,7 @@ void Application::enable_pending_loops_() {
     // Clear the pending flag and enable the loop
     component->pending_enable_loop_ = false;
     ESP_LOGVV(TAG, "%s loop enabled from ISR", LOG_STR_ARG(component->get_component_log_str()));
-    component->component_state_ &= ~COMPONENT_STATE_MASK;
-    component->component_state_ |= COMPONENT_STATE_LOOP;
+    component->set_component_state_(COMPONENT_STATE_LOOP);
 
     // Move to active section
     this->activate_looping_component_(i);

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -297,10 +297,6 @@ void Component::mark_failed() {
   // Also remove from loop since failed components shouldn't loop
   App.disable_component_loop_(this);
 }
-void Component::set_component_state_(uint8_t state) {
-  this->component_state_ &= ~COMPONENT_STATE_MASK;
-  this->component_state_ |= state;
-}
 void Component::disable_loop() {
   if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
     ESP_LOGVV(TAG, "%s loop disabled", LOG_STR_ARG(this->get_component_log_str()));

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -294,7 +294,10 @@ class Component {
   void call_dump_config_();
 
   /// Helper to set component state (clears state bits and sets new state)
-  void set_component_state_(uint8_t state);
+  inline void set_component_state_(uint8_t state) {
+    this->component_state_ &= ~COMPONENT_STATE_MASK;
+    this->component_state_ |= state;
+  }
 
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *


### PR DESCRIPTION
# What does this implement/fix?

Move `set_component_state_()` from `component.cpp` to the header as an inline method so it can be reused wherever `Component` state needs to be updated without manual bit manipulation.

Replace the manual bit masking in `Application::enable_pending_loops_()` with a call to the helper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal refactor, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).