### PR TITLE
[api] Inline ProtoVarInt::parse fast path and return consumed in struct

### DIFF
--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -138,7 +138,8 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
 
     if (msg_size_varint.value > MAX_MESSAGE_SIZE) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint.value, MAX_MESSAGE_SIZE);
+      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u",
+                 static_cast<uint32_t>(msg_size_varint.value), MAX_MESSAGE_SIZE);
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_len_ = static_cast<uint16_t>(msg_size_varint.value);
@@ -153,8 +154,8 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
     }
     if (msg_type_varint.value > std::numeric_limits<uint16_t>::max()) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint.value,
-                 std::numeric_limits<uint16_t>::max());
+      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u",
+                 static_cast<uint32_t>(msg_type_varint.value), std::numeric_limits<uint16_t>::max());
       return APIError::BAD_DATA_PACKET;
     }
     rx_header_parsed_type_ = static_cast<uint16_t>(msg_type_varint.value);

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -128,37 +128,36 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
 
     // Skip indicator byte at position 0
     uint8_t varint_pos = 1;
-    uint32_t consumed = 0;
 
-    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos, &consumed);
+    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos);
     if (!msg_size_varint.has_value()) {
       // not enough data there yet
       continue;
     }
 
-    if (msg_size_varint->as_uint32() > MAX_MESSAGE_SIZE) {
+    if (msg_size_varint.as_uint32() > MAX_MESSAGE_SIZE) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint->as_uint32(),
+      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint.as_uint32(),
                  MAX_MESSAGE_SIZE);
       return APIError::BAD_DATA_PACKET;
     }
-    rx_header_parsed_len_ = msg_size_varint->as_uint16();
+    rx_header_parsed_len_ = msg_size_varint.as_uint16();
 
     // Move to next varint position
-    varint_pos += consumed;
+    varint_pos += msg_size_varint.consumed;
 
-    auto msg_type_varint = ProtoVarInt::parse(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos, &consumed);
+    auto msg_type_varint = ProtoVarInt::parse(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos);
     if (!msg_type_varint.has_value()) {
       // not enough data there yet
       continue;
     }
-    if (msg_type_varint->as_uint32() > std::numeric_limits<uint16_t>::max()) {
+    if (msg_type_varint.as_uint32() > std::numeric_limits<uint16_t>::max()) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint->as_uint32(),
+      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint.as_uint32(),
                  std::numeric_limits<uint16_t>::max());
       return APIError::BAD_DATA_PACKET;
     }
-    rx_header_parsed_type_ = msg_type_varint->as_uint16();
+    rx_header_parsed_type_ = msg_type_varint.as_uint16();
     rx_header_parsed_ = true;
   }
   // header reading done

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -129,7 +129,8 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
     // Skip indicator byte at position 0
     uint8_t varint_pos = 1;
 
-    auto msg_size_varint = ProtoVarInt::parse(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos);
+    // rx_header_buf_pos_ >= 3 and varint_pos == 1, so len >= 2
+    auto msg_size_varint = ProtoVarInt::parse_non_empty(&rx_header_buf_[varint_pos], rx_header_buf_pos_ - varint_pos);
     if (!msg_size_varint.has_value()) {
       // not enough data there yet
       continue;

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -136,13 +136,12 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
       continue;
     }
 
-    if (msg_size_varint.as_uint32() > MAX_MESSAGE_SIZE) {
+    if (msg_size_varint.value > MAX_MESSAGE_SIZE) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint.as_uint32(),
-                 MAX_MESSAGE_SIZE);
+      HELPER_LOG("Bad packet: message size %" PRIu32 " exceeds maximum %u", msg_size_varint.value, MAX_MESSAGE_SIZE);
       return APIError::BAD_DATA_PACKET;
     }
-    rx_header_parsed_len_ = msg_size_varint.as_uint16();
+    rx_header_parsed_len_ = static_cast<uint16_t>(msg_size_varint.value);
 
     // Move to next varint position
     varint_pos += msg_size_varint.consumed;
@@ -152,13 +151,13 @@ APIError APIPlaintextFrameHelper::try_read_frame_() {
       // not enough data there yet
       continue;
     }
-    if (msg_type_varint.as_uint32() > std::numeric_limits<uint16_t>::max()) {
+    if (msg_type_varint.value > std::numeric_limits<uint16_t>::max()) {
       state_ = State::FAILED;
-      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint.as_uint32(),
+      HELPER_LOG("Bad packet: message type %" PRIu32 " exceeds maximum %u", msg_type_varint.value,
                  std::numeric_limits<uint16_t>::max());
       return APIError::BAD_DATA_PACKET;
     }
-    rx_header_parsed_type_ = msg_type_varint.as_uint16();
+    rx_header_parsed_type_ = static_cast<uint16_t>(msg_type_varint.value);
     rx_header_parsed_ = true;
   }
   // header reading done

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7,7 +7,7 @@
 
 namespace esphome::api {
 
-bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->api_version_major = value.as_uint32();
@@ -316,7 +316,7 @@ uint32_t CoverStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 4:
       this->has_position = value.as_bool();
@@ -423,7 +423,7 @@ uint32_t FanStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_state = value.as_bool();
@@ -571,7 +571,7 @@ uint32_t LightStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_state = value.as_bool();
@@ -787,7 +787,7 @@ uint32_t SwitchStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->state = value.as_bool();
@@ -863,7 +863,7 @@ uint32_t TextSensorStateResponse::calculate_size() const {
   return size;
 }
 #endif
-bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->level = static_cast<enums::LogLevel>(value.as_uint32());
@@ -971,7 +971,7 @@ uint32_t HomeassistantActionRequest::calculate_size() const {
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
-bool HomeassistantActionResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool HomeassistantActionResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->call_id = value.as_uint32();
@@ -1036,7 +1036,7 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
   return true;
 }
 #endif
-bool DSTRule::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool DSTRule::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->time_seconds = value.as_sint32();
@@ -1061,7 +1061,7 @@ bool DSTRule::decode_varint(uint32_t field_id, ProtoVarInt value) {
   }
   return true;
 }
-bool ParsedTimezone::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ParsedTimezone::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->std_offset_seconds = value.as_sint32();
@@ -1142,7 +1142,7 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->supports_response));
   return size;
 }
-bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->bool_ = value.as_bool();
@@ -1202,7 +1202,7 @@ void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
   this->string_array.init(count_string_array);
   ProtoDecodableMessage::decode(buffer, length);
 }
-bool ExecuteServiceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ExecuteServiceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
     case 3:
@@ -1313,7 +1313,7 @@ uint32_t CameraImageResponse::calculate_size() const {
 #endif
   return size;
 }
-bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->single = value.as_bool();
@@ -1468,7 +1468,7 @@ uint32_t ClimateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_mode = value.as_bool();
@@ -1631,7 +1631,7 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
   size += ProtoSize::calc_float(1, this->target_temperature_high);
   return size;
 }
-bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_fields = value.as_uint32();
@@ -1731,7 +1731,7 @@ uint32_t NumberStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool NumberCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool NumberCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -1812,7 +1812,7 @@ uint32_t SelectStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -1903,7 +1903,7 @@ uint32_t SirenStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_state = value.as_bool();
@@ -2011,7 +2011,7 @@ uint32_t LockStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::LockCommand>(value.as_uint32());
@@ -2082,7 +2082,7 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ButtonCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ButtonCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 2:
@@ -2182,7 +2182,7 @@ uint32_t MediaPlayerStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_command = value.as_bool();
@@ -2238,7 +2238,7 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->flags = value.as_uint32();
@@ -2274,7 +2274,7 @@ uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   }
   return size;
 }
-bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2307,7 +2307,7 @@ uint32_t BluetoothDeviceConnectionResponse::calculate_size() const {
   size += ProtoSize::calc_int32(1, this->error);
   return size;
 }
-bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2413,7 +2413,7 @@ uint32_t BluetoothGATTGetServicesDoneResponse::calculate_size() const {
   size += ProtoSize::calc_uint64(1, this->address);
   return size;
 }
-bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2438,7 +2438,7 @@ uint32_t BluetoothGATTReadResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2466,7 +2466,7 @@ bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDeli
   }
   return true;
 }
-bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2479,7 +2479,7 @@ bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoV
   }
   return true;
 }
-bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2504,7 +2504,7 @@ bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, Proto
   }
   return true;
 }
-bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();
@@ -2632,7 +2632,7 @@ uint32_t BluetoothScannerStateResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->configured_mode));
   return size;
 }
-bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->mode = static_cast<enums::BluetoothScannerMode>(value.as_uint32());
@@ -2644,7 +2644,7 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIn
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
-bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->subscribe = value.as_bool();
@@ -2685,7 +2685,7 @@ uint32_t VoiceAssistantRequest::calculate_size() const {
   size += ProtoSize::calc_length(1, this->wake_word_phrase.size());
   return size;
 }
-bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->port = value.as_uint32();
@@ -2713,7 +2713,7 @@ bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->event_type = static_cast<enums::VoiceAssistantEvent>(value.as_uint32());
@@ -2734,7 +2734,7 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
   return true;
 }
-bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->end = value.as_bool();
@@ -2766,7 +2766,7 @@ uint32_t VoiceAssistantAudio::calculate_size() const {
   size += ProtoSize::calc_bool(1, this->end);
   return size;
 }
-bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value.as_uint32());
@@ -2800,7 +2800,7 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
   return true;
 }
-bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 4:
       this->start_conversation = value.as_bool();
@@ -2853,7 +2853,7 @@ uint32_t VoiceAssistantWakeWord::calculate_size() const {
   }
   return size;
 }
-bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 5:
       this->model_size = value.as_uint32();
@@ -2990,7 +2990,7 @@ uint32_t AlarmControlPanelStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::AlarmControlPanelStateCommand>(value.as_uint32());
@@ -3082,7 +3082,7 @@ uint32_t TextStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -3167,7 +3167,7 @@ uint32_t DateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->year = value.as_uint32();
@@ -3250,7 +3250,7 @@ uint32_t TimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->hour = value.as_uint32();
@@ -3393,7 +3393,7 @@ uint32_t ValveStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->has_position = value.as_bool();
@@ -3472,7 +3472,7 @@ uint32_t DateTimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool DateTimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool DateTimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -3561,7 +3561,7 @@ uint32_t UpdateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::UpdateCommand>(value.as_uint32());
@@ -3606,7 +3606,7 @@ uint32_t ZWaveProxyFrame::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len);
   return size;
 }
-bool ZWaveProxyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool ZWaveProxyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->type = static_cast<enums::ZWaveProxyRequestType>(value.as_uint32());
@@ -3672,7 +3672,7 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_IR_RF
-bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 1:
@@ -3737,7 +3737,7 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 }
 #endif
 #ifdef USE_SERIAL_PROXY
-bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->instance = value.as_uint32();
@@ -3772,7 +3772,7 @@ uint32_t SerialProxyDataReceived::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->instance = value.as_uint32();
@@ -3794,7 +3794,7 @@ bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->instance = value.as_uint32();
@@ -3807,7 +3807,7 @@ bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarIn
   }
   return true;
 }
-bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->instance = value.as_uint32();
@@ -3827,7 +3827,7 @@ uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, this->line_states);
   return size;
 }
-bool SerialProxyRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool SerialProxyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->instance = value.as_uint32();
@@ -3856,7 +3856,7 @@ uint32_t SerialProxyRequestResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, ProtoVarInt value) {
+bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
   switch (field_id) {
     case 1:
       this->address = value.as_uint64();

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7,11 +7,7 @@
 
 namespace esphome::api {
 
-#ifdef USE_API_VARINT64
-bool HelloRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool HelloRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool HelloRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->api_version_major = value;
@@ -320,11 +316,7 @@ uint32_t CoverStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool CoverCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool CoverCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool CoverCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 4:
       this->has_position = value != 0;
@@ -431,11 +423,7 @@ uint32_t FanStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool FanCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool FanCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool FanCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_state = value != 0;
@@ -583,11 +571,7 @@ uint32_t LightStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool LightCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool LightCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool LightCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_state = value != 0;
@@ -803,11 +787,7 @@ uint32_t SwitchStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool SwitchCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SwitchCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SwitchCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->state = value != 0;
@@ -883,11 +863,7 @@ uint32_t TextSensorStateResponse::calculate_size() const {
   return size;
 }
 #endif
-#ifdef USE_API_VARINT64
-bool SubscribeLogsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SubscribeLogsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SubscribeLogsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->level = static_cast<enums::LogLevel>(value);
@@ -995,11 +971,7 @@ uint32_t HomeassistantActionRequest::calculate_size() const {
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
-#ifdef USE_API_VARINT64
-bool HomeassistantActionResponse::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool HomeassistantActionResponse::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool HomeassistantActionResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->call_id = value;
@@ -1064,11 +1036,7 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
   return true;
 }
 #endif
-#ifdef USE_API_VARINT64
-bool DSTRule::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool DSTRule::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->time_seconds = decode_zigzag32(value);
@@ -1093,11 +1061,7 @@ bool DSTRule::decode_varint(uint32_t field_id, uint32_t value) {
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool ParsedTimezone::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ParsedTimezone::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ParsedTimezone::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->std_offset_seconds = decode_zigzag32(value);
@@ -1178,11 +1142,7 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->supports_response));
   return size;
 }
-#ifdef USE_API_VARINT64
-bool ExecuteServiceArgument::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ExecuteServiceArgument::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ExecuteServiceArgument::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->bool_ = value != 0;
@@ -1242,11 +1202,7 @@ void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
   this->string_array.init(count_string_array);
   ProtoDecodableMessage::decode(buffer, length);
 }
