### PR TITLE
[core] Make register_component protected, remove runtime checks

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,24 +79,7 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
-void Application::register_component_(Component *comp) {
-  if (comp == nullptr) {
-    ESP_LOGW(TAG, "Tried to register null component!");
-    return;
-  }
-
-  for (auto *c : this->components_) {
-    if (comp == c) {
-      ESP_LOGW(TAG, "Component %s already registered! (%p)", LOG_STR_ARG(c->get_component_log_str()), c);
-      return;
-    }
-  }
-  if (this->components_.size() >= ESPHOME_COMPONENT_COUNT) {
-    ESP_LOGE(TAG, "Cannot register component %s - at capacity!", LOG_STR_ARG(comp->get_component_log_str()));
-    return;
-  }
-  this->components_.push_back(comp);
-}
+void Application::register_component_(Component *comp) { this->components_.push_back(comp); }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,7 +79,7 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
-void Application::register_component_impl_(Component *comp) { this->components_.push_back(comp); }
+void Application::register_component_(Component *comp) { this->components_.push_back(comp); }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,7 +79,7 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
-void Application::register_component_(Component *comp) { this->components_.push_back(comp); }
+void Application::register_component_impl_(Component *comp) { this->components_.push_back(comp); }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,6 +79,7 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
+void Application::register_component_(Component *comp) { this->components_.push_back(comp); }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -79,7 +79,6 @@ static void insertion_sort_by_priority(Iterator first, Iterator last) {
   }
 }
 
