### PR TITLE
[core] Fix compile-time loop() detection for multiple inheritance

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -120,9 +120,9 @@ namespace esphome {
 
 /// SFINAE helper: resolves to true when &T::loop compiles and differs from &Component::loop.
 /// Falls back to true when &T::loop is ambiguous (e.g. multiple inheritance with separate loop() methods).
-template<typename T, typename = void> struct has_loop_override : std::true_type {};
+template<typename T, typename = void> struct HasLoopOverride : std::true_type {};
 template<typename T>
-struct has_loop_override<T, std::void_t<decltype(&T::loop)>>
+struct HasLoopOverride<T, std::void_t<decltype(&T::loop)>>
     : std::bool_constant<!std::is_same_v<decltype(&T::loop), decltype(&Component::loop)>> {};
 
 // Teardown timeout constant (in milliseconds)
@@ -551,9 +551,9 @@ class Application {
 #endif
 
   /// Register a component, detecting loop() override at compile time.
-  /// Uses has_loop_override<T> which handles ambiguous &T::loop from multiple inheritance.
+  /// Uses HasLoopOverride<T> which handles ambiguous &T::loop from multiple inheritance.
   template<typename T> void register_component_(T *comp) {
-    this->register_component_impl_(comp, has_loop_override<T>::value);
+    this->register_component_impl_(comp, HasLoopOverride<T>::value);
   }
 
   void register_component_impl_(Component *comp, bool has_loop);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -118,6 +118,13 @@ void original_setup();  // NOLINT(readability-redundant-declaration) - used by c
 
 namespace esphome {
 
+/// SFINAE helper: resolves to true when &T::loop compiles and differs from &Component::loop.
+/// Falls back to true when &T::loop is ambiguous (e.g. multiple inheritance with separate loop() methods).
+template<typename T, typename = void> struct has_loop_override : std::true_type {};
+template<typename T>
+struct has_loop_override<T, std::void_t<decltype(&T::loop)>>
+    : std::bool_constant<!std::is_same_v<decltype(&T::loop), decltype(&Component::loop)>> {};
+
 // Teardown timeout constant (in milliseconds)
 // For reboots, it's more important to shut down quickly than disconnect cleanly
 // since we're not entering deep sleep. The only consequence of not shutting down
@@ -544,10 +551,9 @@ class Application {
 #endif
 
   /// Register a component, detecting loop() override at compile time.
-  /// The template resolves &T::loop vs &Component::loop as a constexpr bool
-  /// and forwards it to register_component_impl_ which stores it in component_state_.
+  /// Uses has_loop_override<T> which handles ambiguous &T::loop from multiple inheritance.
   template<typename T> void register_component_(T *comp) {
-    this->register_component_impl_(comp, !std::is_same_v<decltype(&T::loop), decltype(&Component::loop)>);
+    this->register_component_impl_(comp, has_loop_override<T>::value);
   }
 
   void register_component_impl_(Component *comp, bool has_loop);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -118,8 +118,9 @@ void original_setup();  // NOLINT(readability-redundant-declaration) - used by c
 
 namespace esphome {
 
-/// SFINAE helper: resolves to true when &T::loop compiles and differs from &Component::loop.
-/// Falls back to true when &T::loop is ambiguous (e.g. multiple inheritance with separate loop() methods).
+/// SFINAE helper: detects whether T overrides Component::loop().
+/// When &T::loop is ambiguous (multiple inheritance with separate loop() methods),
+/// the ambiguity itself proves an override exists, so the true_type default is correct.
 template<typename T, typename = void> struct HasLoopOverride : std::true_type {};
 template<typename T>
 struct HasLoopOverride<T, std::void_t<decltype(&T::loop)>>

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -517,10 +517,10 @@ async def _add_looping_components() -> None:
         return
 
     # Build constexpr sum for the exact count, deduplicating by type
-    # Uses has_loop_override<T> which handles ambiguous &T::loop from multiple inheritance
+    # Uses HasLoopOverride<T> which handles ambiguous &T::loop from multiple inheritance
     type_counts = Counter(entries)
     terms = [
-        f"({count} * has_loop_override<{cpp_type}>::value)"
+        f"({count} * HasLoopOverride<{cpp_type}>::value)"
         for cpp_type, count in type_counts.items()
     ]
     constexpr_expr = " + \\\n  ".join(terms)

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -517,9 +517,10 @@ async def _add_looping_components() -> None:
         return
 
     # Build constexpr sum for the exact count, deduplicating by type
+    # Uses has_loop_override<T> which handles ambiguous &T::loop from multiple inheritance
     type_counts = Counter(entries)
     terms = [
-        f"({count} * !std::is_same_v<decltype(&{cpp_type}::loop), decltype(&Component::loop)>)"
+        f"({count} * has_loop_override<{cpp_type}>::value)"
         for cpp_type, count in type_counts.items()
     ]
     constexpr_expr = " + \\\n  ".join(terms)


### PR DESCRIPTION
# What does this implement/fix?

The compile-time `loop()` override detection introduced in #14405 uses `decltype(&T::loop)` to check whether a component overrides `loop()`. This fails to compile when a component inherits from both `Component` (via `PollingComponent`) and `BLEClientNode`, since both independently define `loop()` methods, making the `decltype` expression ambiguous.

Affected components include `AirthingsWaveMini`, `AirthingsWavePlus`, `Alpha3`, `Am43`, `RadonEyeRD200`, `BLEClientRSSISensor`, and others that inherit from both `PollingComponent` and `BLEClientNode`.

The fix adds a SFINAE-based `HasLoopOverride<T>` trait. When `decltype(&T::loop)` is well-formed, it checks whether the type differs from `&Component::loop`. When `decltype(&T::loop)` is ill-formed due to ambiguity from multiple inheritance, the primary template returns `true` — this is not merely conservative but correct: the ambiguity itself proves that a non-`Component` `loop()` exists in the hierarchy, so the component must be treated as having a loop override.

Both `register_component_()` in `application.h` and the generated `ESPHOME_LOOPING_COMPONENT_COUNT` constexpr in `config.py` are updated to use this trait.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes compilation failure introduced by #14405 when BLE components are combined

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal fix, no user-facing changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes compilation of existing BLE component configurations
# Tested with 40 BLE components combined in a single build:
# airthings_wave_mini, airthings_wave_plus, alpha3, am43, anova,
# atc_mithermometer, b_parasite, bedjet, ble_client, ble_presence,
# ble_rssi, ble_scanner, bthome_mithermometer, esp32_ble, esp32_ble_beacon,
# esp32_ble_client, esp32_ble_server, esp32_ble_tracker, etc.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).