### PR TITLE
[zwave_proxy] Fix uint8_t overflow for buffer index and frame end

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -281,6 +281,10 @@ bool ZWaveProxy::parse_byte_(uint8_t byte) {
       break;
     }
     case ZWAVE_PARSING_STATE_READ_BL_MENU:
+      if (this->buffer_index_ >= this->buffer_.size()) {
+        this->parsing_state_ = ZWAVE_PARSING_STATE_WAIT_START;
+        break;
+      }
       this->buffer_[this->buffer_index_++] = byte;
       if (!byte) {
         this->parsing_state_ = ZWAVE_PARSING_STATE_WAIT_START;

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -81,10 +81,10 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   api::APIConnection *api_connection_{nullptr};  // Current subscribed client
   uint32_t setup_time_{0};                       // Time when setup() was called
 
-  // 8-bit values (grouped together to minimize padding)
-  uint8_t buffer_index_{0};     // Index for populating the data buffer
-  uint8_t end_frame_after_{0};  // Payload reception ends after this index
-  uint8_t last_response_{0};    // Last response type sent
+  // Small values (grouped by size to minimize padding)
+  uint16_t buffer_index_{0};     // Index for populating the data buffer
+  uint16_t end_frame_after_{0};  // Payload reception ends after this index
+  uint8_t last_response_{0};     // Last response type sent
   ZWaveParsingState parsing_state_{ZWAVE_PARSING_STATE_WAIT_START};
   bool in_bootloader_{false};  // True if the device is detected to be in bootloader mode
   bool home_id_ready_{false};  // True when home ID has been received from Z-Wave module


### PR DESCRIPTION
# What does this implement/fix?

`buffer_index_` and `end_frame_after_` were `uint8_t` (max 255) but the buffer is 257 bytes (`MAX_ZWAVE_FRAME_SIZE`). With LENGTH=255, `end_frame_after_` wraps to 0, corrupting frame parsing. Changed both to `uint16_t`.

Also added a bounds check in bootloader menu parsing — previously, unterminated bootloader data would write past the buffer end with no limit.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).