### PR TITLE
[api] Define NATIVE_LITTLE_ENDIAN for libsodium crypto optimization

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -455,7 +455,8 @@ async def to_code(config: ConfigType) -> None:
         cg.add_define("USE_API_NOISE")
         # libsodium uses NATIVE_LITTLE_ENDIAN to enable optimized 32-bit
         # load/store via memcpy instead of byte-at-a-time operations in
-        # poly1305 and chacha20.
+        # poly1305 and chacha20. All current ESPHome targets are
+        # little-endian (ESP32, ESP8266, RP2040, LibreTiny, host).
         if (
             CORE.is_esp32
             or CORE.is_esp8266
@@ -463,6 +464,7 @@ async def to_code(config: ConfigType) -> None:
             or CORE.is_bk72xx
             or CORE.is_rtl87xx
             or CORE.is_ln882x
+            or CORE.is_host
         ):
             cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
         cg.add_library("esphome/noise-c", "0.1.10")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -455,18 +455,8 @@ async def to_code(config: ConfigType) -> None:
         cg.add_define("USE_API_NOISE")
         # libsodium uses NATIVE_LITTLE_ENDIAN to enable optimized 32-bit
         # load/store via memcpy instead of byte-at-a-time operations in
-        # poly1305 and chacha20. All current ESPHome targets are
-        # little-endian (ESP32, ESP8266, RP2040, LibreTiny, host).
-        if (
-            CORE.is_esp32
-            or CORE.is_esp8266
-            or CORE.is_rp2040
-            or CORE.is_bk72xx
-            or CORE.is_rtl87xx
-            or CORE.is_ln882x
-            or CORE.is_host
-        ):
-            cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
+        # poly1305 and chacha20. All ESPHome targets are little-endian.
+        cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
         cg.add_library("esphome/noise-c", "0.1.10")
     else:
         cg.add_define("USE_API_PLAINTEXT")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -456,7 +456,10 @@ async def to_code(config: ConfigType) -> None:
         # libsodium uses NATIVE_LITTLE_ENDIAN to enable optimized 32-bit
         # load/store via memcpy instead of byte-at-a-time operations in
         # poly1305 and chacha20. All ESPHome targets are little-endian.
-        cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
+        # ESP8266 excluded: its older GCC doesn't optimize memcpy into
+        # a single load, making the memcpy path 16 bytes larger.
+        if not CORE.is_esp8266:
+            cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
         cg.add_library("esphome/noise-c", "0.1.10")
     else:
         cg.add_define("USE_API_PLAINTEXT")

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -453,6 +453,18 @@ async def to_code(config: ConfigType) -> None:
             # and plaintext disabled. Only a factory reset can remove it.
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
+        # libsodium uses NATIVE_LITTLE_ENDIAN to enable optimized 32-bit
+        # load/store via memcpy instead of byte-at-a-time operations in
+        # poly1305 and chacha20.
+        if (
+            CORE.is_esp32
+            or CORE.is_esp8266
+            or CORE.is_rp2040
+            or CORE.is_bk72xx
+            or CORE.is_rtl87xx
+            or CORE.is_ln882x
+        ):
+            cg.add_build_flag("-DNATIVE_LITTLE_ENDIAN")
         cg.add_library("esphome/noise-c", "0.1.10")
     else:
         cg.add_define("USE_API_PLAINTEXT")


### PR DESCRIPTION
# What does this implement/fix?

libsodium's autoconf-generated config normally sets `NATIVE_LITTLE_ENDIAN`, but PlatformIO skips autoconf. Without this define, libsodium falls back to byte-at-a-time load/store operations in poly1305 and chacha20 instead of optimized 32-bit `memcpy`.

This saves flash and improves encryption/decryption throughput on every API noise packet.

ESP8266 is excluded because its older Arduino GCC doesn't optimize small `memcpy` into single load/store instructions — the memcpy path is actually 16 bytes larger and slower on that platform (byte loads → stack stores → 32-bit stack load, adding unnecessary stack round-trips).

### Flash savings by platform

| Platform | Without Flag | With Flag | Savings |
|----------|-------------|-----------|---------|
| ESP32 IDF | 881,959 B | 881,619 B | **-340 B** |
| BK72xx | 562,066 B | 561,538 B | **-528 B** |
| RTL87xx | 524,585 B | 524,161 B | **-424 B** |
| RP2040 | 515,268 B | 515,244 B | **-24 B** |
| ESP8266 | 424,223 B | 424,239 B | +16 B (excluded) |

### poly1305_finish size by platform

| Platform | Without Flag | With Flag | Savings |
|----------|-------------|-----------|---------|
| BK72xx | 538 B | 494 B | **-44 B** |
| RTL87xx | 394 B | 340 B | **-54 B** |
| RP2040 | 478 B | 470 B | **-8 B** |
| ESP32 IDF | 429 B | 401 B | **-28 B** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - automatic when using noise encryption
api:
  encryption:
    key: "your_key_here"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).