### PR TITLE
[iaqcore][scd30][sen21231][beken_spi_led_strip] Fix uninitialized variables and missing error checks

### DIFF
--- a/esphome/components/beken_spi_led_strip/led_strip.cpp
+++ b/esphome/components/beken_spi_led_strip/led_strip.cpp
@@ -78,7 +78,7 @@ static void spi_set_clock(uint32_t max_hz) {
   int source_clk = 0;
   int spi_clk = 0;
   int div = 0;
-  uint32_t param;
+  uint32_t param = PWD_SPI_CLK_BIT;
   if (max_hz > 4333000) {
     if (max_hz > 30000000) {
       spi_clk = 30000000;

--- a/esphome/components/iaqcore/iaqcore.cpp
+++ b/esphome/components/iaqcore/iaqcore.cpp
@@ -10,11 +10,13 @@ static const char *const TAG = "iaqcore";
 
 enum IAQCoreErrorCode : uint8_t { ERROR_OK = 0, ERROR_RUNIN = 0x10, ERROR_BUSY = 0x01, ERROR_ERROR = 0x80 };
 
+static const size_t SENSOR_DATA_LENGTH = 9;
+
 struct SensorData {
-  uint16_t co2;
-  IAQCoreErrorCode status;
   int32_t resistance;
+  uint16_t co2;
   uint16_t tvoc;
+  IAQCoreErrorCode status;
 
   SensorData(const uint8_t *buffer) {
     this->co2 = encode_uint16(buffer[0], buffer[1]);
@@ -33,9 +35,9 @@ void IAQCore::setup() {
 }
 
 void IAQCore::update() {
-  uint8_t buffer[sizeof(SensorData)];
+  uint8_t buffer[SENSOR_DATA_LENGTH];
 
-  if (this->read_register(0xB5, buffer, sizeof(buffer)) != i2c::ERROR_OK) {
+  if (this->read_register(0xB5, buffer, SENSOR_DATA_LENGTH) != i2c::ERROR_OK) {
     ESP_LOGD(TAG, "Read failed");
     this->status_set_warning();
     this->publish_nans_();

--- a/esphome/components/iaqcore/iaqcore.cpp
+++ b/esphome/components/iaqcore/iaqcore.cpp
@@ -10,7 +10,7 @@ static const char *const TAG = "iaqcore";
 
 enum IAQCoreErrorCode : uint8_t { ERROR_OK = 0, ERROR_RUNIN = 0x10, ERROR_BUSY = 0x01, ERROR_ERROR = 0x80 };
 
-static const size_t SENSOR_DATA_LENGTH = 9;
+static constexpr size_t SENSOR_DATA_LENGTH = 9;
 
 struct SensorData {
   int32_t resistance;

--- a/esphome/components/scd30/scd30.cpp
+++ b/esphome/components/scd30/scd30.cpp
@@ -222,7 +222,7 @@ bool SCD30Component::force_recalibration_with_reference(uint16_t co2_reference) 
 }
 
 uint16_t SCD30Component::get_forced_calibration_reference() {
-  uint16_t forced_calibration_reference;
+  uint16_t forced_calibration_reference = 0;
   // Get current CO2 calibration
   if (!this->get_register(SCD30_CMD_FORCED_CALIBRATION, forced_calibration_reference)) {
     ESP_LOGE(TAG, "Unable to read forced calibration reference.");

--- a/esphome/components/sen21231/sen21231.cpp
+++ b/esphome/components/sen21231/sen21231.cpp
@@ -20,7 +20,12 @@ void Sen21231Sensor::dump_config() {
 
 void Sen21231Sensor::read_data_() {
   person_sensor_results_t results;
-  this->read_bytes(PERSON_SENSOR_I2C_ADDRESS, (uint8_t *) &results, sizeof(results));
+  if (!this->read_bytes(PERSON_SENSOR_I2C_ADDRESS, (uint8_t *) &results, sizeof(results))) {
+    ESP_LOGW(TAG, "Failed to read data from SEN21231");
+    this->status_set_warning();
+    return;
+  }
+  this->status_clear_warning();
   ESP_LOGD(TAG, "SEN21231: %d faces detected", results.num_faces);
   this->publish_state(results.num_faces);
   if (results.num_faces == 1) {


### PR DESCRIPTION
# What does this implement/fix?

Fix uninitialized variables and missing error handling across four components:

- **iaqcore**: `sizeof(SensorData)` is 12 bytes due to struct padding (int32_t alignment) but the I2C payload is only 9 bytes. Use an explicit constant for the wire payload size.
- **scd30**: `get_forced_calibration_reference()` returns an uninitialized `forced_calibration_reference` when `get_register()` fails (undefined behavior). Initialize to 0.
- **sen21231**: `read_bytes()` return value was ignored. On I2C failure the uninitialized `person_sensor_results_t` struct would be published as sensor state. Add error check and status warning.
- **beken_spi_led_strip**: `param` was uninitialized when passed to `sddev_control(CMD_CLK_PWR_DOWN)`. The ICU driver dereferences this as a bitmask and ORs it into the clock power-down register, potentially powering down unrelated peripherals. Initialize to `PWD_SPI_CLK_BIT` to correctly power down the SPI clock before switching clock sources.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - these are internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).