### PR TITLE
[ld2410][ld2412] Fix signed char causing incorrect distance values

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -359,17 +359,14 @@ void LD2410Component::handle_periodic_data_() {
     Detect distance: 16~17th bytes
   */
 #ifdef USE_SENSOR
-  SAFE_PUBLISH_SENSOR(
-      this->moving_target_distance_sensor_,
-      ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
+  SAFE_PUBLISH_SENSOR(this->moving_target_distance_sensor_,
+                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]))
   SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
-  SAFE_PUBLISH_SENSOR(
-      this->still_target_distance_sensor_,
-      ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]));
+  SAFE_PUBLISH_SENSOR(this->still_target_distance_sensor_,
+                      encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]));
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY]);
-  SAFE_PUBLISH_SENSOR(
-      this->detection_distance_sensor_,
-      ld24xx::two_byte_to_uint16(this->buffer_data_[DETECT_DISTANCE_LOW], this->buffer_data_[DETECT_DISTANCE_HIGH]));
+  SAFE_PUBLISH_SENSOR(this->detection_distance_sensor_,
+                      encode_uint16(this->buffer_data_[DETECT_DISTANCE_HIGH], this->buffer_data_[DETECT_DISTANCE_LOW]));
 
   if (engineering_mode) {
     /*
@@ -576,8 +573,8 @@ bool LD2410Component::handle_ack_data_() {
       /*
         None Duration: 33~34th bytes
       */
-      updates.push_back(set_number_value(this->timeout_number_,
-                                         ld24xx::two_byte_to_uint16(this->buffer_data_[32], this->buffer_data_[33])));
+      updates.push_back(
+          set_number_value(this->timeout_number_, encode_uint16(this->buffer_data_[33], this->buffer_data_[32])));
       for (auto &update : updates) {
         update();
       }

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -173,8 +173,6 @@ static constexpr uint8_t DATA_FRAME_FOOTER[HEADER_FOOTER_SIZE] = {0xF8, 0xF7, 0x
 // MAC address the module uses when Bluetooth is disabled
 static constexpr uint8_t NO_MAC[] = {0x08, 0x05, 0x04, 0x03, 0x02, 0x01};
 
-static inline int two_byte_to_int(char firstbyte, char secondbyte) { return (int16_t) (secondbyte << 8) + firstbyte; }
-
 static inline bool validate_header_footer(const uint8_t *header_footer, const uint8_t *buffer) {
   return std::memcmp(header_footer, buffer, HEADER_FOOTER_SIZE) == 0;
 }
@@ -363,15 +361,15 @@ void LD2410Component::handle_periodic_data_() {
 #ifdef USE_SENSOR
   SAFE_PUBLISH_SENSOR(
       this->moving_target_distance_sensor_,
-      ld2410::two_byte_to_int(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
+      ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
   SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
   SAFE_PUBLISH_SENSOR(
       this->still_target_distance_sensor_,
-      ld2410::two_byte_to_int(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]));
+      ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]));
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY]);
   SAFE_PUBLISH_SENSOR(
       this->detection_distance_sensor_,
-      ld2410::two_byte_to_int(this->buffer_data_[DETECT_DISTANCE_LOW], this->buffer_data_[DETECT_DISTANCE_HIGH]));
+      ld24xx::two_byte_to_uint16(this->buffer_data_[DETECT_DISTANCE_LOW], this->buffer_data_[DETECT_DISTANCE_HIGH]));
 
   if (engineering_mode) {
     /*
@@ -579,7 +577,7 @@ bool LD2410Component::handle_ack_data_() {
         None Duration: 33~34th bytes
       */
       updates.push_back(set_number_value(this->timeout_number_,
-                                         ld2410::two_byte_to_int(this->buffer_data_[32], this->buffer_data_[33])));
+                                         ld24xx::two_byte_to_uint16(this->buffer_data_[32], this->buffer_data_[33])));
       for (auto &update : updates) {
         update();
       }

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -192,8 +192,6 @@ static constexpr uint8_t DATA_FRAME_FOOTER[HEADER_FOOTER_SIZE] = {0xF8, 0xF7, 0x
 // MAC address the module uses when Bluetooth is disabled
 static constexpr uint8_t NO_MAC[] = {0x08, 0x05, 0x04, 0x03, 0x02, 0x01};
 
-static inline int two_byte_to_int(char firstbyte, char secondbyte) { return (int16_t) (secondbyte << 8) + firstbyte; }
-
 static inline bool validate_header_footer(const uint8_t *header_footer, const uint8_t *buffer) {
   return std::memcmp(header_footer, buffer, HEADER_FOOTER_SIZE) == 0;
 }
@@ -400,20 +398,20 @@ void LD2412Component::handle_periodic_data_() {
 #ifdef USE_SENSOR
   SAFE_PUBLISH_SENSOR(
       this->moving_target_distance_sensor_,
-      ld2412::two_byte_to_int(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
+      ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
   SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
   SAFE_PUBLISH_SENSOR(
       this->still_target_distance_sensor_,
-      ld2412::two_byte_to_int(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]))
+      ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]))
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY])
   if (this->detection_distance_sensor_ != nullptr) {
     int new_detect_distance = 0;
     if (target_state != 0x00 && (target_state & MOVE_BITMASK)) {
       new_detect_distance =
-          ld2412::two_byte_to_int(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]);
+          ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]);
     } else if (target_state != 0x00) {
       new_detect_distance =
-          ld2412::two_byte_to_int(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]);
+          ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]);
     }
     this->detection_distance_sensor_->publish_state_if_not_dup(new_detect_distance);
   }
