### PR TITLE
[openthread] Cache is_connected() for cheap inline access

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -48,10 +48,10 @@ void OpenThreadComponent::dump_config() {
   }
 }
 
-bool OpenThreadComponent::is_connected() {
+bool OpenThreadComponent::is_connected_() const {
   auto lock = InstanceLock::try_acquire(100);
   if (!lock) {
-    ESP_LOGW(TAG, "Failed to acquire OpenThread lock in is_connected");
+    ESP_LOGW(TAG, "Failed to acquire OpenThread lock in is_connected_");
     return false;
   }
 
@@ -64,6 +64,13 @@ bool OpenThreadComponent::is_connected() {
 
   // TODO: If we're a leader, check that there is at least 1 known peer
   return role >= OT_DEVICE_ROLE_CHILD;
+}
+
+void OpenThreadComponent::update_connected_state_() {
+  bool connected = this->is_connected_();
+  if (connected != this->connected_) {
+    this->connected_ = connected;
+  }
 }
 
 // Gets the off-mesh routable address
@@ -228,6 +235,8 @@ void *OpenThreadSrpComponent::pool_alloc_(size_t size) {
 }
 
 void OpenThreadSrpComponent::set_mdns(esphome::mdns::MDNSComponent *mdns) { this->mdns_ = mdns; }
+
+void OpenThreadComponent::loop() { this->update_connected_state_(); }
 
 bool OpenThreadComponent::teardown() {
   if (!this->teardown_started_) {

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -1,9 +1,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_OPENTHREAD
 #include "openthread.h"
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
 #include "esp_openthread.h"
-#endif
 
 #include <freertos/portmacro.h>
 
@@ -48,28 +46,14 @@ void OpenThreadComponent::dump_config() {
   }
 }
 
-bool OpenThreadComponent::is_connected_() const {
-  auto lock = InstanceLock::try_acquire(100);
-  if (!lock) {
-    ESP_LOGW(TAG, "Failed to acquire OpenThread lock in is_connected_");
-    return false;
-  }
-
-  otInstance *instance = lock->get_instance();
-  if (instance == nullptr) {
-    return false;
-  }
-
-  otDeviceRole role = otThreadGetDeviceRole(instance);
-
-  // TODO: If we're a leader, check that there is at least 1 known peer
-  return role >= OT_DEVICE_ROLE_CHILD;
-}
-
-void OpenThreadComponent::update_connected_state_() {
-  bool connected = this->is_connected_();
-  if (connected != this->connected_) {
-    this->connected_ = connected;
+void OpenThreadComponent::on_state_changed_(otChangedFlags flags, void *context) {
+  if (flags & OT_CHANGED_THREAD_ROLE) {
+    auto *self = static_cast<OpenThreadComponent *>(context);
+    // This runs on the OpenThread task thread with the OT lock held,
+    // so we can safely call otThreadGetDeviceRole directly.
+    otInstance *instance = esp_openthread_get_instance();
+    otDeviceRole role = otThreadGetDeviceRole(instance);
+    self->connected_ = role >= OT_DEVICE_ROLE_CHILD;
   }
 }
 
@@ -235,8 +219,6 @@ void *OpenThreadSrpComponent::pool_alloc_(size_t size) {
 }
 
 void OpenThreadSrpComponent::set_mdns(esphome::mdns::MDNSComponent *mdns) { this->mdns_ = mdns; }
-
-void OpenThreadComponent::loop() { this->update_connected_state_(); }
 
 bool OpenThreadComponent::teardown() {
   if (!this->teardown_started_) {

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -8,6 +8,7 @@
 
 #include <openthread/srp_client.h>
 #include <openthread/srp_client_buffers.h>
+#include <openthread/instance.h>
 #include <openthread/thread.h>
 
 #include <optional>
@@ -23,7 +24,6 @@ class OpenThreadComponent : public Component {
   ~OpenThreadComponent();
   void dump_config() override;
   void setup() override;
-  void loop() override;
   bool teardown() override;
   float get_setup_priority() const override { return setup_priority::WIFI; }
 
@@ -43,8 +43,7 @@ class OpenThreadComponent : public Component {
 
  protected:
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
-  bool is_connected_() const;
-  void update_connected_state_();
+  static void on_state_changed_(otChangedFlags flags, void *context);
   std::function<void()> factory_reset_external_callback_;
 #if CONFIG_OPENTHREAD_MTD
   uint32_t poll_period_{0};

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -23,10 +23,11 @@ class OpenThreadComponent : public Component {
   ~OpenThreadComponent();
   void dump_config() override;
   void setup() override;
+  void loop() override;
   bool teardown() override;
   float get_setup_priority() const override { return setup_priority::WIFI; }
 
-  bool is_connected();
+  bool is_connected() const { return this->connected_; }
   network::IPAddresses get_ip_addresses();
   std::optional<otIp6Address> get_omr_address();
   void ot_main();
@@ -42,6 +43,8 @@ class OpenThreadComponent : public Component {
 
  protected:
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
+  bool is_connected_() const;
+  void update_connected_state_();
   std::function<void()> factory_reset_external_callback_;
 #if CONFIG_OPENTHREAD_MTD
   uint32_t poll_period_{0};
@@ -49,6 +52,7 @@ class OpenThreadComponent : public Component {
   std::optional<int8_t> output_power_{};
   bool teardown_started_{false};
   bool teardown_complete_{false};
+  bool connected_{false};
 
  private:
   // Stores a pointer to a string literal (static storage duration).

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -175,6 +175,9 @@ void OpenThreadComponent::ot_main() {
   // Pass the existing dataset, or NULL which will use the preprocessor definitions
   ESP_ERROR_CHECK(esp_openthread_auto_start(dataset.mLength > 0 ? &dataset : nullptr));
 
+  // Register state change callback to update connected_ reactively instead of polling
+  otSetStateChangedCallback(instance, OpenThreadComponent::on_state_changed_, this);
+
   esp_openthread_launch_mainloop();
 
   // Clean up


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
OpenThreadComponent::is_connected() previously locked openthread to determine connected status. This prevented the method from being inlined and added overhead for the many callers that check it every loop iteration (network::is_connected(), API server, MQTT, status sensor, improv, etc.).

This PR caches the connected state as a bool field and moves is_connected() to the header as an inline single-field return. Instead of polling with a loop() override, the cached state is updated reactively via `otSetStateChangedCallback` which fires on `OT_CHANGED_THREAD_ROLE` events.

Benefits over polling:
- No `loop()` override needed — zero per-loop cost
- No mutex lock acquisition on every iteration
- No risk of false disconnection blips from lock timeout
- The callback runs on the OpenThread task thread where the OT lock is already held, so `otThreadGetDeviceRole()` is safe to call directly

Thread safety of `connected_`: The field is written by the OT task thread (callback) and read by the ESPHome main loop (`is_connected()`). On ESP32 (Xtensa and RISC-V), aligned `bool` writes are atomic at the hardware level (single byte store), so there is no torn read. `std::atomic` is not needed — the worst case is the main loop sees a stale value for one iteration, which is fine for a connectivity status check.

This matches how the ethernet component already handles is_connected() — a simple state field check.

Together with https://github.com/esphome/esphome/pull/14464, the full network::is_connected() → wifi::is_connected() chain becomes inlineable end-to-end.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#14464

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
openthread:
  tlv: !secret openthread_tlv
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).