### PR TITLE
[sx127x][sx126x][max6956] Fix null deref, unterminated string, and pin bounds check

### DIFF
--- a/esphome/components/max6956/max6956.cpp
+++ b/esphome/components/max6956/max6956.cpp
@@ -111,6 +111,8 @@ void MAX6956::write_brightness_mode() {
 }
 
 void MAX6956::set_pin_brightness(uint8_t pin, float brightness) {
+  if (pin < MAX6956_MIN || pin > MAX6956_MAX)
+    return;
   uint8_t reg_addr = MAX6956_CURRENT_START + (pin - MAX6956_MIN) / 2;
   uint8_t config = 0;
   uint8_t shift = 4 * (pin % 2);

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -155,7 +155,7 @@ void SX126x::configure() {
   }
 
   // check silicon version to make sure hw is ok
-  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, 15);
+  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, 16);
   this->version_[15] = '\0';
   if (strncmp(this->version_, "SX126", 5) != 0 && strncmp(this->version_, "LLCC68", 6) != 0) {
     this->mark_failed();

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -155,7 +155,8 @@ void SX126x::configure() {
   }
 
   // check silicon version to make sure hw is ok
-  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, 16);
+  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, 15);
+  this->version_[15] = '\0';
   if (strncmp(this->version_, "SX126", 5) != 0 && strncmp(this->version_, "LLCC68", 6) != 0) {
     this->mark_failed();
     return;

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -155,8 +155,8 @@ void SX126x::configure() {
   }
 
   // check silicon version to make sure hw is ok
-  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, 16);
-  this->version_[15] = '\0';
+  this->read_register_(REG_VERSION_STRING, (uint8_t *) this->version_, sizeof(this->version_));
+  this->version_[sizeof(this->version_) - 1] = '\0';
   if (strncmp(this->version_, "SX126", 5) != 0 && strncmp(this->version_, "LLCC68", 6) != 0) {
     this->mark_failed();
     return;

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -119,7 +119,7 @@ class SX126x : public Component,
   GPIOPin *dio1_pin_{nullptr};
   GPIOPin *rst_pin_{nullptr};
   std::string hw_version_;
-  char version_[16];
+  char version_[17]{};
   SX126xBw bandwidth_{SX126X_BW_125000};
   uint32_t bitrate_{0};
   bool crc_enable_{false};

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -119,7 +119,7 @@ class SX126x : public Component,
   GPIOPin *dio1_pin_{nullptr};
   GPIOPin *rst_pin_{nullptr};
   std::string hw_version_;
-  char version_[17]{};
+  char version_[16];
   SX126xBw bandwidth_{SX126X_BW_125000};
   uint32_t bitrate_{0};
   bool crc_enable_{false};

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -260,6 +260,11 @@ SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
     return SX127xError::INVALID_PARAMS;
   }
 
+  if (this->dio0_pin_ == nullptr) {
+    ESP_LOGE(TAG, "DIO0 pin not configured, cannot wait for transmit completion");
+    return SX127xError::INVALID_PARAMS;
+  }
+
   SX127xError ret = SX127xError::NONE;
   if (this->modulation_ == MOD_LORA) {
     this->set_mode_standby();
@@ -281,10 +286,6 @@ SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
 
   // wait until transmit completes, typically the delay will be less than 100 ms
   uint32_t start = millis();
-  if (this->dio0_pin_ == nullptr) {
-    ESP_LOGE(TAG, "DIO0 pin not configured, cannot wait for transmit completion");
-    return SX127xError::TIMEOUT;
-  }
   while (!this->dio0_pin_->digital_read()) {
     if (millis() - start > 4000) {
       ESP_LOGE(TAG, "Transmit packet failure");

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -281,6 +281,10 @@ SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
 
   // wait until transmit completes, typically the delay will be less than 100 ms
   uint32_t start = millis();
+  if (this->dio0_pin_ == nullptr) {
+    ESP_LOGE(TAG, "DIO0 pin not configured, cannot wait for transmit completion");
+    return SX127xError::TIMEOUT;
+  }
   while (!this->dio0_pin_->digital_read()) {
     if (millis() - start > 4000) {
       ESP_LOGE(TAG, "Transmit packet failure");


### PR DESCRIPTION
# What does this implement/fix?

Fix three bugs found during code audit:

- **sx127x**: `transmit_packet()` dereferences `dio0_pin_` without a null check. If DIO0 is not configured, this crashes. Added a null guard that returns `TIMEOUT` with an error log.
- **sx126x**: `version_` is a `char[16]` buffer that gets 16 bytes read into it via `read_register_()`, leaving no room for a null terminator. `strncmp` happens to work since it only checks the first 5-6 chars, but `version_` is also used in `dump_config()` as a C string. Added explicit null termination at index 15.
- **max6956**: `set_pin_brightness()` uses `pin - MAX6956_MIN` to compute a register address without first validating that `pin` is in the valid range (4-31). An out-of-range pin would compute a wrong register address. Added bounds check.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).