### PR TITLE
[mipi_dsi][e131] Fix semaphore cast, missing return, and light count overread

### DIFF
--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -54,8 +54,8 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
   int32_t output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
-  // packet.count is the number of DMX bytes; divide by channels to get the number of lights
-  int lights_in_packet = (packet.count > 1) ? (packet.count - 1) / channels_ : 0;
+  // packet.count is the number of DMX bytes including start code; divide by channels to get the number of lights
+  int lights_in_packet = (packet.count > 0) ? (packet.count - 1) / channels_ : 0;
   int output_end =
       std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + lights_in_packet));
   auto *input_data = packet.values + 1;

--- a/esphome/components/e131/e131_addressable_light_effect.cpp
+++ b/esphome/components/e131/e131_addressable_light_effect.cpp
@@ -54,8 +54,10 @@ bool E131AddressableLightEffect::process_(int universe, const E131Packet &packet
 
   int32_t output_offset = (universe - first_universe_) * get_lights_per_universe();
   // limit amount of lights per universe and received
+  // packet.count is the number of DMX bytes; divide by channels to get the number of lights
+  int lights_in_packet = (packet.count > 1) ? (packet.count - 1) / channels_ : 0;
   int output_end =
-      std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + packet.count - 1));
+      std::min(it->size(), std::min(output_offset + get_lights_per_universe(), output_offset + lights_in_packet));
   auto *input_data = packet.values + 1;
 
   auto effect_name = get_name();

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -10,7 +10,7 @@ namespace mipi_dsi {
 static constexpr size_t MIPI_DSI_MAX_CMD_LOG_BYTES = 64;
 
 static bool notify_refresh_ready(esp_lcd_panel_handle_t panel, esp_lcd_dpi_panel_event_data_t *edata, void *user_ctx) {
-  auto *sem = static_cast<SemaphoreHandle_t *>(user_ctx);
+  auto sem = static_cast<SemaphoreHandle_t>(user_ctx);
   BaseType_t need_yield = pdFALSE;
   xSemaphoreGiveFromISR(sem, &need_yield);
   return (need_yield == pdTRUE);
@@ -190,6 +190,7 @@ void MIPI_DSI::draw_pixels_at(int x_start, int y_start, int w, int h, const uint
   if (bitness != this->color_depth_) {
     display::Display::draw_pixels_at(x_start, y_start, w, h, ptr, order, bitness, big_endian, x_offset, y_offset,
                                      x_pad);
+    return;
   }
   this->write_to_display_(x_start, y_start, w, h, ptr, x_offset, y_offset, x_pad);
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix three bugs found during code audit:

- **mipi_dsi**: `notify_refresh_ready()` casts `user_ctx` (a `void*`) to `SemaphoreHandle_t*` (double pointer) instead of `SemaphoreHandle_t` (which is already a `void*`). This happens to work because `xSemaphoreGiveFromISR` is a macro that casts its argument, but the types are wrong. Fixed the cast to `SemaphoreHandle_t`.
- **mipi_dsi**: `draw_pixels_at()` falls through to `write_to_display_()` after calling the base class fallback for mismatched color depth. The base class converts the pixel data and calls `draw_pixels_at` again with the correct bitness, but without a `return`, execution continues to `write_to_display_()` with unconverted data. Added `return` after the base class call.
- **e131**: `process_()` used `packet.count - 1` directly as a light count in the `output_end` calculation. However, `packet.count` is the E1.31 `property_value_count` which equals the number of DMX bytes including the start code — not a light count. For RGB (3 channels per light), this resulted in computing 3x too many lights, causing out-of-bounds reads from the packet buffer. Fixed by dividing `(packet.count - 1) / channels_` to get the correct number of complete lights. Also added a guard for `packet.count == 0` to prevent `uint16_t` underflow.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).