### PR TITLE
[usb_uart] Don't claim interrupt interface for ch34x

### DIFF
--- a/esphome/components/usb_uart/ch34x.cpp
+++ b/esphome/components/usb_uart/ch34x.cpp
@@ -75,6 +75,15 @@ void USBUartTypeCH34X::enable_channels() {
   }
   this->start_channels();
 }
+
+std::vector<CdcEps> USBUartTypeCH34X::parse_descriptors(usb_device_handle_t dev_hdl) {
+  auto result = USBUartTypeCdcAcm::parse_descriptors(dev_hdl);
+  // ch34x doesn't use the interrupt endpoint, and we don't have endpoints to spare
+  for (auto &cdc_dev : result) {
+    cdc_dev.interrupt_interface_number = 0xFF;
+  }
+  return result;
+}
 }  // namespace esphome::usb_uart
 
 #endif  // USE_ESP32_VARIANT_ESP32P4 || USE_ESP32_VARIANT_ESP32S2 || USE_ESP32_VARIANT_ESP32S3

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -20,6 +20,7 @@ static optional<CdcEps> get_cdc(const usb_config_desc_t *config_desc, uint8_t in
   // look for an interface with an interrupt endpoint (notify), and one with two bulk endpoints (data in/out)
   CdcEps eps{};
   eps.bulk_interface_number = 0xFF;
+  eps.interrupt_interface_number = 0xFF;
   for (;;) {
     const auto *intf_desc = usb_parse_interface_descriptor(config_desc, intf_idx++, 0, &conf_offset);
     if (!intf_desc) {
@@ -130,7 +131,7 @@ size_t RingBuffer::pop(uint8_t *data, size_t len) {
 }
 void USBUartChannel::write_array(const uint8_t *data, size_t len) {
   if (!this->initialised_.load()) {
-    ESP_LOGV(TAG, "Channel not initialised - write ignored");
+    ESP_LOGD(TAG, "Channel not initialised - write ignored");
     return;
   }
 #ifdef USE_UART_DEBUGGER
@@ -415,14 +416,15 @@ void USBUartTypeCdcAcm::on_connected() {
     // Claim the communication (interrupt) interface so CDC class requests are accepted
     // by the device. Some CDC ACM implementations (e.g. EFR32 NCP) require this before
     // they enable data flow on the bulk endpoints.
-    if (channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
+    if (channel->cdc_dev_.interrupt_interface_number != 0xFF &&
+        channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
       auto err_comm = usb_host_interface_claim(this->handle_, this->device_handle_,
                                                channel->cdc_dev_.interrupt_interface_number, 0);
       if (err_comm != ESP_OK) {
         ESP_LOGW(TAG, "Could not claim comm interface %d: %s", channel->cdc_dev_.interrupt_interface_number,
                  esp_err_to_name(err_comm));
+        channel->cdc_dev_.interrupt_interface_number = 0xFF;  // Mark as unavailable, but continue anyway
       } else {
-        channel->cdc_dev_.comm_interface_claimed = true;
         ESP_LOGD(TAG, "Claimed comm interface %d", channel->cdc_dev_.interrupt_interface_number);
       }
     }
@@ -436,6 +438,7 @@ void USBUartTypeCdcAcm::on_connected() {
       return;
     }
   }
+  this->status_clear_error();
   this->enable_channels();
 }
 
@@ -453,9 +456,10 @@ void USBUartTypeCdcAcm::on_disconnected() {
       usb_host_endpoint_halt(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
       usb_host_endpoint_flush(this->device_handle_, channel->cdc_dev_.notify_ep->bEndpointAddress);
     }
-    if (channel->cdc_dev_.comm_interface_claimed) {
+    if (channel->cdc_dev_.interrupt_interface_number != 0xFF &&
+        channel->cdc_dev_.interrupt_interface_number != channel->cdc_dev_.bulk_interface_number) {
       usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.interrupt_interface_number);
-      channel->cdc_dev_.comm_interface_claimed = false;
+      channel->cdc_dev_.interrupt_interface_number = 0xFF;
     }
     usb_host_interface_release(this->handle_, this->device_handle_, channel->cdc_dev_.bulk_interface_number);
     // Reset the input and output started flags to their initial state to avoid the possibility of spurious restarts

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -32,7 +32,6 @@ struct CdcEps {
   const usb_ep_desc_t *out_ep;
   uint8_t bulk_interface_number;
   uint8_t interrupt_interface_number;
-  bool comm_interface_claimed{false};
 };
 
 enum UARTParityOptions {
@@ -192,6 +191,7 @@ class USBUartTypeCH34X : public USBUartTypeCdcAcm {
 
  protected:
   void enable_channels() override;
+  std::vector<CdcEps> parse_descriptors(usb_device_handle_t dev_hdl) override;
 };
 
 }  // namespace esphome::usb_uart


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Recent PR claims an additional endpoint in USB-UART devices for control purposes; this breaks ch34x multi-channel units because there are no endpoints to spare, and the ch34x doesn't use the interrupt endpoint.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
