### PR TITLE
[uart] Fully enable raw mode with host serial

### DIFF
--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -124,17 +124,10 @@ void HostUartComponent::setup() {
   fcntl(this->file_descriptor_, F_SETFL, 0);
   struct termios options;
   tcgetattr(this->file_descriptor_, &options);
+  cfmakeraw(&options);
   options.c_cflag &= ~CRTSCTS;
   options.c_cflag |= CREAD | CLOCAL;
-  options.c_lflag &= ~ICANON;
-  options.c_lflag &= ~ECHO;
-  options.c_lflag &= ~ECHOE;
-  options.c_lflag &= ~ECHONL;
-  options.c_lflag &= ~ISIG;
-  options.c_iflag &= ~(IXON | IXOFF | IXANY);
-  options.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL);
-  options.c_oflag &= ~OPOST;
-  options.c_oflag &= ~ONLCR;
+  options.c_iflag &= ~(IXOFF | IXANY);
   // Set data bits
   options.c_cflag &= ~CSIZE;  // Mask the character size bits
   switch (this->data_bits_) {


### PR DESCRIPTION
# What does this implement/fix?

`IEXTEN` is not cleared in `c_lflag` when the serial port is being set up, resulting in a serial port that mangles the bytestream (`\017` and `\026` are removed on macOS). I suspect this is a macOS-only problem but this can be solved in a cross-platform way by just using `cfmakeraw()`, which fully clears these flags before setting up the port.

For background, I'm finishing up adding support for https://github.com/esphome/esphome/pull/13944 in https://github.com/puddly/serialx/pull/23 and am currently exploring running ESPHome itself in CI.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
