### PR TITLE
[openthread] static log level code quality improvement

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -49,6 +49,15 @@ AUTO_LOAD = ["network"]
 CONFLICTS_WITH = ["wifi"]
 DEPENDENCIES = ["esp32"]
 
+IDF_TO_OT_LOG_LEVEL = {
+    "NONE": "NONE",
+    "ERROR": "CRIT",
+    "WARN": "WARN",
+    "INFO": "NOTE",
+    "DEBUG": "INFO",
+    "VERBOSE": "DEBG",
+}
+
 CONF_DEVICE_TYPES = [
     "FTD",
     "MTD",
@@ -207,22 +216,8 @@ def _final_validate(_):
         and (log_level := fw_config.get(CONF_LOG_LEVEL)) is not None
     ):
         add_idf_sdkconfig_option("CONFIG_OPENTHREAD_LOG_LEVEL_DYNAMIC", False)
-        # Line Logs up numerically 1 through 5
-        # 0 NONE -> NONE
-        # 1 ERROR -> CRIT
-        # 2 WARN -> WARN
-        # 3 INFO -> NOTE
-        # 4 DEBUG -> INFO
-        # 5 VERBOSE -> DEBG
-        if log_level == "ERROR":
-            log_level = "CRIT"
-        elif log_level == "INFO":
-            log_level = "NOTE"
-        elif log_level == "DEBUG":
-            log_level = "INFO"
-        elif log_level == "VERBOSE":
-            log_level = "DEBG"
-        add_idf_sdkconfig_option(f"CONFIG_OPENTHREAD_LOG_LEVEL_{log_level}", True)
+        ot_log_level = IDF_TO_OT_LOG_LEVEL.get(log_level, log_level)
+        add_idf_sdkconfig_option(f"CONFIG_OPENTHREAD_LOG_LEVEL_{ot_log_level}", True)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -14,9 +14,12 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHANNEL,
     CONF_ENABLE_IPV6,
+    CONF_FRAMEWORK,
     CONF_ID,
+    CONF_LOG_LEVEL,
     CONF_OUTPUT_POWER,
     CONF_USE_ADDRESS,
+    PLATFORM_ESP32,
 )
 from esphome.core import CORE, TimePeriodMilliseconds
 import esphome.final_validate as fv
@@ -197,6 +200,29 @@ def _final_validate(_):
             "OpenThread requires IPv6 to be enabled in the network component. "
             "Please set `enable_ipv6: true` in the `network` configuration."
         )
+
+    if (
+        (esp32_config := full_config.get(PLATFORM_ESP32)) is not None
+        and (fw_config := esp32_config.get(CONF_FRAMEWORK)) is not None
+        and (log_level := fw_config.get(CONF_LOG_LEVEL)) is not None
+    ):
+        add_idf_sdkconfig_option("CONFIG_OPENTHREAD_LOG_LEVEL_DYNAMIC", False)
+        # Line Logs up numerically 1 through 5
+        # 0 NONE -> NONE
+        # 1 ERROR -> CRIT
+        # 2 WARN -> WARN
+        # 3 INFO -> NOTE
+        # 4 DEBUG -> INFO
+        # 5 VERBOSE -> DEBG
+        if log_level == "ERROR":
+            log_level = "CRIT"
+        elif log_level == "INFO":
+            log_level = "NOTE"
+        elif log_level == "DEBUG":
+            log_level = "INFO"
+        elif log_level == "VERBOSE":
+            log_level = "DEBG"
+        add_idf_sdkconfig_option(f"CONFIG_OPENTHREAD_LOG_LEVEL_{log_level}", True)
 
 
 FINAL_VALIDATE_SCHEMA = _final_validate

--- a/tests/components/openthread/test.esp32-c6-idf.yaml
+++ b/tests/components/openthread/test.esp32-c6-idf.yaml
@@ -1,3 +1,9 @@
+esp32:
+  board: esp32-c6-devkitc-1
+  framework:
+    type: esp-idf
+    log_level: DEBUG
+
 network:
   enable_ipv6: true
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Changes the internal logging of the openthread task from dynamic to static using CONFIG_OPENTHREAD_LOG_LEVEL_<label> setting.
The OpenThread log level is now controlled by the `esp32.framework.log_level` setting. The ESP-IDF log level labels are mapped to OpenThread log levels:
* 0 NONE -> NONE
* 1 ERROR -> CRIT
* 2 WARN -> WARN
* 3 INFO -> NOTE
* 4 DEBUG -> INFO
* 5 VERBOSE -> DEBG

This is a breaking change because the OpenThread log level was previously dynamic and is now statically set based on the framework log level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6219

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esp32:
  board: esp32-h2-devkitm-1
  variant: ESP32H2
  framework:
    type: esp-idf
    log_level: INFO

network:
  enable_ipv6: true

openthread:
  tlv: !secret openthread_tlv
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).