### PR TITLE
[network] Inline network::is_connected() and ethernet is_connected()

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -687,8 +687,6 @@ void EthernetComponent::start_connect_() {
   this->status_set_warning();
 }
 
-bool EthernetComponent::is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
-
 void EthernetComponent::dump_connect_params_() {
   esp_netif_ip_info_t ip;
   esp_netif_get_ip_info(this->eth_netif_, &ip);

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -76,7 +76,7 @@ class EthernetComponent : public Component {
   void dump_config() override;
   float get_setup_priority() const override;
   void on_powerdown() override { powerdown(); }
-  bool is_connected();
+  bool is_connected() { return this->state_ == EthernetComponentState::CONNECTED; }
 
 #ifdef USE_ETHERNET_SPI
   void set_clk_pin(uint8_t clk_pin);

--- a/esphome/components/network/util.cpp
+++ b/esphome/components/network/util.cpp
@@ -1,53 +1,8 @@
 #include "util.h"
 #include "esphome/core/defines.h"
 #ifdef USE_NETWORK
-#ifdef USE_WIFI
-#include "esphome/components/wifi/wifi_component.h"
-#endif
-
-#ifdef USE_ETHERNET
-#include "esphome/components/ethernet/ethernet_component.h"
-#endif
-
-#ifdef USE_OPENTHREAD
-#include "esphome/components/openthread/openthread.h"
-#endif
-
-#ifdef USE_MODEM
-#include "esphome/components/modem/modem_component.h"
-#endif
 
 namespace esphome::network {
-
-// The order of the components is important: WiFi should come after any possible main interfaces (it may be used as
-// an AP that use a previous interface for NAT).
-
-bool is_connected() {
-#ifdef USE_ETHERNET
-  if (ethernet::global_eth_component != nullptr && ethernet::global_eth_component->is_connected())
-    return true;
-#endif
-
-#ifdef USE_MODEM
-  if (modem::global_modem_component != nullptr)
-    return modem::global_modem_component->is_connected();
-#endif
-
-#ifdef USE_WIFI
-  if (wifi::global_wifi_component != nullptr)
-    return wifi::global_wifi_component->is_connected();
-#endif
-
-#ifdef USE_OPENTHREAD
-  if (openthread::global_openthread_component != nullptr)
-    return openthread::global_openthread_component->is_connected();
-#endif
-
-#ifdef USE_HOST
-  return true;  // Assume its connected
-#endif
-  return false;
-}
 
 bool is_disabled() {
 #ifdef USE_MODEM

--- a/esphome/components/network/util.cpp
+++ b/esphome/components/network/util.cpp
@@ -4,6 +4,9 @@
 
 namespace esphome::network {
 
+// The order of the components is important: WiFi should come after any possible main interfaces (it may be used as
+// an AP that uses a previous interface for NAT).
+
 bool is_disabled() {
 #ifdef USE_MODEM
   if (modem::global_modem_component != nullptr)

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -4,10 +4,52 @@
 #include <string>
 #include "ip_address.h"
 
+#ifdef USE_ETHERNET
+#include "esphome/components/ethernet/ethernet_component.h"
+#endif
+#ifdef USE_MODEM
+#include "esphome/components/modem/modem_component.h"
+#endif
+#ifdef USE_WIFI
+#include "esphome/components/wifi/wifi_component.h"
+#endif
+#ifdef USE_OPENTHREAD
+#include "esphome/components/openthread/openthread.h"
+#endif
+
 namespace esphome::network {
 
+// The order of the components is important: WiFi should come after any possible main interfaces (it may be used as
+// an AP that use a previous interface for NAT).
+
 /// Return whether the node is connected to the network (through wifi, eth, ...)
-bool is_connected();
+inline bool is_connected() {
+#ifdef USE_ETHERNET
+  if (ethernet::global_eth_component != nullptr && ethernet::global_eth_component->is_connected())
+    return true;
+#endif
+
+#ifdef USE_MODEM
+  if (modem::global_modem_component != nullptr)
+    return modem::global_modem_component->is_connected();
+#endif
+
+#ifdef USE_WIFI
+  if (wifi::global_wifi_component != nullptr)
+    return wifi::global_wifi_component->is_connected();
+#endif
+
+#ifdef USE_OPENTHREAD
+  if (openthread::global_openthread_component != nullptr)
+    return openthread::global_openthread_component->is_connected();
+#endif
+
+#ifdef USE_HOST
+  return true;  // Assume its connected
+#endif
+  return false;
+}
+
 /// Return whether the network is disabled (only wifi for now)
 bool is_disabled();
 /// Get the active network hostname

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -20,7 +20,7 @@
 namespace esphome::network {
 
 // The order of the components is important: WiFi should come after any possible main interfaces (it may be used as
-// an AP that use a previous interface for NAT).
+// an AP that uses a previous interface for NAT).
 
 /// Return whether the node is connected to the network (through wifi, eth, ...)
 inline bool is_connected() {

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -45,7 +45,7 @@ inline bool is_connected() {
 #endif
 
 #ifdef USE_HOST
-  return true;  // Assume its connected
+  return true;  // Assume it's connected
 #endif
   return false;
 }

--- a/esphome/components/network/util.h
+++ b/esphome/components/network/util.h
@@ -2,6 +2,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_NETWORK
 #include <string>
+#include "esphome/core/helpers.h"
 #include "ip_address.h"
 
 #ifdef USE_ETHERNET
@@ -23,7 +24,7 @@ namespace esphome::network {
 // an AP that uses a previous interface for NAT).
 
 /// Return whether the node is connected to the network (through wifi, eth, ...)
-inline bool is_connected() {
+ESPHOME_ALWAYS_INLINE inline bool is_connected() {
 #ifdef USE_ETHERNET
   if (ethernet::global_eth_component != nullptr && ethernet::global_eth_component->is_connected())
     return true;


### PR DESCRIPTION
# What does this implement/fix?

`network::is_connected()` is called frequently from many components every loop iteration (API server, MQTT, status sensor, improv, etc.), but being defined in a .cpp file prevents the compiler from inlining it. This PR moves it to the header as an `inline` function so the compiler can eliminate the function call overhead at each call site.

Additionally, `EthernetComponent::is_connected()` (a trivial single-field state check) is moved inline into the header, so the ethernet check within `network::is_connected()` can also be fully inlined.

Companion to #14463 which does the same for WiFi's `is_connected()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- #14463

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).