### PR TITLE
[openthread] Disable default enabled OT diag code

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -53,6 +53,9 @@ def set_sdkconfig_options(config):
     # There is a conflict if the logger's uart also uses the default UART, which is seen as a watchdog failure on "ot_cli"
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_CLI", False)
 
+    # Diag unused, if needed for lab/cert/etc tests then enable separately
+    add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DIAG", False)
+
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_ENABLED", True)
 
     if tlv := config.get(CONF_TLV):


### PR DESCRIPTION
# What does this implement/fix?

Noticed in generated sdkconfig following section when openthread component was enabled:

```
CONFIG_OPENTHREAD_DIAG=y
```

So openthread diag code is being built, although diag function is not explicitly requested in 'openthread`/`openthread_info` module, and IMHO never used. Diag API is IMHO more intended for lowlevel tests (MAC, radio) circumventing the regular highlevel OT API, e.g. lab tests, certification tests, etc.

## Rationale

Relates to IDF `components/openthread/Kconfig`, which default enables OT diag.

## Impact

Local flash size increase due to unneeded code seemed to be ca 1.5kB in a real OT project, but also in belowcited minimal OT sample YAML.

CI M.I.A.: Backs same local measurements of ~1.5kB flash reduction.

## Back compatibility

Some custom lambda might theoretically already call OT diag C API for own purposes.

If such, it would be better for that one to enable config define `CONFIG_OPENTHREAD_DIAG` in its build. Regular ESPHome users will not be aware to disable diag. However, marked as undocumented C++ API change to denote this.

## Outlook

There are even other IDF sdkconfig candidates for reducing OT stack footprint. Locally stabletesting OT firmwares with following additional sdkconfig overrides:

```yaml
esp32:
  framework:
    sdkconfig_options:
      CONFIG_OPENTHREAD_PARENT_SEARCH_MTD: n # If only 1 parent...
      
      CONFIG_OPENTHREAD_DNS_CLIENT: n # only internal HA OTBR traffic
      CONFIG_OPENTHREAD_DNS64_CLIENT: n
```
Which seems to reduce flash footprint by further ~6kB.

But latter likely would need to be controlled by some new (backcompat default enabled) `CONF` key, as they may be needed by some OT setups.
**--> Separate PR/topic**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [X] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: openthread

esp32:
  variant: esp32c6

network:
  enable_ipv6: true

openthread:
  tlv: ""  # Required, but irrelevant for sample
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
