### PR TITLE
[pid][nextion][pn532_i2c][pipsolar] Fix copy-paste and logic bugs

### DIFF
--- a/esphome/components/nextion/nextion_component.cpp
+++ b/esphome/components/nextion/nextion_component.cpp
@@ -88,7 +88,7 @@ void NextionComponent::update_component_settings(bool force_update) {
     this->send_state_to_nextion();
   }
 
-  if (this->component_flags_.bco_needs_update || (force_update && this->component_flags_.bco2_is_set)) {
+  if (this->component_flags_.bco_needs_update || (force_update && this->component_flags_.bco_is_set)) {
     this->nextion_->set_component_background_color(this->variable_name_.c_str(), this->bco_);
     this->component_flags_.bco_needs_update = false;
   }

--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -97,7 +97,7 @@ PIDAutotuner::PIDAutotuneResult PIDAutotuner::update(float setpoint, float proce
   }
 
   bool zc_symmetrical = this->frequency_detector_.is_increase_decrease_symmetrical();
-  bool amplitude_convergent = this->frequency_detector_.is_increase_decrease_symmetrical();
+  bool amplitude_convergent = this->amplitude_detector_.is_amplitude_convergent();
   if (!zc_symmetrical || !amplitude_convergent) {
     // The frequency/amplitude is not fully accurate yet, try to wait
     // until the fault clears, or terminate after a while anyway
@@ -362,7 +362,7 @@ bool PIDAutotuner::OscillationAmplitudeDetector::is_amplitude_convergent() const
   for (auto v : this->phase_mins)
     global_min = std::min(global_min, v);
   for (auto v : this->phase_maxs)
-    global_max = std::min(global_max, v);
+    global_max = std::max(global_max, v);
   float global_amplitude = (global_max - global_min) / 2.0f;
   float mean_amplitude = this->get_mean_oscillation_amplitude();
   return (mean_amplitude - global_amplitude) / (global_amplitude) < 0.05f;

--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -647,6 +647,7 @@ void Pipsolar::handle_qpiws_(const char *message) {
       case 34:
         this->publish_binary_sensor_(enabled, this->warning_high_ac_input_during_bus_soft_start_);
         value_warnings_present |= enabled.value_or(false);
+        break;
       case 35:
         this->publish_binary_sensor_(enabled, this->warning_battery_equalization_);
         value_warnings_present |= enabled.value_or(false);

--- a/esphome/components/pn532_i2c/pn532_i2c.cpp
+++ b/esphome/components/pn532_i2c/pn532_i2c.cpp
@@ -49,7 +49,7 @@ bool PN532I2C::read_response(uint8_t command, std::vector<uint8_t> &data) {
     return false;
   }
 
-  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+  if (data[1] != 0x00 || data[2] != 0x00 || data[3] != 0xFF) {
     // invalid packet
     ESP_LOGV(TAG, "read data invalid preamble!");
     return false;
@@ -95,7 +95,7 @@ uint8_t PN532I2C::read_response_length_() {
     return 0;
   }
 
-  if (data[1] != 0x00 && data[2] != 0x00 && data[3] != 0xFF) {
+  if (data[1] != 0x00 || data[2] != 0x00 || data[3] != 0xFF) {
     // invalid packet
     ESP_LOGV(TAG, "read data invalid preamble!");
     return 0;


### PR DESCRIPTION
# What does this implement/fix?

Fix several copy-paste and logic bugs across four components:

- **pid**: Autotuner `amplitude_convergent` check called `frequency_detector_.is_increase_decrease_symmetrical()` instead of `amplitude_detector_.is_amplitude_convergent()` — wrong object and wrong method. Also `global_max` computation used `std::min` instead of `std::max`.
- **nextion**: Background color force update checked `bco2_is_set` instead of `bco_is_set`, so background color was only force-updated when the *pressed* background color was set.
- **pn532_i2c**: Preamble validation used `&&` instead of `||`, so it only rejected packets where ALL three preamble bytes were wrong simultaneously. Any single correct byte would pass validation.
- **pipsolar**: Missing `break` in case 34 caused fallthrough to case 35, publishing warning 35's sensor with warning 34's value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).