### PR TITLE
[fingerprint_grow] Fix OOB write and uint16 overflow

### DIFF
--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -207,7 +207,6 @@ uint8_t FingerprintGrowComponent::save_fingerprint_() {
       break;
     case ENROLL_MISMATCH:
       ESP_LOGE(TAG, "Scans do not match");
-      break;
     default:
       return this->data_[0];
   }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -207,6 +207,7 @@ uint8_t FingerprintGrowComponent::save_fingerprint_() {
       break;
     case ENROLL_MISMATCH:
       ESP_LOGE(TAG, "Scans do not match");
+      break;
     default:
       return this->data_[0];
   }
@@ -464,7 +465,7 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer)
     idx++;
   }
   ESP_LOGE(TAG, "No response received from reader");
-  (*p_data_buffer)[0] = TIMEOUT;
+  p_data_buffer->push_back(TIMEOUT);
   this->last_transfer_ms_ = millis();
   return TIMEOUT;
 }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -464,6 +464,7 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> &data_buffer) {
     idx++;
   }
   ESP_LOGE(TAG, "No response received from reader");
+  data_buffer.clear();
   data_buffer.push_back(TIMEOUT);
   this->last_transfer_ms_ = millis();
   return TIMEOUT;

--- a/esphome/components/fingerprint_grow/fingerprint_grow.cpp
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.cpp
@@ -361,7 +361,7 @@ void FingerprintGrowComponent::aura_led_control(uint8_t state, uint8_t speed, ui
   }
 }
 
-uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer) {
+uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> &data_buffer) {
   while (this->available())
     this->read();
   this->write((uint8_t) (START_CODE >> 8));
@@ -372,12 +372,12 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer)
   this->write(this->address_[3]);
   this->write(COMMAND);
 
-  uint16_t wire_length = p_data_buffer->size() + 2;
+  uint16_t wire_length = data_buffer.size() + 2;
   this->write((uint8_t) (wire_length >> 8));
   this->write((uint8_t) (wire_length & 0xFF));
 
   uint16_t sum = (wire_length >> 8) + (wire_length & 0xFF) + COMMAND;
-  for (auto data : *p_data_buffer) {
+  for (auto data : data_buffer) {
     this->write(data);
     sum += data;
   }
@@ -385,7 +385,7 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer)
   this->write((uint8_t) (sum >> 8));
   this->write((uint8_t) (sum & 0xFF));
 
-  p_data_buffer->clear();
+  data_buffer.clear();
 
   uint8_t byte;
   uint16_t idx = 0, length = 0;
@@ -431,9 +431,9 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer)
         length |= byte;
         break;
       default:
-        p_data_buffer->push_back(byte);
+        data_buffer.push_back(byte);
         if ((idx - 8) == length) {
-          switch ((*p_data_buffer)[0]) {
+          switch (data_buffer[0]) {
             case OK:
             case NO_FINGER:
             case IMAGE_FAIL:
@@ -453,25 +453,25 @@ uint8_t FingerprintGrowComponent::transfer_(std::vector<uint8_t> *p_data_buffer)
               ESP_LOGE(TAG, "Reader failed to process request");
               break;
             default:
-              ESP_LOGE(TAG, "Unknown response received from reader: 0x%.2X", (*p_data_buffer)[0]);
+              ESP_LOGE(TAG, "Unknown response received from reader: 0x%.2X", data_buffer[0]);
               break;
           }
           this->last_transfer_ms_ = millis();
-          return (*p_data_buffer)[0];
+          return data_buffer[0];
         }
         break;
     }
     idx++;
   }
   ESP_LOGE(TAG, "No response received from reader");
-  p_data_buffer->push_back(TIMEOUT);
+  data_buffer.push_back(TIMEOUT);
   this->last_transfer_ms_ = millis();
   return TIMEOUT;
 }
 
 uint8_t FingerprintGrowComponent::send_command_() {
   this->sensor_wakeup_();
-  return this->transfer_(&this->data_);
+  return this->transfer_(this->data_);
 }
 
 void FingerprintGrowComponent::sensor_wakeup_() {
@@ -517,7 +517,7 @@ void FingerprintGrowComponent::sensor_wakeup_() {
   std::vector<uint8_t> buffer = {VERIFY_PASSWORD, (uint8_t) (this->password_ >> 24), (uint8_t) (this->password_ >> 16),
                                  (uint8_t) (this->password_ >> 8), (uint8_t) (this->password_ & 0xFF)};
 
-  if (this->transfer_(&buffer) != OK) {
+  if (this->transfer_(buffer) != OK) {
     ESP_LOGE(TAG, "Wrong password");
   }
 }

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -190,7 +190,7 @@ class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevic
   bool is_sensor_awake_ = false;
   uint32_t last_transfer_ms_ = 0;
   uint32_t last_aura_led_control_ = 0;
-  uint16_t last_aura_led_duration_ = 0;
+  uint32_t last_aura_led_duration_ = 0;
   uint16_t system_identifier_code_ = 0;
   uint32_t idle_period_to_sleep_ms_ = UINT32_MAX;
   sensor::Sensor *fingerprint_count_sensor_{nullptr};

--- a/esphome/components/fingerprint_grow/fingerprint_grow.h
+++ b/esphome/components/fingerprint_grow/fingerprint_grow.h
@@ -169,7 +169,7 @@ class FingerprintGrowComponent : public PollingComponent, public uart::UARTDevic
   bool set_password_();
   bool get_parameters_();
   void get_fingerprint_count_();
-  uint8_t transfer_(std::vector<uint8_t> *p_data_buffer);
+  uint8_t transfer_(std::vector<uint8_t> &data_buffer);
   uint8_t send_command_();
   void sensor_wakeup_();
   void sensor_sleep_();


### PR DESCRIPTION
# What does this implement/fix?

Fix two bugs and clean up `transfer_()` in fingerprint_grow, found during code audit:

- **OOB write on timeout**: `transfer_()` clears the data buffer, then on timeout writes to index 0 of the empty vector via `(*p_data_buffer)[0] = TIMEOUT`. Fixed by using `clear()` + `push_back()` instead.

- **uint16_t overflow**: `aura_led_control()` computes `10 * speed * count` where speed and count are `uint8_t` (max 255). The result can reach 650,250 which overflows `last_aura_led_duration_` (`uint16_t`). Changed field to `uint32_t`.

- **Pass by reference**: Changed `transfer_()` parameter from `std::vector<uint8_t> *` to `std::vector<uint8_t> &` to clean up pointer dereference syntax throughout the function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfixes only, no configuration changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).