### PR TITLE
[ds2484] Fix read64() using uint8_t accumulator instead of uint64_t

### DIFF
--- a/esphome/components/ds2484/ds2484.cpp
+++ b/esphome/components/ds2484/ds2484.cpp
@@ -110,9 +110,9 @@ uint8_t DS2484OneWireBus::read8() {
 }
 
 uint64_t DS2484OneWireBus::read64() {
-  uint8_t response = 0;
+  uint64_t response = 0;
   for (uint8_t i = 0; i < 8; i++) {
-    response |= (this->read8() << (i * 8));
+    response |= (static_cast<uint64_t>(this->read8()) << (i * 8));
   }
   return response;
 }


### PR DESCRIPTION
# What does this implement/fix?

`read64()` used a `uint8_t` accumulator instead of `uint64_t`. Only the first byte of the 1-Wire address was preserved — shifts of 8+ on a `uint8_t` lose all bits, and shifts >= 32 are undefined behavior. This corrupted all 1-Wire device addresses read through the DS2484.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).