### PR TITLE
[ci] Fix codeowner approval label workflow for fork PRs

### DIFF
--- a/.github/scripts/codeowners.js
+++ b/.github/scripts/codeowners.js
@@ -2,7 +2,7 @@
 //
 // Used by:
 //   - codeowner-review-request.yml
-//   - codeowner-approved-label.yml
+//   - codeowner-approved-label.yml + codeowner-approved-label-update.yml
 //   - auto-label-pr/detectors.js (detectCodeOwner)
 
 /**
@@ -133,11 +133,95 @@ function loadCodeowners(repoRoot = '.') {
   return parseCodeowners(content);
 }
 
+/** Possible label actions returned by determineLabelAction. */
+const LabelAction = Object.freeze({
+  ADD: 'add',
+  REMOVE: 'remove',
+  NONE: 'none',
+});
+
+/**
+ * Determine what label action is needed for a PR based on codeowner approvals.
+ *
+ * Checks changed files against CODEOWNERS patterns, reviews, and current labels
+ * to decide if the label should be added, removed, or left unchanged.
+ *
+ * @param {object} github              - octokit instance from actions/github-script
+ * @param {string} owner               - repo owner
+ * @param {string} repo                - repo name
+ * @param {number} pr_number           - pull request number
+ * @param {Array}  codeownersPatterns   - from loadCodeowners / fetchCodeowners
+ * @param {string} labelName           - label to manage
+ * @returns {Promise<LabelAction>}
+ */
+async function determineLabelAction(github, owner, repo, pr_number, codeownersPatterns, labelName) {
+  // Get the list of changed files in this PR
+  const prFiles = await github.paginate(
+    github.rest.pulls.listFiles,
+    { owner, repo, pull_number: pr_number }
+  );
+
+  const changedFiles = prFiles.map(file => file.filename);
+  console.log(`Found ${changedFiles.length} changed files`);
+
+  if (changedFiles.length === 0) {
+    console.log('No changed files found');
+    return LabelAction.NONE;
+  }
+
+  // Get effective owners using last-match-wins semantics
+  const effective = getEffectiveOwners(changedFiles, codeownersPatterns);
+  const componentCodeowners = effective.users;
+
+  console.log(`Component-specific codeowners: ${Array.from(componentCodeowners).join(', ') || '(none)'}`);
+
+  // Get current labels
+  const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+    owner, repo, issue_number: pr_number
+  });
+  const hasLabel = currentLabels.some(label => label.name === labelName);
+
+  if (componentCodeowners.size === 0) {
+    console.log('No component-specific codeowners found');
+    return hasLabel ? LabelAction.REMOVE : LabelAction.NONE;
+  }
+
+  // Get all reviews and find latest per user
+  const reviews = await github.paginate(
+    github.rest.pulls.listReviews,
+    { owner, repo, pull_number: pr_number }
+  );
+
+  const latestReviewByUser = new Map();
+  for (const review of reviews) {
+    if (!review.user || review.user.type === 'Bot' || review.state === 'COMMENTED') continue;
+    latestReviewByUser.set(review.user.login, review);
+  }
+
+  // Check if any component-specific codeowner has an active approval
+  let hasCodeownerApproval = false;
+  for (const [login, review] of latestReviewByUser) {
+    if (review.state === 'APPROVED' && componentCodeowners.has(login)) {
+      console.log(`Codeowner '${login}' has approved`);
+      hasCodeownerApproval = true;
+      break;
+    }
+  }
+
+  if (hasCodeownerApproval && !hasLabel) return LabelAction.ADD;
+  if (!hasCodeownerApproval && hasLabel) return LabelAction.REMOVE;
+
+  console.log(`Label already ${hasLabel ? 'present' : 'absent'}, no change needed`);
+  return LabelAction.NONE;
+}
+
 module.exports = {
   globToRegex,
   parseCodeowners,
   fetchCodeowners,
   loadCodeowners,
   classifyOwners,
-  getEffectiveOwners
+  getEffectiveOwners,
+  LabelAction,
+  determineLabelAction
 };

