### PR TITLE
[ci] Fix TypeError in ci-custom.py when POST lint checks fail

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -959,7 +959,7 @@ def main():
             continue
         run_checks(LINT_CONTENT_CHECKS, fname, fname, content)
 
-    run_checks(LINT_POST_CHECKS, "POST")
+    run_checks(LINT_POST_CHECKS, Path("POST"))
 
     for f, errs in sorted(errors.items()):
         bold = functools.partial(styled, colorama.Style.BRIGHT)


### PR DESCRIPTION
# What does this implement/fix?

Fixes `TypeError: '<' not supported between instances of 'str' and 'PosixPath'` in `script/ci-custom.py` when any POST lint check fails.

The `run_checks(LINT_POST_CHECKS, "POST")` call on line 962 passes a string `"POST"` as `fname`, while all other callers pass `Path` objects. When any POST check adds errors to the `errors` dict (typed as `defaultdict[Path, list]`), `sorted(errors.items())` on line 964 fails because Python cannot compare `str` and `PosixPath` keys.

Fix: wrap `"POST"` in `Path()` to match the dict's type annotation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A — discovered via CI failure.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — CI script fix, no config.yaml changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).