### PR TITLE
[http_request] Make ESP8266 SSL buffer sizes configurable

### DIFF
--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -118,11 +118,11 @@ CONFIG_SCHEMA = cv.All(
                 cv.positive_not_null_time_period,
                 cv.positive_time_period_milliseconds,
             ),
-            cv.SplitDefault(CONF_BUFFER_SIZE_RX, esp32=512): cv.All(
-                cv.uint16_t, cv.only_on_esp32
+            cv.SplitDefault(CONF_BUFFER_SIZE_RX, esp32=512, esp8266=512): cv.All(
+                cv.uint16_t, cv.Any(cv.only_on_esp32, cv.only_on_esp8266)
             ),
-            cv.SplitDefault(CONF_BUFFER_SIZE_TX, esp32=512): cv.All(
-                cv.uint16_t, cv.only_on_esp32
+            cv.SplitDefault(CONF_BUFFER_SIZE_TX, esp32=512, esp8266=512): cv.All(
+                cv.uint16_t, cv.Any(cv.only_on_esp32, cv.only_on_esp8266)
             ),
             cv.Optional(CONF_CA_CERTIFICATE_PATH): cv.All(
                 cv.file_,
@@ -150,6 +150,10 @@ async def to_code(config):
 
     if CORE.is_esp8266 and not config[CONF_ESP8266_DISABLE_SSL_SUPPORT]:
         cg.add_define("USE_HTTP_REQUEST_ESP8266_HTTPS")
+
+    if CORE.is_esp8266:
+        cg.add(var.set_buffer_size_rx(config[CONF_BUFFER_SIZE_RX]))
+        cg.add(var.set_buffer_size_tx(config[CONF_BUFFER_SIZE_TX]))
 
     if timeout_ms := config.get(CONF_WATCHDOG_TIMEOUT):
         cg.add(var.set_watchdog_timeout(timeout_ms))

--- a/esphome/components/http_request/http_request_arduino.cpp
+++ b/esphome/components/http_request/http_request_arduino.cpp
@@ -18,8 +18,6 @@ namespace esphome::http_request {
 
 static const char *const TAG = "http_request.arduino";
 #ifdef USE_ESP8266
-static constexpr int RX_BUFFER_SIZE = 512;
-static constexpr int TX_BUFFER_SIZE = 512;
 // ESP8266 Arduino core (WiFiClientSecureBearSSL.cpp) returns -1000 on OOM
 static constexpr int ESP8266_SSL_ERR_OOM = -1000;
 #endif
@@ -58,7 +56,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
     ESP_LOGV(TAG, "ESP8266 HTTPS connection with WiFiClientSecure");
     stream_ptr = std::make_unique<WiFiClientSecure>();
     WiFiClientSecure *secure_client = static_cast<WiFiClientSecure *>(stream_ptr.get());
-    secure_client->setBufferSizes(RX_BUFFER_SIZE, TX_BUFFER_SIZE);
+    secure_client->setBufferSizes(this->buffer_size_rx_, this->buffer_size_tx_);
     secure_client->setInsecure();
   } else {
     stream_ptr = std::make_unique<WiFiClient>();
@@ -139,7 +137,7 @@ std::shared_ptr<HttpContainer> HttpRequestArduino::perform(const std::string &ur
         ESP_LOGW(TAG, "SSL failure: %s (Code: %d)", LOG_STR_ARG(error_msg), last_error);
         if (last_error == ESP8266_SSL_ERR_OOM) {
           ESP_LOGW(TAG, "Heap free: %u bytes, configured buffer sizes: %u bytes", ESP.getFreeHeap(),
-                   static_cast<unsigned int>(RX_BUFFER_SIZE + TX_BUFFER_SIZE));
+                   static_cast<unsigned int>(this->buffer_size_rx_ + this->buffer_size_tx_));
         }
       } else {
         ESP_LOGW(TAG, "Connection failure with no error code");

--- a/esphome/components/http_request/http_request_arduino.h
+++ b/esphome/components/http_request/http_request_arduino.h
@@ -47,10 +47,20 @@ class HttpContainerArduino : public HttpContainer {
 };
 
 class HttpRequestArduino : public HttpRequestComponent {
+ public:
+#ifdef USE_ESP8266
+  void set_buffer_size_rx(uint16_t size) { this->buffer_size_rx_ = size; }
+  void set_buffer_size_tx(uint16_t size) { this->buffer_size_tx_ = size; }
+#endif
+
  protected:
   std::shared_ptr<HttpContainer> perform(const std::string &url, const std::string &method, const std::string &body,
                                          const std::vector<Header> &request_headers,
                                          const std::vector<std::string> &lower_case_collect_headers) override;
+#ifdef USE_ESP8266
+  uint16_t buffer_size_rx_{512};
+  uint16_t buffer_size_tx_{512};
+#endif
 };
 
 }  // namespace esphome::http_request


### PR DESCRIPTION


# What does this implement/fix?

The BearSSL receive and transmit buffer sizes on ESP8266 were hardcoded to 512 bytes in `http_request_arduino.cpp`. This is too small for TLS records from most HTTPS servers — GitHub, Home Assistant, and most other servers send standard 16384-byte TLS records, causing `BR_ERR_TOO_LARGE` failures when ESP8266 devices attempt HTTPS connections (e.g., for HTTP OTA updates).

This PR makes `buffer_size_rx` and `buffer_size_tx` configurable for ESP8266, matching the existing ESP32 IDF configuration options. The default remains 512 bytes for backward compatibility.

### Usage

```yaml
http_request:
  buffer_size_rx: 16384
  buffer_size_tx: 512
```

Users performing HTTPS OTA updates or connecting to servers that don't support TLS Maximum Fragment Length Negotiation (MFLN) will need to increase `buffer_size_rx` to accommodate full-size TLS records. The required value depends on the server — 16384 covers all standard servers but costs ~16 KB of heap RAM.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Fixes HTTPS failures on ESP8266 with `BR_ERR_TOO_LARGE` ("Incoming TLS record does not fit in receive buffer").

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

TBD — documentation PR needed to add `buffer_size_rx`/`buffer_size_tx` to the ESP8266 section of the http_request docs.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  buffer_size_rx: 16384
  buffer_size_tx: 512
  verify_ssl: false

update:
  - platform: http_request
    name: Firmware Update
    source: https://example.com/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).