### PR TITLE
[core] Skip zero-initialization of StaticVector data array

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -215,7 +215,7 @@ template<typename T, size_t N> class StaticVector {
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
  private:
-  std::array<T, N> data_{};
+  std::array<T, N> data_;  // intentionally not value-initialized to avoid memset
   size_t count_{0};
 
  public:


### PR DESCRIPTION
# What does this implement/fix?

Remove value-initialization (`{}`) from `StaticVector`'s underlying `std::array`. Elements beyond `count_` are never read — reading them would be a bug, just as it would be with `std::vector`. All access paths are bounded by `count_`: `end()` returns `begin() + count_`, `clear()` just resets `count_`, and `span` conversion uses `count_` as the length.

Since the uninitialized elements are never observable, zero-filling them is pure waste. This eliminates a `memset` on every construction. Most impactful for stack-allocated `StaticVector`s in hot paths like `APIPlaintextFrameHelper::write_protobuf_messages`, which was memsetting 276 bytes of iovec storage on every BLE proxy flush (~10 times/second).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No user-facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).