### PR TITLE
[multiple] Add array bounds checks

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.cpp
+++ b/esphome/components/addressable_light/addressable_light_display.cpp
@@ -58,7 +58,10 @@ void HOT AddressableLightDisplay::draw_absolute_pixel_internal(int x, int y, Col
 
   if (this->pixel_mapper_f_.has_value()) {
     // Params are passed by reference, so they may be modified in call.
-    this->addressable_light_buffer_[(*this->pixel_mapper_f_)(x, y)] = color;
+    int index = (*this->pixel_mapper_f_)(x, y);
+    if (index < 0 || static_cast<size_t>(index) >= this->addressable_light_buffer_.size())
+      return;
+    this->addressable_light_buffer_[index] = color;
   } else {
     this->addressable_light_buffer_[y * this->get_width_internal() + x] = color;
   }

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -383,7 +383,7 @@ void BME680BSECComponent::publish_(const bsec_output_t *outputs, uint8_t num_out
     switch (outputs[i].sensor_id) {
       case BSEC_OUTPUT_IAQ:
       case BSEC_OUTPUT_STATIC_IAQ: {
-        uint8_t accuracy = std::min(outputs[i].accuracy, (uint8_t) 3);
+        uint8_t accuracy = std::min<uint8_t>(outputs[i].accuracy, std::size(IAQ_ACCURACY_STATES) - 1);
         this->queue_push_([this, signal]() { this->publish_sensor_(this->iaq_sensor_, signal); });
         this->queue_push_([this, accuracy]() {
           this->publish_sensor_(this->iaq_accuracy_text_sensor_, IAQ_ACCURACY_STATES[accuracy]);

--- a/esphome/components/bme680_bsec/bme680_bsec.cpp
+++ b/esphome/components/bme680_bsec/bme680_bsec.cpp
@@ -383,7 +383,7 @@ void BME680BSECComponent::publish_(const bsec_output_t *outputs, uint8_t num_out
     switch (outputs[i].sensor_id) {
       case BSEC_OUTPUT_IAQ:
       case BSEC_OUTPUT_STATIC_IAQ: {
-        uint8_t accuracy = outputs[i].accuracy;
+        uint8_t accuracy = std::min(outputs[i].accuracy, (uint8_t) 3);
         this->queue_push_([this, signal]() { this->publish_sensor_(this->iaq_sensor_, signal); });
         this->queue_push_([this, accuracy]() {
           this->publish_sensor_(this->iaq_accuracy_text_sensor_, IAQ_ACCURACY_STATES[accuracy]);

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -438,6 +438,7 @@ void BME68xBSEC2Component::publish_(const bsec_output_t *outputs, uint8_t num_ou
     }
   }
   if (update_accuracy) {
+    max_accuracy = std::min(max_accuracy, (uint8_t) 3);
 #ifdef USE_SENSOR
     this->queue_push_(
         [this, max_accuracy]() { this->publish_sensor_(this->iaq_accuracy_sensor_, max_accuracy, true); });

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -438,7 +438,7 @@ void BME68xBSEC2Component::publish_(const bsec_output_t *outputs, uint8_t num_ou
     }
   }
   if (update_accuracy) {
-    max_accuracy = std::min(max_accuracy, (uint8_t) 3);
+    max_accuracy = std::min<uint8_t>(max_accuracy, std::size(IAQ_ACCURACY_STATES) - 1);
 #ifdef USE_SENSOR
     this->queue_push_(
         [this, max_accuracy]() { this->publish_sensor_(this->iaq_accuracy_sensor_, max_accuracy, true); });

--- a/esphome/components/dac7678/dac7678_output.cpp
+++ b/esphome/components/dac7678/dac7678_output.cpp
@@ -62,7 +62,7 @@ void DAC7678Output::register_channel(DAC7678Channel *channel) {
 }
 
 void DAC7678Output::set_channel_value_(uint8_t channel, uint16_t value) {
-  if (channel >= 8)
+  if (channel >= std::size(this->dac_input_reg_))
     return;
   if (this->dac_input_reg_[channel] != value) {
     ESP_LOGV(TAG, "Channel %01u: input_reg=%04u ", channel, value);

--- a/esphome/components/dac7678/dac7678_output.cpp
+++ b/esphome/components/dac7678/dac7678_output.cpp
@@ -62,6 +62,8 @@ void DAC7678Output::register_channel(DAC7678Channel *channel) {
 }
 
 void DAC7678Output::set_channel_value_(uint8_t channel, uint16_t value) {
+  if (channel >= 8)
+    return;
   if (this->dac_input_reg_[channel] != value) {
     ESP_LOGV(TAG, "Channel %01u: input_reg=%04u ", channel, value);
 

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -452,7 +452,8 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
       }
       break;
     case 0x83:
-      if (this->custom_presence_of_detection_sensor_ != nullptr && data[FRAME_DATA_INDEX] < 7) {
+      if (this->custom_presence_of_detection_sensor_ != nullptr &&
+          data[FRAME_DATA_INDEX] < std::size(S_PRESENCE_OF_DETECTION_RANGE_STR)) {
         this->custom_presence_of_detection_sensor_->publish_state(
             S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
       }
@@ -646,7 +647,7 @@ void MR24HPC1Component::r24_frame_parse_human_information_(uint8_t *data) {
 #ifdef USE_BINARY_SENSOR
     case 0x01:
     case 0x81:
-      if (this->has_target_binary_sensor_ != nullptr && data[FRAME_DATA_INDEX] < 2) {
+      if (this->has_target_binary_sensor_ != nullptr && data[FRAME_DATA_INDEX] < std::size(S_SOMEONE_EXISTS_STR)) {
         this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
       }
       break;

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -452,7 +452,7 @@ void MR24HPC1Component::r24_frame_parse_open_underlying_information_(uint8_t *da
       }
       break;
     case 0x83:
-      if (this->custom_presence_of_detection_sensor_ != nullptr) {
+      if (this->custom_presence_of_detection_sensor_ != nullptr && data[FRAME_DATA_INDEX] < 7) {
         this->custom_presence_of_detection_sensor_->publish_state(
             S_PRESENCE_OF_DETECTION_RANGE_STR[data[FRAME_DATA_INDEX]]);
       }
@@ -646,7 +646,7 @@ void MR24HPC1Component::r24_frame_parse_human_information_(uint8_t *data) {
 #ifdef USE_BINARY_SENSOR
     case 0x01:
     case 0x81:
-      if (this->has_target_binary_sensor_ != nullptr) {
+      if (this->has_target_binary_sensor_ != nullptr && data[FRAME_DATA_INDEX] < 2) {
         this->has_target_binary_sensor_->publish_state(S_SOMEONE_EXISTS_STR[data[FRAME_DATA_INDEX]]);
       }
       break;

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -334,6 +334,8 @@ void MR60FDA2Component::process_frame_() {
 
 // Send Heartbeat Packet Command
 void MR60FDA2Component::set_install_height(uint8_t index) {
+  if (index >= 7)
+    return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x04, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00};
   float_to_bytes(INSTALL_HEIGHT[index], &send_data[8]);
   send_data[12] = calculate_checksum(send_data + 8, 4);
@@ -345,6 +347,8 @@ void MR60FDA2Component::set_install_height(uint8_t index) {
 }
 
 void MR60FDA2Component::set_height_threshold(uint8_t index) {
+  if (index >= 7)
+    return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x08, 0xFC, 0x00, 0x00, 0x00, 0x00, 0x00};
   float_to_bytes(HEIGHT_THRESHOLD[index], &send_data[8]);
   send_data[12] = calculate_checksum(send_data + 8, 4);
@@ -356,6 +360,8 @@ void MR60FDA2Component::set_height_threshold(uint8_t index) {
 }
 
 void MR60FDA2Component::set_sensitivity(uint8_t index) {
+  if (index >= 3)
+    return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x0A, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00};
 
   int_to_bytes(SENSITIVITY[index], &send_data[8]);

--- a/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
+++ b/esphome/components/seeed_mr60fda2/seeed_mr60fda2.cpp
@@ -334,7 +334,7 @@ void MR60FDA2Component::process_frame_() {
 
 // Send Heartbeat Packet Command
 void MR60FDA2Component::set_install_height(uint8_t index) {
-  if (index >= 7)
+  if (index >= std::size(INSTALL_HEIGHT))
     return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x04, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00};
   float_to_bytes(INSTALL_HEIGHT[index], &send_data[8]);
@@ -347,7 +347,7 @@ void MR60FDA2Component::set_install_height(uint8_t index) {
 }
 
 void MR60FDA2Component::set_height_threshold(uint8_t index) {
-  if (index >= 7)
+  if (index >= std::size(HEIGHT_THRESHOLD))
     return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x08, 0xFC, 0x00, 0x00, 0x00, 0x00, 0x00};
   float_to_bytes(HEIGHT_THRESHOLD[index], &send_data[8]);
@@ -360,7 +360,7 @@ void MR60FDA2Component::set_height_threshold(uint8_t index) {
 }
 
 void MR60FDA2Component::set_sensitivity(uint8_t index) {
-  if (index >= 3)
+  if (index >= std::size(SENSITIVITY))
     return;
   uint8_t send_data[13] = {0x01, 0x00, 0x00, 0x00, 0x04, 0x0E, 0x0A, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00};
 


### PR DESCRIPTION
# What does this implement/fix?

Adds bounds checks before array accesses indexed by external/unchecked data:

- **seeed_mr24hpc1**: `S_SOMEONE_EXISTS_STR[2]` and `S_PRESENCE_OF_DETECTION_RANGE_STR[7]` indexed by unchecked `uint8_t` from radar data
- **seeed_mr60fda2**: `INSTALL_HEIGHT[7]`, `HEIGHT_THRESHOLD[7]`, `SENSITIVITY[3]` indexed by unchecked `uint8_t` parameter
- **bme680_bsec**: `IAQ_ACCURACY_STATES[4]` indexed by unchecked accuracy value from BSEC output
- **bme68x_bsec2**: Same pattern as bme680_bsec
- **dac7678**: `dac_input_reg_[8]` indexed by unchecked channel parameter
- **addressable_light**: `addressable_light_buffer_` indexed by unchecked user callback return value

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - defensive guards only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).