### PR TITLE
[http_request] Add HTTP request media source

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -235,6 +235,7 @@ esphome/components/host/* @clydebarrow @esphome/core
 esphome/components/host/time/* @clydebarrow
 esphome/components/hrxl_maxsonar_wr/* @netmikey
 esphome/components/hte501/* @Stock-M
+esphome/components/http_request/media_source/* @kahrendt
 esphome/components/http_request/ota/* @oarcher
 esphome/components/http_request/update/* @jesserockz
 esphome/components/htu31d/* @betterengineering

--- a/esphome/components/http_request/media_source/__init__.py
+++ b/esphome/components/http_request/media_source/__init__.py
@@ -7,7 +7,8 @@ from esphome.types import ConfigType
 from .. import CONF_HTTP_REQUEST_ID, HttpRequestComponent, http_request_ns
 
 CODEOWNERS = ["@kahrendt"]
-DEPENDENCIES = ["http_request", "media_source", "audio"]
+AUTO_LOAD = ["audio"]
+DEPENDENCIES = ["http_request"]
 
 HTTPRequestMediaSource = http_request_ns.class_(
     "HTTPRequestMediaSource", cg.Component, media_source.MediaSource

--- a/esphome/components/http_request/media_source/__init__.py
+++ b/esphome/components/http_request/media_source/__init__.py
@@ -1,0 +1,59 @@
+import esphome.codegen as cg
+from esphome.components import media_source, network, psram
+import esphome.config_validation as cv
+from esphome.const import CONF_BUFFER_SIZE, CONF_ID, CONF_TASK_STACK_IN_PSRAM
+from esphome.types import ConfigType
+
+from .. import CONF_HTTP_REQUEST_ID, HttpRequestComponent, http_request_ns
+
+CODEOWNERS = ["@kahrendt"]
+DEPENDENCIES = ["http_request", "media_source", "audio"]
+
+HTTPRequestMediaSource = http_request_ns.class_(
+    "HTTPRequestMediaSource", cg.Component, media_source.MediaSource
+)
+
+
+def _register_network_requirements(config: ConfigType) -> ConfigType:
+    """Register network requirements for http_request media_source component."""
+    from esphome.components import socket
+
+    # http_request media_source uses one socket (single-pipeline)
+    socket.consume_sockets(1, "http_request_media_source")(config)
+
+    network.require_high_performance_networking()
+
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    media_source.media_source_schema(
+        HTTPRequestMediaSource,
+    )
+    .extend(
+        {
+            cv.GenerateID(CONF_HTTP_REQUEST_ID): cv.use_id(HttpRequestComponent),
+            cv.Optional(CONF_BUFFER_SIZE, default=51200): cv.int_range(
+                min=8 * 1024, max=500 * 1024
+            ),
+            cv.Optional(CONF_TASK_STACK_IN_PSRAM): cv.All(
+                cv.boolean, cv.requires_component(psram.DOMAIN)
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.only_on_esp32,
+    _register_network_requirements,
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await media_source.register_media_source(var, config)
+    await cg.register_parented(var, config[CONF_HTTP_REQUEST_ID])
+
+    cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))
+
+    if CONF_TASK_STACK_IN_PSRAM in config:
+        cg.add(var.set_task_stack_in_psram(config[CONF_TASK_STACK_IN_PSRAM]))

--- a/esphome/components/http_request/media_source/__init__.py
+++ b/esphome/components/http_request/media_source/__init__.py
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await media_source.register_media_source(var, config)

--- a/esphome/components/http_request/media_source/decoder_task.cpp
+++ b/esphome/components/http_request/media_source/decoder_task.cpp
@@ -62,7 +62,14 @@ void decode_task(void *params) {
       break;
     }
 
-    decoder->add_source(this_source->raw_file_ring_buffer_);
+    err = decoder->add_source(this_source->raw_file_ring_buffer_);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to add decoder source: %s", esp_err_to_name(err));
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED);
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_ERROR | EventGroupBits::COMMAND_STOP |
+                                                        EventGroupBits::DECODER_STOPPING);
+      break;
+    }
 
     // Signal reader task that we've acquired the ring buffer shared_ptr
     xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED);

--- a/esphome/components/http_request/media_source/decoder_task.cpp
+++ b/esphome/components/http_request/media_source/decoder_task.cpp
@@ -86,7 +86,7 @@ void decode_task(void *params) {
         break;
       }
 
-      bool paused = event_bits & EventGroupBits::COMMAND_PAUSE;
+      bool paused = (event_bits & EventGroupBits::COMMAND_PAUSE) != 0;
       decoder->set_pause_output_state(paused);
       if (paused) {
         xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_PAUSED);

--- a/esphome/components/http_request/media_source/decoder_task.cpp
+++ b/esphome/components/http_request/media_source/decoder_task.cpp
@@ -28,17 +28,16 @@ void decode_task(void *params) {
     xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_STARTING);
 
     // Wait until the reader notifies us that it's ready or receive a stop command
-    EventBits_t event_bits = xEventGroupWaitBits(
-        this_source->event_group_,
-        EventGroupBits::READER_READY | EventGroupBits::COMMAND_STOP,  // Bit message to read
-        pdFALSE,                                                      // Don't clear the bit on exit
-        pdFALSE,                                                      // Wait for any bit
-        pdMS_TO_TICKS(
-            CONNECTION_TIMEOUT_MS));  // Timeout to avoid indefinitely waiting for the reader task to get ready
+    EventBits_t event_bits =
+        xEventGroupWaitBits(this_source->event_group_,
+                            EventGroupBits::READER_READY | EventGroupBits::COMMAND_STOP,  // Bit message to read
+                            pdFALSE,                                                      // Don't clear the bit on exit
+                            pdFALSE,                                                      // Wait for any bit
+                            portMAX_DELAY);  // Wait indefinitely; reader sets COMMAND_STOP on failure
     xEventGroupClearBits(this_source->event_group_, EventGroupBits::READER_READY);
 
-    // Exit if stop was requested or if READER_READY was never set (timeout)
-    if ((event_bits & EventGroupBits::COMMAND_STOP) || !(event_bits & EventGroupBits::READER_READY)) {
+    // Exit if stop was requested
+    if (event_bits & EventGroupBits::COMMAND_STOP) {
       // Signal reader task so it doesn't wait forever for us to acquire the ring buffer.
       // Set COMMAND_STOP so the read task stops promptly; e.g., on timeout.
       xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED |

--- a/esphome/components/http_request/media_source/decoder_task.cpp
+++ b/esphome/components/http_request/media_source/decoder_task.cpp
@@ -1,0 +1,139 @@
+#include "http_request_media_source_internal.h"
+
+#ifdef USE_ESP32
+
+#include "http_request_media_source.h"
+
+#include "esphome/components/audio/audio_decoder.h"
+#include "esphome/core/log.h"
+
+namespace esphome::http_request {
+
+namespace {  // anonymous namespace for internal linkage
+struct AudioSinkAdapter : public audio::AudioSinkCallback {
+  media_source::MediaSource *source;
+  audio::AudioStreamInfo stream_info;
+
+  size_t audio_sink_write(uint8_t *data, size_t length, TickType_t ticks_to_wait) override {
+    return this->source->write_output(data, length, pdTICKS_TO_MS(ticks_to_wait), this->stream_info);
+  }
+};
+}  // namespace
+
+void decode_task(void *params) {
+  HTTPRequestMediaSource *this_source = static_cast<HTTPRequestMediaSource *>(params);
+
+  do {  // do-while(false) ensures RAII objects are destroyed on all exit paths via break
+
+    xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_STARTING);
+
+    // Wait until the reader notifies us that it's ready or receive a stop command
+    EventBits_t event_bits = xEventGroupWaitBits(
+        this_source->event_group_,
+        EventGroupBits::READER_READY | EventGroupBits::COMMAND_STOP,  // Bit message to read
+        pdFALSE,                                                      // Don't clear the bit on exit
+        pdFALSE,                                                      // Wait for any bit
+        pdMS_TO_TICKS(
+            CONNECTION_TIMEOUT_MS));  // Timeout to avoid indefinitely waiting for the reader task to get ready
+    xEventGroupClearBits(this_source->event_group_, EventGroupBits::READER_READY);
+
+    // Exit if stop was requested or if READER_READY was never set (timeout)
+    if ((event_bits & EventGroupBits::COMMAND_STOP) || !(event_bits & EventGroupBits::READER_READY)) {
+      // Signal reader task so it doesn't wait forever for us to acquire the ring buffer.
+      // Set COMMAND_STOP so the read task stops promptly; e.g., on timeout.
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED |
+                                                        EventGroupBits::COMMAND_STOP |
+                                                        EventGroupBits::DECODER_STOPPING);
+      break;
+    }
+
+    size_t transfer_buffer_size = std::min(this_source->buffer_size_ / 4, DEFAULT_TRANSFER_BUFFER_SIZE);
+    std::unique_ptr<audio::AudioDecoder> decoder =
+        make_unique<audio::AudioDecoder>(transfer_buffer_size, transfer_buffer_size);
+
+    esp_err_t err = decoder->start(this_source->current_audio_file_type_);
+
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to start decoder: %s", esp_err_to_name(err));
+      // Signal reader task so it doesn't wait forever for us to acquire the ring buffer
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED);
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_ERROR | EventGroupBits::COMMAND_STOP |
+                                                        EventGroupBits::DECODER_STOPPING);
+      break;
+    }
+
+    decoder->add_source(this_source->raw_file_ring_buffer_);
+
+    // Signal reader task that we've acquired the ring buffer shared_ptr
+    xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RINGBUF_ACQUIRED);
+
+    xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_RUNNING);
+
+    AudioSinkAdapter audio_sink;
+    bool has_stream_info = false;
+
+    while (true) {
+      event_bits = xEventGroupGetBits(this_source->event_group_);
+
+      if (event_bits & EventGroupBits::COMMAND_STOP) {
+        break;
+      }
+
+      bool paused = event_bits & EventGroupBits::COMMAND_PAUSE;
+      decoder->set_pause_output_state(paused);
+      if (paused) {
+        xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_PAUSED);
+        vTaskDelay(pdMS_TO_TICKS(20));
+      } else {
+        xEventGroupClearBits(this_source->event_group_, EventGroupBits::DECODER_PAUSED);
+      }
+
+      // Will stop gracefully once reader finished
+      audio::AudioDecoderState decoder_state = decoder->decode(event_bits & EventGroupBits::READER_FINISHED);
+
+      if (decoder_state == audio::AudioDecoderState::FINISHED) {
+        ESP_LOGD(TAG, "Decoding finished");
+        break;
+      } else if (decoder_state == audio::AudioDecoderState::FAILED) {
+        ESP_LOGE(TAG, "Decoding failed");
+        xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_ERROR | EventGroupBits::COMMAND_STOP);
+        break;
+      }
+
+      if (!has_stream_info && decoder->get_audio_stream_info().has_value()) {
+        has_stream_info = true;
+
+        audio::AudioStreamInfo stream_info = decoder->get_audio_stream_info().value();
+
+        ESP_LOGD(TAG, "Bits per sample: %d, Channels: %d, Sample rate: %d", stream_info.get_bits_per_sample(),
+                 stream_info.get_channels(), stream_info.get_sample_rate());
+
+        if (stream_info.get_bits_per_sample() != 16 || stream_info.get_channels() > 2) {
+          ESP_LOGE(TAG, "Incompatible audio stream. Only 16 bits per sample and 1 or 2 channels are supported");
+          xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_ERROR | EventGroupBits::COMMAND_STOP);
+          break;
+        }
+
+        audio_sink.source = this_source;
+        audio_sink.stream_info = stream_info;
+        esp_err_t err = decoder->add_sink(&audio_sink);
+        if (err != ESP_OK) {
+          ESP_LOGE(TAG, "Failed to add sink: %s", esp_err_to_name(err));
+          xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_ERROR | EventGroupBits::COMMAND_STOP);
+          break;
+        }
+      }
+    }
+
+    xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_STOPPING);
+  } while (false);
+
+  // All RAII objects from the do-while block (decoder, audio_sink, etc.) are now destroyed.
+
+  xEventGroupSetBits(this_source->event_group_, EventGroupBits::DECODER_STOPPED);
+  vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
+}
+
+}  // namespace esphome::http_request
+
+#endif  // USE_ESP32

--- a/esphome/components/http_request/media_source/http_request_media_source.cpp
+++ b/esphome/components/http_request/media_source/http_request_media_source.cpp
@@ -1,0 +1,167 @@
+#include "http_request_media_source.h"
+
+#ifdef USE_ESP32
+
+#include "http_request_media_source_internal.h"
+
+#include "esphome/core/log.h"
+
+namespace esphome::http_request {
+
+void HTTPRequestMediaSource::dump_config() {
+  ESP_LOGCONFIG(TAG, "HTTP Media Source:");
+  ESP_LOGCONFIG(TAG, "  Buffer Size: %zu bytes", this->buffer_size_);
+  ESP_LOGCONFIG(TAG, "  Task Stack in PSRAM: %s", this->task_stack_in_psram_ ? "Yes" : "No");
+}
+
+void HTTPRequestMediaSource::setup() {
+  this->disable_loop();
+
+  this->event_group_ = xEventGroupCreate();
+  if (this->event_group_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create event group");
+    this->mark_failed();
+    return;
+  }
+}
+
+void HTTPRequestMediaSource::loop() {
+  EventBits_t event_bits = xEventGroupGetBits(this->event_group_);
+
+  if (event_bits & REQUEST_START) {
+    xEventGroupClearBits(this->event_group_, REQUEST_START);
+    this->decoding_state_ = HTTPDecodingState::START_TASKS;
+  }
+
+  switch (this->decoding_state_) {
+    case HTTPDecodingState::START_TASKS: {
+      if (!this->read_task_.is_created() && !this->decode_task_.is_created()) {
+        xEventGroupClearBits(this->event_group_, ALL_BITS);
+
+        // Reader task uses HttpContainer which uses esp_http_client. This crashes on IDF 5.4 if the task
+        // stack is in PSRAM. As a workaround, always allocate the read task in internal memory.
+        if (!this->read_task_.create(read_task, "HTTPRead", READ_TASK_STACK_SIZE, this, 1, false)) {
+          ESP_LOGE(TAG, "Failed to create task");
+          this->status_momentary_error("task_create", 1000);
+          this->set_state_(media_source::MediaSourceState::ERROR);
+          this->decoding_state_ = HTTPDecodingState::IDLE;
+          return;
+        }
+
+        if (!this->decode_task_.create(decode_task, "HTTPDecode", DECODE_TASK_STACK_SIZE, this, 1,
+                                       this->task_stack_in_psram_)) {
+          ESP_LOGE(TAG, "Failed to create task");
+          // Signal read task to stop and let the DECODING state handle cleanup.
+          // Set DECODER_STOPPED + DECODER_RINGBUF_ACQUIRED since no decode task exists to set them.
+          xEventGroupSetBits(this->event_group_, EventGroupBits::COMMAND_STOP | EventGroupBits::DECODER_STOPPED |
+                                                     EventGroupBits::DECODER_RINGBUF_ACQUIRED);
+          this->status_momentary_error("task_create", 1000);
+          this->set_state_(media_source::MediaSourceState::ERROR);
+          this->decoding_state_ = HTTPDecodingState::DECODING;
+          return;
+        }
+      }
+      this->decoding_state_ = HTTPDecodingState::DECODING;
+      break;
+    }
+    case HTTPDecodingState::DECODING: {
+      if (event_bits & DECODER_STARTING) {
+        ESP_LOGD(TAG, "Starting");
+        xEventGroupClearBits(this->event_group_, DECODER_STARTING);
+      }
+
+      if (event_bits & DECODER_RUNNING) {
+        ESP_LOGV(TAG, "Started");
+        xEventGroupClearBits(this->event_group_, DECODER_RUNNING);
+        this->set_state_(media_source::MediaSourceState::PLAYING);
+      }
+
+      if ((event_bits & DECODER_PAUSED) && this->get_state() != media_source::MediaSourceState::PAUSED) {
+        this->set_state_(media_source::MediaSourceState::PAUSED);
+      } else if (!(event_bits & DECODER_PAUSED) && this->get_state() == media_source::MediaSourceState::PAUSED) {
+        this->set_state_(media_source::MediaSourceState::PLAYING);
+      }
+
+      if (event_bits & (READER_ERROR | DECODER_ERROR)) {
+        // Report error so the orchestrator knows playback failed; task will have already logged the specific error
+        this->set_state_(media_source::MediaSourceState::ERROR);
+      }
+
+      if (event_bits & DECODER_STOPPING) {
+        ESP_LOGV(TAG, "Stopping");
+        xEventGroupClearBits(this->event_group_, DECODER_STOPPING);
+      }
+
+      // Check if both tasks have stopped
+      if ((event_bits & READER_STOPPED) && (event_bits & DECODER_STOPPED)) {
+        ESP_LOGD(TAG, "Stopped");
+        xEventGroupClearBits(this->event_group_, ALL_BITS);
+
+        this->read_task_.destroy();
+        this->decode_task_.destroy();
+        this->set_state_(media_source::MediaSourceState::IDLE);
+        this->decoding_state_ = HTTPDecodingState::IDLE;
+      }
+      break;
+    }
+    case HTTPDecodingState::IDLE: {
+      if (this->get_state() == media_source::MediaSourceState::ERROR && !this->status_has_error()) {
+        this->set_state_(media_source::MediaSourceState::IDLE);
+      }
+      break;
+    }
+  }
+
+  if ((this->decoding_state_ == HTTPDecodingState::IDLE) &&
+      (this->get_state() == media_source::MediaSourceState::IDLE)) {
+    this->disable_loop();
+  }
+}
+
+// Called from the orchestrator's main loop, so no synchronization needed with loop()
+bool HTTPRequestMediaSource::play_uri(const std::string &uri) {
+  if (!this->is_ready() || this->is_failed() || this->status_has_error() || !this->has_listener() ||
+      xEventGroupGetBits(this->event_group_) & REQUEST_START) {
+    return false;
+  }
+
+  if (this->get_state() != media_source::MediaSourceState::IDLE) {
+    ESP_LOGE(TAG, "Cannot play '%s': source is busy", uri.c_str());
+    return false;
+  }
+
+  if (!uri.starts_with("http://") && !uri.starts_with("https://")) {
+    ESP_LOGE(TAG, "Invalid URI: '%s'", uri.c_str());
+    return false;
+  }
+
+  this->current_uri_ = uri;
+  xEventGroupSetBits(this->event_group_, EventGroupBits::REQUEST_START);
+  this->enable_loop();
+  return true;
+}
+
+// Called from the orchestrator's main loop, so no synchronization needed with loop()
+void HTTPRequestMediaSource::handle_command(media_source::MediaSourceCommand command) {
+  if (this->decoding_state_ != HTTPDecodingState::DECODING) {
+    return;
+  }
+
+  switch (command) {
+    case media_source::MediaSourceCommand::STOP:
+      xEventGroupSetBits(this->event_group_, EventGroupBits::COMMAND_STOP);
+      break;
+    case media_source::MediaSourceCommand::PAUSE:
+      xEventGroupSetBits(this->event_group_, EventGroupBits::COMMAND_PAUSE);
+      break;
+    case media_source::MediaSourceCommand::PLAY:
+      xEventGroupClearBits(this->event_group_, EventGroupBits::COMMAND_PAUSE);
+      break;
+    default:
+      break;
+  }
+}
+
+}  // namespace esphome::http_request
+
+#endif  // USE_ESP32

--- a/esphome/components/http_request/media_source/http_request_media_source.h
+++ b/esphome/components/http_request/media_source/http_request_media_source.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/components/audio/audio.h"
+#include "esphome/components/http_request/http_request.h"
+#include "esphome/components/media_source/media_source.h"
+#include "esphome/core/component.h"
+#include "esphome/core/static_task.h"
+#include "esphome/core/ring_buffer.h"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+
+namespace esphome::http_request {
+
+enum class HTTPDecodingState : uint8_t {
+  START_TASKS,
+  DECODING,
+  IDLE,
+};
+
+class HTTPRequestMediaSource : public Component,
+                               public media_source::MediaSource,
+                               public Parented<HttpRequestComponent> {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  // MediaSource interface implementation
+  bool play_uri(const std::string &uri) override;
+  void handle_command(media_source::MediaSourceCommand command) override;
+  bool can_handle(const std::string &uri) const override {
+    return uri.starts_with("http://") || uri.starts_with("https://");
+  }
+
+  void set_buffer_size(size_t buffer_size) { this->buffer_size_ = buffer_size; }
+  void set_task_stack_in_psram(bool task_stack_in_psram) { this->task_stack_in_psram_ = task_stack_in_psram; }
+
+ protected:
+  friend void read_task(void *params);
+  friend void decode_task(void *params);
+
+  std::string current_uri_;
+  audio::AudioFileType current_audio_file_type_{audio::AudioFileType::NONE};
+
+  HTTPDecodingState decoding_state_{HTTPDecodingState::IDLE};
+  EventGroupHandle_t event_group_{nullptr};
+
+  std::weak_ptr<RingBuffer> raw_file_ring_buffer_;
+
+  StaticTask read_task_;
+  StaticTask decode_task_;
+
+  size_t buffer_size_{24 * 1024};  // Ring buffer size between read and decode tasks
+
+  bool task_stack_in_psram_{false};
+};
+
+}  // namespace esphome::http_request
+
+#endif  // USE_ESP32

--- a/esphome/components/http_request/media_source/http_request_media_source.h
+++ b/esphome/components/http_request/media_source/http_request_media_source.h
@@ -37,6 +37,8 @@ class HTTPRequestMediaSource : public Component,
     return uri.starts_with("http://") || uri.starts_with("https://");
   }
 
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
+
   void set_buffer_size(size_t buffer_size) { this->buffer_size_ = buffer_size; }
   void set_task_stack_in_psram(bool task_stack_in_psram) { this->task_stack_in_psram_ = task_stack_in_psram; }
 

--- a/esphome/components/http_request/media_source/http_request_media_source_internal.h
+++ b/esphome/components/http_request/media_source/http_request_media_source_internal.h
@@ -13,12 +13,12 @@ namespace esphome::http_request {
 //
 // Three components coordinate via FreeRTOS event bits and a shared ring buffer:
 //
-//   Main Loop (http_media_source.cpp)
+//   Main Loop (http_request_media_source.cpp)
 //     - Orchestrates lifecycle: creates/destroys tasks, monitors state
 //     - Sets REQUEST_START, COMMAND_STOP, COMMAND_PAUSE
 //     - Reads DECODER_* and READER_* bits to track state
 //
-//   Read Task (http_read_task.cpp)          Decode Task (http_decode_task.cpp)
+//   Read Task (reader_task.cpp)              Decode Task (decoder_task.cpp)
 //     - Fetches audio over HTTP               - Decodes raw audio stream
 //     - Writes raw bytes to ring buffer       - Reads from ring buffer
 //     - Signals READER_READY, READER_FINISHED - Signals DECODER_RUNNING, etc.
@@ -42,7 +42,7 @@ namespace esphome::http_request {
 //   - DECODER_RINGBUF_ACQUIRED synchronizes the handoff
 //   - Ring buffer is freed when both shared_ptrs are released
 
-// FreeRTOS task entry points (defined in http_read_task.cpp and http_decode_task.cpp)
+// FreeRTOS task entry points (defined in reader_task.cpp and decoder_task.cpp)
 void read_task(void *params);
 void decode_task(void *params);
 

--- a/esphome/components/http_request/media_source/http_request_media_source_internal.h
+++ b/esphome/components/http_request/media_source/http_request_media_source_internal.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include <cstddef>
+#include <cstdint>
+
+namespace esphome::http_request {
+
+// Inter-task communication overview
+//
+// Three components coordinate via FreeRTOS event bits and a shared ring buffer:
+//
+//   Main Loop (http_media_source.cpp)
+//     - Orchestrates lifecycle: creates/destroys tasks, monitors state
+//     - Sets REQUEST_START, COMMAND_STOP, COMMAND_PAUSE
+//     - Reads DECODER_* and READER_* bits to track state
+//
+//   Read Task (http_read_task.cpp)          Decode Task (http_decode_task.cpp)
+//     - Fetches audio over HTTP               - Decodes raw audio stream
+//     - Writes raw bytes to ring buffer       - Reads from ring buffer
+//     - Signals READER_READY, READER_FINISHED - Signals DECODER_RUNNING, etc.
+//
+// Startup sequence:
+//   1. play_uri() sets REQUEST_START
+//   2. loop() creates both tasks
+//   3. Read task opens HTTP connection, creates ring buffer, sets READER_READY
+//   4. Decode task waits for READER_READY, acquires ring buffer, sets DECODER_RINGBUF_ACQUIRED
+//   5. Read task waits for DECODER_RINGBUF_ACQUIRED before releasing its ring buffer guard
+//   6. Both tasks run in parallel: read streams to ring buffer, decode consumes from it
+//
+// Shutdown sequence:
+//   1. COMMAND_STOP set (by main loop or timeout)
+//   2. Both tasks exit their loops and set *_STOPPED
+//   3. loop() detects both stopped, destroys tasks, returns to IDLE
+//
+// Ring buffer lifetime:
+//   - Read task creates it as shared_ptr, stores weak_ptr in HTTPRequestMediaSource
+//   - Decode task locks the weak_ptr to get its own shared_ptr
+//   - DECODER_RINGBUF_ACQUIRED synchronizes the handoff
+//   - Ring buffer is freed when both shared_ptrs are released
+
+// FreeRTOS task entry points (defined in http_read_task.cpp and http_decode_task.cpp)
+void read_task(void *params);
+void decode_task(void *params);
+
+inline constexpr char TAG[] = "http_media_source";
+
+// Task stack sizes
+inline constexpr uint32_t READ_TASK_STACK_SIZE = 5 * 1024;
+#if defined(USE_AUDIO_OPUS_SUPPORT)  // Opus requires more task stack
+inline constexpr uint32_t DECODE_TASK_STACK_SIZE = 5 * 1024;
+#else
+inline constexpr uint32_t DECODE_TASK_STACK_SIZE = 3 * 1024;
+#endif
+
+// Buffer and timeout constants
+inline constexpr size_t DEFAULT_TRANSFER_BUFFER_SIZE = 24 * 1024;
+inline constexpr uint32_t READ_WRITE_TIMEOUT_MS = 20;
+inline constexpr uint32_t CONNECTION_TIMEOUT_MS = 30000;  // 30 second timeout for no data
+inline constexpr uint8_t MAX_CONNECTION_ATTEMPTS = 6;
+
+enum EventGroupBits : uint32_t {
+  // Requests to start playback (set by play_uri, handled by loop)
+  REQUEST_START = (1 << 0),
+  // Commands from main loop to tasks
+  COMMAND_STOP = (1 << 1),
+  COMMAND_PAUSE = (1 << 2),
+  // Inter-task coordination
+  READER_READY = (1 << 3),
+  READER_FINISHED = (1 << 4),
+  DECODER_RINGBUF_ACQUIRED = (1 << 5),
+  // Read task lifecycle (read task -> loop)
+  READER_STOPPED = (1 << 6),
+  READER_ERROR = (1 << 7),
+  // Decode task lifecycle (decode task -> loop, mirrors)
+  DECODER_STARTING = (1 << 8),
+  DECODER_RUNNING = (1 << 9),
+  DECODER_PAUSED = (1 << 10),
+  DECODER_STOPPING = (1 << 11),
+  DECODER_STOPPED = (1 << 12),
+  DECODER_ERROR = (1 << 13),
+  ALL_BITS = 0x00FFFFFF,  // All valid FreeRTOS event group bits
+};
+
+}  // namespace esphome::http_request
+
+#endif  // USE_ESP32

--- a/esphome/components/http_request/media_source/reader_task.cpp
+++ b/esphome/components/http_request/media_source/reader_task.cpp
@@ -17,7 +17,7 @@ namespace esphome::http_request {
 /// @return A valid HttpContainer on success, or nullptr on failure
 static std::shared_ptr<HttpContainer> open_connection(HttpRequestComponent *client, const std::string &uri,
                                                       EventGroupHandle_t event_group) {
-  static const std::vector<std::string> collect_headers = {"content-type"};
+  static const std::vector<std::string> COLLECT_HEADERS = {"content-type"};
   std::vector<Header> headers = {};
 
   std::shared_ptr<HttpContainer> container;
@@ -26,7 +26,7 @@ static std::shared_ptr<HttpContainer> open_connection(HttpRequestComponent *clie
       return nullptr;
     }
 
-    container = client->get(uri, headers, collect_headers);
+    container = client->get(uri, headers, COLLECT_HEADERS);
 
     if (container != nullptr && is_success(container->status_code)) {
       return container;

--- a/esphome/components/http_request/media_source/reader_task.cpp
+++ b/esphome/components/http_request/media_source/reader_task.cpp
@@ -79,7 +79,10 @@ static void stream_to_ring_buffer(std::shared_ptr<HttpContainer> &container,
       if (received_len > 0) {
         last_data_time = millis();
         transfer_buffer->increase_buffer_length(received_len);
-      } else if (received_len == 0 && container->is_read_complete()) {
+        continue;
+      }
+
+      if (received_len == 0 && container->is_read_complete()) {
         // Flush remaining buffered data to the ring buffer, retrying until empty
         while (transfer_buffer->available() > 0) {
           if (xEventGroupGetBits(event_group) & EventGroupBits::COMMAND_STOP) {
@@ -89,14 +92,22 @@ static void stream_to_ring_buffer(std::shared_ptr<HttpContainer> &container,
         }
         ESP_LOGD(TAG, "Reader finished");
         return;
-      } else if (millis() - last_data_time >= CONNECTION_TIMEOUT_MS) {
+      }
+
+      // Connection closed prematurely; fail immediately
+      if (received_len == HTTP_ERROR_CONNECTION_CLOSED) {
+        xEventGroupSetBits(event_group, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+        return;
+      }
+
+      // No data yet or transient transport timeout (e.g., EAGAIN)
+      if (millis() - last_data_time >= CONNECTION_TIMEOUT_MS) {
         ESP_LOGE(TAG, "Reader timed out");
         xEventGroupSetBits(event_group, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
         return;
-      } else {
-        // No data yet or transient error; e.g., EAGAIN, loop continues
-        vTaskDelay(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
       }
+
+      vTaskDelay(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
     }
   }
 }

--- a/esphome/components/http_request/media_source/reader_task.cpp
+++ b/esphome/components/http_request/media_source/reader_task.cpp
@@ -47,9 +47,6 @@ static std::shared_ptr<HttpContainer> open_connection(HttpRequestComponent *clie
   }
 
   ESP_LOGE(TAG, "Request failed after %u attempts", MAX_CONNECTION_ATTEMPTS);
-  if (container != nullptr) {
-    container->end();
-  }
   xEventGroupSetBits(event_group, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
   return nullptr;
 }

--- a/esphome/components/http_request/media_source/reader_task.cpp
+++ b/esphome/components/http_request/media_source/reader_task.cpp
@@ -1,0 +1,196 @@
+#include "http_request_media_source_internal.h"
+
+#ifdef USE_ESP32
+
+#include "http_request_media_source.h"
+
+#include "esphome/components/audio/audio_transfer_buffer.h"
+#include "esphome/core/log.h"
+
+namespace esphome::http_request {
+
+/// @brief Open an HTTP connection with retries on transient failures
+/// Sets READER_ERROR and COMMAND_STOP event bits on failure.
+/// @param client The HTTP client to use for requests
+/// @param uri The URI to fetch
+/// @param event_group Event group to check for stop commands between retries; error bits set on failure
+/// @return A valid HttpContainer on success, or nullptr on failure
+static std::shared_ptr<HttpContainer> open_connection(HttpRequestComponent *client, const std::string &uri,
+                                                      EventGroupHandle_t event_group) {
+  static const std::vector<std::string> collect_headers = {"content-type"};
+  std::vector<Header> headers = {};
+
+  std::shared_ptr<HttpContainer> container;
+  for (uint8_t attempt = 0; attempt < MAX_CONNECTION_ATTEMPTS; ++attempt) {
+    if (xEventGroupGetBits(event_group) & EventGroupBits::COMMAND_STOP) {
+      return nullptr;
+    }
+
+    container = client->get(uri, headers, collect_headers);
+
+    if (container != nullptr && is_success(container->status_code)) {
+      return container;
+    }
+
+    // Clean up failed attempt
+    if (container != nullptr) {
+      ESP_LOGW(TAG, "Attempt %u failed with status %d", attempt + 1, container->status_code);
+      container->end();
+      container.reset();
+    } else {
+      ESP_LOGW(TAG, "Attempt %u failed to connect", attempt + 1);
+    }
+
+    if (attempt + 1 < MAX_CONNECTION_ATTEMPTS) {
+      vTaskDelay(pdMS_TO_TICKS(1000));  // wait before retry
+    }
+  }
+
+  ESP_LOGE(TAG, "Request failed after %u attempts", MAX_CONNECTION_ATTEMPTS);
+  if (container != nullptr) {
+    container->end();
+  }
+  xEventGroupSetBits(event_group, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+  return nullptr;
+}
+
+/// @brief Stream HTTP response data into a ring buffer via a transfer buffer
+/// Sets READER_ERROR and COMMAND_STOP event bits on timeout.
+/// @param container The active HTTP connection to read from
+/// @param transfer_buffer The transfer buffer to use for batching writes
+/// @param event_group Event group to check for stop commands; error bits set on timeout
+static void stream_to_ring_buffer(std::shared_ptr<HttpContainer> &container,
+                                  std::unique_ptr<audio::AudioSinkTransferBuffer> &transfer_buffer,
+                                  EventGroupHandle_t event_group) {
+  uint32_t last_data_time = millis();
+
+  // We don't use http_read_loop_result() here because:
+  // - We're on a dedicated FreeRTOS task, not the main loop
+  // - esp_http_client_read() blocks, so tight-spinning isn't a concern
+  // - Transient errors; e.g., -ESP_ERR_HTTP_EAGAIN, should retry, not fail immediately
+  while (true) {
+    if (xEventGroupGetBits(event_group) & EventGroupBits::COMMAND_STOP) {
+      return;
+    }
+
+    // Transfer any buffered data to the ring buffer
+    transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
+
+    if (transfer_buffer->available() == 0) {
+      int received_len = container->read(transfer_buffer->get_buffer_end(), transfer_buffer->free());
+
+      if (received_len > 0) {
+        last_data_time = millis();
+        transfer_buffer->increase_buffer_length(received_len);
+      } else if (received_len == 0 && container->is_read_complete()) {
+        // Flush remaining buffered data to the ring buffer, retrying until empty
+        while (transfer_buffer->available() > 0) {
+          if (xEventGroupGetBits(event_group) & EventGroupBits::COMMAND_STOP) {
+            return;
+          }
+          transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS), false);
+        }
+        ESP_LOGD(TAG, "Reader finished");
+        return;
+      } else if (millis() - last_data_time >= CONNECTION_TIMEOUT_MS) {
+        ESP_LOGE(TAG, "Reader timed out");
+        xEventGroupSetBits(event_group, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+        return;
+      } else {
+        // No data yet or transient error; e.g., EAGAIN, loop continues
+        vTaskDelay(pdMS_TO_TICKS(READ_WRITE_TIMEOUT_MS));
+      }
+    }
+  }
+}
+
+void read_task(void *params) {
+  HTTPRequestMediaSource *this_source = static_cast<HTTPRequestMediaSource *>(params);
+
+  // Holds ring buffer alive until the decode task acquires its own shared_ptr reference.
+  // Declared outside the inner scope so it survives past transfer_buffer cleanup.
+  std::shared_ptr<RingBuffer> ring_buffer_guard;
+
+  do {  // do-while(false) ensures RAII objects are destroyed on all exit paths via break
+    // Open HTTP connection with retries (sets error bits on failure)
+    std::shared_ptr<HttpContainer> container =
+        open_connection(this_source->get_parent(), this_source->current_uri_, this_source->event_group_);
+
+    if (container == nullptr) {
+      break;
+    }
+
+    // Detect audio file type from Content-Type header or URL
+    std::string content_type = container->get_response_header("content-type");
+    this_source->current_audio_file_type_ =
+        audio::detect_audio_file_type(content_type.c_str(), this_source->current_uri_.c_str());
+
+    if (this_source->current_audio_file_type_ == audio::AudioFileType::NONE) {
+      ESP_LOGE(TAG, "Unable to determine file type");
+      container->end();
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+      break;
+    }
+
+    // Create transfer buffer for efficient writes to ring buffer
+    size_t transfer_buffer_size = std::min(this_source->buffer_size_ / 4, DEFAULT_TRANSFER_BUFFER_SIZE);
+    std::unique_ptr<audio::AudioSinkTransferBuffer> transfer_buffer =
+        audio::AudioSinkTransferBuffer::create(transfer_buffer_size);
+
+    if (transfer_buffer == nullptr) {
+      ESP_LOGE(TAG, "Failed to create transfer buffer");
+      container->end();
+      xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+      break;
+    }
+
+    {  // Ensures temp_ring_buffer falls out of scope and deallocates
+      std::shared_ptr<RingBuffer> temp_ring_buffer;
+      if (this_source->raw_file_ring_buffer_.expired()) {
+        temp_ring_buffer = RingBuffer::create(this_source->buffer_size_);
+        this_source->raw_file_ring_buffer_ = temp_ring_buffer;
+      }
+
+      if (this_source->raw_file_ring_buffer_.expired()) {
+        ESP_LOGE(TAG, "Failed to create ring buffer");
+        container->end();
+        xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_ERROR | EventGroupBits::COMMAND_STOP);
+        break;
+      }
+
+      transfer_buffer->set_sink(this_source->raw_file_ring_buffer_);
+      ring_buffer_guard = temp_ring_buffer;
+    }
+
+    // Signal that reader is ready
+    xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_READY);
+
+    // Stream HTTP data into the ring buffer (sets error bits on timeout)
+    stream_to_ring_buffer(container, transfer_buffer, this_source->event_group_);
+
+    // Clean up HTTP connection (transfer_buffer and container destructors handle the rest)
+    container->end();
+  } while (false);
+
+  // All RAII objects from the do-while block are now destroyed.
+
+  // Signal we're done reading data (on error, COMMAND_STOP is already set so decode task won't act on this)
+  xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_FINISHED);
+
+  // Wait for decode task to acquire the ring buffer shared_ptr before we release ours.
+  // On error paths, COMMAND_STOP is already set so this returns immediately.
+  xEventGroupWaitBits(this_source->event_group_,
+                      EventGroupBits::DECODER_RINGBUF_ACQUIRED | EventGroupBits::COMMAND_STOP, pdFALSE, pdFALSE,
+                      portMAX_DELAY);
+
+  // Safe to release now as decode task has acquired its own shared_ptr (or exited).
+  // On error paths where ring_buffer_guard was never assigned, this is a no-op.
+  ring_buffer_guard.reset();
+
+  xEventGroupSetBits(this_source->event_group_, EventGroupBits::READER_STOPPED);
+  vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
+}
+
+}  // namespace esphome::http_request
+
+#endif  // USE_ESP32

--- a/tests/components/http_request/test-media_source.esp32-idf.yaml
+++ b/tests/components/http_request/test-media_source.esp32-idf.yaml
@@ -1,0 +1,6 @@
+<<: !include common.yaml
+
+media_source:
+  - platform: http_request
+    id: http_request_noise_source
+    buffer_size: 50000


### PR DESCRIPTION
# What does this implement/fix?

This PR is built on top of #14507 (those are the changes to the audio component).

Adds a new media source component that streams and decodes audio from HTTP URLs. It uses two dedicated FreeRTOS tasks (reader and decoder) that communicate via event group bits and a shared ring buffer.

- Reader task fetches audio over HTTP with retry logic and streams raw bytes into a ring buffer
- Decoder task consumes from the ring buffer, decodes audio (supports formats handled by the audio decoder), and writes PCM output to the media source listener
- Supports pause, play, and stop commands from the orchestrator
- Configurable buffer size and optional PSRAM task stack placement

The inter-task communication is summarized `http_request_media_source_internal.h`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) -- [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) -- [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6218

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:

media_source:
  - platform: http_request
    buffer_size: 51200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).