### PR TITLE
[alpha3][mpu6886][emc2101] Fix copy-paste bugs

### DIFF
--- a/esphome/components/alpha3/alpha3.cpp
+++ b/esphome/components/alpha3/alpha3.cpp
@@ -125,7 +125,7 @@ void Alpha3::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc
         this->current_sensor_->publish_state(NAN);
       if (this->speed_sensor_ != nullptr)
         this->speed_sensor_->publish_state(NAN);
-      if (this->speed_sensor_ != nullptr)
+      if (this->voltage_sensor_ != nullptr)
         this->voltage_sensor_->publish_state(NAN);
       break;
     }

--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -71,15 +71,16 @@ void Emc2101Component::setup() {
   if (this->dac_mode_) {
     config |= EMC2101_DAC_BIT;
   }
+  if (this->inverted_) {
+    reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_POLARITY_BIT;
+  }
+
   if (this->dac_mode_) {  // DAC mode configurations
     // set DAC conversion rate
     reg(EMC2101_REGISTER_DAC_CONV_RATE) = this->dac_conversion_rate_;
   } else {  // PWM mode configurations
     // set PWM divider
     reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_CLK_OVR_BIT;
-    if (this->inverted_) {
-      reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_POLARITY_BIT;
-    }
     reg(EMC2101_REGISTER_PWM_DIV) = this->pwm_divider_;
 
     // set PWM resolution

--- a/esphome/components/emc2101/emc2101.cpp
+++ b/esphome/components/emc2101/emc2101.cpp
@@ -71,16 +71,15 @@ void Emc2101Component::setup() {
   if (this->dac_mode_) {
     config |= EMC2101_DAC_BIT;
   }
-  if (this->inverted_) {
-    config |= EMC2101_POLARITY_BIT;
-  }
-
   if (this->dac_mode_) {  // DAC mode configurations
     // set DAC conversion rate
     reg(EMC2101_REGISTER_DAC_CONV_RATE) = this->dac_conversion_rate_;
   } else {  // PWM mode configurations
     // set PWM divider
     reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_CLK_OVR_BIT;
+    if (this->inverted_) {
+      reg(EMC2101_REGISTER_FAN_CONFIG) |= EMC2101_POLARITY_BIT;
+    }
     reg(EMC2101_REGISTER_PWM_DIV) = this->pwm_divider_;
 
     // set PWM resolution

--- a/esphome/components/mpu6886/mpu6886.cpp
+++ b/esphome/components/mpu6886/mpu6886.cpp
@@ -80,7 +80,7 @@ void MPU6886Component::setup() {
   accel_config &= 0b11100111;
   accel_config |= (MPU6886_RANGE_2G << 3);
   ESP_LOGV(TAG, "    Output accel_config: 0b" BYTE_TO_BINARY_PATTERN, BYTE_TO_BINARY(accel_config));
-  if (!this->write_byte(MPU6886_REGISTER_GYRO_CONFIG, gyro_config)) {
+  if (!this->write_byte(MPU6886_REGISTER_ACCEL_CONFIG, accel_config)) {
     this->mark_failed();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fix three copy-paste bugs where wrong variables, registers, or register addresses were used:

- **alpha3**: Null check tested `speed_sensor_` but then dereferenced `voltage_sensor_` — crash when voltage sensor not configured but speed sensor is
- **mpu6886**: Accelerometer config value written to `MPU6886_REGISTER_GYRO_CONFIG` with `gyro_config` variable instead of `MPU6886_REGISTER_ACCEL_CONFIG` with `accel_config` — accelerometer range setting silently ignored
- **emc2101**: Fan polarity bit written to config register (0x03) instead of fan config register (0x4A) — since `EMC2101_POLARITY_BIT` and `EMC2101_DAC_BIT` are both `1 << 4`, this accidentally enabled DAC mode whenever `inverted: true` was set in PWM mode

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bug fixes only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).