@@ -638,8 +636,8 @@ bool LD2412Component::handle_ack_data_() {
         None Duration: 11~12th bytes
       */
       updates.push_back(set_number_value(this->timeout_number_,
-                                         ld2412::two_byte_to_int(this->buffer_data_[12], this->buffer_data_[13])));
-      ESP_LOGV(TAG, "timeout_number_: %u", ld2412::two_byte_to_int(this->buffer_data_[12], this->buffer_data_[13]));
+                                         ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13])));
+      ESP_LOGV(TAG, "timeout_number_: %u", ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13]));
       /*
         Output pin configuration: 13th bytes
       */

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -396,22 +396,19 @@ void LD2412Component::handle_periodic_data_() {
     Detect distance: 16~17th bytes
   */
 #ifdef USE_SENSOR
-  SAFE_PUBLISH_SENSOR(
-      this->moving_target_distance_sensor_,
-      ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]))
+  SAFE_PUBLISH_SENSOR(this->moving_target_distance_sensor_,
+                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]))
   SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
-  SAFE_PUBLISH_SENSOR(
-      this->still_target_distance_sensor_,
-      ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]))
+  SAFE_PUBLISH_SENSOR(this->still_target_distance_sensor_,
+                      encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]))
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY])
   if (this->detection_distance_sensor_ != nullptr) {
     int new_detect_distance = 0;
     if (target_state != 0x00 && (target_state & MOVE_BITMASK)) {
       new_detect_distance =
-          ld24xx::two_byte_to_uint16(this->buffer_data_[MOVING_TARGET_LOW], this->buffer_data_[MOVING_TARGET_HIGH]);
+          encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]);
     } else if (target_state != 0x00) {
-      new_detect_distance =
-          ld24xx::two_byte_to_uint16(this->buffer_data_[STILL_TARGET_LOW], this->buffer_data_[STILL_TARGET_HIGH]);
+      new_detect_distance = encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]);
     }
     this->detection_distance_sensor_->publish_state_if_not_dup(new_detect_distance);
   }
@@ -635,10 +632,9 @@ bool LD2412Component::handle_ack_data_() {
       /*
         None Duration: 11~12th bytes
       */
-      updates.push_back(set_number_value(this->timeout_number_,
-                                         ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13])));
-      ESP_LOGV(TAG, "timeout_number_: %u",
-               static_cast<unsigned int>(ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13])));
+      updates.push_back(
+          set_number_value(this->timeout_number_, encode_uint16(this->buffer_data_[13], this->buffer_data_[12])));
+      ESP_LOGV(TAG, "timeout_number_: %u", encode_uint16(this->buffer_data_[13], this->buffer_data_[12]));
       /*
         Output pin configuration: 13th bytes
       */

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -637,7 +637,8 @@ bool LD2412Component::handle_ack_data_() {
       */
       updates.push_back(set_number_value(this->timeout_number_,
                                          ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13])));
