### PR TITLE
[multiple] Fix assorted medium-severity bugs

### DIFF
--- a/esphome/components/bytebuffer/bytebuffer.h
+++ b/esphome/components/bytebuffer/bytebuffer.h
@@ -263,7 +263,7 @@ class ByteBuffer {
 
   void put_uint8(uint8_t value, size_t offset) { this->data_[offset] = value; }
   void put_uint16(uint16_t value, size_t offset) { this->put(value, offset); }
-  void put_uint24(uint32_t value, size_t offset) { this->put(value, offset); }
+  void put_uint24(uint32_t value, size_t offset) { this->put_uint32_(value, offset, 3); }
   void put_uint32(uint32_t value, size_t offset) { this->put(value, offset); }
   void put_uint64(uint64_t value, size_t offset) { this->put(value, offset); }
   // Signed versions of the put functions

--- a/esphome/components/cap1188/cap1188.cpp
+++ b/esphome/components/cap1188/cap1188.cpp
@@ -92,7 +92,7 @@ void CAP1188Component::loop() {
     this->read_register(CAP1188_MAIN, &data, 1);
     data = data & ~CAP1188_MAIN_INT;
 
-    this->write_register(CAP1188_MAIN, &data, 2);
+    this->write_register(CAP1188_MAIN, &data, 1);
   }
 
   for (auto *channel : this->channels_) {

--- a/esphome/components/hte501/hte501.cpp
+++ b/esphome/components/hte501/hte501.cpp
@@ -49,7 +49,7 @@ void HTE501Component::update() {
   this->set_timeout(50, [this]() {
     uint8_t i2c_response[6];
     this->read(i2c_response, 6);
-    if (i2c_response[2] != crc8(i2c_response, 2, 0xFF, 0x31, true) &&
+    if (i2c_response[2] != crc8(i2c_response, 2, 0xFF, 0x31, true) ||
         i2c_response[5] != crc8(i2c_response + 3, 2, 0xFF, 0x31, true)) {
       this->error_code_ = CRC_CHECK_FAILED;
       this->status_set_warning();

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -599,11 +599,7 @@ bool INA2XX::read_unsigned_16_(uint8_t reg, uint16_t &out) {
 }
 
 int64_t INA2XX::two_complement_(uint64_t value, uint8_t bits) {
-  if (value > (1ULL << (bits - 1))) {
-    return (int64_t) (value - (1ULL << bits));
-  } else {
-    return (int64_t) value;
-  }
+  return (int64_t) (value << (64 - bits)) >> (64 - bits);
 }
 }  // namespace ina2xx_base
 }  // namespace esphome

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -704,7 +704,7 @@ void Inkplate::vscan_start_() {
 }
 
 void Inkplate::hscan_start_(uint32_t d) {
-  uint8_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1 << this->cl_pin_->get_pin());
   this->sph_pin_->digital_write(false);
   GPIO.out_w1ts = d | clock;
   GPIO.out_w1tc = this->get_data_pin_mask_() | clock;

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -407,7 +407,7 @@ void Inkplate::display1b_() {
       break;
   }
 
-  uint32_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1UL << this->cl_pin_->get_pin());
   uint32_t data_mask = this->get_data_pin_mask_();
   ESP_LOGV(TAG, "Display1b start loops (%ums)", millis() - start_time);
 
@@ -575,7 +575,7 @@ void Inkplate::display3b_() {
       break;
   }
 
-  uint32_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1UL << this->cl_pin_->get_pin());
   uint32_t data_mask = this->get_data_pin_mask_();
   uint32_t pos;
   uint32_t data;
@@ -646,7 +646,7 @@ bool Inkplate::partial_update_() {
   int rep = (this->model_ == INKPLATE_6_V2) ? 6 : 5;
 
   eink_on_();
-  uint32_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1UL << this->cl_pin_->get_pin());
   uint32_t data_mask = this->get_data_pin_mask_();
   for (int k = 0; k < rep; k++) {
     vscan_start_();
@@ -704,7 +704,7 @@ void Inkplate::vscan_start_() {
 }
 
 void Inkplate::hscan_start_(uint32_t d) {
-  uint32_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1UL << this->cl_pin_->get_pin());
   this->sph_pin_->digital_write(false);
   GPIO.out_w1ts = d | clock;
   GPIO.out_w1tc = this->get_data_pin_mask_() | clock;
@@ -751,7 +751,7 @@ void Inkplate::clean_fast_(uint8_t c, uint8_t rep) {
 
   uint32_t send = ((data & 0b00000011) << 4) | (((data & 0b00001100) >> 2) << 18) | (((data & 0b00010000) >> 4) << 23) |
                   (((data & 0b11100000) >> 5) << 25);
-  uint32_t clock = (1 << this->cl_pin_->get_pin());
+  uint32_t clock = (1UL << this->cl_pin_->get_pin());
 
   for (int k = 0; k < rep; k++) {
     vscan_start_();

--- a/esphome/components/msa3xx/msa3xx.cpp
+++ b/esphome/components/msa3xx/msa3xx.cpp
@@ -364,11 +364,7 @@ void MSA3xxComponent::setup_offset_(float offset_x, float offset_y, float offset
 }
 
 int64_t MSA3xxComponent::twos_complement_(uint64_t value, uint8_t bits) {
-  if (value > (1ULL << (bits - 1))) {
-    return (int64_t) (value - (1ULL << bits));
-  } else {
-    return (int64_t) value;
-  }
+  return (int64_t) (value << (64 - bits)) >> (64 - bits);
 }
 
 void binary_event_debounce(bool state, bool old_state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger,

--- a/esphome/components/nfc/ndef_record_text.cpp
+++ b/esphome/components/nfc/ndef_record_text.cpp
@@ -14,6 +14,11 @@ NdefRecordText::NdefRecordText(const std::vector<uint8_t> &payload) {
 
   uint8_t language_code_length = payload[0] & 0b00111111;  // Todo, make use of encoding bit?
 
+  if (1 + language_code_length > payload.size()) {
+    ESP_LOGE(TAG, "Record payload too short for language code");
+    return;
+  }
+
   this->language_code_ = std::string(payload.begin() + 1, payload.begin() + 1 + language_code_length);
 
   this->text_ = std::string(payload.begin() + 1 + language_code_length, payload.end());

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -50,7 +50,7 @@ uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
 
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
   auto i = get_mifare_classic_ndef_start_index(data);
-  if (i >= data.size() || data[i] != 0x03) {
+  if (i >= 0xFE || i >= data.size() || data[i] != 0x03) {
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;
   }

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -35,7 +35,7 @@ uint8_t guess_tag_type(uint8_t uid_length) {
   }
 }
 
-uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
+int8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
   for (uint8_t i = 0; i < MIFARE_CLASSIC_BLOCK_SIZE; i++) {
     if (data[i] == 0x00) {
       // Do nothing, skip
@@ -50,7 +50,7 @@ uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
 
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
   auto i = get_mifare_classic_ndef_start_index(data);
-  if (i >= 0xFE || i >= data.size() || data[i] != 0x03) {
+  if (i < 0 || static_cast<size_t>(i) >= data.size() || data[i] != 0x03) {
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;
   }

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -58,12 +58,13 @@ bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_len
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;
   }
-  if (i + 4 <= data.size() && data[i + 1] == 0xFF) {
-    message_length = ((0xFF & data[i + 2]) << 8) | (0xFF & data[i + 3]);
-    message_start_index = i + MIFARE_CLASSIC_LONG_TLV_SIZE;
-  } else if (i + 2 <= data.size()) {
-    message_length = data[i + 1];
-    message_start_index = i + MIFARE_CLASSIC_SHORT_TLV_SIZE;
+  uint8_t idx = static_cast<uint8_t>(i);
+  if (idx + 4 <= data.size() && data[idx + 1] == 0xFF) {
+    message_length = ((0xFF & data[idx + 2]) << 8) | (0xFF & data[idx + 3]);
+    message_start_index = idx + MIFARE_CLASSIC_LONG_TLV_SIZE;
+  } else if (idx + 2 <= data.size()) {
+    message_length = data[idx + 1];
+    message_start_index = idx + MIFARE_CLASSIC_SHORT_TLV_SIZE;
   } else {
     ESP_LOGE(TAG, "Error, TLV data too short.");
     return false;

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -50,16 +50,19 @@ uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
 
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
   auto i = get_mifare_classic_ndef_start_index(data);
-  if (data[i] != 0x03) {
+  if (i >= data.size() || data[i] != 0x03) {
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;
   }
-  if (data[i + 1] == 0xFF) {
+  if (i + 4 <= data.size() && data[i + 1] == 0xFF) {
     message_length = ((0xFF & data[i + 2]) << 8) | (0xFF & data[i + 3]);
     message_start_index = i + MIFARE_CLASSIC_LONG_TLV_SIZE;
-  } else {
+  } else if (i + 2 <= data.size()) {
     message_length = data[i + 1];
     message_start_index = i + MIFARE_CLASSIC_SHORT_TLV_SIZE;
+  } else {
+    ESP_LOGE(TAG, "Error, TLV data too short.");
+    return false;
   }
   return true;
 }

--- a/esphome/components/nfc/nfc.cpp
+++ b/esphome/components/nfc/nfc.cpp
@@ -49,8 +49,12 @@ int8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data) {
 }
 
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index) {
+  if (data.size() < MIFARE_CLASSIC_BLOCK_SIZE) {
+    ESP_LOGE(TAG, "Error, data too short for NDEF detection.");
+    return false;
+  }
   auto i = get_mifare_classic_ndef_start_index(data);
-  if (i < 0 || static_cast<size_t>(i) >= data.size() || data[i] != 0x03) {
+  if (i < 0 || data[i] != 0x03) {
     ESP_LOGE(TAG, "Error, Can't decode message length.");
     return false;
   }

--- a/esphome/components/nfc/nfc.h
+++ b/esphome/components/nfc/nfc.h
@@ -72,7 +72,7 @@ ESPDEPRECATED("Use format_bytes_to() with stack buffer instead. Removed in 2026.
 std::string format_bytes(std::span<const uint8_t> bytes);
 
 uint8_t guess_tag_type(uint8_t uid_length);
-uint8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data);
+int8_t get_mifare_classic_ndef_start_index(std::vector<uint8_t> &data);
 bool decode_mifare_classic_tlv(std::vector<uint8_t> &data, uint32_t &message_length, uint8_t &message_start_index);
 uint32_t get_mifare_classic_buffer_size(uint32_t message_length);
 

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -52,7 +52,10 @@ template<uint8_t SZ> class TextSaver : public TemplateTextSaverBase {
     bool hasdata = this->pref_.load(&temp);
 
     if (hasdata) {
-      value.assign(temp + 1, (size_t) temp[0]);
+      size_t len = static_cast<uint8_t>(temp[0]);
+      if (len > SZ)
+        len = SZ;
+      value.assign(temp + 1, len);
     }
 
     this->prev_.assign(value);

--- a/esphome/components/template/text/template_text.h
+++ b/esphome/components/template/text/template_text.h
@@ -53,8 +53,9 @@ template<uint8_t SZ> class TextSaver : public TemplateTextSaverBase {
 
     if (hasdata) {
       size_t len = static_cast<uint8_t>(temp[0]);
-      if (len > SZ)
+      if (len > SZ) {
         len = SZ;
+      }
       value.assign(temp + 1, len);
     }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes 9 bugs found during a component scan:

- **template text** (`template_text.h`): `TextSaver::setup` uses `temp[0]` as string length from flash without clamping to buffer size `SZ`. Corrupted flash data causes OOB stack read.

- **nfc** (`ndef_record_text.cpp`): `language_code_length` from payload byte not validated against payload size. Constructs `std::string` with iterators past the end.

- **nfc** (`nfc.cpp`): `get_mifare_classic_ndef_start_index` returns `uint8_t` but error values -1/-2 wrap to 254/255. `decode_mifare_classic_tlv` uses the result to index a 16-byte vector without bounds check. Also added bounds checks for subsequent TLV data accesses.

- **ina2xx_base** (`ina2xx_base.cpp`): Off-by-one in `two_complement_()` — `>` should be `>=`. The most-negative value (e.g. -32768 for 16-bit) was returned as positive. Simplified to shift-based sign extension.

- **msa3xx** (`msa3xx.cpp`): Same off-by-one and simplification in `twos_complement_()`.

- **bytebuffer** (`bytebuffer.h`): `put_uint24(value, offset)` called `put(value, offset)` which writes `sizeof(uint32_t)` = 4 bytes, corrupting the adjacent byte. Changed to `put_uint32_(value, offset, 3)` matching `put_int24`.

- **cap1188** (`cap1188.cpp`): `write_register(CAP1188_MAIN, &data, 2)` passes length 2 for a 1-byte `uint8_t` variable, reading 1 byte of stack garbage and writing it to the adjacent register.

- **hte501** (`hte501.cpp`): CRC validation uses `&&` instead of `||`. Both CRCs must fail for the error to be detected — a single CRC failure is silently accepted.

- **inkplate** (`inkplate.cpp`): `uint8_t clock = (1 << pin)` truncates for GPIO pins >= 8. Changed to `uint32_t` to match `GPIO.out_w1ts` type.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — these are internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).