### PR TITLE
[multiple] Fix undefined behavior across components

### DIFF
--- a/esphome/components/e131/e131_packet.cpp
+++ b/esphome/components/e131/e131_packet.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <cstring>
 #include "e131.h"
 #ifdef USE_NETWORK
@@ -57,7 +58,7 @@ union E131RawPacket {
 
 // We need to have at least one `1` value
 // Get the offset of `property_values[1]`
-const size_t E131_MIN_PACKET_SIZE = reinterpret_cast<size_t>(&((E131RawPacket *) nullptr)->property_values[1]);
+const size_t E131_MIN_PACKET_SIZE = offsetof(E131RawPacket, property_values) + sizeof(uint8_t);
 
 bool E131Component::join_igmp_groups_() {
   if (this->listen_method_ != E131_MULTICAST)

--- a/esphome/components/globals/globals_component.h
+++ b/esphome/components/globals/globals_component.h
@@ -84,7 +84,7 @@ template<typename T, uint8_t SZ> class RestoringGlobalStringComponent : public P
     this->rtc_ = global_preferences->make_preference<uint8_t[SZ]>(1944399030U ^ this->name_hash_);
     bool hasdata = this->rtc_.load(&temp);
     if (hasdata) {
-      this->value_.assign(temp + 1, temp[0]);
+      this->value_.assign(temp + 1, static_cast<uint8_t>(temp[0]));
     }
     this->last_checked_value_.assign(this->value_);
   }

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.cpp
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.cpp
@@ -139,7 +139,8 @@ void GroveMotorDriveTB6612FNG::stepper_run(StepperModeTypeT mode, int16_t steps,
 }
 
 void GroveMotorDriveTB6612FNG::stepper_stop() {
-  if (this->write_register(GROVE_MOTOR_DRIVER_I2C_CMD_STEPPER_STOP, nullptr, 1) != i2c::ERROR_OK) {
+  uint8_t status = 0;
+  if (this->write_register(GROVE_MOTOR_DRIVER_I2C_CMD_STEPPER_STOP, &status, 1) != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "Send stop stepper failed!");
     this->status_set_warning();
     return;

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -28,12 +28,14 @@ class UARTStream : public Stream {
   int available() override { return this->uart_->available(); }
   int read() override {
     uint8_t data;
-    this->uart_->read_byte(&data);
+    if (!this->uart_->read_byte(&data))
+      return -1;
     return data;
   }
   int peek() override {
     uint8_t data;
-    this->uart_->peek_byte(&data);
+    if (!this->uart_->peek_byte(&data))
+      return -1;
     return data;
   }
   size_t write(uint8_t data) override {

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -651,11 +651,7 @@ void Nextion::process_nextion_commands_() {
           break;
         }
 
-        int value = 0;
-
-        for (int i = 0; i < 4; ++i) {
-          value += to_process[i] << (8 * i);
-        }
+        int value = static_cast<int>(encode_uint32(to_process[3], to_process[2], to_process[1], to_process[0]));
 
         NextionQueue *nb = this->nextion_queue_.front();
         if (!nb || !nb->component) {
@@ -751,10 +747,8 @@ void Nextion::process_nextion_commands_() {
         index = to_process.find('\0');
         variable_name = to_process.substr(0, index);
         // // Get variable name
-        int value = 0;
-        for (int i = 0; i < 4; ++i) {
-          value += to_process[i + index + 1] << (8 * i);
-        }
+        int value = static_cast<int>(
+            encode_uint32(to_process[index + 4], to_process[index + 3], to_process[index + 2], to_process[index + 1]));
 
         ESP_LOGN(TAG, "Sensor: %s=%d", variable_name.c_str(), value);
 

--- a/esphome/components/ruuvi_ble/ruuvi_ble.cpp
+++ b/esphome/components/ruuvi_ble/ruuvi_ble.cpp
@@ -21,11 +21,11 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       const float temperature = temp_sign == 0 ? temp_val : -1 * temp_val;
 
       const float humidity = data[0] * 0.5f;
-      const float pressure = (uint16_t(data[3] << 8) + uint16_t(data[4]) + 50000.0f) / 100.0f;
-      const float acceleration_x = (int16_t(data[5] << 8) + int16_t(data[6])) / 1000.0f;
-      const float acceleration_y = (int16_t(data[7] << 8) + int16_t(data[8])) / 1000.0f;
-      const float acceleration_z = (int16_t(data[9] << 8) + int16_t(data[10])) / 1000.0f;
-      const float battery_voltage = (uint16_t(data[11] << 8) + uint16_t(data[12])) / 1000.0f;
+      const float pressure = (encode_uint16(data[3], data[4]) + 50000.0f) / 100.0f;
+      const float acceleration_x = static_cast<int16_t>(encode_uint16(data[5], data[6])) / 1000.0f;
+      const float acceleration_y = static_cast<int16_t>(encode_uint16(data[7], data[8])) / 1000.0f;
+      const float acceleration_z = static_cast<int16_t>(encode_uint16(data[9], data[10])) / 1000.0f;
+      const float battery_voltage = encode_uint16(data[11], data[12]) / 1000.0f;
 
       result.humidity = humidity;
       result.temperature = temperature;
@@ -43,19 +43,19 @@ bool parse_ruuvi_data_byte(const esp32_ble_tracker::adv_data_t &adv_data, RuuviP
       if (adv_data.size() != 24)
         return false;
 
-      const float temperature = (int16_t(data[0] << 8) + int16_t(data[1])) * 0.005f;
-      const float humidity = (uint16_t(data[2] << 8) | uint16_t(data[3])) / 400.0f;
-      const float pressure = ((uint16_t(data[4] << 8) | uint16_t(data[5])) + 50000.0f) / 100.0f;
-      const float acceleration_x = (int16_t(data[6] << 8) + int16_t(data[7])) / 1000.0f;
-      const float acceleration_y = (int16_t(data[8] << 8) + int16_t(data[9])) / 1000.0f;
-      const float acceleration_z = (int16_t(data[10] << 8) + int16_t(data[11])) / 1000.0f;
+      const float temperature = static_cast<int16_t>(encode_uint16(data[0], data[1])) * 0.005f;
+      const float humidity = encode_uint16(data[2], data[3]) / 400.0f;
+      const float pressure = (encode_uint16(data[4], data[5]) + 50000.0f) / 100.0f;
+      const float acceleration_x = static_cast<int16_t>(encode_uint16(data[6], data[7])) / 1000.0f;
+      const float acceleration_y = static_cast<int16_t>(encode_uint16(data[8], data[9])) / 1000.0f;
+      const float acceleration_z = static_cast<int16_t>(encode_uint16(data[10], data[11])) / 1000.0f;
 
-      const uint16_t power_info = (uint16_t(data[12] << 8) | data[13]);
+      const uint16_t power_info = encode_uint16(data[12], data[13]);
       const float battery_voltage = ((power_info >> 5) + 1600.0f) / 1000.0f;
       const float tx_power = ((power_info & 0x1F) * 2.0f) - 40.0f;
 
       const float movement_counter = float(data[14]);
-      const float measurement_sequence_number = float(uint16_t(data[15] << 8) | uint16_t(data[16]));
+      const float measurement_sequence_number = float(encode_uint16(data[15], data[16]));
 
       result.temperature = data[0] == 0x7F && data[1] == 0xFF ? NAN : temperature;
       result.humidity = data[2] == 0xFF && data[3] == 0xFF ? NAN : humidity;

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -99,7 +99,7 @@ struct MessageHeader {
 
   // payload_size returns the amount of payload bytes to be read from the uart
   // buffer after reading the header.
-  uint32_t payload_size() { return this->len - sizeof(this->type); }
+  uint32_t payload_size() { return this->len > sizeof(this->type) ? this->len - sizeof(this->type) : 0; }
 } __attribute__((packed));
 
 // StatusType denotes which 'page' of information needs to be retrieved.


### PR DESCRIPTION
# What does this implement/fix?

Fix undefined behavior across 7 components:

- **nextion**: Use `encode_uint32()` helper to reconstruct 32-bit values from serial bytes instead of manual shifting of `char` which causes sign extension and signed overflow UB on `<< 24`.
- **e131**: Replace null pointer dereference (used to compute struct offset) with standard `offsetof()`.
- **ruuvi_ble**: Use `encode_uint16()` helper instead of manual `data[N] << 8` which causes sign extension via implicit promotion to signed `int`.
- **midea**: Check `read_byte()`/`peek_byte()` return value and return -1 on failure instead of returning uninitialized stack data.
- **grove_tb6612fng**: Pass valid buffer instead of `nullptr` with length 1 to `write_register()`, which would dereference null in `std::copy()`. Matches the pattern used by `standby()`/`not_standby()` in the same file.
- **tormatic**: Guard against unsigned underflow in `payload_size()` when `len < sizeof(type)` on malformed UART messages.
- **globals**: Cast `char` length byte to `uint8_t` before passing to `std::string::assign()` to prevent sign extension on platforms with signed `char` (e.g. host/Linux builds). Strings >127 chars would corrupt on restore.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - defensive fixes only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).