### PR TITLE
[api] Sync api.proto from aioesphomeapi

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -58,6 +58,7 @@ service APIConnection {
   rpc subscribe_bluetooth_connections_free(SubscribeBluetoothConnectionsFreeRequest) returns (BluetoothConnectionsFreeResponse) {}
   rpc unsubscribe_bluetooth_le_advertisements(UnsubscribeBluetoothLEAdvertisementsRequest) returns (void) {}
   rpc bluetooth_scanner_set_mode(BluetoothScannerSetModeRequest) returns (void) {}
+  rpc bluetooth_set_connection_params(BluetoothSetConnectionParamsRequest) returns (BluetoothSetConnectionParamsResponse) {}
 
   rpc subscribe_voice_assistant(SubscribeVoiceAssistantRequest) returns (void) {}
   rpc voice_assistant_get_configuration(VoiceAssistantConfigurationRequest) returns (VoiceAssistantConfigurationResponse) {}
@@ -69,6 +70,12 @@ service APIConnection {
   rpc zwave_proxy_request(ZWaveProxyRequest) returns (void) {}
 
   rpc infrared_rf_transmit_raw_timings(InfraredRFTransmitRawTimingsRequest) returns (void) {}
+
+  rpc serial_proxy_configure(SerialProxyConfigureRequest) returns (void) {}
+  rpc serial_proxy_write(SerialProxyWriteRequest) returns (void) {}
+  rpc serial_proxy_set_modem_pins(SerialProxySetModemPinsRequest) returns (void) {}
+  rpc serial_proxy_get_modem_pins(SerialProxyGetModemPinsRequest) returns (void) {}
+  rpc serial_proxy_request(SerialProxyRequest) returns (void) {}
 }
 
 
@@ -198,6 +205,17 @@ message DeviceInfo {
   uint32 area_id = 3;
 }
 
+enum SerialProxyPortType {
+  SERIAL_PROXY_PORT_TYPE_TTL = 0;
+  SERIAL_PROXY_PORT_TYPE_RS232 = 1;
+  SERIAL_PROXY_PORT_TYPE_RS485 = 2;
+}
+
+message SerialProxyInfo {
+  string name = 1;                    // Human-readable port name
+  SerialProxyPortType port_type = 2;  // Port type (RS232, RS485)
+}
+
 message DeviceInfoResponse {
   option (id) = 10;
   option (source) = SOURCE_SERVER;
@@ -260,6 +278,9 @@ message DeviceInfoResponse {
   // Indicates if Z-Wave proxy support is available and features supported
   uint32 zwave_proxy_feature_flags = 23 [(field_ifdef) = "USE_ZWAVE_PROXY"];
   uint32 zwave_home_id = 24 [(field_ifdef) = "USE_ZWAVE_PROXY"];
+
+  // Serial proxy instance metadata
+  repeated SerialProxyInfo serial_proxies = 25 [(field_ifdef) = "USE_SERIAL_PROXY", (fixed_array_size_define) = "SERIAL_PROXY_COUNT"];
 }
 
 message ListEntitiesRequest {
@@ -2516,4 +2537,115 @@ message InfraredRFReceiveEvent {
   uint32 device_id = 1 [(field_ifdef) = "USE_DEVICES"];
   fixed32 key = 2;                                    // Key identifying the receiver instance
   repeated sint32 timings = 3 [packed = true, (container_pointer_no_template) = "std::vector<int32_t>"];  // Raw timings in microseconds (zigzag-encoded): alternating mark/space periods
+}
+
+// ==================== SERIAL PROXY ====================
+
+enum SerialProxyParity {
+  SERIAL_PROXY_PARITY_NONE = 0;
+  SERIAL_PROXY_PARITY_EVEN = 1;
+  SERIAL_PROXY_PARITY_ODD = 2;
+}
+
+// Configure UART parameters for a serial proxy instance
+message SerialProxyConfigureRequest {
+  option (id) = 138;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SERIAL_PROXY";
+
+  uint32 instance = 1;          // Instance index (0-based)
+  uint32 baudrate = 2;          // Baud rate in bits per second
+  bool flow_control = 3;        // Enable hardware flow control
+  SerialProxyParity parity = 4; // Parity setting
+  uint32 stop_bits = 5;         // Number of stop bits (1 or 2)
+  uint32 data_size = 6;         // Number of data bits (5-8)
+}
+
+// Data received from a serial device, forwarded to clients
+message SerialProxyDataReceived {
+  option (id) = 139;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SERIAL_PROXY";
+  option (no_delay) = true;
+
+  uint32 instance = 1;          // Instance index (0-based)
+  bytes data = 2;               // Raw data received from the serial device
+}
+
+// Write data to a serial device
+message SerialProxyWriteRequest {
+  option (id) = 140;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SERIAL_PROXY";
+  option (no_delay) = true;
+
+  uint32 instance = 1;          // Instance index (0-based)
+  bytes data = 2;               // Raw data to write to the serial device
+}
+
+// Set modem control pin states (RTS and DTR)
+message SerialProxySetModemPinsRequest {
+  option (id) = 141;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SERIAL_PROXY";
+
+  uint32 instance = 1;          // Instance index (0-based)
+  uint32 line_states = 2;       // Bitmask of SerialProxyLineStateFlags
+}
+
+// Request current modem control pin states
+message SerialProxyGetModemPinsRequest {
+  option (id) = 142;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SERIAL_PROXY";
+
+  uint32 instance = 1;          // Instance index (0-based)
+}
+
+// Response with current modem control pin states
+message SerialProxyGetModemPinsResponse {
+  option (id) = 143;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_SERIAL_PROXY";
+
+  uint32 instance = 1;          // Instance index (0-based)
+  uint32 line_states = 2;       // Bitmask of SerialProxyLineStateFlags
+}
+
+enum SerialProxyRequestType {
+  SERIAL_PROXY_REQUEST_TYPE_SUBSCRIBE = 0;   // Subscribe to receive data from this serial proxy instance
+  SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE = 1; // Unsubscribe from this serial proxy instance
+  SERIAL_PROXY_REQUEST_TYPE_FLUSH = 2;       // Flush the serial port (block until all TX data is sent)
+}
+
+// Generic request message for simple serial proxy operations
+message SerialProxyRequest {
+  option (id) = 144;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_SERIAL_PROXY";
+
+  uint32 instance = 1;                  // Instance index (0-based)
+  SerialProxyRequestType type = 2;      // Request type
+}
+
+// ==================== BLUETOOTH CONNECTION PARAMS ====================
+message BluetoothSetConnectionParamsRequest {
+  option (id) = 145;
+  option (source) = SOURCE_CLIENT;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  uint32 min_interval = 2;  // units of 1.25ms
+  uint32 max_interval = 3;  // units of 1.25ms
+  uint32 latency = 4;
+  uint32 timeout = 5;       // units of 10ms
+}
+
+message BluetoothSetConnectionParamsResponse {
+  option (id) = 146;
+  option (source) = SOURCE_SERVER;
+  option (ifdef) = "USE_BLUETOOTH_PROXY";
+
+  uint64 address = 1;
+  int32 error = 2;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -71,6 +71,18 @@ uint32_t DeviceInfo::calculate_size() const {
   return size;
 }
 #endif
+#ifdef USE_SERIAL_PROXY
+void SerialProxyInfo::encode(ProtoWriteBuffer &buffer) const {
+  buffer.encode_string(1, this->name);
+  buffer.encode_uint32(2, static_cast<uint32_t>(this->port_type));
+}
+uint32_t SerialProxyInfo::calculate_size() const {
+  uint32_t size = 0;
+  size += ProtoSize::calc_length(1, this->name.size());
+  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->port_type));
+  return size;
+}
+#endif
 void DeviceInfoResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(2, this->name);
   buffer.encode_string(3, this->mac_address);
@@ -124,6 +136,11 @@ void DeviceInfoResponse::encode(ProtoWriteBuffer &buffer) const {
 #endif
 #ifdef USE_ZWAVE_PROXY
   buffer.encode_uint32(24, this->zwave_home_id);
+#endif
+#ifdef USE_SERIAL_PROXY
+  for (const auto &it : this->serial_proxies) {
+    buffer.encode_message(25, it);
+  }
 #endif
 }
 uint32_t DeviceInfoResponse::calculate_size() const {
@@ -180,6 +197,11 @@ uint32_t DeviceInfoResponse::calculate_size() const {
 #endif
 #ifdef USE_ZWAVE_PROXY
   size += ProtoSize::calc_uint32(2, this->zwave_home_id);
+#endif
+#ifdef USE_SERIAL_PROXY
+  for (const auto &it : this->serial_proxies) {
+    size += ProtoSize::calc_message_force(2, it.calculate_size());
+  }
 #endif
   return size;
 }
@@ -3711,6 +3733,145 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
       size += ProtoSize::calc_sint32_force(1, it);
     }
   }
+  return size;
+}
+#endif
+#ifdef USE_SERIAL_PROXY
+bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->instance = value.as_uint32();
+      break;
+    case 2:
+      this->baudrate = value.as_uint32();
+      break;
+    case 3:
+      this->flow_control = value.as_bool();
+      break;
+    case 4:
+      this->parity = static_cast<enums::SerialProxyParity>(value.as_uint32());
+      break;
+    case 5:
+      this->stop_bits = value.as_uint32();
+      break;
+    case 6:
+      this->data_size = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+void SerialProxyDataReceived::encode(ProtoWriteBuffer &buffer) const {
+  buffer.encode_uint32(1, this->instance);
+  buffer.encode_bytes(2, this->data_ptr_, this->data_len_);
+}
+uint32_t SerialProxyDataReceived::calculate_size() const {
+  uint32_t size = 0;
+  size += ProtoSize::calc_uint32(1, this->instance);
+  size += ProtoSize::calc_length(1, this->data_len_);
+  return size;
+}
+bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->instance = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
+  switch (field_id) {
+    case 2: {
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
+  }
+  return true;
+}
+bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->instance = value.as_uint32();
+      break;
+    case 2:
+      this->line_states = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->instance = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+void SerialProxyGetModemPinsResponse::encode(ProtoWriteBuffer &buffer) const {
+  buffer.encode_uint32(1, this->instance);
+  buffer.encode_uint32(2, this->line_states);
+}
+uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
+  uint32_t size = 0;
+  size += ProtoSize::calc_uint32(1, this->instance);
+  size += ProtoSize::calc_uint32(1, this->line_states);
+  return size;
+}
+bool SerialProxyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->instance = value.as_uint32();
+      break;
+    case 2:
+      this->type = static_cast<enums::SerialProxyRequestType>(value.as_uint32());
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+  switch (field_id) {
+    case 1:
+      this->address = value.as_uint64();
+      break;
+    case 2:
+      this->min_interval = value.as_uint32();
+      break;
+    case 3:
+      this->max_interval = value.as_uint32();
+      break;
+    case 4:
+      this->latency = value.as_uint32();
+      break;
+    case 5:
+      this->timeout = value.as_uint32();
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+void BluetoothSetConnectionParamsResponse::encode(ProtoWriteBuffer &buffer) const {
+  buffer.encode_uint64(1, this->address);
+  buffer.encode_int32(2, this->error);
+}
+uint32_t BluetoothSetConnectionParamsResponse::calculate_size() const {
+  uint32_t size = 0;
+  size += ProtoSize::calc_uint64(1, this->address);
+  size += ProtoSize::calc_int32(1, this->error);
   return size;
 }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -11,6 +11,11 @@ namespace esphome::api {
 
 namespace enums {
 
+enum SerialProxyPortType : uint32_t {
+  SERIAL_PROXY_PORT_TYPE_TTL = 0,
+  SERIAL_PROXY_PORT_TYPE_RS232 = 1,
+  SERIAL_PROXY_PORT_TYPE_RS485 = 2,
+};
 enum EntityCategory : uint32_t {
   ENTITY_CATEGORY_NONE = 0,
   ENTITY_CATEGORY_CONFIG = 1,
@@ -317,6 +322,18 @@ enum ZWaveProxyRequestType : uint32_t {
   ZWAVE_PROXY_REQUEST_TYPE_HOME_ID_CHANGE = 2,
 };
 #endif
+#ifdef USE_SERIAL_PROXY
+enum SerialProxyParity : uint32_t {
+  SERIAL_PROXY_PARITY_NONE = 0,
+  SERIAL_PROXY_PARITY_EVEN = 1,
+  SERIAL_PROXY_PARITY_ODD = 2,
+};
+enum SerialProxyRequestType : uint32_t {
+  SERIAL_PROXY_REQUEST_TYPE_SUBSCRIBE = 0,
+  SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE = 1,
+  SERIAL_PROXY_REQUEST_TYPE_FLUSH = 2,
+};
+#endif
 
 }  // namespace enums
 
@@ -477,10 +494,24 @@ class DeviceInfo final : public ProtoMessage {
  protected:
 };
 #endif
+#ifdef USE_SERIAL_PROXY
+class SerialProxyInfo final : public ProtoMessage {
+ public:
+  StringRef name{};
+  enums::SerialProxyPortType port_type{};
+  void encode(ProtoWriteBuffer &buffer) const;
+  uint32_t calculate_size() const;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+};
+#endif
 class DeviceInfoResponse final : public ProtoMessage {
  public:
   static constexpr uint8_t MESSAGE_TYPE = 10;
-  static constexpr uint8_t ESTIMATED_SIZE = 255;
+  static constexpr uint16_t ESTIMATED_SIZE = 309;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *message_name() const override { return "device_info_response"; }
 #endif
@@ -532,6 +563,9 @@ class DeviceInfoResponse final : public ProtoMessage {
 #endif
 #ifdef USE_ZWAVE_PROXY
   uint32_t zwave_home_id{0};
+#endif
+#ifdef USE_SERIAL_PROXY
+  std::array<SerialProxyInfo, SERIAL_PROXY_COUNT> serial_proxies{};
 #endif
   void encode(ProtoWriteBuffer &buffer) const;
   uint32_t calculate_size() const;
@@ -3052,6 +3086,170 @@ class InfraredRFReceiveEvent final : public ProtoMessage {
 #endif
   uint32_t key{0};
   const std::vector<int32_t> *timings{};
+  void encode(ProtoWriteBuffer &buffer) const;
+  uint32_t calculate_size() const;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+};
+#endif
+#ifdef USE_SERIAL_PROXY
+class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 138;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_configure_request"; }
+#endif
+  uint32_t instance{0};
+  uint32_t baudrate{0};
+  bool flow_control{false};
+  enums::SerialProxyParity parity{};
+  uint32_t stop_bits{0};
+  uint32_t data_size{0};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SerialProxyDataReceived final : public ProtoMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 139;
+  static constexpr uint8_t ESTIMATED_SIZE = 23;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_data_received"; }
+#endif
+  uint32_t instance{0};
+  const uint8_t *data_ptr_{nullptr};
+  size_t data_len_{0};
+  void set_data(const uint8_t *data, size_t len) {
+    this->data_ptr_ = data;
+    this->data_len_ = len;
+  }
+  void encode(ProtoWriteBuffer &buffer) const;
+  uint32_t calculate_size() const;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+};
+class SerialProxyWriteRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 140;
+  static constexpr uint8_t ESTIMATED_SIZE = 23;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_write_request"; }
+#endif
+  uint32_t instance{0};
+  const uint8_t *data{nullptr};
+  uint16_t data_len{0};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 141;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_set_modem_pins_request"; }
+#endif
+  uint32_t instance{0};
+  uint32_t line_states{0};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 142;
+  static constexpr uint8_t ESTIMATED_SIZE = 4;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_get_modem_pins_request"; }
+#endif
+  uint32_t instance{0};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class SerialProxyGetModemPinsResponse final : public ProtoMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 143;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_get_modem_pins_response"; }
+#endif
+  uint32_t instance{0};
+  uint32_t line_states{0};
+  void encode(ProtoWriteBuffer &buffer) const;
+  uint32_t calculate_size() const;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+};
+class SerialProxyRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 144;
+  static constexpr uint8_t ESTIMATED_SIZE = 6;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "serial_proxy_request"; }
+#endif
+  uint32_t instance{0};
+  enums::SerialProxyRequestType type{};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 145;
+  static constexpr uint8_t ESTIMATED_SIZE = 20;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "bluetooth_set_connection_params_request"; }
+#endif
+  uint64_t address{0};
+  uint32_t min_interval{0};
+  uint32_t max_interval{0};
+  uint32_t latency{0};
+  uint32_t timeout{0};
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *dump_to(DumpBuffer &out) const override;
+#endif
+
+ protected:
+  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+};
+class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
+ public:
+  static constexpr uint8_t MESSAGE_TYPE = 146;
+  static constexpr uint8_t ESTIMATED_SIZE = 8;
+#ifdef HAS_PROTO_MESSAGE_DUMP
+  const char *message_name() const override { return "bluetooth_set_connection_params_response"; }
+#endif
+  uint64_t address{0};
+  int32_t error{0};
   void encode(ProtoWriteBuffer &buffer) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -100,6 +100,18 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
   out.append(hex_buf).append("\n");
 }
 
