### PR TITLE
[remote_base][remote_receiver] Fix OOB access in pronto comparison and RMT buffer allocation

### DIFF
--- a/esphome/components/remote_base/pronto_protocol.cpp
+++ b/esphome/components/remote_base/pronto_protocol.cpp
@@ -44,9 +44,13 @@ bool ProntoData::operator==(const ProntoData &rhs) const {
   std::vector<uint16_t> data1 = encode_pronto(data);
   std::vector<uint16_t> data2 = encode_pronto(rhs.data);
 
+  if (data1.size() != data2.size() || data1.empty()) {
+    return false;
+  }
+
   uint32_t total_diff = 0;
   // Don't need to check the last one, it's the large gap at the end.
-  for (std::vector<uint16_t>::size_type i = 0; i < data1.size() - 1; ++i) {
+  for (size_t i = 0; i < data1.size() - 1; ++i) {
     int diff = data2[i] - data1[i];
     diff *= diff;
     if (rhs.delta == -1 && diff > 9)

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -106,7 +106,7 @@ void RemoteReceiverComponent::setup() {
   this->store_.filter_symbols = this->filter_symbols_;
   this->store_.receive_size = this->receive_symbols_ * sizeof(rmt_symbol_word_t);
   this->store_.buffer_size = std::max((event_size + this->store_.receive_size) * 2, this->buffer_size_);
-  this->store_.buffer = new uint8_t[this->buffer_size_];
+  this->store_.buffer = new uint8_t[this->store_.buffer_size];
   error = rmt_receive(this->channel_, (uint8_t *) this->store_.buffer + event_size, this->store_.receive_size,
                       &this->store_.config);
   if (error != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

Two out-of-bounds access fixes in the remote IR components:

1. **remote_base pronto_protocol**: `ProntoData::operator==` loops over `data1.size() - 1` but `size()` returns `size_t` (unsigned), so empty vectors underflow to `SIZE_MAX` causing billions of OOB iterations. Also indexes into `data2` using `data1`'s length without checking `data2` is the same size. Added early return when sizes differ or vectors are empty.

2. **remote_receiver RMT**: Buffer allocated with `buffer_size_` (user-configured value) instead of `store_.buffer_size` (the computed maximum). When the computed minimum `(event_size + receive_size) * 2` exceeds the user value, the ISR uses `store_.buffer_size` for bounds checking against a smaller allocation, causing heap buffer overflow.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - these are bug fixes in existing functionality
remote_receiver:
  pin: GPIO4
  dump: pronto

remote_transmitter:
  pin: GPIO5
  carrier_duty_percent: 50%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).