### PR TITLE
[ota] Devirtualize OTA backend calls

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -86,17 +86,7 @@ class ESPHomeOTAComponent final : public ota::OTAComponent {
 
   socket::ListenSocket *server_{nullptr};
   std::unique_ptr<socket::Socket> client_;
-#ifdef USE_ESP8266
-  std::unique_ptr<ota::ESP8266OTABackend> backend_;
-#elif defined(USE_ESP32)
-  std::unique_ptr<ota::IDFOTABackend> backend_;
-#elif defined(USE_RP2040)
-  std::unique_ptr<ota::ArduinoRP2040OTABackend> backend_;
-#elif defined(USE_LIBRETINY)
-  std::unique_ptr<ota::ArduinoLibreTinyOTABackend> backend_;
-#elif defined(USE_HOST)
-  std::unique_ptr<ota::HostOTABackend> backend_;
-#endif
+  ota::OTABackendPtr backend_;
 
   uint32_t client_connect_time_{0};
   uint16_t port_;

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -2,7 +2,7 @@
 
 #include "esphome/core/defines.h"
 #ifdef USE_OTA
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -86,7 +86,17 @@ class ESPHomeOTAComponent final : public ota::OTAComponent {
 
   socket::ListenSocket *server_{nullptr};
   std::unique_ptr<socket::Socket> client_;
-  std::unique_ptr<ota::OTABackend> backend_;
+#ifdef USE_ESP8266
+  std::unique_ptr<ota::ESP8266OTABackend> backend_;
+#elif defined(USE_ESP32)
+  std::unique_ptr<ota::IDFOTABackend> backend_;
+#elif defined(USE_RP2040)
+  std::unique_ptr<ota::ArduinoRP2040OTABackend> backend_;
+#elif defined(USE_LIBRETINY)
+  std::unique_ptr<ota::ArduinoLibreTinyOTABackend> backend_;
+#elif defined(USE_HOST)
+  std::unique_ptr<ota::HostOTABackend> backend_;
+#endif
 
   uint32_t client_connect_time_{0};
   uint16_t port_;

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -65,8 +65,7 @@ void OtaHttpRequestComponent::flash() {
   }
 }
 
-void OtaHttpRequestComponent::cleanup_(decltype(ota::make_ota_backend()) backend,
-                                       const std::shared_ptr<HttpContainer> &container) {
+void OtaHttpRequestComponent::cleanup_(ota::OTABackendPtr backend, const std::shared_ptr<HttpContainer> &container) {
   if (this->update_started_) {
     ESP_LOGV(TAG, "Aborting OTA backend");
     backend->abort();

--- a/esphome/components/http_request/ota/ota_http_request.cpp
+++ b/esphome/components/http_request/ota/ota_http_request.cpp
@@ -8,10 +8,6 @@
 
 #include "esphome/components/md5/md5.h"
 #include "esphome/components/watchdog/watchdog.h"
-#include "esphome/components/ota/ota_backend.h"
-#include "esphome/components/ota/ota_backend_esp8266.h"
-#include "esphome/components/ota/ota_backend_arduino_rp2040.h"
-#include "esphome/components/ota/ota_backend_esp_idf.h"
 
 namespace esphome {
 namespace http_request {
@@ -69,7 +65,7 @@ void OtaHttpRequestComponent::flash() {
   }
 }
 
-void OtaHttpRequestComponent::cleanup_(std::unique_ptr<ota::OTABackend> backend,
+void OtaHttpRequestComponent::cleanup_(decltype(ota::make_ota_backend()) backend,
                                        const std::shared_ptr<HttpContainer> &container) {
   if (this->update_started_) {
     ESP_LOGV(TAG, "Aborting OTA backend");

--- a/esphome/components/http_request/ota/ota_http_request.h
+++ b/esphome/components/http_request/ota/ota_http_request.h
@@ -39,7 +39,7 @@ class OtaHttpRequestComponent final : public ota::OTAComponent, public Parented<
   void flash();
 
  protected:
-  void cleanup_(decltype(ota::make_ota_backend()) backend, const std::shared_ptr<HttpContainer> &container);
+  void cleanup_(ota::OTABackendPtr backend, const std::shared_ptr<HttpContainer> &container);
   uint8_t do_ota_();
   std::string get_url_with_auth_(const std::string &url);
   bool http_get_md5_();

--- a/esphome/components/http_request/ota/ota_http_request.h
+++ b/esphome/components/http_request/ota/ota_http_request.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
@@ -39,7 +39,7 @@ class OtaHttpRequestComponent final : public ota::OTAComponent, public Parented<
   void flash();
 
  protected:
-  void cleanup_(std::unique_ptr<ota::OTABackend> backend, const std::shared_ptr<HttpContainer> &container);
+  void cleanup_(decltype(ota::make_ota_backend()) backend, const std::shared_ptr<HttpContainer> &container);
   uint8_t do_ota_();
   std::string get_url_with_auth_(const std::string &url);
   bool http_get_md5_();

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -49,17 +49,6 @@ enum OTAState {
   OTA_ERROR,
 };
 
-class OTABackend {
- public:
-  virtual ~OTABackend() = default;
-  virtual OTAResponseTypes begin(size_t image_size) = 0;
-  virtual void set_update_md5(const char *md5) = 0;
-  virtual OTAResponseTypes write(uint8_t *data, size_t len) = 0;
-  virtual OTAResponseTypes end() = 0;
-  virtual void abort() = 0;
-  virtual bool supports_compression() = 0;
-};
-
 /** Listener interface for OTA state changes.
  *
  * Components can implement this interface to receive OTA state updates

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -130,7 +130,5 @@ OTAGlobalCallback *get_global_ota_callback();
 // - notify_state_deferred_() when in separate task (e.g., web_server OTA)
 // This ensures proper listener execution in all contexts.
 #endif
-std::unique_ptr<ota::OTABackend> make_ota_backend();
-
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/components/ota/ota_backend_arduino_libretiny.cpp
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.cpp
@@ -12,7 +12,7 @@ namespace ota {
 
 static const char *const TAG = "ota.arduino_libretiny";
 
-std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ArduinoLibreTinyOTABackend>(); }
+std::unique_ptr<ArduinoLibreTinyOTABackend> make_ota_backend() { return make_unique<ArduinoLibreTinyOTABackend>(); }
 
 OTAResponseTypes ArduinoLibreTinyOTABackend::begin(size_t image_size) {
   // Handle UPDATE_SIZE_UNKNOWN (0) which is used by web server OTA

--- a/esphome/components/ota/ota_backend_arduino_libretiny.h
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.h
@@ -20,6 +20,8 @@ class ArduinoLibreTinyOTABackend final : public OTABackend {
   bool md5_set_{false};
 };
 
+std::unique_ptr<ArduinoLibreTinyOTABackend> make_ota_backend();
+
 }  // namespace ota
 }  // namespace esphome
 

--- a/esphome/components/ota/ota_backend_arduino_libretiny.h
+++ b/esphome/components/ota/ota_backend_arduino_libretiny.h
@@ -7,14 +7,14 @@
 namespace esphome {
 namespace ota {
 
-class ArduinoLibreTinyOTABackend final : public OTABackend {
+class ArduinoLibreTinyOTABackend final {
  public:
-  OTAResponseTypes begin(size_t image_size) override;
-  void set_update_md5(const char *md5) override;
-  OTAResponseTypes write(uint8_t *data, size_t len) override;
-  OTAResponseTypes end() override;
-  void abort() override;
-  bool supports_compression() override { return false; }
+  OTAResponseTypes begin(size_t image_size);
+  void set_update_md5(const char *md5);
+  OTAResponseTypes write(uint8_t *data, size_t len);
+  OTAResponseTypes end();
+  void abort();
+  bool supports_compression() { return false; }
 
  private:
   bool md5_set_{false};

--- a/esphome/components/ota/ota_backend_arduino_rp2040.cpp
+++ b/esphome/components/ota/ota_backend_arduino_rp2040.cpp
@@ -14,7 +14,7 @@ namespace ota {
 
 static const char *const TAG = "ota.arduino_rp2040";
 
-std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ArduinoRP2040OTABackend>(); }
+std::unique_ptr<ArduinoRP2040OTABackend> make_ota_backend() { return make_unique<ArduinoRP2040OTABackend>(); }
 
 OTAResponseTypes ArduinoRP2040OTABackend::begin(size_t image_size) {
   // OTA size of 0 is not currently handled, but

--- a/esphome/components/ota/ota_backend_arduino_rp2040.h
+++ b/esphome/components/ota/ota_backend_arduino_rp2040.h
@@ -22,6 +22,8 @@ class ArduinoRP2040OTABackend final : public OTABackend {
   bool md5_set_{false};
 };
 
+std::unique_ptr<ArduinoRP2040OTABackend> make_ota_backend();
+
 }  // namespace ota
 }  // namespace esphome
 

--- a/esphome/components/ota/ota_backend_arduino_rp2040.h
+++ b/esphome/components/ota/ota_backend_arduino_rp2040.h
@@ -9,14 +9,14 @@
 namespace esphome {
 namespace ota {
 
-class ArduinoRP2040OTABackend final : public OTABackend {
+class ArduinoRP2040OTABackend final {
  public:
-  OTAResponseTypes begin(size_t image_size) override;
-  void set_update_md5(const char *md5) override;
-  OTAResponseTypes write(uint8_t *data, size_t len) override;
-  OTAResponseTypes end() override;
-  void abort() override;
-  bool supports_compression() override { return false; }
+  OTAResponseTypes begin(size_t image_size);
+  void set_update_md5(const char *md5);
+  OTAResponseTypes write(uint8_t *data, size_t len);
+  OTAResponseTypes end();
+  void abort();
+  bool supports_compression() { return false; }
 
  private:
   bool md5_set_{false};

--- a/esphome/components/ota/ota_backend_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_esp8266.cpp
@@ -48,7 +48,7 @@ namespace esphome::ota {
 
 static const char *const TAG = "ota.esp8266";
 
-std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::ESP8266OTABackend>(); }
+std::unique_ptr<ESP8266OTABackend> make_ota_backend() { return make_unique<ESP8266OTABackend>(); }
 
 OTAResponseTypes ESP8266OTABackend::begin(size_t image_size) {
   // Handle UPDATE_SIZE_UNKNOWN (0) by calculating available space

--- a/esphome/components/ota/ota_backend_esp8266.h
+++ b/esphome/components/ota/ota_backend_esp8266.h
@@ -12,15 +12,15 @@ namespace esphome::ota {
 /// OTA backend for ESP8266 using native SDK functions.
 /// This implementation bypasses the Arduino Updater library to save ~228 bytes of RAM
 /// by not having a global Update object in .bss.
-class ESP8266OTABackend final : public OTABackend {
+class ESP8266OTABackend final {
  public:
-  OTAResponseTypes begin(size_t image_size) override;
-  void set_update_md5(const char *md5) override;
-  OTAResponseTypes write(uint8_t *data, size_t len) override;
-  OTAResponseTypes end() override;
-  void abort() override;
+  OTAResponseTypes begin(size_t image_size);
+  void set_update_md5(const char *md5);
+  OTAResponseTypes write(uint8_t *data, size_t len);
+  OTAResponseTypes end();
+  void abort();
   // Compression supported in all ESP8266 Arduino versions ESPHome supports (>= 2.7.0)
-  bool supports_compression() override { return true; }
+  bool supports_compression() { return true; }
 
  protected:
   /// Erase flash sector if current address is at sector boundary

--- a/esphome/components/ota/ota_backend_esp8266.h
+++ b/esphome/components/ota/ota_backend_esp8266.h
@@ -54,5 +54,7 @@ class ESP8266OTABackend final : public OTABackend {
   bool md5_set_{false};
 };
 
+std::unique_ptr<ESP8266OTABackend> make_ota_backend();
+
 }  // namespace esphome::ota
 #endif  // USE_ESP8266

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -11,7 +11,7 @@
 namespace esphome {
 namespace ota {
 
-std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::IDFOTABackend>(); }
+std::unique_ptr<IDFOTABackend> make_ota_backend() { return make_unique<IDFOTABackend>(); }
 
 OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
 #ifdef USE_OTA_ROLLBACK

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -27,6 +27,8 @@ class IDFOTABackend final : public OTABackend {
   bool md5_set_{false};
 };
 
+std::unique_ptr<IDFOTABackend> make_ota_backend();
+
 }  // namespace ota
 }  // namespace esphome
 #endif  // USE_ESP32

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -10,14 +10,14 @@
 namespace esphome {
 namespace ota {
 
-class IDFOTABackend final : public OTABackend {
+class IDFOTABackend final {
  public:
-  OTAResponseTypes begin(size_t image_size) override;
-  void set_update_md5(const char *md5) override;
-  OTAResponseTypes write(uint8_t *data, size_t len) override;
-  OTAResponseTypes end() override;
-  void abort() override;
-  bool supports_compression() override { return false; }
+  OTAResponseTypes begin(size_t image_size);
+  void set_update_md5(const char *md5);
+  OTAResponseTypes write(uint8_t *data, size_t len);
+  OTAResponseTypes end();
+  void abort();
+  bool supports_compression() { return false; }
 
  private:
   esp_ota_handle_t update_handle_{0};

--- a/esphome/components/ota/ota_backend_factory.h
+++ b/esphome/components/ota/ota_backend_factory.h
@@ -13,3 +13,5 @@
 #elif defined(USE_HOST)
 #include "ota_backend_host.h"
 #endif
+
+namespace esphome::ota {}  // namespace esphome::ota

--- a/esphome/components/ota/ota_backend_factory.h
+++ b/esphome/components/ota/ota_backend_factory.h
@@ -21,3 +21,7 @@ struct StubOTABackend {};
 std::unique_ptr<StubOTABackend> make_ota_backend();
 }  // namespace esphome::ota
 #endif
+
+namespace esphome::ota {
+using OTABackendPtr = decltype(make_ota_backend());
+}  // namespace esphome::ota

--- a/esphome/components/ota/ota_backend_factory.h
+++ b/esphome/components/ota/ota_backend_factory.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "ota_backend.h"
+
+#ifdef USE_ESP8266
+#include "ota_backend_esp8266.h"
+#elif defined(USE_ESP32)
+#include "ota_backend_esp_idf.h"
+#elif defined(USE_RP2040)
+#include "ota_backend_arduino_rp2040.h"
+#elif defined(USE_LIBRETINY)
+#include "ota_backend_arduino_libretiny.h"
+#elif defined(USE_HOST)
+#include "ota_backend_host.h"
+#endif

--- a/esphome/components/ota/ota_backend_factory.h
+++ b/esphome/components/ota/ota_backend_factory.h
@@ -2,6 +2,8 @@
 
 #include "ota_backend.h"
 
+#include <memory>
+
 #ifdef USE_ESP8266
 #include "ota_backend_esp8266.h"
 #elif defined(USE_ESP32)
@@ -12,6 +14,10 @@
 #include "ota_backend_arduino_libretiny.h"
 #elif defined(USE_HOST)
 #include "ota_backend_host.h"
+#else
+// Stub for static analysis when no platform is defined
+namespace esphome::ota {
+struct StubOTABackend {};
+std::unique_ptr<StubOTABackend> make_ota_backend();
+}  // namespace esphome::ota
 #endif
-
-namespace esphome::ota {}  // namespace esphome::ota

--- a/esphome/components/ota/ota_backend_host.cpp
+++ b/esphome/components/ota/ota_backend_host.cpp
@@ -8,7 +8,7 @@ namespace esphome::ota {
 // Stub implementation - OTA is not supported on host platform.
 // All methods return error codes to allow compilation of configs with OTA triggers.
 
-std::unique_ptr<ota::OTABackend> make_ota_backend() { return make_unique<ota::HostOTABackend>(); }
+std::unique_ptr<HostOTABackend> make_ota_backend() { return make_unique<HostOTABackend>(); }
 
 OTAResponseTypes HostOTABackend::begin(size_t image_size) { return OTA_RESPONSE_ERROR_UPDATE_PREPARE; }
 

--- a/esphome/components/ota/ota_backend_host.h
+++ b/esphome/components/ota/ota_backend_host.h
@@ -7,14 +7,14 @@ namespace esphome::ota {
 /// Stub OTA backend for host platform - allows compilation but does not implement OTA.
 /// All operations return error codes immediately. This enables configurations with
 /// OTA triggers to compile for host platform during development.
-class HostOTABackend final : public OTABackend {
+class HostOTABackend final {
  public:
-  OTAResponseTypes begin(size_t image_size) override;
-  void set_update_md5(const char *md5) override;
-  OTAResponseTypes write(uint8_t *data, size_t len) override;
-  OTAResponseTypes end() override;
-  void abort() override;
-  bool supports_compression() override { return false; }
+  OTAResponseTypes begin(size_t image_size);
+  void set_update_md5(const char *md5);
+  OTAResponseTypes write(uint8_t *data, size_t len);
+  OTAResponseTypes end();
+  void abort();
+  bool supports_compression() { return false; }
 };
 
 std::unique_ptr<HostOTABackend> make_ota_backend();

--- a/esphome/components/ota/ota_backend_host.h
+++ b/esphome/components/ota/ota_backend_host.h
@@ -17,5 +17,7 @@ class HostOTABackend final : public OTABackend {
   bool supports_compression() override { return false; }
 };
 
+std::unique_ptr<HostOTABackend> make_ota_backend();
+
 }  // namespace esphome::ota
 #endif

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -71,7 +71,7 @@ class OTARequestHandler : public AsyncWebHandler {
   bool ota_success_{false};
 
  private:
-  decltype(ota::make_ota_backend()) ota_backend_{nullptr};
+  ota::OTABackendPtr ota_backend_{nullptr};
 };
 
 void OTARequestHandler::report_ota_progress_(AsyncWebServerRequest *request) {

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -1,7 +1,7 @@
 #include "ota_web_server.h"
 #ifdef USE_WEBSERVER_OTA
 
-#include "esphome/components/ota/ota_backend.h"
+#include "esphome/components/ota/ota_backend_factory.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
@@ -71,7 +71,7 @@ class OTARequestHandler : public AsyncWebHandler {
   bool ota_success_{false};
 
  private:
-  std::unique_ptr<ota::OTABackend> ota_backend_{nullptr};
+  decltype(ota::make_ota_backend()) ota_backend_{nullptr};
 };
 
 void OTARequestHandler::report_ota_progress_(AsyncWebServerRequest *request) {


### PR DESCRIPTION
# What does this implement/fix?

Eliminates virtual dispatch overhead for OTA backend calls by removing the `OTABackend` base class entirely.

There is only ever one OTA backend per platform, so the virtual/polymorphic design was the wrong abstraction for the use case. Removing it eliminates the vtable (40 bytes on ESP32) and allows the compiler to inline and directly call all OTA methods.

Changes:
- Remove `OTABackend` abstract base class
- Move `make_ota_backend()` declaration to each concrete backend header with concrete return type
- Add `ota_backend_factory.h` convenience header that includes the correct concrete backend for the current platform and provides `OTABackendPtr` type alias
- Use concrete `unique_ptr` types in `ota_esphome`, `http_request/ota`, and `web_server/ota` consumers
- Use `ota::OTABackendPtr` type alias for member variables and parameters

## Migration guide for external components

The `OTABackend` abstract base class has been removed. Components that use OTA backends need the following changes:

**Include change:**
```cpp
// Before
#include "esphome/components/ota/ota_backend.h"

// After - if you need make_ota_backend() or the concrete backend type
#include "esphome/components/ota/ota_backend_factory.h"
```

**Local variables — use `auto`:**
```cpp
// Before
std::unique_ptr<ota::OTABackend> backend = ota::make_ota_backend();

// After
auto backend = ota::make_ota_backend();
```

**Member variables and function parameters — use `OTABackendPtr`:**
```cpp
// Before
std::unique_ptr<ota::OTABackend> backend_;
void cleanup(std::unique_ptr<ota::OTABackend> backend);

// After
ota::OTABackendPtr backend_;
void cleanup(ota::OTABackendPtr backend);
```

The concrete backend API is unchanged — `begin()`, `write()`, `end()`, `abort()`, `set_update_md5()`, and `supports_compression()` all work the same way.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal optimization
ota:
  - platform: esphome
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).