### PR TITLE
[dfplayer][ufire_ise][ufire_ec][qmp6988][atm90e26] Fix wrong operators and masks

### DIFF
--- a/esphome/components/atm90e26/atm90e26.cpp
+++ b/esphome/components/atm90e26/atm90e26.cpp
@@ -197,7 +197,7 @@ float ATM90E26Component::get_reactive_power_() {
 float ATM90E26Component::get_power_factor_() {
   const uint16_t val = this->read16_(ATM90E26_REGISTER_POWERF);  // signed
   if (val & 0x8000) {
-    return -(val & 0x7FF) / 1000.0f;
+    return -(val & 0x7FFF) / 1000.0f;
   } else {
     return val / 1000.0f;
   }

--- a/esphome/components/dfplayer/dfplayer.cpp
+++ b/esphome/components/dfplayer/dfplayer.cpp
@@ -260,6 +260,7 @@ void DFPlayer::loop() {
               ESP_LOGV(TAG, "Playback finished (USB drive)");
               this->is_playing_ = false;
               this->on_finished_playback_callback_.call();
+              break;
             case 0x3D:
               ESP_LOGV(TAG, "Playback finished (SD card)");
               this->is_playing_ = false;

--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -251,7 +251,7 @@ void QMP6988Component::set_power_mode_(uint8_t power_mode) {
 void QMP6988Component::write_filter_(QMP6988IIRFilter filter) {
   uint8_t data;
 
-  data = (filter & 0x03);
+  data = (filter & QMP6988_CONFIG_REG_FILTER_MSK);
   this->write_byte(QMP6988_CONFIG_REG, data);
   delay(10);
 }

--- a/esphome/components/ufire_ec/ufire_ec.cpp
+++ b/esphome/components/ufire_ec/ufire_ec.cpp
@@ -8,7 +8,7 @@ static const char *const TAG = "ufire_ec";
 
 void UFireECComponent::setup() {
   uint8_t version;
-  if (!this->read_byte(REGISTER_VERSION, &version) && version != 0xFF) {
+  if (!this->read_byte(REGISTER_VERSION, &version) || version == 0xFF) {
     this->mark_failed();
     return;
   }

--- a/esphome/components/ufire_ise/ufire_ise.cpp
+++ b/esphome/components/ufire_ise/ufire_ise.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "ufire_ise";
 
 void UFireISEComponent::setup() {
   uint8_t version;
-  if (!this->read_byte(REGISTER_VERSION, &version) && version != 0xFF) {
+  if (!this->read_byte(REGISTER_VERSION, &version) || version == 0xFF) {
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fix five one-liner bugs involving wrong operators or bit masks:

- **dfplayer**: Add missing `break` after `case 0x3C` — USB playback finish fell through to SD card case, calling the finished callback twice
- **ufire_ise**: Fix `&&` to `||` in setup error check — component never called `mark_failed()` on absent device (read failure was AND'd with version check on uninitialized variable)
- **ufire_ec**: Same `&&` to `||` fix as ufire_ise
- **qmp6988**: Fix IIR filter mask `0x03` to `QMP6988_CONFIG_REG_FILTER_MSK` (`0x07`) — 3-bit field was truncated to 2 bits, so filter coefficients 4 (16X) and above mapped to wrong values
- **atm90e26**: Fix power factor sign-magnitude mask `0x7FF` to `0x7FFF` — bits 11-14 were discarded, producing incorrect negative power factor readings

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bug fixes only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).