### PR TITLE
[ld2450] Use integer dedup for direction text sensor updates

### DIFF
--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -528,10 +528,11 @@ void LD2450Component::handle_periodic_data_() {
     } else {
       direction = DIRECTION_STATIONARY;
     }
-    text_sensor::TextSensor *tsd = this->direction_text_sensors_[index];
-    const auto *dir_str = find_str(ld2450::DIRECTION_BY_UINT, direction);
-    if (tsd != nullptr && (!tsd->has_state() || tsd->get_state() != dir_str)) {
-      tsd->publish_state(dir_str);
+    if (this->direction_dedup_[index].next(direction)) {
+      text_sensor::TextSensor *tsd = this->direction_text_sensors_[index];
+      if (tsd != nullptr) {
+        tsd->publish_state(find_str(ld2450::DIRECTION_BY_UINT, direction));
+      }
     }
 #endif
 

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -194,7 +194,8 @@ class LD2450Component : public Component, public uart::UARTDevice {
   std::array<SensorWithDedup<uint8_t> *, MAX_ZONES> zone_moving_target_count_sensors_{};
 #endif
 #ifdef USE_TEXT_SENSOR
-  std::array<text_sensor::TextSensor *, 3> direction_text_sensors_{};
+  std::array<text_sensor::TextSensor *, MAX_TARGETS> direction_text_sensors_{};
+  std::array<Deduplicator<uint8_t>, MAX_TARGETS> direction_dedup_{};
 #endif
 
   LazyCallbackManager<void()> data_callback_;


### PR DESCRIPTION
# What does this implement/fix?

Replace per-frame string comparison with `Deduplicator<uint8_t>` on the direction enum value for text sensor updates.

The previous code called `get_state()` and compared `std::string` against `const char*` on every periodic data frame for each target (~75 comparisons/sec at 25 fps × 3 targets). The new approach does a single `uint8_t` comparison via the existing `Deduplicator` and only looks up the direction string and publishes when the direction actually changes.

Also uses `MAX_TARGETS` instead of hardcoded `3` for the `direction_text_sensors_` array size for consistency with all other sensor arrays in the class.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal optimization only
ld2450:
  uart_id: my_uart
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).