### PR TITLE
[multiple] Fix wrong behavior in sensor calculations and drivers

### DIFF
--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -147,11 +147,11 @@ void BME280Component::setup() {
   this->calibration_.h1 = read_u8_(BME280_REGISTER_DIG_H1);
   this->calibration_.h2 = read_s16_le_(BME280_REGISTER_DIG_H2);
   this->calibration_.h3 = read_u8_(BME280_REGISTER_DIG_H3);
-  // h4 and h5 are signed 12-bit values; sign-extend to int16_t
+  // h4 and h5 are signed 12-bit values; shift left then arithmetic right shift to sign-extend
   int16_t h4_raw = read_u8_(BME280_REGISTER_DIG_H4) << 4 | (read_u8_(BME280_REGISTER_DIG_H4 + 1) & 0x0F);
-  this->calibration_.h4 = h4_raw >= 2048 ? h4_raw - 4096 : h4_raw;
+  this->calibration_.h4 = static_cast<int16_t>(h4_raw << 4) >> 4;
   int16_t h5_raw = read_u8_(BME280_REGISTER_DIG_H5 + 1) << 4 | (read_u8_(BME280_REGISTER_DIG_H5) >> 4);
-  this->calibration_.h5 = h5_raw >= 2048 ? h5_raw - 4096 : h5_raw;
+  this->calibration_.h5 = static_cast<int16_t>(h5_raw << 4) >> 4;
   this->calibration_.h6 = read_u8_(BME280_REGISTER_DIG_H6);
 
   uint8_t humid_control_val = 0;

--- a/esphome/components/bme280_base/bme280_base.cpp
+++ b/esphome/components/bme280_base/bme280_base.cpp
@@ -147,8 +147,11 @@ void BME280Component::setup() {
   this->calibration_.h1 = read_u8_(BME280_REGISTER_DIG_H1);
   this->calibration_.h2 = read_s16_le_(BME280_REGISTER_DIG_H2);
   this->calibration_.h3 = read_u8_(BME280_REGISTER_DIG_H3);
-  this->calibration_.h4 = read_u8_(BME280_REGISTER_DIG_H4) << 4 | (read_u8_(BME280_REGISTER_DIG_H4 + 1) & 0x0F);
-  this->calibration_.h5 = read_u8_(BME280_REGISTER_DIG_H5 + 1) << 4 | (read_u8_(BME280_REGISTER_DIG_H5) >> 4);
+  // h4 and h5 are signed 12-bit values; sign-extend to int16_t
+  int16_t h4_raw = read_u8_(BME280_REGISTER_DIG_H4) << 4 | (read_u8_(BME280_REGISTER_DIG_H4 + 1) & 0x0F);
+  this->calibration_.h4 = h4_raw >= 2048 ? h4_raw - 4096 : h4_raw;
+  int16_t h5_raw = read_u8_(BME280_REGISTER_DIG_H5 + 1) << 4 | (read_u8_(BME280_REGISTER_DIG_H5) >> 4);
+  this->calibration_.h5 = h5_raw >= 2048 ? h5_raw - 4096 : h5_raw;
   this->calibration_.h6 = read_u8_(BME280_REGISTER_DIG_H6);
 
   uint8_t humid_control_val = 0;

--- a/esphome/components/bme680/bme680.h
+++ b/esphome/components/bme680/bme680.h
@@ -32,8 +32,8 @@ enum BME680Oversampling {
 /// Struct for storing calibration data for the BME680.
 struct BME680CalibrationData {
   uint16_t t1;
-  uint16_t t2;
-  uint8_t t3;
+  int16_t t2;
+  int8_t t3;
 
   uint16_t p1;
   int16_t p2;

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <cmath>
 
 namespace esphome::cse7766 {
 
@@ -192,12 +193,12 @@ void CSE7766Component::parse_data_() {
       this->apparent_power_sensor_->publish_state(apparent_power);
     }
     if (have_power && this->reactive_power_sensor_ != nullptr) {
-      const float reactive_power = apparent_power - power;
-      if (reactive_power < 0.0f) {
-        ESP_LOGD(TAG, "Impossible reactive power: %.4f is negative", reactive_power);
+      const float q_squared = apparent_power * apparent_power - power * power;
+      if (q_squared < 0.0f) {
+        ESP_LOGD(TAG, "Impossible reactive power: S^2-P^2 is negative (%.4f)", q_squared);
         this->reactive_power_sensor_->publish_state(0.0f);
       } else {
-        this->reactive_power_sensor_->publish_state(reactive_power);
+        this->reactive_power_sensor_->publish_state(std::sqrt(q_squared));
       }
     }
     if (this->power_factor_sensor_ != nullptr && (have_power || power_cycle_exceeds_range)) {

--- a/esphome/components/hitachi_ac344/hitachi_ac344.h
+++ b/esphome/components/hitachi_ac344/hitachi_ac344.h
@@ -96,7 +96,7 @@ class HitachiClimate : public climate_ir::ClimateIR {
   void set_power_(bool on);
   uint8_t get_mode_();
   void set_mode_(uint8_t mode);
-  void set_temp_(uint8_t celsius, bool set_previous = false);
+  void set_temp_(uint8_t celsius, bool set_previous = true);
   uint8_t get_fan_();
   void set_fan_(uint8_t speed);
   void set_swing_v_toggle_(bool on);

--- a/esphome/components/rx8130/rx8130.cpp
+++ b/esphome/components/rx8130/rx8130.cpp
@@ -75,7 +75,7 @@ void RX8130Component::read_time() {
       .second = bcd2dec(date[0] & 0x7f),
       .minute = bcd2dec(date[1] & 0x7f),
       .hour = bcd2dec(date[2] & 0x3f),
-      .day_of_week = bcd2dec(date[3] & 0x7f),
+      .day_of_week = static_cast<uint8_t>((date[3] & 0x7f) ? __builtin_ctz(date[3] & 0x7f) + 1 : 1),
       .day_of_month = bcd2dec(date[4] & 0x3f),
       .day_of_year = 1,  // ignored by recalc_timestamp_utc(false)
       .month = bcd2dec(date[5] & 0x1f),
@@ -103,7 +103,7 @@ void RX8130Component::write_time() {
   buff[0] = dec2bcd(now.second);
   buff[1] = dec2bcd(now.minute);
   buff[2] = dec2bcd(now.hour);
-  buff[3] = dec2bcd(now.day_of_week);
+  buff[3] = 1 << (now.day_of_week - 1);
   buff[4] = dec2bcd(now.day_of_month);
   buff[5] = dec2bcd(now.month);
   buff[6] = dec2bcd(now.year % 100);

--- a/esphome/components/usb_uart/cp210x.cpp
+++ b/esphome/components/usb_uart/cp210x.cpp
@@ -65,7 +65,7 @@ std::vector<CdcEps> USBUartTypeCP210X::parse_descriptors(usb_device_handle_t dev
   }
 
   for (uint8_t i = 0; i != config_desc->bNumInterfaces; i++) {
-    auto data_desc = usb_parse_interface_descriptor(config_desc, 0, 0, &conf_offset);
+    auto data_desc = usb_parse_interface_descriptor(config_desc, i, 0, &conf_offset);
     if (!data_desc) {
       ESP_LOGE(TAG, "data_desc: usb_parse_interface_descriptor failed");
       break;


### PR DESCRIPTION
# What does this implement/fix?

Fix wrong behavior bugs that produce incorrect results across 6 components:

- **bme680**: Temperature calibration fields `t2` and `t3` were declared as unsigned (`uint16_t`/`uint8_t`) but the BME680 datasheet specifies them as signed (`int16_t`/`int8_t`). Negative calibration values were misinterpreted as large positive numbers, producing wrong temperature readings.
- **bme280_base**: Humidity calibration values `h4` and `h5` are signed 12-bit values, but were assembled from unsigned byte reads without sign extension. Values ≥ 2048 (which represent negative calibration) were stored as positive, corrupting humidity calculations. Fixed with shift-based sign extension.
- **hitachi_ac344**: `set_temp_()` had `set_previous` defaulting to `false`, so `previous_temp_` was never updated during normal operation. On mode changes, the temperature always reset to the initial value of 27°C. Changed default to `true` (the only caller that needs `false` already passes it explicitly for FAN mode).
- **rx8130**: The RX8130CE RTC's WEEK register uses 1-hot encoding (bit 0 = first day, bit 6 = seventh day) per the [datasheet](https://download.epsondevice.com/td/pdf/app/RX8130CE_en.pdf), but the code applied `bcd2dec()`/`dec2bcd()`. This worked by coincidence for days 1–2 (values 0x01, 0x02) but produced wrong results for days 3–7 (e.g., Tuesday 0x04 decoded as day 4 instead of day 3). Fixed read to use `__builtin_ctz` and write to use bit shift.
- **cse7766**: Reactive power was calculated as `S - P` (apparent minus active power) instead of the correct power triangle formula `√(S² - P²)`. This is mathematically wrong — e.g., with S=100VA, P=80W: old code gives Q=20VAR, correct answer is Q=60VAR. The CSE7766 chip measures voltage, current, and active power directly; reactive power must be derived from the power triangle.
- **usb_uart**: The CP210X interface descriptor parsing loop used hardcoded `0` instead of the loop variable `i`, so multi-interface CP210X devices only ever parsed interface 0 repeatedly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - these fix incorrect internal calculations
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).