### PR TITLE
[wifi] Cache is_connected() for cheap inline access

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2128,9 +2128,7 @@ bool WiFiComponent::is_connected_() const {
   return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
          this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
 }
-void WiFiComponent::update_connected_state_() {
-  this->connected_ = this->is_connected_();
-}
+void WiFiComponent::update_connected_state_() { this->connected_ = this->is_connected_(); }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2129,10 +2129,7 @@ bool WiFiComponent::is_connected_() const {
          this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
 }
 void WiFiComponent::update_connected_state_() {
-  bool connected = this->is_connected_();
-  if (connected != this->connected_) {
-    this->connected_ = connected;
-  }
+  this->connected_ = this->is_connected_();
 }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -725,6 +725,7 @@ void WiFiComponent::restart_adapter() {
 void WiFiComponent::loop() {
   this->wifi_loop_();
   const uint32_t now = App.get_loop_component_start_time();
+  this->update_connected_state_();
 
   if (this->has_sta()) {
 #if defined(USE_WIFI_CONNECT_TRIGGER) || defined(USE_WIFI_DISCONNECT_TRIGGER)
@@ -776,7 +777,7 @@ void WiFiComponent::loop() {
       }
 
       case WIFI_COMPONENT_STATE_STA_CONNECTED: {
-        if (!this->is_connected()) {
+        if (!this->is_connected_()) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
           this->retry_connect();
@@ -2118,14 +2119,20 @@ bool WiFiComponent::can_proceed() {
   if (!this->has_sta() || this->state_ == WIFI_COMPONENT_STATE_DISABLED || this->ap_setup_) {
     return true;
   }
-  return this->is_connected();
+  return this->is_connected_();
 }
 #endif
 
 void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
-bool WiFiComponent::is_connected() const {
+bool WiFiComponent::is_connected_() const {
   return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
          this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
+}
+void WiFiComponent::update_connected_state_() {
+  bool connected = this->is_connected_();
+  if (connected != this->connected_) {
+    this->connected_ = connected;
+  }
 }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -443,7 +443,7 @@ class WiFiComponent : public Component {
 
   void set_reboot_timeout(uint32_t reboot_timeout);
 
-  bool is_connected() const;
+  bool is_connected() const { return this->connected_; }
 
   void set_power_save_mode(WiFiPowerSaveMode power_save);
   void set_min_auth_mode(WifiMinAuthMode min_auth_mode) { min_auth_mode_ = min_auth_mode; }
@@ -678,6 +678,8 @@ class WiFiComponent : public Component {
   bool wifi_sta_connect_(const WiFiAP &ap);
   void wifi_pre_setup_();
   WiFiSTAConnectStatus wifi_sta_connect_status_() const;
+  bool is_connected_() const;
+  void update_connected_state_();
   bool wifi_scan_start_(bool passive);
 
 #ifdef USE_WIFI_AP
@@ -854,6 +856,7 @@ class WiFiComponent : public Component {
   bool has_completed_scan_after_captive_portal_start_{
       false};  // Tracks if we've completed a scan after captive portal started
   bool skip_cooldown_next_cycle_{false};
+  bool connected_{false};
   bool post_connect_roaming_{true};  // Enabled by default
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   bool is_high_performance_mode_{false};


### PR DESCRIPTION
# What does this implement/fix?

`WiFiComponent::is_connected()` previously called `wifi_sta_connect_status_()` on every invocation, which makes SDK calls on ESP8266 (`wifi_station_get_connect_status()`) and RP2040 (`cyw43_wifi_link_status()` + `WiFi.status()`). This prevented the method from being inlined and added overhead for the many callers that check it every loop iteration (`network::is_connected()`, API server, MQTT, status sensor, improv, etc.).

This PR caches the connected state as a `bool` field and moves `is_connected()` to the header as an inline single-field return. The cached state is updated once per `loop()` after `wifi_loop_()` processes platform events. Internal call sites that need a live SDK query (STA_CONNECTED loss detection, RP2040 `can_proceed()`) use the new `is_connected_()` private method directly.

This matches how the ethernet component already handles `is_connected()` — a simple state field check.

Together with #14464, the full `network::is_connected()` → `wifi::is_connected()` chain becomes inlineable end-to-end.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #14464

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).