### PR TITLE
[mipi_rgb] Fix byte order and dirty bounds in fill()

### DIFF
--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -288,9 +288,7 @@ void MipiRgb::draw_pixel_at(int x, int y, Color color) {
   if (!this->check_buffer_())
     return;
   size_t pos = (y * this->width_) + x;
-  uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
-  uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
-  uint16_t new_color = hi_byte | (lo_byte << 8);  // big endian
+  uint16_t new_color = convert_big_endian(display::ColorUtil::color_to_565(color));
   if (this->buffer_[pos] == new_color)
     return;
   this->buffer_[pos] = new_color;
@@ -315,9 +313,7 @@ void MipiRgb::fill(Color color) {
   }
 
   auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
-  uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
-  uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
-  uint16_t new_color = hi_byte | (lo_byte << 8);
+  uint16_t new_color = convert_big_endian(display::ColorUtil::color_to_565(color));
   std::fill_n(ptr_16, this->width_ * this->height_, new_color);
   this->x_low_ = 0;
   this->y_low_ = 0;

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -317,8 +317,12 @@ void MipiRgb::fill(Color color) {
   auto *ptr_16 = reinterpret_cast<uint16_t *>(this->buffer_);
   uint8_t hi_byte = static_cast<uint8_t>(color.r & 0xF8) | (color.g >> 5);
   uint8_t lo_byte = static_cast<uint8_t>((color.g & 0x1C) << 3) | (color.b >> 3);
-  uint16_t new_color = lo_byte | (hi_byte << 8);  // little endian
+  uint16_t new_color = hi_byte | (lo_byte << 8);
   std::fill_n(ptr_16, this->width_ * this->height_, new_color);
+  this->x_low_ = 0;
+  this->y_low_ = 0;
+  this->x_high_ = this->width_ - 1;
+  this->y_high_ = this->height_ - 1;
 }
 
 int MipiRgb::get_width() {


### PR DESCRIPTION
# What does this implement/fix?

Fix two bugs in `MipiRgb::fill()`:

1. **Byte order**: `fill()` used little-endian byte order (`lo_byte | (hi_byte << 8)`) while `draw_pixel_at()` uses big-endian (`hi_byte | (lo_byte << 8)`). The display is big-endian (determined by pin mapping), so `fill()` was producing swapped colors.

2. **Missing dirty bounds**: `fill()` wrote to the buffer but never updated the dirty region bounds (`x_low_`, `y_low_`, `x_high_`, `y_high_`), so the display would not refresh after a fill.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal bug fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).