### PR TITLE
[api] Inline varint and encode_varint_raw fast paths for hot loop performance

### DIFF
--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -8,18 +8,7 @@ namespace esphome::api {
 
 static const char *const TAG = "api.proto";
 
-uint32_t ProtoSize::varint_slow(uint32_t value) {
-  // value is guaranteed >= 128 here (fast path handled inline)
-  if (value < 16384) {
-    return 2;  // 14 bits
-  } else if (value < 2097152) {
-    return 3;  // 21 bits
-  } else if (value < 268435456) {
-    return 4;  // 28 bits
-  } else {
-    return 5;  // 32 bits (maximum for uint32_t)
-  }
-}
+uint32_t ProtoSize::varint_slow(uint32_t value) { return varint_wide(value); }
 
 #ifdef USE_API_VARINT64
 optional<ProtoVarInt> ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, uint32_t *consumed,

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -10,6 +10,16 @@ static const char *const TAG = "api.proto";
 
 uint32_t ProtoSize::varint_slow(uint32_t value) { return varint_wide(value); }
 
+void ProtoWriteBuffer::encode_varint_raw_slow_(uint32_t value) {
+  do {
+    this->debug_check_bounds_(1);
+    *this->pos_++ = static_cast<uint8_t>(value | 0x80);
+    value >>= 7;
+  } while (value > 0x7F);
+  this->debug_check_bounds_(1);
+  *this->pos_++ = static_cast<uint8_t>(value);
+}
+
 #ifdef USE_API_VARINT64
 optional<ProtoVarInt> ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, uint32_t *consumed,
                                               uint32_t result32) {

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -8,6 +8,19 @@ namespace esphome::api {
 
 static const char *const TAG = "api.proto";
 
+uint32_t ProtoSize::varint_slow_(uint32_t value) {
+  // value is guaranteed >= 128 here (fast path handled inline)
+  if (value < 16384) {
+    return 2;  // 14 bits
+  } else if (value < 2097152) {
+    return 3;  // 21 bits
+  } else if (value < 268435456) {
+    return 4;  // 28 bits
+  } else {
+    return 5;  // 32 bits (maximum for uint32_t)
+  }
+}
+
 #ifdef USE_API_VARINT64
 optional<ProtoVarInt> ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, uint32_t *consumed,
                                               uint32_t result32) {

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -8,7 +8,7 @@ namespace esphome::api {
 
 static const char *const TAG = "api.proto";
 
-uint32_t ProtoSize::varint_slow_(uint32_t value) {
+uint32_t ProtoSize::varint_slow(uint32_t value) {
   // value is guaranteed >= 128 here (fast path handled inline)
   if (value < 16384) {
     return 2;  // 14 bits

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -514,21 +514,26 @@ class ProtoSize {
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint(uint32_t value) {
     if (value < 128)
       return 1;  // Fast path: 7 bits, most common case
-    if (__builtin_is_constant_evaluated()) {
-      // Compile-time: full cascade for constexpr callers
-      if (value < 16384)
-        return 2;
-      if (value < 2097152)
-        return 3;
-      if (value < 268435456)
-        return 4;
-      return 5;
-    }
+    if (__builtin_is_constant_evaluated())
+      return varint_wide(value);
     return varint_slow(value);
   }
   // Slow path for varint >= 128, outlined to keep fast path small
   static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
 
+ private:
+  // Shared cascade for values >= 128 (used by both constexpr and noinline paths)
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint_wide(uint32_t value) {
+    if (value < 16384)
+      return 2;
+    if (value < 2097152)
+      return 3;
+    if (value < 268435456)
+      return 4;
+    return 5;
+  }
+
+ public:
   /**
    * @brief Calculates the size in bytes needed to encode a uint64_t value as a varint
    *

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -240,14 +240,13 @@ class ProtoWriteBuffer {
   ProtoWriteBuffer(std::vector<uint8_t> *buffer) : buffer_(buffer), pos_(buffer->data() + buffer->size()) {}
   ProtoWriteBuffer(std::vector<uint8_t> *buffer, size_t write_pos)
       : buffer_(buffer), pos_(buffer->data() + write_pos) {}
-  void encode_varint_raw(uint32_t value) {
-    while (value > 0x7F) {
+  inline void ESPHOME_ALWAYS_INLINE encode_varint_raw(uint32_t value) {
+    if (value < 128) [[likely]] {
       this->debug_check_bounds_(1);
-      *this->pos_++ = static_cast<uint8_t>(value | 0x80);
-      value >>= 7;
+      *this->pos_++ = static_cast<uint8_t>(value);
+      return;
     }
-    this->debug_check_bounds_(1);
-    *this->pos_++ = static_cast<uint8_t>(value);
+    this->encode_varint_raw_slow_(value);
   }
   void encode_varint_raw_64(uint64_t value) {
     while (value > 0x7F) {
@@ -378,6 +377,9 @@ class ProtoWriteBuffer {
   std::vector<uint8_t> *get_buffer() const { return buffer_; }
 
  protected:
+  // Slow path for encode_varint_raw values >= 128, outlined to keep fast path small
+  void encode_varint_raw_slow_(uint32_t value) __attribute__((noinline));
+
 #ifdef ESPHOME_DEBUG_API
   void debug_check_bounds_(size_t bytes, const char *caller = __builtin_FUNCTION());
   void debug_check_encode_size_(uint32_t field_id, uint32_t expected, ptrdiff_t actual);
@@ -512,7 +514,7 @@ class ProtoSize {
    * @return The number of bytes needed to encode the value
    */
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint(uint32_t value) {
-    if (value < 128)
+    if (value < 128) [[likely]]
       return 1;  // Fast path: 7 bits, most common case
     if (__builtin_is_constant_evaluated())
       return varint_wide(value);

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -609,7 +609,7 @@ class ProtoSize {
   static constexpr uint32_t calc_int32_force(uint32_t field_id_size, int32_t value) {
     return field_id_size + (value < 0 ? 10 : varint(static_cast<uint32_t>(value)));
   }
-  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_uint32(uint32_t field_id_size, uint32_t value) {
+  static constexpr uint32_t calc_uint32(uint32_t field_id_size, uint32_t value) {
     return value ? field_id_size + varint(value) : 0;
   }
   static constexpr uint32_t calc_uint32_force(uint32_t field_id_size, uint32_t value) {
@@ -644,7 +644,7 @@ class ProtoSize {
   static constexpr uint32_t calc_uint64_force(uint32_t field_id_size, uint64_t value) {
     return field_id_size + varint(value);
   }
-  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_length(uint32_t field_id_size, size_t len) {
+  static constexpr uint32_t calc_length(uint32_t field_id_size, size_t len) {
     return len ? field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len) : 0;
   }
   static constexpr uint32_t calc_length_force(uint32_t field_id_size, size_t len) {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -518,10 +518,10 @@ class ProtoSize {
       return varint_wide(value);
     return varint_slow(value);
   }
-  // Slow path for varint >= 128, outlined to keep fast path small
-  static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
 
  private:
+  // Slow path for varint >= 128, outlined to keep fast path small
+  static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
   // Shared cascade for values >= 128 (used by both constexpr and noinline paths)
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint_wide(uint32_t value) {
     if (value < 16384)

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -524,10 +524,10 @@ class ProtoSize {
         return 4;
       return 5;
     }
-    return varint_slow_(value);
+    return varint_slow(value);
   }
   // Slow path for varint >= 128, outlined to keep fast path small
-  static uint32_t varint_slow_(uint32_t value) __attribute__((noinline));
+  static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
 
   /**
    * @brief Calculates the size in bytes needed to encode a uint64_t value as a varint

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -511,23 +511,23 @@ class ProtoSize {
    * @param value The uint32_t value to calculate size for
    * @return The number of bytes needed to encode the value
    */
-  static constexpr uint32_t varint(uint32_t value) {
-    // Optimized varint size calculation using leading zeros
-    // Each 7 bits requires one byte in the varint encoding
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint(uint32_t value) {
     if (value < 128)
-      return 1;  // 7 bits, common case for small values
-
-    // For larger values, count bytes needed based on the position of the highest bit set
-    if (value < 16384) {
-      return 2;  // 14 bits
-    } else if (value < 2097152) {
-      return 3;  // 21 bits
-    } else if (value < 268435456) {
-      return 4;  // 28 bits
-    } else {
-      return 5;  // 32 bits (maximum for uint32_t)
+      return 1;  // Fast path: 7 bits, most common case
+    if (__builtin_is_constant_evaluated()) {
+      // Compile-time: full cascade for constexpr callers
+      if (value < 16384)
+        return 2;
+      if (value < 2097152)
+        return 3;
+      if (value < 268435456)
+        return 4;
+      return 5;
     }
+    return varint_slow_(value);
   }
+  // Slow path for varint >= 128, outlined to keep fast path small
+  static uint32_t varint_slow_(uint32_t value) __attribute__((noinline));
 
   /**
    * @brief Calculates the size in bytes needed to encode a uint64_t value as a varint
@@ -609,7 +609,7 @@ class ProtoSize {
   static constexpr uint32_t calc_int32_force(uint32_t field_id_size, int32_t value) {
     return field_id_size + (value < 0 ? 10 : varint(static_cast<uint32_t>(value)));
   }
-  static constexpr uint32_t calc_uint32(uint32_t field_id_size, uint32_t value) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_uint32(uint32_t field_id_size, uint32_t value) {
     return value ? field_id_size + varint(value) : 0;
   }
   static constexpr uint32_t calc_uint32_force(uint32_t field_id_size, uint32_t value) {
@@ -644,7 +644,7 @@ class ProtoSize {
   static constexpr uint32_t calc_uint64_force(uint32_t field_id_size, uint64_t value) {
     return field_id_size + varint(value);
   }
-  static constexpr uint32_t calc_length(uint32_t field_id_size, size_t len) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_length(uint32_t field_id_size, size_t len) {
     return len ? field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len) : 0;
   }
   static constexpr uint32_t calc_length_force(uint32_t field_id_size, size_t len) {


### PR DESCRIPTION
# What does this implement/fix?

Splits `ProtoSize::varint()` and `ProtoWriteBuffer::encode_varint_raw()` into always-inlined fast paths with `noinline` slow paths, eliminating indirect function calls on hot encode paths like BLE advertisement batching.

## 1. `ProtoSize::varint()` — calculate_size fast path

Splits into an always-inlined fast path (`value < 128 → return 1`) and a `noinline` slow path (`varint_slow()`).

**Why this matters:** On the BLE proxy hot path, `calculate_size()` is called for every advertisement in a batch (up to 16). Each advertisement previously made 3-4 indirect `callx8` calls through a function pointer to `varint()` (loaded from a literal pool). The `< 128` check covers the vast majority of cases (address_type 0-1, data_len < 62, field tags < 128) and is now just a compare + branch inline — no function call overhead.

Uses `__builtin_is_constant_evaluated()` to preserve `constexpr` compatibility — compile-time callers still get the full cascade inline, while runtime callers get the split fast/slow path.

Only `varint()` is force-inlined. Higher-level helpers like `calc_uint32()` and `calc_length()` are left to compiler heuristics to avoid flash bloat in cold `calculate_size()` callers (e.g., `DeviceInfoResponse`, `HelloResponse`).

## 2. `ProtoWriteBuffer::encode_varint_raw()` — encode fast path

Applies the same pattern to `encode_varint_raw()`: the single-byte write (`value < 128`) is force-inlined at each call site, while the multi-byte varint loop is outlined into `encode_varint_raw_slow_()`.

**Why this matters:** Xtensa ESP32 disassembly showed `encode_varint_raw` placed ~550KB from its callers, forcing every call through `l32r` + `callx8` (literal pool load + indirect call). Per advertisement, there are ~7-8 calls to `encode_varint_raw` (field tags for IDs 1-4 are always single bytes, plus small field values like address_type 0-1, data_len 0-62). With 16 advertisements per batch, that was ~105-120 indirect function calls per flush — each with full `entry`/`retw` register window rotation overhead — to write single bytes.

Now the common case is just: compare, branch, store byte, increment pointer — inlined directly at the call site.

## Combined impact

**Verified via Xtensa ESP32 disassembly:**
- `ProtoSize::varint` eliminated as a separate hot path function (was 44 bytes)
- `encode_varint_raw` eliminated as a separate hot path function (was 40 bytes)
- ~48-64 indirect `varint()` calls eliminated per 16-advertisement batch flush
- ~105-120 indirect `encode_varint_raw()` calls eliminated per 16-advertisement batch flush
- Total hot path code: 1552 bytes across 22 functions (was 1564 bytes across 23 functions)

Both fast paths use `[[likely]]` to hint branch prediction.

**On-device benchmarks (ESP32-IDF, 10k iterations):**

| Benchmark | Before | After | Change |
|-----------|--------|-------|--------|
| BLERawAdvs12 calculate_size | 15,289 ns | 10,500 ns | **-31.3%** |
| BLERawAdvs12 encode | — | 38,382 ns | — |
| BLERawAdvs12 calc+encode | 57,109 ns | 48,932 ns | **-14.3%** |
| LogResponse calculate_size | 669.5 ns | 389.3 ns | **-41.9%** |
| SensorState calculate_size | — | 408.0 ns | — |

**Flash cost:** +52 bytes (ESP32-IDF real device), +32 bytes (ESP8266 CI).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A — performance optimization

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing changes

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Benchmark button to measure protobuf encode performance
button:
  - platform: template
    name: Proto Benchmark
    on_press:
      - lambda: |-
          using namespace esphome::api;
          static const char *TAG = "proto_bench";
          const int ITERATIONS = 10000;

          // --- SensorStateResponse ---
          {
            SensorStateResponse msg;
            msg.key = 0x12345678;
            msg.state = 23.5f;
            msg.missing_state = false;

            uint32_t cs = 0;
            uint32_t start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              cs += msg.calculate_size();
            }
            uint32_t elapsed = micros() - start;
            ESP_LOGI(TAG, "SensorState calculate_size: %u us / %d = %.1f ns/op (cs=%u)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, cs);

            std::vector<uint8_t> buf;
            uint32_t total_size = msg.calculate_size();
            buf.resize(total_size);
            start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              ProtoWriteBuffer writer(&buf, 0);
              msg.encode(writer);
            }
            elapsed = micros() - start;
            ESP_LOGI(TAG, "SensorState encode:         %u us / %d = %.1f ns/op (%u bytes)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, total_size);
          }

          // --- SubscribeLogsResponse ---
          {
            SubscribeLogsResponse msg;
            msg.level = enums::LOG_LEVEL_DEBUG;
            static const char log_line[] = "[sensor:042]: 'Temperature': Sending state 23.50 C with 1 decimals of accuracy";
            msg.set_message(reinterpret_cast<const uint8_t *>(log_line), sizeof(log_line) - 1);

            uint32_t cs = 0;
            uint32_t start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              cs += msg.calculate_size();
            }
            uint32_t elapsed = micros() - start;
            ESP_LOGI(TAG, "LogResponse  calculate_size: %u us / %d = %.1f ns/op (cs=%u)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, cs);

            std::vector<uint8_t> buf;
            uint32_t total_size = msg.calculate_size();
            buf.resize(total_size);
            start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              ProtoWriteBuffer writer(&buf, 0);
              msg.encode(writer);
            }
            elapsed = micros() - start;
            ESP_LOGI(TAG, "LogResponse  encode:         %u us / %d = %.1f ns/op (%u bytes)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, total_size);
          }

          // --- BluetoothLERawAdvertisementsResponse (12 adverts) ---
          {
            BluetoothLERawAdvertisementsResponse msg;
            msg.advertisements_len = 12;
            static const uint8_t fake_adv_data[] = {
              0x02, 0x01, 0x06, 0x03, 0x03, 0x9F, 0xFE, 0x17, 0x16, 0x9F, 0xFE,
              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
              0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
            };
            for (int i = 0; i < 12; i++) {
              auto &adv = msg.advertisements[i];
              adv.address = 0xAABBCCDD0000ULL + i;
              adv.rssi = -60 - i;
              adv.address_type = 1;
              memcpy(adv.data, fake_adv_data, sizeof(fake_adv_data));
              adv.data_len = sizeof(fake_adv_data);
            }

            uint32_t total_size = msg.calculate_size();

            // Benchmark calculate_size alone
            uint32_t cs = 0;
            uint32_t start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              cs += msg.calculate_size();
            }
            uint32_t elapsed = micros() - start;
            ESP_LOGI(TAG, "BLERawAdvs12 calculate_size: %u us / %d = %.1f ns/op (cs=%u)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, cs);

            // Benchmark encode alone (pre-sized buffer, no resize in loop)
            std::vector<uint8_t> buf;
            buf.resize(total_size);
            start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              ProtoWriteBuffer writer(&buf, 0);
              msg.encode(writer);
            }
            elapsed = micros() - start;
            ESP_LOGI(TAG, "BLERawAdvs12 encode:         %u us / %d = %.1f ns/op (%u bytes)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, total_size);

            // Benchmark full send path: calculate_size + encode (what actually happens per flush)
            start = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              uint32_t sz = msg.calculate_size();
              buf.resize(sz);
              ProtoWriteBuffer writer(&buf, 0);
              msg.encode(writer);
            }
            elapsed = micros() - start;
            ESP_LOGI(TAG, "BLERawAdvs12 calc+encode:    %u us / %d = %.1f ns/op (%u bytes)",
                     elapsed, ITERATIONS, (double)elapsed * 1000.0 / ITERATIONS, total_size);
          }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).