### PR TITLE
[i2s_audio] Include legacy driver IDF component when use_legacy is set

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -281,6 +281,8 @@ async def to_code(config):
 
     if use_legacy():
         cg.add_define("USE_I2S_LEGACY")
+        # Legacy I2S API lives in the "driver" shim component (driver/i2s.h)
+        include_builtin_idf_component("driver")
 
     # Helps avoid callbacks being skipped due to processor load
     add_idf_sdkconfig_option("CONFIG_I2S_ISR_IRAM_SAFE", True)


### PR DESCRIPTION
# What does this implement/fix?

The `driver` shim IDF component (providing `driver/i2s.h`) was excluded by default in #13623 to reduce compile time. When `use_legacy: true` is set in the i2s_audio configuration, the component includes `<driver/i2s.h>` which requires the `driver` shim component to be present. This PR re-enables it when the legacy driver is in use.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #13623

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2s_audio:
  i2s_bclk_pin: GPIO15
  i2s_lrclk_pin: GPIO4
  i2s_mclk_pin: GPIO5
  use_legacy: true

microphone:
  - platform: i2s_audio
    i2s_din_pin: GPIO33
    adc_type: external
    pdm: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).