### PR TITLE
[globals] Fix handling of string booleans in yaml

### DIFF
--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -51,7 +51,7 @@ _RESTORING_SCHEMA = cv.Schema(
 
 def _globals_schema(config: ConfigType) -> ConfigType:
     """Select schema based on restore_value setting."""
-    if config.get(CONF_RESTORE_VALUE, False):
+    if cv.boolean(config.get(CONF_RESTORE_VALUE, False)):
         return _RESTORING_SCHEMA(config)
     return _NON_RESTORING_SCHEMA(config)
 

--- a/tests/components/globals/common.yaml
+++ b/tests/components/globals/common.yaml
@@ -27,3 +27,14 @@ globals:
     type: bool
     restore_value: false
     initial_value: "false"
+  # Test restore_value with string "false" - should be converted to bool false
+  - id: glob_no_restore_string_false
+    type: int
+    restore_value: "false"
+    initial_value: "42"
+  # Test restore_value with string "true" - should be converted to bool true
+  - id: glob_restore_string_true
+    type: int
+    restore_value: "true"
+    initial_value: "99"
+    update_interval: 5s


### PR DESCRIPTION
# What does this implement/fix?

This fix addresses an issue where the string "false" was being treated as a truthy value in YAML configurations for the globals component. The problem was that the `restore_value` configuration option was not being converted to a boolean using `cv.boolean()` before being used in a conditional check.

## The Issue

When a user wrote:
```yaml
globals:
  - id: my_global
    type: int
    restore_value: "false"
    initial_value: 0
```

The string "false" would be treated as truthy (since any non-empty string is truthy in Python), causing the component to incorrectly use the restoring schema and polling behavior.

## The Fix

Changed line 54 in `esphome/components/globals/__init__.py` from:
```python
if config.get(CONF_RESTORE_VALUE, False):
```
to:
```python
if cv.boolean(config.get(CONF_RESTORE_VALUE, False)):
```

This ensures that string representations of "false" and "true" are properly converted to boolean values before the conditional check.

## Test Coverage

Added test cases to verify:
- `glob_no_restore_string_false`: Tests that `restore_value: "false"` is properly converted to boolean false
- `glob_restore_string_true`: Tests that `restore_value: "true"` is properly converted to boolean true

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
globals:
  - id: my_global
    type: int
    restore_value: false
    initial_value: 0
  - id: another_global
    type: bool
    restore_value: true
    initial_value: "false"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).