### PR TITLE
[nfc] Fix off-by-one in NDEF message parsing

### DIFF
--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "nfc.ndef_message";
 NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Building NdefMessage with %zu bytes", data.size());
   uint8_t index = 0;
-  while (index <= data.size()) {
+  while (index < data.size()) {
     uint8_t tnf_byte = data[index++];
     bool me = tnf_byte & 0x40;      // Message End bit (is set if this is the last record of the message)
     bool sr = tnf_byte & 0x10;      // Short record bit (is set if payload size is less or equal to 255 bytes)

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -8,8 +8,14 @@ static const char *const TAG = "nfc.ndef_message";
 
 NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Building NdefMessage with %zu bytes", data.size());
-  uint8_t index = 0;
+  size_t index = 0;
   while (index < data.size()) {
+    // Minimum record: TNF byte + type length byte + payload length (1 or 4 bytes)
+    if (index + 2 >= data.size()) {
+      ESP_LOGE(TAG, "Truncated record header; aborting");
+      break;
+    }
+
     uint8_t tnf_byte = data[index++];
     bool me = tnf_byte & 0x40;      // Message End bit (is set if this is the last record of the message)
     bool sr = tnf_byte & 0x10;      // Short record bit (is set if payload size is less or equal to 255 bytes)
@@ -23,6 +29,10 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
     if (sr) {
       payload_length = data[index++];
     } else {
+      if (index + 4 > data.size()) {
+        ESP_LOGE(TAG, "Truncated payload length; aborting");
+        break;
+      }
       payload_length = (static_cast<uint32_t>(data[index]) << 24) | (static_cast<uint32_t>(data[index + 1]) << 16) |
                        (static_cast<uint32_t>(data[index + 2]) << 8) | static_cast<uint32_t>(data[index + 3]);
       index += 4;
@@ -30,6 +40,10 @@ NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
 
     uint8_t id_length = 0;
     if (il) {
+      if (index >= data.size()) {
+        ESP_LOGE(TAG, "Truncated ID length; aborting");
+        break;
+      }
       id_length = data[index++];
     }
 


### PR DESCRIPTION
# What does this implement/fix?

Fix off-by-one error in the NDEF message constructor. The while loop condition used `index <= data.size()` instead of `index < data.size()`, allowing a read one byte past the end of the vector on the next iteration before any bounds check occurs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).