### PR TITLE
[core] Call loop() directly in main loop, bypass call() indirection

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -153,6 +153,14 @@ void Application::setup() {
   this->setup_wake_loop_threadsafe_();
 #endif
 
+  // Ensure all active looping components are in LOOP state.
+  // Components after the last blocking component only got one call() during setup
+  // (CONSTRUCTION→SETUP) and never received the second call() (SETUP→LOOP).
+  // The main loop calls loop() directly, bypassing call()'s state machine.
+  for (uint16_t i = 0; i < this->looping_components_active_end_; i++) {
+    this->looping_components_[i]->set_component_state_(COMPONENT_STATE_LOOP);
+  }
+
   this->schedule_dump_config();
 }
 void Application::loop() {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -173,7 +173,7 @@ void Application::loop() {
     {
       this->set_current_component(component);
       WarnIfComponentBlockingGuard guard{component, last_op_end_time};
-      component->call();
+      component->loop();
       // Use the finish method to get the current time as the end time
       last_op_end_time = guard.finish();
     }


### PR DESCRIPTION
# What does this implement/fix?

In `Application::loop()`, replace `component->call()` with `component->loop()` to bypass two unnecessary function call frames per component per iteration.

`call()` contains a state machine dispatch (`switch` on CONSTRUCTION/SETUP/LOOP/FAILED/LOOP_DONE) that is only needed during `Application::setup()`. In the main loop, components in the `looping_components_` active section are guaranteed to be in `LOOP` state:

- `FAILED` components are removed by `mark_failed()` → `disable_component_loop_()`
- `LOOP_DONE` components are removed by `disable_loop()` → `disable_component_loop_()`
- `CONSTRUCTION` and `SETUP` states only exist during `Application::setup()`

To ensure this invariant, any remaining SETUP-state components are explicitly transitioned to LOOP at the end of `setup()`. This handles the case where components after the last blocking component (e.g. WiFi) only received one `call()` (CONSTRUCTION→SETUP) during setup and never got the second `call()` that would have transitioned them to LOOP.

This became unnecessary overhead when `looping_components_` partitioning was introduced in #10652. Before that, `Application::loop()` iterated `components_[]` which contained all states, so the state check in `call()` was necessary.

The current call chain per component is:

```
Application::loop()
  → Component::call()          entry/retw + state dispatch
    → Component::call_loop_()  entry/retw
      → Component::loop()      virtual dispatch (the actual work)
```

After this change:

```
Application::loop()
  → Component::loop()          virtual dispatch (the actual work)
```

This eliminates 2 `entry`/`retw` (Xtensa register window rotation) pairs per component per loop iteration. On a device with 120 looping components, that's 240 unnecessary function frames removed per main loop cycle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal optimization, no user-facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).