+template<> const char *proto_enum_to_string<enums::SerialProxyPortType>(enums::SerialProxyPortType value) {
+  switch (value) {
+    case enums::SERIAL_PROXY_PORT_TYPE_TTL:
+      return "SERIAL_PROXY_PORT_TYPE_TTL";
+    case enums::SERIAL_PROXY_PORT_TYPE_RS232:
+      return "SERIAL_PROXY_PORT_TYPE_RS232";
+    case enums::SERIAL_PROXY_PORT_TYPE_RS485:
+      return "SERIAL_PROXY_PORT_TYPE_RS485";
+    default:
+      return "UNKNOWN";
+  }
+}
 template<> const char *proto_enum_to_string<enums::EntityCategory>(enums::EntityCategory value) {
   switch (value) {
     case enums::ENTITY_CATEGORY_NONE:
@@ -752,6 +764,32 @@ template<> const char *proto_enum_to_string<enums::ZWaveProxyRequestType>(enums:
   }
 }
 #endif
+#ifdef USE_SERIAL_PROXY
+template<> const char *proto_enum_to_string<enums::SerialProxyParity>(enums::SerialProxyParity value) {
+  switch (value) {
+    case enums::SERIAL_PROXY_PARITY_NONE:
+      return "SERIAL_PROXY_PARITY_NONE";
+    case enums::SERIAL_PROXY_PARITY_EVEN:
+      return "SERIAL_PROXY_PARITY_EVEN";
+    case enums::SERIAL_PROXY_PARITY_ODD:
+      return "SERIAL_PROXY_PARITY_ODD";
+    default:
+      return "UNKNOWN";
+  }
+}
+template<> const char *proto_enum_to_string<enums::SerialProxyRequestType>(enums::SerialProxyRequestType value) {
+  switch (value) {
+    case enums::SERIAL_PROXY_REQUEST_TYPE_SUBSCRIBE:
+      return "SERIAL_PROXY_REQUEST_TYPE_SUBSCRIBE";
+    case enums::SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE:
+      return "SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE";
+    case enums::SERIAL_PROXY_REQUEST_TYPE_FLUSH:
+      return "SERIAL_PROXY_REQUEST_TYPE_FLUSH";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
 
 const char *HelloRequest::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, "HelloRequest");
@@ -798,6 +836,14 @@ const char *DeviceInfo::dump_to(DumpBuffer &out) const {
   dump_field(out, "device_id", this->device_id);
   dump_field(out, "name", this->name);
   dump_field(out, "area_id", this->area_id);
+  return out.c_str();
+}
+#endif
+#ifdef USE_SERIAL_PROXY
+const char *SerialProxyInfo::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyInfo");
+  dump_field(out, "name", this->name);
+  dump_field(out, "port_type", static_cast<enums::SerialProxyPortType>(this->port_type));
   return out.c_str();
 }
 #endif
@@ -861,6 +907,13 @@ const char *DeviceInfoResponse::dump_to(DumpBuffer &out) const {
 #endif
 #ifdef USE_ZWAVE_PROXY
   dump_field(out, "zwave_home_id", this->zwave_home_id);
+#endif
+#ifdef USE_SERIAL_PROXY
+  for (const auto &it : this->serial_proxies) {
+    out.append("  serial_proxies: ");
+    it.dump_to(out);
+    out.append("\n");
+  }
 #endif
   return out.c_str();
 }
@@ -2507,6 +2560,70 @@ const char *InfraredRFReceiveEvent::dump_to(DumpBuffer &out) const {
   for (const auto &it : *this->timings) {
     dump_field(out, "timings", it, 4);
   }
+  return out.c_str();
+}
+#endif
+#ifdef USE_SERIAL_PROXY
+const char *SerialProxyConfigureRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyConfigureRequest");
+  dump_field(out, "instance", this->instance);
+  dump_field(out, "baudrate", this->baudrate);
+  dump_field(out, "flow_control", this->flow_control);
+  dump_field(out, "parity", static_cast<enums::SerialProxyParity>(this->parity));
+  dump_field(out, "stop_bits", this->stop_bits);
+  dump_field(out, "data_size", this->data_size);
+  return out.c_str();
+}
+const char *SerialProxyDataReceived::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyDataReceived");
+  dump_field(out, "instance", this->instance);
+  dump_bytes_field(out, "data", this->data_ptr_, this->data_len_);
+  return out.c_str();
+}
+const char *SerialProxyWriteRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyWriteRequest");
+  dump_field(out, "instance", this->instance);
+  dump_bytes_field(out, "data", this->data, this->data_len);
+  return out.c_str();
+}
+const char *SerialProxySetModemPinsRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxySetModemPinsRequest");
+  dump_field(out, "instance", this->instance);
+  dump_field(out, "line_states", this->line_states);
+  return out.c_str();
+}
+const char *SerialProxyGetModemPinsRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyGetModemPinsRequest");
+  dump_field(out, "instance", this->instance);
+  return out.c_str();
+}
+const char *SerialProxyGetModemPinsResponse::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyGetModemPinsResponse");
+  dump_field(out, "instance", this->instance);
+  dump_field(out, "line_states", this->line_states);
+  return out.c_str();
+}
+const char *SerialProxyRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "SerialProxyRequest");
+  dump_field(out, "instance", this->instance);
+  dump_field(out, "type", static_cast<enums::SerialProxyRequestType>(this->type));
+  return out.c_str();
+}
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+const char *BluetoothSetConnectionParamsRequest::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "BluetoothSetConnectionParamsRequest");
+  dump_field(out, "address", this->address);
+  dump_field(out, "min_interval", this->min_interval);
+  dump_field(out, "max_interval", this->max_interval);
+  dump_field(out, "latency", this->latency);
+  dump_field(out, "timeout", this->timeout);
+  return out.c_str();
+}
+const char *BluetoothSetConnectionParamsResponse::dump_to(DumpBuffer &out) const {
+  MessageDumpHelper helper(out, "BluetoothSetConnectionParamsResponse");
+  dump_field(out, "address", this->address);
+  dump_field(out, "error", this->error);
   return out.c_str();
 }
 #endif

