### PR TITLE
[core] Extract set_status_flag_ helper to deduplicate status_set methods

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -383,31 +383,30 @@ bool Component::is_idle() const { return (this->component_state_ & COMPONENT_STA
 bool Component::can_proceed() { return true; }
 bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
 bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
+bool Component::set_status_flag_(uint8_t flag) {
+  if ((this->component_state_ & flag) != 0)
+    return false;
+  this->component_state_ |= flag;
+  App.app_state_ |= flag;
+  return true;
+}
 
 void Component::status_set_warning(const char *message) {
-  // Don't spam the log. This risks missing different warning messages though.
-  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
+  if (!this->set_status_flag_(STATUS_LED_WARNING))
     return;
-  this->component_state_ |= STATUS_LED_WARNING;
-  App.app_state_ |= STATUS_LED_WARNING;
   ESP_LOGW(TAG, "%s set Warning flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? message : LOG_STR_LITERAL("unspecified"));
 }
 void Component::status_set_warning(const LogString *message) {
-  // Don't spam the log. This risks missing different warning messages though.
-  if ((this->component_state_ & STATUS_LED_WARNING) != 0)
+  if (!this->set_status_flag_(STATUS_LED_WARNING))
     return;
-  this->component_state_ |= STATUS_LED_WARNING;
-  App.app_state_ |= STATUS_LED_WARNING;
   ESP_LOGW(TAG, "%s set Warning flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
 }
 void Component::status_set_error() { this->status_set_error((const LogString *) nullptr); }
 void Component::status_set_error(const char *message) {
-  if ((this->component_state_ & STATUS_LED_ERROR) != 0)
+  if (!this->set_status_flag_(STATUS_LED_ERROR))
     return;
-  this->component_state_ |= STATUS_LED_ERROR;
-  App.app_state_ |= STATUS_LED_ERROR;
   ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? message : LOG_STR_LITERAL("unspecified"));
   if (message != nullptr) {
@@ -415,10 +414,8 @@ void Component::status_set_error(const char *message) {
   }
 }
 void Component::status_set_error(const LogString *message) {
-  if ((this->component_state_ & STATUS_LED_ERROR) != 0)
+  if (!this->set_status_flag_(STATUS_LED_ERROR))
     return;
-  this->component_state_ |= STATUS_LED_ERROR;
-  App.app_state_ |= STATUS_LED_ERROR;
   ESP_LOGE(TAG, "%s set Error flag: %s", LOG_STR_ARG(this->get_component_log_str()),
            message ? LOG_STR_ARG(message) : LOG_STR_LITERAL("unspecified"));
   if (message != nullptr) {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -299,6 +299,10 @@ class Component {
     this->component_state_ |= state;
   }
 
+  /// Helper to set a status LED flag on both this component and the app.
+  /// Returns true if the flag was newly set, false if it was already set.
+  bool set_status_flag_(uint8_t flag);
+
   /** Set an interval function with a unique name. Empty name means no cancelling possible.
    *
    * This will call f every interval ms. Can be cancelled via CancelInterval().

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -301,6 +301,8 @@ class Component {
 
   /// Helper to set a status LED flag on both this component and the app.
   /// Returns true if the flag was newly set, false if it was already set.
+  /// Note: Callers often use the return value to decide whether to log a warning/error,
+  /// so once a flag is set, subsequent (potentially different) messages may be suppressed.
   bool set_status_flag_(uint8_t flag);
 
   /** Set an interval function with a unique name. Empty name means no cancelling possible.


### PR DESCRIPTION
# What does this implement/fix?

Extract a `set_status_flag_()` helper that consolidates the repeated check-and-set pattern across `status_set_warning()` and `status_set_error()` overloads.

Each of the four overloads duplicated the same three lines:
1. Check if the flag is already set on `component_state_` → return early
2. Set the flag on `component_state_`
3. Set the flag on `App.app_state_`

The new protected helper returns `true` if the flag was newly set (caller should proceed to log), or `false` if already set (caller should return early). No behavioral change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes — internal refactoring only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).