### PR TITLE
[ld2420] Fix buffer overflows in simple mode, energy mode, and calibration

### DIFF
--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -460,6 +460,10 @@ void LD2420Component::handle_energy_mode_(uint8_t *buffer, int len) {
   uint8_t index = 6;  // Start at presence byte position
   uint16_t range;
   const uint8_t elements = sizeof(this->gate_energy_) / sizeof(this->gate_energy_[0]);
+  if (len < index + 1 + sizeof(range) + elements * sizeof(this->gate_energy_[0])) {
+    ESP_LOGW(TAG, "Energy frame too short: %d bytes", len);
+    return;
+  }
   this->set_presence_(buffer[index]);
   index++;
   memcpy(&range, &buffer[index], sizeof(range));
@@ -471,8 +475,11 @@ void LD2420Component::handle_energy_mode_(uint8_t *buffer, int len) {
   }
 
   if (this->current_operating_mode == OP_CALIBRATE_MODE) {
-    this->update_radar_data(gate_energy_, sample_number_counter);
-    this->sample_number_counter > CALIBRATE_SAMPLES ? this->sample_number_counter = 0 : this->sample_number_counter++;
+    this->update_radar_data(gate_energy_, this->sample_number_counter);
+    this->sample_number_counter++;
+    if (this->sample_number_counter >= CALIBRATE_SAMPLES) {
+      this->sample_number_counter = 0;
+    }
   }
 
   // Resonable refresh rate for home assistant database size health
@@ -503,9 +510,9 @@ void LD2420Component::handle_simple_mode_(const uint8_t *inbuf, int len) {
   char *endptr{nullptr};
   char outbuf[bufsize]{0};
   while (true) {
-    if (inbuf[pos - 2] == 'O' && inbuf[pos - 1] == 'F' && inbuf[pos] == 'F') {
+    if (pos >= 2 && inbuf[pos - 2] == 'O' && inbuf[pos - 1] == 'F' && inbuf[pos] == 'F') {
       this->set_presence_(false);
-    } else if (inbuf[pos - 1] == 'O' && inbuf[pos] == 'N') {
+    } else if (pos >= 1 && inbuf[pos - 1] == 'O' && inbuf[pos] == 'N') {
       this->set_presence_(true);
     }
     if (inbuf[pos] >= '0' && inbuf[pos] <= '9') {

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -518,14 +518,12 @@ void LD2420Component::handle_simple_mode_(const uint8_t *inbuf, int len) {
     if (inbuf[pos] >= '0' && inbuf[pos] <= '9') {
       if (index < bufsize - 1) {
         outbuf[index++] = inbuf[pos];
-        pos++;
       }
+    }
+    if (pos < len - 1) {
+      pos++;
     } else {
-      if (pos < len - 1) {
-        pos++;
-      } else {
-        break;
-      }
+      break;
     }
   }
   outbuf[index] = '\0';

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -460,7 +460,7 @@ void LD2420Component::handle_energy_mode_(uint8_t *buffer, int len) {
   uint8_t index = 6;  // Start at presence byte position
   uint16_t range;
   const uint8_t elements = sizeof(this->gate_energy_) / sizeof(this->gate_energy_[0]);
-  if (len < index + 1 + sizeof(range) + elements * sizeof(this->gate_energy_[0])) {
+  if (len < static_cast<int>(index + 1 + sizeof(range) + elements * sizeof(this->gate_energy_[0]))) {
     ESP_LOGW(TAG, "Energy frame too short: %d bytes", len);
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Three out-of-bounds access bugs in the LD2420 radar component:

1. **`handle_simple_mode_` uint8_t underflow**: `inbuf[pos - 2]` when `pos` is 0 wraps the `uint8_t` to 254, reading far past the 50-byte buffer. Added `pos >= 2` and `pos >= 1` guards before the subtraction.

2. **`handle_energy_mode_` calibration off-by-one**: `sample_number_counter` was used as an array index *before* the bounds check, and the check used `>` instead of `>=`. The counter reached 64 and wrote past `radar_data[][64]` (valid indices 0–63). Moved the bounds check after the increment with `>=`.

3. **`handle_energy_mode_` missing length validation**: No check that the buffer contains enough bytes for the expected energy frame format (41 bytes minimum). Truncated UART frames caused out-of-bounds reads in `memcpy`. Added an early return on short frames.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a bug fix in existing functionality
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

ld2420:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).