### PR TITLE
[noblex] Fix IR receive losing decoded bytes between calls

### DIFF
--- a/esphome/components/noblex/noblex.cpp
+++ b/esphome/components/noblex/noblex.cpp
@@ -118,15 +118,15 @@ void NoblexClimate::transmit_state() {
   data->mark(NOBLEX_HEADER_MARK);
   data->space(NOBLEX_HEADER_SPACE);
   // Data (sent remote_state from the MSB to the LSB)
-  for (uint8_t i : remote_state) {
-    for (int8_t j = 7; j >= 0; j--) {
-      if ((i == 4) && (j == 4)) {
+  for (int byte_idx = 0; byte_idx < 8; byte_idx++) {
+    for (int8_t bit_idx = 7; bit_idx >= 0; bit_idx--) {
+      if ((byte_idx == 4) && (bit_idx == 4)) {
         // Header intermediate
         data->mark(NOBLEX_BIT_MARK);
         data->space(NOBLEX_GAP);  // gap en bit 36
       } else {
         data->mark(NOBLEX_BIT_MARK);
-        bool bit = i & (1 << j);
+        bool bit = remote_state[byte_idx] & (1 << bit_idx);
         data->space(bit ? NOBLEX_ONE_SPACE : NOBLEX_ZERO_SPACE);
       }
     }
@@ -149,12 +149,14 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
     // First part: header + first 36 bits, followed by 20ms gap
     data.expect_item(NOBLEX_HEADER_MARK, NOBLEX_HEADER_SPACE);
     ESP_LOGV(TAG, "Header");
+    this->receiving_ = false;
     memset(this->remote_state_, 0, sizeof(this->remote_state_));
     for (int i = 0; i < 5; i++) {
       for (int j = 7; j >= 0; j--) {
         if ((i == 4) && (j == 4)) {
           this->remote_state_[i] |= 1 << j;
           ESP_LOGVV(TAG, "GAP");
+          this->receiving_ = true;
           return false;
         } else if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
           this->remote_state_[i] |= 1 << j;
@@ -169,6 +171,10 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Second part: remaining 28 bits + 4-bit CRC + footer
+  if (!this->receiving_) {
+    return false;
+  }
+  this->receiving_ = false;
   for (int i = 4; i < 8; i++) {
     for (int j = 7; j >= 0; j--) {
       if ((i == 4) && (j >= 4)) {

--- a/esphome/components/noblex/noblex.cpp
+++ b/esphome/components/noblex/noblex.cpp
@@ -120,7 +120,7 @@ void NoblexClimate::transmit_state() {
   // Data (sent remote_state from the MSB to the LSB)
   for (uint8_t i : remote_state) {
     for (int8_t j = 7; j >= 0; j--) {
-      if ((i == 4) & (j == 4)) {
+      if ((i == 4) && (j == 4)) {
         // Header intermediate
         data->mark(NOBLEX_BIT_MARK);
         data->space(NOBLEX_GAP);  // gap en bit 36
@@ -145,76 +145,65 @@ void NoblexClimate::transmit_state() {
 
 // Handle received IR Buffer
 bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
-  uint8_t remote_state[8] = {0};
-  uint8_t crc = 0, crc_calculated = 0;
-
-  if (!receiving_) {
-    // Validate header
-    if (data.expect_item(NOBLEX_HEADER_MARK, NOBLEX_HEADER_SPACE)) {
-      ESP_LOGV(TAG, "Header");
-      receiving_ = true;
-      // Read first 36 bits
-      for (int i = 0; i < 5; i++) {
-        // Read bit
-        for (int j = 7; j >= 0; j--) {
-          if ((i == 4) & (j == 4)) {
-            remote_state[i] |= 1 << j;
-            // Header intermediate
-            ESP_LOGVV(TAG, "GAP");
-            return false;
-          } else if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
-            remote_state[i] |= 1 << j;
-          } else if (!data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ZERO_SPACE)) {
-            ESP_LOGVV(TAG, "Byte %d bit %d fail", i, j);
-            return false;
-          }
-        }
-        ESP_LOGV(TAG, "Byte %d %02X", i, remote_state[i]);
-      }
-
-    } else {
-      ESP_LOGV(TAG, "Header fail");
-      receiving_ = false;
-      return false;
-    }
-
-  } else {
-    // Read the remaining 28 bits
-    for (int i = 4; i < 8; i++) {
-      // Read bit
+  if (data.peek_item(NOBLEX_HEADER_MARK, NOBLEX_HEADER_SPACE)) {
+    // First part: header + first 36 bits, followed by 20ms gap
+    data.expect_item(NOBLEX_HEADER_MARK, NOBLEX_HEADER_SPACE);
+    ESP_LOGV(TAG, "Header");
+    memset(this->remote_state_, 0, sizeof(this->remote_state_));
+    for (int i = 0; i < 5; i++) {
       for (int j = 7; j >= 0; j--) {
-        if ((i == 4) & (j >= 4)) {
-          // nothing
+        if ((i == 4) && (j == 4)) {
+          this->remote_state_[i] |= 1 << j;
+          ESP_LOGVV(TAG, "GAP");
+          return false;
         } else if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
-          remote_state[i] |= 1 << j;
+          this->remote_state_[i] |= 1 << j;
         } else if (!data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ZERO_SPACE)) {
           ESP_LOGVV(TAG, "Byte %d bit %d fail", i, j);
           return false;
         }
       }
-      ESP_LOGV(TAG, "Byte %d %02X", i, remote_state[i]);
+      ESP_LOGV(TAG, "Byte %d %02X", i, this->remote_state_[i]);
     }
+    return false;
+  }
 
-    // Read crc
-    for (int i = 3; i >= 0; i--) {
-      if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
-        crc |= 1 << i;
+  // Second part: remaining 28 bits + 4-bit CRC + footer
+  for (int i = 4; i < 8; i++) {
+    for (int j = 7; j >= 0; j--) {
+      if ((i == 4) && (j >= 4)) {
+        // already decoded in first part
+      } else if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
+        this->remote_state_[i] |= 1 << j;
       } else if (!data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ZERO_SPACE)) {
-        ESP_LOGVV(TAG, "Bit %d CRC fail", i);
+        ESP_LOGVV(TAG, "Byte %d bit %d fail", i, j);
         return false;
       }
     }
-    ESP_LOGV(TAG, "CRC %02X", crc);
-
-    // Validate footer
-    if (!data.expect_mark(NOBLEX_BIT_MARK)) {
-      ESP_LOGV(TAG, "Footer fail");
-      return false;
-    }
-    receiving_ = false;
+    ESP_LOGV(TAG, "Byte %d %02X", i, this->remote_state_[i]);
   }
 
-  for (uint8_t i : remote_state)
+  // Read CRC
+  uint8_t crc = 0;
+  for (int i = 3; i >= 0; i--) {
+    if (data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ONE_SPACE)) {
+      crc |= 1 << i;
+    } else if (!data.expect_item(NOBLEX_BIT_MARK, NOBLEX_ZERO_SPACE)) {
+      ESP_LOGVV(TAG, "Bit %d CRC fail", i);
+      return false;
+    }
+  }
+  ESP_LOGV(TAG, "CRC %02X", crc);
+
+  // Validate footer
+  if (!data.expect_mark(NOBLEX_BIT_MARK)) {
+    ESP_LOGV(TAG, "Footer fail");
+    return false;
+  }
+
+  // Validate CRC
+  uint8_t crc_calculated = 0;
+  for (uint8_t i : this->remote_state_)
     crc_calculated += reverse_bits(i);
   crc_calculated = reverse_bits(uint8_t(crc_calculated & 0x0F)) >> 4;
   ESP_LOGVV(TAG, "CRC calc %02X", crc_calculated);
@@ -224,11 +213,12 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
     return false;
   }
 
-  ESP_LOGD(TAG, "Received noblex code: %02X%02X %02X%02X %02X%02X %02X%02X", remote_state[0], remote_state[1],
-           remote_state[2], remote_state[3], remote_state[4], remote_state[5], remote_state[6], remote_state[7]);
+  ESP_LOGD(TAG, "Received noblex code: %02X%02X %02X%02X %02X%02X %02X%02X", this->remote_state_[0],
+           this->remote_state_[1], this->remote_state_[2], this->remote_state_[3], this->remote_state_[4],
+           this->remote_state_[5], this->remote_state_[6], this->remote_state_[7]);
 
   auto powered_on = false;
-  if ((remote_state[0] & NOBLEX_POWER) == NOBLEX_POWER) {
+  if ((this->remote_state_[0] & NOBLEX_POWER) == NOBLEX_POWER) {
     powered_on = true;
     this->powered_on_assumed = powered_on;
   } else {
@@ -241,7 +231,7 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
 
   // Set received mode
   if (powered_on_assumed) {
-    auto mode = (remote_state[0] & 0xE0) >> 5;
+    auto mode = (this->remote_state_[0] & 0xE0) >> 5;
     ESP_LOGV(TAG, "Mode: %02X", mode);
     switch (mode) {
       case IRNoblexMode::IR_NOBLEX_MODE_AUTO:
@@ -263,7 +253,7 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Set received temp
-  uint8_t temp = remote_state[1];
+  uint8_t temp = this->remote_state_[1];
   ESP_LOGVV(TAG, "Temperature Raw: %02X", temp);
 
   temp = 0x0F & reverse_bits(temp);
@@ -272,7 +262,7 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
   this->target_temperature = temp;
 
   // Set received fan speed
-  auto fan = (remote_state[0] & 0x0C) >> 2;
+  auto fan = (this->remote_state_[0] & 0x0C) >> 2;
   ESP_LOGV(TAG, "Fan: %02X", fan);
   switch (fan) {
     case IRNoblexFan::IR_NOBLEX_FAN_HIGH:
@@ -291,7 +281,7 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
   }
 
   // Set received swing status
-  if (remote_state[0] & 0x02) {
+  if (this->remote_state_[0] & 0x02) {
     ESP_LOGV(TAG, "Swing vertical");
     this->swing_mode = climate::CLIMATE_SWING_VERTICAL;
   } else {
@@ -299,8 +289,6 @@ bool NoblexClimate::on_receive(remote_base::RemoteReceiveData data) {
     this->swing_mode = climate::CLIMATE_SWING_OFF;
   }
 
-  for (uint8_t &i : remote_state)
-    i = 0;
   this->publish_state();
   return true;
 }  // end on_receive()

--- a/esphome/components/noblex/noblex.h
+++ b/esphome/components/noblex/noblex.h
@@ -41,6 +41,7 @@ class NoblexClimate : public climate_ir::ClimateIR {
   /// Handle received IR Buffer.
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool send_swing_cmd_{false};
+  bool receiving_{false};
   uint8_t remote_state_[8]{};
 };
 

--- a/esphome/components/noblex/noblex.h
+++ b/esphome/components/noblex/noblex.h
@@ -41,7 +41,7 @@ class NoblexClimate : public climate_ir::ClimateIR {
   /// Handle received IR Buffer.
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool send_swing_cmd_{false};
-  bool receiving_ = false;
+  uint8_t remote_state_[8]{};
 };
 
 }  // namespace noblex


### PR DESCRIPTION
# What does this implement/fix?

Fix IR receive in the Noblex climate component which has never worked since the component was added in #4913.

The Noblex IR protocol splits across two `on_receive()` calls due to a 20ms gap at bit 36. The original code used a local `remote_state[8]` variable that was re-initialized to zero on each call, so bytes 0-3 decoded in the first call were lost before the second call could validate the CRC. This caused CRC to always fail, making IR receive non-functional.

Changes:
- Move `remote_state` to a class member so it persists between calls
- Use `peek_item` to detect the header instead of tracking state with a `receiving_` flag — if the data starts with a header, it's the first part; otherwise it's the second part
- Only validate CRC in the second part (was previously running after both parts, but only meaningful after the second)
- Remove `receiving_` member variable (no longer needed)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
remote_receiver:
  pin: GPIO19
  dump: all

climate:
  - platform: noblex
    name: "Noblex AC"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).