### PR TITLE
[esp32_improv][rf_bridge][esp32_ble_server][display][lvgl][pipsolar] Fix unsigned integer underflows

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -661,6 +661,9 @@ void Display::printf(int x, int y, BaseFont *font, const char *format, ...) {
 void Display::set_writer(display_writer_t &&writer) { this->writer_ = writer; }
 
 void Display::set_pages(std::vector<DisplayPage *> pages) {
+  if (pages.empty())
+    return;
+
   for (auto *page : pages)
     page->set_parent(this);
 

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -209,6 +209,10 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
 
       esp_gatt_rsp_t response;
       if (param->read.is_long) {
+        if (this->value_read_offset_ >= this->value_.size()) {
+          this->value_read_offset_ = 0;
+          break;
+        }
         if (this->value_.size() - this->value_read_offset_ < max_offset) {
           //  Last message in the chain
           response.attr_value.len = this->value_.size() - this->value_read_offset_;

--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -210,10 +210,10 @@ void BLECharacteristic::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt
       esp_gatt_rsp_t response;
       if (param->read.is_long) {
         if (this->value_read_offset_ >= this->value_.size()) {
+          response.attr_value.len = 0;
+          response.attr_value.offset = this->value_read_offset_;
           this->value_read_offset_ = 0;
-          break;
-        }
-        if (this->value_.size() - this->value_read_offset_ < max_offset) {
+        } else if (this->value_.size() - this->value_read_offset_ < max_offset) {
           //  Last message in the chain
           response.attr_value.len = this->value_.size() - this->value_read_offset_;
           response.attr_value.offset = this->value_read_offset_;

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -314,6 +314,8 @@ void ESP32ImprovComponent::dump_config() {
 }
 
 void ESP32ImprovComponent::process_incoming_data_() {
+  if (this->incoming_data_.size() < 3)
+    return;
   uint8_t length = this->incoming_data_[1];
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -167,7 +167,7 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const Color &current_color) override {
-    if (this->scan_width_ >= it.size())
+    if (this->scan_width_ >= static_cast<uint32_t>(it.size()))
       return;
 
     const uint32_t now = millis();

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -167,6 +167,9 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const Color &current_color) override {
+    if (this->scan_width_ >= it.size())
+      return;
+
     const uint32_t now = millis();
     if (now - this->last_move_ < this->move_interval_)
       return;

--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -167,9 +167,6 @@ class AddressableScanEffect : public AddressableLightEffect {
   void set_move_interval(uint32_t move_interval) { this->move_interval_ = move_interval; }
   void set_scan_width(uint32_t scan_width) { this->scan_width_ = scan_width; }
   void apply(AddressableLight &it, const Color &current_color) override {
-    if (this->scan_width_ >= static_cast<uint32_t>(it.size()))
-      return;
-
     const uint32_t now = millis();
     if (now - this->last_move_ < this->move_interval_)
       return;

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -421,7 +421,10 @@ void LvglComponent::write_random_() {
     col = col / this->draw_rounding * this->draw_rounding;
     auto row = random_uint32() % this->disp_drv_.ver_res;
     row = row / this->draw_rounding * this->draw_rounding;
-    auto size = (random_uint32() % 32) / this->draw_rounding * this->draw_rounding - 1;
+    auto size = (random_uint32() % 32) / this->draw_rounding * this->draw_rounding;
+    if (size == 0)
+      continue;
+    size -= 1;
     lv_area_t area;
     area.x1 = col;
     area.y1 = row;

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -421,10 +421,7 @@ void LvglComponent::write_random_() {
     col = col / this->draw_rounding * this->draw_rounding;
     auto row = random_uint32() % this->disp_drv_.ver_res;
     row = row / this->draw_rounding * this->draw_rounding;
-    auto size = (random_uint32() % 32) / this->draw_rounding * this->draw_rounding;
-    if (size == 0)
-      continue;
-    size -= 1;
+    auto size = ((random_uint32() % 32) / this->draw_rounding + 2) * this->draw_rounding - 1;
     lv_area_t area;
     area.x1 = col;
     area.y1 = row;

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -162,13 +162,15 @@ void Pipsolar::loop() {
 }
 
 uint8_t Pipsolar::check_incoming_length_(uint8_t length) {
-  if (this->read_pos_ - 3 == length) {
+  if (this->read_pos_ >= 3 && this->read_pos_ - 3 == length) {
     return 1;
   }
   return 0;
 }
 
 uint8_t Pipsolar::check_incoming_crc_() {
+  if (this->read_pos_ < 3)
+    return 0;
   uint16_t crc16;
   crc16 = this->pipsolar_crc_(read_buffer_, read_pos_ - 3);
   if (((uint8_t) ((crc16) >> 8)) == read_buffer_[read_pos_ - 3] &&

--- a/esphome/components/rf_bridge/rf_bridge.cpp
+++ b/esphome/components/rf_bridge/rf_bridge.cpp
@@ -74,7 +74,7 @@ bool RFBridgeComponent::parse_bridge_byte_(uint8_t byte) {
       data.length = raw[2];
       data.protocol = raw[3];
       char next_byte[3];  // 2 hex chars + null
-      for (uint8_t i = 0; i < data.length - 1; i++) {
+      for (uint8_t i = 0; i + 1 < data.length; i++) {
         buf_append_printf(next_byte, sizeof(next_byte), 0, "%02X", raw[4 + i]);
         data.code += next_byte;
       }


### PR DESCRIPTION
# What does this implement/fix?

Fix unsigned integer underflows across 7 components that can cause OOB memory access, buffer overreads, or incorrect behavior.

**High severity:**
- **light**: `it.size() - scan_width_` underflows when `scan_width >= strip size` in scan effect, causing OOB writes past the LED strip buffer
- **esp32_improv**: `incoming_data_[1]` accessed without size check, and `incoming_data_.size() - 3` underflows when size < 3
- **rf_bridge**: `data.length - 1` wraps to 255 when length is 0, causing a 255-iteration loop with OOB reads from the receive buffer

**Medium severity:**
- **esp32_ble_server**: `value_.size() - value_read_offset_` underflows if value shrinks during a BLE long read, causing OOB memcpy
- **display**: `pages.size() - 1` underflows when pages vector is empty in `set_pages()`
- **lvgl**: `(random_uint32() % 32) / draw_rounding * draw_rounding - 1` underflows to `SIZE_MAX` when the rounded value is 0
- **pipsolar**: `read_pos_ - 3` underflows in `check_incoming_length_()` and `check_incoming_crc_()` when fewer than 3 bytes received

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bug fixes to existing components, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).