### PR TITLE
[core] Remove pre-sleep socket scan from fast select path

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -651,21 +651,16 @@ void Application::yield_with_select_(uint32_t delay_ms) {
     return;
   }
 
-  // Check if any socket already has pending data before sleeping.
-  // If a socket still has unread data (rcvevent > 0) but the task notification was already
-  // consumed, ulTaskNotifyTake would block until timeout — adding up to delay_ms latency.
-  // This scan preserves select() semantics: return immediately when any fd is ready.
-  for (struct lwip_sock *sock : this->monitored_sockets_) {
-    if (esphome_lwip_socket_has_data(sock)) {
-      yield();
-      return;
-    }
-  }
-
   // Sleep with instant wake via FreeRTOS task notification.
   // Woken by: callback wrapper (socket data arrives), wake_loop_threadsafe() (other tasks), or timeout.
   // Without USE_WAKE_LOOP_THREADSAFE, only hooked socket callbacks wake the task —
   // background tasks won't call wake, so this degrades to a pure timeout (same as old select path).
+  //
+  // No pre-sleep socket scan needed: xTaskNotifyGive from the lwip callback persists
+  // until consumed by ulTaskNotifyTake, so notifications received while the task is
+  // running are not lost. The only unhandled case is intentionally undrained sockets
+  // (e.g., API's MAX_MESSAGES_PER_LOOP throttle), where the delay_ms latency before
+  // re-checking is the desired behavior — waking immediately would defeat the throttle.
   ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -660,7 +660,8 @@ void Application::yield_with_select_(uint32_t delay_ms) {
   // until consumed by ulTaskNotifyTake, so notifications received while the task is
   // running are not lost. The only unhandled case is intentionally undrained sockets
   // (e.g., API's MAX_MESSAGES_PER_LOOP throttle), where the delay_ms latency before
-  // re-checking is the desired behavior — waking immediately would defeat the throttle.
+  // re-checking is the desired behavior — waking immediately would defeat the throttle
+  // which exists to let other tasks and components run.
   ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_ms));
 
 #elif defined(USE_SOCKET_SELECT_SUPPORT)


### PR DESCRIPTION
# What does this implement/fix?

Remove the pre-sleep scan of all monitored sockets from the fast select path (`yield_with_select_`). This scan performed N volatile cross-core reads (one per monitored socket) every loop iteration to check for pending data before sleeping.

This scan was originally added based on a Copilot suggestion in #14249 to "preserve select() semantics" by checking for pending socket data before sleeping. After further analysis, this scan is unnecessary with the FreeRTOS task notification approach and should not have been accepted:

- `xTaskNotifyGive` from the lwip callback persists until consumed by `ulTaskNotifyTake`, so notifications received while the task is running (not sleeping) are not lost — `ulTaskNotifyTake` returns immediately when the notification value is non-zero. The `ulTaskNotifyTake` critical section makes the check-and-block atomic, so there is no race between a notification arriving and the task deciding to sleep.

- The only case the scan caught was intentionally undrained sockets (e.g., API's `MAX_MESSAGES_PER_LOOP=5` throttle). Adding up to 16ms (`loop_interval`) latency before re-checking undrained data is the desired behavior — waking immediately would defeat the purpose of the throttle, which exists to let other tasks and components run.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14249

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).