### PR TITLE
[ci] Skip PR title check for dependabot PRs

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -26,14 +26,19 @@ jobs:
             } = require('./.github/scripts/detect-tags.js');
 
             const title = context.payload.pull_request.title;
+            const author = context.payload.pull_request.user.login;
+
+            // Skip bot PRs (e.g. dependabot) - they have their own title format
+            if (author === 'dependabot[bot]') {
+              return;
+            }
 
             // Block titles starting with "word:" or "word(scope):" patterns
             const commitStylePattern = /^\w+(\(.*?\))?[!]?\s*:/;
             if (commitStylePattern.test(title)) {
               core.setFailed(
                 `PR title should not start with a "prefix:" style format.\n` +
-                `Please use the format: [component] Brief description\n` +
-                `Example: [pn532] Add health checking and auto-reset`
+                `Please use the format: [component] Brief description\n`
               );
               return;
             }


### PR DESCRIPTION
# What does this implement/fix?

The PR title check workflow (#14345) fails on dependabot PRs because their titles use "Bump X from Y to Z" format which doesn't match the `[tag]` prefix requirement. Skip the check entirely for `dependabot[bot]` authored PRs. Also remove the example line from the commit-style error message.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).