### PR TITLE
[dfrobot_sen0395][sx1509] Fix structural bugs

### DIFF
--- a/esphome/components/dfrobot_sen0395/commands.h
+++ b/esphome/components/dfrobot_sen0395/commands.h
@@ -30,11 +30,9 @@ class Command {
 
 class ReadStateCommand : public Command {
  public:
+  ReadStateCommand() { timeout_ms_ = 500; }
   uint8_t execute(DfrobotSen0395Component *parent) override;
   uint8_t on_message(std::string &message) override;
-
- protected:
-  uint32_t timeout_ms_{500};
 };
 
 class PowerCommand : public Command {
@@ -99,12 +97,12 @@ class ResetSystemCommand : public Command {
 
 class SaveCfgCommand : public Command {
  public:
-  SaveCfgCommand() { cmd_ = "saveCfg 0x45670123 0xCDEF89AB 0x956128C6 0xDF54AC89"; }
+  SaveCfgCommand() {
+    cmd_ = "saveCfg 0x45670123 0xCDEF89AB 0x956128C6 0xDF54AC89";
+    cmd_duration_ms_ = 3000;
+    timeout_ms_ = 3500;
+  }
   uint8_t on_message(std::string &message) override;
-
- protected:
-  uint32_t cmd_duration_ms_{3000};
-  uint32_t timeout_ms_{3500};
 };
 
 class LedModeCommand : public Command {

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -56,11 +56,11 @@ void SX1509Component::loop() {
       return;
     }
     int row, col;
-    for (row = 0; row < 7; row++) {
+    for (row = 0; row < 8; row++) {
       if (key_data & (1 << row))
         break;
     }
-    for (col = 8; col < 15; col++) {
+    for (col = 8; col < 16; col++) {
       if (key_data & (1 << col))
         break;
     }
@@ -229,7 +229,7 @@ void SX1509Component::setup_keypad_() {
   this->read_byte_16(REG_DIR_B, &this->ddr_mask_);
   for (int i = 0; i < this->rows_; i++)
     this->ddr_mask_ &= ~(1 << i);
-  for (int i = 8; i < (this->cols_ * 2); i++)
+  for (int i = 8; i < (8 + this->cols_); i++)
     this->ddr_mask_ |= (1 << i);
   this->write_byte_16(REG_DIR_B, this->ddr_mask_);
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes structural bugs in dfrobot_sen0395 and sx1509 components.

**dfrobot_sen0395:** `ReadStateCommand` and `SaveCfgCommand` re-declared `timeout_ms_` and `cmd_duration_ms_` as protected members, shadowing the base class `Command` fields. The derived class fields get initialized with the intended values (500, 3000, 3500), but the base class methods that actually use these fields read the base class copies with different defaults. Fix: remove shadowed declarations and set the base class fields in the constructor instead.

**sx1509:** Three keypad bugs:
- `row < 7` should be `row < 8` — row 7 was never detected
- `col < 15` should be `col < 16` — column 15 was never detected
- `cols_ * 2` should be `8 + cols_` — columns start at bit 8 in the 16-bit direction register; the formula `cols_ * 2` only works by coincidence when `cols_ == 8`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# dfrobot_sen0395
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 115200

dfrobot_sen0395:
  uart_id: uart_bus

# sx1509
i2c:
  sda: GPIO21
  scl: GPIO22

sx1509:
  id: sx1509_hub
  address: 0x3E
  keypad:
    key_rows: 4
    key_columns: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).