### PR TITLE
[bluetooth_proxy] Add null checks for api_connection

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_connection.cpp
@@ -415,11 +415,14 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
         this->proxy_->send_gatt_error(this->address_, param->read.handle, param->read.status);
         break;
       }
+      auto *api_connection = this->proxy_->get_api_connection();
+      if (api_connection == nullptr)
+        break;
       api::BluetoothGATTReadResponse resp;
       resp.address = this->address_;
       resp.handle = param->read.handle;
       resp.set_data(param->read.value, param->read.value_len);
-      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTReadResponse::MESSAGE_TYPE);
+      api_connection->send_message(resp, api::BluetoothGATTReadResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_WRITE_CHAR_EVT:
@@ -429,10 +432,13 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
         this->proxy_->send_gatt_error(this->address_, param->write.handle, param->write.status);
         break;
       }
+      auto *api_connection = this->proxy_->get_api_connection();
+      if (api_connection == nullptr)
+        break;
       api::BluetoothGATTWriteResponse resp;
       resp.address = this->address_;
       resp.handle = param->write.handle;
-      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTWriteResponse::MESSAGE_TYPE);
+      api_connection->send_message(resp, api::BluetoothGATTWriteResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_UNREG_FOR_NOTIFY_EVT: {
@@ -442,10 +448,13 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
         this->proxy_->send_gatt_error(this->address_, param->unreg_for_notify.handle, param->unreg_for_notify.status);
         break;
       }
+      auto *api_connection = this->proxy_->get_api_connection();
+      if (api_connection == nullptr)
+        break;
       api::BluetoothGATTNotifyResponse resp;
       resp.address = this->address_;
       resp.handle = param->unreg_for_notify.handle;
-      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
+      api_connection->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_REG_FOR_NOTIFY_EVT: {
@@ -455,20 +464,26 @@ bool BluetoothConnection::gattc_event_handler(esp_gattc_cb_event_t event, esp_ga
         this->proxy_->send_gatt_error(this->address_, param->reg_for_notify.handle, param->reg_for_notify.status);
         break;
       }
+      auto *api_connection = this->proxy_->get_api_connection();
+      if (api_connection == nullptr)
+        break;
       api::BluetoothGATTNotifyResponse resp;
       resp.address = this->address_;
       resp.handle = param->reg_for_notify.handle;
-      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
+      api_connection->send_message(resp, api::BluetoothGATTNotifyResponse::MESSAGE_TYPE);
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
       ESP_LOGV(TAG, "[%d] [%s] ESP_GATTC_NOTIFY_EVT: handle=0x%2X", this->connection_index_, this->address_str_,
                param->notify.handle);
+      auto *api_connection = this->proxy_->get_api_connection();
+      if (api_connection == nullptr)
+        break;
       api::BluetoothGATTNotifyDataResponse resp;
       resp.address = this->address_;
       resp.handle = param->notify.handle;
       resp.set_data(param->notify.value, param->notify.value_len);
-      this->proxy_->get_api_connection()->send_message(resp, api::BluetoothGATTNotifyDataResponse::MESSAGE_TYPE);
+      api_connection->send_message(resp, api::BluetoothGATTNotifyDataResponse::MESSAGE_TYPE);
       break;
     }
     default:

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -420,6 +420,8 @@ void BluetoothProxy::send_gatt_error(uint64_t address, uint16_t handle, esp_err_
 }
 
 void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, esp_err_t error) {
+  if (this->api_connection_ == nullptr)
+    return;
   api::BluetoothDevicePairingResponse call;
   call.address = address;
   call.paired = paired;
@@ -429,6 +431,8 @@ void BluetoothProxy::send_device_pairing(uint64_t address, bool paired, esp_err_
 }
 
 void BluetoothProxy::send_device_unpairing(uint64_t address, bool success, esp_err_t error) {
+  if (this->api_connection_ == nullptr)
+    return;
   api::BluetoothDeviceUnpairingResponse call;
   call.address = address;
   call.success = success;


### PR DESCRIPTION
# What does this implement/fix?

Add missing null checks for `api_connection_` in `send_device_pairing()` and `send_device_unpairing()`, and for `get_api_connection()` in five GATT event handlers in `bluetooth_connection.cpp`.

All surrounding methods (`send_device_connection`, `send_gatt_error`, `send_gatt_services_done`, etc.) already check for null before dereferencing. If the API client disconnects during an active BLE operation, these unchecked paths would null dereference.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal bug fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).