-      ESP_LOGV(TAG, "timeout_number_: %u", ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13]));
+      ESP_LOGV(TAG, "timeout_number_: %u",
+               static_cast<unsigned int>(ld24xx::two_byte_to_uint16(this->buffer_data_[12], this->buffer_data_[13])));
       /*
         Output pin configuration: 13th bytes
       */

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -40,7 +40,7 @@
 namespace esphome::ld24xx {
 
 /// Parse a little-endian 16-bit unsigned value from two bytes.
-static inline uint16_t two_byte_to_uint16(uint8_t low, uint8_t high) { return ((uint16_t) high << 8) | low; }
+static constexpr uint16_t two_byte_to_uint16(uint8_t low, uint8_t high) { return ((uint16_t) high << 8) | low; }
 
 // Helper to find index of value in constexpr array
 template<size_t N> optional<size_t> find_index(const uint32_t (&arr)[N], uint32_t value) {

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -39,6 +39,9 @@
 
 namespace esphome::ld24xx {
 
+/// Parse a little-endian 16-bit unsigned value from two bytes.
+static inline uint16_t two_byte_to_uint16(uint8_t low, uint8_t high) { return ((uint16_t) high << 8) | low; }
+
 // Helper to find index of value in constexpr array
 template<size_t N> optional<size_t> find_index(const uint32_t (&arr)[N], uint32_t value) {
   for (size_t i = 0; i < N; i++) {

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -39,9 +39,6 @@
 
 namespace esphome::ld24xx {
 
-/// Parse a little-endian 16-bit unsigned value from two bytes.
-static constexpr uint16_t two_byte_to_uint16(uint8_t low, uint8_t high) { return ((uint16_t) high << 8) | low; }
-
 // Helper to find index of value in constexpr array
 template<size_t N> optional<size_t> find_index(const uint32_t (&arr)[N], uint32_t value) {
   for (size_t i = 0; i < N; i++) {


### PR DESCRIPTION
# What does this implement/fix?

Fix `two_byte_to_int()` in both ld2410 and ld2412 components using signed `char` parameters instead of `uint8_t`. When `char` is signed (most platforms), byte values >= 0x80 are sign-extended during integer promotion, producing incorrect sensor values for distances where `value % 256 >= 128`.

For example, 128cm was reported as -128, 200cm as -56, and 500cm as 244.

This affects approximately 1/3 of the LD2410/LD2412 usable range (128–255cm, 384–511cm for the LD2410's typical 0–600cm range).

The fix:
- Removes the duplicate `two_byte_to_int` functions from both components
- Replaces all call sites with `encode_uint16` from `esphome/core/helpers.h`
- Argument order was carefully swapped at every call site: the old `two_byte_to_int(low, high)` took low byte first, while `encode_uint16(msb, lsb)` takes high byte first

### Verified against reference implementations

Per the [LD2410 protocol specification](https://wiki.dfrobot.com/SKU_SEN0557_24GHz_Human_Presence_Sensing_Module), all multi-byte values are little-endian and distance values are unsigned 16-bit integers with a max range of 600cm.

Third-party libraries confirm distances should be parsed as unsigned:

- [`ncmreynolds/ld2410` (line 364-365)](https://github.com/ncmreynolds/ld2410/blob/425eda7/src/ld2410.cpp#L364-L365) — parses distances as `uint16_t`:
  ```cpp
  stationary_target_distance_ = *(uint16_t*)(&radar_data_frame_[12]);
  moving_target_distance_ = *(uint16_t*)(&radar_data_frame_[9]);
  ```
- [`ginkel/LD2412` (line 210-214)](https://github.com/ginkel/LD2412/blob/8a7a08f/src/MyLD2410.cpp#L210-L214) — uses unsigned bitwise OR:
  ```cpp
  sData.mTargetDistance = inBuf[3] | (inBuf[4] << 8);
  sData.sTargetDistance = inBuf[6] | (inBuf[7] << 8);
  sData.distance = inBuf[9] | (inBuf[10] << 8);
  ```

Discovered while building UART mock testing infrastructure in #14377 — the tests didn't pass the first time due to this bug.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #14377

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — this is an internal bugfix
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 256000

ld2410:
  id: my_ld2410

sensor:
  - platform: ld2410
    moving_distance:
      name: "Moving Distance"
    still_distance:
      name: "Still Distance"
    detection_distance:
      name: "Detection Distance"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).