### PR TITLE
[veml7700] Fix initial settling timeout using raw enum instead of milliseconds

### DIFF
--- a/esphome/components/veml7700/veml7700.cpp
+++ b/esphome/components/veml7700/veml7700.cpp
@@ -141,7 +141,7 @@ void VEML7700Component::loop() {
     // Datasheet: 2.5 ms before the first measurement is needed, allowing for the correct start of the signal processor
     // and oscillator.
     // Reality: wait for couple integration times to have first samples captured
-    this->set_timeout(2 * this->integration_time_, [this]() { this->state_ = State::IDLE; });
+    this->set_timeout(2 * get_itime_ms(this->integration_time_), [this]() { this->state_ = State::IDLE; });
   }
 
   if (this->is_ready()) {


### PR DESCRIPTION
# What does this implement/fix?

The initial settling timeout after setup used the raw `IntegrationTime` enum value instead of converting to milliseconds via `get_itime_ms()`.

For example, `INTEGRATION_TIME_100MS` has enum value `0`, so `2 * 0 = 0` — zero timeout, no settling time. `INTEGRATION_TIME_200MS` has enum value `1`, so `2 * 1 = 2ms` instead of the intended 400ms.

Fixed by wrapping the enum in `get_itime_ms()` to convert to actual milliseconds, consistent with all other `set_timeout` calls in the same file.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).