### PR TITLE
[core] Require explicit synchronous= for register_action

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -59,8 +59,6 @@ def maybe_conf(conf, *validators):
     return validate
 
 
-_UNSET = object()
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -69,7 +67,7 @@ def register_action(
     action_type: MockObjClass,
     schema: cv.Schema,
     *,
-    synchronous: bool | object = _UNSET,
+    synchronous: bool | None = None,
 ):
     """Register an action type.
 
@@ -85,7 +83,7 @@ def register_action(
     outlive the initial call, so string args use owning std::string to
     prevent dangling references.
     """
-    if synchronous is _UNSET:
+    if synchronous is None:
         _LOGGER.warning(
             "register_action('%s', ...) is missing the synchronous= parameter. "
             "Defaulting to synchronous=False (safe but prevents StringRef "

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -1,3 +1,5 @@
+import logging
+
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
@@ -57,22 +59,43 @@ def maybe_conf(conf, *validators):
     return validate
 
 
+_UNSET = object()
+
+_LOGGER = logging.getLogger(__name__)
+
+
 def register_action(
     name: str,
     action_type: MockObjClass,
     schema: cv.Schema,
     *,
-    synchronous: bool = False,
+    synchronous: bool | object = _UNSET,
 ):
     """Register an action type.
 
-    Actions default to ``synchronous=False`` (safe default), meaning string
-    arguments use owning std::string to prevent dangling references.
+    All callers must pass ``synchronous`` explicitly.
 
-    Set ``synchronous=True`` only for actions that complete synchronously
-    and never store trigger arguments for later execution.  This allows
-    the code generator to use non-owning StringRef for zero-copy access.
+    ``synchronous=True`` — the action never defers ``play_next_()`` to a
+    later point (callback, timer, or ``loop()``).  Trigger arguments are
+    only used during the initial call, so string args can use non-owning
+    StringRef for zero-copy access.
+
+    ``synchronous=False`` — the action defers ``play_next_()`` via a
+    callback, timer, or ``Component::loop()``.  Trigger arguments must
+    outlive the initial call, so string args use owning std::string to
+    prevent dangling references.
     """
+    if synchronous is _UNSET:
+        _LOGGER.warning(
+            "register_action('%s', ...) is missing the synchronous= parameter. "
+            "Defaulting to synchronous=False (safe but prevents StringRef "
+            "optimization). Check the C++ class: use synchronous=False if "
+            "play_next_() is deferred to a callback, timer, or loop(); "
+            "use synchronous=True if play_next_() always runs before the "
+            "initial play/play_complex call returns",
+            name,
+        )
+        synchronous = False
     return ACTION_REGISTRY.register(name, action_type, schema, synchronous=synchronous)
 
 
@@ -353,6 +376,7 @@ async def component_is_idle_condition_to_code(
     "delay",
     DelayAction,
     cv.templatable(cv.positive_time_period_milliseconds),
+    synchronous=False,
 )
 async def delay_action_to_code(
     config: ConfigType,
@@ -465,7 +489,7 @@ _validate_wait_until = cv.maybe_simple_value(
 )
 
 
-@register_action("wait_until", WaitUntilAction, _validate_wait_until)
+@register_action("wait_until", WaitUntilAction, _validate_wait_until, synchronous=False)
 async def wait_until_action_to_code(
     config: ConfigType,
     action_id: ID,
@@ -611,7 +635,7 @@ def has_non_synchronous_actions(actions: ConfigType) -> bool:
 
     Non-synchronous actions (delay, wait_until, script.wait, etc.) store
     trigger args for later execution, making non-owning types like StringRef
-    unsafe.  Actions that haven't been audited default to non-synchronous.
+    unsafe.
     """
     if isinstance(actions, list):
         return any(has_non_synchronous_actions(item) for item in actions)

--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -92,6 +92,7 @@ AGS10_NEW_I2C_ADDRESS_SCHEMA = cv.maybe_simple_value(
     "ags10.new_i2c_address",
     AGS10NewI2cAddressAction,
     AGS10_NEW_I2C_ADDRESS_SCHEMA,
+    synchronous=True,
 )
 async def ags10newi2caddress_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -121,6 +122,7 @@ AGS10_SET_ZERO_POINT_SCHEMA = cv.Schema(
     "ags10.set_zero_point",
     AGS10SetZeroPointAction,
     AGS10_SET_ZERO_POINT_SCHEMA,
+    synchronous=True,
 )
 async def ags10setzeropoint_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/aic3204/audio_dac.py
+++ b/esphome/components/aic3204/audio_dac.py
@@ -34,7 +34,10 @@ SET_AUTO_MUTE_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "aic3204.set_auto_mute_mode", SetAutoMuteAction, SET_AUTO_MUTE_ACTION_SCHEMA
+    "aic3204.set_auto_mute_mode",
+    SetAutoMuteAction,
+    SET_AUTO_MUTE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def aic3204_set_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/alarm_control_panel/__init__.py
+++ b/esphome/components/alarm_control_panel/__init__.py
@@ -243,7 +243,10 @@ async def new_alarm_control_panel(config, *args):
 
 
 @automation.register_action(
-    "alarm_control_panel.arm_away", ArmAwayAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.arm_away",
+    ArmAwayAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_arm_away_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -255,7 +258,10 @@ async def alarm_action_arm_away_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.arm_home", ArmHomeAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.arm_home",
+    ArmHomeAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_arm_home_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -267,7 +273,10 @@ async def alarm_action_arm_home_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.arm_night", ArmNightAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.arm_night",
+    ArmNightAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_arm_night_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -279,7 +288,10 @@ async def alarm_action_arm_night_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.disarm", DisarmAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.disarm",
+    DisarmAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_disarm_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -291,7 +303,10 @@ async def alarm_action_disarm_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.pending", PendingAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.pending",
+    PendingAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_pending_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -299,7 +314,10 @@ async def alarm_action_pending_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.triggered", TriggeredAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.triggered",
+    TriggeredAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_trigger_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -307,7 +325,10 @@ async def alarm_action_trigger_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.chime", ChimeAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.chime",
+    ChimeAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def alarm_action_chime_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -315,7 +336,10 @@ async def alarm_action_chime_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "alarm_control_panel.ready", ReadyAction, ALARM_CONTROL_PANEL_ACTION_SCHEMA
+    "alarm_control_panel.ready",
+    ReadyAction,
+    ALARM_CONTROL_PANEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_condition(
     "alarm_control_panel.ready",

--- a/esphome/components/animation/__init__.py
+++ b/esphome/components/animation/__init__.py
@@ -69,9 +69,15 @@ SET_FRAME_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("animation.next_frame", NextFrameAction, NEXT_FRAME_SCHEMA)
-@automation.register_action("animation.prev_frame", PrevFrameAction, PREV_FRAME_SCHEMA)
-@automation.register_action("animation.set_frame", SetFrameAction, SET_FRAME_SCHEMA)
+@automation.register_action(
+    "animation.next_frame", NextFrameAction, NEXT_FRAME_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "animation.prev_frame", PrevFrameAction, PREV_FRAME_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "animation.set_frame", SetFrameAction, SET_FRAME_SCHEMA, synchronous=True
+)
 async def animation_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -712,6 +712,7 @@ API_RESPOND_ACTION_SCHEMA = cv.All(
     "api.respond",
     APIRespondAction,
     API_RESPOND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def api_respond_to_code(
     config: ConfigType,

--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -89,6 +89,7 @@ AT581XSettingsAction = at581x_ns.class_("AT581XSettingsAction", automation.Actio
             cv.Required(CONF_ID): cv.use_id(AT581XComponent),
         }
     ),
+    synchronous=True,
 )
 async def at581x_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -160,6 +161,7 @@ RADAR_SETTINGS_SCHEMA = cv.Schema(
     "at581x.settings",
     AT581XSettingsAction,
     RADAR_SETTINGS_SCHEMA,
+    synchronous=True,
 )
 async def at581x_settings_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/audio_adc/__init__.py
+++ b/esphome/components/audio_adc/__init__.py
@@ -23,7 +23,10 @@ SET_MIC_GAIN_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "audio_adc.set_mic_gain", SetMicGainAction, SET_MIC_GAIN_ACTION_SCHEMA
+    "audio_adc.set_mic_gain",
+    SetMicGainAction,
+    SET_MIC_GAIN_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def audio_adc_set_mic_gain_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/audio_dac/__init__.py
+++ b/esphome/components/audio_dac/__init__.py
@@ -31,15 +31,22 @@ SET_VOLUME_ACTION_SCHEMA = cv.maybe_simple_value(
 )
 
 
-@automation.register_action("audio_dac.mute_off", MuteOffAction, MUTE_ACTION_SCHEMA)
-@automation.register_action("audio_dac.mute_on", MuteOnAction, MUTE_ACTION_SCHEMA)
+@automation.register_action(
+    "audio_dac.mute_off", MuteOffAction, MUTE_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "audio_dac.mute_on", MuteOnAction, MUTE_ACTION_SCHEMA, synchronous=True
+)
 async def audio_dac_mute_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @automation.register_action(
-    "audio_dac.set_volume", SetVolumeAction, SET_VOLUME_ACTION_SCHEMA
+    "audio_dac.set_volume",
+    SetVolumeAction,
+    SET_VOLUME_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def audio_dac_set_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -685,6 +685,7 @@ async def to_code(config):
         },
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def binary_sensor_invalidate_state_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/bl0906/sensor.py
+++ b/esphome/components/bl0906/sensor.py
@@ -143,6 +143,7 @@ FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
             cv.Required(CONF_ID): cv.use_id(BL0906),
         }
     ),
+    synchronous=True,
 )
 async def reset_energy_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/ble_client/__init__.py
+++ b/esphome/components/ble_client/__init__.py
@@ -172,7 +172,10 @@ BLE_REMOVE_BOND_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "ble_client.disconnect", BLEDisconnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.disconnect",
+    BLEDisconnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_disconnect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -180,7 +183,10 @@ async def ble_disconnect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.connect", BLEConnectAction, BLE_CONNECT_ACTION_SCHEMA
+    "ble_client.connect",
+    BLEConnectAction,
+    BLE_CONNECT_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_connect_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -188,7 +194,10 @@ async def ble_connect_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ble_client.ble_write", BLEWriteAction, BLE_WRITE_ACTION_SCHEMA
+    "ble_client.ble_write",
+    BLEWriteAction,
+    BLE_WRITE_ACTION_SCHEMA,
+    synchronous=False,
 )
 async def ble_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -247,6 +256,7 @@ async def ble_write_to_code(config, action_id, template_arg, args):
     "ble_client.numeric_comparison_reply",
     BLENumericComparisonReplyAction,
     BLE_NUMERIC_COMPARISON_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def numeric_comparison_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -263,7 +273,10 @@ async def numeric_comparison_reply_to_code(config, action_id, template_arg, args
 
 
 @automation.register_action(
-    "ble_client.passkey_reply", BLEPasskeyReplyAction, BLE_PASSKEY_REPLY_ACTION_SCHEMA
+    "ble_client.passkey_reply",
+    BLEPasskeyReplyAction,
+    BLE_PASSKEY_REPLY_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def passkey_reply_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -283,6 +296,7 @@ async def passkey_reply_to_code(config, action_id, template_arg, args):
     "ble_client.remove_bond",
     BLERemoveBondAction,
     BLE_REMOVE_BOND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def remove_bond_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/bm8563/time.py
+++ b/esphome/components/bm8563/time.py
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.use_id(BM8563),
         }
     ),
+    synchronous=True,
 )
 async def bm8563_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -49,6 +50,7 @@ async def bm8563_write_time_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_DURATION): cv.templatable(cv.positive_time_period_seconds),
         }
     ),
+    synchronous=True,
 )
 async def bm8563_start_timer_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -66,6 +68,7 @@ async def bm8563_start_timer_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(BM8563),
         }
     ),
+    synchronous=True,
 )
 async def bm8563_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -155,6 +155,7 @@ async def register_canbus(var, config):
         validate_id,
         key=CONF_DATA,
     ),
+    synchronous=True,
 )
 async def canbus_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/cc1101/__init__.py
+++ b/esphome/components/cc1101/__init__.py
@@ -287,10 +287,18 @@ CC1101_ACTION_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("cc1101.begin_tx", BeginTxAction, CC1101_ACTION_SCHEMA)
-@automation.register_action("cc1101.begin_rx", BeginRxAction, CC1101_ACTION_SCHEMA)
-@automation.register_action("cc1101.reset", ResetAction, CC1101_ACTION_SCHEMA)
-@automation.register_action("cc1101.set_idle", SetIdleAction, CC1101_ACTION_SCHEMA)
+@automation.register_action(
+    "cc1101.begin_tx", BeginTxAction, CC1101_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "cc1101.begin_rx", BeginRxAction, CC1101_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "cc1101.reset", ResetAction, CC1101_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "cc1101.set_idle", SetIdleAction, CC1101_ACTION_SCHEMA, synchronous=True
+)
 async def cc1101_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
@@ -317,7 +325,10 @@ SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "cc1101.send_packet", SendPacketAction, SEND_PACKET_ACTION_SCHEMA
+    "cc1101.send_packet",
+    SendPacketAction,
+    SEND_PACKET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def send_packet_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -419,9 +430,9 @@ def _register_setter_actions():
                 cg.add(getattr(var, _setter)(_map[data] if _map else data))
             return var
 
-        automation.register_action(f"cc1101.{setter_name}", action_cls, schema)(
-            _setter_action_to_code
-        )
+        automation.register_action(
+            f"cc1101.{setter_name}", action_cls, schema, synchronous=True
+        )(_setter_action_to_code)
 
 
 _register_setter_actions()

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -476,7 +476,10 @@ CLIMATE_CONTROL_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "climate.control", ControlAction, CLIMATE_CONTROL_ACTION_SCHEMA
+    "climate.control",
+    ControlAction,
+    CLIMATE_CONTROL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def climate_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/cm1106/sensor.py
+++ b/esphome/components/cm1106/sensor.py
@@ -65,6 +65,7 @@ CALIBRATION_ACTION_SCHEMA = maybe_simple_id(
     "cm1106.calibrate_zero",
     CM1106CalibrateZeroAction,
     CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def cm1106_calibration_to_code(config, action_id, template_arg, args) -> None:
     """Service code generation entry point."""

--- a/esphome/components/cs5460a/sensor.py
+++ b/esphome/components/cs5460a/sensor.py
@@ -132,6 +132,7 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(CS5460AComponent),
         }
     ),
+    synchronous=True,
 )
 async def restart_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/datetime/__init__.py
+++ b/esphome/components/datetime/__init__.py
@@ -187,6 +187,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def datetime_date_set_to_code(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -218,6 +219,7 @@ async def datetime_date_set_to_code(config, action_id, template_arg, args):
             ),
         }
     ),
+    synchronous=True,
 )
 async def datetime_time_set_to_code(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)
@@ -249,6 +251,7 @@ async def datetime_time_set_to_code(config, action_id, template_arg, args):
             ),
         },
     ),
+    synchronous=True,
 )
 async def datetime_datetime_set_to_code(config, action_id, template_arg, args):
     action_var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -405,7 +405,10 @@ DEEP_SLEEP_ENTER_SCHEMA = cv.All(
 
 
 @automation.register_action(
-    "deep_sleep.enter", EnterDeepSleepAction, DEEP_SLEEP_ENTER_SCHEMA
+    "deep_sleep.enter",
+    EnterDeepSleepAction,
+    DEEP_SLEEP_ENTER_SCHEMA,
+    synchronous=True,
 )
 async def deep_sleep_enter_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -428,11 +431,13 @@ async def deep_sleep_enter_to_code(config, action_id, template_arg, args):
     "deep_sleep.prevent",
     PreventDeepSleepAction,
     automation.maybe_simple_id(DEEP_SLEEP_ACTION_SCHEMA),
+    synchronous=True,
 )
 @automation.register_action(
     "deep_sleep.allow",
     AllowDeepSleepAction,
     automation.maybe_simple_id(DEEP_SLEEP_ACTION_SCHEMA),
+    synchronous=True,
 )
 async def deep_sleep_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/dfplayer/__init__.py
+++ b/esphome/components/dfplayer/__init__.py
@@ -91,6 +91,7 @@ async def to_code(config):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_next_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -106,6 +107,7 @@ async def dfplayer_next_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_previous_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -123,6 +125,7 @@ async def dfplayer_previous_to_code(config, action_id, template_arg, args):
         },
         key=CONF_FILE,
     ),
+    synchronous=True,
 )
 async def dfplayer_play_mp3_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -143,6 +146,7 @@ async def dfplayer_play_mp3_to_code(config, action_id, template_arg, args):
         },
         key=CONF_FILE,
     ),
+    synchronous=True,
 )
 async def dfplayer_play_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -166,6 +170,7 @@ async def dfplayer_play_to_code(config, action_id, template_arg, args):
             cv.Optional(CONF_LOOP): cv.templatable(cv.boolean),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_play_folder_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -191,6 +196,7 @@ async def dfplayer_play_folder_to_code(config, action_id, template_arg, args):
         },
         key=CONF_DEVICE,
     ),
+    synchronous=True,
 )
 async def dfplayer_set_device_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -210,6 +216,7 @@ async def dfplayer_set_device_to_code(config, action_id, template_arg, args):
         },
         key=CONF_VOLUME,
     ),
+    synchronous=True,
 )
 async def dfplayer_set_volume_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -227,6 +234,7 @@ async def dfplayer_set_volume_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_volume_up_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -242,6 +250,7 @@ async def dfplayer_volume_up_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_volume_down_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -259,6 +268,7 @@ async def dfplayer_volume_down_to_code(config, action_id, template_arg, args):
         },
         key=CONF_EQ_PRESET,
     ),
+    synchronous=True,
 )
 async def dfplayer_set_eq_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -276,6 +286,7 @@ async def dfplayer_set_eq_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_sleep_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -291,6 +302,7 @@ async def dfplayer_sleep_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -306,6 +318,7 @@ async def dfplayer_reset_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_start_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -321,6 +334,7 @@ async def dfplayer_start_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_pause_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -336,6 +350,7 @@ async def dfplayer_pause_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -351,6 +366,7 @@ async def dfplayer_stop_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DFPlayer),
         }
     ),
+    synchronous=True,
 )
 async def dfplayer_random_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -52,6 +52,7 @@ async def to_code(config):
             cv.GenerateID(): cv.use_id(DfrobotSen0395Component),
         }
     ),
+    synchronous=True,
 )
 async def dfrobot_sen0395_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -151,6 +152,7 @@ MMWAVE_SETTINGS_SCHEMA = cv.Schema(
     "dfrobot_sen0395.settings",
     DfrobotSen0395SettingsAction,
     MMWAVE_SETTINGS_SCHEMA,
+    synchronous=True,
 )
 async def dfrobot_sen0395_settings_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -159,6 +159,7 @@ async def register_display(var, config):
             cv.Required(CONF_ID): cv.templatable(cv.use_id(DisplayPage)),
         }
     ),
+    synchronous=True,
 )
 async def display_page_show_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -179,6 +180,7 @@ async def display_page_show_to_code(config, action_id, template_arg, args):
             cv.GenerateID(CONF_ID): cv.templatable(cv.use_id(Display)),
         }
     ),
+    synchronous=True,
 )
 async def display_page_show_next_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -193,6 +195,7 @@ async def display_page_show_next_to_code(config, action_id, template_arg, args):
             cv.GenerateID(CONF_ID): cv.templatable(cv.use_id(Display)),
         }
     ),
+    synchronous=True,
 )
 async def display_page_show_previous_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -294,50 +294,67 @@ MENU_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action("display_menu.up", UpAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.up", UpAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_up_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.down", DownAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.down", DownAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_down_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.left", LeftAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.left", LeftAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_left_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.right", RightAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.right", RightAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_right_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.enter", EnterAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.enter", EnterAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_enter_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.show", ShowAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.show", ShowAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_show_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("display_menu.hide", HideAction, MENU_ACTION_SCHEMA)
+@automation.register_action(
+    "display_menu.hide", HideAction, MENU_ACTION_SCHEMA, synchronous=True
+)
 async def menu_hide_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
 @automation.register_action(
-    "display_menu.show_main", ShowMainAction, MENU_ACTION_SCHEMA
+    "display_menu.show_main",
+    ShowMainAction,
+    MENU_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def menu_show_main_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/ds1307/time.py
+++ b/esphome/components/ds1307/time.py
@@ -27,6 +27,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
             cv.GenerateID(): cv.use_id(DS1307Component),
         }
     ),
+    synchronous=True,
 )
 async def ds1307_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -42,6 +43,7 @@ async def ds1307_write_time_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(DS1307Component),
         }
     ),
+    synchronous=True,
 )
 async def ds1307_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/duty_time/sensor.py
+++ b/esphome/components/duty_time/sensor.py
@@ -90,21 +90,27 @@ DUTY_TIME_ID_SCHEMA = maybe_simple_id(
 )
 
 
-@register_action("sensor.duty_time.start", StartAction, DUTY_TIME_ID_SCHEMA)
+@register_action(
+    "sensor.duty_time.start", StartAction, DUTY_TIME_ID_SCHEMA, synchronous=True
+)
 async def sensor_runtime_start_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
 
-@register_action("sensor.duty_time.stop", StopAction, DUTY_TIME_ID_SCHEMA)
+@register_action(
+    "sensor.duty_time.stop", StopAction, DUTY_TIME_ID_SCHEMA, synchronous=True
+)
 async def sensor_runtime_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
 
 
-@register_action("sensor.duty_time.reset", ResetAction, DUTY_TIME_ID_SCHEMA)
+@register_action(
+    "sensor.duty_time.reset", ResetAction, DUTY_TIME_ID_SCHEMA, synchronous=True
+)
 async def sensor_runtime_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -604,11 +604,15 @@ async def ble_enabled_to_code(config, condition_id, template_arg, args):
     return cg.new_Pvariable(condition_id, template_arg)
 
 
-@automation.register_action("ble.enable", BLEEnableAction, cv.Schema({}))
+@automation.register_action(
+    "ble.enable", BLEEnableAction, cv.Schema({}), synchronous=True
+)
 async def ble_enable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
 
-@automation.register_action("ble.disable", BLEDisableAction, cv.Schema({}))
+@automation.register_action(
+    "ble.disable", BLEDisableAction, cv.Schema({}), synchronous=True
+)
 async def ble_disable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -622,6 +622,7 @@ async def to_code(config):
         ),
         validate_set_value_action,
     ),
+    synchronous=True,
 )
 async def ble_server_characteristic_set_value(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -641,6 +642,7 @@ async def ble_server_characteristic_set_value(config, action_id, template_arg, a
             cv.Required(CONF_VALUE): value_schema(),
         }
     ),
+    synchronous=True,
 )
 async def ble_server_descriptor_set_value(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -662,6 +664,7 @@ async def ble_server_descriptor_set_value(config, action_id, template_arg, args)
         ),
         validate_notify_action,
     ),
+    synchronous=True,
 )
 async def ble_server_characteristic_notify(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/esp32_ble_tracker/__init__.py
+++ b/esphome/components/esp32_ble_tracker/__init__.py
@@ -373,6 +373,7 @@ ESP32_BLE_START_SCAN_ACTION_SCHEMA = cv.Schema(
     "esp32_ble_tracker.start_scan",
     ESP32BLEStartScanAction,
     ESP32_BLE_START_SCAN_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def esp32_ble_tracker_start_scan_action_to_code(
     config, action_id, template_arg, args
@@ -396,6 +397,7 @@ ESP32_BLE_STOP_SCAN_ACTION_SCHEMA = automation.maybe_simple_id(
     "esp32_ble_tracker.stop_scan",
     ESP32BLEStopScanAction,
     ESP32_BLE_STOP_SCAN_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def esp32_ble_tracker_stop_scan_action_to_code(
     config, action_id, template_arg, args

--- a/esphome/components/esp8266_pwm/output.py
+++ b/esphome/components/esp8266_pwm/output.py
@@ -57,6 +57,7 @@ async def to_code(config) -> None:
             cv.Required(CONF_FREQUENCY): cv.templatable(validate_frequency),
         }
     ),
+    synchronous=True,
 )
 async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/esp_ldo/__init__.py
+++ b/esphome/components/esp_ldo/__init__.py
@@ -129,6 +129,7 @@ def adjusted_ldo_id(value):
             ),
         }
     ),
+    synchronous=True,
 )
 async def ldo_voltage_adjust_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -220,6 +220,7 @@ SEND_SCHEMA.add_extra(_validate_send_action)
     "espnow.send",
     SendAction,
     SEND_SCHEMA,
+    synchronous=False,
 )
 @automation.register_action(
     "espnow.broadcast",
@@ -232,6 +233,7 @@ SEND_SCHEMA.add_extra(_validate_send_action)
         ),
         key=CONF_DATA,
     ),
+    synchronous=False,
 )
 async def send_action(
     config: ConfigType,
@@ -271,6 +273,7 @@ async def send_action(
         PEER_SCHEMA,
         key=CONF_ADDRESS,
     ),
+    synchronous=True,
 )
 @automation.register_action(
     "espnow.peer.delete",
@@ -279,6 +282,7 @@ async def send_action(
         PEER_SCHEMA,
         key=CONF_ADDRESS,
     ),
+    synchronous=True,
 )
 async def peer_action(
     config: ConfigType,
@@ -303,6 +307,7 @@ async def peer_action(
         },
         key=CONF_CHANNEL,
     ),
+    synchronous=True,
 )
 async def channel_action(
     config: ConfigType,

--- a/esphome/components/event/__init__.py
+++ b/esphome/components/event/__init__.py
@@ -129,7 +129,9 @@ TRIGGER_EVENT_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("event.trigger", TriggerEventAction, TRIGGER_EVENT_SCHEMA)
+@automation.register_action(
+    "event.trigger", TriggerEventAction, TRIGGER_EVENT_SCHEMA, synchronous=True
+)
 async def event_fire_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/ezo_pmp/__init__.py
+++ b/esphome/components/ezo_pmp/__init__.py
@@ -81,7 +81,10 @@ EzoPMPArbitraryCommandAction = ezo_pmp_ns.class_(
 
 
 @automation.register_action(
-    "ezo_pmp.find", EzoPMPFindAction, EZO_PMP_NO_ARGS_ACTION_SCHEMA
+    "ezo_pmp.find",
+    EzoPMPFindAction,
+    EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_find_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -92,6 +95,7 @@ async def ezo_pmp_find_to_code(config, action_id, template_arg, args):
     "ezo_pmp.dose_continuously",
     EzoPMPDoseContinuouslyAction,
     EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_dose_continuously_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -102,6 +106,7 @@ async def ezo_pmp_dose_continuously_to_code(config, action_id, template_arg, arg
     "ezo_pmp.clear_total_volume_dosed",
     EzoPMPClearTotalVolumeDispensedAction,
     EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_clear_total_volume_dosed_to_code(
     config, action_id, template_arg, args
@@ -114,6 +119,7 @@ async def ezo_pmp_clear_total_volume_dosed_to_code(
     "ezo_pmp.clear_calibration",
     EzoPMPClearCalibrationAction,
     EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_clear_calibration_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -121,7 +127,10 @@ async def ezo_pmp_clear_calibration_to_code(config, action_id, template_arg, arg
 
 
 @automation.register_action(
-    "ezo_pmp.pause_dosing", EzoPMPPauseDosingAction, EZO_PMP_NO_ARGS_ACTION_SCHEMA
+    "ezo_pmp.pause_dosing",
+    EzoPMPPauseDosingAction,
+    EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_pause_dosing_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -129,7 +138,10 @@ async def ezo_pmp_pause_dosing_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "ezo_pmp.stop_dosing", EzoPMPStopDosingAction, EZO_PMP_NO_ARGS_ACTION_SCHEMA
+    "ezo_pmp.stop_dosing",
+    EzoPMPStopDosingAction,
+    EZO_PMP_NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_stop_dosing_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -149,7 +161,10 @@ EZO_PMP_DOSE_VOLUME_ACTION_SCHEMA = cv.All(
 
 
 @automation.register_action(
-    "ezo_pmp.dose_volume", EzoPMPDoseVolumeAction, EZO_PMP_DOSE_VOLUME_ACTION_SCHEMA
+    "ezo_pmp.dose_volume",
+    EzoPMPDoseVolumeAction,
+    EZO_PMP_DOSE_VOLUME_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_dose_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -178,6 +193,7 @@ EZO_PMP_DOSE_VOLUME_OVER_TIME_ACTION_SCHEMA = cv.All(
     "ezo_pmp.dose_volume_over_time",
     EzoPMPDoseVolumeOverTimeAction,
     EZO_PMP_DOSE_VOLUME_OVER_TIME_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_dose_volume_over_time_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -209,6 +225,7 @@ EZO_PMP_DOSE_WITH_CONSTANT_FLOW_RATE_ACTION_SCHEMA = cv.All(
     "ezo_pmp.dose_with_constant_flow_rate",
     EzoPMPDoseWithConstantFlowRateAction,
     EZO_PMP_DOSE_WITH_CONSTANT_FLOW_RATE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_dose_with_constant_flow_rate_to_code(
     config, action_id, template_arg, args
@@ -239,6 +256,7 @@ EZO_PMP_SET_CALIBRATION_VOLUME_ACTION_SCHEMA = cv.All(
     "ezo_pmp.set_calibration_volume",
     EzoPMPSetCalibrationVolumeAction,
     EZO_PMP_SET_CALIBRATION_VOLUME_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_set_calibration_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -262,6 +280,7 @@ EZO_PMP_CHANGE_I2C_ADDRESS_ACTION_SCHEMA = cv.All(
     "ezo_pmp.change_i2c_address",
     EzoPMPChangeI2CAddressAction,
     EZO_PMP_CHANGE_I2C_ADDRESS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_change_i2c_address_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -285,6 +304,7 @@ EZO_PMP_ARBITRARY_COMMAND_ACTION_SCHEMA = cv.All(
     "ezo_pmp.arbitrary_command",
     EzoPMPArbitraryCommandAction,
     EZO_PMP_ARBITRARY_COMMAND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ezo_pmp_arbitrary_command_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -365,6 +365,7 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
             cv.Optional(CONF_OFF_SPEED_CYCLE, default=True): cv.boolean,
         }
     ),
+    synchronous=True,
 )
 async def fan_cycle_speed_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/fingerprint_grow/__init__.py
+++ b/esphome/components/fingerprint_grow/__init__.py
@@ -261,6 +261,7 @@ async def to_code(config):
         },
         key=CONF_FINGER_ID,
     ),
+    synchronous=True,
 )
 async def fingerprint_grow_enroll_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -282,6 +283,7 @@ async def fingerprint_grow_enroll_to_code(config, action_id, template_arg, args)
             cv.GenerateID(): cv.use_id(FingerprintGrowComponent),
         }
     ),
+    synchronous=True,
 )
 async def fingerprint_grow_cancel_enroll_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -299,6 +301,7 @@ async def fingerprint_grow_cancel_enroll_to_code(config, action_id, template_arg
         },
         key=CONF_FINGER_ID,
     ),
+    synchronous=True,
 )
 async def fingerprint_grow_delete_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -317,6 +320,7 @@ async def fingerprint_grow_delete_to_code(config, action_id, template_arg, args)
             cv.GenerateID(): cv.use_id(FingerprintGrowComponent),
         }
     ),
+    synchronous=True,
 )
 async def fingerprint_grow_delete_all_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -337,6 +341,7 @@ FINGERPRINT_GROW_LED_CONTROL_ACTION_SCHEMA = cv.maybe_simple_value(
     "fingerprint_grow.led_control",
     LEDControlAction,
     FINGERPRINT_GROW_LED_CONTROL_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def fingerprint_grow_led_control_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -359,6 +364,7 @@ async def fingerprint_grow_led_control_to_code(config, action_id, template_arg, 
             cv.Required(CONF_COUNT): cv.templatable(cv.uint8_t),
         }
     ),
+    synchronous=True,
 )
 async def fingerprint_grow_aura_led_control_to_code(
     config, action_id, template_arg, args

--- a/esphome/components/grove_tb6612fng/__init__.py
+++ b/esphome/components/grove_tb6612fng/__init__.py
@@ -72,6 +72,7 @@ async def to_code(config):
             cv.Required(CONF_DIRECTION): cv.enum(DIRECTION_TYPE, upper=True),
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_run_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -96,6 +97,7 @@ async def grove_tb6612fng_run_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_CHANNEL): cv.templatable(cv.int_range(min=0, max=1)),
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_break_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -115,6 +117,7 @@ async def grove_tb6612fng_break_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_CHANNEL): cv.templatable(cv.int_range(min=0, max=1)),
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -133,6 +136,7 @@ async def grove_tb6612fng_stop_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(GROVE_TB6612FNG),
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_standby_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -149,6 +153,7 @@ async def grove_tb6612fng_standby_to_code(config, action_id, template_arg, args)
             cv.Required(CONF_ID): cv.use_id(GROVE_TB6612FNG),
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_no_standby_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -166,6 +171,7 @@ async def grove_tb6612fng_no_standby_to_code(config, action_id, template_arg, ar
             cv.Required(CONF_ADDRESS): cv.i2c_address,
         }
     ),
+    synchronous=True,
 )
 async def grove_tb6612fng_change_address_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -319,10 +319,16 @@ HAIER_HON_BASE_ACTION_SCHEMA = automation.maybe_simple_id(
 
 
 @automation.register_action(
-    "climate.haier.display_on", DisplayOnAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.display_on",
+    DisplayOnAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "climate.haier.display_off", DisplayOffAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.display_off",
+    DisplayOffAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def display_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -330,10 +336,16 @@ async def display_action_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "climate.haier.beeper_on", BeeperOnAction, HAIER_HON_BASE_ACTION_SCHEMA
+    "climate.haier.beeper_on",
+    BeeperOnAction,
+    HAIER_HON_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "climate.haier.beeper_off", BeeperOffAction, HAIER_HON_BASE_ACTION_SCHEMA
+    "climate.haier.beeper_off",
+    BeeperOffAction,
+    HAIER_HON_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def beeper_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -345,11 +357,13 @@ async def beeper_action_to_code(config, action_id, template_arg, args):
     "climate.haier.start_self_cleaning",
     StartSelfCleaningAction,
     HAIER_HON_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "climate.haier.start_steri_cleaning",
     StartSteriCleaningAction,
     HAIER_HON_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def start_cleaning_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -368,6 +382,7 @@ async def start_cleaning_to_code(config, action_id, template_arg, args):
             ),
         }
     ),
+    synchronous=True,
 )
 async def haier_set_vertical_airflow_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -391,6 +406,7 @@ async def haier_set_vertical_airflow_to_code(config, action_id, template_arg, ar
             ),
         }
     ),
+    synchronous=True,
 )
 async def haier_set_horizontal_airflow_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -403,10 +419,16 @@ async def haier_set_horizontal_airflow_to_code(config, action_id, template_arg, 
 
 
 @automation.register_action(
-    "climate.haier.health_on", HealthOnAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.health_on",
+    HealthOnAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "climate.haier.health_off", HealthOffAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.health_off",
+    HealthOffAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def health_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -414,13 +436,22 @@ async def health_action_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "climate.haier.power_on", PowerOnAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.power_on",
+    PowerOnAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "climate.haier.power_off", PowerOffAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.power_off",
+    PowerOffAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "climate.haier.power_toggle", PowerToggleAction, HAIER_BASE_ACTION_SCHEMA
+    "climate.haier.power_toggle",
+    PowerToggleAction,
+    HAIER_BASE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def power_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/hbridge/fan/__init__.py
+++ b/esphome/components/hbridge/fan/__init__.py
@@ -52,6 +52,7 @@ CONFIG_SCHEMA = (
     "fan.hbridge.brake",
     BrakeAction,
     maybe_simple_id({cv.GenerateID(): cv.use_id(HBridgeFan)}),
+    synchronous=True,
 )
 async def fan_hbridge_brake_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/hc8/sensor.py
+++ b/esphome/components/hc8/sensor.py
@@ -68,7 +68,10 @@ CALIBRATION_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "hc8.calibrate", HC8CalibrateAction, CALIBRATION_ACTION_SCHEMA
+    "hc8.calibrate",
+    HC8CalibrateAction,
+    CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def hc8_calibration_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/hdc302x/sensor.py
+++ b/esphome/components/hdc302x/sensor.py
@@ -114,7 +114,10 @@ HDC302X_HEATER_ON_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "hdc302x.heater_on", HeaterOnAction, HDC302X_HEATER_ON_ACTION_SCHEMA
+    "hdc302x.heater_on",
+    HeaterOnAction,
+    HDC302X_HEATER_ON_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def hdc302x_heater_on_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -127,7 +130,10 @@ async def hdc302x_heater_on_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "hdc302x.heater_off", HeaterOffAction, HDC302X_ACTION_SCHEMA
+    "hdc302x.heater_off",
+    HeaterOffAction,
+    HDC302X_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def hdc302x_heater_off_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/hlk_fm22x/__init__.py
+++ b/esphome/components/hlk_fm22x/__init__.py
@@ -170,6 +170,7 @@ async def to_code(config):
         },
         key=CONF_NAME,
     ),
+    synchronous=True,
 )
 async def hlk_fm22x_enroll_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -192,6 +193,7 @@ async def hlk_fm22x_enroll_to_code(config, action_id, template_arg, args):
         },
         key=CONF_FACE_ID,
     ),
+    synchronous=True,
 )
 async def hlk_fm22x_delete_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -210,6 +212,7 @@ async def hlk_fm22x_delete_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
         }
     ),
+    synchronous=True,
 )
 async def hlk_fm22x_delete_all_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -225,6 +228,7 @@ async def hlk_fm22x_delete_all_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
         }
     ),
+    synchronous=True,
 )
 async def hlk_fm22x_scan_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -240,6 +244,7 @@ async def hlk_fm22x_scan_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
         }
     ),
+    synchronous=True,
 )
 async def hlk_fm22x_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/http_request/__init__.py
+++ b/esphome/components/http_request/__init__.py
@@ -279,13 +279,22 @@ HTTP_REQUEST_SEND_ACTION_SCHEMA = HTTP_REQUEST_ACTION_SCHEMA.extend(
 
 
 @automation.register_action(
-    "http_request.get", HttpRequestSendAction, HTTP_REQUEST_GET_ACTION_SCHEMA
+    "http_request.get",
+    HttpRequestSendAction,
+    HTTP_REQUEST_GET_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "http_request.post", HttpRequestSendAction, HTTP_REQUEST_POST_ACTION_SCHEMA
+    "http_request.post",
+    HttpRequestSendAction,
+    HTTP_REQUEST_POST_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "http_request.send", HttpRequestSendAction, HTTP_REQUEST_SEND_ACTION_SCHEMA
+    "http_request.send",
+    HttpRequestSendAction,
+    HTTP_REQUEST_SEND_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def http_request_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/http_request/ota/__init__.py
+++ b/esphome/components/http_request/ota/__init__.py
@@ -70,6 +70,7 @@ OTA_HTTP_REQUEST_FLASH_ACTION_SCHEMA = cv.All(
     "ota.http_request.flash",
     OtaHttpRequestComponentFlashAction,
     OTA_HTTP_REQUEST_FLASH_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def ota_http_request_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/htu21d/sensor.py
+++ b/esphome/components/htu21d/sensor.py
@@ -93,6 +93,7 @@ async def to_code(config):
         },
         key=CONF_LEVEL,
     ),
+    synchronous=True,
 )
 async def set_heater_level_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -112,6 +113,7 @@ async def set_heater_level_to_code(config, action_id, template_arg, args):
         },
         key=CONF_STATUS,
     ),
+    synchronous=True,
 )
 async def set_heater_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -652,6 +652,7 @@ async def to_code(config: ConfigType) -> None:
         },
         key=CONF_BRIGHTNESS,
     ),
+    synchronous=True,
 )
 async def hub75_set_brightness_to_code(
     config: ConfigType,

--- a/esphome/components/integration/sensor.py
+++ b/esphome/components/integration/sensor.py
@@ -111,6 +111,7 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(IntegrationSensor),
         }
     ),
+    synchronous=True,
 )
 async def sensor_integration_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -127,6 +128,7 @@ async def sensor_integration_reset_to_code(config, action_id, template_arg, args
             cv.Required(CONF_VALUE): cv.templatable(cv.float_),
         }
     ),
+    synchronous=True,
 )
 async def sensor_integration_set_value_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/key_collector/__init__.py
+++ b/esphome/components/key_collector/__init__.py
@@ -142,6 +142,7 @@ async def to_code(config):
             cv.GenerateID(): cv.use_id(KeyCollector),
         }
     ),
+    synchronous=True,
 )
 async def enable_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -157,6 +158,7 @@ async def enable_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(KeyCollector),
         }
     ),
+    synchronous=True,
 )
 async def disable_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/ld2410/__init__.py
+++ b/esphome/components/ld2410/__init__.py
@@ -97,7 +97,10 @@ BLUETOOTH_PASSWORD_SET_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "bluetooth_password.set", BluetoothPasswordSetAction, BLUETOOTH_PASSWORD_SET_SCHEMA
+    "bluetooth_password.set",
+    BluetoothPasswordSetAction,
+    BLUETOOTH_PASSWORD_SET_SCHEMA,
+    synchronous=True,
 )
 async def bluetooth_password_set_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -77,6 +77,7 @@ async def to_code(config):
             cv.Required(CONF_FREQUENCY): cv.templatable(validate_frequency),
         }
     ),
+    synchronous=True,
 )
 async def ledc_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/libretiny_pwm/output.py
+++ b/esphome/components/libretiny_pwm/output.py
@@ -38,6 +38,7 @@ async def to_code(config):
             cv.Required(CONF_FREQUENCY): cv.templatable(cv.int_),
         }
     ),
+    synchronous=True,
 )
 async def libretiny_pwm_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -278,7 +278,10 @@ LIGHT_ADDRESSABLE_SET_ACTION_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "light.addressable_set", AddressableSet, LIGHT_ADDRESSABLE_SET_ACTION_SCHEMA
+    "light.addressable_set",
+    AddressableSet,
+    LIGHT_ADDRESSABLE_SET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def light_addressable_set_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/lightwaverf/__init__.py
+++ b/esphome/components/lightwaverf/__init__.py
@@ -55,6 +55,7 @@ LIGHTWAVE_SEND_SCHEMA = cv.Any(
     "lightwaverf.send_raw",
     LightwaveRawAction,
     LIGHTWAVE_SEND_SCHEMA,
+    synchronous=True,
 )
 async def send_raw_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/lock/__init__.py
+++ b/esphome/components/lock/__init__.py
@@ -129,9 +129,15 @@ LOCK_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action("lock.unlock", UnlockAction, LOCK_ACTION_SCHEMA)
-@automation.register_action("lock.lock", LockAction, LOCK_ACTION_SCHEMA)
-@automation.register_action("lock.open", OpenAction, LOCK_ACTION_SCHEMA)
+@automation.register_action(
+    "lock.unlock", UnlockAction, LOCK_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "lock.lock", LockAction, LOCK_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "lock.open", OpenAction, LOCK_ACTION_SCHEMA, synchronous=True
+)
 async def lock_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -545,6 +545,7 @@ async def logger_log_action_to_code(config, action_id, template_arg, args):
         },
         key=CONF_LEVEL,
     ),
+    synchronous=True,
 )
 async def logger_set_level_to_code(config, action_id, template_arg, args):
     level = LOG_LEVELS[config[CONF_LEVEL]]

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -182,6 +182,7 @@ async def disp_update(disp, config: dict):
         ),
         LVGL_SCHEMA,
     ),
+    synchronous=True,
 )
 async def obj_invalidate_to_code(config, action_id, template_arg, args):
     if CONF_LVGL_ID in config:
@@ -202,6 +203,7 @@ async def obj_invalidate_to_code(config, action_id, template_arg, args):
     DISP_BG_SCHEMA.extend(LVGL_SCHEMA).add_extra(
         cv.has_at_least_one_key(CONF_DISP_BG_COLOR, CONF_DISP_BG_IMAGE)
     ),
+    synchronous=True,
 )
 async def lvgl_update_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config, CONF_LVGL_ID)
@@ -222,6 +224,7 @@ async def lvgl_update_to_code(config, action_id, template_arg, args):
             cv.Optional(CONF_SHOW_SNOW, default=False): lv_bool,
         }
     ),
+    synchronous=True,
 )
 async def pause_action_to_code(config, action_id, template_arg, args):
     lv_comp = await cg.get_variable(config[CONF_LVGL_ID])
@@ -237,6 +240,7 @@ async def pause_action_to_code(config, action_id, template_arg, args):
     "lvgl.resume",
     LvglAction,
     LVGL_SCHEMA,
+    synchronous=True,
 )
 async def resume_action_to_code(config, action_id, template_arg, args):
     lv_comp = await cg.get_variable(config[CONF_LVGL_ID])
@@ -247,7 +251,9 @@ async def resume_action_to_code(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("lvgl.widget.disable", ObjUpdateAction, LIST_ACTION_SCHEMA)
+@automation.register_action(
+    "lvgl.widget.disable", ObjUpdateAction, LIST_ACTION_SCHEMA, synchronous=True
+)
 async def obj_disable_to_code(config, action_id, template_arg, args):
     async def do_disable(widget: Widget):
         widget.add_state(LV_STATE.DISABLED)
@@ -257,7 +263,9 @@ async def obj_disable_to_code(config, action_id, template_arg, args):
     )
 
 
-@automation.register_action("lvgl.widget.enable", ObjUpdateAction, LIST_ACTION_SCHEMA)
+@automation.register_action(
+    "lvgl.widget.enable", ObjUpdateAction, LIST_ACTION_SCHEMA, synchronous=True
+)
 async def obj_enable_to_code(config, action_id, template_arg, args):
     async def do_enable(widget: Widget):
         widget.clear_state(LV_STATE.DISABLED)
@@ -267,7 +275,9 @@ async def obj_enable_to_code(config, action_id, template_arg, args):
     )
 
 
-@automation.register_action("lvgl.widget.hide", ObjUpdateAction, LIST_ACTION_SCHEMA)
+@automation.register_action(
+    "lvgl.widget.hide", ObjUpdateAction, LIST_ACTION_SCHEMA, synchronous=True
+)
 async def obj_hide_to_code(config, action_id, template_arg, args):
     async def do_hide(widget: Widget):
         widget.add_flag("LV_OBJ_FLAG_HIDDEN")
@@ -276,7 +286,9 @@ async def obj_hide_to_code(config, action_id, template_arg, args):
     return await action_to_code(widgets, do_hide, action_id, template_arg, args)
 
 
-@automation.register_action("lvgl.widget.show", ObjUpdateAction, LIST_ACTION_SCHEMA)
+@automation.register_action(
+    "lvgl.widget.show", ObjUpdateAction, LIST_ACTION_SCHEMA, synchronous=True
+)
 async def obj_show_to_code(config, action_id, template_arg, args):
     async def do_show(widget: Widget):
         widget.clear_flag("LV_OBJ_FLAG_HIDDEN")
@@ -318,6 +330,7 @@ def focused_id(value):
             key=CONF_ID,
         ),
     ),
+    synchronous=True,
 )
 async def widget_focus(config, action_id, template_arg, args):
     widget = await get_widgets(config)
@@ -357,7 +370,10 @@ async def widget_focus(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "lvgl.widget.update", ObjUpdateAction, base_update_schema(lv_obj_base_t, PARTS)
+    "lvgl.widget.update",
+    ObjUpdateAction,
+    base_update_schema(lv_obj_base_t, PARTS),
+    synchronous=True,
 )
 async def obj_update_to_code(config, action_id, template_arg, args):
     async def do_update(widget: Widget):
@@ -389,6 +405,7 @@ def validate_refresh_config(config):
         ),
         validate_refresh_config,
     ),
+    synchronous=True,
 )
 async def obj_refresh_to_code(config, action_id, template_arg, args):
     widget = await get_widgets(config)

--- a/esphome/components/lvgl/styles.py
+++ b/esphome/components/lvgl/styles.py
@@ -59,6 +59,7 @@ async def styles_to_code(config):
             cv.Required(CONF_ID): cv.use_id(lv_style_t),
         }
     ),
+    synchronous=True,
 )
 async def style_update_to_code(config, action_id, template_arg, args):
     await wait_for_widgets()

--- a/esphome/components/lvgl/types.py
+++ b/esphome/components/lvgl/types.py
@@ -164,6 +164,7 @@ class WidgetType:
                 f"lvgl.{self.name}.update",
                 ObjUpdateAction,
                 base_update_schema(self, self.parts).extend(self.modify_schema),
+                synchronous=True,
             )(update_to_code)
 
     @property

--- a/esphome/components/lvgl/widgets/animimg.py
+++ b/esphome/components/lvgl/widgets/animimg.py
@@ -83,6 +83,7 @@ animimg_spec = AnimimgType()
         },
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def animimg_start(config, action_id, template_arg, args):
     widget = await get_widgets(config)
@@ -102,6 +103,7 @@ async def animimg_start(config, action_id, template_arg, args):
         },
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def animimg_stop(config, action_id, template_arg, args):
     widget = await get_widgets(config)

--- a/esphome/components/lvgl/widgets/buttonmatrix.py
+++ b/esphome/components/lvgl/widgets/buttonmatrix.py
@@ -245,6 +245,7 @@ buttonmatrix_spec = ButtonMatrixType()
             cv.Optional(CONF_SELECTED): lv_bool,
         }
     ),
+    synchronous=True,
 )
 async def button_update_to_code(config, action_id, template_arg, args):
     widgets = await get_widgets(config[CONF_ID])

--- a/esphome/components/lvgl/widgets/canvas.py
+++ b/esphome/components/lvgl/widgets/canvas.py
@@ -97,6 +97,7 @@ canvas_spec = CanvasType()
             cv.Optional(CONF_OPA, default="COVER"): opacity,
         },
     ),
+    synchronous=True,
 )
 async def canvas_fill(config, action_id, template_arg, args):
     widget = await get_widgets(config)
@@ -120,6 +121,7 @@ async def canvas_fill(config, action_id, template_arg, args):
             cv.Required(CONF_POINTS): cv.ensure_list(point_schema),
         },
     ),
+    synchronous=True,
 )
 async def canvas_set_pixel(config, action_id, template_arg, args):
     widget = await get_widgets(config)
@@ -229,6 +231,7 @@ RECT_PROPS = {
             **{cv.Optional(prop): STYLE_PROPS[prop] for prop in RECT_PROPS},
         }
     ),
+    synchronous=True,
 )
 async def canvas_draw_rect(config, action_id, template_arg, args):
     width = await pixels.process(config[CONF_WIDTH])
@@ -268,6 +271,7 @@ TEXT_PROPS = {
             **{cv.Optional(prop): STYLE_PROPS[f"text_{prop}"] for prop in TEXT_PROPS},
         },
     ),
+    synchronous=True,
 )
 async def canvas_draw_text(config, action_id, template_arg, args):
     text = await lv_text.process(config[CONF_TEXT])
@@ -302,6 +306,7 @@ IMG_PROPS = {
             **{cv.Optional(prop): validator for prop, validator in IMG_PROPS.items()},
         }
     ),
+    synchronous=True,
 )
 async def canvas_draw_image(config, action_id, template_arg, args):
     src = await lv_image.process(config[CONF_SRC])
@@ -341,6 +346,7 @@ LINE_PROPS = {
             **{cv.Optional(prop): validator for prop, validator in LINE_PROPS.items()},
         }
     ),
+    synchronous=True,
 )
 async def canvas_draw_line(config, action_id, template_arg, args):
     points = [
@@ -369,6 +375,7 @@ async def canvas_draw_line(config, action_id, template_arg, args):
             **{cv.Optional(prop): STYLE_PROPS[prop] for prop in RECT_PROPS},
         },
     ),
+    synchronous=True,
 )
 async def canvas_draw_polygon(config, action_id, template_arg, args):
     points = [
@@ -408,6 +415,7 @@ ARC_PROPS = {
             **{cv.Optional(prop): validator for prop, validator in ARC_PROPS.items()},
         }
     ),
+    synchronous=True,
 )
 async def canvas_draw_arc(config, action_id, template_arg, args):
     radius = await size.process(config[CONF_RADIUS])

--- a/esphome/components/lvgl/widgets/meter.py
+++ b/esphome/components/lvgl/widgets/meter.py
@@ -297,6 +297,7 @@ meter_spec = MeterType()
             cv.Optional(CONF_OPA): opacity,
         }
     ),
+    synchronous=True,
 )
 async def indicator_update_to_code(config, action_id, template_arg, args):
     widget = await get_widgets(config)

--- a/esphome/components/lvgl/widgets/page.py
+++ b/esphome/components/lvgl/widgets/page.py
@@ -85,6 +85,7 @@ page_spec = PageType()
     "lvgl.page.next",
     LvglAction,
     SHOW_SCHEMA,
+    synchronous=True,
 )
 async def page_next_to_code(config, action_id, template_arg, args):
     animation = await LV_ANIM.process(config[CONF_ANIMATION])
@@ -125,6 +126,7 @@ async def page_is_showing_to_code(config, condition_id, template_arg, args):
     "lvgl.page.previous",
     LvglAction,
     SHOW_SCHEMA,
+    synchronous=True,
 )
 async def page_previous_to_code(config, action_id, template_arg, args):
     animation = await LV_ANIM.process(config[CONF_ANIMATION])
@@ -148,6 +150,7 @@ async def page_previous_to_code(config, action_id, template_arg, args):
         ),
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def page_show_to_code(config, action_id, template_arg, args):
     widget = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/lvgl/widgets/spinbox.py
+++ b/esphome/components/lvgl/widgets/spinbox.py
@@ -147,6 +147,7 @@ spinbox_spec = SpinboxType()
         },
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def spinbox_increment(config, action_id, template_arg, args):
     widgets = await get_widgets(config)
@@ -166,6 +167,7 @@ async def spinbox_increment(config, action_id, template_arg, args):
         },
         key=CONF_ID,
     ),
+    synchronous=True,
 )
 async def spinbox_decrement(config, action_id, template_arg, args):
     widgets = await get_widgets(config)

--- a/esphome/components/lvgl/widgets/tabview.py
+++ b/esphome/components/lvgl/widgets/tabview.py
@@ -109,6 +109,7 @@ tabview_spec = TabviewType()
             cv.Required(CONF_INDEX): lv_int,
         },
     ).add_extra(cv.has_at_least_one_key(CONF_INDEX, CONF_TAB_ID)),
+    synchronous=True,
 )
 async def tabview_select(config, action_id, template_arg, args):
     widget = await get_widgets(config)

--- a/esphome/components/lvgl/widgets/tileview.py
+++ b/esphome/components/lvgl/widgets/tileview.py
@@ -112,6 +112,7 @@ def tile_select_validate(config):
             cv.Optional(CONF_TILE_ID): cv.use_id(lv_tile_t),
         },
     ).add_extra(tile_select_validate),
+    synchronous=True,
 )
 async def tileview_select(config, action_id, template_arg, args):
     widgets = await get_widgets(config)

--- a/esphome/components/max17043/sensor.py
+++ b/esphome/components/max17043/sensor.py
@@ -71,7 +71,9 @@ MAX17043_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action("max17043.sleep_mode", SleepAction, MAX17043_ACTION_SCHEMA)
+@automation.register_action(
+    "max17043.sleep_mode", SleepAction, MAX17043_ACTION_SCHEMA, synchronous=True
+)
 async def max17043_sleep_mode_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/max6956/__init__.py
+++ b/esphome/components/max6956/__init__.py
@@ -112,6 +112,7 @@ async def max6956_pin_to_code(config):
         },
         key=CONF_BRIGHTNESS_GLOBAL,
     ),
+    synchronous=True,
 )
 async def max6956_set_brightness_global_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -133,6 +134,7 @@ async def max6956_set_brightness_global_to_code(config, action_id, template_arg,
         },
         key=CONF_BRIGHTNESS_MODE,
     ),
+    synchronous=True,
 )
 async def max6956_set_brightness_mode_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/max7219digit/display.py
+++ b/esphome/components/max7219digit/display.py
@@ -133,10 +133,16 @@ MAX7219_ON_ACTION_SCHEMA = automation.maybe_simple_id(
 
 
 @automation.register_action(
-    "max7219digit.invert_off", DisplayInvertAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.invert_off",
+    DisplayInvertAction,
+    MAX7219_OFF_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "max7219digit.invert_on", DisplayInvertAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.invert_on",
+    DisplayInvertAction,
+    MAX7219_ON_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def max7219digit_invert_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -146,10 +152,16 @@ async def max7219digit_invert_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "max7219digit.turn_off", DisplayVisibilityAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.turn_off",
+    DisplayVisibilityAction,
+    MAX7219_OFF_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "max7219digit.turn_on", DisplayVisibilityAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.turn_on",
+    DisplayVisibilityAction,
+    MAX7219_ON_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def max7219digit_visible_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -159,10 +171,16 @@ async def max7219digit_visible_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "max7219digit.reverse_off", DisplayReverseAction, MAX7219_OFF_ACTION_SCHEMA
+    "max7219digit.reverse_off",
+    DisplayReverseAction,
+    MAX7219_OFF_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "max7219digit.reverse_on", DisplayReverseAction, MAX7219_ON_ACTION_SCHEMA
+    "max7219digit.reverse_on",
+    DisplayReverseAction,
+    MAX7219_ON_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def max7219digit_reverse_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -183,7 +201,10 @@ MAX7219_INTENSITY_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "max7219digit.intensity", DisplayIntensityAction, MAX7219_INTENSITY_SCHEMA
+    "max7219digit.intensity",
+    DisplayIntensityAction,
+    MAX7219_INTENSITY_SCHEMA,
+    synchronous=True,
 )
 async def max7219digit_intensity_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -177,6 +177,7 @@ MEDIA_PLAYER_CONDITION_SCHEMA = automation.maybe_simple_id(
         },
         key=CONF_MEDIA_URL,
     ),
+    synchronous=True,
 )
 async def media_player_play_media_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -206,7 +207,10 @@ def _register_command_actions():
             class_name, automation.Action, cg.Parented.template(MediaPlayer)
         )
         automation.register_action(
-            f"media_player.{action_name}", action_class, MEDIA_PLAYER_ACTION_SCHEMA
+            f"media_player.{action_name}",
+            action_class,
+            MEDIA_PLAYER_ACTION_SCHEMA,
+            synchronous=True,
         )(handler)
 
 
@@ -242,6 +246,7 @@ _register_state_conditions()
         },
         key=CONF_VOLUME,
     ),
+    synchronous=True,
 )
 async def media_player_volume_set_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/mhz19/sensor.py
+++ b/esphome/components/mhz19/sensor.py
@@ -112,13 +112,22 @@ NO_ARGS_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "mhz19.calibrate_zero", MHZ19CalibrateZeroAction, NO_ARGS_ACTION_SCHEMA
+    "mhz19.calibrate_zero",
+    MHZ19CalibrateZeroAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "mhz19.abc_enable", MHZ19ABCEnableAction, NO_ARGS_ACTION_SCHEMA
+    "mhz19.abc_enable",
+    MHZ19ABCEnableAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "mhz19.abc_disable", MHZ19ABCDisableAction, NO_ARGS_ACTION_SCHEMA
+    "mhz19.abc_disable",
+    MHZ19ABCDisableAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def mhz19_no_args_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -137,7 +146,10 @@ RANGE_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "mhz19.detection_range_set", MHZ19DetectionRangeSetAction, RANGE_ACTION_SCHEMA
+    "mhz19.detection_range_set",
+    MHZ19DetectionRangeSetAction,
+    RANGE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def mhz19_detection_range_set_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -529,8 +529,15 @@ async def to_code(config):
 MICRO_WAKE_WORD_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(MicroWakeWord)})
 
 
-@register_action("micro_wake_word.start", StartAction, MICRO_WAKE_WORD_ACTION_SCHEMA)
-@register_action("micro_wake_word.stop", StopAction, MICRO_WAKE_WORD_ACTION_SCHEMA)
+@register_action(
+    "micro_wake_word.start",
+    StartAction,
+    MICRO_WAKE_WORD_ACTION_SCHEMA,
+    synchronous=True,
+)
+@register_action(
+    "micro_wake_word.stop", StopAction, MICRO_WAKE_WORD_ACTION_SCHEMA, synchronous=True
+)
 @register_condition(
     "micro_wake_word.is_running", IsRunningCondition, MICRO_WAKE_WORD_ACTION_SCHEMA
 )
@@ -551,11 +558,13 @@ MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA = automation.maybe_simple_id(
     "micro_wake_word.enable_model",
     EnableModelAction,
     MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 @register_action(
     "micro_wake_word.disable_model",
     DisableModelAction,
     MICRO_WAKE_WORLD_MODEL_ACTION_SCHEMA,
+    synchronous=True,
 )
 @register_condition(
     "micro_wake_word.model_is_enabled",

--- a/esphome/components/microphone/__init__.py
+++ b/esphome/components/microphone/__init__.py
@@ -190,19 +190,25 @@ async def microphone_action(config, action_id, template_arg, args):
 
 
 automation.register_action(
-    "microphone.capture", CaptureAction, MICROPHONE_ACTION_SCHEMA
+    "microphone.capture",
+    CaptureAction,
+    MICROPHONE_ACTION_SCHEMA,
+    synchronous=True,
 )(microphone_action)
 
 automation.register_action(
-    "microphone.stop_capture", StopCaptureAction, MICROPHONE_ACTION_SCHEMA
+    "microphone.stop_capture",
+    StopCaptureAction,
+    MICROPHONE_ACTION_SCHEMA,
+    synchronous=True,
 )(microphone_action)
 
-automation.register_action("microphone.mute", MuteAction, MICROPHONE_ACTION_SCHEMA)(
-    microphone_action
-)
-automation.register_action("microphone.unmute", UnmuteAction, MICROPHONE_ACTION_SCHEMA)(
-    microphone_action
-)
+automation.register_action(
+    "microphone.mute", MuteAction, MICROPHONE_ACTION_SCHEMA, synchronous=True
+)(microphone_action)
+automation.register_action(
+    "microphone.unmute", UnmuteAction, MICROPHONE_ACTION_SCHEMA, synchronous=True
+)(microphone_action)
 
 automation.register_condition(
     "microphone.is_capturing", IsCapturingCondition, MICROPHONE_ACTION_SCHEMA

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -53,7 +53,9 @@ def templatize(value):
 
 def register_action(name, type_, schema):
     validator = templatize(schema).extend(MIDEA_ACTION_BASE_SCHEMA)
-    registerer = automation.register_action(f"midea_ac.{name}", type_, validator)
+    registerer = automation.register_action(
+        f"midea_ac.{name}", type_, validator, synchronous=True
+    )
 
     def decorator(func):
         async def new_func(config, action_id, template_arg, args):

--- a/esphome/components/mixer/speaker/__init__.py
+++ b/esphome/components/mixer/speaker/__init__.py
@@ -162,6 +162,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def ducking_set_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -607,6 +607,7 @@ async def mqtt_connected_to_code(config, condition_id, template_arg, args):
             cv.GenerateID(): cv.use_id(MQTTClientComponent),
         }
     ),
+    synchronous=True,
 )
 async def mqtt_enable_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -621,6 +622,7 @@ async def mqtt_enable_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(MQTTClientComponent),
         }
     ),
+    synchronous=True,
 )
 async def mqtt_disable_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nau7802/sensor.py
+++ b/esphome/components/nau7802/sensor.py
@@ -117,16 +117,19 @@ NAU7802_CALIBRATE_SCHEMA = maybe_simple_id(
     "nau7802.calibrate_internal_offset",
     NAU7802CalbrateInternalOffsetAction,
     NAU7802_CALIBRATE_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "nau7802.calibrate_external_offset",
     NAU7802CalbrateExternalOffsetAction,
     NAU7802_CALIBRATE_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "nau7802.calibrate_gain",
     NAU7802CalbrateGainAction,
     NAU7802_CALIBRATE_SCHEMA,
+    synchronous=True,
 )
 async def nau7802_calibrate_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/nextion/binary_sensor/__init__.py
+++ b/esphome/components/nextion/binary_sensor/__init__.py
@@ -70,6 +70,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -137,6 +137,7 @@ CONFIG_SCHEMA = (
         },
         key=CONF_BRIGHTNESS,
     ),
+    synchronous=True,
 )
 async def nextion_set_brightness_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nextion/sensor/__init__.py
+++ b/esphome/components/nextion/sensor/__init__.py
@@ -110,6 +110,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nextion/switch/__init__.py
+++ b/esphome/components/nextion/switch/__init__.py
@@ -52,6 +52,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/nextion/text_sensor/__init__.py
+++ b/esphome/components/nextion/text_sensor/__init__.py
@@ -48,6 +48,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -106,9 +106,14 @@ RELEASE_IMAGE_SCHEMA = automation.maybe_simple_id(
 )
 
 
-@automation.register_action("online_image.set_url", SetUrlAction, SET_URL_SCHEMA)
 @automation.register_action(
-    "online_image.release", ReleaseImageAction, RELEASE_IMAGE_SCHEMA
+    "online_image.set_url", SetUrlAction, SET_URL_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "online_image.release",
+    ReleaseImageAction,
+    RELEASE_IMAGE_SCHEMA,
+    synchronous=True,
 )
 async def online_image_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -118,6 +118,7 @@ async def output_set_level_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_MIN_POWER): cv.templatable(cv.percentage),
         }
     ),
+    synchronous=True,
 )
 async def output_set_min_power_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -136,6 +137,7 @@ async def output_set_min_power_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_MAX_POWER): cv.templatable(cv.percentage),
         }
     ),
+    synchronous=True,
 )
 async def output_set_max_power_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pcf85063/time.py
+++ b/esphome/components/pcf85063/time.py
@@ -29,6 +29,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
             cv.GenerateID(): cv.use_id(PCF85063Component),
         }
     ),
+    synchronous=True,
 )
 async def pcf85063_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -44,6 +45,7 @@ async def pcf85063_write_time_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(PCF85063Component),
         }
     ),
+    synchronous=True,
 )
 async def pcf85063_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/pcf8563/time.py
+++ b/esphome/components/pcf8563/time.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
             cv.GenerateID(): cv.use_id(pcf8563Component),
         }
     ),
+    synchronous=True,
 )
 async def pcf8563_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -47,6 +48,7 @@ async def pcf8563_write_time_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(pcf8563Component),
         }
     ),
+    synchronous=True,
 )
 async def pcf8563_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -133,6 +133,7 @@ async def to_code(config):
             cv.Required(CONF_ID): cv.use_id(PIDClimate),
         }
     ),
+    synchronous=True,
 )
 async def pid_reset_integral_term(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -154,6 +155,7 @@ async def pid_reset_integral_term(config, action_id, template_arg, args):
             ): cv.possibly_negative_percentage,
         }
     ),
+    synchronous=True,
 )
 async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -175,6 +177,7 @@ async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
             cv.Optional(CONF_KD, default=0.0): cv.templatable(cv.float_),
         }
     ),
+    synchronous=True,
 )
 async def set_control_parameters(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pipsolar/output/__init__.py
+++ b/esphome/components/pipsolar/output/__init__.py
@@ -98,6 +98,7 @@ async def to_code(config):
             cv.Required(CONF_VALUE): cv.templatable(cv.positive_float),
         }
     ),
+    synchronous=True,
 )
 async def output_pipsolar_set_level_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pmwcs3/sensor.py
+++ b/esphome/components/pmwcs3/sensor.py
@@ -106,11 +106,13 @@ PMWCS3_CALIBRATION_SCHEMA = cv.Schema(
     "pmwcs3.air_calibration",
     PMWCS3AirCalibrationAction,
     PMWCS3_CALIBRATION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "pmwcs3.water_calibration",
     PMWCS3WaterCalibrationAction,
     PMWCS3_CALIBRATION_SCHEMA,
+    synchronous=True,
 )
 async def pmwcs3_calibration_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
@@ -130,6 +132,7 @@ PMWCS3_NEW_I2C_ADDRESS_SCHEMA = cv.maybe_simple_value(
     "pmwcs3.new_i2c_address",
     PMWCS3NewI2cAddressAction,
     PMWCS3_NEW_I2C_ADDRESS_SCHEMA,
+    synchronous=True,
 )
 async def pmwcs3newi2caddress_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pn7150/__init__.py
+++ b/esphome/components/pn7150/__init__.py
@@ -119,11 +119,13 @@ PN7150_SCHEMA = cv.Schema(
     "tag.set_emulation_message",
     SetEmulationMessageAction,
     SET_MESSAGE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "tag.set_write_message",
     SetWriteMessageAction,
     SET_MESSAGE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def pn7150_set_message_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -138,22 +140,43 @@ async def pn7150_set_message_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "tag.emulation_off", EmulationOffAction, SIMPLE_ACTION_SCHEMA
-)
-@automation.register_action("tag.emulation_on", EmulationOnAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action("tag.polling_off", PollingOffAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action("tag.polling_on", PollingOnAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action(
-    "tag.set_clean_mode", SetCleanModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.emulation_off",
+    EmulationOffAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "tag.set_format_mode", SetFormatModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.emulation_on", EmulationOnAction, SIMPLE_ACTION_SCHEMA, synchronous=True
 )
 @automation.register_action(
-    "tag.set_read_mode", SetReadModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.polling_off", PollingOffAction, SIMPLE_ACTION_SCHEMA, synchronous=True
 )
 @automation.register_action(
-    "tag.set_write_mode", SetWriteModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.polling_on", PollingOnAction, SIMPLE_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "tag.set_clean_mode",
+    SetCleanModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_format_mode",
+    SetFormatModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_read_mode",
+    SetReadModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_write_mode",
+    SetWriteModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def pn7150_simple_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/pn7160/__init__.py
+++ b/esphome/components/pn7160/__init__.py
@@ -123,11 +123,13 @@ PN7160_SCHEMA = cv.Schema(
     "tag.set_emulation_message",
     SetEmulationMessageAction,
     SET_MESSAGE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "tag.set_write_message",
     SetWriteMessageAction,
     SET_MESSAGE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def pn7160_set_message_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -142,22 +144,43 @@ async def pn7160_set_message_to_code(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "tag.emulation_off", EmulationOffAction, SIMPLE_ACTION_SCHEMA
-)
-@automation.register_action("tag.emulation_on", EmulationOnAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action("tag.polling_off", PollingOffAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action("tag.polling_on", PollingOnAction, SIMPLE_ACTION_SCHEMA)
-@automation.register_action(
-    "tag.set_clean_mode", SetCleanModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.emulation_off",
+    EmulationOffAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "tag.set_format_mode", SetFormatModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.emulation_on", EmulationOnAction, SIMPLE_ACTION_SCHEMA, synchronous=True
 )
 @automation.register_action(
-    "tag.set_read_mode", SetReadModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.polling_off", PollingOffAction, SIMPLE_ACTION_SCHEMA, synchronous=True
 )
 @automation.register_action(
-    "tag.set_write_mode", SetWriteModeAction, SIMPLE_ACTION_SCHEMA
+    "tag.polling_on", PollingOnAction, SIMPLE_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "tag.set_clean_mode",
+    SetCleanModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_format_mode",
+    SetFormatModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_read_mode",
+    SetReadModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "tag.set_write_mode",
+    SetWriteModeAction,
+    SIMPLE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def pn7160_simple_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -155,6 +155,7 @@ async def to_code(config):
             cv.Required(CONF_VALUE): cv.templatable(cv.uint32_t),
         }
     ),
+    synchronous=True,
 )
 async def set_total_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pulse_meter/sensor.py
+++ b/esphome/components/pulse_meter/sensor.py
@@ -105,6 +105,7 @@ async def to_code(config):
             cv.Required(CONF_VALUE): cv.templatable(cv.uint32_t),
         }
     ),
+    synchronous=True,
 )
 async def set_total_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pzemac/sensor.py
+++ b/esphome/components/pzemac/sensor.py
@@ -88,6 +88,7 @@ CONFIG_SCHEMA = (
             cv.Required(CONF_ID): cv.use_id(PZEMAC),
         }
     ),
+    synchronous=True,
 )
 async def reset_energy_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/pzemdc/sensor.py
+++ b/esphome/components/pzemdc/sensor.py
@@ -72,6 +72,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_ID): cv.use_id(PZEMDC),
         }
     ),
+    synchronous=True,
 )
 async def reset_energy_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -163,7 +163,10 @@ BASE_REMOTE_TRANSMITTER_SCHEMA = cv.Schema(
 def register_action(name, type_, schema):
     validator = templatize(schema).extend(BASE_REMOTE_TRANSMITTER_SCHEMA)
     registerer = automation.register_action(
-        f"remote_transmitter.transmit_{name}", type_, validator
+        f"remote_transmitter.transmit_{name}",
+        type_,
+        validator,
+        synchronous=True,
     )
 
     def decorator(func):

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -120,7 +120,10 @@ DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "remote_transmitter.digital_write", DigitalWriteAction, DIGITAL_WRITE_ACTION_SCHEMA
+    "remote_transmitter.digital_write",
+    DigitalWriteAction,
+    DIGITAL_WRITE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def digital_write_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/rf_bridge/__init__.py
+++ b/esphome/components/rf_bridge/__init__.py
@@ -114,7 +114,10 @@ RFBRIDGE_SEND_CODE_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "rf_bridge.send_code", RFBridgeSendCodeAction, RFBRIDGE_SEND_CODE_SCHEMA
+    "rf_bridge.send_code",
+    RFBridgeSendCodeAction,
+    RFBRIDGE_SEND_CODE_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_send_code_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -133,7 +136,9 @@ async def rf_bridge_send_code_to_code(config, action_id, template_args, args):
 RFBRIDGE_ID_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(RFBridgeComponent)})
 
 
-@automation.register_action("rf_bridge.learn", RFBridgeLearnAction, RFBRIDGE_ID_SCHEMA)
+@automation.register_action(
+    "rf_bridge.learn", RFBridgeLearnAction, RFBRIDGE_ID_SCHEMA, synchronous=True
+)
 async def rf_bridge_learnx_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_args, paren)
@@ -143,6 +148,7 @@ async def rf_bridge_learnx_to_code(config, action_id, template_args, args):
     "rf_bridge.start_advanced_sniffing",
     RFBridgeStartAdvancedSniffingAction,
     RFBRIDGE_ID_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_start_advanced_sniffing_to_code(
     config, action_id, template_args, args
@@ -155,6 +161,7 @@ async def rf_bridge_start_advanced_sniffing_to_code(
     "rf_bridge.stop_advanced_sniffing",
     RFBridgeStopAdvancedSniffingAction,
     RFBRIDGE_ID_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_stop_advanced_sniffing_to_code(
     config, action_id, template_args, args
@@ -167,6 +174,7 @@ async def rf_bridge_stop_advanced_sniffing_to_code(
     "rf_bridge.start_bucket_sniffing",
     RFBridgeStartBucketSniffingAction,
     RFBRIDGE_ID_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_start_bucket_sniffing_to_code(
     config, action_id, template_args, args
@@ -189,6 +197,7 @@ RFBRIDGE_SEND_ADVANCED_CODE_SCHEMA = cv.Schema(
     "rf_bridge.send_advanced_code",
     RFBridgeSendAdvancedCodeAction,
     RFBRIDGE_SEND_ADVANCED_CODE_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_send_advanced_code_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -211,7 +220,10 @@ RFBRIDGE_SEND_RAW_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "rf_bridge.send_raw", RFBridgeSendRawAction, RFBRIDGE_SEND_RAW_SCHEMA
+    "rf_bridge.send_raw",
+    RFBridgeSendRawAction,
+    RFBRIDGE_SEND_RAW_SCHEMA,
+    synchronous=True,
 )
 async def rf_bridge_send_raw_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -229,7 +241,9 @@ RFBRIDGE_BEEP_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("rf_bridge.beep", RFBridgeBeepAction, RFBRIDGE_BEEP_SCHEMA)
+@automation.register_action(
+    "rf_bridge.beep", RFBridgeBeepAction, RFBRIDGE_BEEP_SCHEMA, synchronous=True
+)
 async def rf_bridge_beep_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_args, paren)

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -139,6 +139,7 @@ async def to_code(config):
             cv.Required(CONF_VALUE): cv.templatable(cv.int_),
         }
     ),
+    synchronous=True,
 )
 async def sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/rp2040_pwm/output.py
+++ b/esphome/components/rp2040_pwm/output.py
@@ -42,6 +42,7 @@ async def to_code(config):
             cv.Required(CONF_FREQUENCY): cv.templatable(validate_frequency),
         }
     ),
+    synchronous=True,
 )
 async def rp2040_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/rtttl/__init__.py
+++ b/esphome/components/rtttl/__init__.py
@@ -117,6 +117,7 @@ async def to_code(config):
         },
         key=CONF_RTTTL,
     ),
+    synchronous=True,
 )
 async def rtttl_play_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -134,6 +135,7 @@ async def rtttl_play_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(Rtttl),
         }
     ),
+    synchronous=True,
 )
 async def rtttl_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/rx8130/time.py
+++ b/esphome/components/rx8130/time.py
@@ -27,6 +27,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
             cv.GenerateID(): cv.use_id(RX8130Component),
         }
     ),
+    synchronous=True,
 )
 async def rx8130_write_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -42,6 +43,7 @@ async def rx8130_write_time_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(RX8130Component),
         }
     ),
+    synchronous=True,
 )
 async def rx8130_read_time_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -62,6 +62,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.use_id(SafeModeComponent),
         }
     ),
+    synchronous=True,
 )
 async def safe_mode_mark_successful_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/scd30/sensor.py
+++ b/esphome/components/scd30/sensor.py
@@ -128,6 +128,7 @@ async def to_code(config):
         },
         key=CONF_VALUE,
     ),
+    synchronous=True,
 )
 async def scd30_force_recalibration_with_reference_to_code(
     config, action_id, template_arg, args

--- a/esphome/components/scd4x/sensor.py
+++ b/esphome/components/scd4x/sensor.py
@@ -141,6 +141,7 @@ SCD4X_ACTION_SCHEMA = maybe_simple_id(
     "scd4x.perform_forced_calibration",
     PerformForcedCalibrationAction,
     SCD4X_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def scd4x_frc_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -158,7 +159,10 @@ SCD4X_RESET_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "scd4x.factory_reset", FactoryResetAction, SCD4X_RESET_ACTION_SCHEMA
+    "scd4x.factory_reset",
+    FactoryResetAction,
+    SCD4X_RESET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def scd4x_reset_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/script/__init__.py
+++ b/esphome/components/script/__init__.py
@@ -221,6 +221,7 @@ async def script_stop_action_to_code(config, action_id, template_arg, args):
     "script.wait",
     ScriptWaitAction,
     maybe_simple_id({cv.Required(CONF_ID): cv.use_id(Script)}),
+    synchronous=False,
 )
 async def script_wait_action_to_code(config, action_id, template_arg, args):
     full_id, paren = await cg.get_variable_with_full_id(config[CONF_ID])

--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -267,7 +267,10 @@ SEN5X_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "sen5x.start_fan_autoclean", StartFanAction, SEN5X_ACTION_SCHEMA
+    "sen5x.start_fan_autoclean",
+    StartFanAction,
+    SEN5X_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def sen54_fan_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/senseair/sensor.py
+++ b/esphome/components/senseair/sensor.py
@@ -73,20 +73,31 @@ CALIBRATION_ACTION_SCHEMA = maybe_simple_id(
     "senseair.background_calibration",
     SenseAirBackgroundCalibrationAction,
     CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
     "senseair.background_calibration_result",
     SenseAirBackgroundCalibrationResultAction,
     CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "senseair.abc_enable", SenseAirABCEnableAction, CALIBRATION_ACTION_SCHEMA
+    "senseair.abc_enable",
+    SenseAirABCEnableAction,
+    CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "senseair.abc_disable", SenseAirABCDisableAction, CALIBRATION_ACTION_SCHEMA
+    "senseair.abc_disable",
+    SenseAirABCDisableAction,
+    CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "senseair.abc_get_period", SenseAirABCGetPeriodAction, CALIBRATION_ACTION_SCHEMA
+    "senseair.abc_get_period",
+    SenseAirABCGetPeriodAction,
+    CALIBRATION_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def senseair_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/servo/__init__.py
+++ b/esphome/components/servo/__init__.py
@@ -62,6 +62,7 @@ async def to_code(config):
             cv.Required(CONF_LEVEL): cv.templatable(cv.possibly_negative_percentage),
         }
     ),
+    synchronous=True,
 )
 async def servo_write_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -79,6 +80,7 @@ async def servo_write_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ID): cv.use_id(Servo),
         }
     ),
+    synchronous=True,
 )
 async def servo_detach_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/sim800l/__init__.py
+++ b/esphome/components/sim800l/__init__.py
@@ -135,7 +135,10 @@ SIM800L_SEND_SMS_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "sim800l.send_sms", Sim800LSendSmsAction, SIM800L_SEND_SMS_SCHEMA
+    "sim800l.send_sms",
+    Sim800LSendSmsAction,
+    SIM800L_SEND_SMS_SCHEMA,
+    synchronous=True,
 )
 async def sim800l_send_sms_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -155,7 +158,9 @@ SIM800L_DIAL_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("sim800l.dial", Sim800LDialAction, SIM800L_DIAL_SCHEMA)
+@automation.register_action(
+    "sim800l.dial", Sim800LDialAction, SIM800L_DIAL_SCHEMA, synchronous=True
+)
 async def sim800l_dial_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
@@ -168,6 +173,7 @@ async def sim800l_dial_to_code(config, action_id, template_arg, args):
     "sim800l.connect",
     Sim800LConnectAction,
     cv.Schema({cv.GenerateID(): cv.use_id(Sim800LComponent)}),
+    synchronous=True,
 )
 async def sim800l_connect_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -183,7 +189,10 @@ SIM800L_SEND_USSD_SCHEMA = cv.Schema(
 
 
 @automation.register_action(
-    "sim800l.send_ussd", Sim800LSendUssdAction, SIM800L_SEND_USSD_SCHEMA
+    "sim800l.send_ussd",
+    Sim800LSendUssdAction,
+    SIM800L_SEND_USSD_SCHEMA,
+    synchronous=True,
 )
 async def sim800l_send_ussd_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -197,6 +206,7 @@ async def sim800l_send_ussd_to_code(config, action_id, template_arg, args):
     "sim800l.disconnect",
     Sim800LDisconnectAction,
     cv.Schema({cv.GenerateID(): cv.use_id(Sim800LComponent)}),
+    synchronous=True,
 )
 async def sim800l_disconnect_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/sound_level/sensor.py
+++ b/esphome/components/sound_level/sensor.py
@@ -89,8 +89,12 @@ SOUND_LEVEL_ACTION_SCHEMA = automation.maybe_simple_id(
 )
 
 
-@automation.register_action("sound_level.start", StartAction, SOUND_LEVEL_ACTION_SCHEMA)
-@automation.register_action("sound_level.stop", StopAction, SOUND_LEVEL_ACTION_SCHEMA)
+@automation.register_action(
+    "sound_level.start", StartAction, SOUND_LEVEL_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "sound_level.stop", StopAction, SOUND_LEVEL_ACTION_SCHEMA, synchronous=True
+)
 async def sound_level_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -78,6 +78,7 @@ async def speaker_action(config, action_id, template_arg, args):
         },
         key=CONF_DATA,
     ),
+    synchronous=True,
 )
 async def speaker_play_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -95,12 +96,12 @@ async def speaker_play_action(config, action_id, template_arg, args):
     return var
 
 
-automation.register_action("speaker.stop", StopAction, SPEAKER_AUTOMATION_SCHEMA)(
-    speaker_action
-)
-automation.register_action("speaker.finish", FinishAction, SPEAKER_AUTOMATION_SCHEMA)(
-    speaker_action
-)
+automation.register_action(
+    "speaker.stop", StopAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True
+)(speaker_action)
+automation.register_action(
+    "speaker.finish", FinishAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True
+)(speaker_action)
 
 automation.register_condition(
     "speaker.is_playing", IsPlayingCondition, SPEAKER_AUTOMATION_SCHEMA
@@ -121,6 +122,7 @@ automation.register_condition(
         },
         key=CONF_VOLUME,
     ),
+    synchronous=True,
 )
 async def speaker_volume_set_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -131,9 +133,14 @@ async def speaker_volume_set_action(config, action_id, template_arg, args):
 
 
 @automation.register_action(
-    "speaker.mute_off", MuteOffAction, SPEAKER_AUTOMATION_SCHEMA
+    "speaker.mute_off",
+    MuteOffAction,
+    SPEAKER_AUTOMATION_SCHEMA,
+    synchronous=True,
 )
-@automation.register_action("speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA)
+@automation.register_action(
+    "speaker.mute_on", MuteOnAction, SPEAKER_AUTOMATION_SCHEMA, synchronous=True
+)
 async def speaker_mute_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -505,6 +505,7 @@ async def to_code(config):
         },
         key=CONF_MEDIA_FILE,
     ),
+    synchronous=True,
 )
 async def play_on_device_media_media_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -422,6 +422,7 @@ CONFIG_SCHEMA = cv.All(
     "sprinkler.set_divider",
     SetDividerAction,
     SPRINKLER_ACTION_SET_DIVIDER_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_set_divider_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -435,6 +436,7 @@ async def sprinkler_set_divider_to_code(config, action_id, template_arg, args):
     "sprinkler.set_multiplier",
     SetMultiplierAction,
     SPRINKLER_ACTION_SET_MULTIPLIER_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_set_multiplier_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -448,6 +450,7 @@ async def sprinkler_set_multiplier_to_code(config, action_id, template_arg, args
     "sprinkler.queue_valve",
     QueueValveAction,
     SPRINKLER_ACTION_QUEUE_VALVE_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_set_queued_valve_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -463,6 +466,7 @@ async def sprinkler_set_queued_valve_to_code(config, action_id, template_arg, ar
     "sprinkler.set_repeat",
     SetRepeatAction,
     SPRINKLER_ACTION_REPEAT_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_set_repeat_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -476,6 +480,7 @@ async def sprinkler_set_repeat_to_code(config, action_id, template_arg, args):
     "sprinkler.set_valve_run_duration",
     SetRunDurationAction,
     SPRINKLER_ACTION_SET_RUN_DURATION_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_set_valve_run_duration_to_code(
     config, action_id, template_arg, args
@@ -490,7 +495,10 @@ async def sprinkler_set_valve_run_duration_to_code(
 
 
 @automation.register_action(
-    "sprinkler.start_from_queue", StartFromQueueAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.start_from_queue",
+    StartFromQueueAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_start_from_queue_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -498,7 +506,10 @@ async def sprinkler_start_from_queue_to_code(config, action_id, template_arg, ar
 
 
 @automation.register_action(
-    "sprinkler.start_full_cycle", StartFullCycleAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.start_full_cycle",
+    StartFullCycleAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_start_full_cycle_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -509,6 +520,7 @@ async def sprinkler_start_full_cycle_to_code(config, action_id, template_arg, ar
     "sprinkler.start_single_valve",
     StartSingleValveAction,
     SPRINKLER_ACTION_SINGLE_VALVE_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_start_single_valve_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -522,21 +534,40 @@ async def sprinkler_start_single_valve_to_code(config, action_id, template_arg, 
 
 
 @automation.register_action(
-    "sprinkler.clear_queued_valves", ClearQueuedValvesAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.clear_queued_valves",
+    ClearQueuedValvesAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sprinkler.next_valve", NextValveAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.next_valve",
+    NextValveAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sprinkler.previous_valve", PreviousValveAction, SPRINKLER_ACTION_SCHEMA
-)
-@automation.register_action("sprinkler.pause", PauseAction, SPRINKLER_ACTION_SCHEMA)
-@automation.register_action("sprinkler.resume", ResumeAction, SPRINKLER_ACTION_SCHEMA)
-@automation.register_action(
-    "sprinkler.resume_or_start_full_cycle", ResumeOrStartAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.previous_valve",
+    PreviousValveAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sprinkler.shutdown", ShutdownAction, SPRINKLER_ACTION_SCHEMA
+    "sprinkler.pause", PauseAction, SPRINKLER_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "sprinkler.resume", ResumeAction, SPRINKLER_ACTION_SCHEMA, synchronous=True
+)
+@automation.register_action(
+    "sprinkler.resume_or_start_full_cycle",
+    ResumeOrStartAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
+)
+@automation.register_action(
+    "sprinkler.shutdown",
+    ShutdownAction,
+    SPRINKLER_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def sprinkler_simple_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/sps30/sensor.py
+++ b/esphome/components/sps30/sensor.py
@@ -180,13 +180,22 @@ SPS30_ACTION_SCHEMA = maybe_simple_id(
 
 
 @automation.register_action(
-    "sps30.start_fan_autoclean", StartFanAction, SPS30_ACTION_SCHEMA
+    "sps30.start_fan_autoclean",
+    StartFanAction,
+    SPS30_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sps30.start_measurement", StartMeasurementAction, SPS30_ACTION_SCHEMA
+    "sps30.start_measurement",
+    StartMeasurementAction,
+    SPS30_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sps30.stop_measurement", StopMeasurementAction, SPS30_ACTION_SCHEMA
+    "sps30.stop_measurement",
+    StopMeasurementAction,
+    SPS30_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def sps30_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -97,6 +97,7 @@ async def register_stepper(var, config):
             cv.Required(CONF_TARGET): cv.templatable(cv.int_),
         }
     ),
+    synchronous=True,
 )
 async def stepper_set_target_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -115,6 +116,7 @@ async def stepper_set_target_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_POSITION): cv.templatable(cv.int_),
         }
     ),
+    synchronous=True,
 )
 async def stepper_report_position_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -133,6 +135,7 @@ async def stepper_report_position_to_code(config, action_id, template_arg, args)
             cv.Required(CONF_SPEED): cv.templatable(validate_speed),
         }
     ),
+    synchronous=True,
 )
 async def stepper_set_speed_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -151,6 +154,7 @@ async def stepper_set_speed_to_code(config, action_id, template_arg, args):
             cv.Required(CONF_ACCELERATION): cv.templatable(validate_acceleration),
         }
     ),
+    synchronous=True,
 )
 async def stepper_set_acceleration_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -169,6 +173,7 @@ async def stepper_set_acceleration_to_code(config, action_id, template_arg, args
             cv.Required(CONF_DECELERATION): cv.templatable(validate_acceleration),
         }
     ),
+    synchronous=True,
 )
 async def stepper_set_deceleration_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -290,19 +290,34 @@ NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
 
 
 @automation.register_action(
-    "sx126x.run_image_cal", RunImageCalAction, NO_ARGS_ACTION_SCHEMA
+    "sx126x.run_image_cal",
+    RunImageCalAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx126x.set_mode_tx", SetModeTxAction, NO_ARGS_ACTION_SCHEMA
+    "sx126x.set_mode_tx",
+    SetModeTxAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx126x.set_mode_rx", SetModeRxAction, NO_ARGS_ACTION_SCHEMA
+    "sx126x.set_mode_rx",
+    SetModeRxAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx126x.set_mode_sleep", SetModeSleepAction, NO_ARGS_ACTION_SCHEMA
+    "sx126x.set_mode_sleep",
+    SetModeSleepAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx126x.set_mode_standby", SetModeStandbyAction, NO_ARGS_ACTION_SCHEMA
+    "sx126x.set_mode_standby",
+    SetModeStandbyAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def no_args_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -320,7 +335,10 @@ SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "sx126x.send_packet", SendPacketAction, SEND_PACKET_ACTION_SCHEMA
+    "sx126x.send_packet",
+    SendPacketAction,
+    SEND_PACKET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def send_packet_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/sx127x/__init__.py
+++ b/esphome/components/sx127x/__init__.py
@@ -283,19 +283,34 @@ NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
 
 
 @automation.register_action(
-    "sx127x.run_image_cal", RunImageCalAction, NO_ARGS_ACTION_SCHEMA
+    "sx127x.run_image_cal",
+    RunImageCalAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx127x.set_mode_tx", SetModeTxAction, NO_ARGS_ACTION_SCHEMA
+    "sx127x.set_mode_tx",
+    SetModeTxAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx127x.set_mode_rx", SetModeRxAction, NO_ARGS_ACTION_SCHEMA
+    "sx127x.set_mode_rx",
+    SetModeRxAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx127x.set_mode_sleep", SetModeSleepAction, NO_ARGS_ACTION_SCHEMA
+    "sx127x.set_mode_sleep",
+    SetModeSleepAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 @automation.register_action(
-    "sx127x.set_mode_standby", SetModeStandbyAction, NO_ARGS_ACTION_SCHEMA
+    "sx127x.set_mode_standby",
+    SetModeStandbyAction,
+    NO_ARGS_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def no_args_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -313,7 +328,10 @@ SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
 
 
 @automation.register_action(
-    "sx127x.send_packet", SendPacketAction, SEND_PACKET_ACTION_SCHEMA
+    "sx127x.send_packet",
+    SendPacketAction,
+    SEND_PACKET_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def send_packet_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/template/binary_sensor/__init__.py
+++ b/esphome/components/template/binary_sensor/__init__.py
@@ -59,6 +59,7 @@ async def to_code(config):
             cv.Required(CONF_STATE): cv.templatable(cv.boolean),
         }
     ),
+    synchronous=True,
 )
 async def binary_sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/template/cover/__init__.py
+++ b/esphome/components/template/cover/__init__.py
@@ -125,6 +125,7 @@ async def to_code(config):
             cv.Optional(CONF_TILT): cv.templatable(cv.zero_to_one_float),
         }
     ),
+    synchronous=True,
 )
 async def cover_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/template/lock/__init__.py
+++ b/esphome/components/template/lock/__init__.py
@@ -90,6 +90,7 @@ async def to_code(config):
         },
         key=CONF_STATE,
     ),
+    synchronous=True,
 )
 async def lock_template_publish_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/template/sensor/__init__.py
+++ b/esphome/components/template/sensor/__init__.py
@@ -44,6 +44,7 @@ async def to_code(config):
             cv.Required(CONF_STATE): cv.templatable(cv.float_),
         }
     ),
+    synchronous=True,
 )
 async def sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/template/switch/__init__.py
+++ b/esphome/components/template/switch/__init__.py
@@ -80,6 +80,7 @@ async def to_code(config):
             cv.Required(CONF_STATE): cv.templatable(cv.boolean),
         }
     ),
+    synchronous=True,
 )
 async def switch_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/template/text_sensor/__init__.py
+++ b/esphome/components/template/text_sensor/__init__.py
@@ -43,6 +43,7 @@ async def to_code(config):
             cv.Required(CONF_STATE): cv.templatable(cv.string_strict),
         }
     ),
+    synchronous=True,
 )
 async def text_sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/template/valve/__init__.py
+++ b/esphome/components/template/valve/__init__.py
@@ -112,6 +112,7 @@ async def to_code(config):
             ),
         }
     ),
+    synchronous=True,
 )
 async def valve_template_publish_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/template/water_heater/__init__.py
+++ b/esphome/components/template/water_heater/__init__.py
@@ -134,6 +134,7 @@ async def to_code(config: ConfigType) -> None:
             cv.Optional(CONF_IS_ON): cv.templatable(cv.boolean),
         }
     ),
+    synchronous=True,
 )
 async def water_heater_template_publish_to_code(
     config: ConfigType,

--- a/esphome/components/tm1651/__init__.py
+++ b/esphome/components/tm1651/__init__.py
@@ -73,6 +73,7 @@ BINARY_OUTPUT_ACTION_SCHEMA = maybe_simple_id(
         },
         key=CONF_BRIGHTNESS,
     ),
+    synchronous=True,
 )
 async def tm1651_set_brightness_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -92,6 +93,7 @@ async def tm1651_set_brightness_to_code(config, action_id, template_arg, args):
         },
         key=CONF_LEVEL,
     ),
+    synchronous=True,
 )
 async def tm1651_set_level_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -111,6 +113,7 @@ async def tm1651_set_level_to_code(config, action_id, template_arg, args):
         },
         key=CONF_LEVEL_PERCENT,
     ),
+    synchronous=True,
 )
 async def tm1651_set_level_percent_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -121,7 +124,10 @@ async def tm1651_set_level_percent_to_code(config, action_id, template_arg, args
 
 
 @automation.register_action(
-    "tm1651.turn_off", TurnOffAction, BINARY_OUTPUT_ACTION_SCHEMA
+    "tm1651.turn_off",
+    TurnOffAction,
+    BINARY_OUTPUT_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def output_turn_off_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -129,7 +135,9 @@ async def output_turn_off_to_code(config, action_id, template_arg, args):
     return var
 
 
-@automation.register_action("tm1651.turn_on", TurnOnAction, BINARY_OUTPUT_ACTION_SCHEMA)
+@automation.register_action(
+    "tm1651.turn_on", TurnOnAction, BINARY_OUTPUT_ACTION_SCHEMA, synchronous=True
+)
 async def output_turn_on_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/uart/__init__.py
+++ b/esphome/components/uart/__init__.py
@@ -494,6 +494,7 @@ async def register_uart_device(var, config):
         },
         key=CONF_DATA,
     ),
+    synchronous=True,
 )
 async def uart_write_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -171,6 +171,7 @@ def validate_raw_data(value):
         },
         key=CONF_DATA,
     ),
+    synchronous=True,
 )
 async def udp_write_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/ufire_ec/sensor.py
+++ b/esphome/components/ufire_ec/sensor.py
@@ -97,6 +97,7 @@ UFIRE_EC_CALIBRATE_PROBE_SCHEMA = cv.Schema(
     "ufire_ec.calibrate_probe",
     UFireECCalibrateProbeAction,
     UFIRE_EC_CALIBRATE_PROBE_SCHEMA,
+    synchronous=True,
 )
 async def ufire_ec_calibrate_probe_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -119,6 +120,7 @@ UFIRE_EC_RESET_SCHEMA = cv.Schema(
     "ufire_ec.reset",
     UFireECResetAction,
     UFIRE_EC_RESET_SCHEMA,
+    synchronous=True,
 )
 async def ufire_ec_reset_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/ufire_ise/sensor.py
+++ b/esphome/components/ufire_ise/sensor.py
@@ -91,6 +91,7 @@ UFIRE_ISE_CALIBRATE_PROBE_SCHEMA = cv.Schema(
     "ufire_ise.calibrate_probe_low",
     UFireISECalibrateProbeLowAction,
     UFIRE_ISE_CALIBRATE_PROBE_SCHEMA,
+    synchronous=True,
 )
 async def ufire_ise_calibrate_probe_low_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -104,6 +105,7 @@ async def ufire_ise_calibrate_probe_low_to_code(config, action_id, template_arg,
     "ufire_ise.calibrate_probe_high",
     UFireISECalibrateProbeHighAction,
     UFIRE_ISE_CALIBRATE_PROBE_SCHEMA,
+    synchronous=True,
 )
 async def ufire_ise_calibrate_probe_high_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
@@ -120,6 +122,7 @@ UFIRE_ISE_RESET_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(UFireISEComponent
     "ufire_ise.reset",
     UFireISEResetAction,
     UFIRE_ISE_RESET_SCHEMA,
+    synchronous=True,
 )
 async def ufire_ise_reset_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])

--- a/esphome/components/update/__init__.py
+++ b/esphome/components/update/__init__.py
@@ -138,6 +138,7 @@ async def to_code(config):
             cv.Optional(CONF_FORCE_UPDATE, default=False): cv.templatable(cv.boolean),
         }
     ),
+    synchronous=True,
 )
 async def update_perform_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -156,6 +157,7 @@ async def update_perform_action_to_code(config, action_id, template_arg, args):
             cv.GenerateID(): cv.use_id(UpdateEntity),
         }
     ),
+    synchronous=True,
 )
 async def update_check_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -180,25 +180,33 @@ VALVE_ACTION_SCHEMA = maybe_simple_id(
 )
 
 
-@automation.register_action("valve.open", OpenAction, VALVE_ACTION_SCHEMA)
+@automation.register_action(
+    "valve.open", OpenAction, VALVE_ACTION_SCHEMA, synchronous=True
+)
 async def valve_open_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("valve.close", CloseAction, VALVE_ACTION_SCHEMA)
+@automation.register_action(
+    "valve.close", CloseAction, VALVE_ACTION_SCHEMA, synchronous=True
+)
 async def valve_close_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("valve.stop", StopAction, VALVE_ACTION_SCHEMA)
+@automation.register_action(
+    "valve.stop", StopAction, VALVE_ACTION_SCHEMA, synchronous=True
+)
 async def valve_stop_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
 
-@automation.register_action("valve.toggle", ToggleAction, VALVE_ACTION_SCHEMA)
+@automation.register_action(
+    "valve.toggle", ToggleAction, VALVE_ACTION_SCHEMA, synchronous=True
+)
 async def valve_toggle_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
@@ -214,7 +222,9 @@ VALVE_CONTROL_ACTION_SCHEMA = cv.Schema(
 )
 
 
-@automation.register_action("valve.control", ControlAction, VALVE_CONTROL_ACTION_SCHEMA)
+@automation.register_action(
+    "valve.control", ControlAction, VALVE_CONTROL_ACTION_SCHEMA, synchronous=True
+)
 async def valve_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)

--- a/esphome/components/voice_assistant/__init__.py
+++ b/esphome/components/voice_assistant/__init__.py
@@ -393,6 +393,7 @@ VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssis
     "voice_assistant.start_continuous",
     StartContinuousAction,
     VOICE_ASSISTANT_ACTION_SCHEMA,
+    synchronous=True,
 )
 @register_action(
     "voice_assistant.start",
@@ -403,6 +404,7 @@ VOICE_ASSISTANT_ACTION_SCHEMA = cv.Schema({cv.GenerateID(): cv.use_id(VoiceAssis
             cv.Optional(CONF_WAKE_WORD): cv.templatable(cv.string),
         }
     ),
+    synchronous=True,
 )
 async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -415,7 +417,9 @@ async def voice_assistant_listen_to_code(config, action_id, template_arg, args):
     return var
 
 
-@register_action("voice_assistant.stop", StopAction, VOICE_ASSISTANT_ACTION_SCHEMA)
+@register_action(
+    "voice_assistant.stop", StopAction, VOICE_ASSISTANT_ACTION_SCHEMA, synchronous=True
+)
 async def voice_assistant_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -670,12 +670,16 @@ async def wifi_ap_active_to_code(config, condition_id, template_arg, args):
     return cg.new_Pvariable(condition_id, template_arg)
 
 
-@automation.register_action("wifi.enable", WiFiEnableAction, cv.Schema({}))
+@automation.register_action(
+    "wifi.enable", WiFiEnableAction, cv.Schema({}), synchronous=True
+)
 async def wifi_enable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
 
-@automation.register_action("wifi.disable", WiFiDisableAction, cv.Schema({}))
+@automation.register_action(
+    "wifi.disable", WiFiDisableAction, cv.Schema({}), synchronous=True
+)
 async def wifi_disable_to_code(config, action_id, template_arg, args):
     return cg.new_Pvariable(action_id, template_arg)
 
@@ -781,6 +785,7 @@ async def final_step():
             cv.Optional(CONF_ON_ERROR): automation.validate_automation(single=True),
         }
     ),
+    synchronous=False,
 )
 async def wifi_set_sta_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -168,6 +168,7 @@ async def wireguard_enabled_to_code(config, condition_id, template_arg, args):
     "wireguard.enable",
     WireguardEnableAction,
     cv.Schema({cv.GenerateID(): cv.use_id(Wireguard)}),
+    synchronous=True,
 )
 async def wireguard_enable_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
@@ -179,6 +180,7 @@ async def wireguard_enable_to_code(config, action_id, template_arg, args):
     "wireguard.disable",
     WireguardDisableAction,
     cv.Schema({cv.GenerateID(): cv.use_id(Wireguard)}),
+    synchronous=True,
 )
 async def wireguard_disable_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)

--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -195,6 +195,7 @@ FactoryResetAction = zigbee_ns.class_(
     "zigbee.factory_reset",
     FactoryResetAction,
     ZIGBEE_ACTION_SCHEMA,
+    synchronous=True,
 )
 async def reset_zigbee_to_code(
     config: ConfigType,


### PR DESCRIPTION
# What does this implement/fix?

All `register_action()` calls now require an explicit `synchronous=True` or `synchronous=False` parameter. This enables the StringRef optimization for synchronous actions (zero-copy string argument passing) while ensuring asynchronous actions safely use owning `std::string` to prevent dangling references.

All ~450 existing `register_action()` calls in the codebase have been audited and marked. Calls without the parameter now emit a warning at config time explaining how to determine the correct value.

## Breaking change for external component authors

`register_action()` now warns if `synchronous=` is not passed explicitly. The safe default (`synchronous=False`) is still applied, so **existing external components will continue to work** — they will just see a warning until updated.

### How to determine the correct value

The `synchronous` flag controls whether trigger arguments (especially strings) use zero-copy `StringRef` or owning `std::string`. The question to ask is:

**Does `play_next_()` always run before the initial `play()`/`play_complex()` call returns?**

- **Yes → `synchronous=True`** — Trigger arguments are only referenced during the call. StringRef is safe.
- **No → `synchronous=False`** — Trigger arguments must outlive the call. Owning std::string is required.

### How to tell if `play_next_()` is deferred

Look at the C++ Action class. `play_next_()` is deferred if any of these apply:

1. The action schedules a **timer/timeout** and calls `play_next_()` from the callback (e.g. `DelayAction`)
2. The action stores args and calls `play_next_()` from a **`Component::loop()`** override (e.g. `WaitUntilAction`, `ScriptWaitAction`)
3. The action registers an **event callback** and calls `play_next_()` from it (e.g. `BLEClientWriteAction` calling from `gattc_event_handler`)

If the action just calls a method and returns (the vast majority of actions), it is synchronous.

### Migration example

Before:
```python
@automation.register_action("my_comp.do_thing", DoThingAction, DO_THING_SCHEMA)
```

After:
```python
@automation.register_action(
    "my_comp.do_thing", DoThingAction, DO_THING_SCHEMA, synchronous=True,
)
```

### Actions marked `synchronous=False` (8 total)

These are the only actions in the codebase that defer `play_next_()`:

| Action | Reason |
|--------|--------|
| `delay` | Timer callback |
| `wait_until` | Component loop polling |
| `script.wait` | Component loop polling |
| `espnow.send` / `espnow.broadcast` | Send completion callback |
| `ble_client.connect` / `ble_client.disconnect` / `ble_client.ble_write` | GATTC event callback |
| `wifi.configure` | Component loop + timeout |

All other actions (~440) are `synchronous=True`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (Python API change, not user-facing config)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — this is a Python API change for component developers, not a user-facing config change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).