### PR TITLE
[host] Add null checks for getenv and fopen in preferences

### DIFF
--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include "preferences.h"
 #include "esphome/core/application.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 namespace host {
@@ -14,7 +15,12 @@ static const char *const TAG = "host.preferences";
 void HostPreferences::setup_() {
   if (this->setup_complete_)
     return;
-  this->filename_.append(getenv("HOME"));
+  const char *home = getenv("HOME");
+  if (home == nullptr) {
+    ESP_LOGE(TAG, "HOME environment variable is not set");
+    abort();
+  }
+  this->filename_.append(home);
   this->filename_.append("/.esphome");
   this->filename_.append("/prefs");
   fs::create_directories(this->filename_);
@@ -44,9 +50,12 @@ void HostPreferences::setup_() {
 bool HostPreferences::sync() {
   this->setup_();
   FILE *fp = fopen(this->filename_.c_str(), "wb");
-  std::map<uint32_t, std::vector<uint8_t>>::iterator it;
+  if (fp == nullptr) {
+    ESP_LOGE(TAG, "Failed to open preferences file for writing: %s", this->filename_.c_str());
+    return false;
+  }
 
-  for (it = this->data.begin(); it != this->data.end(); ++it) {
+  for (auto it = this->data.begin(); it != this->data.end(); ++it) {
     fwrite(&it->first, sizeof(uint32_t), 1, fp);
     uint8_t len = it->second.size();
     fwrite(&len, sizeof(len), 1, fp);


### PR DESCRIPTION
# What does this implement/fix?

Fix two potential null pointer issues in the host preferences component:

- **`getenv("HOME")`** can return `nullptr` when the `HOME` environment variable is not set (e.g. minimal containers, `env -i`, certain service configurations). Passing `nullptr` to `std::string::append()` is undefined behavior and crashes on all major standard library implementations. Since there's no recovery path without a home directory, this now aborts with an error message.
- **`fopen()` for writing** can return `nullptr` if the preferences file can't be created (permissions, disk full, etc). The code previously passed the null `FILE*` to `fwrite`/`fclose`, which is undefined behavior. Now returns `false` with an error log.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).