-#ifdef USE_API_VARINT64
-bool ExecuteServiceRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ExecuteServiceRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ExecuteServiceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
     case 3:
@@ -1357,11 +1313,7 @@ uint32_t CameraImageResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool CameraImageRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool CameraImageRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->single = value != 0;
@@ -1516,11 +1468,7 @@ uint32_t ClimateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool ClimateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ClimateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ClimateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_mode = value != 0;
@@ -1683,11 +1631,7 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
   size += ProtoSize::calc_float(1, this->target_temperature_high);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_fields = value;
@@ -1787,11 +1731,7 @@ uint32_t NumberStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool NumberCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool NumberCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool NumberCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -1872,11 +1812,7 @@ uint32_t SelectStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool SelectCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SelectCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SelectCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -1967,11 +1903,7 @@ uint32_t SirenStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool SirenCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SirenCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SirenCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_state = value != 0;
@@ -2079,11 +2011,7 @@ uint32_t LockStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool LockCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool LockCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool LockCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::LockCommand>(value);
@@ -2154,11 +2082,7 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool ButtonCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ButtonCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ButtonCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 2:
@@ -2258,11 +2182,7 @@ uint32_t MediaPlayerStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_command = value != 0;
@@ -2318,11 +2238,7 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-#ifdef USE_API_VARINT64
-bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->flags = value;
@@ -2358,11 +2274,7 @@ uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   }
   return size;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2395,11 +2307,7 @@ uint32_t BluetoothDeviceConnectionResponse::calculate_size() const {
   size += ProtoSize::calc_int32(1, this->error);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2505,11 +2413,7 @@ uint32_t BluetoothGATTGetServicesDoneResponse::calculate_size() const {
   size += ProtoSize::calc_uint64(1, this->address);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2534,11 +2438,7 @@ uint32_t BluetoothGATTReadResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2566,11 +2466,7 @@ bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDeli
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2583,11 +2479,7 @@ bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, uint32
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2612,11 +2504,7 @@ bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, Proto
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;
@@ -2744,11 +2632,7 @@ uint32_t BluetoothScannerStateResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->configured_mode));
   return size;
 }
-#ifdef USE_API_VARINT64
-bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->mode = static_cast<enums::BluetoothScannerMode>(value);
@@ -2760,11 +2644,7 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, uint32_t v
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
-#ifdef USE_API_VARINT64
-bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->subscribe = value != 0;
@@ -2805,11 +2685,7 @@ uint32_t VoiceAssistantRequest::calculate_size() const {
   size += ProtoSize::calc_length(1, this->wake_word_phrase.size());
   return size;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantResponse::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantResponse::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->port = value;
@@ -2837,11 +2713,7 @@ bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->event_type = static_cast<enums::VoiceAssistantEvent>(value);
@@ -2862,11 +2734,7 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantAudio::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantAudio::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantAudio::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->end = value != 0;
@@ -2898,11 +2766,7 @@ uint32_t VoiceAssistantAudio::calculate_size() const {
   size += ProtoSize::calc_bool(1, this->end);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value);
@@ -2936,11 +2800,7 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 4:
       this->start_conversation = value != 0;
@@ -2993,11 +2853,7 @@ uint32_t VoiceAssistantWakeWord::calculate_size() const {
   }
   return size;
 }
-#ifdef USE_API_VARINT64
-bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 5:
       this->model_size = value;
@@ -3134,11 +2990,7 @@ uint32_t AlarmControlPanelStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::AlarmControlPanelStateCommand>(value);
@@ -3230,11 +3082,7 @@ uint32_t TextStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool TextCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool TextCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool TextCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -3319,11 +3167,7 @@ uint32_t DateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool DateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool DateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool DateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->year = value;
@@ -3406,11 +3250,7 @@ uint32_t TimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool TimeCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool TimeCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool TimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->hour = value;
@@ -3553,11 +3393,7 @@ uint32_t ValveStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool ValveCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ValveCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ValveCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->has_position = value != 0;
@@ -3636,11 +3472,7 @@ uint32_t DateTimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool DateTimeCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool DateTimeCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool DateTimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
@@ -3729,11 +3561,7 @@ uint32_t UpdateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-#ifdef USE_API_VARINT64
-bool UpdateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool UpdateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool UpdateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
       this->command = static_cast<enums::UpdateCommand>(value);
@@ -3778,11 +3606,7 @@ uint32_t ZWaveProxyFrame::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool ZWaveProxyRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool ZWaveProxyRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool ZWaveProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->type = static_cast<enums::ZWaveProxyRequestType>(value);
@@ -3848,11 +3672,7 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_IR_RF
-#ifdef USE_API_VARINT64
-bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
     case 1:
@@ -3917,11 +3737,7 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 }
 #endif
 #ifdef USE_SERIAL_PROXY
-#ifdef USE_API_VARINT64
-bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->instance = value;
@@ -3956,11 +3772,7 @@ uint32_t SerialProxyDataReceived::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->instance = value;
@@ -3982,11 +3794,7 @@ bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->instance = value;
@@ -3999,11 +3807,7 @@ bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, uint32_t v
   }
   return true;
 }
-#ifdef USE_API_VARINT64
-bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->instance = value;
@@ -4023,11 +3827,7 @@ uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, this->line_states);
   return size;
 }
-#ifdef USE_API_VARINT64
-bool SerialProxyRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool SerialProxyRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool SerialProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->instance = value;
@@ -4056,11 +3856,7 @@ uint32_t SerialProxyRequestResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-#ifdef USE_API_VARINT64
-bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, uint64_t value) {
-#else
-bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, uint32_t value) {
-#endif
+bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
       this->address = value;

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1039,7 +1039,7 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
 bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
-      this->time_seconds = decode_zigzag32(value);
+      this->time_seconds = decode_zigzag32(static_cast<uint32_t>(value));
       break;
     case 2:
       this->day = value;
@@ -1064,10 +1064,10 @@ bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
 bool ParsedTimezone::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
-      this->std_offset_seconds = decode_zigzag32(value);
+      this->std_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
       break;
     case 2:
-      this->dst_offset_seconds = decode_zigzag32(value);
+      this->dst_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
       break;
     default:
       return false;
@@ -1151,13 +1151,13 @@ bool ExecuteServiceArgument::decode_varint(uint32_t field_id, proto_varint_value
       this->legacy_int = static_cast<int32_t>(value);
       break;
     case 5:
-      this->int_ = decode_zigzag32(value);
+      this->int_ = decode_zigzag32(static_cast<uint32_t>(value));
       break;
     case 6:
       this->bool_array.push_back(value != 0);
       break;
     case 7:
-      this->int_array.push_back(decode_zigzag32(value));
+      this->int_array.push_back(decode_zigzag32(static_cast<uint32_t>(value)));
       break;
     default:
       return false;

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -7,13 +7,17 @@
 
 namespace esphome::api {
 
-bool HelloRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool HelloRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool HelloRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->api_version_major = value.as_uint32();
+      this->api_version_major = value;
       break;
     case 3:
-      this->api_version_minor = value.as_uint32();
+      this->api_version_minor = value;
       break;
     default:
       return false;
@@ -316,20 +320,24 @@ uint32_t CoverStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool CoverCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool CoverCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool CoverCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 4:
-      this->has_position = value.as_bool();
+      this->has_position = value != 0;
       break;
     case 6:
-      this->has_tilt = value.as_bool();
+      this->has_tilt = value != 0;
       break;
     case 8:
-      this->stop = value.as_bool();
+      this->stop = value != 0;
       break;
 #ifdef USE_DEVICES
     case 9:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -423,38 +431,42 @@ uint32_t FanStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool FanCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool FanCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool FanCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_state = value.as_bool();
+      this->has_state = value != 0;
       break;
     case 3:
-      this->state = value.as_bool();
+      this->state = value != 0;
       break;
     case 6:
-      this->has_oscillating = value.as_bool();
+      this->has_oscillating = value != 0;
       break;
     case 7:
-      this->oscillating = value.as_bool();
+      this->oscillating = value != 0;
       break;
     case 8:
-      this->has_direction = value.as_bool();
+      this->has_direction = value != 0;
       break;
     case 9:
-      this->direction = static_cast<enums::FanDirection>(value.as_uint32());
+      this->direction = static_cast<enums::FanDirection>(value);
       break;
     case 10:
-      this->has_speed_level = value.as_bool();
+      this->has_speed_level = value != 0;
       break;
     case 11:
-      this->speed_level = value.as_int32();
+      this->speed_level = static_cast<int32_t>(value);
       break;
     case 12:
-      this->has_preset_mode = value.as_bool();
+      this->has_preset_mode = value != 0;
       break;
 #ifdef USE_DEVICES
     case 14:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -571,59 +583,63 @@ uint32_t LightStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool LightCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool LightCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool LightCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_state = value.as_bool();
+      this->has_state = value != 0;
       break;
     case 3:
-      this->state = value.as_bool();
+      this->state = value != 0;
       break;
     case 4:
-      this->has_brightness = value.as_bool();
+      this->has_brightness = value != 0;
       break;
     case 22:
-      this->has_color_mode = value.as_bool();
+      this->has_color_mode = value != 0;
       break;
     case 23:
-      this->color_mode = static_cast<enums::ColorMode>(value.as_uint32());
+      this->color_mode = static_cast<enums::ColorMode>(value);
       break;
     case 20:
-      this->has_color_brightness = value.as_bool();
+      this->has_color_brightness = value != 0;
       break;
     case 6:
-      this->has_rgb = value.as_bool();
+      this->has_rgb = value != 0;
       break;
     case 10:
-      this->has_white = value.as_bool();
+      this->has_white = value != 0;
       break;
     case 12:
-      this->has_color_temperature = value.as_bool();
+      this->has_color_temperature = value != 0;
       break;
     case 24:
-      this->has_cold_white = value.as_bool();
+      this->has_cold_white = value != 0;
       break;
     case 26:
-      this->has_warm_white = value.as_bool();
+      this->has_warm_white = value != 0;
       break;
     case 14:
-      this->has_transition_length = value.as_bool();
+      this->has_transition_length = value != 0;
       break;
     case 15:
-      this->transition_length = value.as_uint32();
+      this->transition_length = value;
       break;
     case 16:
-      this->has_flash_length = value.as_bool();
+      this->has_flash_length = value != 0;
       break;
     case 17:
-      this->flash_length = value.as_uint32();
+      this->flash_length = value;
       break;
     case 18:
-      this->has_effect = value.as_bool();
+      this->has_effect = value != 0;
       break;
 #ifdef USE_DEVICES
     case 28:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -787,14 +803,18 @@ uint32_t SwitchStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SwitchCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SwitchCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SwitchCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->state = value.as_bool();
+      this->state = value != 0;
       break;
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -863,13 +883,17 @@ uint32_t TextSensorStateResponse::calculate_size() const {
   return size;
 }
 #endif
-bool SubscribeLogsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SubscribeLogsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SubscribeLogsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->level = static_cast<enums::LogLevel>(value.as_uint32());
+      this->level = static_cast<enums::LogLevel>(value);
       break;
     case 2:
-      this->dump_config = value.as_bool();
+      this->dump_config = value != 0;
       break;
     default:
       return false;
@@ -971,13 +995,17 @@ uint32_t HomeassistantActionRequest::calculate_size() const {
 }
 #endif
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
-bool HomeassistantActionResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool HomeassistantActionResponse::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool HomeassistantActionResponse::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->call_id = value.as_uint32();
+      this->call_id = value;
       break;
     case 2:
-      this->success = value.as_bool();
+      this->success = value != 0;
       break;
     default:
       return false;
@@ -1036,38 +1064,46 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
   return true;
 }
 #endif
-bool DSTRule::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool DSTRule::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool DSTRule::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->time_seconds = value.as_sint32();
+      this->time_seconds = decode_zigzag32(value);
       break;
     case 2:
-      this->day = value.as_uint32();
+      this->day = value;
       break;
     case 3:
-      this->type = static_cast<enums::DSTRuleType>(value.as_uint32());
+      this->type = static_cast<enums::DSTRuleType>(value);
       break;
     case 4:
-      this->month = value.as_uint32();
+      this->month = value;
       break;
     case 5:
-      this->week = value.as_uint32();
+      this->week = value;
       break;
     case 6:
-      this->day_of_week = value.as_uint32();
+      this->day_of_week = value;
       break;
     default:
       return false;
   }
   return true;
 }