--- a/esphome/components/api/api_pb2_service.cpp
+++ b/esphome/components/api/api_pb2_service.cpp
@@ -635,6 +635,72 @@ void APIServerConnectionBase::read_message(uint32_t msg_size, uint32_t msg_type,
       break;
     }
 #endif
+#ifdef USE_SERIAL_PROXY
+    case SerialProxyConfigureRequest::MESSAGE_TYPE: {
+      SerialProxyConfigureRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_serial_proxy_configure_request"), msg);
+#endif
+      this->on_serial_proxy_configure_request(msg);
+      break;
+    }
+#endif
+#ifdef USE_SERIAL_PROXY
+    case SerialProxyWriteRequest::MESSAGE_TYPE: {
+      SerialProxyWriteRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_serial_proxy_write_request"), msg);
+#endif
+      this->on_serial_proxy_write_request(msg);
+      break;
+    }
+#endif
+#ifdef USE_SERIAL_PROXY
+    case SerialProxySetModemPinsRequest::MESSAGE_TYPE: {
+      SerialProxySetModemPinsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_serial_proxy_set_modem_pins_request"), msg);
+#endif
+      this->on_serial_proxy_set_modem_pins_request(msg);
+      break;
+    }
+#endif
+#ifdef USE_SERIAL_PROXY
+    case SerialProxyGetModemPinsRequest::MESSAGE_TYPE: {
+      SerialProxyGetModemPinsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_serial_proxy_get_modem_pins_request"), msg);
+#endif
+      this->on_serial_proxy_get_modem_pins_request(msg);
+      break;
+    }
+#endif
+#ifdef USE_SERIAL_PROXY
+    case SerialProxyRequest::MESSAGE_TYPE: {
+      SerialProxyRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_serial_proxy_request"), msg);
+#endif
+      this->on_serial_proxy_request(msg);
+      break;
+    }
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+    case BluetoothSetConnectionParamsRequest::MESSAGE_TYPE: {
+      BluetoothSetConnectionParamsRequest msg;
+      msg.decode(msg_data, msg_size);
+#ifdef HAS_PROTO_MESSAGE_DUMP
+      this->log_receive_message_(LOG_STR("on_bluetooth_set_connection_params_request"), msg);
+#endif
+      this->on_bluetooth_set_connection_params_request(msg);
+      break;
+    }
+#endif
     default:
       break;
   }

