### PR TITLE
[core] Inline trivial Component state accessors

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -233,7 +233,6 @@ void Component::call_dump_config_() {
   }
 }
 
-uint8_t Component::get_component_state() const { return this->component_state_; }
 void Component::call() {
   uint8_t state = this->component_state_ & COMPONENT_STATE_MASK;
   switch (state) {
@@ -339,9 +338,6 @@ void Component::reset_to_construction_state() {
     this->status_clear_error();
   }
 }
-bool Component::is_in_loop_state() const {
-  return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP;
-}
 void Component::defer(std::function<void()> &&f) {  // NOLINT
   App.scheduler.set_timeout(this, static_cast<const char *>(nullptr), 0, std::move(f));
 }
@@ -380,16 +376,12 @@ void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std:
   App.scheduler.set_retry(this, "", initial_wait_time, max_attempts, std::move(f), backoff_increase_factor);
 #pragma GCC diagnostic pop
 }
-bool Component::is_failed() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 bool Component::is_ready() const {
   return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP ||
          (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE ||
          (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_SETUP;
 }
-bool Component::is_idle() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE; }
 bool Component::can_proceed() { return true; }
-bool Component::status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
-bool Component::status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
 bool Component::set_status_flag_(uint8_t flag) {
   if ((this->component_state_ & flag) != 0)
     return false;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -142,7 +142,7 @@ class Component {
    */
   virtual void on_powerdown() {}
 
-  uint8_t get_component_state() const;
+  uint8_t get_component_state() const { return this->component_state_; }
 
   /** Reset this component back to the construction state to allow setup to run again.
    *
@@ -154,7 +154,7 @@ class Component {
    *
    * @return True if in loop state, false otherwise.
    */
-  bool is_in_loop_state() const;
+  bool is_in_loop_state() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP; }
 
   /** Check if this component is idle.
    * Being idle means being in LOOP_DONE state.
@@ -162,7 +162,7 @@ class Component {
    *
    * @return True if the component is idle
    */
-  bool is_idle() const;
+  bool is_idle() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE; }
 
   /** Mark this component as failed. Any future timeouts/intervals/setup/loop will no longer be called.
    *
@@ -230,15 +230,15 @@ class Component {
    */
   void enable_loop_soon_any_context();
 
-  bool is_failed() const;
+  bool is_failed() const { return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_FAILED; }
 
   bool is_ready() const;
 
   virtual bool can_proceed();
 
-  bool status_has_warning() const;
+  bool status_has_warning() const { return this->component_state_ & STATUS_LED_WARNING; }
 
-  bool status_has_error() const;
+  bool status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
 
   void status_set_warning(const char *message = nullptr);
   void status_set_warning(const LogString *message);


### PR DESCRIPTION
# What does this implement/fix?

Move trivial `component_state_` accessors from out-of-line definitions in `component.cpp` to inline definitions in the header. These are all single-expression field reads that the compiler can inline at call sites, eliminating function call overhead.

Most notably, `get_component_state()` is called per-component per-loop iteration in `Application::loop()`, where the out-of-line call was pure overhead for a single byte load.

Inlined methods:
- `get_component_state()` — `return this->component_state_;`
- `is_in_loop_state()` — `(component_state_ & MASK) == LOOP`
- `is_idle()` — `(component_state_ & MASK) == LOOP_DONE`
- `is_failed()` — `(component_state_ & MASK) == FAILED`
- `status_has_warning()` — `component_state_ & WARNING`
- `status_has_error()` — `component_state_ & ERROR`

Kept out-of-line: `is_ready()` (3-way OR, larger body)

Measured flash savings: -48 to -56 bytes depending on config.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).