-bool ParsedTimezone::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ParsedTimezone::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ParsedTimezone::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->std_offset_seconds = value.as_sint32();
+      this->std_offset_seconds = decode_zigzag32(value);
       break;
     case 2:
-      this->dst_offset_seconds = value.as_sint32();
+      this->dst_offset_seconds = decode_zigzag32(value);
       break;
     default:
       return false;
@@ -1142,22 +1178,26 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->supports_response));
   return size;
 }
-bool ExecuteServiceArgument::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ExecuteServiceArgument::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ExecuteServiceArgument::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->bool_ = value.as_bool();
+      this->bool_ = value != 0;
       break;
     case 2:
-      this->legacy_int = value.as_int32();
+      this->legacy_int = static_cast<int32_t>(value);
       break;
     case 5:
-      this->int_ = value.as_sint32();
+      this->int_ = decode_zigzag32(value);
       break;
     case 6:
-      this->bool_array.push_back(value.as_bool());
+      this->bool_array.push_back(value != 0);
       break;
     case 7:
-      this->int_array.push_back(value.as_sint32());
+      this->int_array.push_back(decode_zigzag32(value));
       break;
     default:
       return false;
@@ -1202,16 +1242,20 @@ void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
   this->string_array.init(count_string_array);
   ProtoDecodableMessage::decode(buffer, length);
 }
-bool ExecuteServiceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ExecuteServiceRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ExecuteServiceRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
     case 3:
-      this->call_id = value.as_uint32();
+      this->call_id = value;
       break;
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
     case 4:
-      this->return_response = value.as_bool();
+      this->return_response = value != 0;
       break;
 #endif
     default:
@@ -1313,13 +1357,17 @@ uint32_t CameraImageResponse::calculate_size() const {
 #endif
   return size;
 }
-bool CameraImageRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool CameraImageRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool CameraImageRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->single = value.as_bool();
+      this->single = value != 0;
       break;
     case 2:
-      this->stream = value.as_bool();
+      this->stream = value != 0;
       break;
     default:
       return false;
@@ -1468,53 +1516,57 @@ uint32_t ClimateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ClimateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ClimateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ClimateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_mode = value.as_bool();
+      this->has_mode = value != 0;
       break;
     case 3:
-      this->mode = static_cast<enums::ClimateMode>(value.as_uint32());
+      this->mode = static_cast<enums::ClimateMode>(value);
       break;
     case 4:
-      this->has_target_temperature = value.as_bool();
+      this->has_target_temperature = value != 0;
       break;
     case 6:
-      this->has_target_temperature_low = value.as_bool();
+      this->has_target_temperature_low = value != 0;
       break;
     case 8:
-      this->has_target_temperature_high = value.as_bool();
+      this->has_target_temperature_high = value != 0;
       break;
     case 12:
-      this->has_fan_mode = value.as_bool();
+      this->has_fan_mode = value != 0;
       break;
     case 13:
-      this->fan_mode = static_cast<enums::ClimateFanMode>(value.as_uint32());
+      this->fan_mode = static_cast<enums::ClimateFanMode>(value);
       break;
     case 14:
-      this->has_swing_mode = value.as_bool();
+      this->has_swing_mode = value != 0;
       break;
     case 15:
-      this->swing_mode = static_cast<enums::ClimateSwingMode>(value.as_uint32());
+      this->swing_mode = static_cast<enums::ClimateSwingMode>(value);
       break;
     case 16:
-      this->has_custom_fan_mode = value.as_bool();
+      this->has_custom_fan_mode = value != 0;
       break;
     case 18:
-      this->has_preset = value.as_bool();
+      this->has_preset = value != 0;
       break;
     case 19:
-      this->preset = static_cast<enums::ClimatePreset>(value.as_uint32());
+      this->preset = static_cast<enums::ClimatePreset>(value);
       break;
     case 20:
-      this->has_custom_preset = value.as_bool();
+      this->has_custom_preset = value != 0;
       break;
     case 22:
-      this->has_target_humidity = value.as_bool();
+      this->has_target_humidity = value != 0;
       break;
 #ifdef USE_DEVICES
     case 24:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -1631,21 +1683,25 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
   size += ProtoSize::calc_float(1, this->target_temperature_high);
   return size;
 }
-bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_fields = value.as_uint32();
+      this->has_fields = value;
       break;
     case 3:
-      this->mode = static_cast<enums::WaterHeaterMode>(value.as_uint32());
+      this->mode = static_cast<enums::WaterHeaterMode>(value);
       break;
 #ifdef USE_DEVICES
     case 5:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     case 6:
-      this->state = value.as_uint32();
+      this->state = value;
       break;
     default:
       return false;
@@ -1731,11 +1787,15 @@ uint32_t NumberStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool NumberCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool NumberCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool NumberCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -1812,11 +1872,15 @@ uint32_t SelectStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SelectCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SelectCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SelectCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -1903,29 +1967,33 @@ uint32_t SirenStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool SirenCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SirenCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SirenCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_state = value.as_bool();
+      this->has_state = value != 0;
       break;
     case 3:
-      this->state = value.as_bool();
+      this->state = value != 0;
       break;
     case 4:
-      this->has_tone = value.as_bool();
+      this->has_tone = value != 0;
       break;
     case 6:
-      this->has_duration = value.as_bool();
+      this->has_duration = value != 0;
       break;
     case 7:
-      this->duration = value.as_uint32();
+      this->duration = value;
       break;
     case 8:
-      this->has_volume = value.as_bool();
+      this->has_volume = value != 0;
       break;
 #ifdef USE_DEVICES
     case 10:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -2011,17 +2079,21 @@ uint32_t LockStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool LockCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool LockCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool LockCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->command = static_cast<enums::LockCommand>(value.as_uint32());
+      this->command = static_cast<enums::LockCommand>(value);
       break;
     case 3:
-      this->has_code = value.as_bool();
+      this->has_code = value != 0;
       break;
 #ifdef USE_DEVICES
     case 5:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -2082,11 +2154,15 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ButtonCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ButtonCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ButtonCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 2:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -2182,29 +2258,33 @@ uint32_t MediaPlayerStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_command = value.as_bool();
+      this->has_command = value != 0;
       break;
     case 3:
-      this->command = static_cast<enums::MediaPlayerCommand>(value.as_uint32());
+      this->command = static_cast<enums::MediaPlayerCommand>(value);
       break;
     case 4:
-      this->has_volume = value.as_bool();
+      this->has_volume = value != 0;
       break;
     case 6:
-      this->has_media_url = value.as_bool();
+      this->has_media_url = value != 0;
       break;
     case 8:
-      this->has_announcement = value.as_bool();
+      this->has_announcement = value != 0;
       break;
     case 9:
-      this->announcement = value.as_bool();
+      this->announcement = value != 0;
       break;
 #ifdef USE_DEVICES
     case 10:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -2238,10 +2318,14 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->flags = value.as_uint32();
+      this->flags = value;
       break;
     default:
       return false;
@@ -2274,19 +2358,23 @@ uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   }
   return size;
 }
-bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value.as_uint32());
+      this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value);
       break;
     case 3:
-      this->has_address_type = value.as_bool();
+      this->has_address_type = value != 0;
       break;
     case 4:
-      this->address_type = value.as_uint32();
+      this->address_type = value;
       break;
     default:
       return false;
@@ -2307,10 +2395,14 @@ uint32_t BluetoothDeviceConnectionResponse::calculate_size() const {
   size += ProtoSize::calc_int32(1, this->error);
   return size;
 }
-bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     default:
       return false;
@@ -2413,13 +2505,17 @@ uint32_t BluetoothGATTGetServicesDoneResponse::calculate_size() const {
   size += ProtoSize::calc_uint64(1, this->address);
   return size;
 }
-bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->handle = value.as_uint32();
+      this->handle = value;
       break;
     default:
       return false;
@@ -2438,16 +2534,20 @@ uint32_t BluetoothGATTReadResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->handle = value.as_uint32();
+      this->handle = value;
       break;
     case 3:
-      this->response = value.as_bool();
+      this->response = value != 0;
       break;
     default:
       return false;
@@ -2466,26 +2566,34 @@ bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDeli
   }
   return true;
 }
-bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->handle = value.as_uint32();
+      this->handle = value;
       break;
     default:
       return false;
   }
   return true;
 }
-bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->handle = value.as_uint32();
+      this->handle = value;
       break;
     default:
       return false;
@@ -2504,16 +2612,20 @@ bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, Proto
   }
   return true;
 }
-bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->handle = value.as_uint32();
+      this->handle = value;
       break;
     case 3:
-      this->enable = value.as_bool();
+      this->enable = value != 0;
       break;
     default:
       return false;
@@ -2632,10 +2744,14 @@ uint32_t BluetoothScannerStateResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->configured_mode));
   return size;
 }
-bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->mode = static_cast<enums::BluetoothScannerMode>(value.as_uint32());
+      this->mode = static_cast<enums::BluetoothScannerMode>(value);
       break;
     default:
       return false;
@@ -2644,13 +2760,17 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, ProtoVarIn
 }
 #endif
 #ifdef USE_VOICE_ASSISTANT
-bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->subscribe = value.as_bool();
+      this->subscribe = value != 0;
       break;
     case 2:
-      this->flags = value.as_uint32();
+      this->flags = value;
       break;
     default:
       return false;
@@ -2685,13 +2805,17 @@ uint32_t VoiceAssistantRequest::calculate_size() const {
   size += ProtoSize::calc_length(1, this->wake_word_phrase.size());
   return size;
 }
-bool VoiceAssistantResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantResponse::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantResponse::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->port = value.as_uint32();
+      this->port = value;
       break;
     case 2:
-      this->error = value.as_bool();
+      this->error = value != 0;
       break;
     default:
       return false;
@@ -2713,10 +2837,14 @@ bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->event_type = static_cast<enums::VoiceAssistantEvent>(value.as_uint32());
+      this->event_type = static_cast<enums::VoiceAssistantEvent>(value);
       break;
     default:
       return false;
@@ -2734,10 +2862,14 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
   return true;
 }
-bool VoiceAssistantAudio::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantAudio::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantAudio::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->end = value.as_bool();
+      this->end = value != 0;
       break;
     default:
       return false;
@@ -2766,19 +2898,23 @@ uint32_t VoiceAssistantAudio::calculate_size() const {
   size += ProtoSize::calc_bool(1, this->end);
   return size;
 }
-bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value.as_uint32());
+      this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value);
       break;
     case 4:
-      this->total_seconds = value.as_uint32();
+      this->total_seconds = value;
       break;
     case 5:
-      this->seconds_left = value.as_uint32();
+      this->seconds_left = value;
       break;
     case 6:
-      this->is_active = value.as_bool();
+      this->is_active = value != 0;
       break;
     default:
       return false;
@@ -2800,10 +2936,14 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
   return true;
 }
-bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 4:
-      this->start_conversation = value.as_bool();
+      this->start_conversation = value != 0;
       break;
     default:
       return false;
@@ -2853,10 +2993,14 @@ uint32_t VoiceAssistantWakeWord::calculate_size() const {
   }
   return size;
 }
-bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 5:
-      this->model_size = value.as_uint32();
+      this->model_size = value;
       break;
     default:
       return false;
@@ -2990,14 +3134,18 @@ uint32_t AlarmControlPanelStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->command = static_cast<enums::AlarmControlPanelStateCommand>(value.as_uint32());
+      this->command = static_cast<enums::AlarmControlPanelStateCommand>(value);
       break;
 #ifdef USE_DEVICES
     case 4:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3082,11 +3230,15 @@ uint32_t TextStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool TextCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool TextCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool TextCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3167,20 +3319,24 @@ uint32_t DateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool DateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool DateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool DateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->year = value.as_uint32();
+      this->year = value;
       break;
     case 3:
-      this->month = value.as_uint32();
+      this->month = value;
       break;
     case 4:
-      this->day = value.as_uint32();
+      this->day = value;
       break;
 #ifdef USE_DEVICES
     case 5:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3250,20 +3406,24 @@ uint32_t TimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool TimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool TimeCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool TimeCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->hour = value.as_uint32();
+      this->hour = value;
       break;
     case 3:
-      this->minute = value.as_uint32();
+      this->minute = value;
       break;
     case 4:
-      this->second = value.as_uint32();
+      this->second = value;
       break;
 #ifdef USE_DEVICES
     case 5:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3393,17 +3553,21 @@ uint32_t ValveStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool ValveCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ValveCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ValveCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->has_position = value.as_bool();
