### PR TITLE
[ssd1322][ssd1325][ssd1327] Fix nibble mask bug in grayscale draw_pixel

### DIFF
--- a/esphome/components/ssd1322_base/ssd1322_base.cpp
+++ b/esphome/components/ssd1322_base/ssd1322_base.cpp
@@ -169,7 +169,7 @@ void HOT SSD1322::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ensure 'color4' is valid (only 4 bits aka 1 nibble) and shift the bits left when necessary
   color4 = (color4 & SSD1322_COLORMASK) << shift;
   // first mask off the nibble we must change...
-  this->buffer_[pos] &= (~SSD1322_COLORMASK >> shift);
+  this->buffer_[pos] &= (static_cast<uint8_t>(~SSD1322_COLORMASK) >> shift);
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }

--- a/esphome/components/ssd1325_base/ssd1325_base.cpp
+++ b/esphome/components/ssd1325_base/ssd1325_base.cpp
@@ -202,7 +202,7 @@ void HOT SSD1325::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ensure 'color4' is valid (only 4 bits aka 1 nibble) and shift the bits left when necessary
   color4 = (color4 & SSD1325_COLORMASK) << shift;
   // first mask off the nibble we must change...
-  this->buffer_[pos] &= (~SSD1325_COLORMASK >> shift);
+  this->buffer_[pos] &= (static_cast<uint8_t>(~SSD1325_COLORMASK) >> shift);
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }

--- a/esphome/components/ssd1327_base/ssd1327_base.cpp
+++ b/esphome/components/ssd1327_base/ssd1327_base.cpp
@@ -145,7 +145,7 @@ void HOT SSD1327::draw_absolute_pixel_internal(int x, int y, Color color) {
   // ensure 'color4' is valid (only 4 bits aka 1 nibble) and shift the bits left when necessary
   color4 = (color4 & SSD1327_COLORMASK) << shift;
   // first mask off the nibble we must change...
-  this->buffer_[pos] &= (~SSD1327_COLORMASK >> shift);
+  this->buffer_[pos] &= (static_cast<uint8_t>(~SSD1327_COLORMASK) >> shift);
   // ...then lay the new nibble back on top. done!
   this->buffer_[pos] |= color4;
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a grayscale pixel corruption bug in ssd1322, ssd1325, and ssd1327 display drivers caused by C++ integer promotion rules.

`~COLORMASK` where COLORMASK is `uint8_t 0x0F` gets promoted to `int` before the bitwise NOT, producing `0xFFFFFFF0` instead of the intended `0xF0`. When right-shifted by 4 (for odd pixels), this becomes `0x0FFFFFFF` which truncates to `0xFF` — clearing **both** nibbles instead of just the target one. Every time an odd-x pixel is drawn, the adjacent even-x pixel's color gets zeroed out.

Fix: cast to `uint8_t` after `~` to truncate to 8 bits before shifting.

```cpp
// Before (broken):
this->buffer_[pos] &= (~SSD1322_COLORMASK >> shift);

// After (correct):
this->buffer_[pos] &= (static_cast<uint8_t>(~SSD1322_COLORMASK) >> shift);
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23

display:
  - platform: ssd1325_spi
    model: "SSD1325 128x64"
    cs_pin: GPIO5
    dc_pin: GPIO16
    reset_pin: GPIO17
    lambda: |-
      it.print(0, 0, id(font), "Hello");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).