### PR TITLE
[canbus] Fix high frame rates causing crashes due to unbounded iteration

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -16,6 +16,7 @@ CONF_REMOTE_TRANSMISSION_REQUEST = "remote_transmission_request"
 CONF_CANBUS_ID = "canbus_id"
 CONF_BIT_RATE = "bit_rate"
 CONF_ON_FRAME = "on_frame"
+CONF_MAX_FRAMES_PER_LOOP = "max_frames_per_loop"
 
 
 def validate_id(config):
@@ -85,6 +86,7 @@ CANBUS_SCHEMA = cv.Schema(
         cv.Required(CONF_CAN_ID): cv.int_range(min=0, max=0x1FFFFFFF),
         cv.Optional(CONF_BIT_RATE, default="125KBPS"): cv.enum(CAN_SPEEDS, upper=True),
         cv.Optional(CONF_USE_EXTENDED_ID, default=False): cv.boolean,
+        cv.Optional(CONF_MAX_FRAMES_PER_LOOP, default=50): cv.positive_int,
         cv.Optional(CONF_ON_FRAME): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CanbusTrigger),
@@ -108,6 +110,7 @@ async def setup_canbus_core_(var, config):
     cg.add(var.set_can_id([config[CONF_CAN_ID]]))
     cg.add(var.set_use_extended_id([config[CONF_USE_EXTENDED_ID]]))
     cg.add(var.set_bitrate(CAN_SPEEDS[config[CONF_BIT_RATE]]))
+    cg.add(var.set_max_frames_per_loop(config[CONF_MAX_FRAMES_PER_LOOP]))
 
     for conf in config.get(CONF_ON_FRAME, []):
         can_id = conf[CONF_CAN_ID]

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -67,15 +67,18 @@ void Canbus::add_trigger(CanbusTrigger *trigger) {
 
 void Canbus::loop() {
   struct CanFrame can_message;
-  // read all messages until queue is empty
-  int message_counter = 0;
-  while (this->read_message(&can_message) == canbus::ERROR_OK) {
-    message_counter++;
+  uint32_t message_counter = 0;
+  for (; message_counter < this->max_frames_per_loop_; message_counter++) {
+    if (this->read_message(&can_message) != canbus::ERROR_OK) {
+      break;
+    }
+
     if (can_message.use_extended_id) {
-      ESP_LOGD(TAG, "received can message (#%d) extended can_id=0x%" PRIx32 " size=%d", message_counter,
+      ESP_LOGD(TAG, "received can message (#%" PRIu32 ") extended can_id=0x%" PRIx32 " size=%d", message_counter + 1,
                can_message.can_id, can_message.can_data_length_code);
     } else {
-      ESP_LOGD(TAG, "received can message (#%d) std can_id=0x%" PRIx32 " size=%d", message_counter, can_message.can_id,
+      ESP_LOGD(TAG, "received can message (#%" PRIu32 ") std can_id=0x%" PRIx32 " size=%d", message_counter + 1,
+               can_message.can_id,
                can_message.can_data_length_code);
     }
 
@@ -99,6 +102,10 @@ void Canbus::loop() {
         trigger->trigger(data, can_message.can_id, can_message.remote_transmission_request);
       }
     }
+  }
+
+  if (message_counter == this->max_frames_per_loop_) {
+    ESP_LOGW(TAG, "Reached max_frames_per_loop=%" PRIu32 ", deferring remaining CAN frames", this->max_frames_per_loop_);
   }
 }
 

--- a/esphome/components/canbus/canbus.cpp
+++ b/esphome/components/canbus/canbus.cpp
@@ -78,8 +78,7 @@ void Canbus::loop() {
                can_message.can_id, can_message.can_data_length_code);
     } else {
       ESP_LOGD(TAG, "received can message (#%" PRIu32 ") std can_id=0x%" PRIx32 " size=%d", message_counter + 1,
-               can_message.can_id,
-               can_message.can_data_length_code);
+               can_message.can_id, can_message.can_data_length_code);
     }
 
     std::vector<uint8_t> data;
@@ -105,7 +104,8 @@ void Canbus::loop() {
   }
 
   if (message_counter == this->max_frames_per_loop_) {
-    ESP_LOGW(TAG, "Reached max_frames_per_loop=%" PRIu32 ", deferring remaining CAN frames", this->max_frames_per_loop_);
+    ESP_LOGW(TAG, "Reached max_frames_per_loop=%" PRIu32 ", deferring remaining CAN frames",
+             this->max_frames_per_loop_);
   }
 }
 

--- a/esphome/components/canbus/canbus.h
+++ b/esphome/components/canbus/canbus.h
@@ -78,6 +78,7 @@ class Canbus : public Component {
   void set_can_id(uint32_t can_id) { this->can_id_ = can_id; }
   void set_use_extended_id(bool use_extended_id) { this->use_extended_id_ = use_extended_id; }
   void set_bitrate(CanSpeed bit_rate) { this->bit_rate_ = bit_rate; }
+  void set_max_frames_per_loop(uint32_t max_frames_per_loop) { this->max_frames_per_loop_ = max_frames_per_loop; }
 
   void add_trigger(CanbusTrigger *trigger);
   /**
@@ -98,6 +99,7 @@ class Canbus : public Component {
   uint32_t can_id_;
   bool use_extended_id_;
   CanSpeed bit_rate_;
+  uint32_t max_frames_per_loop_;
   CallbackManager<void(uint32_t can_id, bool extended_id, bool rtr, const std::vector<uint8_t> &data)>
       callback_manager_{};
 


### PR DESCRIPTION
# What does this implement/fix?

This change limits the amount of frames `canbus` is able to handle per loop, deferring processing until the next loop in case the frame queue is not overrun. In general having an unbounded while loop like we did previously is not a good idea. This fixes that.

At high bit rates like 500KBPS, a saturated channel is capable of producing a tad less than 4000 frames a second. Assuming an optimistic 7ms per loop, that means we would need to process close to 30 frames per loop. The chosen default (50) is a bit above that so it should not cause dropped frames for this example. The highest rate possible is `1000KBPS`, which would double the previous frame rate, so this limit will start to take effect at that rate for very congested buses.

It's worth noting that this hammering of the bus can happen when ACKs stop being received from a sender while the esp is configured in listen only mode. This happened to me with a deye battery, where the inverter turned off and the esp that's monitoring the battery would crash constantly because of this overrun.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** https://github.com/esphome/esphome-docs/pull/6349

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

TODO

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
