### PR TITLE
[GPS] fix component Python declaration to match C++ implementation

### DIFF
--- a/esphome/components/gps/__init__.py
+++ b/esphome/components/gps/__init__.py
@@ -34,7 +34,7 @@ AUTO_LOAD = ["sensor"]
 CODEOWNERS = ["@coogle", "@ximex"]
 
 gps_ns = cg.esphome_ns.namespace("gps")
-GPS = gps_ns.class_("GPS", cg.Component, uart.UARTDevice)
+GPS = gps_ns.class_("GPS", cg.PollingComponent, uart.UARTDevice)
 GPSListener = gps_ns.class_("GPSListener")
 
 MULTI_CONF = True


### PR DESCRIPTION
# What does this implement/fix?

This PR fixes a bug in the GPS component where the Python codegen declaration did not match the actual C++ class inheritance.

## Problem:

In C++, the GPS class inherits from `PollingComponent` but in  python, the class was incorrectly declared as inheriting from `Component` instead of `PollingComponent` 

## Impact:
This mismatch prevented users from using 
```yaml
on_...::
  component.update: gps_id
``` 
action with GPS components, as ESPHome's validation system (based on Python declarations) rejected it with the error:

```
ID 'gps_id' of type gps::GPS doesn't inherit from PollingComponent
```


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
