### PR TITLE
[uart] Fix flow_control_pin inverted flag ignored on ESP-IDF

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -193,6 +193,9 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != nullptr && this->rx_pin_->is_inverted()) {
     invert |= UART_SIGNAL_RXD_INV;
   }
+  if (this->flow_control_pin_ != nullptr && this->flow_control_pin_->is_inverted()) {
+    invert |= UART_SIGNAL_RTS_INV;
+  }
 
   err = uart_set_line_inverse(this->uart_num_, invert);
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

The `inverted: true` setting on `flow_control_pin` in the UART component has no effect on ESP-IDF. The pin is always active-high regardless of the setting. The schema accepts the flag (via `internal_gpio_output_pin_schema`) but the C++ code never checks it.

This adds the missing `UART_SIGNAL_RTS_INV` check for the flow control pin, matching the existing TX/RX inversion pattern. When `flow_control_pin` is set, the driver uses `UART_MODE_RS485_HALF_DUPLEX` mode, where ESP-IDF uses the RTS pin as the RS485 direction control signal. `UART_SIGNAL_RTS_INV` inverts that signal's polarity.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14401

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation change needed — existing config option now works as documented)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 9600
  flow_control_pin:
    number: GPIO4
    inverted: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).