### PR TITLE
[light] Fix unsigned underflow in addressable scan effect

### DIFF
--- a/esphome/components/light/addressable_light_effect.h
+++ b/esphome/components/light/addressable_light_effect.h
@@ -171,12 +171,27 @@ class AddressableScanEffect : public AddressableLightEffect {
     if (now - this->last_move_ < this->move_interval_)
       return;
 
-    if (direction_) {
+    const auto num_leds = static_cast<uint32_t>(it.size());
+    if (this->scan_width_ >= num_leds) {
+      it.all() = current_color;
+      it.schedule_show();
+      this->last_move_ = now;
+      return;
+    }
+
+    const uint32_t max_pos = num_leds - this->scan_width_;
+    if (this->at_led_ >= max_pos) {
+      this->at_led_ = max_pos;
+      this->direction_ = false;
+    }
+
+    if (this->direction_) {
       this->at_led_++;
-      if (this->at_led_ == it.size() - this->scan_width_)
+      if (this->at_led_ >= max_pos)
         this->direction_ = false;
     } else {
-      this->at_led_--;
+      if (this->at_led_ > 0)
+        this->at_led_--;
       if (this->at_led_ == 0)
         this->direction_ = true;
     }


### PR DESCRIPTION
# What does this implement/fix?

Fix unsigned integer underflow in `AddressableScanEffect::apply()`. The expression `it.size() - this->scan_width_` wraps around when `scan_width_ >= it.size()` since both are unsigned, causing `at_led_` to increment indefinitely and write past the LED buffer.

Fix by:
- Early return when `scan_width` fills the entire strip
- Clamping `at_led_` if it's at or past the max position (handles strip size changes at runtime)
- Guarding the decrement to prevent underflow at 0

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: neopixelbus
    effects:
      - addressable_scan:
          scan_width: 3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).