### PR TITLE
[uart] init tx_pin, rx_pin, flow control, rx_buffer_size

### DIFF
--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -183,10 +183,10 @@ class UARTComponent {
   virtual void check_logger_conflict() = 0;
   bool check_read_timeout_(size_t len = 1);
 
-  InternalGPIOPin *tx_pin_;
-  InternalGPIOPin *rx_pin_;
-  InternalGPIOPin *flow_control_pin_;
-  size_t rx_buffer_size_;
+  InternalGPIOPin *tx_pin_{};
+  InternalGPIOPin *rx_pin_{};
+  InternalGPIOPin *flow_control_pin_{};
+  size_t rx_buffer_size_{};
   size_t rx_full_threshold_{1};
   size_t rx_timeout_{0};
   uint32_t baud_rate_{0};


### PR DESCRIPTION
# What does this implement/fix?

Review comment from https://github.com/esphome/esphome/pull/14320


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
