### PR TITLE
[ble_nus] make ble_nus timeout shorter than watchdog

### DIFF
--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -101,10 +101,10 @@ size_t BLENUS::available() {
 }
 
 uart::FlushResult BLENUS::flush() {
-  constexpr uint32_t timeout_5sec = 5000;
+  constexpr uint32_t timeout_500ms = 500;
   uint32_t start = millis();
   while (atomic_get(&this->tx_status_) != TX_DISABLED && !ring_buf_is_empty(&global_ble_tx_ring_buf)) {
-    if (millis() - start > timeout_5sec) {
+    if (millis() - start > timeout_500ms) {
       ESP_LOGW(TAG, "Flush timeout");
       return uart::FlushResult::TIMEOUT;
     }

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -71,7 +71,10 @@ bool BLENUS::read_array(uint8_t *data, size_t len) {
     this->has_peek_ = false;
     data++;
     if (--len == 0) {  // Decrement len first, then check it...
-      return true;     // No more to read
+#ifdef USE_UART_DEBUGGER
+      this->debug_callback_.call(uart::UART_DIRECTION_RX, data[0]);
+#endif
+      return true;  // No more to read
     }
   }
 

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -72,7 +72,7 @@ bool BLENUS::read_array(uint8_t *data, size_t len) {
     data++;
     if (--len == 0) {  // Decrement len first, then check it...
 #ifdef USE_UART_DEBUGGER
-      this->debug_callback_.call(uart::UART_DIRECTION_RX, data[0]);
+      this->debug_callback_.call(uart::UART_DIRECTION_RX, this->peek_buffer_);
 #endif
       return true;  // No more to read
     }


### PR DESCRIPTION
# What does this implement/fix?

watchdog timeout for nrf52 is 2 sec. And 10 sec when zigbee is used. Waiting 5 sec makes no sense. The board would be reset by watchdog. 
- change timeout to 500ms
- fix debugging of single byte

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
