### PR TITLE
[sgp4x] Fix undefined behavior from mutating entity config at runtime

### DIFF
--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -35,13 +35,9 @@ void SGP4xComponent::setup() {
     this->self_test_time_ = SPG40_SELFTEST_TIME;
     this->measure_time_ = SGP40_MEASURE_TIME;
     if (this->nox_sensor_) {
-      ESP_LOGE(TAG, "SGP41 required for NOx");
-      // disable the sensor
-      this->nox_sensor_->set_disabled_by_default(true);
-      // make sure it's not visible in HA
-      this->nox_sensor_->set_internal(true);
-      this->nox_sensor_->state = NAN;
-      // remove pointer to sensor
+      ESP_LOGE(TAG, "SGP41 required for NOx, disabling NOx sensor");
+      // Drop the pointer so update() never publishes to it.
+      // The entity remains registered but will never receive state updates.
       this->nox_sensor_ = nullptr;
     }
   } else if (featureset == SGP41_FEATURESET) {


### PR DESCRIPTION
## What does this implement/fix?

Fixes undefined behavior in the SGP4x component introduced in #3382, noticed while auditing codegen-only setters in #14444. When the component detects an SGP40 chip (which doesn't support NOx), it was calling `set_disabled_by_default()` and `set_internal()` on the NOx sensor entity at runtime. These are codegen-only configuration setters that must not be called after `setup()` — mutating entity configuration flags at runtime after the entity has been registered leads to inconsistent state since the entity has already been registered with clients.

The fix simply drops the `nox_sensor_` pointer. The rest of the code already null-checks it everywhere, so the sensor will never receive state updates. The entity remains registered but inactive.

This was the only component found in the audit that mutated entity configuration flags at runtime.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — this fixes runtime behavior when an SGP40
# is detected but a NOx sensor was configured (requires SGP41)
sensor:
  - platform: sgp4x
    voc:
      name: "VOC Index"
    nox:
      name: "NOx Index"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).