### PR TITLE
[api] Outline keepalive ping logic from APIConnection::loop()

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -242,24 +242,11 @@ void APIConnection::loop() {
     return;
   }
 
-  if (this->flags_.sent_ping) {
-    // Disconnect if not responded within 2.5*keepalive
-    if (now - this->last_traffic_ > KEEPALIVE_DISCONNECT_TIMEOUT) {
-      on_fatal_error();
-      this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("is unresponsive; disconnecting"));
-    }
-  } else if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS && !this->flags_.remove) {
-    // Only send ping if we're not disconnecting
-    ESP_LOGVV(TAG, "Sending keepalive PING");
-    PingRequest req;
-    this->flags_.sent_ping = this->send_message(req, PingRequest::MESSAGE_TYPE);
-    if (!this->flags_.sent_ping) {
-      // If we can't send the ping request directly (tx_buffer full),
-      // schedule it at the front of the batch so it will be sent with priority
-      ESP_LOGW(TAG, "Buffer full, ping queued");
-      this->schedule_message_front_(nullptr, PingRequest::MESSAGE_TYPE, PingRequest::ESTIMATED_SIZE);
-      this->flags_.sent_ping = true;  // Mark as sent to avoid scheduling multiple pings
-    }
+  // Keepalive: only call into the cold path when enough time has elapsed.
+  // When sent_ping is true, last_traffic_ hasn't been updated so this
+  // condition is already satisfied — covers both send-ping and disconnect cases.
+  if (now - this->last_traffic_ > KEEPALIVE_TIMEOUT_MS) {
+    this->check_keepalive_(now);
   }
 
 #ifdef USE_API_HOMEASSISTANT_STATES
@@ -273,6 +260,29 @@ void APIConnection::loop() {
   // (missing a frame is fine, missing a state update is not)
   this->try_send_camera_image_();
 #endif
+}
+
+void APIConnection::check_keepalive_(uint32_t now) {
+  // Caller guarantees: now - last_traffic_ > KEEPALIVE_TIMEOUT_MS
+  if (this->flags_.sent_ping) {
+    // Disconnect if not responded within 2.5*keepalive
+    if (now - this->last_traffic_ > KEEPALIVE_DISCONNECT_TIMEOUT) {
+      on_fatal_error();
+      this->log_client_(ESPHOME_LOG_LEVEL_WARN, LOG_STR("is unresponsive; disconnecting"));
+    }
+  } else if (!this->flags_.remove) {
+    // Only send ping if we're not disconnecting
+    ESP_LOGVV(TAG, "Sending keepalive PING");
+    PingRequest req;
+    this->flags_.sent_ping = this->send_message(req, PingRequest::MESSAGE_TYPE);
+    if (!this->flags_.sent_ping) {
+      // If we can't send the ping request directly (tx_buffer full),
+      // schedule it at the front of the batch so it will be sent with priority
+      ESP_LOGW(TAG, "Buffer full, ping queued");
+      this->schedule_message_front_(nullptr, PingRequest::MESSAGE_TYPE, PingRequest::ESTIMATED_SIZE);
+      this->flags_.sent_ping = true;  // Mark as sent to avoid scheduling multiple pings
+    }
+  }
 }
 
 void APIConnection::process_active_iterator_() {

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -370,6 +370,10 @@ class APIConnection final : public APIServerConnectionBase {
     return this->client_supports_api_version(1, 14) ? MAX_INITIAL_PER_BATCH : MAX_INITIAL_PER_BATCH_LEGACY;
   }
 
+  // Send keepalive ping or disconnect unresponsive client.
+  // Cold path — extracted from loop() to reduce instruction cache pressure.
+  void __attribute__((noinline)) check_keepalive_(uint32_t now);
+
   // Process active iterator (list_entities/initial_state) during connection setup.
   // Extracted from loop() — only runs during initial handshake, NONE in steady state.
   void __attribute__((noinline)) process_active_iterator_();


### PR DESCRIPTION
# What does this implement/fix?

Extract the keepalive ping/disconnect cold path into a separate noinline `check_keepalive_()` method. This code only fires once per minute but was contributing ~110 bytes to the hot `loop()` body that runs every ~16ms.

The inline guard in `loop()` is a single subtract+compare (`now - last_traffic_ > KEEPALIVE_TIMEOUT_MS`) that short-circuits 99.99% of iterations. When `sent_ping` is already true, `last_traffic_` hasn't been updated so this condition is inherently satisfied — a single check covers both the send-ping and disconnect-timeout cases.

Results on ESP32 (xtensa):
- `loop()`: 374 → 263 bytes (-111 bytes, -30%)
- `check_keepalive_()`: 136 bytes (new, cold path)
- Net: +25 bytes total (call overhead), but the hot path icache footprint is significantly reduced

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal refactor only
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).