--- a/.github/workflows/codeowner-approved-label-update.yml
+++ b/.github/workflows/codeowner-approved-label-update.yml
@@ -1,0 +1,95 @@
+# Fallback for fork PRs: phase 1 (codeowner-approved-label.yml) handles
+# non-fork PRs directly but can't write labels on fork PRs (read-only token).
+# This workflow re-determines the action and applies it if needed.
+
+name: Codeowner Approved Label Update
+
+on:
+  workflow_run:
+    workflows: ["Codeowner Approved Label"]
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: read
+  contents: read
+
+jobs:
+  update-label:
+    name: Run
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request_review'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr_data=$(gh pr list --repo "$REPO" --state open --search "$HEAD_SHA" \
+            --json number,baseRefName --jq '.[0] // empty')
+
+          if [ -z "$pr_data" ]; then
+            echo "No open PR found for SHA $HEAD_SHA, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          pr_number=$(echo "$pr_data" | jq -r '.number')
+          base_ref=$(echo "$pr_data" | jq -r '.baseRefName')
+
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$base_ref" >> "$GITHUB_OUTPUT"
+          echo "Found PR #$pr_number targeting $base_ref"
+
+      - name: Checkout base repository
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ steps.pr.outputs.base_ref }}
+          sparse-checkout: |
+            .github/scripts/codeowners.js
+            CODEOWNERS
+
+      - name: Update label
+        if: steps.pr.outputs.skip != 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        with:
+          script: |
+            const { loadCodeowners, determineLabelAction, LabelAction } = require('./.github/scripts/codeowners.js');
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pr_number = parseInt(process.env.PR_NUMBER, 10);
+            const LABEL_NAME = 'code-owner-approved';
+
+            console.log(`Processing PR #${pr_number} for codeowner approval label`);
+
+            const codeownersPatterns = loadCodeowners();
+            const action = await determineLabelAction(
+              github, owner, repo, pr_number, codeownersPatterns, LABEL_NAME
+            );
+
+            if (action === LabelAction.ADD) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr_number, labels: [LABEL_NAME]
+              });
+              console.log(`Added '${LABEL_NAME}' label`);
+            } else if (action === LabelAction.REMOVE) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pr_number, name: LABEL_NAME
+                });
+                console.log(`Removed '${LABEL_NAME}' label`);
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            } else {
+              console.log('No label change needed');
+            }

--- a/.github/workflows/codeowner-approved-label.yml
+++ b/.github/workflows/codeowner-approved-label.yml
@@ -1,9 +1,9 @@
-# This workflow adds/removes a 'code-owner-approved' label when a
-# component-specific codeowner approves (or dismisses) a PR.
-# This helps maintainers prioritize PRs that have codeowner sign-off.
+# Adds/removes a 'code-owner-approved' label when a component-specific
+# codeowner approves (or dismisses) a PR.
 #
-# Only component-specific codeowners count — the catch-all @esphome/core
-# team is excluded so the label reflects domain-expert approval.
+# Handles non-fork PRs directly. For fork PRs the GITHUB_TOKEN is read-only,
+# so label writes are deferred to codeowner-approved-label-update.yml which
+# triggers via workflow_run with write permissions.
 
 name: Codeowner Approved Label
 
@@ -26,134 +26,53 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          sparse-checkout: |
+            .github/scripts/codeowners.js
+            CODEOWNERS
 
       - name: Check codeowner approval and update label
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
           script: |
-            const { loadCodeowners, getEffectiveOwners } = require('./.github/scripts/codeowners.js');
+            const { loadCodeowners, determineLabelAction, LabelAction } = require('./.github/scripts/codeowners.js');
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const pr_number = context.payload.pull_request.number;
+            const pr_number = parseInt(process.env.PR_NUMBER, 10);
             const LABEL_NAME = 'code-owner-approved';
 
             console.log(`Processing PR #${pr_number} for codeowner approval label`);
 
