### PR TITLE
[media_source] Clarify threading contract

### DIFF
--- a/esphome/components/media_source/media_source.h
+++ b/esphome/components/media_source/media_source.h
@@ -67,11 +67,13 @@ class MediaSource {
   /// @brief Start playing the given URI
   /// Sources should validate the URI and state, returning false if the source is busy.
   /// The orchestrator is responsible for stopping active sources before starting a new one.
+  /// @note Must only be called from the main loop.
   /// @param uri URI to play; e.g., "http://stream_url"
   /// @return true if playback started successfully, false otherwise
   virtual bool play_uri(const std::string &uri) = 0;
 
-  /// @brief Handle playback commands (pause, stop, next, etc.)
+  /// @brief Handle playback commands; e.g., pause, stop, next, etc.
+  /// @note Must only be called from the main loop.
   /// @param command Command to execute
   virtual void handle_command(MediaSourceCommand command) = 0;
 
@@ -81,7 +83,8 @@ class MediaSource {
 
   // === State Access ===
 
-  /// @brief Get current playback state (must only be called from the main loop)
+  /// @brief Get current playback state
+  /// @note Must only be called from the main loop.
   /// @return Current state of this source
   MediaSourceState get_state() const { return this->state_; }
 
@@ -136,9 +139,10 @@ class MediaSource {
   virtual void notify_audio_played(uint32_t frames, int64_t timestamp) {}
 
  protected:
-  /// @brief Update state and notify listener (must only be called from the main loop)
+  /// @brief Update state and notify listener
   /// This is the only way to change state_, ensuring listener notifications always fire.
   /// Sources running FreeRTOS tasks should signal via event groups and call this from loop().
+  /// @note Must only be called from the main loop.
   /// @param state New state to set
   void set_state_(MediaSourceState state) {
     if (this->state_ != state) {


### PR DESCRIPTION
# What does this implement/fix?

- Clarifies the thread-safety contract documentation: ``play_uri`` and ``handle_command`` should only be called from the main loop thread. 
- Updates the description for ``get_state`` and ``set_state_`` to follow the same consistent `@note` docstring style.

(I realized this was unspecified when working on finishing up the specific media source implementation and source media player PRs. It was something I was already doing, I just didn't specify it directly)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable
```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
