### PR TITLE
[pn532_spi] Fix preamble check logic and OOB access when full_len is zero

### DIFF
--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -91,6 +91,7 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
   if (header[0] != 0x00 || header[1] != 0x00 || header[2] != 0xFF) {
     // invalid packet
     ESP_LOGV(TAG, "read data invalid preamble!");
+    this->disable();
     return false;
   }
 
@@ -100,12 +101,13 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 
   if (!valid_header) {
     ESP_LOGV(TAG, "read data invalid header!");
+    this->disable();
     return false;
   }
 
-  // full length of message, including command response
+  // full length of message, including command response (minimum 2: TFI + command response)
   uint8_t full_len = header[3];
-  if (full_len == 0) {
+  if (full_len < 2) {
     ESP_LOGV(TAG, "read data has no payload");
     this->disable();
     return false;

--- a/esphome/components/pn532_spi/pn532_spi.cpp
+++ b/esphome/components/pn532_spi/pn532_spi.cpp
@@ -88,7 +88,7 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 #endif
   ESP_LOGV(TAG, "Header data: %s", format_hex_pretty_to(hex_buf, sizeof(hex_buf), header.data(), header.size()));
 
-  if (header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF) {
+  if (header[0] != 0x00 || header[1] != 0x00 || header[2] != 0xFF) {
     // invalid packet
     ESP_LOGV(TAG, "read data invalid preamble!");
     return false;
@@ -105,10 +105,14 @@ bool PN532Spi::read_response(uint8_t command, std::vector<uint8_t> &data) {
 
   // full length of message, including command response
   uint8_t full_len = header[3];
+  if (full_len == 0) {
+    ESP_LOGV(TAG, "read data has no payload");
+    this->disable();
+    return false;
+  }
+
   // length of data, excluding command response
   uint8_t len = full_len - 1;
-  if (full_len == 0)
-    len = 0;
 
   ESP_LOGV(TAG, "Reading response of length %d", len);
 


### PR DESCRIPTION
# What does this implement/fix?

Two bugs in the PN532 SPI response parser:

1. **Preamble validation uses `&&` instead of `||`**: The check `header[0] != 0x00 && header[1] != 0x00 && header[2] != 0xFF` only rejects packets where ALL three bytes are wrong. Any single correct byte passes the check, accepting malformed packets. Fixed to use `||`.

2. **OOB access when `full_len == 0`**: When the length field is 0, `len` is set to 0, but `data[len - 1]` wraps to `data[255]` (uint8_t underflow) and the checksum loop `i < len - 1` wraps to `i < 255`, iterating way out of bounds. Fixed by returning early when `full_len == 0`.

Note: `pn532_i2c` has the same `&&` vs `||` preamble bug (#76 in the scan).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).