### PR TITLE
[component] Add support for fallback repository

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -453,7 +453,11 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
-        cg.add_library("esphome/noise-c", "0.1.11")
+        cg.add_library(
+            "esphome/noise-c",
+            "0.1.11",
+            "https://github.com/esphome/noise-c.git#v0.1.11",
+        )
     else:
         cg.add_define("USE_API_PLAINTEXT")
 

--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -94,4 +94,8 @@ async def to_code(config):
     cg.add_library("Wire", None)
 
     cg.add_define("USE_BSEC")
-    cg.add_library("boschsensortec/BSEC Software Library", "1.6.1480")
+    cg.add_library(
+        "boschsensortec/BSEC Software Library",
+        "1.6.1480",
+        "https://github.com/boschsensortec/BSEC-Arduino-library.git#v1.6.1480",
+    )

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -184,10 +184,16 @@ async def to_code_base(config):
     if core.CORE.using_arduino:
         cg.add_library("Wire", None)
         cg.add_library("SPI", None)
+
+    # The BME68x Sensor library package from the PlatformIO registry is missing
+    # the library.json file. We must set lib_compat_mode to "off"; otherwise,
+    # the library will be flagged as incompatible.
+    cg.add_platformio_option("lib_compat_mode", "off")
+
     cg.add_library(
         "BME68x Sensor library",
         "1.3.40408",
-        "https://github.com/boschsensortec/Bosch-BME68x-Library",
+        "https://github.com/boschsensortec/Bosch-BME68x-Library.git#v1.3.40408",
     )
     cg.add_library(
         "BSEC2 Software Library",

--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -66,7 +66,15 @@ async def to_code(config):
     cg.add_build_flag("-DDSMR_WATER_MBUS_ID=" + str(config[CONF_WATER_MBUS_ID]))
 
     # DSMR Parser
-    cg.add_library("esphome/dsmr_parser", "1.1.0")
+    cg.add_library(
+        "esphome/dsmr_parser",
+        "1.1.0",
+        "https://github.com/esphome-libs/dsmr_parser.git#v1.1.0",
+    )
 
     # Crypto
-    cg.add_library("polargoose/Crypto-no-arduino", "0.4.0")
+    cg.add_library(
+        "polargoose/Crypto-no-arduino",
+        "0.4.0",
+        "https://github.com/PolarGoose/arduinolibs-crypto-library-no-arduino.git#3f2efdac0a8e46543ae44a684c3ffb57d362f103",
+    )

--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -40,6 +40,8 @@ async def new_fastled_light(config):
     if CONF_MAX_REFRESH_RATE in config:
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
-    cg.add_library("fastled/FastLED", "3.9.16")
+    cg.add_library(
+        "fastled/FastLED", "3.9.16", "https://github.com/FastLED/FastLED.git#v3.9.16"
+    )
     await light.register_light(var, config)
     return var

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -544,5 +544,8 @@ async def to_code(config):
         await automation.build_automation(
             trigger, [(cg.const_char_ptr, "data"), (cg.size_t, "data_size")], conf
         )
-    # https://github.com/paveldn/HaierProtocol
-    cg.add_library("pavlodn/HaierProtocol", "0.9.31")
+    cg.add_library(
+        "pavlodn/HaierProtocol",
+        "0.9.31",
+        "https://github.com/paveldn/HaierProtocol.git#7bab6a487cc0c77f7b0d5aba831de7580ca3bcbe",
+    )

--- a/esphome/components/heatpumpir/climate.py
+++ b/esphome/components/heatpumpir/climate.py
@@ -127,6 +127,10 @@ async def to_code(config):
     cg.add(var.set_min_temperature(config[CONF_MIN_TEMPERATURE]))
     cg.add_build_flag("-Wno-error=overloaded-virtual")
 
-    cg.add_library("tonia/HeatpumpIR", "1.0.40")
+    cg.add_library(
+        "tonia/HeatpumpIR",
+        "1.0.40",
+        "https://github.com/ToniA/arduino-heatpumpir.git#1.0.40",
+    )
     if CORE.is_libretiny or CORE.is_esp32:
         CORE.add_platformio_option("lib_ignore", ["IRremoteESP8266"])

--- a/esphome/components/i2s_audio/media_player/__init__.py
+++ b/esphome/components/i2s_audio/media_player/__init__.py
@@ -117,5 +117,9 @@ async def to_code(config):
     cg.add_library("WiFi", None)
     cg.add_library("NetworkClientSecure", None)
     cg.add_library("HTTPClient", None)
-    cg.add_library("esphome/ESP32-audioI2S", "2.3.0")
+    cg.add_library(
+        "esphome/ESP32-audioI2S",
+        "2.3.0",
+        "https://github.com/esphome/ESP32-audioI2S.git#2.3.0",
+    )
     cg.add_build_flag("-DAUDIO_NO_SD_FS")

--- a/esphome/components/improv_base/__init__.py
+++ b/esphome/components/improv_base/__init__.py
@@ -42,4 +42,6 @@ async def setup_improv_core(var: MockObj, config: ConfigType, component: str):
         cg.add(var.set_next_url(_process_next_url(next_url)))
         cg.add_define(f"USE_{component.upper()}_NEXT_URL")
 
-    cg.add_library("improv/Improv", "1.2.4")
+    cg.add_library(
+        "improv/Improv", "1.2.4", "https://github.com/improv-wifi/sdk-cpp.git#v1.2.4"
+    )

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -460,7 +460,11 @@ async def to_code(config):
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")
     cg.add_build_flag("-DESP_NN")
 
-    cg.add_library("kahrendt/ESPMicroSpeechFeatures", "1.1.0")
+    cg.add_library(
+        "kahrendt/ESPMicroSpeechFeatures",
+        "1.1.0",
+        "https://github.com/kahrendt/ESPMicroSpeechFeatures.git#v1.1.0",
+    )
 
     if vad_model := config.get(CONF_VAD):
         cg.add_define("USE_MICRO_WAKE_WORD_VAD")

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -295,4 +295,6 @@ async def to_code(config):
     # MideaUART library requires WiFi (WiFi auto-enables Network via dependency mapping)
     if CORE.is_esp32:
         cg.add_library("WiFi", None)
-    cg.add_library("dudanov/MideaUART", "1.1.9")
+    cg.add_library(
+        "dudanov/MideaUART", "1.1.9", "https://github.com/dudanov/MideaUART.git#v1.1.9"
+    )

--- a/esphome/components/mlx90393/sensor.py
+++ b/esphome/components/mlx90393/sensor.py
@@ -159,4 +159,8 @@ async def to_code(config):
         pin = await cg.gpio_pin_expression(config[CONF_DRDY_PIN])
         cg.add(var.set_drdy_gpio(pin))
 
-    cg.add_library("functionpointer/arduino-MLX90393", "1.0.2")
+    cg.add_library(
+        "functionpointer/arduino-MLX90393",
+        "1.0.2",
+        "https://github.com/functionpointer/arduino-MLX90393.git#v1.0.2",
+    )

--- a/esphome/components/neopixelbus/light.py
+++ b/esphome/components/neopixelbus/light.py
@@ -244,6 +244,10 @@ async def to_code(config):
         # disable built in rgb support as it uses the new RMT drivers and will
         # conflict with NeoPixelBus which uses the legacy drivers
         cg.add_build_flag("-DESP32_ARDUINO_NO_RGB_BUILTIN")
-        cg.add_library("makuna/NeoPixelBus", "2.8.0")
+        cg.add_library(
+            "makuna/NeoPixelBus",
+            "2.8.0",
+            "https://github.com/Makuna/NeoPixelBus.git#2.8.0",
+        )
     else:
         cg.add_library("makuna/NeoPixelBus", "2.7.3")

--- a/esphome/components/qr_code/__init__.py
+++ b/esphome/components/qr_code/__init__.py
@@ -33,7 +33,11 @@ CONFIG_SCHEMA = cv.ensure_list(
 
 
 async def to_code(config):
-    cg.add_library("wjtje/qr-code-generator-library", "^1.7.0")
+    cg.add_library(
+        "wjtje/qr-code-generator-library",
+        "1.7.0",
+        "https://github.com/wjtje/QR-Code-generator-esphome.git#5f7449c095cf975bb14a34e1813b191205f78ccb",
+    )
 
     for entry in config:
         var = cg.new_Pvariable(entry[CONF_ID])

--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -85,7 +85,7 @@ class PNGFormat(Format):
 
     def actions(self) -> None:
         cg.add_define("USE_RUNTIME_IMAGE_PNG")
-        cg.add_library("pngle", "1.1.0")
+        cg.add_library("pngle", "1.1.0", "https://github.com/kikuchan/pngle#v1.1.0")
 
 
 # Registry of available formats

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -137,7 +137,11 @@ async def to_code(config):
     # the '+1' modifier is relative to the device's own address that will
     # be automatically added to the provided list.
     cg.add_build_flag(f"-DCONFIG_WIREGUARD_MAX_SRC_IPS={len(allowed_ips) + 1}")
-    cg.add_library("droscy/esp_wireguard", "0.4.2")
+    cg.add_library(
+        "droscy/esp_wireguard",
+        "0.4.2",
+        "https://github.com/droscy/esp_wireguard.git#v0.4.2",
+    )
 
     await cg.register_component(var, config)
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -463,14 +463,13 @@ class Library:
 
     @property
     def as_lib_dep(self):
+        if self.name is not None and self.version is not None:
+            return f"{self.name}@{self.version}"
         if self.repository is not None:
             if self.name is not None:
                 return f"{self.name}={self.repository}"
             return self.repository
-
-        if self.version is None:
-            return self.name
-        return f"{self.name}@{self.version}"
+        return self.name
 
     @property
     def as_tuple(self):


### PR DESCRIPTION
# What does this implement/fix?

- as_lib_dep returns now name/version if are available then check for repository. Previous behavior was to checking repository first.
- for all components add an URL to the repository using either tag or full commit hash.
- The URL will be used during a build with --native-idf switch in order to grab the sources without using PlatformIO registry.

## Types of changes
- [X] New feature
- [X] Breaking change: If name, version, and repository are used, and name/version PlatformIO dependency has different sources than repository.

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/backlog/issues/87

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
