### PR TITLE
[mixer][resampler][speaker] Use core static task manager

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -439,23 +439,13 @@ void MixerSpeaker::loop() {
   if (event_group_bits & MIXER_TASK_COMMAND_START) {
     // Only start the task if it's fully stopped and cleaned up
     if (!this->status_has_error() && !this->task_.is_created()) {
-      esp_err_t err = this->start_task_();
-      switch (err) {
-        case ESP_OK:
-          xEventGroupClearBits(this->event_group_, MIXER_TASK_COMMAND_START);
-          break;
-        case ESP_ERR_NO_MEM:
-          ESP_LOGE(TAG, "Failed to start; retrying in 1 second");
-          this->status_momentary_error("memory-failure", 1000);
-          return;
-        case ESP_ERR_INVALID_STATE:
-          ESP_LOGE(TAG, "Failed to start; retrying in 1 second");
-          this->status_momentary_error("task-failure", 1000);
-          return;
-        default:
-          ESP_LOGE(TAG, "Failed to start; retrying in 1 second");
-          this->status_momentary_error("failure", 1000);
-          return;
+      if (this->task_.create(audio_mixer_task, "mixer", TASK_STACK_SIZE, (void *) this, MIXER_TASK_PRIORITY,
+                             this->task_stack_in_psram_)) {
+        xEventGroupClearBits(this->event_group_, MIXER_TASK_COMMAND_START);
+      } else {
+        ESP_LOGE(TAG, "Failed to start; retrying in 1 second");
+        this->status_momentary_error("failure", 1000);
+        return;
       }
     }
   }
@@ -478,10 +468,9 @@ void MixerSpeaker::loop() {
     xEventGroupClearBits(this->event_group_, MIXER_TASK_STATE_STOPPING);
   }
   if (event_group_bits & MIXER_TASK_STATE_STOPPED) {
-    if (this->delete_task_() == ESP_OK) {
-      ESP_LOGD(TAG, "Stopped");
-      xEventGroupClearBits(this->event_group_, MIXER_TASK_ALL_BITS);
-    }
+    this->task_.deallocate();
+    ESP_LOGD(TAG, "Stopped");
+    xEventGroupClearBits(this->event_group_, MIXER_TASK_ALL_BITS);
   }
 
   if (this->task_.is_created()) {
@@ -535,20 +524,6 @@ esp_err_t MixerSpeaker::start(audio::AudioStreamInfo &stream_info) {
 #endif
   }
 
-  return ESP_OK;
-}
-
-esp_err_t MixerSpeaker::start_task_() {
-  if (!this->task_.create(audio_mixer_task, "mixer", TASK_STACK_SIZE, (void *) this, MIXER_TASK_PRIORITY,
-                          this->task_stack_in_psram_)) {
-    return ESP_ERR_NO_MEM;
-  }
-
-  return ESP_OK;
-}
-
-esp_err_t MixerSpeaker::delete_task_() {
-  this->task_.deallocate();
   return ESP_OK;
 }
 

--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -438,7 +438,7 @@ void MixerSpeaker::loop() {
   // Handle pending start request
   if (event_group_bits & MIXER_TASK_COMMAND_START) {
     // Only start the task if it's fully stopped and cleaned up
-    if (!this->status_has_error() && (this->task_handle_ == nullptr) && (this->task_stack_buffer_ == nullptr)) {
+    if (!this->status_has_error() && !this->task_.is_created()) {
       esp_err_t err = this->start_task_();
       switch (err) {
         case ESP_OK:
@@ -484,7 +484,7 @@ void MixerSpeaker::loop() {
     }
   }
 
-  if (this->task_handle_ != nullptr) {
+  if (this->task_.is_created()) {
     // If the mixer task is running, check if all source speakers are stopped
 
     bool all_stopped = true;
@@ -497,7 +497,7 @@ void MixerSpeaker::loop() {
       // Send stop command signal to the mixer task since no source speakers are active
       xEventGroupSetBits(this->event_group_, MIXER_TASK_COMMAND_STOP);
     }
-  } else if (this->task_stack_buffer_ == nullptr) {
+  } else {
     // Task is fully stopped and cleaned up, check if we can disable loop
     event_group_bits = xEventGroupGetBits(this->event_group_);
     if (event_group_bits == 0) {
@@ -539,56 +539,16 @@ esp_err_t MixerSpeaker::start(audio::AudioStreamInfo &stream_info) {
 }
 
 esp_err_t MixerSpeaker::start_task_() {
-  if (this->task_stack_buffer_ == nullptr) {
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    }
-  }
-
-  if (this->task_stack_buffer_ == nullptr) {
+  if (!this->task_.create(audio_mixer_task, "mixer", TASK_STACK_SIZE, (void *) this, MIXER_TASK_PRIORITY,
+                          this->task_stack_in_psram_)) {
     return ESP_ERR_NO_MEM;
-  }
-
-  if (this->task_handle_ == nullptr) {
-    this->task_handle_ = xTaskCreateStatic(audio_mixer_task, "mixer", TASK_STACK_SIZE, (void *) this,
-                                           MIXER_TASK_PRIORITY, this->task_stack_buffer_, &this->task_stack_);
-  }
-
-  if (this->task_handle_ == nullptr) {
-    return ESP_ERR_INVALID_STATE;
   }
 
   return ESP_OK;
 }
 
 esp_err_t MixerSpeaker::delete_task_() {
-  if (this->task_handle_ != nullptr) {
-    // Delete the task
-    vTaskDelete(this->task_handle_);
-    this->task_handle_ = nullptr;
-  }
-
-  if ((this->task_handle_ == nullptr) && (this->task_stack_buffer_ != nullptr)) {
-    // Deallocate the task stack buffer
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    }
-
-    this->task_stack_buffer_ = nullptr;
-  }
-
-  if ((this->task_handle_ != nullptr) || (this->task_stack_buffer_ != nullptr)) {
-    return ESP_ERR_INVALID_STATE;
-  }
-
+  this->task_.deallocate();
   return ESP_OK;
 }
 

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -143,8 +143,6 @@ class MixerSpeaker : public Component {
   /// @param stream_info The calling source speaker's audio stream information
   /// @return ESP_ERR_NOT_SUPPORTED if the incoming stream is incompatible due to unsupported bits per sample
   ///         ESP_ERR_INVALID_ARG if the incoming stream is incompatible to be mixed with the other input audio stream
-  ///         ESP_ERR_NO_MEM if there isn't enough memory for the task's stack
-  ///         ESP_ERR_INVALID_STATE if the task fails to start
   ///         ESP_OK if the incoming stream is compatible and the mixer task starts
   esp_err_t start(audio::AudioStreamInfo &stream_info);
 
@@ -187,16 +185,6 @@ class MixerSpeaker : public Component {
                                 uint32_t frames_to_mix);
 
   static void audio_mixer_task(void *params);
-
-  /// @brief Starts the mixer task after allocating memory for the task stack.
-  /// @return ESP_ERR_NO_MEM if there isn't enough memory for the task's stack
-  ///         ESP_ERR_INVALID_STATE if the task didn't start
-  ///         ESP_OK if successful
-  esp_err_t start_task_();
-
-  /// @brief If the task is stopped, it sets the task handle to the nullptr and deallocates its stack
-  /// @return ESP_OK if the task was stopped, ESP_ERR_INVALID_STATE otherwise.
-  esp_err_t delete_task_();
 
   EventGroupHandle_t event_group_{nullptr};
 

--- a/esphome/components/mixer/speaker/mixer_speaker.h
+++ b/esphome/components/mixer/speaker/mixer_speaker.h
@@ -8,8 +8,8 @@
 
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#include "esphome/core/static_task.h"
 
-#include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 
 #include <atomic>
@@ -207,9 +207,7 @@ class MixerSpeaker : public Component {
   bool queue_mode_;
   bool task_stack_in_psram_{false};
 
-  TaskHandle_t task_handle_{nullptr};
-  StaticTask_t task_stack_;
-  StackType_t *task_stack_buffer_{nullptr};
+  StaticTask task_;
 
   optional<audio::AudioStreamInfo> audio_stream_info_;
 

--- a/esphome/components/resampler/speaker/resampler_speaker.cpp
+++ b/esphome/components/resampler/speaker/resampler_speaker.cpp
@@ -147,7 +147,7 @@ void ResamplerSpeaker::loop() {
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::STATE_STOPPING);
   }
   if (event_group_bits & ResamplingEventGroupBits::STATE_STOPPED) {
-    this->delete_task_();
+    this->task_.deallocate();
     ESP_LOGD(TAG, "Stopped");
     xEventGroupClearBits(this->event_group_, ResamplingEventGroupBits::ALL_BITS);
   }
@@ -209,9 +209,6 @@ void ResamplerSpeaker::loop() {
 
 void ResamplerSpeaker::set_start_error_(esp_err_t err) {
   switch (err) {
-    case ESP_ERR_INVALID_STATE:
-      this->status_set_error(LOG_STR("Task failed to start"));
-      break;
     case ESP_ERR_NO_MEM:
       this->status_set_error(LOG_STR("Not enough memory"));
       break;
@@ -267,16 +264,10 @@ esp_err_t ResamplerSpeaker::start_() {
 
   if (this->requires_resampling_()) {
     // Start the resampler task to handle converting sample rates
-    return this->start_task_();
-  }
-
-  return ESP_OK;
-}
-
-esp_err_t ResamplerSpeaker::start_task_() {
-  if (!this->task_.create(resample_task, "resampler", TASK_STACK_SIZE, (void *) this, RESAMPLER_TASK_PRIORITY,
-                          this->task_stack_in_psram_)) {
-    return ESP_ERR_NO_MEM;
+    if (!this->task_.create(resample_task, "resampler", TASK_STACK_SIZE, (void *) this, RESAMPLER_TASK_PRIORITY,
+                            this->task_stack_in_psram_)) {
+      return ESP_ERR_NO_MEM;
+    }
   }
 
   return ESP_OK;
@@ -292,8 +283,6 @@ void ResamplerSpeaker::enter_stopping_state_() {
   }
   this->output_speaker_->stop();
 }
-
-void ResamplerSpeaker::delete_task_() { this->task_.deallocate(); }
 
 void ResamplerSpeaker::finish() { this->send_command_(ResamplingEventGroupBits::COMMAND_FINISH); }
 

--- a/esphome/components/resampler/speaker/resampler_speaker.cpp
+++ b/esphome/components/resampler/speaker/resampler_speaker.cpp
@@ -190,7 +190,7 @@ void ResamplerSpeaker::loop() {
         this->output_speaker_->stop();
       }
 
-      if (this->output_speaker_->is_stopped() && (this->task_handle_ == nullptr)) {
+      if (this->output_speaker_->is_stopped() && !this->task_.is_created()) {
         // Only transition to stopped state once the output speaker and resampler task are fully stopped
         this->waiting_for_output_ = false;
         this->state_ = speaker::STATE_STOPPED;
@@ -274,27 +274,9 @@ esp_err_t ResamplerSpeaker::start_() {
 }
 
 esp_err_t ResamplerSpeaker::start_task_() {
-  if (this->task_stack_buffer_ == nullptr) {
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      this->task_stack_buffer_ = stack_allocator.allocate(TASK_STACK_SIZE);
-    }
-  }
-
-  if (this->task_stack_buffer_ == nullptr) {
+  if (!this->task_.create(resample_task, "resampler", TASK_STACK_SIZE, (void *) this, RESAMPLER_TASK_PRIORITY,
+                          this->task_stack_in_psram_)) {
     return ESP_ERR_NO_MEM;
-  }
-
-  if (this->task_handle_ == nullptr) {
-    this->task_handle_ = xTaskCreateStatic(resample_task, "resampler", TASK_STACK_SIZE, (void *) this,
-                                           RESAMPLER_TASK_PRIORITY, this->task_stack_buffer_, &this->task_stack_);
-  }
-
-  if (this->task_handle_ == nullptr) {
-    return ESP_ERR_INVALID_STATE;
   }
 
   return ESP_OK;
@@ -305,32 +287,13 @@ void ResamplerSpeaker::stop() { this->send_command_(ResamplingEventGroupBits::CO
 void ResamplerSpeaker::enter_stopping_state_() {
   this->state_ = speaker::STATE_STOPPING;
   this->state_start_ms_ = App.get_loop_component_start_time();
-  if (this->task_handle_ != nullptr) {
+  if (this->task_.is_created()) {
     xEventGroupSetBits(this->event_group_, ResamplingEventGroupBits::TASK_COMMAND_STOP);
   }
   this->output_speaker_->stop();
 }
 
-void ResamplerSpeaker::delete_task_() {
-  if (this->task_handle_ != nullptr) {
-    // Delete the suspended task
-    vTaskDelete(this->task_handle_);
-    this->task_handle_ = nullptr;
-  }
-
-  if (this->task_stack_buffer_ != nullptr) {
-    // Deallocate the task stack buffer
-    if (this->task_stack_in_psram_) {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    } else {
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      stack_allocator.deallocate(this->task_stack_buffer_, TASK_STACK_SIZE);
-    }
-
-    this->task_stack_buffer_ = nullptr;
-  }
-}
+void ResamplerSpeaker::delete_task_() { this->task_.deallocate(); }
 
 void ResamplerSpeaker::finish() { this->send_command_(ResamplingEventGroupBits::COMMAND_FINISH); }
 

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -7,8 +7,8 @@
 #include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/component.h"
+#include "esphome/core/static_task.h"
 
-#include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 
 namespace esphome {
@@ -92,9 +92,7 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
   bool task_stack_in_psram_{false};
   bool waiting_for_output_{false};
 
-  TaskHandle_t task_handle_{nullptr};
-  StaticTask_t task_stack_;
-  StackType_t *task_stack_buffer_{nullptr};
+  StaticTask task_;
 
   audio::AudioStreamInfo target_stream_info_;
 

--- a/esphome/components/resampler/speaker/resampler_speaker.h
+++ b/esphome/components/resampler/speaker/resampler_speaker.h
@@ -57,15 +57,9 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
  protected:
   /// @brief Starts the output speaker after setting the resampled stream info. If resampling is required, it starts the
   /// task.
-  /// @return ESP_OK if resampling is required
-  ///         return value of start_task_() if resampling is required
-  esp_err_t start_();
-
-  /// @brief Starts the resampler task after allocating the task stack
   /// @return ESP_OK if successful,
-  ///         ESP_ERR_NO_MEM if the task stack couldn't be allocated
-  ///         ESP_ERR_INVALID_STATE if the task wasn't created
-  esp_err_t start_task_();
+  ///         ESP_ERR_NO_MEM if the resampler task couldn't be created
+  esp_err_t start_();
 
   /// @brief Transitions to STATE_STOPPING, records the stopping timestamp, sends the task stop command if the task is
   /// running, and stops the output speaker.
@@ -73,9 +67,6 @@ class ResamplerSpeaker : public Component, public speaker::Speaker {
 
   /// @brief Sets the appropriate status error based on the start failure reason.
   void set_start_error_(esp_err_t err);
-
-  /// @brief Deletes the resampler task if suspended, deallocates the task stack, and resets the related pointers.
-  void delete_task_();
 
   /// @brief Sends a command via event group bits, enables the loop, and optionally wakes the main loop.
   void send_command_(uint32_t command_bit, bool wake_loop = false);

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -87,20 +87,20 @@ void AudioPipeline::set_pause_state(bool pause_state) {
 }
 
 void AudioPipeline::suspend_tasks() {
-  if (this->read_task_handle_ != nullptr) {
-    vTaskSuspend(this->read_task_handle_);
+  if (this->read_task_.is_created()) {
+    vTaskSuspend(this->read_task_.get_handle());
   }
-  if (this->decode_task_handle_ != nullptr) {
-    vTaskSuspend(this->decode_task_handle_);
+  if (this->decode_task_.is_created()) {
+    vTaskSuspend(this->decode_task_.get_handle());
   }
 }
 
 void AudioPipeline::resume_tasks() {
-  if (this->read_task_handle_ != nullptr) {
-    vTaskResume(this->read_task_handle_);
+  if (this->read_task_.is_created()) {
+    vTaskResume(this->read_task_.get_handle());
   }
-  if (this->decode_task_handle_ != nullptr) {
-    vTaskResume(this->decode_task_handle_);
+  if (this->decode_task_.is_created()) {
+    vTaskResume(this->decode_task_.get_handle());
   }
 }
 
@@ -159,7 +159,7 @@ AudioPipelineState AudioPipeline::process_state() {
     // Init command pending
     if (!(event_bits & EventGroupBits::PIPELINE_COMMAND_STOP)) {
       // Only start if there is no pending stop command
-      if ((this->read_task_handle_ == nullptr) || (this->decode_task_handle_ == nullptr)) {
+      if (!this->read_task_.is_created() || !this->decode_task_.is_created()) {
         // At least one task isn't running
         this->start_tasks_();
       }
@@ -202,7 +202,7 @@ AudioPipelineState AudioPipeline::process_state() {
 
     if (!this->is_playing_) {
       // The tasks have been stopped for two ``process_state`` calls in a row, so delete the tasks
-      if ((this->read_task_handle_ != nullptr) || (this->decode_task_handle_ != nullptr)) {
+      if (this->read_task_.is_created() || this->decode_task_.is_created()) {
         this->delete_tasks_();
         if (this->hard_stop_) {
           // Stop command was sent, so immediately end the playback
@@ -234,7 +234,7 @@ AudioPipelineState AudioPipeline::process_state() {
     }
   }
 
-  if ((this->read_task_handle_ == nullptr) && (this->decode_task_handle_ == nullptr)) {
+  if (!this->read_task_.is_created() && !this->decode_task_.is_created()) {
     // No tasks are running, so the pipeline is stopped.
     xEventGroupClearBits(this->event_group_, EventGroupBits::PIPELINE_COMMAND_STOP);
     return AudioPipelineState::STOPPED;
@@ -262,52 +262,19 @@ esp_err_t AudioPipeline::allocate_communications_() {
 }
 
 esp_err_t AudioPipeline::start_tasks_() {
-  if (this->read_task_handle_ == nullptr) {
-    if (this->read_task_stack_buffer_ == nullptr) {
-      // Reader task uses the AudioReader class which uses esp_http_client. This crashes on IDF 5.4 if the task stack is
-      // in PSRAM. As a workaround, always allocate the read task in internal memory.
-      RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-      this->read_task_stack_buffer_ = stack_allocator.allocate(READ_TASK_STACK_SIZE);
-    }
-
-    if (this->read_task_stack_buffer_ == nullptr) {
+  if (!this->read_task_.is_created()) {
+    // Reader task uses the AudioReader class which uses esp_http_client. This crashes on IDF 5.4 if the task stack is
+    // in PSRAM. As a workaround, always allocate the read task in internal memory.
+    if (!this->read_task_.create(read_task, (this->base_name_ + "_read").c_str(), READ_TASK_STACK_SIZE, (void *) this,
+                                 this->priority_, false)) {
       return ESP_ERR_NO_MEM;
-    }
-
-    if (this->read_task_handle_ == nullptr) {
-      this->read_task_handle_ =
-          xTaskCreateStatic(read_task, (this->base_name_ + "_read").c_str(), READ_TASK_STACK_SIZE, (void *) this,
-                            this->priority_, this->read_task_stack_buffer_, &this->read_task_stack_);
-    }
-
-    if (this->read_task_handle_ == nullptr) {
-      return ESP_ERR_INVALID_STATE;
     }
   }
 
-  if (this->decode_task_handle_ == nullptr) {
-    if (this->decode_task_stack_buffer_ == nullptr) {
-      if (this->task_stack_in_psram_) {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-        this->decode_task_stack_buffer_ = stack_allocator.allocate(DECODE_TASK_STACK_SIZE);
-      } else {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-        this->decode_task_stack_buffer_ = stack_allocator.allocate(DECODE_TASK_STACK_SIZE);
-      }
-    }
-
-    if (this->decode_task_stack_buffer_ == nullptr) {
+  if (!this->decode_task_.is_created()) {
+    if (!this->decode_task_.create(decode_task, (this->base_name_ + "_decode").c_str(), DECODE_TASK_STACK_SIZE,
+                                   (void *) this, this->priority_, this->task_stack_in_psram_)) {
       return ESP_ERR_NO_MEM;
-    }
-
-    if (this->decode_task_handle_ == nullptr) {
-      this->decode_task_handle_ =
-          xTaskCreateStatic(decode_task, (this->base_name_ + "_decode").c_str(), DECODE_TASK_STACK_SIZE, (void *) this,
-                            this->priority_, this->decode_task_stack_buffer_, &this->decode_task_stack_);
-    }
-
-    if (this->decode_task_handle_ == nullptr) {
-      return ESP_ERR_INVALID_STATE;
     }
   }
 
@@ -315,39 +282,8 @@ esp_err_t AudioPipeline::start_tasks_() {
 }
 
 void AudioPipeline::delete_tasks_() {
-  if (this->read_task_handle_ != nullptr) {
-    vTaskDelete(this->read_task_handle_);
-
-    if (this->read_task_stack_buffer_ != nullptr) {
-      if (this->task_stack_in_psram_) {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-        stack_allocator.deallocate(this->read_task_stack_buffer_, READ_TASK_STACK_SIZE);
-      } else {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-        stack_allocator.deallocate(this->read_task_stack_buffer_, READ_TASK_STACK_SIZE);
-      }
-
-      this->read_task_stack_buffer_ = nullptr;
-      this->read_task_handle_ = nullptr;
-    }
-  }
-
-  if (this->decode_task_handle_ != nullptr) {
-    vTaskDelete(this->decode_task_handle_);
-
-    if (this->decode_task_stack_buffer_ != nullptr) {
-      if (this->task_stack_in_psram_) {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_EXTERNAL);
-        stack_allocator.deallocate(this->decode_task_stack_buffer_, DECODE_TASK_STACK_SIZE);
-      } else {
-        RAMAllocator<StackType_t> stack_allocator(RAMAllocator<StackType_t>::ALLOC_INTERNAL);
-        stack_allocator.deallocate(this->decode_task_stack_buffer_, DECODE_TASK_STACK_SIZE);
-      }
-
-      this->decode_task_stack_buffer_ = nullptr;
-      this->decode_task_handle_ = nullptr;
-    }
-  }
+  this->read_task_.deallocate();
+  this->decode_task_.deallocate();
 }
 
 void AudioPipeline::read_task(void *params) {

--- a/esphome/components/speaker/media_player/audio_pipeline.cpp
+++ b/esphome/components/speaker/media_player/audio_pipeline.cpp
@@ -203,7 +203,8 @@ AudioPipelineState AudioPipeline::process_state() {
     if (!this->is_playing_) {
       // The tasks have been stopped for two ``process_state`` calls in a row, so delete the tasks
       if (this->read_task_.is_created() || this->decode_task_.is_created()) {
-        this->delete_tasks_();
+        this->read_task_.deallocate();
+        this->decode_task_.deallocate();
         if (this->hard_stop_) {
           // Stop command was sent, so immediately end the playback
           this->speaker_->stop();
@@ -279,11 +280,6 @@ esp_err_t AudioPipeline::start_tasks_() {
   }
 
   return ESP_OK;
-}
-
-void AudioPipeline::delete_tasks_() {
-  this->read_task_.deallocate();
-  this->decode_task_.deallocate();
 }
 
 void AudioPipeline::read_task(void *params) {

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -104,9 +104,6 @@ class AudioPipeline {
   /// @return ESP_OK if successful or an appropriate error if not
   esp_err_t start_tasks_();
 
-  /// @brief Resets the task related pointers and deallocates their stacks.
-  void delete_tasks_();
-
   std::string base_name_;
   UBaseType_t priority_;
 

--- a/esphome/components/speaker/media_player/audio_pipeline.h
+++ b/esphome/components/speaker/media_player/audio_pipeline.h
@@ -8,10 +8,10 @@
 #include "esphome/components/speaker/speaker.h"
 
 #include "esphome/core/ring_buffer.h"
+#include "esphome/core/static_task.h"
 
 #include "esp_err.h"
 
-#include <freertos/FreeRTOS.h>
 #include <freertos/event_groups.h>
 #include <freertos/queue.h>
 
@@ -143,15 +143,11 @@ class AudioPipeline {
 
   // Handles reading the media file from flash or a url
   static void read_task(void *params);
-  TaskHandle_t read_task_handle_{nullptr};
-  StaticTask_t read_task_stack_;
-  StackType_t *read_task_stack_buffer_{nullptr};
+  StaticTask read_task_;
 
   // Decodes the media file into PCM audio
   static void decode_task(void *params);
-  TaskHandle_t decode_task_handle_{nullptr};
-  StaticTask_t decode_task_stack_;
-  StackType_t *decode_task_stack_buffer_{nullptr};
+  StaticTask decode_task_;
 };
 
 }  // namespace speaker


### PR DESCRIPTION
# What does this implement/fix?

Follow up to #14446 which added the StaticTask core helper to manage the lifecycle of statically allocated tasks. Updates the mixer, resampler, and speaker media player components to use the new helper.

This greatly simplifies the behavior, so I've removed most of the task creation and deletion helpers, as this can all be inlined in the same amount of space. Also, static tasks will really only ever fail on the allocation aspect, not the task creation aspect, so it was pointless to try and distinguish between the two before. Now the StaticTask class only returns success or failure, allowing us to simplify the error handling as well.

There should be no change functionality changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

speaker:
  - platform: i2s_audio
    id: box_speaker
    i2s_dout_pin: GPIOXX
    dac_type: external
    sample_rate: 44100
    bits_per_sample: 16bit
    channel: left
    audio_dac: es8311_dac
    buffer_duration: 100ms
  - platform: mixer
    output_speaker: box_speaker
    source_speakers:
      - id: announcement_mixer_speaker
  - platform: resampler
    output_speaker: announcement_mixer_speaker
    id: announcement_resampler
    sample_rate: 44100

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: announcement_resampler
      format: FLAC
      sample_rate: 48000
      num_channels: 1

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
