### PR TITLE
[usb_cdc_acm][scd4x][pulse_counter][mopeka_std_check][ruuvi_ble] Fix assorted one-liner bugs

### DIFF
--- a/esphome/components/mopeka_std_check/mopeka_std_check.cpp
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.cpp
@@ -108,7 +108,7 @@ bool MopekaStdCheck::parse_device(const esp32_ble_tracker::ESPBTDevice &device) 
   }
 
   // Get temperature of sensor
-  uint8_t temp_in_c = this->parse_temperature_(mopeka_data);
+  int8_t temp_in_c = this->parse_temperature_(mopeka_data);
   if (this->temperature_ != nullptr) {
     this->temperature_->publish_state(temp_in_c);
   }
@@ -223,12 +223,12 @@ uint8_t MopekaStdCheck::parse_battery_level_(const mopeka_std_package *message) 
   return (uint8_t) percent;
 }
 
-uint8_t MopekaStdCheck::parse_temperature_(const mopeka_std_package *message) {
+int8_t MopekaStdCheck::parse_temperature_(const mopeka_std_package *message) {
   uint8_t tmp = message->raw_temp;
   if (tmp == 0x0) {
     return -40;
   } else {
-    return (uint8_t) ((tmp - 25.0f) * 1.776964f);
+    return static_cast<int8_t>((tmp - 25.0f) * 1.776964f);
   }
 }
 

--- a/esphome/components/mopeka_std_check/mopeka_std_check.h
+++ b/esphome/components/mopeka_std_check/mopeka_std_check.h
@@ -71,7 +71,7 @@ class MopekaStdCheck : public Component, public esp32_ble_tracker::ESPBTDeviceLi
 
   float get_lpg_speed_of_sound_(float temperature);
   uint8_t parse_battery_level_(const mopeka_std_package *message);
-  uint8_t parse_temperature_(const mopeka_std_package *message);
+  int8_t parse_temperature_(const mopeka_std_package *message);
 };
 
 }  // namespace mopeka_std_check

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "nfc.ndef_message";
 NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Building NdefMessage with %zu bytes", data.size());
   uint8_t index = 0;
