### PR TITLE
[rp2040] Wrap printf/vprintf/fprintf to eliminate _vfprintf_r (~9.2 KB flash)

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -190,6 +190,11 @@ async def to_code(config):
         ],
     )
 
+    # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
+    # (~8.9 KB). See printf_stubs.cpp for implementation.
+    for symbol in ("vprintf", "printf", "fprintf"):
+        cg.add_build_flag(f"-Wl,--wrap={symbol}")
+
     cg.add_platformio_option("board_build.core", "earlephilhower")
     cg.add_platformio_option("board_build.filesystem_size", "1m")
 

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -21,7 +21,13 @@ from esphome.const import (
 from esphome.core import CORE, CoroPriority, EsphomeError, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, read_file, write_file_if_changed
 
-from .const import KEY_BOARD, KEY_PIO_FILES, KEY_RP2040, rp2040_ns
+from .const import (
+    CONF_ENABLE_FULL_PRINTF,
+    KEY_BOARD,
+    KEY_PIO_FILES,
+    KEY_RP2040,
+    rp2040_ns,
+)
 
 # force import gpio to register pin schema
 from .gpio import rp2040_pin_to_code  # noqa
@@ -153,6 +159,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.positive_time_period_milliseconds,
                 cv.Range(max=cv.TimePeriod(milliseconds=8388)),
             ),
+            cv.Optional(CONF_ENABLE_FULL_PRINTF, default=False): cv.boolean,
         }
     ),
     set_core_data,
@@ -191,9 +198,12 @@ async def to_code(config):
     )
 
     # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
-    # (~8.9 KB). See printf_stubs.cpp for implementation.
-    for symbol in ("vprintf", "printf", "fprintf"):
-        cg.add_build_flag(f"-Wl,--wrap={symbol}")
+    # (~9.2 KB). See printf_stubs.cpp for implementation.
+    if config.get(CONF_ENABLE_FULL_PRINTF):
+        cg.add_define("USE_FULL_PRINTF")
+    else:
+        for symbol in ("vprintf", "printf", "fprintf"):
+            cg.add_build_flag(f"-Wl,--wrap={symbol}")
 
     cg.add_platformio_option("board_build.core", "earlephilhower")
     cg.add_platformio_option("board_build.filesystem_size", "1m")

--- a/esphome/components/rp2040/const.py
+++ b/esphome/components/rp2040/const.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 
+CONF_ENABLE_FULL_PRINTF = "enable_full_printf"
 KEY_BOARD = "board"
 KEY_RP2040 = "rp2040"
 KEY_PIO_FILES = "pio_files"

--- a/esphome/components/rp2040/printf_stubs.cpp
+++ b/esphome/components/rp2040/printf_stubs.cpp
@@ -1,0 +1,71 @@
+/*
+ * Linker wrap stubs for FILE*-based printf functions.
+ *
+ * The RP2040 Arduino framework and libraries may reference printf(),
+ * vprintf(), and fprintf() which pull in newlib's _vfprintf_r (~8.9 KB).
+ * ESPHome never uses these — all logging goes through the logger component
+ * which uses snprintf/vsnprintf, so the libc FILE*-based printf path is
+ * dead code.
+ *
+ * These stubs redirect through vsnprintf() (which is already in the binary)
+ * and fwrite(), allowing the linker to dead-code eliminate _vfprintf_r.
+ *
+ * Saves ~8.9 KB of flash.
+ */
+
+#if defined(USE_RP2040) && !defined(USE_FULL_PRINTF)
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+
+namespace esphome::rp2040 {}
+
+static constexpr size_t PRINTF_BUFFER_SIZE = 512;
+
+// These stubs are essentially dead code at runtime — ESPHome uses its own
+// logging through snprintf/vsnprintf, not libc printf.
+// The buffer overflow check is purely defensive and should never trigger.
+static int write_printf_buffer(FILE *stream, char *buf, int len) {
+  if (len < 0) {
+    return len;
+  }
+  size_t write_len = len;
+  if (write_len >= PRINTF_BUFFER_SIZE) {
+    fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
+    abort();
+  }
+  if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {
+    return -1;
+  }
+  return len;
+}
+
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+extern "C" {
+
+int __wrap_vprintf(const char *fmt, va_list ap) {
+  char buf[PRINTF_BUFFER_SIZE];
+  return write_printf_buffer(stdout, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+}
+
+int __wrap_printf(const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  int len = __wrap_vprintf(fmt, ap);
+  va_end(ap);
+  return len;
+}
+
+int __wrap_fprintf(FILE *stream, const char *fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  char buf[PRINTF_BUFFER_SIZE];
+  int len = write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+  va_end(ap);
+  return len;
+}
+
+}  // extern "C"
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+
+#endif  // USE_RP2040 && !USE_FULL_PRINTF

--- a/esphome/components/rp2040/printf_stubs.cpp
+++ b/esphome/components/rp2040/printf_stubs.cpp
@@ -32,6 +32,9 @@ static int write_printf_buffer(FILE *stream, char *buf, int len) {
   size_t write_len = len;
   if (write_len >= PRINTF_BUFFER_SIZE) {
     fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
+    // Use fwrite for the message to avoid recursive __wrap_printf call
+    static const char msg[] = "\nprintf buffer overflow\n";
+    fwrite(msg, 1, sizeof(msg) - 1, stream);
     abort();
   }
   if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {

--- a/tests/components/rp2040/test.rp2040-ard.yaml
+++ b/tests/components/rp2040/test.rp2040-ard.yaml
@@ -1,3 +1,6 @@
+rp2040:
+  enable_full_printf: false
+
 logger:
   level: VERBOSE
 


### PR DESCRIPTION
# What does this implement/fix?

Apply the same linker wrap technique used on ESP32 (#14362) to RP2040. ESPHome logging uses `snprintf`/`vsnprintf`, not libc `printf`, so the FILE*-based printf path (`_vfprintf_r`) is dead code at runtime.

The stubs redirect `printf`/`vprintf`/`fprintf` through `vsnprintf` + `fwrite`, allowing the linker to garbage-collect `_vfprintf_r` and related symbols.

**Saves 9,188 bytes of flash (-7.77%).**

The wraps eliminate `_vfprintf_r` (8,892 B) plus its wrappers (`printf`, `_printf_r`, `vfprintf`, `vprintf`, `_vprintf_r`) — totaling 9,016 bytes removed. The replacement stubs + `_fwrite_r` cost only 526 bytes.

An `enable_full_printf` config option is provided as an escape hatch for external components that need full FILE*-based printf.

All external libraries were already audited during the ESP32 PR (#14362) — no libraries actually call `printf`/`vprintf`/`fprintf` at runtime. The references only exist in debug/assert paths that are GC'd or never reached. The same libraries are used across platforms, so these stubs are truly dead code on RP2040 as well.

LibreTiny already ships `__wrap_printf`/`__wrap_vprintf` via its `library-printf` package, so this is not needed there.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (follows #14362 pattern for ESP32)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6239

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - optimization is enabled by default.
# To disable (if an external component needs full printf):
rp2040:
  board: rpipicow
  enable_full_printf: true
```

## Checklist:
  - [x] The code change is tested and works locally. Tested on real RP2040 device.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).