+      this->has_position = value != 0;
       break;
     case 4:
-      this->stop = value.as_bool();
+      this->stop = value != 0;
       break;
 #ifdef USE_DEVICES
     case 5:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3472,11 +3636,15 @@ uint32_t DateTimeStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool DateTimeCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool DateTimeCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool DateTimeCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3561,14 +3729,18 @@ uint32_t UpdateStateResponse::calculate_size() const {
 #endif
   return size;
 }
-bool UpdateCommandRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool UpdateCommandRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool UpdateCommandRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 2:
-      this->command = static_cast<enums::UpdateCommand>(value.as_uint32());
+      this->command = static_cast<enums::UpdateCommand>(value);
       break;
 #ifdef USE_DEVICES
     case 3:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     default:
@@ -3606,10 +3778,14 @@ uint32_t ZWaveProxyFrame::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len);
   return size;
 }
-bool ZWaveProxyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool ZWaveProxyRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool ZWaveProxyRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->type = static_cast<enums::ZWaveProxyRequestType>(value.as_uint32());
+      this->type = static_cast<enums::ZWaveProxyRequestType>(value);
       break;
     default:
       return false;
@@ -3672,18 +3848,22 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_IR_RF
-bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
 #ifdef USE_DEVICES
     case 1:
-      this->device_id = value.as_uint32();
+      this->device_id = value;
       break;
 #endif
     case 3:
-      this->carrier_frequency = value.as_uint32();
+      this->carrier_frequency = value;
       break;
     case 4:
-      this->repeat_count = value.as_uint32();
+      this->repeat_count = value;
       break;
     default:
       return false;
@@ -3737,25 +3917,29 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 }
 #endif
 #ifdef USE_SERIAL_PROXY
-bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->instance = value.as_uint32();
+      this->instance = value;
       break;
     case 2:
-      this->baudrate = value.as_uint32();
+      this->baudrate = value;
       break;
     case 3:
-      this->flow_control = value.as_bool();
+      this->flow_control = value != 0;
       break;
     case 4:
-      this->parity = static_cast<enums::SerialProxyParity>(value.as_uint32());
+      this->parity = static_cast<enums::SerialProxyParity>(value);
       break;
     case 5:
-      this->stop_bits = value.as_uint32();
+      this->stop_bits = value;
       break;
     case 6:
-      this->data_size = value.as_uint32();
+      this->data_size = value;
       break;
     default:
       return false;
@@ -3772,10 +3956,14 @@ uint32_t SerialProxyDataReceived::calculate_size() const {
   size += ProtoSize::calc_length(1, this->data_len_);
   return size;
 }
-bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->instance = value.as_uint32();
+      this->instance = value;
       break;
     default:
       return false;
@@ -3794,23 +3982,31 @@ bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
-bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->instance = value.as_uint32();
+      this->instance = value;
       break;
     case 2:
-      this->line_states = value.as_uint32();
+      this->line_states = value;
       break;
     default:
       return false;
   }
   return true;
 }
-bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->instance = value.as_uint32();
+      this->instance = value;
       break;
     default:
       return false;
@@ -3827,13 +4023,17 @@ uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
   size += ProtoSize::calc_uint32(1, this->line_states);
   return size;
 }
-bool SerialProxyRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool SerialProxyRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool SerialProxyRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->instance = value.as_uint32();
+      this->instance = value;
       break;
     case 2:
-      this->type = static_cast<enums::SerialProxyRequestType>(value.as_uint32());
+      this->type = static_cast<enums::SerialProxyRequestType>(value);
       break;
     default:
       return false;
@@ -3856,22 +4056,26 @@ uint32_t SerialProxyRequestResponse::calculate_size() const {
 }
 #endif
 #ifdef USE_BLUETOOTH_PROXY
-bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, ProtoVarIntResult value) {
+#ifdef USE_API_VARINT64
+bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, uint64_t value) {
+#else
+bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, uint32_t value) {
+#endif
   switch (field_id) {
     case 1:
-      this->address = value.as_uint64();
+      this->address = value;
       break;
     case 2:
-      this->min_interval = value.as_uint32();
+      this->min_interval = value;
       break;
     case 3:
-      this->max_interval = value.as_uint32();
+      this->max_interval = value;
       break;
     case 4:
-      this->latency = value.as_uint32();
+      this->latency = value;
       break;
     case 5:
-      this->timeout = value.as_uint32();
+      this->timeout = value;
       break;
     default:
       return false;

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -399,7 +399,7 @@ class HelloRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class HelloResponse final : public ProtoMessage {
  public:
@@ -688,7 +688,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_FAN
@@ -756,7 +756,7 @@ class FanCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_LIGHT
@@ -846,7 +846,7 @@ class LightCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_SENSOR
@@ -936,7 +936,7 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -988,7 +988,7 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SubscribeLogsResponse final : public ProtoMessage {
  public:
@@ -1110,7 +1110,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
@@ -1176,7 +1176,7 @@ class DSTRule final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class ParsedTimezone final : public ProtoDecodableMessage {
  public:
@@ -1190,7 +1190,7 @@ class ParsedTimezone final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
@@ -1261,7 +1261,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
@@ -1286,7 +1286,7 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
@@ -1365,7 +1365,7 @@ class CameraImageRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_CLIMATE
@@ -1464,7 +1464,7 @@ class ClimateCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_WATER_HEATER
@@ -1528,7 +1528,7 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_NUMBER
@@ -1584,7 +1584,7 @@ class NumberCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_SELECT
@@ -1636,7 +1636,7 @@ class SelectCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_SIREN
@@ -1696,7 +1696,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_LOCK
@@ -1752,7 +1752,7 @@ class LockCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_BUTTON
@@ -1785,7 +1785,7 @@ class ButtonCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -1862,7 +1862,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -1879,7 +1879,7 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothLERawAdvertisement final : public ProtoMessage {
  public:
@@ -1929,7 +1929,7 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
@@ -1963,7 +1963,7 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTDescriptor final : public ProtoMessage {
  public:
@@ -2054,7 +2054,7 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
@@ -2097,7 +2097,7 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2113,7 +2113,7 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2132,7 +2132,7 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
@@ -2149,7 +2149,7 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
@@ -2329,7 +2329,7 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
@@ -2347,7 +2347,7 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantAudioSettings final : public ProtoMessage {
  public:
@@ -2396,7 +2396,7 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
@@ -2424,7 +2424,7 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
@@ -2444,7 +2444,7 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
@@ -2465,7 +2465,7 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
@@ -2484,7 +2484,7 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
@@ -2530,7 +2530,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:
@@ -2632,7 +2632,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_TEXT
@@ -2687,7 +2687,7 @@ class TextCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATE
@@ -2741,7 +2741,7 @@ class DateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_DATETIME_TIME
@@ -2795,7 +2795,7 @@ class TimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_EVENT
@@ -2886,7 +2886,7 @@ class ValveCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -2936,7 +2936,7 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_UPDATE
@@ -2994,7 +2994,7 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_ZWAVE_PROXY
@@ -3034,7 +3034,7 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 #endif
 #ifdef USE_INFRARED
@@ -3079,7 +3079,7 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class InfraredRFReceiveEvent final : public ProtoMessage {
  public:
@@ -3121,7 +3121,7 @@ class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SerialProxyDataReceived final : public ProtoMessage {
  public:
@@ -3161,7 +3161,7 @@ class SerialProxyWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3177,7 +3177,7 @@ class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3192,7 +3192,7 @@ class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SerialProxyGetModemPinsResponse final : public ProtoMessage {
  public:
@@ -3225,7 +3225,7 @@ class SerialProxyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class SerialProxyRequestResponse final : public ProtoMessage {
  public:
@@ -3265,7 +3265,7 @@ class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarInt value) override;
+  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
 };
 class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -399,7 +399,11 @@ class HelloRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class HelloResponse final : public ProtoMessage {
  public:
@@ -688,7 +692,11 @@ class CoverCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_FAN
@@ -756,7 +764,11 @@ class FanCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_LIGHT
@@ -846,7 +858,11 @@ class LightCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_SENSOR
@@ -936,7 +952,11 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -988,7 +1008,11 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SubscribeLogsResponse final : public ProtoMessage {
  public:
@@ -1110,7 +1134,11 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
@@ -1176,7 +1204,11 @@ class DSTRule final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class ParsedTimezone final : public ProtoDecodableMessage {
  public:
@@ -1190,7 +1222,11 @@ class ParsedTimezone final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
@@ -1261,7 +1297,11 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
@@ -1286,7 +1326,11 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
@@ -1365,7 +1409,11 @@ class CameraImageRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_CLIMATE
@@ -1464,7 +1512,11 @@ class ClimateCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_WATER_HEATER
@@ -1528,7 +1580,11 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_NUMBER
@@ -1584,7 +1640,11 @@ class NumberCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_SELECT
@@ -1636,7 +1696,11 @@ class SelectCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_SIREN
@@ -1696,7 +1760,11 @@ class SirenCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_LOCK
@@ -1752,7 +1820,11 @@ class LockCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_BUTTON
@@ -1785,7 +1857,11 @@ class ButtonCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -1862,7 +1938,11 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -1879,7 +1959,11 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothLERawAdvertisement final : public ProtoMessage {
  public:
@@ -1929,7 +2013,11 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
@@ -1963,7 +2051,11 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTDescriptor final : public ProtoMessage {
  public:
@@ -2054,7 +2146,11 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
@@ -2097,7 +2193,11 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2113,7 +2213,11 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2132,7 +2236,11 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
@@ -2149,7 +2257,11 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
@@ -2329,7 +2441,11 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
@@ -2347,7 +2463,11 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantAudioSettings final : public ProtoMessage {
  public:
@@ -2396,7 +2516,11 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
@@ -2424,7 +2548,11 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
@@ -2444,7 +2572,11 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
@@ -2465,7 +2597,11 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
@@ -2484,7 +2620,11 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
@@ -2530,7 +2670,11 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:
@@ -2632,7 +2776,11 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_TEXT
@@ -2687,7 +2835,11 @@ class TextCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_DATETIME_DATE
@@ -2741,7 +2893,11 @@ class DateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_DATETIME_TIME
@@ -2795,7 +2951,11 @@ class TimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_EVENT
@@ -2886,7 +3046,11 @@ class ValveCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -2936,7 +3100,11 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_UPDATE
@@ -2994,7 +3162,11 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_ZWAVE_PROXY
@@ -3034,7 +3206,11 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 #endif
 #ifdef USE_INFRARED
@@ -3079,7 +3255,11 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class InfraredRFReceiveEvent final : public ProtoMessage {
  public:
@@ -3121,7 +3301,11 @@ class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SerialProxyDataReceived final : public ProtoMessage {
  public:
@@ -3161,7 +3345,11 @@ class SerialProxyWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3177,7 +3365,11 @@ class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3192,7 +3384,11 @@ class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SerialProxyGetModemPinsResponse final : public ProtoMessage {
  public:
@@ -3225,7 +3421,11 @@ class SerialProxyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class SerialProxyRequestResponse final : public ProtoMessage {
  public:
@@ -3265,7 +3465,11 @@ class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;
+#ifdef USE_API_VARINT64
+  bool decode_varint(uint32_t field_id, uint64_t value) override;
+#else
+  bool decode_varint(uint32_t field_id, uint32_t value) override;
+#endif
 };
 class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
  public:

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -399,11 +399,7 @@ class HelloRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class HelloResponse final : public ProtoMessage {
  public:
@@ -692,11 +688,7 @@ class CoverCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_FAN
@@ -764,11 +756,7 @@ class FanCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_LIGHT
@@ -858,11 +846,7 @@ class LightCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SENSOR
@@ -952,11 +936,7 @@ class SwitchCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -1008,11 +988,7 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SubscribeLogsResponse final : public ProtoMessage {
  public:
@@ -1134,11 +1110,7 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
@@ -1204,11 +1176,7 @@ class DSTRule final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class ParsedTimezone final : public ProtoDecodableMessage {
  public:
@@ -1222,11 +1190,7 @@ class ParsedTimezone final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
@@ -1297,11 +1261,7 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
@@ -1326,11 +1286,7 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
@@ -1409,11 +1365,7 @@ class CameraImageRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_CLIMATE
@@ -1512,11 +1464,7 @@ class ClimateCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_WATER_HEATER
@@ -1580,11 +1528,7 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_NUMBER
@@ -1640,11 +1584,7 @@ class NumberCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SELECT
@@ -1696,11 +1636,7 @@ class SelectCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SIREN
@@ -1760,11 +1696,7 @@ class SirenCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_LOCK
@@ -1820,11 +1752,7 @@ class LockCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_BUTTON
@@ -1857,11 +1785,7 @@ class ButtonCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -1938,11 +1862,7 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -1959,11 +1879,7 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothLERawAdvertisement final : public ProtoMessage {
  public:
@@ -2013,11 +1929,7 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
@@ -2051,11 +1963,7 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTDescriptor final : public ProtoMessage {
  public:
@@ -2146,11 +2054,7 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
@@ -2193,11 +2097,7 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2213,11 +2113,7 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2236,11 +2132,7 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
@@ -2257,11 +2149,7 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
@@ -2441,11 +2329,7 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
@@ -2463,11 +2347,7 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAudioSettings final : public ProtoMessage {
  public:
@@ -2516,11 +2396,7 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
@@ -2548,11 +2424,7 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
@@ -2572,11 +2444,7 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
@@ -2597,11 +2465,7 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
@@ -2620,11 +2484,7 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
@@ -2670,11 +2530,7 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:
@@ -2776,11 +2632,7 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_TEXT
@@ -2835,11 +2687,7 @@ class TextCommandRequest final : public CommandProtoMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATE
@@ -2893,11 +2741,7 @@ class DateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_TIME
@@ -2951,11 +2795,7 @@ class TimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_EVENT
@@ -3046,11 +2886,7 @@ class ValveCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -3100,11 +2936,7 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_UPDATE
@@ -3162,11 +2994,7 @@ class UpdateCommandRequest final : public CommandProtoMessage {
 
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_ZWAVE_PROXY
@@ -3206,11 +3034,7 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_INFRARED
@@ -3255,11 +3079,7 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
  protected:
   bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class InfraredRFReceiveEvent final : public ProtoMessage {
  public:
@@ -3301,11 +3121,7 @@ class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyDataReceived final : public ProtoMessage {
  public:
@@ -3345,11 +3161,7 @@ class SerialProxyWriteRequest final : public ProtoDecodableMessage {
 
  protected:
   bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3365,11 +3177,7 @@ class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3384,11 +3192,7 @@ class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyGetModemPinsResponse final : public ProtoMessage {
  public:
@@ -3421,11 +3225,7 @@ class SerialProxyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyRequestResponse final : public ProtoMessage {
  public:
@@ -3465,11 +3265,7 @@ class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-#ifdef USE_API_VARINT64
-  bool decode_varint(uint32_t field_id, uint64_t value) override;
-#else
-  bool decode_varint(uint32_t field_id, uint32_t value) override;
-#endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
  public:

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -227,7 +227,11 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Invalid VarInt at offset %ld", (long) (ptr - buffer));
           return;
         }
-        if (!this->decode_varint(field_id, res)) {
+#ifdef USE_API_VARINT64
+        if (!this->decode_varint(field_id, res.as_uint64())) {
+#else
+        if (!this->decode_varint(field_id, res.as_uint32())) {
+#endif
           ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res.as_uint32());
         }
         ptr += res.consumed;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -38,7 +38,7 @@ ProtoVarIntResult ProtoVarInt::parse_slow(const uint8_t *buffer, uint32_t len) {
 #ifdef USE_API_VARINT64
   return parse_wide(buffer, len, result32);
 #else
-  return {0, 0};
+  return {0, PROTO_VARINT_PARSE_FAILED};
 #endif
 }
 
@@ -53,7 +53,7 @@ ProtoVarIntResult ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, u
       return {result64, i + 1};
     }
   }
-  return {0, 0};
+  return {0, PROTO_VARINT_PARSE_FAILED};
 }
 #endif
 

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -20,20 +20,40 @@ void ProtoWriteBuffer::encode_varint_raw_slow_(uint32_t value) {
   *this->pos_++ = static_cast<uint8_t>(value);
 }
 
+ProtoVarIntResult ProtoVarInt::parse_slow_(const uint8_t *buffer, uint32_t len) {
+  // Multi-byte varint: first byte already checked to have high bit set
+  uint32_t result32 = buffer[0] & 0x7F;
 #ifdef USE_API_VARINT64
-optional<ProtoVarInt> ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, uint32_t *consumed,
-                                              uint32_t result32) {
+  uint32_t limit = std::min(len, uint32_t(4));
+#else
+  uint32_t limit = std::min(len, uint32_t(5));
+#endif
+  for (uint32_t i = 1; i < limit; i++) {
+    uint8_t val = buffer[i];
+    result32 |= uint32_t(val & 0x7F) << (i * 7);
+    if ((val & 0x80) == 0) {
+      return {result32, i + 1};
+    }
+  }
+#ifdef USE_API_VARINT64
+  return parse_wide_(buffer, len, result32);
+#else
+  return {0, 0};
+#endif
+}
+
+#ifdef USE_API_VARINT64
+ProtoVarIntResult ProtoVarInt::parse_wide_(const uint8_t *buffer, uint32_t len, uint32_t result32) {
   uint64_t result64 = result32;
   uint32_t limit = std::min(len, uint32_t(10));
   for (uint32_t i = 4; i < limit; i++) {
     uint8_t val = buffer[i];
     result64 |= uint64_t(val & 0x7F) << (i * 7);
     if ((val & 0x80) == 0) {
-      *consumed = i + 1;
-      return ProtoVarInt(result64);
+      return {result64, i + 1};
     }
   }
-  return {};
+  return {0, 0};
 }
 #endif
 
@@ -43,18 +63,16 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
   const uint8_t *end = buffer + length;
 
   while (ptr < end) {
-    uint32_t consumed;
-
     // Parse field header (tag)
-    auto res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+    auto res = ProtoVarInt::parse(ptr, end - ptr);
     if (!res.has_value()) {
       break;  // Invalid data, stop counting
     }
 
-    uint32_t tag = res->as_uint32();
+    uint32_t tag = res.as_uint32();
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
-    ptr += consumed;
+    ptr += res.consumed;
 
     // Count if this is the target field
     if (field_id == target_field_id) {
@@ -64,20 +82,20 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
     // Skip field data based on wire type
     switch (field_type) {
       case WIRE_TYPE_VARINT: {  // VarInt - parse and skip
-        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr);
         if (!res.has_value()) {
           return count;  // Invalid data, return what we have
         }
-        ptr += consumed;
+        ptr += res.consumed;
         break;
       }
       case WIRE_TYPE_LENGTH_DELIMITED: {  // Length-delimited - parse length and skip data
-        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr);
         if (!res.has_value()) {
           return count;
         }
-        uint32_t field_length = res->as_uint32();
-        ptr += consumed;
+        uint32_t field_length = res.as_uint32();
+        ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           return count;  // Out of bounds
         }
@@ -190,41 +208,39 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
   const uint8_t *end = buffer + length;
 
   while (ptr < end) {
-    uint32_t consumed;
-
     // Parse field header
-    auto res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+    auto res = ProtoVarInt::parse(ptr, end - ptr);
     if (!res.has_value()) {
       ESP_LOGV(TAG, "Invalid field start at offset %ld", (long) (ptr - buffer));
       return;
     }
 
-    uint32_t tag = res->as_uint32();
+    uint32_t tag = res.as_uint32();
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
-    ptr += consumed;
+    ptr += res.consumed;
 
     switch (field_type) {
       case WIRE_TYPE_VARINT: {  // VarInt
-        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr);
         if (!res.has_value()) {
           ESP_LOGV(TAG, "Invalid VarInt at offset %ld", (long) (ptr - buffer));
           return;
         }
-        if (!this->decode_varint(field_id, *res)) {
-          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res->as_uint32());
+        if (!this->decode_varint(field_id, res)) {
+          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res.as_uint32());
         }
-        ptr += consumed;
+        ptr += res.consumed;
         break;
       }
       case WIRE_TYPE_LENGTH_DELIMITED: {  // Length-delimited
-        res = ProtoVarInt::parse(ptr, end - ptr, &consumed);
+        res = ProtoVarInt::parse(ptr, end - ptr);
         if (!res.has_value()) {
           ESP_LOGV(TAG, "Invalid Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
-        uint32_t field_length = res->as_uint32();
-        ptr += consumed;
+        uint32_t field_length = res.as_uint32();
+        ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));
           return;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -21,8 +21,6 @@ void ProtoWriteBuffer::encode_varint_raw_slow_(uint32_t value) {
 }
 
 ProtoVarIntResult ProtoVarInt::parse_slow(const uint8_t *buffer, uint32_t len) {
-  if (len == 0)
-    return {0, 0};
   // Multi-byte varint: first byte already checked to have high bit set
   uint32_t result32 = buffer[0] & 0x7F;
 #ifdef USE_API_VARINT64

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -63,8 +63,8 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
   const uint8_t *end = buffer + length;
 
   while (ptr < end) {
-    // Parse field header (tag)
-    auto res = ProtoVarInt::parse(ptr, end - ptr);
+    // Parse field header (tag) - ptr < end guarantees len >= 1
+    auto res = ProtoVarInt::parse_non_empty(ptr, end - ptr);
     if (!res.has_value()) {
       break;  // Invalid data, stop counting
     }
@@ -208,8 +208,8 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
   const uint8_t *end = buffer + length;
 
   while (ptr < end) {
-    // Parse field header
-    auto res = ProtoVarInt::parse(ptr, end - ptr);
+    // Parse field header - ptr < end guarantees len >= 1
+    auto res = ProtoVarInt::parse_non_empty(ptr, end - ptr);
     if (!res.has_value()) {
       ESP_LOGV(TAG, "Invalid field start at offset %ld", (long) (ptr - buffer));
       return;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -21,6 +21,8 @@ void ProtoWriteBuffer::encode_varint_raw_slow_(uint32_t value) {
 }
 
 ProtoVarIntResult ProtoVarInt::parse_slow(const uint8_t *buffer, uint32_t len) {
+  if (len == 0)
+    return {0, 0};
   // Multi-byte varint: first byte already checked to have high bit set
   uint32_t result32 = buffer[0] & 0x7F;
 #ifdef USE_API_VARINT64

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -69,7 +69,7 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
       break;  // Invalid data, stop counting
     }
 
-    uint32_t tag = res.as_uint32();
+    uint32_t tag = res.value;
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
     ptr += res.consumed;
@@ -94,7 +94,7 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
         if (!res.has_value()) {
           return count;
         }
-        uint32_t field_length = res.as_uint32();
+        uint32_t field_length = res.value;
         ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           return count;  // Out of bounds
@@ -215,7 +215,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
       return;
     }
 
-    uint32_t tag = res.as_uint32();
+    uint32_t tag = res.value;
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
     ptr += res.consumed;
@@ -228,7 +228,8 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           return;
         }
         if (!this->decode_varint(field_id, res.value)) {
-          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res.as_uint32());
+          ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu64 "!", field_id,
+                   static_cast<uint64_t>(res.value));
         }
         ptr += res.consumed;
         break;
@@ -239,7 +240,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Invalid Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
-        uint32_t field_length = res.as_uint32();
+        uint32_t field_length = res.value;
         ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -227,11 +227,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Invalid VarInt at offset %ld", (long) (ptr - buffer));
           return;
         }
-#ifdef USE_API_VARINT64
-        if (!this->decode_varint(field_id, res.as_uint64())) {
-#else
-        if (!this->decode_varint(field_id, res.as_uint32())) {
-#endif
+        if (!this->decode_varint(field_id, res.value)) {
           ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu32 "!", field_id, res.as_uint32());
         }
         ptr += res.consumed;

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -20,7 +20,7 @@ void ProtoWriteBuffer::encode_varint_raw_slow_(uint32_t value) {
   *this->pos_++ = static_cast<uint8_t>(value);
 }
 
-ProtoVarIntResult ProtoVarInt::parse_slow_(const uint8_t *buffer, uint32_t len) {
+ProtoVarIntResult ProtoVarInt::parse_slow(const uint8_t *buffer, uint32_t len) {
   // Multi-byte varint: first byte already checked to have high bit set
   uint32_t result32 = buffer[0] & 0x7F;
 #ifdef USE_API_VARINT64
@@ -36,14 +36,14 @@ ProtoVarIntResult ProtoVarInt::parse_slow_(const uint8_t *buffer, uint32_t len) 
     }
   }
 #ifdef USE_API_VARINT64
-  return parse_wide_(buffer, len, result32);
+  return parse_wide(buffer, len, result32);
 #else
   return {0, 0};
 #endif
 }
 
 #ifdef USE_API_VARINT64
-ProtoVarIntResult ProtoVarInt::parse_wide_(const uint8_t *buffer, uint32_t len, uint32_t result32) {
+ProtoVarIntResult ProtoVarInt::parse_wide(const uint8_t *buffer, uint32_t len, uint32_t result32) {
   uint64_t result64 = result32;
   uint32_t limit = std::min(len, uint32_t(10));
   for (uint32_t i = 4; i < limit; i++) {

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -69,7 +69,7 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
       break;  // Invalid data, stop counting
     }
 
-    uint32_t tag = res.value;
+    uint32_t tag = static_cast<uint32_t>(res.value);
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
     ptr += res.consumed;
@@ -94,7 +94,7 @@ uint32_t ProtoDecodableMessage::count_repeated_field(const uint8_t *buffer, size
         if (!res.has_value()) {
           return count;
         }
-        uint32_t field_length = res.value;
+        uint32_t field_length = static_cast<uint32_t>(res.value);
         ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           return count;  // Out of bounds
@@ -215,7 +215,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
       return;
     }
 
-    uint32_t tag = res.value;
+    uint32_t tag = static_cast<uint32_t>(res.value);
     uint32_t field_type = tag & WIRE_TYPE_MASK;
     uint32_t field_id = tag >> 3;
     ptr += res.consumed;
@@ -240,7 +240,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Invalid Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
-        uint32_t field_length = res.value;
+        uint32_t field_length = static_cast<uint32_t>(res.value);
         ptr += res.consumed;
         if (field_length > static_cast<size_t>(end - ptr)) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -132,11 +132,11 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. Returns result with consumed=0 on failure.
   static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse(const uint8_t *buffer, uint32_t len) {
-    if (len == 0)
-      return {0, 0};
     // Fast path: single-byte varints (0-127) are the most common case
     // (booleans, small enums, field tags, small message sizes/types).
-    if ((buffer[0] & 0x80) == 0) [[likely]]
+    // len==0 check is folded into the condition to minimize inline size;
+    // parse_slow() handles len==0.
+    if (len != 0 && (buffer[0] & 0x80) == 0) [[likely]]
       return {buffer[0], 1};
     return parse_slow(buffer, len);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -117,22 +117,11 @@ struct ProtoVarIntResult {
   constexpr bool has_value() const { return this->consumed != PROTO_VARINT_PARSE_FAILED; }
   constexpr uint16_t as_uint16() const { return this->value; }
   constexpr uint32_t as_uint32() const { return this->value; }
-  constexpr bool as_bool() const { return this->value; }
-  constexpr int32_t as_int32() const { return static_cast<int32_t>(this->value); }
-  constexpr int32_t as_sint32() const { return decode_zigzag32(static_cast<uint32_t>(this->value)); }
-#ifdef USE_API_VARINT64
-  constexpr uint64_t as_uint64() const { return this->value; }
-  constexpr int64_t as_int64() const { return static_cast<int64_t>(this->value); }
-  constexpr int64_t as_sint64() const { return decode_zigzag64(this->value); }
-#endif
 };
 
-/// Representation of a VarInt - in ProtoBuf should be 64bit but we only use 32bit
+/// Static varint parsing methods for the protobuf wire format.
 class ProtoVarInt {
  public:
-  ProtoVarInt() : value_(0) {}
-  explicit ProtoVarInt(uint64_t value) : value_(value) {}
-
   /// Parse a varint from buffer. Caller must ensure len >= 1.
   /// Returns result with consumed=0 on failure (truncated multi-byte varint).
   static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse_non_empty(const uint8_t *buffer, uint32_t len) {
@@ -161,37 +150,6 @@ class ProtoVarInt {
 #ifdef USE_API_VARINT64
   /// Continue parsing varint bytes 4-9 with 64-bit arithmetic.
   static ProtoVarIntResult parse_wide(const uint8_t *buffer, uint32_t len, uint32_t result32) __attribute__((noinline));
-#endif
-
- public:
-  constexpr uint16_t as_uint16() const { return this->value_; }
-  constexpr uint32_t as_uint32() const { return this->value_; }
-  constexpr bool as_bool() const { return this->value_; }
-  constexpr int32_t as_int32() const {
-    // Not ZigZag encoded
-    return static_cast<int32_t>(this->value_);
-  }
-  constexpr int32_t as_sint32() const {
-    // with ZigZag encoding
-    return decode_zigzag32(static_cast<uint32_t>(this->value_));
-  }
-#ifdef USE_API_VARINT64
-  constexpr uint64_t as_uint64() const { return this->value_; }
-  constexpr int64_t as_int64() const {
-    // Not ZigZag encoded
-    return static_cast<int64_t>(this->value_);
-  }
-  constexpr int64_t as_sint64() const {
-    // with ZigZag encoding
-    return decode_zigzag64(this->value_);
-  }
-#endif
-
- protected:
-#ifdef USE_API_VARINT64
-  uint64_t value_;
-#else
-  uint32_t value_;
 #endif
 };
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -98,17 +98,20 @@ inline void encode_varint_to_buffer(uint32_t val, uint8_t *buffer) {
  * within the same function scope where temporaries are created.
  */
 
+/// Type used for decoded varint values - uint64_t when BLE needs 64-bit addresses, uint32_t otherwise
+#ifdef USE_API_VARINT64
+using proto_varint_value_t = uint64_t;
+#else
+using proto_varint_value_t = uint32_t;
+#endif
+
 /// Sentinel value for consumed field indicating parse failure
 inline constexpr uint32_t PROTO_VARINT_PARSE_FAILED = 0;
 
 /// Result of parsing a varint: value + number of bytes consumed.
 /// consumed == PROTO_VARINT_PARSE_FAILED indicates parse failure (not enough data or invalid).
 struct ProtoVarIntResult {
-#ifdef USE_API_VARINT64
-  uint64_t value;
-#else
-  uint32_t value;
-#endif
+  proto_varint_value_t value;
   uint32_t consumed;  // PROTO_VARINT_PARSE_FAILED = parse failed
 
   constexpr bool has_value() const { return this->consumed != PROTO_VARINT_PARSE_FAILED; }
@@ -506,11 +509,7 @@ class ProtoDecodableMessage : public ProtoMessage {
 
  protected:
   ~ProtoDecodableMessage() = default;
-#ifdef USE_API_VARINT64
-  virtual bool decode_varint(uint32_t field_id, uint64_t value) { return false; }
-#else
-  virtual bool decode_varint(uint32_t field_id, uint32_t value) { return false; }
-#endif
+  virtual bool decode_varint(uint32_t field_id, proto_varint_value_t value) { return false; }
   virtual bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
   virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
   // NOTE: decode_64bit removed - wire type 1 not supported

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -98,17 +98,20 @@ inline void encode_varint_to_buffer(uint32_t val, uint8_t *buffer) {
  * within the same function scope where temporaries are created.
  */
 
+/// Sentinel value for consumed field indicating parse failure
+inline constexpr uint32_t PROTO_VARINT_PARSE_FAILED = 0;
+
 /// Result of parsing a varint: value + number of bytes consumed.
-/// consumed == 0 indicates parse failure (not enough data or invalid).
+/// consumed == PROTO_VARINT_PARSE_FAILED indicates parse failure (not enough data or invalid).
 struct ProtoVarIntResult {
 #ifdef USE_API_VARINT64
   uint64_t value;
 #else
   uint32_t value;
 #endif
-  uint32_t consumed;  // 0 = parse failed
+  uint32_t consumed;  // PROTO_VARINT_PARSE_FAILED = parse failed
 
-  constexpr bool has_value() const { return this->consumed != 0; }
+  constexpr bool has_value() const { return this->consumed != PROTO_VARINT_PARSE_FAILED; }
   constexpr uint16_t as_uint16() const { return this->value; }
   constexpr uint32_t as_uint32() const { return this->value; }
   constexpr bool as_bool() const { return this->value; }
@@ -135,17 +138,16 @@ class ProtoVarInt {
     // (booleans, small enums, field tags, small message sizes/types).
     if ((buffer[0] & 0x80) == 0) [[likely]]
       return {buffer[0], 1};
-    return parse_slow_(buffer, len);
+    return parse_slow(buffer, len);
   }
 
  protected:
   // Slow path for multi-byte varints (>= 128), outlined to keep fast path small
-  static ProtoVarIntResult parse_slow_(const uint8_t *buffer, uint32_t len) __attribute__((noinline));
+  static ProtoVarIntResult parse_slow(const uint8_t *buffer, uint32_t len) __attribute__((noinline));
 
 #ifdef USE_API_VARINT64
   /// Continue parsing varint bytes 4-9 with 64-bit arithmetic.
-  static ProtoVarIntResult parse_wide_(const uint8_t *buffer, uint32_t len, uint32_t result32)
-      __attribute__((noinline));
+  static ProtoVarIntResult parse_wide(const uint8_t *buffer, uint32_t len, uint32_t result32) __attribute__((noinline));
 #endif
 
  public:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -98,62 +98,57 @@ inline void encode_varint_to_buffer(uint32_t val, uint8_t *buffer) {
  * within the same function scope where temporaries are created.
  */
 
+/// Result of parsing a varint: value + number of bytes consumed.
+/// consumed == 0 indicates parse failure (not enough data or invalid).
+struct ProtoVarIntResult {
+#ifdef USE_API_VARINT64
+  uint64_t value;
+#else
+  uint32_t value;
+#endif
+  uint32_t consumed;  // 0 = parse failed
+
+  constexpr bool has_value() const { return this->consumed != 0; }
+  constexpr uint16_t as_uint16() const { return this->value; }
+  constexpr uint32_t as_uint32() const { return this->value; }
+  constexpr bool as_bool() const { return this->value; }
+  constexpr int32_t as_int32() const { return static_cast<int32_t>(this->value); }
+  constexpr int32_t as_sint32() const { return decode_zigzag32(static_cast<uint32_t>(this->value)); }
+#ifdef USE_API_VARINT64
+  constexpr uint64_t as_uint64() const { return this->value; }
+  constexpr int64_t as_int64() const { return static_cast<int64_t>(this->value); }
+  constexpr int64_t as_sint64() const { return decode_zigzag64(this->value); }
+#endif
+};
+
 /// Representation of a VarInt - in ProtoBuf should be 64bit but we only use 32bit
 class ProtoVarInt {
  public:
   ProtoVarInt() : value_(0) {}
   explicit ProtoVarInt(uint64_t value) : value_(value) {}
 
-  /// Parse a varint from buffer. consumed must be a valid pointer (not null).
-  static optional<ProtoVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
-#ifdef ESPHOME_DEBUG_API
-    assert(consumed != nullptr);
-#endif
+  /// Parse a varint from buffer. Returns result with consumed=0 on failure.
+  static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse(const uint8_t *buffer, uint32_t len) {
     if (len == 0)
-      return {};
+      return {0, 0};
     // Fast path: single-byte varints (0-127) are the most common case
-    // (booleans, small enums, field tags). Avoid loop overhead entirely.
-    if ((buffer[0] & 0x80) == 0) {
-      *consumed = 1;
-      return ProtoVarInt(buffer[0]);
-    }
-    // 32-bit phase: process remaining bytes with native 32-bit shifts.
-    // Without USE_API_VARINT64: cover bytes 1-4 (shifts 7, 14, 21, 28) — the uint32_t
-    // shift at byte 4 (shift by 28) may lose bits 32-34, but those are always zero for valid uint32 values.
-    // With USE_API_VARINT64: cover bytes 1-3 (shifts 7, 14, 21) so parse_wide handles
-    // byte 4+ with full 64-bit arithmetic (avoids truncating values > UINT32_MAX).
-    uint32_t result32 = buffer[0] & 0x7F;
-#ifdef USE_API_VARINT64
-    uint32_t limit = std::min(len, uint32_t(4));
-#else
-    uint32_t limit = std::min(len, uint32_t(5));
-#endif
-    for (uint32_t i = 1; i < limit; i++) {
-      uint8_t val = buffer[i];
-      result32 |= uint32_t(val & 0x7F) << (i * 7);
-      if ((val & 0x80) == 0) {
-        *consumed = i + 1;
-        return ProtoVarInt(result32);
-      }
-    }
-    // 64-bit phase for remaining bytes (BLE addresses etc.)
-#ifdef USE_API_VARINT64
-    return parse_wide(buffer, len, consumed, result32);
-#else
-    return {};
-#endif
+    // (booleans, small enums, field tags, small message sizes/types).
+    if ((buffer[0] & 0x80) == 0) [[likely]]
+      return {buffer[0], 1};
+    return parse_slow_(buffer, len);
   }
 
-#ifdef USE_API_VARINT64
  protected:
-  /// Continue parsing varint bytes 4-9 with 64-bit arithmetic.
-  /// Separated to keep 64-bit shift code (__ashldi3 on 32-bit platforms) out of the common path.
-  static optional<ProtoVarInt> parse_wide(const uint8_t *buffer, uint32_t len, uint32_t *consumed, uint32_t result32)
-      __attribute__((noinline));
+  // Slow path for multi-byte varints (>= 128), outlined to keep fast path small
+  static ProtoVarIntResult parse_slow_(const uint8_t *buffer, uint32_t len) __attribute__((noinline));
 
- public:
+#ifdef USE_API_VARINT64
+  /// Continue parsing varint bytes 4-9 with 64-bit arithmetic.
+  static ProtoVarIntResult parse_wide_(const uint8_t *buffer, uint32_t len, uint32_t result32)
+      __attribute__((noinline));
 #endif
 
+ public:
   constexpr uint16_t as_uint16() const { return this->value_; }
   constexpr uint32_t as_uint32() const { return this->value_; }
   constexpr bool as_bool() const { return this->value_; }
@@ -499,7 +494,7 @@ class ProtoDecodableMessage : public ProtoMessage {
 
  protected:
   ~ProtoDecodableMessage() = default;
-  virtual bool decode_varint(uint32_t field_id, ProtoVarInt value) { return false; }
+  virtual bool decode_varint(uint32_t field_id, ProtoVarIntResult value) { return false; }
   virtual bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
   virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
   // NOTE: decode_64bit removed - wire type 1 not supported

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -115,8 +115,6 @@ struct ProtoVarIntResult {
   uint32_t consumed;  // PROTO_VARINT_PARSE_FAILED = parse failed
 
   constexpr bool has_value() const { return this->consumed != PROTO_VARINT_PARSE_FAILED; }
-  constexpr uint16_t as_uint16() const { return this->value; }
-  constexpr uint32_t as_uint32() const { return this->value; }
 };
 
 /// Static varint parsing methods for the protobuf wire format.

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -132,15 +132,23 @@ class ProtoVarInt {
 
   /// Parse a varint from buffer. Caller must ensure len >= 1.
   /// Returns result with consumed=0 on failure (truncated multi-byte varint).
-  static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse(const uint8_t *buffer, uint32_t len) {
+  static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse_non_empty(const uint8_t *buffer, uint32_t len) {
 #ifdef ESPHOME_DEBUG_API
-    assert(len > 0);  // All callers guarantee len > 0
+    assert(len > 0);
 #endif
     // Fast path: single-byte varints (0-127) are the most common case
     // (booleans, small enums, field tags, small message sizes/types).
     if ((buffer[0] & 0x80) == 0) [[likely]]
       return {buffer[0], 1};
     return parse_slow(buffer, len);
+  }
+
+  /// Parse a varint from buffer (safe for empty buffers).
+  /// Returns result with consumed=0 on failure (empty buffer or truncated varint).
+  static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse(const uint8_t *buffer, uint32_t len) {
+    if (len == 0)
+      return {0, PROTO_VARINT_PARSE_FAILED};
+    return parse_non_empty(buffer, len);
   }
 
  protected:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -130,13 +130,15 @@ class ProtoVarInt {
   ProtoVarInt() : value_(0) {}
   explicit ProtoVarInt(uint64_t value) : value_(value) {}
 
-  /// Parse a varint from buffer. Returns result with consumed=0 on failure.
+  /// Parse a varint from buffer. Caller must ensure len >= 1.
+  /// Returns result with consumed=0 on failure (truncated multi-byte varint).
   static inline ProtoVarIntResult ESPHOME_ALWAYS_INLINE parse(const uint8_t *buffer, uint32_t len) {
+#ifdef ESPHOME_DEBUG_API
+    assert(len > 0);  // All callers guarantee len > 0
+#endif
     // Fast path: single-byte varints (0-127) are the most common case
     // (booleans, small enums, field tags, small message sizes/types).
-    // len==0 check is folded into the condition to minimize inline size;
-    // parse_slow() handles len==0.
-    if (len != 0 && (buffer[0] & 0x80) == 0) [[likely]]
+    if ((buffer[0] & 0x80) == 0) [[likely]]
       return {buffer[0], 1};
     return parse_slow(buffer, len);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -506,7 +506,11 @@ class ProtoDecodableMessage : public ProtoMessage {
 
  protected:
   ~ProtoDecodableMessage() = default;
-  virtual bool decode_varint(uint32_t field_id, ProtoVarIntResult value) { return false; }
+#ifdef USE_API_VARINT64
+  virtual bool decode_varint(uint32_t field_id, uint64_t value) { return false; }
+#else
+  virtual bool decode_varint(uint32_t field_id, uint32_t value) { return false; }
+#endif
   virtual bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
   virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
   // NOTE: decode_64bit removed - wire type 1 not supported

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -193,6 +193,7 @@ class TypeInfo(ABC):
         return f"case {self.number}: this->{self.field_name} = {content}; break;"
 
     decode_varint = None
+    is_varint64 = False
 
     @property
     def decode_length_content(self) -> str:
@@ -461,7 +462,8 @@ class FloatType(TypeInfo):
 class Int64Type(TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
-    decode_varint = "value.as_int64()"
+    decode_varint = "static_cast<int64_t>(value)"
+    is_varint64 = True
     encode_func = "encode_int64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -481,7 +483,8 @@ class Int64Type(TypeInfo):
 class UInt64Type(TypeInfo):
     cpp_type = "uint64_t"
     default_value = "0"
-    decode_varint = "value.as_uint64()"
+    decode_varint = "value"
+    is_varint64 = True
     encode_func = "encode_uint64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -501,7 +504,7 @@ class UInt64Type(TypeInfo):
 class Int32Type(TypeInfo):
     cpp_type = "int32_t"
     default_value = "0"
-    decode_varint = "value.as_int32()"
+    decode_varint = "static_cast<int32_t>(value)"
     encode_func = "encode_int32"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -573,7 +576,7 @@ class Fixed32Type(TypeInfo):
 class BoolType(TypeInfo):
     cpp_type = "bool"
     default_value = "false"
-    decode_varint = "value.as_bool()"
+    decode_varint = "value != 0"
     encode_func = "encode_bool"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1151,7 +1154,7 @@ class FixedArrayBytesType(TypeInfo):
 class UInt32Type(TypeInfo):
     cpp_type = "uint32_t"
     default_value = "0"
-    decode_varint = "value.as_uint32()"
+    decode_varint = "value"
     encode_func = "encode_uint32"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1175,7 +1178,7 @@ class EnumType(TypeInfo):
 
     @property
     def decode_varint(self) -> str:
-        return f"static_cast<{self.cpp_type}>(value.as_uint32())"
+        return f"static_cast<{self.cpp_type}>(value)"
 
     default_value = ""
     wire_type = WireType.VARINT  # Uses wire type 0
@@ -1262,7 +1265,7 @@ class SFixed64Type(TypeInfo):
 class SInt32Type(TypeInfo):
     cpp_type = "int32_t"
     default_value = "0"
-    decode_varint = "value.as_sint32()"
+    decode_varint = "decode_zigzag32(value)"
     encode_func = "encode_sint32"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1282,7 +1285,8 @@ class SInt32Type(TypeInfo):
 class SInt64Type(TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
-    decode_varint = "value.as_sint64()"
+    decode_varint = "decode_zigzag64(value)"
+    is_varint64 = True
     encode_func = "encode_sint64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1619,6 +1623,10 @@ class RepeatedTypeInfo(TypeInfo):
         For repeated fields, we use the same wire type as the underlying field.
         """
         return self._ti.wire_type
+
+    @property
+    def is_varint64(self):
+        return self._ti.is_varint64
 
     @property
     def decode_varint_content(self) -> str:
@@ -2205,7 +2213,12 @@ def build_message_type(
 
     cpp = ""
     if decode_varint:
-        o = f"bool {desc.name}::decode_varint(uint32_t field_id, ProtoVarIntResult value) {{\n"
+        # Use conditional parameter type to match base class
+        o = "#ifdef USE_API_VARINT64\n"
+        o += f"bool {desc.name}::decode_varint(uint32_t field_id, uint64_t value) {{\n"
+        o += "#else\n"
+        o += f"bool {desc.name}::decode_varint(uint32_t field_id, uint32_t value) {{\n"
+        o += "#endif\n"
         o += "  switch (field_id) {\n"
         o += indent("\n".join(decode_varint), "    ") + "\n"
         o += "    default: return false;\n"
@@ -2213,10 +2226,15 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = (
-            "bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;"
-        )
-        protected_content.insert(0, prot)
+        prot_lines = [
+            "#ifdef USE_API_VARINT64",
+            "bool decode_varint(uint32_t field_id, uint64_t value) override;",
+            "#else",
+            "bool decode_varint(uint32_t field_id, uint32_t value) override;",
+            "#endif",
+        ]
+        for i, line in enumerate(prot_lines):
+            protected_content.insert(i, line)
     if decode_length:
         o = f"bool {desc.name}::decode_length(uint32_t field_id, ProtoLengthDelimited value) {{\n"
         o += "  switch (field_id) {\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1262,7 +1262,7 @@ class SFixed64Type(TypeInfo):
 class SInt32Type(TypeInfo):
     cpp_type = "int32_t"
     default_value = "0"
-    decode_varint = "decode_zigzag32(value)"
+    decode_varint = "decode_zigzag32(static_cast<uint32_t>(value))"
     encode_func = "encode_sint32"
     wire_type = WireType.VARINT  # Uses wire type 0
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2205,7 +2205,7 @@ def build_message_type(
 
     cpp = ""
     if decode_varint:
-        o = f"bool {desc.name}::decode_varint(uint32_t field_id, ProtoVarInt value) {{\n"
+        o = f"bool {desc.name}::decode_varint(uint32_t field_id, ProtoVarIntResult value) {{\n"
         o += "  switch (field_id) {\n"
         o += indent("\n".join(decode_varint), "    ") + "\n"
         o += "    default: return false;\n"
@@ -2213,7 +2213,9 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_varint(uint32_t field_id, ProtoVarInt value) override;"
+        prot = (
+            "bool decode_varint(uint32_t field_id, ProtoVarIntResult value) override;"
+        )
         protected_content.insert(0, prot)
     if decode_length:
         o = f"bool {desc.name}::decode_length(uint32_t field_id, ProtoLengthDelimited value) {{\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -193,7 +193,6 @@ class TypeInfo(ABC):
         return f"case {self.number}: this->{self.field_name} = {content}; break;"
 
     decode_varint = None
-    is_varint64 = False
 
     @property
     def decode_length_content(self) -> str:
@@ -463,7 +462,6 @@ class Int64Type(TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
     decode_varint = "static_cast<int64_t>(value)"
-    is_varint64 = True
     encode_func = "encode_int64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -484,7 +482,6 @@ class UInt64Type(TypeInfo):
     cpp_type = "uint64_t"
     default_value = "0"
     decode_varint = "value"
-    is_varint64 = True
     encode_func = "encode_uint64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1286,7 +1283,6 @@ class SInt64Type(TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
     decode_varint = "decode_zigzag64(value)"
-    is_varint64 = True
     encode_func = "encode_sint64"
     wire_type = WireType.VARINT  # Uses wire type 0
 
@@ -1623,10 +1619,6 @@ class RepeatedTypeInfo(TypeInfo):
         For repeated fields, we use the same wire type as the underlying field.
         """
         return self._ti.wire_type
-
-    @property
-    def is_varint64(self):
-        return self._ti.is_varint64
 
     @property
     def decode_varint_content(self) -> str:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2213,12 +2213,7 @@ def build_message_type(
 
     cpp = ""
     if decode_varint:
-        # Use conditional parameter type to match base class
-        o = "#ifdef USE_API_VARINT64\n"
-        o += f"bool {desc.name}::decode_varint(uint32_t field_id, uint64_t value) {{\n"
-        o += "#else\n"
-        o += f"bool {desc.name}::decode_varint(uint32_t field_id, uint32_t value) {{\n"
-        o += "#endif\n"
+        o = f"bool {desc.name}::decode_varint(uint32_t field_id, proto_varint_value_t value) {{\n"
         o += "  switch (field_id) {\n"
         o += indent("\n".join(decode_varint), "    ") + "\n"
         o += "    default: return false;\n"
@@ -2226,15 +2221,8 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot_lines = [
-            "#ifdef USE_API_VARINT64",
-            "bool decode_varint(uint32_t field_id, uint64_t value) override;",
-            "#else",
-            "bool decode_varint(uint32_t field_id, uint32_t value) override;",
-            "#endif",
-        ]
-        for i, line in enumerate(prot_lines):
-            protected_content.insert(i, line)
+        prot = "bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;"
+        protected_content.insert(0, prot)
     if decode_length:
         o = f"bool {desc.name}::decode_length(uint32_t field_id, ProtoLengthDelimited value) {{\n"
         o += "  switch (field_id) {\n"


### PR DESCRIPTION
# What does this implement/fix?

Inline the `ProtoVarInt::parse()` single-byte fast path and replace the `optional<ProtoVarInt>` + `consumed` output pointer API with a `ProtoVarIntResult` struct that returns value + consumed count directly.

**Why:** `ProtoDecodableMessage::decode()` is the core protobuf decode loop — every incoming API message (state updates, commands, entity listings) goes through it. Each field in a message requires two `ProtoVarInt::parse()` calls: one for the field tag, one for the value. The old implementation used `optional<ProtoVarInt>` with 64-bit arithmetic and an out-pointer for `consumed`, all behind a non-inlined function call. This PR eliminates that overhead with an inlined single-byte fast path and a lighter return type.

**What changed:**
- New `ProtoVarIntResult` struct with `{value, consumed}` — `consumed == 0` means parse failure (replaces `optional`)
- `PROTO_VARINT_PARSE_FAILED` named constant for the consumed field sentinel value
- Two parse variants: `parse_non_empty()` (no len check, debug assert) for callers that guarantee `len >= 1` (e.g. tag parse after `while (ptr < end)` in `decode()`), and `parse()` which adds a `len == 0` guard for callers where the buffer may be empty (e.g. value parse after tag advance, frame helper header parsing)
- Both are `ESPHOME_ALWAYS_INLINE` with only the single-byte check inline; multi-byte path outlined to `parse_slow()`
- All callers updated: `res.consumed` instead of separate `consumed` variable, `res.value` (or `static_cast<uint32_t>(res.value)` for narrowing) instead of `res->as_uint32()`
- `decode_varint()` virtual method signature updated to take `proto_varint_value_t` directly (avoids constructing a temporary `ProtoVarInt`)
- `proto_varint_value_t` is conditionally `uint64_t` (when `USE_API_VARINT64` is defined, i.e. BLE proxy builds) or `uint32_t` (all other builds) — benchmarks show the uint64 overhead is only a few percentage points
- Codegen (`api_protobuf.py`) updated to generate the new signature

**Binary size impact (ESP32 IDF, before vs after):**

| Config | dev | This PR | Change |
|--------|-----|---------|--------|
| ol (API, BLE proxy, web server, climate) | 914,323 | 914,315 | **-8 bytes** |
| upstairsdesk89proxy (API, BLE proxy) | 826,119 | 826,163 | **+44 bytes** |

The inlined single-byte fast path adds ~12 bytes per inline site in `decode()`, but this is offset by eliminating the `optional<ProtoVarInt>` machinery and the old non-inlined `parse()` function. Configs with more `decode_varint()` overrides (more message types) see a small increase from the signature change (+6 bytes each), but the total impact is negligible for a ~50% decode speedup.

**On-device benchmarks (ESP32, 100k iterations each):**

*Isolated varint parse (ESP32 IDF, non-BLE, `uint32_t` path):*

| Case | Old (ns) | New (ns) | Delta |
|------|----------|----------|-------|
| 1-byte (0) | 301 | 126 | **-58.2%** |
| 1-byte (42) | 301 | 126 | **-58.1%** |
| 1-byte (127) | 304 | 126 | **-58.7%** |
| 2-byte (300) | 460 | 352 | **-23.5%** |
| 2-byte (16383) | 453 | 352 | **-22.2%** |
| 3-byte (100000) | 572 | 471 | **-17.6%** |
| 5-byte (UINT32_MAX) | 811 | 734 | **-9.5%** |
| 5-byte (FNV hash) | 824 | 726 | **-11.9%** |

The 1-byte fast path (booleans, small enums, field tags, message sizes/types) is ~58% faster — this is the hot path exercised on every API message. The improvement comes from inlining the single-byte check and eliminating the `optional<>` wrapper construction. Multi-byte varints see 10-24% improvement from removing the function call and `optional<>` overhead in `parse_slow()`.

*Full protobuf message decode (`ProtoDecodableMessage::decode()` loop):*

`proto_varint_value_t = uint32_t` (non-BLE build):

| Case | Old (ns) | New (ns) | Delta |
|------|----------|----------|-------|
| Small (3 fields, HelloReq) | 1839 | 899 | **-51.1%** |
| Medium (10 varints) | 6997 | 4275 | **-38.9%** |
| Large (10vi+5f32+1str) | 8974 | 4925 | **-45.1%** |

`proto_varint_value_t = uint64_t` (BLE proxy build):

| Case | Old (ns) | New (ns) | Delta |
|------|----------|----------|-------|
| Small (3 fields, HelloReq) | 2009 | 892 | **-55.6%** |
| Medium (10 varints) | 8250 | 4692 | **-43.1%** |
| Large (10vi+5f32+1str) | 10187 | 5192 | **-49.0%** |

The uint64 widening for BLE builds costs only a few percentage points — medium messages go from 48% to 43% improvement, while small and large messages are within 1-3%. Both builds achieve ~50% faster decode overall. The uint64 cost is negligible compared to the wins from inlining the single-byte fast path and dropping the `optional<>` wrapper.

**On-device benchmarks (ESP8266, 10k iterations each):**

`proto_varint_value_t = uint32_t` (no BLE on ESP8266):

| Case | Old (ns) | New (ns) | Delta |
|------|----------|----------|-------|
| Small (3 fields, HelloReq) | 3751 | 1938 | **-48.3%** |
| Medium (10 varints) | 13211 | 8759 | **-33.7%** |
| Large (10vi+5f32+1str) | 17281 | 10001 | **-42.1%** |

The old dev code already used `uint32_t` arithmetic on ESP8266 (no `USE_API_VARINT64`), so the gains here come purely from dropping the `optional<>` wrapper and inlining the single-byte fast path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14607 (inline varint encode fast path)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal API only)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Decode benchmark button to reproduce on-device measurements. The `OldVarInt` below matches the dev branch for non-BLE builds (`uint32_t` value/arithmetic). For BLE builds (`USE_API_VARINT64`), change `OldVarInt` to use `uint64_t value_` and `uint64_t` arithmetic with `limit = std::min(len, uint32_t(10))` to match dev.

```yaml
button:
  - platform: template
    name: Decode Benchmark
    on_press:
      - lambda: |-
          using namespace esphome::api;
          static const char *TAG = "decode_bench";
          const int ITERATIONS = 100000;  // Use 10000 on ESP8266

          // Helper to encode a varint into a buffer, returns length
          auto encode_varint = [](uint64_t value, uint8_t *buf) -> int {
            int n = 0;
            while (value > 0x7F) {
              buf[n++] = static_cast<uint8_t>(value | 0x80);
              value >>= 7;
            }
            buf[n++] = static_cast<uint8_t>(value);
            return n;
          };

          // === OLD decode loop: matches dev branch for non-BLE builds ===
          // uint32_t value_, uint32_t parse arithmetic, limit=5
          struct OldVarInt {
            uint32_t value_;
            uint32_t as_uint32() const { return value_; }
            static optional<OldVarInt> parse(const uint8_t *buffer, uint32_t len, uint32_t *consumed) {
              if (len == 0) return {};
              if ((buffer[0] & 0x80) == 0) {
                *consumed = 1;
                return OldVarInt{buffer[0]};
              }
              uint32_t result32 = buffer[0] & 0x7F;
              uint32_t limit = std::min(len, uint32_t(5));
              for (uint32_t i = 1; i < limit; i++) {
                uint8_t val = buffer[i];
                result32 |= uint32_t(val & 0x7F) << (i * 7);
                if ((val & 0x80) == 0) {
                  *consumed = i + 1;
                  return OldVarInt{result32};
                }
              }
              return {};
            }
          };

          // Old decode loop
          auto old_decode = [](const uint8_t *buffer, size_t length) __attribute__((noinline)) {
            const uint8_t *ptr = buffer;
            const uint8_t *end = buffer + length;
            volatile uint32_t sink = 0;
            while (ptr < end) {
              uint32_t consumed;
              auto res = OldVarInt::parse(ptr, end - ptr, &consumed);
              if (!res.has_value()) return;
              uint32_t tag = res->as_uint32();
              uint32_t field_type = tag & 0x07;
              ptr += consumed;
              switch (field_type) {
                case 0: {
                  res = OldVarInt::parse(ptr, end - ptr, &consumed);
                  if (!res.has_value()) return;
                  sink += res->as_uint32();
                  ptr += consumed;
                  break;
                }
                case 2: {
                  res = OldVarInt::parse(ptr, end - ptr, &consumed);
                  if (!res.has_value()) return;
                  ptr += consumed + res->as_uint32();
                  break;
                }
                case 5: {
                  if (end - ptr < 4) return;
                  sink += ptr[0];
                  ptr += 4;
                  break;
                }
                default: return;
              }
            }
          };

          // New decode loop - ProtoVarIntResult API
          auto new_decode = [](const uint8_t *buffer, size_t length) __attribute__((noinline)) {
            const uint8_t *ptr = buffer;
            const uint8_t *end = buffer + length;
            volatile uint32_t sink = 0;
            while (ptr < end) {
              auto res = ProtoVarInt::parse(ptr, end - ptr);
              if (!res.has_value()) return;
              uint32_t tag = static_cast<uint32_t>(res.value);
              uint32_t field_type = tag & 0x07;
              ptr += res.consumed;
              switch (field_type) {
                case 0: {
                  res = ProtoVarInt::parse(ptr, end - ptr);
                  if (!res.has_value()) return;
                  sink += static_cast<uint32_t>(res.value);
                  ptr += res.consumed;
                  break;
                }
                case 2: {
                  res = ProtoVarInt::parse(ptr, end - ptr);
                  if (!res.has_value()) return;
                  ptr += res.consumed + static_cast<uint32_t>(res.value);
                  break;
                }
                case 5: {
                  if (end - ptr < 4) return;
                  sink += ptr[0];
                  ptr += 4;
                  break;
                }
                default: return;
              }
            }
          };

          // Build test messages
          uint8_t small_buf[32];
          int small_pos = 0;
          small_buf[small_pos++] = 0x0A;
          const char *client = "aioesphomeapi";
          uint8_t clen = strlen(client);
          small_pos += encode_varint(clen, small_buf + small_pos);
          memcpy(small_buf + small_pos, client, clen);
          small_pos += clen;
          small_buf[small_pos++] = 0x10;
          small_pos += encode_varint(1, small_buf + small_pos);
          small_buf[small_pos++] = 0x18;
          small_pos += encode_varint(10, small_buf + small_pos);

          uint8_t med_buf[64];
          int med_pos = 0;
          for (int f = 1; f <= 10; f++) {
            med_pos += encode_varint((f << 3) | 0, med_buf + med_pos);
            med_pos += encode_varint(f * 42, med_buf + med_pos);
          }

          uint8_t large_buf[128];
          int large_pos = 0;
          for (int f = 1; f <= 10; f++) {
            large_pos += encode_varint((f << 3) | 0, large_buf + large_pos);
            large_pos += encode_varint(f < 8 ? 1 : f * 100, large_buf + large_pos);
          }
          for (int f = 11; f <= 15; f++) {
            large_pos += encode_varint((f << 3) | 5, large_buf + large_pos);
            float fv = f * 0.1f;
            memcpy(large_buf + large_pos, &fv, 4);
            large_pos += 4;
          }
          large_pos += encode_varint((16 << 3) | 2, large_buf + large_pos);
          const char *effect = "rainbow";
          uint8_t elen = strlen(effect);
          large_pos += encode_varint(elen, large_buf + large_pos);
          memcpy(large_buf + large_pos, effect, elen);
          large_pos += elen;

          struct BenchCase {
            const char *label;
            const uint8_t *buf;
            int len;
          };

          BenchCase cases[] = {
            {"Small (3 fields, HelloReq)", small_buf, small_pos},
            {"Medium (10 varints)", med_buf, med_pos},
            {"Large (10vi+5f32+1str)", large_buf, large_pos},
          };

          ESP_LOGI(TAG, "=== Decode Benchmark (%d iters) ===", ITERATIONS);
          ESP_LOGI(TAG, "Old = optional<ProtoVarInt> + consumed ptr decode loop");
          ESP_LOGI(TAG, "New = ProtoVarIntResult decode loop (inlined parse)");
          ESP_LOGI(TAG, "%-30s  %10s  %10s  %8s", "Case", "Old (ns)", "New (ns)", "Delta");
          ESP_LOGI(TAG, "%-30s  %10s  %10s  %8s", "----", "--------", "--------", "-----");

          for (auto &tc : cases) {
            for (int i = 0; i < 1000; i++) {
              old_decode(tc.buf, tc.len);
              new_decode(tc.buf, tc.len);
            }

            App.feed_wdt();

            uint32_t t0 = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              old_decode(tc.buf, tc.len);
            }
            uint32_t elapsed_old = micros() - t0;

            App.feed_wdt();

            t0 = micros();
            for (int i = 0; i < ITERATIONS; i++) {
              new_decode(tc.buf, tc.len);
            }
            uint32_t elapsed_new = micros() - t0;

            double old_ns = (double)elapsed_old * 1000.0 / ITERATIONS;
            double new_ns = (double)elapsed_new * 1000.0 / ITERATIONS;
            double pct = old_ns > 0 ? (new_ns - old_ns) / old_ns * 100.0 : 0;

            ESP_LOGI(TAG, "%-30s  %9.1f   %9.1f   %+5.1f%%  (%d bytes)",
                     tc.label, old_ns, new_ns, pct, tc.len);
          }

          ESP_LOGI(TAG, "=== Decode Benchmark complete ===");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

CI compilation tests across all platforms (ESP32, ESP8266, RP2040, BK72xx, RTL87xx, LN882x) provide comprehensive coverage — the generated `api_pb2.cpp` exercises all 51 `decode_varint()` overrides covering every protobuf wire type and accessor pattern. Integration tests (`tests/integration/`) exercise most message types end-to-end with real protobuf encode/decode. Standalone varint parse/encode/size tests attached as `proto_varint_tests.zip`.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).