### PR TITLE
[ltr501][pvvx_mithermometer][smt100] Convert static locals to instance members

### DIFF
--- a/esphome/components/ltr501/ltr501.cpp
+++ b/esphome/components/ltr501/ltr501.cpp
@@ -146,7 +146,6 @@ void LTRAlsPs501Component::update() {
 
 void LTRAlsPs501Component::loop() {
   ErrorCode err = i2c::ERROR_OK;
-  static uint8_t tries{0};
 
   switch (this->state_) {
     case State::DELAYED_SETUP:
@@ -175,20 +174,20 @@ void LTRAlsPs501Component::loop() {
 
     case State::WAITING_FOR_DATA:
       if (this->is_als_data_ready_(this->als_readings_) == LtrDataAvail::LTR_DATA_OK) {
-        tries = 0;
+        this->tries_ = 0;
         ESP_LOGV(TAG, "Reading sensor data assuming gain = %.0fx, time = %d ms",
                  get_gain_coeff(this->als_readings_.gain), get_itime_ms(this->als_readings_.integration_time));
         this->read_sensor_data_(this->als_readings_);
         this->apply_lux_calculation_(this->als_readings_);
         this->state_ = State::DATA_COLLECTED;
-      } else if (tries >= MAX_TRIES) {
+      } else if (this->tries_ >= MAX_TRIES) {
         ESP_LOGW(TAG, "Can't get data after several tries. Aborting.");
-        tries = 0;
+        this->tries_ = 0;
         this->status_set_warning();
         this->state_ = State::IDLE;
         return;
       } else {
-        tries++;
+        this->tries_++;
       }
       break;
 
@@ -230,21 +229,21 @@ void LTRAlsPs501Component::loop() {
 }
 
 void LTRAlsPs501Component::check_and_trigger_ps_() {
-  static uint32_t last_high_trigger_time{0};
-  static uint32_t last_low_trigger_time{0};
   uint16_t ps_data = this->read_ps_data_();
   uint32_t now = millis();
 
   if (ps_data != this->ps_readings_) {
     this->ps_readings_ = ps_data;
     // Higher values - object is closer to sensor
-    if (ps_data > this->ps_threshold_high_ && now - last_high_trigger_time >= this->ps_cooldown_time_s_ * 1000) {
-      last_high_trigger_time = now;
+    if (ps_data > this->ps_threshold_high_ &&
+        now - this->last_ps_high_trigger_time_ >= this->ps_cooldown_time_s_ * 1000) {
+      this->last_ps_high_trigger_time_ = now;
       ESP_LOGD(TAG, "Proximity high threshold triggered. Value = %d, Trigger level = %d", ps_data,
                this->ps_threshold_high_);
       this->on_ps_high_trigger_callback_.call();
-    } else if (ps_data < this->ps_threshold_low_ && now - last_low_trigger_time >= this->ps_cooldown_time_s_ * 1000) {
-      last_low_trigger_time = now;
+    } else if (ps_data < this->ps_threshold_low_ &&
+               now - this->last_ps_low_trigger_time_ >= this->ps_cooldown_time_s_ * 1000) {
+      this->last_ps_low_trigger_time_ = now;
       ESP_LOGD(TAG, "Proximity low threshold triggered. Value = %d, Trigger level = %d", ps_data,
                this->ps_threshold_low_);
       this->on_ps_low_trigger_callback_.call();

--- a/esphome/components/ltr501/ltr501.h
+++ b/esphome/components/ltr501/ltr501.h
@@ -131,6 +131,10 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
   uint16_t ps_threshold_high_{0xffff};
   uint16_t ps_threshold_low_{0x0000};
 
+  uint8_t tries_{0};
+  uint32_t last_ps_high_trigger_time_{0};
+  uint32_t last_ps_low_trigger_time_{0};
+
   //
   //   Sensors for publishing data
   //

--- a/esphome/components/ltr501/ltr501.h
+++ b/esphome/components/ltr501/ltr501.h
@@ -74,6 +74,7 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
     READY_TO_PUBLISH,
     KEEP_PUBLISHING
   } state_{State::NOT_INITIALIZED};
+  uint8_t tries_{0};
 
   LtrType ltr_type_{LtrType::LTR_TYPE_ALS_ONLY};
 
@@ -130,8 +131,6 @@ class LTRAlsPs501Component : public PollingComponent, public i2c::I2CDevice {
   PsGain501 ps_gain_{PsGain501::PS_GAIN_1};
   uint16_t ps_threshold_high_{0xffff};
   uint16_t ps_threshold_low_{0x0000};
-
-  uint8_t tries_{0};
   uint32_t last_ps_high_trigger_time_{0};
   uint32_t last_ps_low_trigger_time_{0};
 

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.cpp
@@ -66,12 +66,11 @@ optional<ParseResult> PVVXMiThermometer::parse_header_(const esp32_ble_tracker::
     return {};
   }
 
-  static uint8_t last_frame_count = 0;
-  if (last_frame_count == raw[13]) {
-    ESP_LOGVV(TAG, "parse_header(): duplicate data packet received (%hhu).", last_frame_count);
+  if (this->last_frame_count_ == raw[13]) {
+    ESP_LOGVV(TAG, "parse_header(): duplicate data packet received (%hhu).", this->last_frame_count_);
     return {};
   }
-  last_frame_count = raw[13];
+  this->last_frame_count_ = raw[13];
 
   return result;
 }

--- a/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
+++ b/esphome/components/pvvx_mithermometer/pvvx_mithermometer.h
@@ -39,6 +39,8 @@ class PVVXMiThermometer : public Component, public esp32_ble_tracker::ESPBTDevic
   sensor::Sensor *battery_voltage_{nullptr};
   sensor::Sensor *signal_strength_{nullptr};
 
+  uint8_t last_frame_count_{0};
+
   optional<ParseResult> parse_header_(const esp32_ble_tracker::ServiceData &service_data);
   bool parse_message_(const std::vector<uint8_t> &message, ParseResult &result);
   bool report_results_(const optional<ParseResult> &result, const char *address);

--- a/esphome/components/smt100/smt100.cpp
+++ b/esphome/components/smt100/smt100.cpp
@@ -12,10 +12,9 @@ void SMT100Component::update() {
 }
 
 void SMT100Component::loop() {
-  static char buffer[MAX_LINE_LENGTH];
   while (this->available() != 0) {
-    if (readline_(read(), buffer, MAX_LINE_LENGTH) > 0) {
-      int counts = (int) strtol((strtok(buffer, ",")), nullptr, 10);
+    if (this->readline_(this->read(), this->readline_buffer_, MAX_LINE_LENGTH) > 0) {
+      int counts = (int) strtol((strtok(this->readline_buffer_, ",")), nullptr, 10);
       float permittivity = (float) strtod((strtok(nullptr, ",")), nullptr);
       float moisture = (float) strtod((strtok(nullptr, ",")), nullptr);
       float temperature = (float) strtod((strtok(nullptr, ",")), nullptr);
@@ -56,7 +55,6 @@ void SMT100Component::dump_config() {
 }
 
 int SMT100Component::readline_(int readch, char *buffer, int len) {
-  static int pos = 0;
   int rpos;
 
   if (readch > 0) {
@@ -64,13 +62,13 @@ int SMT100Component::readline_(int readch, char *buffer, int len) {
       case '\n':  // Ignore new-lines
         break;
       case '\r':  // Return on CR
-        rpos = pos;
-        pos = 0;  // Reset position index ready for next time
+        rpos = this->readline_pos_;
+        this->readline_pos_ = 0;  // Reset position index ready for next time
         return rpos;
       default:
-        if (pos < len - 1) {
-          buffer[pos++] = readch;
-          buffer[pos] = 0;
+        if (this->readline_pos_ < len - 1) {
+          buffer[this->readline_pos_++] = readch;
+          buffer[this->readline_pos_] = 0;
         }
     }
   }

--- a/esphome/components/smt100/smt100.h
+++ b/esphome/components/smt100/smt100.h
@@ -28,6 +28,9 @@ class SMT100Component : public PollingComponent, public uart::UARTDevice {
  protected:
   int readline_(int readch, char *buffer, int len);
 
+  char readline_buffer_[MAX_LINE_LENGTH]{};
+  int readline_pos_{0};
+
   sensor::Sensor *counts_sensor_{nullptr};
   sensor::Sensor *permittivity_sensor_{nullptr};
   sensor::Sensor *moisture_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Convert `static` local variables to instance members in three components. Static locals are shared across all component instances, causing cross-instance interference when multiple devices of the same type are configured.

- **ltr501**: `static uint8_t tries` in `loop()` and `static uint32_t last_high_trigger_time`/`last_low_trigger_time` in `check_and_trigger_ps_()` — retry counter and proximity cooldown timestamps were shared between all LTR-501 instances. With two sensors, one's retry count or cooldown timer would affect the other.
- **pvvx_mithermometer**: `static uint8_t last_frame_count` in `parse_header_()` — single frame dedup counter shared between all PVVX thermometer instances. If device A sends frame count 5 and then device B sends frame count 5, device B's data gets incorrectly rejected as a duplicate.
- **smt100**: `static char buffer[]` and `static int pos` in `loop()`/`readline_()` — UART parse buffer and position shared between all instances. Two SMT100 sensors on different UARTs would corrupt each other's parsing state.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - these are internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).