### PR TITLE
[core] Defer entity automation codegen to prevent sibling ID deadlocks

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -550,22 +550,8 @@ def binary_sensor_schema(
     return _BINARY_SENSOR_SCHEMA.extend(schema)
 
 
-async def setup_binary_sensor_core_(var, config):
-    await setup_entity(var, config, "binary_sensor")
-
-    if (device_class := config.get(CONF_DEVICE_CLASS)) is not None:
-        cg.add(var.set_device_class(device_class))
-    trigger = config.get(CONF_TRIGGER_ON_INITIAL_STATE, False) or config.get(
-        CONF_PUBLISH_INITIAL_STATE, False
-    )
-    cg.add(var.set_trigger_on_initial_state(trigger))
-    if inverted := config.get(CONF_INVERTED):
-        cg.add(var.set_inverted(inverted))
-    if filters_config := config.get(CONF_FILTERS):
-        cg.add_define("USE_BINARY_SENSOR_FILTER")
-        filters = await cg.build_registry_list(FILTER_REGISTRY, filters_config)
-        cg.add(var.add_filters(filters))
-
+@coroutine_with_priority(CoroPriority.AUTOMATION)
+async def _build_binary_sensor_automations(var, config):
     for conf in config.get(CONF_ON_PRESS, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
@@ -616,6 +602,25 @@ async def setup_binary_sensor_core_(var, config):
             ],
             conf,
         )
