### PR TITLE
[wifi] Revert cyw43_wifi_link_status change for RP2040

### DIFF
--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -116,12 +116,7 @@ const char *get_disconnect_reason_str(uint8_t reason) {
 }
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
-  // Use cyw43_wifi_link_status instead of cyw43_tcpip_link_status because the Arduino
-  // framework's __wrap_cyw43_cb_tcpip_init is a no-op — the SDK's internal netif
-  // (cyw43_state.netif[]) is never initialized. cyw43_tcpip_link_status checks that netif's
-  // flags and would only fall through to cyw43_wifi_link_status when the flags aren't set.
-  // Using cyw43_wifi_link_status directly gives us the actual WiFi radio join state.
-  int status = cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA);
+  int status = cyw43_tcpip_link_status(&cyw43_state, CYW43_ITF_STA);
   switch (status) {
     case CYW43_LINK_JOIN:
     case CYW43_LINK_NOIP:


### PR DESCRIPTION
# What does this implement/fix?

Reverts the switch from `cyw43_tcpip_link_status` to `cyw43_wifi_link_status` in the RP2040 WiFi status detection that was accidentally included in 2026.2.3.

This change was needed for https://github.com/esphome/esphome/pull/14328 (arduino-pico 5.5.0 framework update targeting 2026.3.0) but ended up in #14359 due to merge conflicts.

With the current framework (3.9.4), `cyw43_wifi_link_status` never returns `CYW43_LINK_UP`, so the `CONNECTED` state is unreachable. The device connects to WiFi but the status stays at `CONNECTING` until timeout, causing a connect/disconnect loop with "Unknown connection status 0" in the logs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14422

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).