+            const codeownersPatterns = loadCodeowners();
+            const action = await determineLabelAction(
+              github, owner, repo, pr_number, codeownersPatterns, LABEL_NAME
+            );
+
+            if (action === LabelAction.NONE) {
+              console.log('No label change needed');
+              return;
+            }
+
             try {
-              // Get the list of changed files in this PR (with pagination)
-              const prFiles = await github.paginate(
-                github.rest.pulls.listFiles,
-                {
-                  owner,
-                  repo,
-                  pull_number: pr_number
-                }
-              );
-
-              const changedFiles = prFiles.map(file => file.filename);
-              console.log(`Found ${changedFiles.length} changed files`);
-
-              if (changedFiles.length === 0) {
-                console.log('No changed files found, skipping');
-                return;
-              }
-
-              // Parse CODEOWNERS from the checked-out base branch
-              const codeownersPatterns = loadCodeowners();
-
-              // Get effective owners using last-match-wins semantics
-              const effective = getEffectiveOwners(changedFiles, codeownersPatterns);
-
-              // Only keep individual component-specific codeowners (exclude teams)
-              const componentCodeowners = effective.users;
-
-              console.log(`Component-specific codeowners for changed files: ${Array.from(componentCodeowners).join(', ') || '(none)'}`);
-
-              if (componentCodeowners.size === 0) {
-                console.log('No component-specific codeowners found for changed files');
-                // Remove label if present since there are no component codeowners
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner,
-                    repo,
-                    issue_number: pr_number,
-                    name: LABEL_NAME
-                  });
-                  console.log(`Removed '${LABEL_NAME}' label (no component codeowners)`);
-                } catch (error) {
-                  if (error.status !== 404) {
-                    console.log(`Failed to remove label: ${error.message}`);
-                  }
-                }
-                return;
-              }
-
-              // Get all reviews on the PR
-              const reviews = await github.paginate(
-                github.rest.pulls.listReviews,
-                {
-                  owner,
-                  repo,
-                  pull_number: pr_number
-                }
-              );
-
-              // Get the latest review per user (reviews are returned chronologically)
-              const latestReviewByUser = new Map();
-              for (const review of reviews) {
-                // Skip bot reviews and comment-only reviews
-                if (!review.user || review.user.type === 'Bot' || review.state === 'COMMENTED') continue;
-                latestReviewByUser.set(review.user.login, review);
-              }
-
-              // Check if any component-specific codeowner has an active approval
-              let hasCodeownerApproval = false;
-              for (const [login, review] of latestReviewByUser) {
-                if (review.state === 'APPROVED' && componentCodeowners.has(login)) {
-                  console.log(`Codeowner '${login}' has approved`);
-                  hasCodeownerApproval = true;
-                  break;
-                }
-              }
-
-              // Get current labels to check if label is already present
-              const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
-                owner,
-                repo,
-                issue_number: pr_number
-              });
-              const hasLabel = currentLabels.some(label => label.name === LABEL_NAME);
-
-              if (hasCodeownerApproval && !hasLabel) {
-                // Add the label
+              if (action === LabelAction.ADD) {
                 await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: pr_number,
-                  labels: [LABEL_NAME]
+                  owner, repo, issue_number: pr_number, labels: [LABEL_NAME]
                 });
                 console.log(`Added '${LABEL_NAME}' label`);
-              } else if (!hasCodeownerApproval && hasLabel) {
-                // Remove the label
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner,
-                    repo,
-                    issue_number: pr_number,
-                    name: LABEL_NAME
-                  });
-                  console.log(`Removed '${LABEL_NAME}' label`);
-                } catch (error) {
-                  if (error.status !== 404) {
-                    console.log(`Failed to remove label: ${error.message}`);
-                  }
-                }
-              } else {
-                console.log(`Label already ${hasLabel ? 'present' : 'absent'}, no change needed`);
+              } else if (action === LabelAction.REMOVE) {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pr_number, name: LABEL_NAME
+                });
+                console.log(`Removed '${LABEL_NAME}' label`);
               }
-
             } catch (error) {
-              console.error(error);
-              core.setFailed(`Failed to process codeowner approval label: ${error.message}`);
+              if (error.status === 403) {
+                console.log('Fork PR: deferring label write to phase 2 workflow');
+              } else if (error.status === 404) {
+                console.log('Label already removed');
+              } else {
+                throw error;
+              }
             }


### PR DESCRIPTION
# What does this implement/fix?

The `codeowner-approved-label` workflow fails with `403 Resource not accessible by integration` on fork PRs because `pull_request_review` events give a read-only `GITHUB_TOKEN` for cross-repository PRs — regardless of declared permissions.

PR #14477 tried to fix this by adding `issues: write` permission, but that doesn't override GitHub's security restriction for fork PR tokens.

**Fix:** Two-phase approach where phase 1 handles the common cases directly, and phase 2 provides a fallback for fork PRs:

- **Phase 1** (`codeowner-approved-label.yml`): Triggered by `pull_request_review`. Determines the needed label action and tries to write it directly. For non-fork PRs this succeeds immediately. For fork PRs the 403 is caught gracefully (no red X) and deferred to phase 2.
- **Phase 2** (`codeowner-approved-label-update.yml`): Triggered by `workflow_run` on phase 1 completion. Re-determines the label action — skips if phase 1 already handled it or nothing is needed. Only performs a write for fork PRs where phase 1 couldn't.

**Other improvements:**
- Extracted `determineLabelAction()` and `LabelAction` enum into shared `codeowners.js` — reused by both workflows
- Efficient PR lookup via `gh pr list --search` instead of paginating all open PRs
- All `${{ }}` expressions routed through `env:` vars — no direct interpolation in `run:` or `script:` blocks
- Only base repo code is checked out, never fork code
- Sparse checkout for minimal clone (`codeowners.js` + `CODEOWNERS` only)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes the 403 error seen on https://github.com/esphome/esphome/pull/14474
- Supersedes #14477 which was insufficient

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).