### PR TITLE
[hlk_fm22x] Fix oversized response rejection breaking GET_ALL_FACE_IDS

### DIFF
--- a/esphome/components/hlk_fm22x/hlk_fm22x.cpp
+++ b/esphome/components/hlk_fm22x/hlk_fm22x.cpp
@@ -133,24 +133,22 @@ void HlkFm22xComponent::recv_command_() {
   checksum ^= byte;
   length |= byte;
 
-  if (length > HLK_FM22X_MAX_RESPONSE_SIZE) {
-    ESP_LOGE(TAG, "Response too large: %u bytes", length);
-    // Discard exactly the remaining payload and checksum for this frame
-    for (uint16_t i = 0; i < length + 1 && this->available() > 0; ++i)
-      this->read();
-    return;
-  }
-
+  // Read up to buffer size; discard excess bytes while still computing checksum
+  // GET_ALL_FACE_IDS can return all enrolled face data (hundreds of bytes)
+  // but handlers only need the first few bytes
+  size_t to_store = std::min(static_cast<size_t>(length), HLK_FM22X_MAX_RESPONSE_SIZE);
   for (uint16_t idx = 0; idx < length; ++idx) {
     byte = this->read();
     checksum ^= byte;
-    this->recv_buf_[idx] = byte;
+    if (idx < to_store) {
+      this->recv_buf_[idx] = byte;
+    }
   }
 
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char hex_buf[format_hex_pretty_size(HLK_FM22X_MAX_RESPONSE_SIZE)];
   ESP_LOGV(TAG, "Recv type: 0x%.2X, data: %s", response_type,
-           format_hex_pretty_to(hex_buf, this->recv_buf_.data(), length));
+           format_hex_pretty_to(hex_buf, this->recv_buf_.data(), to_store));
 #endif
 
   byte = this->read();
@@ -160,10 +158,10 @@ void HlkFm22xComponent::recv_command_() {
   }
   switch (response_type) {
     case HlkFm22xResponseType::NOTE:
-      this->handle_note_(this->recv_buf_.data(), length);
+      this->handle_note_(this->recv_buf_.data(), to_store);
       break;
     case HlkFm22xResponseType::REPLY:
-      this->handle_reply_(this->recv_buf_.data(), length);
+      this->handle_reply_(this->recv_buf_.data(), to_store);
       break;
     default:
       ESP_LOGW(TAG, "Unexpected response type: 0x%.2X", response_type);


### PR DESCRIPTION
# What does this implement/fix?

The fixed 36-byte receive buffer introduced in #13859 rejects any response larger than `HLK_FM22X_MAX_RESPONSE_SIZE` (36 bytes). The `GET_ALL_FACE_IDS` command returns all enrolled face data (face IDs + 32-byte names per face), which easily exceeds this limit — e.g., 203 bytes in the reporter's case.

Instead of rejecting oversized responses entirely, this change reads up to the buffer size into `recv_buf_` and discards excess bytes while still computing the checksum correctly. The handlers only need the first few bytes of the response — `GET_ALL_FACE_IDS` only reads `data[2]` (the face count).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14502

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — existing hlk_fm22x configurations work as before
uart:
  rx_pin: GPIO08
  tx_pin: GPIO09
  baud_rate: 115200

hlk_fm22x:

sensor:
  - platform: hlk_fm22x
    face_count:
      name: "Face Count"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).