-void Application::register_component_(Component *comp) { this->components_.push_back(comp); }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");
   ESP_LOGV(TAG, "Sorting components by setup priority");

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,7 +521,7 @@ class Application {
 #endif
 #endif
 
-  void register_component_(Component *comp);
+  __attribute__((noinline)) void register_component_(Component *comp);
 
   void calculate_looping_components_();
   void add_looping_components_by_state_(bool match_loop_done);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -108,8 +108,9 @@ namespace esphome::socket {
 class Socket;
 }  // namespace esphome::socket
 
-// Forward declaration for friend access from codegen-generated setup()
+// Forward declarations for friend access from codegen-generated setup()
 void setup();
+void original_setup();  // Used by cpp unit tests which replace setup() with gtest runner
 
 namespace esphome {
 
@@ -505,6 +506,7 @@ class Application {
   friend Component;
   friend class socket::Socket;
   friend void ::setup();
+  friend void ::original_setup();
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
   /// Fast path for Socket::ready() via friendship - skips negative fd check.

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -109,8 +109,8 @@ class Socket;
 }  // namespace esphome::socket
 
 // Forward declarations for friend access from codegen-generated setup()
-void setup();
-void original_setup();  // Used by cpp unit tests which replace setup() with gtest runner
+void setup();           // NOLINT(readability-redundant-declaration) - may be declared in Arduino.h
+void original_setup();  // NOLINT(readability-redundant-declaration) - used by cpp unit tests
 
 namespace esphome {
 

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,7 +521,7 @@ class Application {
 #endif
 #endif
 
-  void register_component_(Component *comp);
+  inline void register_component_(Component *comp) { this->components_.push_back(comp); }
 
   void calculate_looping_components_();
   void add_looping_components_by_state_(bool match_loop_done);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -108,6 +108,9 @@ namespace esphome::socket {
 class Socket;
 }  // namespace esphome::socket
 
+// Forward declaration for friend access from codegen-generated setup()
+void setup();
+
 namespace esphome {
 
 // Teardown timeout constant (in milliseconds)
@@ -246,13 +249,6 @@ class Application {
 #endif
 
   /// Reserve space for components to avoid memory fragmentation
-
-  /// Register the component in this Application instance.
-  template<class C> C *register_component(C *c) {
-    static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
-    this->register_component_((Component *) c);
-    return c;
-  }
 
   /// Set up all the registered components. Call this at the end of your setup() function.
   void setup();
@@ -508,6 +504,7 @@ class Application {
  protected:
   friend Component;
   friend class socket::Socket;
+  friend void ::setup();
 
 #ifdef USE_SOCKET_SELECT_SUPPORT
   /// Fast path for Socket::ready() via friendship - skips negative fd check.

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,7 +521,14 @@ class Application {
 #endif
 #endif
 
-  __attribute__((noinline)) void register_component_(Component *comp);
+  /// Register a component - only callable from codegen-generated setup() via friend access.
+  template<class C> C *register_component_(C *c) {
+    static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
+    this->register_component_impl_((Component *) c);
+    return c;
+  }
+
+  void register_component_impl_(Component *comp);
 
   void calculate_looping_components_();
   void add_looping_components_by_state_(bool match_loop_done);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,7 +521,7 @@ class Application {
 #endif
 #endif
 
-  inline void register_component_(Component *comp) { this->components_.push_back(comp); }
+  void register_component_(Component *comp);
 
   void calculate_looping_components_();
   void add_looping_components_by_state_(bool match_loop_done);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -521,13 +521,6 @@ class Application {
 #endif
 #endif
 
-  /// Register a component - only callable from codegen-generated setup() via friend access.
-  template<class C> C *register_component(C *c) {
-    static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
-    this->register_component_((Component *) c);
-    return c;
-  }
-
   void register_component_(Component *comp);
 
   void calculate_looping_components_();

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -522,13 +522,13 @@ class Application {
 #endif
 
   /// Register a component - only callable from codegen-generated setup() via friend access.
-  template<class C> C *register_component_(C *c) {
+  template<class C> C *register_component(C *c) {
     static_assert(std::is_base_of<Component, C>::value, "Only Component subclasses can be registered");
-    this->register_component_impl_((Component *) c);
+    this->register_component_((Component *) c);
     return c;
   }
 
-  void register_component_impl_(Component *comp);
+  void register_component_(Component *comp);
 
   void calculate_looping_components_();
   void add_looping_components_by_state_(bool match_loop_done);

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -79,7 +79,7 @@ async def register_component(var, config):
     if name is not None:
         add(var.set_component_source(LogStringLiteral(name)))
 
-    add(App.register_component(var))
+    add(App.register_component_(var))
     return var
 
 

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -79,7 +79,7 @@ async def register_component(var, config):
     if name is not None:
         add(var.set_component_source(LogStringLiteral(name)))
 
-    add(App.register_component_(var))
+    add(App.register_component(var))
     return var
 
 

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -8,7 +8,7 @@ def test_deep_sleep_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep1.yaml")
 
     assert "deepsleep = new deep_sleep::DeepSleepComponent();" in main_cpp
-    assert "App.register_component(deepsleep);" in main_cpp
+    assert "App.register_component_(deepsleep);" in main_cpp
 
 
 def test_deep_sleep_sleep_duration(generate_main):

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -8,7 +8,7 @@ def test_deep_sleep_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep1.yaml")
 
     assert "deepsleep = new deep_sleep::DeepSleepComponent();" in main_cpp
-    assert "App.register_component_(deepsleep);" in main_cpp
+    assert "App.register_component(deepsleep);" in main_cpp
 
 
 def test_deep_sleep_sleep_duration(generate_main):

--- a/tests/component_tests/ota/test_web_server_ota.py
+++ b/tests/component_tests/ota/test_web_server_ota.py
@@ -27,7 +27,7 @@ def test_web_server_ota_generated(generate_main: Callable[[str], str]) -> None:
     assert "global_web_server_base" in main_cpp
 
     # Check component is registered
-    assert "App.register_component(web_server_webserverotacomponent_id)" in main_cpp
+    assert "App.register_component_(web_server_webserverotacomponent_id)" in main_cpp
 
 
 def test_web_server_ota_with_callbacks(generate_main: Callable[[str], str]) -> None:

--- a/tests/component_tests/ota/test_web_server_ota.py
+++ b/tests/component_tests/ota/test_web_server_ota.py
@@ -27,7 +27,7 @@ def test_web_server_ota_generated(generate_main: Callable[[str], str]) -> None:
     assert "global_web_server_base" in main_cpp
 
     # Check component is registered
-    assert "App.register_component_(web_server_webserverotacomponent_id)" in main_cpp
+    assert "App.register_component(web_server_webserverotacomponent_id)" in main_cpp
 
 
 def test_web_server_ota_with_callbacks(generate_main: Callable[[str], str]) -> None:

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -16,10 +16,10 @@ void setup() {
   auto *log = new logger::Logger(115200);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
-  App.register_component(log);
+  App.register_component_(log);
 
   auto *wifi = new wifi::WiFiComponent();  // NOLINT
-  App.register_component(wifi);
+  App.register_component_(wifi);
   wifi::WiFiAP ap;
   ap.set_ssid("Test SSID");
   ap.set_password("password1");

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -16,10 +16,10 @@ void setup() {
   auto *log = new logger::Logger(115200);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
-  App.register_component_(log);
+  App.register_component(log);
 
   auto *wifi = new wifi::WiFiComponent();  // NOLINT
-  App.register_component_(wifi);
+  App.register_component(wifi);
   wifi::WiFiAP ap;
   ap.set_ssid("Test SSID");
   ap.set_password("password1");

--- a/tests/unit_tests/test_cpp_helpers.py
+++ b/tests/unit_tests/test_cpp_helpers.py
@@ -16,7 +16,7 @@ async def test_gpio_pin_expression__conf_is_none(monkeypatch):
 async def test_register_component(monkeypatch):
     var = Mock(base="foo.bar")
 
-    app_mock = Mock(register_component=Mock(return_value=var))
+    app_mock = Mock(register_component_=Mock(return_value=var))
     monkeypatch.setattr(ch, "App", app_mock)
 
     core_mock = Mock(component_ids=["foo.bar"])
@@ -29,7 +29,7 @@ async def test_register_component(monkeypatch):
 
     assert actual is var
     assert add_mock.call_count == 2
-    app_mock.register_component.assert_called_with(var)
+    app_mock.register_component_.assert_called_with(var)
     assert core_mock.component_ids == []
 
 
@@ -48,7 +48,7 @@ async def test_register_component__no_component_id(monkeypatch):
 async def test_register_component__with_setup_priority(monkeypatch):
     var = Mock(base="foo.bar")
 
-    app_mock = Mock(register_component=Mock(return_value=var))
+    app_mock = Mock(register_component_=Mock(return_value=var))
     monkeypatch.setattr(ch, "App", app_mock)
 
     core_mock = Mock(component_ids=["foo.bar"])
@@ -68,5 +68,5 @@ async def test_register_component__with_setup_priority(monkeypatch):
     assert actual is var
     add_mock.assert_called()
     assert add_mock.call_count == 4
-    app_mock.register_component.assert_called_with(var)
+    app_mock.register_component_.assert_called_with(var)
     assert core_mock.component_ids == []

--- a/tests/unit_tests/test_cpp_helpers.py
+++ b/tests/unit_tests/test_cpp_helpers.py
@@ -16,7 +16,7 @@ async def test_gpio_pin_expression__conf_is_none(monkeypatch):
 async def test_register_component(monkeypatch):
     var = Mock(base="foo.bar")
 
-    app_mock = Mock(register_component_=Mock(return_value=var))
+    app_mock = Mock(register_component=Mock(return_value=var))
     monkeypatch.setattr(ch, "App", app_mock)
 
     core_mock = Mock(component_ids=["foo.bar"])
@@ -29,7 +29,7 @@ async def test_register_component(monkeypatch):
 
     assert actual is var
     assert add_mock.call_count == 2
-    app_mock.register_component_.assert_called_with(var)
+    app_mock.register_component.assert_called_with(var)
     assert core_mock.component_ids == []
 
 
@@ -48,7 +48,7 @@ async def test_register_component__no_component_id(monkeypatch):
 async def test_register_component__with_setup_priority(monkeypatch):
     var = Mock(base="foo.bar")
 
-    app_mock = Mock(register_component_=Mock(return_value=var))
+    app_mock = Mock(register_component=Mock(return_value=var))
     monkeypatch.setattr(ch, "App", app_mock)
 
     core_mock = Mock(component_ids=["foo.bar"])
@@ -68,5 +68,5 @@ async def test_register_component__with_setup_priority(monkeypatch):
     assert actual is var
     add_mock.assert_called()
     assert add_mock.call_count == 4
-    app_mock.register_component_.assert_called_with(var)
+    app_mock.register_component.assert_called_with(var)
     assert core_mock.component_ids == []


### PR DESCRIPTION
# What does this implement/fix?

Followup to #13778. Instead of adding runtime checks to catch external components that call `App.register_component()` without declaring their components in config, make the bad behavior impossible at compile time.

Changes:
- Remove the public `register_component<C>()` template wrapper from `Application`
- Grant `friend void ::setup()` access so only the codegen-generated `setup()` function can call the protected `register_component_()`
- Update codegen to emit `App.register_component_()` directly
- Remove all runtime null, duplicate, and capacity checks from `register_component_()` since codegen guarantees correctness

`ESPHOME_COMPONENT_COUNT` is set to exactly `len(CORE.component_ids)` at codegen time, so the `StaticVector` is always correctly sized. External components that were bypassing codegen to call `App.register_component()` directly will now get a compile error, forcing them to properly declare their components in their config schema.

The `static_assert(std::is_base_of<Component, C>::value)` from the removed template is no longer needed — calling `register_component_(Component *)` directly means the compiler enforces the type constraint via the implicit pointer conversion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Followup to https://github.com/esphome/esphome/pull/13778
- Related: https://github.com/esphome/esphome/issues/13771

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal API change, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).