### PR TITLE
[openthread][ethernet][wifi] Add IPv6 address array bounds assert

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -470,6 +470,7 @@ network::IPAddresses EthernetComponent::get_ip_addresses() {
   uint8_t count = 0;
   count = esp_netif_get_all_ip6(this->eth_netif_, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
+  assert(count < addresses.size());
   for (int i = 0; i < count; i++) {
     addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
   }

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -194,8 +194,11 @@ void OpenThreadSrpComponent::setup() {
       // OpenThread SRP client expects the data to persist, so we strdup it
       const char *value_str = MDNS_STR_ARG(txt.value);
       txt_entries[i].mKey = MDNS_STR_ARG(txt.key);
-      txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(strdup(value_str));
-      txt_entries[i].mValueLength = strlen(value_str);
+      size_t value_len = strlen(value_str);
+      char *value_copy = reinterpret_cast<char *>(this->pool_alloc_(value_len + 1));
+      memcpy(value_copy, value_str, value_len + 1);
+      txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(value_copy);
+      txt_entries[i].mValueLength = value_len;
     }
     entry->mService.mTxtEntries = txt_entries;
     entry->mService.mNumTxtEntries = service.txt_records.size();

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -194,11 +194,8 @@ void OpenThreadSrpComponent::setup() {
       // OpenThread SRP client expects the data to persist, so we strdup it
       const char *value_str = MDNS_STR_ARG(txt.value);
       txt_entries[i].mKey = MDNS_STR_ARG(txt.key);
-      size_t value_len = strlen(value_str);
-      char *value_copy = reinterpret_cast<char *>(this->pool_alloc_(value_len + 1));
-      memcpy(value_copy, value_str, value_len + 1);
-      txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(value_copy);
-      txt_entries[i].mValueLength = value_len;
+      txt_entries[i].mValue = reinterpret_cast<const uint8_t *>(strdup(value_str));
+      txt_entries[i].mValueLength = strlen(value_str);
     }
     entry->mService.mTxtEntries = txt_entries;
     entry->mService.mNumTxtEntries = service.txt_records.size();

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -86,11 +86,6 @@ class InstanceLock {
   static InstanceLock acquire();
   ~InstanceLock();
 
-  InstanceLock(const InstanceLock &) = delete;
-  InstanceLock &operator=(const InstanceLock &) = delete;
-  InstanceLock(InstanceLock &&other) noexcept : acquired_(other.acquired_) { other.acquired_ = false; }
-  InstanceLock &operator=(InstanceLock &&) = delete;
-
   // Returns the global openthread instance guarded by this lock
   otInstance *get_instance();
 
@@ -98,7 +93,6 @@ class InstanceLock {
   // Use a private constructor in order to force the handling
   // of acquisition failure
   InstanceLock() {}
-  bool acquired_{true};
 };
 
 }  // namespace esphome::openthread

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -86,13 +86,19 @@ class InstanceLock {
   static InstanceLock acquire();
   ~InstanceLock();
 
+  InstanceLock(const InstanceLock &) = delete;
+  InstanceLock &operator=(const InstanceLock &) = delete;
+  InstanceLock(InstanceLock &&other) noexcept : acquired_(other.acquired_) { other.acquired_ = false; }
+  InstanceLock &operator=(InstanceLock &&) = delete;
+
   // Returns the global openthread instance guarded by this lock
   otInstance *get_instance();
 
  private:
-  // Use a private constructor in order to force thehandling
+  // Use a private constructor in order to force the handling
   // of acquisition failure
   InstanceLock() {}
+  bool acquired_{true};
 };
 
 }  // namespace esphome::openthread

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -220,11 +220,7 @@ InstanceLock InstanceLock::acquire() {
 
 otInstance *InstanceLock::get_instance() { return esp_openthread_get_instance(); }
 
-InstanceLock::~InstanceLock() {
-  if (this->acquired_) {
-    esp_openthread_lock_release();
-  }
-}
+InstanceLock::~InstanceLock() { esp_openthread_lock_release(); }
 
 }  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -197,7 +197,7 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
   esp_netif_t *netif = esp_netif_get_default_netif();
   count = esp_netif_get_all_ip6(netif, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
-  for (int i = 0; i < count; i++) {
+  for (int i = 0; i < count && i + 1 < static_cast<int>(addresses.size()); i++) {
     addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
   }
   return addresses;
@@ -219,7 +219,11 @@ InstanceLock InstanceLock::acquire() {
 
 otInstance *InstanceLock::get_instance() { return esp_openthread_get_instance(); }
 
-InstanceLock::~InstanceLock() { esp_openthread_lock_release(); }
+InstanceLock::~InstanceLock() {
+  if (this->acquired_) {
+    esp_openthread_lock_release();
+  }
+}
 
 }  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -197,7 +197,8 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
   esp_netif_t *netif = esp_netif_get_default_netif();
   count = esp_netif_get_all_ip6(netif, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
-  for (int i = 0; i < count && i + 1 < static_cast<int>(addresses.size()); i++) {
+  assert(count < addresses.size());
+  for (int i = 0; i < count; i++) {
     addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
   }
   return addresses;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -6,6 +6,7 @@
 
 #include <user_interface.h>
 
+#include <cassert>
 #include <utility>
 #include <algorithm>
 #ifdef USE_WIFI_WPA2_EAP
@@ -205,6 +206,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   network::IPAddresses addresses;
   uint8_t index = 0;
   for (auto &addr : addrList) {
+    assert(index < addresses.size());
     addresses[index++] = addr.ipFromNetifNum();
   }
   return addresses;

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -585,6 +585,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
   uint8_t count = 0;
   count = esp_netif_get_all_ip6(s_sta_netif, if_ip6s);
   assert(count <= CONFIG_LWIP_IPV6_NUM_ADDRESSES);
+  assert(count < addresses.size());
   for (int i = 0; i < count; i++) {
     addresses[i + 1] = network::IPAddress(&if_ip6s[i]);
   }

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_WIFI
 #ifdef USE_RP2040
 
+#include <cassert>
+
 #include "lwip/dns.h"
 #include "lwip/err.h"
 #include "lwip/netif.h"
@@ -285,6 +287,7 @@ network::IPAddresses WiFiComponent::wifi_sta_ip_addresses() {
     if (ip == ap_ip) {
       continue;
     }
+    assert(index < addresses.size());
     addresses[index++] = ip;
   }
   return addresses;


### PR DESCRIPTION
# What does this implement/fix?

Add `assert(count < addresses.size())` before the `addresses[i + 1]` loop in all three network components that enumerate IPv6 addresses. The `IPAddresses` array has 5 slots (index 0 for IPv4, 1-4 for IPv6), but `CONFIG_LWIP_IPV6_NUM_ADDRESSES` can be configured to 5+, which would cause an OOB write.

Also fixes a typo in an openthread comment.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).