### PR TITLE
[core] Deduplicate ControllerRegistry notify dispatch loop

### DIFF
--- a/esphome/core/controller_registry.cpp
+++ b/esphome/core/controller_registry.cpp
@@ -10,20 +10,23 @@ StaticVector<Controller *, CONTROLLER_REGISTRY_MAX> ControllerRegistry::controll
 
 void ControllerRegistry::register_controller(Controller *controller) { controllers.push_back(controller); }
 
+void ControllerRegistry::notify(void *obj, DispatchFunc dispatch) {
+  for (auto *controller : controllers) {
+    dispatch(controller, obj);
+  }
+}
+
 // Macro for standard registry notification dispatch - calls on_<entity_name>_update()
+// Each wrapper passes a small trampoline lambda that calls the correct virtual method.
 #define CONTROLLER_REGISTRY_NOTIFY(entity_type, entity_name) \
   void ControllerRegistry::notify_##entity_name##_update(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
-    for (auto *controller : controllers) { \
-      controller->on_##entity_name##_update(obj); \
-    } \
+    notify(obj, [](Controller *c, void *o) { c->on_##entity_name##_update(static_cast<entity_type *>(o)); }); \
   }
 
 // Macro for entities where controller method has no "_update" suffix (Event, Update)
 #define CONTROLLER_REGISTRY_NOTIFY_NO_UPDATE_SUFFIX(entity_type, entity_name) \
   void ControllerRegistry::notify_##entity_name(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
-    for (auto *controller : controllers) { \
-      controller->on_##entity_name(obj); \
-    } \
+    notify(obj, [](Controller *c, void *o) { c->on_##entity_name(static_cast<entity_type *>(o)); }); \
   }
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/core/controller_registry.cpp
+++ b/esphome/core/controller_registry.cpp
@@ -18,16 +18,18 @@ void ControllerRegistry::notify(void *obj, DispatchFunc dispatch) {
 
 // Macro for standard registry notification dispatch - calls on_<entity_name>_update()
 // Each wrapper passes a small trampoline lambda that calls the correct virtual method.
+// NOLINTBEGIN(bugprone-macro-parentheses)
 #define CONTROLLER_REGISTRY_NOTIFY(entity_type, entity_name) \
-  void ControllerRegistry::notify_##entity_name##_update(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
+  void ControllerRegistry::notify_##entity_name##_update(entity_type *obj) { \
     notify(obj, [](Controller *c, void *o) { c->on_##entity_name##_update(static_cast<entity_type *>(o)); }); \
   }
 
 // Macro for entities where controller method has no "_update" suffix (Event, Update)
 #define CONTROLLER_REGISTRY_NOTIFY_NO_UPDATE_SUFFIX(entity_type, entity_name) \
-  void ControllerRegistry::notify_##entity_name(entity_type *obj) { /* NOLINT(bugprone-macro-parentheses) */ \
+  void ControllerRegistry::notify_##entity_name(entity_type *obj) { \
     notify(obj, [](Controller *c, void *o) { c->on_##entity_name(static_cast<entity_type *>(o)); }); \
   }
+// NOLINTEND(bugprone-macro-parentheses)
 
 #ifdef USE_BINARY_SENSOR
 CONTROLLER_REGISTRY_NOTIFY(binary_sensor::BinarySensor, binary_sensor)

--- a/esphome/core/controller_registry.h
+++ b/esphome/core/controller_registry.h
@@ -162,21 +162,6 @@ class ControllerRegistry {
    */
   static void register_controller(Controller *controller);
 
-  /** Type-erased dispatch function pointer.
-   *
-   * Each notify method passes a small trampoline that calls the
-   * correct virtual method on Controller. The shared notify() loop
-   * iterates controllers once, calling the trampoline for each.
-   */
-  using DispatchFunc = void (*)(Controller *, void *);
-
-  /** Shared dispatch loop - iterates controllers and calls dispatch for each.
-   *
-   * Marked noinline to ensure only one copy of the loop exists in flash,
-   * rather than being duplicated into each notify_*_update wrapper.
-   */
-  static void __attribute__((noinline)) notify(void *obj, DispatchFunc dispatch);
-
 #ifdef USE_BINARY_SENSOR
   static void notify_binary_sensor_update(binary_sensor::BinarySensor *obj);
 #endif
@@ -262,6 +247,21 @@ class ControllerRegistry {
 #endif
 
  protected:
+  /** Type-erased dispatch function pointer.
+   *
+   * Each notify method passes a small trampoline that calls the
+   * correct virtual method on Controller. The shared notify() loop
+   * iterates controllers once, calling the trampoline for each.
+   */
+  using DispatchFunc = void (*)(Controller *, void *);
+
+  /** Shared dispatch loop - iterates controllers and calls dispatch for each.
+   *
+   * Marked noinline to ensure only one copy of the loop exists in flash,
+   * rather than being duplicated into each notify_*_update wrapper.
+   */
+  static void __attribute__((noinline)) notify(void *obj, DispatchFunc dispatch);
+
   static StaticVector<Controller *, CONTROLLER_REGISTRY_MAX> controllers;
 };
 

--- a/esphome/core/controller_registry.h
+++ b/esphome/core/controller_registry.h
@@ -162,6 +162,21 @@ class ControllerRegistry {
    */
   static void register_controller(Controller *controller);
 
+  /** Type-erased dispatch function pointer.
+   *
+   * Each notify method passes a small trampoline that calls the
+   * correct virtual method on Controller. The shared notify() loop
+   * iterates controllers once, calling the trampoline for each.
+   */
+  using DispatchFunc = void (*)(Controller *, void *);
+
+  /** Shared dispatch loop - iterates controllers and calls dispatch for each.
+   *
+   * Marked noinline to ensure only one copy of the loop exists in flash,
+   * rather than being duplicated into each notify_*_update wrapper.
+   */
+  static void __attribute__((noinline)) notify(void *obj, DispatchFunc dispatch);
+
 #ifdef USE_BINARY_SENSOR
   static void notify_binary_sensor_update(binary_sensor::BinarySensor *obj);
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Each `ControllerRegistry::notify_*_update()` method contained an identical loop that only differed in the vtable offset for the virtual call into `Controller`. This extracts the shared loop into a single `noinline` `notify()` function. Each wrapper now passes a small captureless lambda trampoline that dispatches to the correct `Controller` virtual method.

The compiler emits each trampoline as 3 instructions (load vtable, index slot, tail-jump) and each wrapper as a tail-call to the shared loop with the trampoline pointer.

**Before:** 8 copies of the loop at ~56 bytes each = ~448 bytes
**After:** 1 shared loop (56 B) + 8 wrappers (16 B each) + 8 trampolines (8 B each) = ~248 bytes

Saves ~200 bytes of flash (verified on ESP8266 build: 485,345 → 485,153 = -192 bytes).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).