### PR TITLE
[api] Inline APIServer::is_connected() for common no-arg path

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -582,11 +582,7 @@ void APIServer::request_time() {
 }
 #endif
 
-bool APIServer::is_connected(bool state_subscription_only) const {
-  if (!state_subscription_only) {
-    return !this->clients_.empty();
-  }
-
+bool APIServer::is_connected_with_state_subscription() const {
   for (const auto &client : this->clients_) {
     if (client->flags_.state_subscription) {
       return true;

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -185,7 +185,8 @@ class APIServer : public Component,
   void send_infrared_rf_receive_event(uint32_t device_id, uint32_t key, const std::vector<int32_t> *timings);
 #endif
 
-  bool is_connected(bool state_subscription_only = false) const;
+  bool is_connected() const { return !this->clients_.empty(); }
+  bool is_connected_with_state_subscription() const;
 
 #ifdef USE_API_HOMEASSISTANT_STATES
   struct HomeAssistantStateSubscription {
@@ -323,7 +324,10 @@ template<typename... Ts> class APIConnectedCondition : public Condition<Ts...> {
   TEMPLATABLE_VALUE(bool, state_subscription_only)
  public:
   bool check(const Ts &...x) override {
-    return global_api_server->is_connected(this->state_subscription_only_.value(x...));
+    if (this->state_subscription_only_.value(x...)) {
+      return global_api_server->is_connected_with_state_subscription();
+    }
+    return global_api_server->is_connected();
   }
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Inlines `APIServer::is_connected()` for the common no-argument path.

The `is_connected()` method is called on every BLE advertisement in the bluetooth_proxy hot path (and many other components), but was forced out-of-line when the `state_subscription_only` parameter was added in #11906.

The default path (no argument) is just `!clients_.empty()` — a simple pointer comparison that the compiler can inline to two loads and a compare. Previously this went through an indirect call via the global pointer, function prologue/epilogue, a branch on the default `false` parameter, and then the same trivial check.

Split into two methods:
- `is_connected()` — inline in header (common fast path, all existing callers)
- `is_connected_with_state_subscription()` — out-of-line (rare path, only used by `APIConnectedCondition`)

No callers pass `true` directly; only `APIConnectedCondition` uses the `state_subscription_only` template value, updated accordingly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal C++ API only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).