### PR TITLE
[inkplate][ezo_pmp][ezo][packet_transport] Fix use-after-free bugs

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -66,8 +66,9 @@ void EZOSensor::loop() {
 
     if (to_run->command_type == EzoCommandType::EZO_SLEEP ||
         to_run->command_type == EzoCommandType::EZO_I2C) {  // Commands with no return data
+      bool update_address = to_run->command_type == EzoCommandType::EZO_I2C;
       this->commands_.pop_front();
-      if (to_run->command_type == EzoCommandType::EZO_I2C)
+      if (update_address)
         this->address_ = this->new_address_;
       return;
     }

--- a/esphome/components/ezo_pmp/ezo_pmp.cpp
+++ b/esphome/components/ezo_pmp/ezo_pmp.cpp
@@ -165,22 +165,23 @@ void EzoPMP::read_command_result_() {
       continue;
     }
 
-    switch (current_parameter) {
-      case 1:
-        first_parameter_buffer[position_in_parameter_buffer] = current_char;
-        first_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
-        break;
-      case 2:
-        second_parameter_buffer[position_in_parameter_buffer] = current_char;
-        second_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
-        break;
-      case 3:
-        third_parameter_buffer[position_in_parameter_buffer] = current_char;
-        third_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
-        break;
+    if (position_in_parameter_buffer < sizeof(first_parameter_buffer) - 1) {
+      switch (current_parameter) {
+        case 1:
+          first_parameter_buffer[position_in_parameter_buffer] = current_char;
+          first_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
+          break;
+        case 2:
+          second_parameter_buffer[position_in_parameter_buffer] = current_char;
+          second_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
+          break;
+        case 3:
+          third_parameter_buffer[position_in_parameter_buffer] = current_char;
+          third_parameter_buffer[position_in_parameter_buffer + 1] = '\0';
+          break;
+      }
+      position_in_parameter_buffer++;
     }
-
-    position_in_parameter_buffer++;
   }
 
   auto parsed_first_parameter = parse_number<float>(first_parameter_buffer);

--- a/esphome/components/ezo_pmp/ezo_pmp.cpp
+++ b/esphome/components/ezo_pmp/ezo_pmp.cpp
@@ -404,7 +404,8 @@ void EzoPMP::send_next_command_() {
       break;
 
     case EZO_PMP_COMMAND_EXEC_ARBITRARY_COMMAND_ADDRESS:  // Run an arbitrary command
-      command_buffer_length = snprintf((char *) command_buffer, sizeof(command_buffer), "%s", this->arbitrary_command_);
+      command_buffer_length =
+          snprintf((char *) command_buffer, sizeof(command_buffer), "%s", this->arbitrary_command_.c_str());
       ESP_LOGI(TAG, "Sending arbitrary command: %s", (char *) command_buffer);
       break;
 
@@ -541,7 +542,7 @@ void EzoPMP::change_i2c_address(int address) {
 }
 
 void EzoPMP::exec_arbitrary_command(const std::basic_string<char> &command) {
-  this->arbitrary_command_ = command.c_str();
+  this->arbitrary_command_ = command;
   this->queue_command_(EZO_PMP_COMMAND_EXEC_ARBITRARY_COMMAND_ADDRESS, 0, 0, true);
 }
 

--- a/esphome/components/ezo_pmp/ezo_pmp.h
+++ b/esphome/components/ezo_pmp/ezo_pmp.h
@@ -85,7 +85,7 @@ class EzoPMP : public PollingComponent, public i2c::I2CDevice {
   bool is_paused_flag_ = false;
   bool is_dosing_flag_ = false;
 
-  const char *arbitrary_command_{nullptr};
+  std::string arbitrary_command_{};
 
   void send_next_command_();
   void read_command_result_();

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -63,16 +63,26 @@ void Inkplate::initialize_() {
   if (buffer_size == 0)
     return;
 
-  if (this->partial_buffer_ != nullptr)
+  if (this->partial_buffer_ != nullptr) {
     allocator.deallocate(this->partial_buffer_, buffer_size);
-  if (this->partial_buffer_2_ != nullptr)
+    this->partial_buffer_ = nullptr;
+  }
+  if (this->partial_buffer_2_ != nullptr) {
     allocator.deallocate(this->partial_buffer_2_, buffer_size * 2);
-  if (this->buffer_ != nullptr)
+    this->partial_buffer_2_ = nullptr;
+  }
+  if (this->buffer_ != nullptr) {
     allocator.deallocate(this->buffer_, buffer_size);
-  if (this->glut_ != nullptr)
+    this->buffer_ = nullptr;
+  }
+  if (this->glut_ != nullptr) {
     allocator32.deallocate(this->glut_, 256 * 9);
-  if (this->glut2_ != nullptr)
+    this->glut_ = nullptr;
+  }
+  if (this->glut2_ != nullptr) {
     allocator32.deallocate(this->glut2_, 256 * 9);
+    this->glut2_ = nullptr;
+  }
 
   this->buffer_ = allocator.allocate(buffer_size);
   if (this->buffer_ == nullptr) {

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -249,7 +249,7 @@ void PacketTransport::init_data_() {
   } else {
     add(this->data_, DATA_KEY);
   }
-  for (auto pkey : this->ping_keys_) {
+  for (const auto &pkey : this->ping_keys_) {
     add(this->data_, PING_KEY);
     add(this->data_, pkey.second);
   }

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -150,7 +150,7 @@ class PacketTransport : public PollingComponent {
   std::vector<uint8_t> ping_header_{};
   std::vector<uint8_t> header_{};
   std::vector<uint8_t> data_{};
-  std::map<const char *, uint32_t> ping_keys_{};
+  std::map<std::string, uint32_t> ping_keys_{};
   const char *platform_name_{""};
   void add_key_(const char *name, uint32_t key);
   void send_ping_pong_request_();


### PR DESCRIPTION
# What does this implement/fix?

Fix use-after-free, dangling pointer, and buffer overrun bugs across 4 components:

- **inkplate**: `initialize_()` deallocates buffers but doesn't null the pointers. If a subsequent allocation fails and `initialize_()` is called again, it double-frees the already-freed memory. Fix: set pointers to nullptr after each deallocation.
- **ezo_pmp**: (1) `exec_arbitrary_command()` stores `command.c_str()` (a raw pointer) in `arbitrary_command_`, but the caller's string may be destroyed before the queued command executes. Fix: store as `std::string` instead of `const char*`. (2) `read_command_result_()` writes to 10-byte parameter buffers with no bounds check on `position_in_parameter_buffer`, causing stack buffer overrun on long parameters. Fix: guard writes against buffer size.
- **ezo**: `to_run` is a raw pointer to the front element of `commands_`. After `pop_front()` destroys the element, `to_run->command_type` is still accessed. Fix: save `command_type` before calling `pop_front()`.
- **packet_transport**: `ping_keys_` is `std::map<const char*, uint32_t>` but keys come from a stack-local `char namebuf[256]` in `process_()`. After the function returns, all map keys are dangling pointers. Additionally, `const char*` map keys compare by pointer value, not string content, so lookups for existing keys never match. Fix: change key type to `std::string`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bug fixes to existing components, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).