### PR TITLE
[lps22] Add support for the LPS22DF variant

### DIFF
--- a/esphome/components/lps22/lps22.cpp
+++ b/esphome/components/lps22/lps22.cpp
@@ -8,6 +8,7 @@ static constexpr const char *const TAG = "lps22";
 static constexpr uint8_t WHO_AM_I = 0x0F;
 static constexpr uint8_t LPS22HB_ID = 0xB1;
 static constexpr uint8_t LPS22HH_ID = 0xB3;
+static constexpr uint8_t LPS22DF_ID = 0xB4;
 static constexpr uint8_t CTRL_REG2 = 0x11;
 static constexpr uint8_t CTRL_REG2_ONE_SHOT_MASK = 0b1;
 static constexpr uint8_t STATUS = 0x27;
@@ -24,8 +25,8 @@ static constexpr float TEMPERATURE_SCALE = 0.01f;
 void LPS22Component::setup() {
   uint8_t value = 0x00;
   this->read_register(WHO_AM_I, &value, 1);
-  if (value != LPS22HB_ID && value != LPS22HH_ID) {
-    ESP_LOGW(TAG, "device IDs as %02x, which isn't a known LPS22HB or LPS22HH ID", value);
+  if (value != LPS22HB_ID && value != LPS22HH_ID && value != LPS22DF_ID) {
+    ESP_LOGW(TAG, "device IDs as %02x, which isn't a known LPS22HB/HH/DF ID", value);
     this->mark_failed();
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Adds support for the DF variants of the LPS22 family of pressure sensors

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6189

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A (no change necessary)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).