### PR TITLE
[ci] Match symbols with changed signatures in memory impact analysis

### DIFF
--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -176,6 +176,9 @@ def _sig_base(sym: str) -> str:
     return sym[:start] + sym[end + 1 :]
 
 
+_AMBIGUOUS = object()
+
+
 def _match_signature_changes(
     changed_symbols: list[tuple[str, int, int, int]],
     new_symbols: list[tuple[str, int]],
@@ -194,33 +197,33 @@ def _match_signature_changes(
     if not new_symbols or not removed_symbols:
         return changed_symbols, new_symbols, removed_symbols
 
-    new_by_base: dict[str, list[int]] = {}
-    for i, (sym, _size) in enumerate(new_symbols):
-        new_by_base.setdefault(_sig_base(sym), []).append(i)
-    removed_by_base: dict[str, list[int]] = {}
-    for i, (sym, _size) in enumerate(removed_symbols):
-        removed_by_base.setdefault(_sig_base(sym), []).append(i)
+    # Build base -> entry maps; mark ambiguous bases with sentinel
+    new_by_base: dict[str, tuple[str, int] | object] = {}
+    for entry in new_symbols:
+        base = _sig_base(entry[0])
+        new_by_base[base] = _AMBIGUOUS if base in new_by_base else entry
+    removed_by_base: dict[str, tuple[str, int] | object] = {}
+    for entry in removed_symbols:
+        base = _sig_base(entry[0])
+        removed_by_base[base] = _AMBIGUOUS if base in removed_by_base else entry
 
-    matched_new: set[int] = set()
-    matched_removed: set[int] = set()
-    for base, new_indices in new_by_base.items():
-        rem_indices = removed_by_base.get(base)
-        if rem_indices and len(new_indices) == 1 and len(rem_indices) == 1:
-            ni, ri = new_indices[0], rem_indices[0]
-            pr_sym, pr_size = new_symbols[ni]
-            _rm_sym, target_size = removed_symbols[ri]
-            delta = pr_size - target_size
-            if delta != 0:
-                changed_symbols.append((pr_sym, target_size, pr_size, delta))
-            matched_new.add(ni)
-            matched_removed.add(ri)
+    matched: set[str] = set()  # matched base keys
+    for base, new_entry in new_by_base.items():
+        if new_entry is _AMBIGUOUS:
+            continue
+        rem_entry = removed_by_base.get(base)
+        if rem_entry is None or rem_entry is _AMBIGUOUS:
+            continue
+        pr_sym, pr_size = new_entry
+        _rm_sym, target_size = rem_entry
+        delta = pr_size - target_size
+        if delta != 0:
+            changed_symbols.append((pr_sym, target_size, pr_size, delta))
+        matched.add(base)
 
-    if matched_new:
-        new_symbols = [s for i, s in enumerate(new_symbols) if i not in matched_new]
-    if matched_removed:
-        removed_symbols = [
-            s for i, s in enumerate(removed_symbols) if i not in matched_removed
-        ]
+    if matched:
+        new_symbols = [e for e in new_symbols if _sig_base(e[0]) not in matched]
+        removed_symbols = [e for e in removed_symbols if _sig_base(e[0]) not in matched]
     return changed_symbols, new_symbols, removed_symbols
 
 

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -163,9 +163,12 @@ def format_change(before: int, after: int, threshold: float | None = None) -> st
 def _sig_base(sym: str) -> str:
     """Strip argument types from a symbol name for fuzzy matching.
 
-    Removes content between the outermost "(" and ")" so that
-    "foo(int)::nested" and "foo(float)::nested" share key "foo()::nested"
-    but "foo(int)" and "foo(int)::nested" do NOT collide.
+    Removes the entire outermost parenthesized argument list (including
+    the parentheses) from the symbol string.
+
+    This makes, for example, "foo(int)::nested" and "foo(float)::nested"
+    share the same key "foo::nested", while "foo(int)" maps to "foo" and
+    therefore does NOT collide with "foo(int)::nested".
     """
     start = sym.find("(")
     if start == -1:

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -200,17 +200,28 @@ def prepare_symbol_changes_data(
             delta = pr_size - target_size
             changed_symbols.append((symbol, target_size, pr_size, delta))
 
-    # Fuzzy-match new/removed symbols whose function name (before the "(")
-    # is the same — these are signature changes (e.g. argument type changed).
+    # Fuzzy-match new/removed symbols whose function name is the same but
+    # argument types differ — these are signature changes.
+    # The base key strips what's between the outermost "(" and ")" so that
+    # "foo(int)::nested" and "foo(float)::nested" share key "foo()::nested"
+    # but "foo(int)" and "foo(int)::nested" do NOT collide.
     if new_symbols and removed_symbols:
+
+        def _sig_base(sym: str) -> str:
+            start = sym.find("(")
+            if start == -1:
+                return sym
+            end = sym.rfind(")")
+            if end == -1:
+                return sym
+            return sym[:start] + sym[end + 1 :]
+
         new_by_base: dict[str, list[int]] = {}
         for i, (sym, _size) in enumerate(new_symbols):
-            base = sym.split("(", 1)[0]
-            new_by_base.setdefault(base, []).append(i)
+            new_by_base.setdefault(_sig_base(sym), []).append(i)
         removed_by_base: dict[str, list[int]] = {}
         for i, (sym, _size) in enumerate(removed_symbols):
-            base = sym.split("(", 1)[0]
-            removed_by_base.setdefault(base, []).append(i)
+            removed_by_base.setdefault(_sig_base(sym), []).append(i)
 
         matched_new: set[int] = set()
         matched_removed: set[int] = set()
@@ -221,7 +232,8 @@ def prepare_symbol_changes_data(
                 pr_sym, pr_size = new_symbols[ni]
                 _rm_sym, target_size = removed_symbols[ri]
                 delta = pr_size - target_size
-                changed_symbols.append((pr_sym, target_size, pr_size, delta))
+                if delta != 0:
+                    changed_symbols.append((pr_sym, target_size, pr_size, delta))
                 matched_new.add(ni)
                 matched_removed.add(ri)
 

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -160,6 +160,70 @@ def format_change(before: int, after: int, threshold: float | None = None) -> st
     return f"{emoji} {delta_str} ({pct_str})"
 
 
+def _sig_base(sym: str) -> str:
+    """Strip argument types from a symbol name for fuzzy matching.
+
+    Removes content between the outermost "(" and ")" so that
+    "foo(int)::nested" and "foo(float)::nested" share key "foo()::nested"
+    but "foo(int)" and "foo(int)::nested" do NOT collide.
+    """
+    start = sym.find("(")
+    if start == -1:
+        return sym
+    end = sym.rfind(")")
+    if end == -1:
+        return sym
+    return sym[:start] + sym[end + 1 :]
+
+
+def _match_signature_changes(
+    changed_symbols: list[tuple[str, int, int, int]],
+    new_symbols: list[tuple[str, int]],
+    removed_symbols: list[tuple[str, int]],
+) -> tuple[
+    list[tuple[str, int, int, int]],
+    list[tuple[str, int]],
+    list[tuple[str, int]],
+]:
+    """Match new/removed symbol pairs that only differ in argument types.
+
+    When a function's argument types change (e.g. foo(vector<>&) -> foo(Buffer&)),
+    it appears as a new + removed symbol. This matches them by base name and moves
+    them to changed_symbols. Only matches unambiguous 1:1 pairs.
+    """
+    if not new_symbols or not removed_symbols:
+        return changed_symbols, new_symbols, removed_symbols
+
+    new_by_base: dict[str, list[int]] = {}
+    for i, (sym, _size) in enumerate(new_symbols):
+        new_by_base.setdefault(_sig_base(sym), []).append(i)
+    removed_by_base: dict[str, list[int]] = {}
+    for i, (sym, _size) in enumerate(removed_symbols):
+        removed_by_base.setdefault(_sig_base(sym), []).append(i)
+
+    matched_new: set[int] = set()
+    matched_removed: set[int] = set()
+    for base, new_indices in new_by_base.items():
+        rem_indices = removed_by_base.get(base)
+        if rem_indices and len(new_indices) == 1 and len(rem_indices) == 1:
+            ni, ri = new_indices[0], rem_indices[0]
+            pr_sym, pr_size = new_symbols[ni]
+            _rm_sym, target_size = removed_symbols[ri]
+            delta = pr_size - target_size
+            if delta != 0:
+                changed_symbols.append((pr_sym, target_size, pr_size, delta))
+            matched_new.add(ni)
+            matched_removed.add(ri)
+
+    if matched_new:
+        new_symbols = [s for i, s in enumerate(new_symbols) if i not in matched_new]
+    if matched_removed:
+        removed_symbols = [
+            s for i, s in enumerate(removed_symbols) if i not in matched_removed
+        ]
+    return changed_symbols, new_symbols, removed_symbols
+
+
 def prepare_symbol_changes_data(
     target_symbols: dict | None, pr_symbols: dict | None
 ) -> dict | None:
@@ -200,49 +264,10 @@ def prepare_symbol_changes_data(
             delta = pr_size - target_size
             changed_symbols.append((symbol, target_size, pr_size, delta))
 
-    # Fuzzy-match new/removed symbols whose function name is the same but
-    # argument types differ — these are signature changes.
-    # The base key strips what's between the outermost "(" and ")" so that
-    # "foo(int)::nested" and "foo(float)::nested" share key "foo()::nested"
-    # but "foo(int)" and "foo(int)::nested" do NOT collide.
-    if new_symbols and removed_symbols:
-
-        def _sig_base(sym: str) -> str:
-            start = sym.find("(")
-            if start == -1:
-                return sym
-            end = sym.rfind(")")
-            if end == -1:
-                return sym
-            return sym[:start] + sym[end + 1 :]
-
-        new_by_base: dict[str, list[int]] = {}
-        for i, (sym, _size) in enumerate(new_symbols):
-            new_by_base.setdefault(_sig_base(sym), []).append(i)
-        removed_by_base: dict[str, list[int]] = {}
-        for i, (sym, _size) in enumerate(removed_symbols):
-            removed_by_base.setdefault(_sig_base(sym), []).append(i)
-
-        matched_new: set[int] = set()
-        matched_removed: set[int] = set()
-        for base, new_indices in new_by_base.items():
-            rem_indices = removed_by_base.get(base)
-            if rem_indices and len(new_indices) == 1 and len(rem_indices) == 1:
-                ni, ri = new_indices[0], rem_indices[0]
-                pr_sym, pr_size = new_symbols[ni]
-                _rm_sym, target_size = removed_symbols[ri]
-                delta = pr_size - target_size
-                if delta != 0:
-                    changed_symbols.append((pr_sym, target_size, pr_size, delta))
-                matched_new.add(ni)
-                matched_removed.add(ri)
-
-        if matched_new:
-            new_symbols = [s for i, s in enumerate(new_symbols) if i not in matched_new]
-        if matched_removed:
-            removed_symbols = [
-                s for i, s in enumerate(removed_symbols) if i not in matched_removed
-            ]
+    # Match new/removed symbols that only differ in argument types
+    changed_symbols, new_symbols, removed_symbols = _match_signature_changes(
+        changed_symbols, new_symbols, removed_symbols
+    )
 
     if not changed_symbols and not new_symbols and not removed_symbols:
         return None

--- a/script/ci_memory_impact_comment.py
+++ b/script/ci_memory_impact_comment.py
@@ -200,6 +200,38 @@ def prepare_symbol_changes_data(
             delta = pr_size - target_size
             changed_symbols.append((symbol, target_size, pr_size, delta))
 
+    # Fuzzy-match new/removed symbols whose function name (before the "(")
+    # is the same — these are signature changes (e.g. argument type changed).
+    if new_symbols and removed_symbols:
+        new_by_base: dict[str, list[int]] = {}
+        for i, (sym, _size) in enumerate(new_symbols):
+            base = sym.split("(", 1)[0]
+            new_by_base.setdefault(base, []).append(i)
+        removed_by_base: dict[str, list[int]] = {}
+        for i, (sym, _size) in enumerate(removed_symbols):
+            base = sym.split("(", 1)[0]
+            removed_by_base.setdefault(base, []).append(i)
+
+        matched_new: set[int] = set()
+        matched_removed: set[int] = set()
+        for base, new_indices in new_by_base.items():
+            rem_indices = removed_by_base.get(base)
+            if rem_indices and len(new_indices) == 1 and len(rem_indices) == 1:
+                ni, ri = new_indices[0], rem_indices[0]
+                pr_sym, pr_size = new_symbols[ni]
+                _rm_sym, target_size = removed_symbols[ri]
+                delta = pr_size - target_size
+                changed_symbols.append((pr_sym, target_size, pr_size, delta))
+                matched_new.add(ni)
+                matched_removed.add(ri)
+
+        if matched_new:
+            new_symbols = [s for i, s in enumerate(new_symbols) if i not in matched_new]
+        if matched_removed:
+            removed_symbols = [
+                s for i, s in enumerate(removed_symbols) if i not in matched_removed
+            ]
+
     if not changed_symbols and not new_symbols and not removed_symbols:
         return None
 

--- a/tests/unit_tests/analyze_memory/test_ci_memory_impact_comment.py
+++ b/tests/unit_tests/analyze_memory/test_ci_memory_impact_comment.py
@@ -1,0 +1,77 @@
+"""Tests for script/ci_memory_impact_comment.py symbol matching."""
+
+from pathlib import Path
+import sys
+
+# Add script directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "script"))
+
+from ci_memory_impact_comment import prepare_symbol_changes_data  # noqa: E402
+
+
+def test_prepare_symbol_changes_signature_match() -> None:
+    """Symbols with same base name but different args are matched as changed."""
+    target = {
+        "Foo::bar(std::vector<unsigned char>&, int)": 300,
+        "unchanged()": 50,
+    }
+    pr = {
+        "Foo::bar(ProtoByteBuffer&, int)": 320,
+        "unchanged()": 50,
+    }
+    result = prepare_symbol_changes_data(target, pr)
+    assert result is not None
+    assert len(result["changed_symbols"]) == 1
+    assert len(result["new_symbols"]) == 0
+    assert len(result["removed_symbols"]) == 0
+    sym, t_size, p_size, delta = result["changed_symbols"][0]
+    assert sym == "Foo::bar(ProtoByteBuffer&, int)"
+    assert t_size == 300
+    assert p_size == 320
+    assert delta == 20
+
+
+def test_prepare_symbol_changes_ambiguous_overloads_not_matched() -> None:
+    """Multiple overloads with same base name stay as new/removed."""
+    target = {
+        "Foo::bar(int)": 100,
+        "Foo::bar(float)": 200,
+    }
+    pr = {
+        "Foo::bar(double)": 150,
+        "Foo::bar(long)": 250,
+    }
+    result = prepare_symbol_changes_data(target, pr)
+    assert result is not None
+    assert len(result["changed_symbols"]) == 0
+    assert len(result["new_symbols"]) == 2
+    assert len(result["removed_symbols"]) == 2
+
+
+def test_prepare_symbol_changes_no_parens_not_matched() -> None:
+    """Symbols without parens (variables) are not fuzzy-matched."""
+    target = {"my_global_var": 100}
+    pr = {"my_global_var_v2": 120}
+    result = prepare_symbol_changes_data(target, pr)
+    assert result is not None
+    assert len(result["changed_symbols"]) == 0
+    assert len(result["new_symbols"]) == 1
+    assert len(result["removed_symbols"]) == 1
+
+
+def test_prepare_symbol_changes_exact_match_preferred() -> None:
+    """Exact name matches are found before fuzzy matching runs."""
+    target = {
+        "Foo::bar(int)": 100,
+    }
+    pr = {
+        "Foo::bar(int)": 120,
+    }
+    result = prepare_symbol_changes_data(target, pr)
+    assert result is not None
+    assert len(result["changed_symbols"]) == 1
+    assert len(result["new_symbols"]) == 0
+    assert len(result["removed_symbols"]) == 0
+    sym, t_size, p_size, delta = result["changed_symbols"][0]
+    assert sym == "Foo::bar(int)"
+    assert delta == 20

--- a/tests/unit_tests/analyze_memory/test_ci_memory_impact_comment.py
+++ b/tests/unit_tests/analyze_memory/test_ci_memory_impact_comment.py
@@ -59,6 +59,28 @@ def test_prepare_symbol_changes_no_parens_not_matched() -> None:
     assert len(result["removed_symbols"]) == 1
 
 
+def test_prepare_symbol_changes_nested_symbols_matched_separately() -> None:
+    """Nested symbols like ::__pstr__ don't collide with parent function."""
+    target = {
+        "Foo::bar(std::vector<unsigned char>&, int)": 300,
+        "Foo::bar(std::vector<unsigned char>&, int)::__pstr__": 19,
+    }
+    pr = {
+        "Foo::bar(ProtoByteBuffer&, int)": 320,
+        "Foo::bar(ProtoByteBuffer&, int)::__pstr__": 19,
+    }
+    result = prepare_symbol_changes_data(target, pr)
+    assert result is not None
+    # Both the function and its nested __pstr__ should be matched (not new/removed)
+    assert len(result["new_symbols"]) == 0
+    assert len(result["removed_symbols"]) == 0
+    # __pstr__ has delta=0 so it's silently dropped, only the function shows
+    assert len(result["changed_symbols"]) == 1
+    sym, t_size, p_size, delta = result["changed_symbols"][0]
+    assert sym == "Foo::bar(ProtoByteBuffer&, int)"
+    assert delta == 20
+
+
 def test_prepare_symbol_changes_exact_match_preferred() -> None:
     """Exact name matches are found before fuzzy matching runs."""
     target = {


### PR DESCRIPTION
# What does this implement/fix?

When a function's argument types change (e.g., `foo(std::vector<>&)` → `foo(ProtoByteBuffer&)`), the CI memory impact comment showed them as separate new/removed entries instead of a single changed entry with a proper size delta.

This adds fuzzy matching by base function name (everything before the `(`) so signature changes appear as changed symbols. Only matches when there is exactly one new and one removed symbol with the same base name to avoid ambiguity with overloads.

**Before:** A function rename like `process_batch_multi_(std::vector<...>&, ...)` → `process_batch_multi_(ProtoByteBuffer&, ...)` shows as:
- New: `process_batch_multi_(ProtoByteBuffer&, ...)` (328 bytes)
- Removed: `process_batch_multi_(std::vector<...>&, ...)` (318 bytes)

**After:** Shows as a single changed entry:
- Changed: `process_batch_multi_(ProtoByteBuffer&, ...)` 318 → 328 bytes (+10)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI script change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).