### PR TITLE
[sgp30] Fix serial number truncation from 48-bit to 24-bit

### DIFF
--- a/esphome/components/sgp30/sgp30.cpp
+++ b/esphome/components/sgp30/sgp30.cpp
@@ -41,7 +41,9 @@ void SGP30Component::setup() {
     this->mark_failed();
     return;
   }
-  this->serial_number_ = encode_uint24(raw_serial_number[0], raw_serial_number[1], raw_serial_number[2]);
+  this->serial_number_ = (static_cast<uint64_t>(raw_serial_number[0]) << 32) |
+                         (static_cast<uint64_t>(raw_serial_number[1]) << 16) |
+                         static_cast<uint64_t>(raw_serial_number[2]);
   ESP_LOGD(TAG, "Serial number: %" PRIu64, this->serial_number_);
 
   // Featureset identification for future use


### PR DESCRIPTION
# What does this implement/fix?

`encode_uint24()` takes `uint8_t` arguments but was called with `uint16_t` values from the SGP30 serial ID register. Each 16-bit word was silently truncated to 8 bits, reducing the 48-bit serial number to 24 bits. This increases the chance of preference hash collisions between different sensors, causing them to share baseline calibration data incorrectly.

**Note:** This changes the preference hash, so existing stored baselines will no longer be found after update. The SGP30 will need to go through its warm-up/calibration period again (up to 12 hours for optimal accuracy).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).