### PR TITLE
[rc522][sml][kamstrup_kmp] Fix buffer bounds checks

### DIFF
--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -136,7 +136,7 @@ void KamstrupKMPComponent::read_command_(uint16_t command) {
   int timeout = 250;  // ms
 
   // Read the data from the UART
-  while (timeout > 0) {
+  while (timeout > 0 && buffer_len < static_cast<int>(sizeof(buffer))) {
     if (this->available()) {
       data = this->read();
       if (data > -1) {
@@ -246,7 +246,7 @@ void KamstrupKMPComponent::parse_command_message_(uint16_t command, const uint8_
 }
 
 void KamstrupKMPComponent::set_sensor_value_(uint16_t command, float value, uint8_t unit_idx) {
-  const char *unit = UNITS[unit_idx];
+  const char *unit = unit_idx < sizeof(UNITS) / sizeof(UNITS[0]) ? UNITS[unit_idx] : "";
 
   // Standard sensors
   if (command == CMD_HEAT_ENERGY && this->heat_energy_sensor_ != nullptr) {

--- a/esphome/components/rc522/rc522.cpp
+++ b/esphome/components/rc522/rc522.cpp
@@ -169,6 +169,7 @@ void RC522::loop() {
         default:
           ESP_LOGE(TAG, "uid_idx_ invalid, uid_idx_ = %d", uid_idx_);
           state_ = STATE_DONE;
+          return;
       }
       buffer_[1] = 32;
       pcd_transceive_data_(2);

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -224,24 +224,19 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
       break;
     case LOCATE_DATA_FRAME:
       this->current_frame_len_++;
-      if (this->current_frame_len_ - LEN_TO_DATA_FRAME >= DATA_BUF_MAX_SIZE) {
-        ESP_LOGD(TAG, "PRACTICE_DATA_FRAME_LEN ERROR: %d", this->current_frame_len_ - LEN_TO_HEAD_CKSUM);
-        this->current_frame_locate_ = LOCATE_FRAME_HEADER;
-        break;
-      }
       this->current_frame_buf_[this->current_frame_len_ - 1] = buffer;
       this->current_data_buf_[this->current_frame_len_ - LEN_TO_DATA_FRAME] = buffer;
       if (this->current_frame_len_ - LEN_TO_HEAD_CKSUM == this->current_data_frame_len_) {
         this->current_frame_locate_++;
       }
+      if (this->current_frame_len_ > FRAME_BUF_MAX_SIZE) {
+        ESP_LOGD(TAG, "PRACTICE_DATA_FRAME_LEN ERROR: %d", this->current_frame_len_ - LEN_TO_HEAD_CKSUM);
+        this->current_frame_locate_ = LOCATE_FRAME_HEADER;
+      }
       break;
     case LOCATE_DATA_CKSUM_FRAME:
       if (validate_checksum(this->current_data_buf_, this->current_data_frame_len_, buffer)) {
         this->current_frame_len_++;
-        if (this->current_frame_len_ > FRAME_BUF_MAX_SIZE) {
-          this->current_frame_locate_ = LOCATE_FRAME_HEADER;
-          break;
-        }
         this->current_frame_buf_[this->current_frame_len_ - 1] = buffer;
         this->current_frame_locate_++;
         this->process_frame_();

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -224,19 +224,24 @@ void MR60FDA2Component::split_frame_(uint8_t buffer) {
       break;
     case LOCATE_DATA_FRAME:
       this->current_frame_len_++;
+      if (this->current_frame_len_ - LEN_TO_DATA_FRAME >= DATA_BUF_MAX_SIZE) {
+        ESP_LOGD(TAG, "PRACTICE_DATA_FRAME_LEN ERROR: %d", this->current_frame_len_ - LEN_TO_HEAD_CKSUM);
+        this->current_frame_locate_ = LOCATE_FRAME_HEADER;
+        break;
+      }
       this->current_frame_buf_[this->current_frame_len_ - 1] = buffer;
       this->current_data_buf_[this->current_frame_len_ - LEN_TO_DATA_FRAME] = buffer;
       if (this->current_frame_len_ - LEN_TO_HEAD_CKSUM == this->current_data_frame_len_) {
         this->current_frame_locate_++;
       }
-      if (this->current_frame_len_ > FRAME_BUF_MAX_SIZE) {
-        ESP_LOGD(TAG, "PRACTICE_DATA_FRAME_LEN ERROR: %d", this->current_frame_len_ - LEN_TO_HEAD_CKSUM);
-        this->current_frame_locate_ = LOCATE_FRAME_HEADER;
-      }
       break;
     case LOCATE_DATA_CKSUM_FRAME:
       if (validate_checksum(this->current_data_buf_, this->current_data_frame_len_, buffer)) {
         this->current_frame_len_++;
+        if (this->current_frame_len_ > FRAME_BUF_MAX_SIZE) {
+          this->current_frame_locate_ = LOCATE_FRAME_HEADER;
+          break;
+        }
         this->current_frame_buf_[this->current_frame_len_ - 1] = buffer;
         this->current_frame_locate_++;
         this->process_frame_();

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -35,6 +35,8 @@ bool SmlFile::setup_node(SmlNode *node) {
 
   // Check if we need additional length bytes
   if (overlength) {
+    if (this->pos_ + 1 >= this->buffer_.size())
+      return false;
     // Shift the current length to the higher nibble
     // and add the lower nibble of the next byte to the length
     length = (length << 4) + (this->buffer_[this->pos_ + 1] & 0x0f);


### PR DESCRIPTION
# What does this implement/fix?

Fix buffer bounds check issues in three components:

- **rc522**: Add missing `return` after error in `STATE_READ_SERIAL` default case, preventing execution from continuing with an invalid `uid_idx_` and writing out of bounds of `uid_buffer_`
- **sml**: Add bounds check before reading overlength byte in `setup_node()`, preventing out-of-bounds read when the buffer ends mid-parse
- **kamstrup_kmp**: Move buffer length check into the while condition in `read_command_()` to stop before overflowing the 20-byte buffer; add bounds check on UNITS array index in `set_sensor_value_()`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - these are internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).