### PR TITLE
[demo] Fix alarm control panel auth bypass when code is omitted

### DIFF
--- a/esphome/components/demo/demo_alarm_control_panel.h
+++ b/esphome/components/demo/demo_alarm_control_panel.h
@@ -32,8 +32,8 @@ class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
     auto code = call.get_code();
     switch (state) {
       case ACP_STATE_ARMED_AWAY:
-        if (this->get_requires_code_to_arm() && code.has_value()) {
-          if (*code != "1234") {
+        if (this->get_requires_code_to_arm()) {
+          if (!code.has_value() || *code != "1234") {
             this->status_momentary_error("invalid_code", 5000);
             return;
           }
@@ -41,8 +41,8 @@ class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
         this->publish_state(ACP_STATE_ARMED_AWAY);
         break;
       case ACP_STATE_DISARMED:
-        if (this->get_requires_code() && code.has_value()) {
-          if (*code != "1234") {
+        if (this->get_requires_code()) {
+          if (!code.has_value() || *code != "1234") {
             this->status_momentary_error("invalid_code", 5000);
             return;
           }


### PR DESCRIPTION
# What does this implement/fix?

Fix authentication bypass in the demo alarm control panel. The condition `requires_code && code.has_value()` meant that when a code was required but not provided, the entire validation block was skipped, allowing unauthenticated arm/disarm actions.

Changed to check `requires_code` first, then reject if the code is missing or wrong:

```cpp
// Before (broken): skips auth entirely when code not provided
if (this->get_requires_code() && code.has_value()) {
  if (*code != "1234") { reject; }
}

// After (fixed): rejects when code required but missing
if (this->get_requires_code()) {
  if (!code.has_value() || *code != "1234") { reject; }
}
```

Note: This is the demo component with a hardcoded password, not a production alarm panel.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal logic fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).