### PR TITLE
[haier][bedjet][vbus][lightwaverf] Fix buffer overflow bugs

### DIFF
--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -69,6 +69,10 @@ BedjetPacket *BedjetCodec::get_set_runtime_remaining_request(const uint8_t hour,
 
 /** Decodes the extra bytes that were received after being notified with a partial packet. */
 void BedjetCodec::decode_extra(const uint8_t *data, uint16_t length) {
+  if (length < 5) {
+    ESP_LOGVV(TAG, "Received extra: %d bytes (too short)", length);
+    return;
+  }
   ESP_LOGVV(TAG, "Received extra: %d bytes: %d %d %d %d", length, data[1], data[2], data[3], data[4]);
   uint8_t offset = this->last_buffer_size_;
   if (offset > 0 && length + offset <= sizeof(BedjetStatusPacket)) {
@@ -119,13 +123,15 @@ bool BedjetCodec::decode_notify(const uint8_t *data, uint16_t length) {
     }
   } else if (data[1] == PACKET_FORMAT_DEBUG || data[3] == PACKET_TYPE_DEBUG) {
     // We don't actually know the packet format for this. Dump packets to log, in case a pattern presents itself.
-    ESP_LOGVV(TAG,
-              "received DEBUG packet: set1=%01fF, set2=%01fF, air=%01fF;  [7]=%d, [8]=%d, [9]=%d, [10]=%d, [11]=%d, "
-              "[12]=%d, [-1]=%d",
-              bedjet_temp_to_f(data[4]), bedjet_temp_to_f(data[5]), bedjet_temp_to_f(data[6]), data[7], data[8],
-              data[9], data[10], data[11], data[12], data[length - 1]);
+    if (length >= 13) {
+      ESP_LOGVV(TAG,
+                "received DEBUG packet: set1=%01fF, set2=%01fF, air=%01fF;  [7]=%d, [8]=%d, [9]=%d, [10]=%d, [11]=%d, "
+                "[12]=%d, [-1]=%d",
+                bedjet_temp_to_f(data[4]), bedjet_temp_to_f(data[5]), bedjet_temp_to_f(data[6]), data[7], data[8],
+                data[9], data[10], data[11], data[12], data[length - 1]);
+    }
 
-    if (this->has_status()) {
+    if (this->has_status() && length >= 7) {
       this->status_packet_->ambient_temp_step = data[6];
     }
   } else {

--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -1,4 +1,5 @@
 #include "bedjet_codec.h"
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 
@@ -96,7 +97,7 @@ bool BedjetCodec::decode_notify(const uint8_t *data, uint16_t length) {
     // Clear old buffer
     memset(&this->buf_, 0, sizeof(BedjetStatusPacket));
     // Copy new data into buffer
-    memcpy(&this->buf_, data, length);
+    memcpy(&this->buf_, data, std::min(static_cast<size_t>(length), sizeof(BedjetStatusPacket)));
     this->last_buffer_size_ = length;
 
     // TODO: validate the packet checksum?

--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -97,8 +97,9 @@ bool BedjetCodec::decode_notify(const uint8_t *data, uint16_t length) {
     // Clear old buffer
     memset(&this->buf_, 0, sizeof(BedjetStatusPacket));
     // Copy new data into buffer
-    memcpy(&this->buf_, data, std::min(static_cast<size_t>(length), sizeof(BedjetStatusPacket)));
-    this->last_buffer_size_ = length;
+    size_t copy_len = std::min(static_cast<size_t>(length), sizeof(BedjetStatusPacket));
+    memcpy(&this->buf_, data, copy_len);
+    this->last_buffer_size_ = copy_len;
 
     // TODO: validate the packet checksum?
     if (this->buf_.mode < 7 && this->buf_.target_temp_step >= 38 && this->buf_.target_temp_step <= 86 &&

--- a/esphome/components/bedjet/bedjet_codec.cpp
+++ b/esphome/components/bedjet/bedjet_codec.cpp
@@ -91,6 +91,10 @@ void BedjetCodec::decode_extra(const uint8_t *data, uint16_t length) {
  * @return `true` if the packet was decoded and represents a "partial" packet; `false` otherwise.
  */
 bool BedjetCodec::decode_notify(const uint8_t *data, uint16_t length) {
+  if (length < 5) {
+    ESP_LOGW(TAG, "Received short packet: %d bytes", length);
+    return false;
+  }
   ESP_LOGV(TAG, "Received: %d bytes: %d %d %d %d", length, data[1], data[2], data[3], data[4]);
 
   if (data[1] == PACKET_FORMAT_V3_HOME && data[3] == PACKET_TYPE_STATUS) {

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -385,7 +385,7 @@ haier_protocol::HaierMessage Smartair2Climate::get_control_message() {
 }
 
 haier_protocol::HandlerError Smartair2Climate::process_status_message_(const uint8_t *packet_buffer, uint8_t size) {
-  if (size < sizeof(smartair2_protocol::HaierStatus))
+  if (size != sizeof(smartair2_protocol::HaierStatus))
     return haier_protocol::HandlerError::WRONG_MESSAGE_STRUCTURE;
   smartair2_protocol::HaierStatus packet;
   memcpy(&packet, packet_buffer, size);

--- a/esphome/components/lightwaverf/LwTx.cpp
+++ b/esphome/components/lightwaverf/LwTx.cpp
@@ -108,6 +108,10 @@ bool LwTx::lwtx_free() { return !this->tx_msg_active; }
   Send a LightwaveRF message (10 nibbles in bytes)
 **/
 void LwTx::lwtx_send(const std::vector<uint8_t> &msg) {
+  if (msg.size() < TX_MSGLEN) {
+    ESP_LOGW("lightwaverf.sensor", "Message too short: %zu < %u", msg.size(), TX_MSGLEN);
+    return;
+  }
   if (this->tx_translate) {
     for (uint8_t i = 0; i < TX_MSGLEN; i++) {
       this->tx_buf[i] = TX_NIBBLE[msg[i] & 0xF];

--- a/esphome/components/lightwaverf/LwTx.cpp
+++ b/esphome/components/lightwaverf/LwTx.cpp
@@ -109,7 +109,7 @@ bool LwTx::lwtx_free() { return !this->tx_msg_active; }
 **/
 void LwTx::lwtx_send(const std::vector<uint8_t> &msg) {
   if (msg.size() < TX_MSGLEN) {
-    ESP_LOGW("lightwaverf.sensor", "Message too short: %zu < %u", msg.size(), TX_MSGLEN);
+    ESP_LOGW("lightwaverf.sensor", "Message too short: %zu < %u", msg.size(), static_cast<unsigned>(TX_MSGLEN));
     return;
   }
   if (this->tx_translate) {

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -1,6 +1,7 @@
 #include "vbus.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <algorithm>
 #include <cinttypes>
 
 namespace esphome {
@@ -107,8 +108,9 @@ void VBus::loop() {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
       char hex_buf[format_hex_size(VBUS_MAX_LOG_BYTES)];
 #endif
+      size_t log_bytes = std::min(this->buffer_.size(), static_cast<size_t>(VBUS_MAX_LOG_BYTES));
       ESP_LOGV(TAG, "P2 C%04x %04x->%04x: %s", this->command_, this->source_, this->dest_,
-               format_hex_to(hex_buf, this->buffer_.data(), this->buffer_.size()));
+               format_hex_to(hex_buf, this->buffer_.data(), log_bytes));
       for (auto &listener : this->listeners_)
         listener->on_message(this->command_, this->source_, this->dest_, this->buffer_);
       this->state_ = 0;

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -107,8 +107,8 @@ void VBus::loop() {
         continue;
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
       char hex_buf[format_hex_size(VBUS_MAX_LOG_BYTES)];
-#endif
       size_t log_bytes = std::min(this->buffer_.size(), static_cast<size_t>(VBUS_MAX_LOG_BYTES));
+#endif
       ESP_LOGV(TAG, "P2 C%04x %04x->%04x: %s", this->command_, this->source_, this->dest_,
                format_hex_to(hex_buf, this->buffer_.data(), log_bytes));
       for (auto &listener : this->listeners_)


### PR DESCRIPTION
# What does this implement/fix?

Fix four buffer overflow bugs:

- **haier**: `memcpy` in `process_status_message_` used packet `size` instead of `sizeof(HaierStatus)` — oversized packets overflowed the stack-allocated struct. Changed guard from `size <` to `size !=` to reject wrong-sized packets entirely.
- **bedjet**: BLE notification `memcpy` in `decode_notify` used unchecked `length` — oversized BLE notification could overwrite adjacent class members. Capped copy to `sizeof(BedjetStatusPacket)`.
- **vbus**: `hex_buf` in verbose logging sized for `VBUS_MAX_LOG_BYTES` (64 bytes) but `buffer_` can hold up to 1020 bytes (255 frames x 4 bytes) — stack buffer overflow on long VBus messages. Clamped bytes passed to `format_hex_to`.
- **lightwaverf**: `lwtx_send` accessed `msg[0..9]` without checking `msg.size() >= TX_MSGLEN` (10) — out-of-bounds read on short messages. Added size check with early return.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bug fixes only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).