+
+
+async def setup_binary_sensor_core_(var, config):
+    await setup_entity(var, config, "binary_sensor")
+
+    if (device_class := config.get(CONF_DEVICE_CLASS)) is not None:
+        cg.add(var.set_device_class(device_class))
+    trigger = config.get(CONF_TRIGGER_ON_INITIAL_STATE, False) or config.get(
+        CONF_PUBLISH_INITIAL_STATE, False
+    )
+    cg.add(var.set_trigger_on_initial_state(trigger))
+    if inverted := config.get(CONF_INVERTED):
+        cg.add(var.set_inverted(inverted))
+    if filters_config := config.get(CONF_FILTERS):
+        cg.add_define("USE_BINARY_SENSOR_FILTER")
+        filters = await cg.build_registry_list(FILTER_REGISTRY, filters_config)
+        cg.add(var.add_filters(filters))
+
+    CORE.add_job(_build_binary_sensor_automations, var, config)
 
     if mqtt_id := config.get(CONF_MQTT_ID):
         mqtt_ = cg.new_Pvariable(mqtt_id, var)

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -240,6 +240,23 @@ def number_schema(
     return _NUMBER_SCHEMA.extend(schema)
 
 
+@coroutine_with_priority(CoroPriority.AUTOMATION)
+async def _build_number_automations(var, config):
+    for conf in config.get(CONF_ON_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(float, "x")], conf)
+    for conf in config.get(CONF_ON_VALUE_RANGE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await cg.register_component(trigger, conf)
+        if CONF_ABOVE in conf:
+            template_ = await cg.templatable(conf[CONF_ABOVE], [(float, "x")], float)
+            cg.add(trigger.set_min(template_))
+        if CONF_BELOW in conf:
+            template_ = await cg.templatable(conf[CONF_BELOW], [(float, "x")], float)
+            cg.add(trigger.set_max(template_))
+        await automation.build_automation(trigger, [(float, "x")], conf)
+
+
 async def setup_number_core_(
     var, config, *, min_value: float, max_value: float, step: float
 ):
@@ -254,19 +271,7 @@ async def setup_number_core_(
     if config[CONF_MODE] != NumberMode.NUMBER_MODE_AUTO:
         cg.add(var.traits.set_mode(config[CONF_MODE]))
 
-    for conf in config.get(CONF_ON_VALUE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(float, "x")], conf)
-    for conf in config.get(CONF_ON_VALUE_RANGE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await cg.register_component(trigger, conf)
-        if CONF_ABOVE in conf:
-            template_ = await cg.templatable(conf[CONF_ABOVE], [(float, "x")], float)
-            cg.add(trigger.set_min(template_))
-        if CONF_BELOW in conf:
-            template_ = await cg.templatable(conf[CONF_BELOW], [(float, "x")], float)
-            cg.add(trigger.set_max(template_))
-        await automation.build_automation(trigger, [(float, "x")], conf)
+    CORE.add_job(_build_number_automations, var, config)
 
     if (unit_of_measurement := config.get(CONF_UNIT_OF_MEASUREMENT)) is not None:
         cg.add(var.traits.set_unit_of_measurement(unit_of_measurement))

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -888,6 +888,26 @@ async def build_filters(config):
     return await cg.build_registry_list(FILTER_REGISTRY, config)
 
 
+@coroutine_with_priority(CoroPriority.AUTOMATION)
+async def _build_sensor_automations(var, config):
+    for conf in config.get(CONF_ON_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(float, "x")], conf)
+    for conf in config.get(CONF_ON_RAW_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(float, "x")], conf)
+    for conf in config.get(CONF_ON_VALUE_RANGE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await cg.register_component(trigger, conf)
+        if (above := conf.get(CONF_ABOVE)) is not None:
+            template_ = await cg.templatable(above, [(float, "x")], float)
+            cg.add(trigger.set_min(template_))
+        if (below := conf.get(CONF_BELOW)) is not None:
+            template_ = await cg.templatable(below, [(float, "x")], float)
+            cg.add(trigger.set_max(template_))
+        await automation.build_automation(trigger, [(float, "x")], conf)
+
+
 async def setup_sensor_core_(var, config):
     await setup_entity(var, config, "sensor")
 
@@ -907,22 +927,7 @@ async def setup_sensor_core_(var, config):
         filters = await build_filters(config[CONF_FILTERS])
         cg.add(var.set_filters(filters))
 
-    for conf in config.get(CONF_ON_VALUE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(float, "x")], conf)
-    for conf in config.get(CONF_ON_RAW_VALUE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(float, "x")], conf)
-    for conf in config.get(CONF_ON_VALUE_RANGE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await cg.register_component(trigger, conf)
-        if (above := conf.get(CONF_ABOVE)) is not None:
-            template_ = await cg.templatable(above, [(float, "x")], float)
-            cg.add(trigger.set_min(template_))
-        if (below := conf.get(CONF_BELOW)) is not None:
-            template_ = await cg.templatable(below, [(float, "x")], float)
-            cg.add(trigger.set_max(template_))
-        await automation.build_automation(trigger, [(float, "x")], conf)
+    CORE.add_job(_build_sensor_automations, var, config)
 
     if (mqtt_id := config.get(CONF_MQTT_ID)) is not None:
         mqtt_ = cg.new_Pvariable(mqtt_id, var)

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -141,11 +141,8 @@ def switch_schema(
     return _SWITCH_SCHEMA.extend(schema)
 
 
-async def setup_switch_core_(var, config):
-    await setup_entity(var, config, "switch")
-
-    if (inverted := config.get(CONF_INVERTED)) is not None:
-        cg.add(var.set_inverted(inverted))
+@coroutine_with_priority(CoroPriority.AUTOMATION)
+async def _build_switch_automations(var, config):
     for conf in config.get(CONF_ON_STATE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [(bool, "x")], conf)
@@ -155,6 +152,15 @@ async def setup_switch_core_(var, config):
     for conf in config.get(CONF_ON_TURN_OFF, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)
+
+
+async def setup_switch_core_(var, config):
+    await setup_entity(var, config, "switch")
+
+    if (inverted := config.get(CONF_INVERTED)) is not None:
+        cg.add(var.set_inverted(inverted))
+
+    CORE.add_job(_build_switch_automations, var, config)
 
     if (mqtt_id := config.get(CONF_MQTT_ID)) is not None:
         mqtt_ = cg.new_Pvariable(mqtt_id, var)

--- a/esphome/components/text_sensor/__init__.py
+++ b/esphome/components/text_sensor/__init__.py
@@ -197,6 +197,17 @@ async def build_filters(config):
     return await cg.build_registry_list(FILTER_REGISTRY, config)
 
 
+@coroutine_with_priority(CoroPriority.AUTOMATION)
+async def _build_text_sensor_automations(var, config):
+    for conf in config.get(CONF_ON_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+    for conf in config.get(CONF_ON_RAW_VALUE, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
+
 async def setup_text_sensor_core_(var, config):
     await setup_entity(var, config, "text_sensor")
 
@@ -208,13 +219,7 @@ async def setup_text_sensor_core_(var, config):
         filters = await build_filters(config[CONF_FILTERS])
         cg.add(var.set_filters(filters))
 
-    for conf in config.get(CONF_ON_VALUE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
-
-    for conf in config.get(CONF_ON_RAW_VALUE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+    CORE.add_job(_build_text_sensor_automations, var, config)
 
     if (mqtt_id := config.get(CONF_MQTT_ID)) is not None:
         mqtt_ = cg.new_Pvariable(mqtt_id, var)


### PR DESCRIPTION
## What does this implement/fix?

Moves automation building (`on_value`, `on_state`, `on_press`, etc.) out of inline entity setup and into separate deferred jobs scheduled at `AUTOMATION` priority (30) instead of `CORE` priority (100).

This prevents codegen deadlocks when an automation on one entity references a sibling entity by ID. For example, a sensor `on_value` that calls `id(sibling_sensor)` would deadlock because `sensor.new_sensor()` processes automations before returning, and the sibling has not been registered yet.

By deferring automation processing, all entity variables are created and registered at CORE priority first. By the time automations run at AUTOMATION priority, all sibling IDs are resolvable.

Supersedes the component-specific fix in #14365 with a general solution that covers all entity types.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**


## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

The existing GPS test in `tests/components/gps/common.yaml` exercises this — `gps_lat` has an `on_value` that references `id(gps_long)`.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).