-  while (index <= data.size()) {
+  while (index < data.size()) {
     uint8_t tnf_byte = data[index++];
     bool me = tnf_byte & 0x40;      // Message End bit (is set if this is the last record of the message)
     bool sr = tnf_byte & 0x10;      // Short record bit (is set if payload size is less or equal to 255 bytes)

--- a/esphome/components/nfc/ndef_message.cpp
+++ b/esphome/components/nfc/ndef_message.cpp
@@ -9,7 +9,7 @@ static const char *const TAG = "nfc.ndef_message";
 NdefMessage::NdefMessage(std::vector<uint8_t> &data) {
   ESP_LOGV(TAG, "Building NdefMessage with %zu bytes", data.size());
   uint8_t index = 0;
-  while (index < data.size()) {
+  while (index <= data.size()) {
     uint8_t tnf_byte = data[index++];
     bool me = tnf_byte & 0x40;      // Message End bit (is set if this is the last record of the message)
     bool sr = tnf_byte & 0x10;      // Short record bit (is set if payload size is less or equal to 255 bytes)

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -175,7 +175,8 @@ void PulseCounterSensor::setup() {
 
 void PulseCounterSensor::set_total_pulses(uint32_t pulses) {
   this->current_total_ = pulses;
-  this->total_sensor_->publish_state(pulses);
+  if (this->total_sensor_ != nullptr)
+    this->total_sensor_->publish_state(pulses);
 }
 
 void PulseCounterSensor::dump_config() {

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -66,7 +66,7 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_y = data[8] == 0xFF && data[9] == 0xFF ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0xFF && data[11] == 0xFF ? NAN : acceleration_z;
       result.acceleration =
-          std::isnan(result.acceleration_x) || std::isnan(result.acceleration_y) || std::isnan(result.acceleration_z)
+          std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
               ? NAN
               : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
                       acceleration_z * acceleration_z);

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -3,8 +3,6 @@
 
 #ifdef USE_ESP32
 
-#include <cmath>
-
 namespace esphome {
 namespace ruuvi_ble {
 
@@ -65,11 +63,11 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_x = data[6] == 0xFF && data[7] == 0xFF ? NAN : acceleration_x;
       result.acceleration_y = data[8] == 0xFF && data[9] == 0xFF ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0xFF && data[11] == 0xFF ? NAN : acceleration_z;
-      result.acceleration =
-          std::isnan(*result.acceleration_x) || std::isnan(*result.acceleration_y) || std::isnan(*result.acceleration_z)
-              ? NAN
-              : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
-                      acceleration_z * acceleration_z);
+      if ((data[6] != 0xFF || data[7] != 0xFF) && (data[8] != 0xFF || data[9] != 0xFF) &&
+          (data[10] != 0xFF || data[11] != 0xFF)) {
+        result.acceleration =
+            sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y + acceleration_z * acceleration_z);
+      }
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
       result.movement_counter = movement_counter;

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -67,6 +67,8 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
           (data[10] != 0xFF || data[11] != 0xFF)) {
         result.acceleration =
             sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y + acceleration_z * acceleration_z);
+      } else {
+        result.acceleration = NAN;
       }
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -1,5 +1,6 @@
 #include "ruuvi_ble.h"
 #include "esphome/core/log.h"
+#include <cmath>
 
 #ifdef USE_ESP32
 
@@ -63,10 +64,11 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       result.acceleration_x = data[6] == 0xFF && data[7] == 0xFF ? NAN : acceleration_x;
       result.acceleration_y = data[8] == 0xFF && data[9] == 0xFF ? NAN : acceleration_y;
       result.acceleration_z = data[10] == 0xFF && data[11] == 0xFF ? NAN : acceleration_z;
-      result.acceleration = result.acceleration_x == NAN || result.acceleration_y == NAN || result.acceleration_z == NAN
-                                ? NAN
-                                : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
-                                        acceleration_z * acceleration_z);
+      result.acceleration =
+          std::isnan(result.acceleration_x) || std::isnan(result.acceleration_y) || std::isnan(result.acceleration_z)
+              ? NAN
+              : sqrtf(acceleration_x * acceleration_x + acceleration_y * acceleration_y +
+                      acceleration_z * acceleration_z);
       result.battery_voltage = (power_info >> 5) == 0x7FF ? NAN : battery_voltage;
       result.tx_power = (power_info & 0x1F) == 0x1F ? NAN : tx_power;
       result.movement_counter = movement_counter;

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -1,8 +1,9 @@
 #include "ruuvi_ble.h"
 #include "esphome/core/log.h"
-#include <cmath>
 
 #ifdef USE_ESP32
+
+#include <cmath>
 
 namespace esphome {
 namespace ruuvi_ble {

--- a/esphome/components/scd4x/scd4x.cpp
+++ b/esphome/components/scd4x/scd4x.cpp
@@ -307,7 +307,7 @@ bool SCD4XComponent::start_measurement_() {
       break;
   }
 
-  static uint8_t remaining_retries = 3;
+  uint8_t remaining_retries = 3;
   while (remaining_retries) {
     if (!this->write_command(measurement_command)) {
       ESP_LOGE(TAG, "Error starting measurements");
@@ -316,6 +316,7 @@ bool SCD4XComponent::start_measurement_() {
       if (--remaining_retries == 0)
         return false;
       delay(50);  // NOLINT wait 50 ms and try again
+      continue;
     }
     this->status_clear_warning();
     return true;

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -161,7 +161,7 @@ void USBCDCACMInstance::setup() {
 
   // Create a simple, unique task name per interface
   char task_name[] = "usb_tx_0";
-  task_name[sizeof(task_name) - 1] = format_hex_char(static_cast<char>(this->itf_));
+  task_name[sizeof(task_name) - 2] = format_hex_char(static_cast<char>(this->itf_));
   xTaskCreate(usb_tx_task_fn, task_name, stack_size, this, 4, &this->usb_tx_task_handle_);
 
   if (this->usb_tx_task_handle_ == nullptr) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes 5 small but impactful bugs found during a component-wide code audit.

- **usb_cdc_acm:** `sizeof(task_name)-1` overwrites the NUL terminator instead of the `'0'` character, passing an unterminated string to `xTaskCreate`. Fix: use `-2`.
- **scd4x:** `static` retry counter never resets across calls, so after 3 total failures the sensor is permanently broken. Also, a missing `continue` after a failed write causes the error path to fall through to `status_clear_warning()` and return success. Fix: remove `static`, add `continue`.
- **pulse_counter:** `set_total_pulses()` dereferences `total_sensor_` without a null check, crashing if no total sensor is configured. Fix: add null check.
- **mopeka_std_check:** `parse_temperature_()` returns `uint8_t` but `return -40` wraps to 216, producing a wildly wrong speed-of-sound calculation and incorrect tank level readings. Fix: change return type to `int8_t`.
- **ruuvi_ble:** `result.acceleration_x == NAN` is always false per IEEE 754, so the acceleration guard is dead code. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# pulse_counter
sensor:
  - platform: pulse_counter
    pin: GPIO4
    name: "Pulse Counter"
    total:
      name: "Total Pulses"

# scd4x
i2c:
  sda: GPIO21
  scl: GPIO22

sensor:
  - platform: scd4x
    co2:
      name: "CO2"
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).