### PR TITLE
[esp32] Fix wrong variable usage in P4 pin validation error msg

### DIFF
--- a/esphome/components/esp32/gpio_esp32_p4.py
+++ b/esphome/components/esp32/gpio_esp32_p4.py
@@ -33,7 +33,7 @@ def esp32_p4_validate_supports(value):
     is_input = mode[CONF_INPUT]
 
     if num < 0 or num > 54:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-54)")
+        raise cv.Invalid(f"Invalid pin number: {num} (must be 0-54)")
     if is_input:
         # All ESP32 pins support input mode
         pass


### PR DESCRIPTION
# What does this implement/fix?

Fix wrong variable usage in P4 pin validation error msg

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
