### PR TITLE
[scheduler] Use `std::atomic<uint8_t>` instead of `std::atomic<bool>` for remove flag

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -178,9 +178,11 @@ class Scheduler {
     uint16_t next_execution_high_;  // Upper 16 bits (millis_major counter)
 
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
-    // Multi-threaded with atomics: use atomic for lock-free access
-    // Place atomic<bool> separately since it can't be packed with bit fields
-    std::atomic<bool> remove{false};
+    // Multi-threaded with atomics: use atomic uint8_t for lock-free access.
+    // std::atomic<bool> is not used because GCC on Xtensa generates an indirect
+    // function call for std::atomic<bool>::load() instead of inlining it.
+    // std::atomic<uint8_t> inlines correctly on all platforms.
+    std::atomic<uint8_t> remove{0};
 
     // Bit-packed fields (4 bits used, 4 bits padding in 1 byte)
     enum Type : uint8_t { TIMEOUT, INTERVAL } type : 1;
@@ -204,7 +206,7 @@ class Scheduler {
           next_execution_low_(0),
           next_execution_high_(0),
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
-          // remove is initialized in the member declaration as std::atomic<bool>{false}
+          // remove is initialized in the member declaration
           type(TIMEOUT),
           name_type_(NameType::STATIC_STRING),
           is_retry(false) {
@@ -508,7 +510,7 @@ class Scheduler {
     // Multi-threaded with atomics: use atomic store with appropriate ordering
     // Release ordering when setting to true ensures cancellation is visible to other threads
     // Relaxed ordering when setting to false is sufficient for initialization
-    item->remove.store(removed, removed ? std::memory_order_release : std::memory_order_relaxed);
+    item->remove.store(removed ? 1 : 0, removed ? std::memory_order_release : std::memory_order_relaxed);
 #else
     // Single-threaded (ESPHOME_THREAD_SINGLE) or
     // multi-threaded without atomics (ESPHOME_THREAD_MULTI_NO_ATOMICS): direct write


### PR DESCRIPTION
# What does this implement/fix?

GCC on Xtensa (ESP32) generates an indirect function call for `std::atomic<bool>::load()` instead of inlining it. This causes unnecessary call overhead on the scheduler hot path, where the `remove` flag is checked multiple times per loop iteration.

`std::atomic<bool>::store()` inlines correctly — the problem is specific to `load()`. Other atomic types like `std::atomic<uint8_t>` inline both `load()` and `store()` correctly, as confirmed by examining the `LockFreeQueue` disassembly which uses `std::atomic<uint8_t>` for `head_` and `tail_`.

### Alternatives considered

1. **`__atomic` builtins on a plain `bool`**: Works and inlines, but using compiler builtins directly is harder to maintain and less readable than the standard `std::atomic` API.

2. **Custom `AtomicBool` wrapper class**: Clean API, but `always_inline` was required to force inlining — without it GCC still generated indirect calls through the wrapper. Added complexity for no benefit over the simpler fix.

3. **`std::atomic<uint8_t>`** (this PR): One-line type change. Same size, same alignment, same memory ordering guarantees. GCC inlines all operations correctly. No new abstractions needed.

### Verification

Disassembly before (indirect call via function pointer):
```asm
l32r    a8, (40157210 <_ZNKSt6atomicIbE4loadESt12memory_order>)
callx8  a8
```

Disassembly after (inline load with barrier):
```asm
memw
l8ui    a8, a8, 34
```

Scheduler hot path: 1,697 → 1,667 bytes (−30 bytes, 5 indirect calls eliminated).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
    - Existing scheduler integration tests cover the `remove` flag behavior (cancel, timeout, interval lifecycle).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).