### PR TITLE
[uart] Enable wake-on-RX by default on ESP32

### DIFF
--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from logging import getLogger
 import math
 import re
@@ -115,38 +114,6 @@ UARTDebugger = uart_ns.class_("UARTDebugger", cg.Component, automation.Action)
 UARTDummyReceiver = uart_ns.class_("UARTDummyReceiver", cg.Component)
 MULTI_CONF = True
 MULTI_CONF_NO_DEFAULT = True
-
-
-@dataclass
-class UARTData:
-    """State data for UART component configuration generation."""
-
-    wake_loop_on_rx: bool = False
-
-
-def _get_data() -> UARTData:
-    """Get UART component data from CORE.data."""
-    if DOMAIN not in CORE.data:
-        CORE.data[DOMAIN] = UARTData()
-    return CORE.data[DOMAIN]
-
-
-def request_wake_loop_on_rx() -> None:
-    """Request that the UART wake the main loop when data is received.
-
-    Components that need low-latency notification of incoming UART data
-    should call this function during their code generation.
-    This enables the RX event task which wakes the main loop when data arrives.
-    """
-    data = _get_data()
-    if not data.wake_loop_on_rx:
-        data.wake_loop_on_rx = True
-
-        # UART RX event task uses wake_loop_threadsafe() to notify the main loop
-        # Automatically enable the socket wake infrastructure when RX wake is requested
-        from esphome.components import socket
-
-        socket.require_wake_loop_threadsafe()
 
 
 def validate_raw_data(value):
@@ -542,7 +509,13 @@ async def uart_write_to_code(config, action_id, template_arg, args):
 @coroutine_with_priority(CoroPriority.FINAL)
 async def final_step():
     """Final code generation step to configure optional UART features."""
-    if _get_data().wake_loop_on_rx:
+    if CORE.is_esp32:
+        # Wake-on-RX is essentially free on ESP32 (just an ISR function pointer
+        # registration) — enable by default to reduce RX buffer overflow risk
+        # by waking the main loop immediately when data arrives.
+        from esphome.components import socket
+
+        socket.require_wake_loop_threadsafe()
         cg.add_define("USE_UART_WAKE_LOOP_ON_RX")
 
 

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -509,10 +509,11 @@ async def uart_write_to_code(config, action_id, template_arg, args):
 @coroutine_with_priority(CoroPriority.FINAL)
 async def final_step():
     """Final code generation step to configure optional UART features."""
-    if CORE.is_esp32:
+    if CORE.is_esp32 and CORE.has_networking:
         # Wake-on-RX is essentially free on ESP32 (just an ISR function pointer
         # registration) — enable by default to reduce RX buffer overflow risk
         # by waking the main loop immediately when data arrives.
+        # Requires networking for the wake_loop_isrsafe() infrastructure.
         from esphome.components import socket
 
         socket.require_wake_loop_threadsafe()

--- a/esphome/components/zwave_proxy/__init__.py
+++ b/esphome/components/zwave_proxy/__init__.py
@@ -41,6 +41,3 @@ async def to_code(config):
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
     cg.add_define("USE_ZWAVE_PROXY")
-
-    # Request UART to wake the main loop when data arrives for low-latency processing
-    uart.request_wake_loop_on_rx()


### PR DESCRIPTION
# What does this implement/fix?

Enables UART wake-on-RX by default for all ESP32 UART instances.

Now that #14382 replaced the expensive FreeRTOS task+queue mechanism with a near-zero-cost ISR callback (just a function pointer registration — no task, no queue, no stack allocation), there's no reason to keep wake-on-RX as opt-in.

**Before:** Components had to explicitly call `uart.request_wake_loop_on_rx()` to enable wake-on-RX (~3.9KB heap cost made opt-in necessary).
**After:** All ESP32 UART instances get wake-on-RX automatically at essentially zero cost. The main loop wakes immediately when UART data arrives instead of waiting for the ~16ms select timeout, reducing RX buffer overflow risk for all UART components.

Changes:
- `final_step()` now unconditionally enables `USE_UART_WAKE_LOOP_ON_RX` on ESP32
- Removed `request_wake_loop_on_rx()`, `UARTData`, and `_get_data()` — no longer needed
- Removed the `zwave_proxy` call to `request_wake_loop_on_rx()` (was the only caller)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Follow-up to #14382

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — wake-on-RX is now automatically enabled
# for all ESP32 UART instances.
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).