--- a/esphome/components/api/api_pb2_service.h
+++ b/esphome/components/api/api_pb2_service.h
@@ -216,6 +216,27 @@ class APIServerConnectionBase : public ProtoService {
   virtual void on_infrared_rf_transmit_raw_timings_request(const InfraredRFTransmitRawTimingsRequest &value){};
 #endif
 
+#ifdef USE_SERIAL_PROXY
+  virtual void on_serial_proxy_configure_request(const SerialProxyConfigureRequest &value){};
+#endif
+
+#ifdef USE_SERIAL_PROXY
+  virtual void on_serial_proxy_write_request(const SerialProxyWriteRequest &value){};
+#endif
+#ifdef USE_SERIAL_PROXY
+  virtual void on_serial_proxy_set_modem_pins_request(const SerialProxySetModemPinsRequest &value){};
+#endif
+#ifdef USE_SERIAL_PROXY
+  virtual void on_serial_proxy_get_modem_pins_request(const SerialProxyGetModemPinsRequest &value){};
+#endif
+
+#ifdef USE_SERIAL_PROXY
+  virtual void on_serial_proxy_request(const SerialProxyRequest &value){};
+#endif
+#ifdef USE_BLUETOOTH_PROXY
+  virtual void on_bluetooth_set_connection_params_request(const BluetoothSetConnectionParamsRequest &value){};
+#endif
+
  protected:
   void read_message(uint32_t msg_size, uint32_t msg_type, const uint8_t *msg_data) override;
 };


### PR DESCRIPTION
# What does this implement/fix?

Sync `api.proto` from aioesphomeapi to esphome, picking up:
- Serial proxy messages (IDs 138-144) and rpc service entries from esphome/aioesphomeapi#1495
- Bluetooth connection params messages (IDs 145-146) and rpc entry from esphome/aioesphomeapi#1518
- Regenerated C++ protobuf files

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Related: home-assistant/core#153977

**Companion pull requests:**

- esphome/aioesphomeapi#1518
- esphome/aioesphomeapi#1521

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - protobuf sync only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).