### PR TITLE
[speaker_source] Add new media player

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -458,6 +458,7 @@ esphome/components/sonoff_d1/* @anatoly-savchenkov
 esphome/components/sound_level/* @kahrendt
 esphome/components/speaker/* @jesserockz @kahrendt
 esphome/components/speaker/media_player/* @kahrendt @synesthesiam
+esphome/components/speaker_source/* @kahrendt
 esphome/components/spi/* @clydebarrow @esphome/core
 esphome/components/spi_device/* @clydebarrow
 esphome/components/spi_led_strip/* @clydebarrow

--- a/esphome/components/speaker_source/automation.h
+++ b/esphome/components/speaker_source/automation.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/automation.h"
+#include "speaker_source_media_player.h"
+
+namespace esphome {
+namespace speaker_source {
+
+template<typename... Ts> class SetPlaylistDelayAction : public Action<Ts...> {
+ public:
+  explicit SetPlaylistDelayAction(SpeakerSourceMediaPlayer *parent) : parent_(parent) {}
+
+  TEMPLATABLE_VALUE(uint8_t, pipeline)
+  TEMPLATABLE_VALUE(uint32_t, delay)
+
+  void play(const Ts &...x) override {
+    this->parent_->set_playlist_delay_ms(this->pipeline_.value(x...), this->delay_.value(x...));
+  }
+
+ protected:
+  SpeakerSourceMediaPlayer *parent_;
+};
+
+}  // namespace speaker_source
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/speaker_source/media_player.py
+++ b/esphome/components/speaker_source/media_player.py
@@ -1,0 +1,300 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import audio, media_player, media_source, speaker
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_DELAY,
+    CONF_FORMAT,
+    CONF_ID,
+    CONF_NUM_CHANNELS,
+    CONF_SAMPLE_RATE,
+    CONF_SPEAKER,
+)
+from esphome.core import ID
+from esphome.core.entity_helpers import inherit_property_from
+from esphome.cpp_generator import MockObj, TemplateArgsType
+from esphome.types import ConfigType
+
+AUTO_LOAD = ["audio"]
+DEPENDENCIES = ["media_source", "speaker"]
+
+CODEOWNERS = ["@kahrendt"]
+
+CONF_ANNOUNCEMENT_PIPELINE = "announcement_pipeline"
+CONF_MEDIA_PIPELINE = "media_pipeline"
+CONF_ON_MUTE = "on_mute"
+CONF_ON_UNMUTE = "on_unmute"
+CONF_ON_VOLUME = "on_volume"
+CONF_PIPELINE = "pipeline"
+CONF_SOURCES = "sources"
+CONF_VOLUME_INCREMENT = "volume_increment"
+CONF_VOLUME_INITIAL = "volume_initial"
+CONF_VOLUME_MAX = "volume_max"
+CONF_VOLUME_MIN = "volume_min"
+
+speaker_source_ns = cg.esphome_ns.namespace("speaker_source")
+
+SpeakerSourceMediaPlayer = speaker_source_ns.class_(
+    "SpeakerSourceMediaPlayer", cg.Component, media_player.MediaPlayer
+)
+
+PipelineContext = speaker_source_ns.struct("PipelineContext")
+
+Pipeline = speaker_source_ns.enum("Pipeline")
+PIPELINE_ENUM = {
+    "media": Pipeline.MEDIA_PIPELINE,
+    "announcement": Pipeline.ANNOUNCEMENT_PIPELINE,
+}
+
+# Maps config key -> (C++ Pipeline enum value, format purpose)
+_PIPELINE_INFO = {
+    CONF_MEDIA_PIPELINE: (
+        Pipeline.MEDIA_PIPELINE,
+        media_player.MEDIA_PLAYER_FORMAT_PURPOSE_ENUM["default"],
+    ),
+    CONF_ANNOUNCEMENT_PIPELINE: (
+        Pipeline.ANNOUNCEMENT_PIPELINE,
+        media_player.MEDIA_PLAYER_FORMAT_PURPOSE_ENUM["announcement"],
+    ),
+}
+
+MuteTrigger = speaker_source_ns.class_("MuteTrigger", automation.Trigger.template())
+UnmuteTrigger = speaker_source_ns.class_("UnmuteTrigger", automation.Trigger.template())
+VolumeTrigger = speaker_source_ns.class_(
+    "VolumeTrigger", automation.Trigger.template(cg.float_)
+)
+
+SetPlaylistDelayAction = speaker_source_ns.class_(
+    "SetPlaylistDelayAction", automation.Action
+)
+
+
+# Returns a media_player.MediaPlayerSupportedFormat struct with the configured
+# format, sample rate, number of channels, purpose, and bytes per sample
+def _get_supported_format_struct(pipeline: ConfigType, purpose: MockObj):
+    args = [
+        media_player.MediaPlayerSupportedFormat,
+    ]
+
+    if pipeline[CONF_FORMAT] == "FLAC":
+        args.append(("format", "flac"))
+    elif pipeline[CONF_FORMAT] == "MP3":
+        args.append(("format", "mp3"))
+    elif pipeline[CONF_FORMAT] == "OPUS":
+        args.append(("format", "opus"))
+    elif pipeline[CONF_FORMAT] == "WAV":
+        args.append(("format", "wav"))
+
+    args.append(("sample_rate", pipeline[CONF_SAMPLE_RATE]))
+    args.append(("num_channels", pipeline[CONF_NUM_CHANNELS]))
+    args.append(("purpose", purpose))
+
+    # Omit sample_bytes for MP3: ffmpeg transcoding in Home Assistant fails
+    # if the number of bytes per sample is specified for MP3.
+    if pipeline[CONF_FORMAT] != "MP3":
+        args.append(("sample_bytes", 2))
+
+    return cg.StructInitializer(*args)
+
+
+def _validate_pipeline(config: ConfigType) -> ConfigType:
+    # Inherit settings from speaker if not manually set
+    inherit_property_from(CONF_NUM_CHANNELS, CONF_SPEAKER)(config)
+    inherit_property_from(CONF_SAMPLE_RATE, CONF_SPEAKER)(config)
+
+    # Opus only supports 48 kHz
+    if config.get(CONF_FORMAT) == "OPUS" and config.get(CONF_SAMPLE_RATE) != 48000:
+        raise cv.Invalid("Opus only supports a sample rate of 48000 Hz")
+
+    audio.final_validate_audio_schema(
+        "speaker_source media_player",
+        audio_device=CONF_SPEAKER,
+        bits_per_sample=16,
+        channels=config.get(CONF_NUM_CHANNELS),
+        sample_rate=config.get(CONF_SAMPLE_RATE),
+    )(config)
+
+    return config
+
+
+PIPELINE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(
+            PipelineContext
+        ),  # Needed to inherit audio settings from the speaker
+        cv.Required(CONF_SPEAKER): cv.use_id(speaker.Speaker),
+        cv.Required(CONF_SOURCES): cv.All(
+            cv.ensure_list(cv.use_id(media_source.MediaSource)),
+            cv.Length(min=1),
+        ),
+        cv.Optional(CONF_FORMAT, default="FLAC"): cv.enum(audio.AUDIO_FILE_TYPE_ENUM),
+        cv.Optional(CONF_SAMPLE_RATE): cv.int_range(min=1),
+        cv.Optional(CONF_NUM_CHANNELS): cv.int_range(1, 2),
+    }
+)
+
+
+def _validate_repeated_speaker(config: ConfigType) -> ConfigType:
+    if (
+        (announcement_config := config.get(CONF_ANNOUNCEMENT_PIPELINE))
+        and (media_config := config.get(CONF_MEDIA_PIPELINE))
+        and announcement_config[CONF_SPEAKER] == media_config[CONF_SPEAKER]
+    ):
+        raise cv.Invalid(
+            "The announcement and media pipelines cannot use the same speaker. "
+            "Use the `mixer` speaker component to create two source speakers."
+        )
+    return config
+
+
+def _validate_volume_settings(config: ConfigType) -> ConfigType:
+    # CONF_VOLUME_INITIAL is in the scaled volume domain (0.0-1.0) and doesn't need to be validated
+    if config[CONF_VOLUME_MIN] > config[CONF_VOLUME_MAX]:
+        raise cv.Invalid(
+            f"{CONF_VOLUME_MIN} ({config[CONF_VOLUME_MIN]}) must be less than or equal to {CONF_VOLUME_MAX} ({config[CONF_VOLUME_MAX]})"
+        )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_VOLUME_INCREMENT, default=0.05): cv.percentage,
+            cv.Optional(CONF_VOLUME_INITIAL, default=0.5): cv.percentage,
+            cv.Optional(CONF_VOLUME_MAX, default=1.0): cv.percentage,
+            cv.Optional(CONF_VOLUME_MIN, default=0.0): cv.percentage,
+            cv.Optional(CONF_ANNOUNCEMENT_PIPELINE): PIPELINE_SCHEMA,
+            cv.Optional(CONF_MEDIA_PIPELINE): PIPELINE_SCHEMA,
+            cv.Optional(CONF_ON_MUTE): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_UNMUTE): automation.validate_automation(single=True),
+            cv.Optional(CONF_ON_VOLUME): automation.validate_automation(single=True),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(media_player.media_player_schema(SpeakerSourceMediaPlayer)),
+    cv.only_on_esp32,
+    cv.has_at_least_one_key(CONF_ANNOUNCEMENT_PIPELINE, CONF_MEDIA_PIPELINE),
+    _validate_repeated_speaker,
+    _validate_volume_settings,
+)
+
+
+def _final_validate_codecs(config: ConfigType) -> ConfigType:
+    # "NONE" means the pipeline accepts any format at runtime, so all codecs must be available.
+    # When a specific format is set, only that codec is requested.
+    needed_formats = set()
+    need_all = False
+
+    for pipeline_key in (CONF_ANNOUNCEMENT_PIPELINE, CONF_MEDIA_PIPELINE):
+        if pipeline := config.get(pipeline_key):
+            fmt = pipeline[CONF_FORMAT]
+            if fmt == "NONE":
+                need_all = True
+            else:
+                needed_formats.add(fmt)
+
+    if need_all:
+        audio.request_flac_support()
+        audio.request_mp3_support()
+        audio.request_opus_support()
+    else:
+        if "FLAC" in needed_formats:
+            audio.request_flac_support()
+        if "MP3" in needed_formats:
+            audio.request_mp3_support()
+        if "OPUS" in needed_formats:
+            audio.request_opus_support()
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_ANNOUNCEMENT_PIPELINE): _validate_pipeline,
+            cv.Optional(CONF_MEDIA_PIPELINE): _validate_pipeline,
+        },
+        extra=cv.ALLOW_EXTRA,
+    ),
+    _final_validate_codecs,
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await media_player.register_media_player(var, config)
+
+    cg.add(var.set_volume_increment(config[CONF_VOLUME_INCREMENT]))
+    cg.add(var.set_volume_initial(config[CONF_VOLUME_INITIAL]))
+    cg.add(var.set_volume_max(config[CONF_VOLUME_MAX]))
+    cg.add(var.set_volume_min(config[CONF_VOLUME_MIN]))
+
+    for pipeline_key, (pipeline_enum, purpose) in _PIPELINE_INFO.items():
+        if pipeline_config := config.get(pipeline_key):
+            for source in pipeline_config[CONF_SOURCES]:
+                src = await cg.get_variable(source)
+                cg.add(var.add_media_source(pipeline_enum, src))
+
+            cg.add(
+                var.set_speaker(
+                    pipeline_enum,
+                    await cg.get_variable(pipeline_config[CONF_SPEAKER]),
+                )
+            )
+            if pipeline_config[CONF_FORMAT] != "NONE":
+                cg.add(
+                    var.set_format(
+                        pipeline_enum,
+                        _get_supported_format_struct(pipeline_config, purpose),
+                    )
+                )
+    if on_mute := config.get(CONF_ON_MUTE):
+        await automation.build_automation(
+            var.get_mute_trigger(),
+            [],
+            on_mute,
+        )
+    if on_unmute := config.get(CONF_ON_UNMUTE):
+        await automation.build_automation(
+            var.get_unmute_trigger(),
+            [],
+            on_unmute,
+        )
+    if on_volume := config.get(CONF_ON_VOLUME):
+        await automation.build_automation(
+            var.get_volume_trigger(),
+            [(cg.float_, "x")],
+            on_volume,
+        )
+
+
+SET_PLAYLIST_DELAY_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(SpeakerSourceMediaPlayer),
+        cv.Required(CONF_PIPELINE): cv.enum(PIPELINE_ENUM, lower=True),
+        cv.Required(CONF_DELAY): cv.templatable(cv.positive_time_period_milliseconds),
+    }
+)
+
+
+@automation.register_action(
+    "speaker_source.set_playlist_delay",
+    SetPlaylistDelayAction,
+    SET_PLAYLIST_DELAY_ACTION_SCHEMA,
+)
+async def set_playlist_delay_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
+    parent = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+
+    cg.add(var.set_pipeline(config[CONF_PIPELINE]))
+
+    template_ = await cg.templatable(config[CONF_DELAY], args, cg.uint32)
+    cg.add(var.set_delay(template_))
+
+    return var

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -1,0 +1,854 @@
+#include "speaker_source_media_player.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include <algorithm>
+
+namespace esphome {
+namespace speaker_source {
+
+static const uint32_t MEDIA_CONTROLS_QUEUE_LENGTH = 20;
+
+static const char *const TAG = "speaker_source_media_player";
+
+// SourceBinding method implementations (defined here because SpeakerSourceMediaPlayer is forward-declared in the
+// header)
+size_t SourceBinding::write_audio(const uint8_t *data, size_t length, uint32_t timeout_ms,
+                                  const audio::AudioStreamInfo &stream_info) {
+  return this->player->handle_media_output_(this->pipeline, this->source, data, length, timeout_ms, stream_info);
+}
+void SourceBinding::report_state(media_source::MediaSourceState state) {
+  this->player->handle_media_state_changed_(this->pipeline, this->source, state);
+}
+void SourceBinding::request_volume(float volume) {
+  this->player->defer([this, volume]() { this->player->handle_volume_request_(volume); });
+}
+void SourceBinding::request_mute(bool is_muted) {
+  this->player->defer([this, is_muted]() { this->player->handle_mute_request_(is_muted); });
+}
+void SourceBinding::request_play_uri(const std::string &uri) {
+  this->player->handle_play_uri_request_(this->pipeline, uri);
+}
+
+void SpeakerSourceMediaPlayer::add_media_source(uint8_t pipeline, media_source::MediaSource *media_source) {
+  auto &binding =
+      this->pipelines_[pipeline].sources.emplace_back(std::make_unique<SourceBinding>(this, media_source, pipeline));
+  media_source->set_listener(binding.get());
+}
+
+void SpeakerSourceMediaPlayer::dump_config() {
+  ESP_LOGCONFIG(TAG, "Speaker Source Media Player:");
+  ESP_LOGCONFIG(TAG, "  Volume Increment: %.2f", this->volume_increment_);
+  ESP_LOGCONFIG(TAG, "  Volume Min: %.2f", this->volume_min_);
+  ESP_LOGCONFIG(TAG, "  Volume Max: %.2f", this->volume_max_);
+}
+
+void SpeakerSourceMediaPlayer::setup() {
+  this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+
+  this->media_control_command_queue_ = xQueueCreate(MEDIA_CONTROLS_QUEUE_LENGTH, sizeof(MediaPlayerControlCommand));
+
+  this->pref_ = this->make_entity_preference<VolumeRestoreState>();
+
+  VolumeRestoreState volume_restore_state;
+  if (this->pref_.load(&volume_restore_state)) {
+    this->set_volume_(volume_restore_state.volume);
+    this->set_mute_state_(volume_restore_state.is_muted);
+  } else {
+    this->set_volume_(this->volume_initial_);
+    this->set_mute_state_(false);
+  }
+
+  // Register callbacks to receive playback notifications from speakers
+  for (size_t i = 0; i < this->pipelines_.size(); i++) {
+    if (this->pipelines_[i].is_configured()) {
+      this->pipelines_[i].speaker->add_audio_output_callback([this, i](uint32_t frames, int64_t timestamp) {
+        this->handle_speaker_playback_callback_(frames, timestamp, i);
+      });
+    }
+  }
+}
+
+void SpeakerSourceMediaPlayer::set_playlist_delay_ms(uint8_t pipeline, uint32_t delay_ms) {
+  if (pipeline < this->pipelines_.size()) {
+    this->pipelines_[pipeline].playlist_delay_ms = delay_ms;
+  }
+}
+
+void SpeakerSourceMediaPlayer::handle_speaker_playback_callback_(uint32_t frames, int64_t timestamp, uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  // Load once so the null check and use below are consistent
+  media_source::MediaSource *active_source = ps.active_source.load(std::memory_order_relaxed);
+  if (active_source == nullptr) {
+    return;
+  }
+
+  // CAS loop to safely subtract frames without underflow. If pending_frames is reset to 0 (new source
+  // starting) between the load and the subtract, compare_exchange_weak will fail and reload the current value.
+  uint32_t current = ps.pending_frames.load(std::memory_order_relaxed);
+  uint32_t source_frames;
+  do {
+    source_frames = std::min(frames, current);
+  } while (source_frames > 0 &&
+           !ps.pending_frames.compare_exchange_weak(current, current - source_frames, std::memory_order_relaxed));
+
+  if (source_frames > 0) {
+    // Notify the source about the played audio
+    active_source->notify_audio_played(source_frames, timestamp);
+  }
+}
+
+void SpeakerSourceMediaPlayer::handle_volume_request_(float volume) {
+  // Update the media player's volume
+  this->set_volume_(volume);
+  this->publish_state();
+}
+
+void SpeakerSourceMediaPlayer::handle_mute_request_(bool is_muted) {
+  // Update the media player's mute state
+  this->set_mute_state_(is_muted);
+  this->publish_state();
+}
+
+void SpeakerSourceMediaPlayer::handle_play_uri_request_(uint8_t pipeline, const std::string &uri) {
+  // Smart source is requesting the player to play a different URI
+  auto call = this->make_call();
+  call.set_media_url(uri);
+  call.set_announcement(pipeline == ANNOUNCEMENT_PIPELINE);
+  call.perform();
+}
+
+void SpeakerSourceMediaPlayer::handle_media_state_changed_(uint8_t pipeline, media_source::MediaSource *source,
+                                                           media_source::MediaSourceState state) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (state == media_source::MediaSourceState::IDLE) {
+    // Source went idle - clear stopping flag if this was the source we asked to stop
+    if (ps.stopping_source == source) {
+      ps.stopping_source = nullptr;
+    }
+
+    // Clear pending flag if this was the source we asked to play
+    if (ps.pending_source == source) {
+      ps.pending_source = nullptr;
+    }
+
+    // Source went idle - clear it if it's the active source
+    if (ps.active_source == source) {
+      ps.last_source = ps.active_source;
+      ps.active_source = nullptr;
+
+      // Finish the speaker to ensure it's ready for the next playback
+      ps.speaker->finish();
+
+      // Queue PLAYLIST_ADVANCE to handle track completion - all playlist logic is in process_control_queue_
+      this->queue_command_(MediaPlayerControlCommand::PLAYLIST_ADVANCE, pipeline);
+    }
+  } else if (state == media_source::MediaSourceState::PLAYING) {
+    // Source started playing - make it the active source if no one else is active
+    if (ps.active_source == nullptr) {
+      ps.active_source = source;
+      ps.last_source = nullptr;
+
+      // Clear pending flag now that the source is active
+      if (ps.pending_source == source) {
+        ps.pending_source = nullptr;
+      }
+    }
+  }
+}
+
+size_t SpeakerSourceMediaPlayer::handle_media_output_(uint8_t pipeline, media_source::MediaSource *source,
+                                                      const uint8_t *data, size_t length, uint32_t timeout_ms,
+                                                      const audio::AudioStreamInfo &stream_info) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  // Single read; the if-body only uses ps.speaker (immutable after setup) and the source parameter.
+  if (ps.active_source == source) {
+    // This source is active - play the audio
+    if (ps.speaker->get_audio_stream_info() != stream_info) {
+      // Setup the speaker to play this stream
+      ps.speaker->set_audio_stream_info(stream_info);
+      vTaskDelay(pdMS_TO_TICKS(timeout_ms));
+      return 0;
+    }
+    size_t bytes_written = ps.speaker->play(data, length, pdMS_TO_TICKS(timeout_ms));
+    if (bytes_written > 0) {
+      // Track frames sent to speaker for this source
+      ps.pending_frames.fetch_add(stream_info.bytes_to_frames(bytes_written), std::memory_order_relaxed);
+    }
+    return bytes_written;
+  }
+
+  // Not the active source - wait for state callback to set us as active when we transition to PLAYING
+  vTaskDelay(pdMS_TO_TICKS(timeout_ms));
+  return 0;
+}
+
+media_player::MediaPlayerState SpeakerSourceMediaPlayer::get_media_pipeline_state_(
+    media_source::MediaSource *source, bool playlist_active, media_player::MediaPlayerState old_state) const {
+  if (source != nullptr) {
+    switch (source->get_state()) {
+      case media_source::MediaSourceState::PLAYING:
+        return media_player::MEDIA_PLAYER_STATE_PLAYING;
+      case media_source::MediaSourceState::PAUSED:
+        return media_player::MEDIA_PLAYER_STATE_PAUSED;
+      case media_source::MediaSourceState::ERROR:
+        ESP_LOGE(TAG, "Source error");
+        return media_player::MEDIA_PLAYER_STATE_IDLE;
+      case media_source::MediaSourceState::IDLE:
+      default:
+        return media_player::MEDIA_PLAYER_STATE_IDLE;
+    }
+  }
+
+  // No active source. Stay PLAYING during playlist transitions
+  if (playlist_active && old_state == media_player::MEDIA_PLAYER_STATE_PLAYING) {
+    return media_player::MEDIA_PLAYER_STATE_PLAYING;
+  }
+  return media_player::MEDIA_PLAYER_STATE_IDLE;
+}
+
+void SpeakerSourceMediaPlayer::loop() {
+  // Process queued control commands
+  this->process_control_queue_();
+
+  // Update state based on active sources - announcement pipeline takes priority
+  media_player::MediaPlayerState old_state = this->state;
+
+  PipelineContext &ann_ps = this->pipelines_[ANNOUNCEMENT_PIPELINE];
+  PipelineContext &media_ps = this->pipelines_[MEDIA_PIPELINE];
+
+  // Check playlist state to detect transitions between items
+  bool announcement_playlist_active = (ann_ps.playlist_index < ann_ps.playlist.size()) ||
+                                      (ann_ps.repeat_mode != REPEAT_OFF && !ann_ps.playlist.empty());
+  bool media_playlist_active = (media_ps.playlist_index < media_ps.playlist.size()) ||
+                               (media_ps.repeat_mode != REPEAT_OFF && !media_ps.playlist.empty());
+
+  // Check announcement pipeline first
+  media_source::MediaSource *announcement_source = ann_ps.active_source;
+  if (announcement_source != nullptr) {
+    media_source::MediaSourceState announcement_state = announcement_source->get_state();
+    if (announcement_state != media_source::MediaSourceState::IDLE) {
+      // Announcement is active - announcements take priority and never report PAUSED
+      switch (announcement_state) {
+        case media_source::MediaSourceState::PLAYING:
+        case media_source::MediaSourceState::PAUSED:  // Treat paused announcements as announcing
+          this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;
+          break;
+        case media_source::MediaSourceState::ERROR:
+          this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
+          ESP_LOGE(TAG, "Announcement source error");
+          break;
+        default:
+          break;
+      }
+    } else {
+      // Announcement source is idle, fall through to media pipeline
+      this->state = this->get_media_pipeline_state_(media_ps.active_source, media_playlist_active, old_state);
+    }
+  } else if (announcement_playlist_active && old_state == media_player::MEDIA_PLAYER_STATE_ANNOUNCING) {
+    this->state = media_player::MEDIA_PLAYER_STATE_ANNOUNCING;
+  } else {
+    // No active announcement, check media pipeline
+    this->state = this->get_media_pipeline_state_(media_ps.active_source, media_playlist_active, old_state);
+  }
+
+  if (this->state != old_state) {
+    this->publish_state();
+    ESP_LOGD(TAG, "State changed to %s", media_player::media_player_state_to_string(this->state));
+  }
+}
+
+media_source::MediaSource *SpeakerSourceMediaPlayer::find_source_for_uri_(const std::string &uri, uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+  for (auto &binding : ps.sources) {
+    if (binding->source->can_handle(uri)) {
+      // Check if this source is idle
+      if (binding->source->get_state() == media_source::MediaSourceState::IDLE) {
+        return binding->source;  // First idle match wins
+      }
+    }
+  }
+  // If no idle source found, try again without checking state (will be stopped by try_execute_play_uri_)
+  for (auto &binding : ps.sources) {
+    if (binding->source->can_handle(uri)) {
+      return binding->source;  // First match wins
+    }
+  }
+  return nullptr;
+}
+
+bool SpeakerSourceMediaPlayer::try_execute_play_uri_(const std::string &uri, uint8_t pipeline) {
+  // Find target source
+  media_source::MediaSource *target_source = this->find_source_for_uri_(uri, pipeline);
+  if (target_source == nullptr) {
+    ESP_LOGW(TAG, "No source for URI");
+    ESP_LOGV(TAG, "URI: %s", uri.c_str());
+    return true;  // Remove from queue (unrecoverable)
+  }
+
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  media_source::MediaSource *active_source = ps.active_source;
+
+  // If active source exists and is not IDLE, stop it and wait
+  if (active_source != nullptr) {
+    media_source::MediaSourceState active_state = active_source->get_state();
+    if (active_state != media_source::MediaSourceState::IDLE) {
+      // Only send END command once per source - check if we've already asked this source to stop
+      if (ps.stopping_source != active_source) {
+        ESP_LOGV(TAG, "Pipeline %u: stopping active source", pipeline);
+        active_source->handle_command(media_source::MediaSourceCommand::STOP);
+        ps.speaker->stop();
+        ps.stopping_source = active_source;
+      }
+      return false;  // Leave in queue, retry next loop
+    }
+  }
+
+  // Also check target source directly - handles case where source errored before PLAYING state
+  media_source::MediaSourceState target_state = target_source->get_state();
+  if (target_state != media_source::MediaSourceState::IDLE) {
+    // Only send STOP command once per source
+    if (ps.stopping_source != target_source) {
+      ESP_LOGV(TAG, "Pipeline %u: target source busy, stopping", pipeline);
+      target_source->handle_command(media_source::MediaSourceCommand::STOP);
+      ps.speaker->stop();
+      ps.stopping_source = target_source;
+    }
+    return false;  // Leave in queue, retry next loop
+  }
+
+  // Clear stopping flag since we're past the stopping phase
+  ps.stopping_source = nullptr;
+
+  // Check if speaker is ready
+  if (!ps.speaker->is_stopped()) {
+    return false;  // Speaker not ready yet, retry later
+  }
+
+  // Set pending source so handle_media_state_changed_ can recognize it when the source transitions to PLAYING
+  ps.pending_source = target_source;
+
+  // Speaker is ready, try to play
+  if (!target_source->play_uri(uri)) {
+    ESP_LOGE(TAG, "Pipeline %u: Failed to play URI: %s", pipeline, uri.c_str());
+    ps.pending_source = nullptr;
+    this->queue_command_(MediaPlayerControlCommand::PLAYLIST_ADVANCE, pipeline);
+  }
+
+  // Reset pending frame counter for this pipeline since we're starting a new source
+  ps.pending_frames.store(0, std::memory_order_relaxed);
+
+  return true;  // Remove from queue
+}
+
+void SpeakerSourceMediaPlayer::queue_command_(MediaPlayerControlCommand::Type type, uint8_t pipeline) {
+  MediaPlayerControlCommand cmd;
+  cmd.type = type;
+  cmd.pipeline = pipeline;
+  if (xQueueSend(this->media_control_command_queue_, &cmd, 0) != pdTRUE) {
+    ESP_LOGE(TAG, "Queue full, command dropped");
+  }
+}
+
+void SpeakerSourceMediaPlayer::queue_play_current_(uint8_t pipeline, uint32_t delay_ms) {
+  if (delay_ms > 0) {
+    this->set_timeout(PipelineContext::TIMEOUT_IDS[pipeline], delay_ms,
+                      [this, pipeline]() { this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline); });
+  } else {
+    this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+  }
+}
+
+void SpeakerSourceMediaPlayer::process_control_queue_() {
+  MediaPlayerControlCommand control_command;
+
+  // Use peek to check command without removing it
+  if (xQueuePeek(this->media_control_command_queue_, &control_command, 0) != pdTRUE) {
+    return;
+  }
+
+  bool command_executed = false;
+  uint8_t pipeline = control_command.pipeline;
+
+  // Get pipeline state
+  PipelineContext &ps = this->pipelines_[pipeline];
+  media_source::MediaSource *active_source = ps.active_source;
+
+  // Check if active source has internal playlist management
+  bool has_internal_playlist = (active_source != nullptr) && active_source->has_internal_playlist();
+
+  switch (control_command.type) {
+    case MediaPlayerControlCommand::PLAY_URI: {
+      // Always use our local playlist to start playback
+      this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
+      ps.playlist.clear();
+      ps.shuffle_indices.clear();  // Clear shuffle when starting fresh playlist
+      ps.playlist_index = 0;       // Reset index
+      ps.playlist.push_back(*control_command.data.uri);
+
+      // Queue PLAY_CURRENT to initiate playback
+      this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+      command_executed = true;
+      break;
+    }
+
+    case MediaPlayerControlCommand::ENQUEUE_URI: {
+      // Always add to our local playlist
+      ps.playlist.push_back(*control_command.data.uri);
+
+      // If shuffle is active, add the new item to the end of the shuffle order
+      if (!ps.shuffle_indices.empty()) {
+        ps.shuffle_indices.push_back(ps.playlist.size() - 1);
+      }
+
+      // If nothing is playing and no upcoming items are queued, start the new item.
+      bool nothing_playing =
+          (active_source == nullptr) || (active_source->get_state() == media_source::MediaSourceState::IDLE);
+      if (nothing_playing && ps.playlist_index >= ps.playlist.size() - 1) {
+        ps.playlist_index = ps.playlist.size() - 1;  // Point to newly added item
+        this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+      }
+      command_executed = true;
+      break;
+    }
+
+    case MediaPlayerControlCommand::PLAYLIST_ADVANCE: {
+      // Internal message: a track finished, advance to next
+      if (ps.repeat_mode != REPEAT_ONE) {
+        ps.playlist_index++;
+      }
+
+      // Check if we should continue playback
+      if (ps.playlist_index < ps.playlist.size()) {
+        this->queue_play_current_(pipeline, ps.playlist_delay_ms);
+      } else if (ps.repeat_mode == REPEAT_ALL && !ps.playlist.empty()) {
+        ps.playlist_index = 0;
+        this->queue_play_current_(pipeline, ps.playlist_delay_ms);
+      }
+      command_executed = true;
+      break;
+    }
+
+    case MediaPlayerControlCommand::PLAY_CURRENT: {
+      // Play the item at current playlist index (mapped through shuffle if active)
+      if (ps.playlist_index < ps.playlist.size()) {
+        size_t actual_position = this->get_playlist_position_(pipeline);
+        command_executed = this->try_execute_play_uri_(ps.playlist[actual_position], pipeline);
+      } else {
+        command_executed = true;  // Index out of bounds or empty playlist
+      }
+      break;
+    }
+
+    case MediaPlayerControlCommand::SEND_COMMAND: {
+      media_player::MediaPlayerCommand player_command = control_command.data.command;
+
+      // Determine target source: prefer active, fall back to last
+      media_source::MediaSource *target_source = nullptr;
+      if (ps.active_source != nullptr) {
+        target_source = ps.active_source;
+      } else if (ps.last_source != nullptr) {
+        target_source = ps.last_source;
+      }
+
+      switch (player_command) {
+        case media_player::MEDIA_PLAYER_COMMAND_TOGGLE: {
+          // Convert TOGGLE to PLAY or PAUSE based on current state
+          if ((active_source != nullptr) && (active_source->get_state() == media_source::MediaSourceState::PLAYING)) {
+            if (target_source != nullptr) {
+              target_source->handle_command(media_source::MediaSourceCommand::PAUSE);
+            }
+          } else if (!has_internal_playlist && active_source == nullptr && !ps.playlist.empty()) {
+            bool last_has_internal_playlist = (ps.last_source != nullptr) && ps.last_source->has_internal_playlist();
+            if (last_has_internal_playlist) {
+              ps.last_source->handle_command(media_source::MediaSourceCommand::PLAY);
+            } else {
+              if (ps.playlist_index >= ps.playlist.size()) {
+                ps.playlist_index = 0;
+              }
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            }
+          } else {
+            if (target_source != nullptr) {
+              target_source->handle_command(media_source::MediaSourceCommand::PLAY);
+            }
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_PLAY: {
+          if (!has_internal_playlist && active_source == nullptr && !ps.playlist.empty()) {
+            bool last_has_internal_playlist = (ps.last_source != nullptr) && ps.last_source->has_internal_playlist();
+            if (last_has_internal_playlist) {
+              ps.last_source->handle_command(media_source::MediaSourceCommand::PLAY);
+            } else {
+              if (ps.playlist_index >= ps.playlist.size()) {
+                ps.playlist_index = 0;
+              }
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            }
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::PLAY);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_PAUSE: {
+          if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::PAUSE);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_STOP: {
+          if (!has_internal_playlist) {
+            this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
+            ps.playlist.clear();
+            ps.shuffle_indices.clear();
+            ps.playlist_index = 0;
+          }
+          if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::STOP);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_NEXT: {
+          if (!has_internal_playlist) {
+            if (ps.playlist_index + 1 < ps.playlist.size()) {
+              ps.playlist_index++;
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            } else if (ps.repeat_mode == REPEAT_ALL && !ps.playlist.empty()) {
+              ps.playlist_index = 0;
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            }
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::NEXT);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_PREVIOUS: {
+          if (!has_internal_playlist) {
+            if (ps.playlist_index > 0) {
+              ps.playlist_index--;
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            } else if (ps.repeat_mode == REPEAT_ALL && !ps.playlist.empty()) {
+              ps.playlist_index = ps.playlist.size() - 1;
+              this->queue_command_(MediaPlayerControlCommand::PLAY_CURRENT, pipeline);
+            }
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::PREVIOUS);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_REPEAT_ONE:
+          if (!has_internal_playlist) {
+            ps.repeat_mode = REPEAT_ONE;
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::REPEAT_ONE);
+          }
+          break;
+
+        case media_player::MEDIA_PLAYER_COMMAND_REPEAT_OFF:
+          if (!has_internal_playlist) {
+            ps.repeat_mode = REPEAT_OFF;
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::REPEAT_OFF);
+          }
+          break;
+
+        case media_player::MEDIA_PLAYER_COMMAND_REPEAT_ALL:
+          if (!has_internal_playlist) {
+            ps.repeat_mode = REPEAT_ALL;
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::REPEAT_ALL);
+          }
+          break;
+
+        case media_player::MEDIA_PLAYER_COMMAND_CLEAR_PLAYLIST: {
+          if (!has_internal_playlist) {
+            this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
+            if (ps.playlist_index < ps.playlist.size()) {
+              size_t actual_position = this->get_playlist_position_(pipeline);
+              ps.playlist[0] = std::move(ps.playlist[actual_position]);
+              ps.playlist.resize(1);
+              ps.playlist_index = 0;
+            } else {
+              ps.playlist.clear();
+              ps.playlist_index = 0;
+            }
+            ps.shuffle_indices.clear();
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::CLEAR_PLAYLIST);
+          }
+          break;
+        }
+
+        case media_player::MEDIA_PLAYER_COMMAND_SHUFFLE:
+          if (!has_internal_playlist) {
+            this->shuffle_playlist_(pipeline);
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::SHUFFLE);
+          }
+          break;
+
+        case media_player::MEDIA_PLAYER_COMMAND_UNSHUFFLE:
+          if (!has_internal_playlist) {
+            this->unshuffle_playlist_(pipeline);
+          } else if (target_source != nullptr) {
+            target_source->handle_command(media_source::MediaSourceCommand::UNSHUFFLE);
+          }
+          break;
+
+        default:
+          // TURN_ON, TURN_OFF, ENQUEUE (handled separately with URL) are no-ops
+          break;
+      }
+
+      command_executed = true;
+      break;
+    }
+  }
+
+  // Only remove from queue if successfully executed
+  if (command_executed) {
+    xQueueReceive(this->media_control_command_queue_, &control_command, 0);
+
+    // Delete the allocated string for PLAY_URI and ENQUEUE_URI commands
+    if (control_command.type == MediaPlayerControlCommand::PLAY_URI ||
+        control_command.type == MediaPlayerControlCommand::ENQUEUE_URI) {
+      delete control_command.data.uri;
+    }
+  }
+}
+
+void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call) {
+  if (!this->is_ready()) {
+    return;
+  }
+
+  MediaPlayerControlCommand control_command;
+
+  // Determine which pipeline to use based on announcement flag, falling back if the preferred pipeline
+  // is not configured
+  if (call.get_announcement().has_value() && call.get_announcement().value()) {
+    if (this->pipelines_[ANNOUNCEMENT_PIPELINE].is_configured()) {
+      control_command.pipeline = ANNOUNCEMENT_PIPELINE;
+    } else {
+      control_command.pipeline = MEDIA_PIPELINE;
+    }
+  } else {
+    if (this->pipelines_[MEDIA_PIPELINE].is_configured()) {
+      control_command.pipeline = MEDIA_PIPELINE;
+    } else {
+      control_command.pipeline = ANNOUNCEMENT_PIPELINE;
+    }
+  }
+
+  if (call.get_media_url().has_value()) {
+    bool enqueue =
+        call.get_command().has_value() && call.get_command().value() == media_player::MEDIA_PLAYER_COMMAND_ENQUEUE;
+
+    if (enqueue) {
+      control_command.type = MediaPlayerControlCommand::ENQUEUE_URI;
+    } else {
+      control_command.type = MediaPlayerControlCommand::PLAY_URI;
+    }
+    // Heap allocation is unavoidable: URIs from Home Assistant are arbitrary-length (media URLs with tokens
+    // can easily exceed 500 bytes). Deleted in process_control_queue_() after the command is consumed. FreeRTOS queues
+    // require items to be copyable, so we store a pointer to the string in the queue rather than the string itself.
+    control_command.data.uri = new std::string(call.get_media_url().value());
+    if (xQueueSend(this->media_control_command_queue_, &control_command, 0) != pdTRUE) {
+      delete control_command.data.uri;
+      ESP_LOGE(TAG, "Queue full, URI dropped");
+    }
+    return;
+  }
+
+  if (call.get_volume().has_value()) {
+    this->set_volume_(call.get_volume().value());
+    this->publish_state();
+    return;
+  }
+
+  if (call.get_command().has_value()) {
+    switch (call.get_command().value()) {
+      case media_player::MEDIA_PLAYER_COMMAND_MUTE:
+        this->set_mute_state_(true);
+        this->publish_state();
+        return;
+      case media_player::MEDIA_PLAYER_COMMAND_UNMUTE:
+        this->set_mute_state_(false);
+        this->publish_state();
+        return;
+      case media_player::MEDIA_PLAYER_COMMAND_VOLUME_UP:
+        this->set_volume_(std::min(1.0f, this->volume + this->volume_increment_));
+        this->publish_state();
+        return;
+      case media_player::MEDIA_PLAYER_COMMAND_VOLUME_DOWN:
+        this->set_volume_(std::max(0.0f, this->volume - this->volume_increment_));
+        this->publish_state();
+        return;
+      default:
+        break;
+    }
+
+    control_command.type = MediaPlayerControlCommand::SEND_COMMAND;
+    control_command.data.command = call.get_command().value();
+    if (xQueueSend(this->media_control_command_queue_, &control_command, 0) != pdTRUE) {
+      ESP_LOGE(TAG, "Queue full, command dropped");
+    }
+  }
+}
+
+media_player::MediaPlayerTraits SpeakerSourceMediaPlayer::get_traits() {
+  // This media player supports more traits like playlists, repeat, and shuffle, but the ESPHome API currently (March
+  // 2026) doesn't support those commands, so we only report pause support for now since that's used by the frontend and
+  // supported by our player.
+  auto traits = media_player::MediaPlayerTraits();
+  traits.set_supports_pause(true);
+
+  for (const auto &ps : this->pipelines_) {
+    if (ps.format.has_value()) {
+      traits.get_supported_formats().push_back(ps.format.value());
+    }
+  }
+
+  return traits;
+}
+
+void SpeakerSourceMediaPlayer::save_volume_restore_state_() {
+  VolumeRestoreState volume_restore_state;
+  volume_restore_state.volume = this->volume;
+  volume_restore_state.is_muted = this->is_muted_;
+  this->pref_.save(&volume_restore_state);
+}
+
+void SpeakerSourceMediaPlayer::set_mute_state_(bool mute_state, bool publish) {
+  for (auto &ps : this->pipelines_) {
+    if (ps.is_configured()) {
+      ps.speaker->set_mute_state(mute_state);
+    }
+  }
+
+  bool old_mute_state = this->is_muted_;
+  this->is_muted_ = mute_state;
+
+  if (publish) {
+    this->save_volume_restore_state_();
+  }
+
+  // Notify all media sources about the mute state change
+  for (auto &ps : this->pipelines_) {
+    for (auto &binding : ps.sources) {
+      binding->source->notify_mute_changed(mute_state);
+    }
+  }
+
+  if (old_mute_state != mute_state) {
+    if (mute_state) {
+      this->defer([this]() { this->mute_trigger_.trigger(); });
+    } else {
+      this->defer([this]() { this->unmute_trigger_.trigger(); });
+    }
+  }
+}
+
+void SpeakerSourceMediaPlayer::set_volume_(float volume, bool publish) {
+  // Remap the volume to fit within the configured limits
+  float bounded_volume = remap<float, float>(volume, 0.0f, 1.0f, this->volume_min_, this->volume_max_);
+
+  for (auto &ps : this->pipelines_) {
+    if (ps.is_configured()) {
+      ps.speaker->set_volume(bounded_volume);
+    }
+  }
+
+  if (publish) {
+    this->volume = volume;
+    this->save_volume_restore_state_();
+  }
+
+  // Notify all media sources about the volume change
+  for (auto &ps : this->pipelines_) {
+    for (auto &binding : ps.sources) {
+      binding->source->notify_volume_changed(volume);
+    }
+  }
+
+  // Turn on the mute state if the volume is effectively zero, off otherwise.
+  // Pass publish=false since set_volume_ already saved above.
+  if (volume < 0.001) {
+    this->set_mute_state_(true, false);
+  } else {
+    this->set_mute_state_(false, false);
+  }
+
+  this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });
+}
+
+size_t SpeakerSourceMediaPlayer::get_playlist_position_(uint8_t pipeline) const {
+  const PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (ps.shuffle_indices.empty() || ps.playlist_index >= ps.shuffle_indices.size()) {
+    return ps.playlist_index;
+  }
+  return ps.shuffle_indices[ps.playlist_index];
+}
+
+void SpeakerSourceMediaPlayer::shuffle_playlist_(uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (ps.playlist.size() <= 1) {
+    ps.shuffle_indices.clear();
+    return;
+  }
+
+  // Capture current actual position BEFORE modifying shuffle_indices
+  size_t current_actual = this->get_playlist_position_(pipeline);
+
+  // Build indices vector
+  ps.shuffle_indices.resize(ps.playlist.size());
+  for (size_t i = 0; i < ps.playlist.size(); i++) {
+    ps.shuffle_indices[i] = i;
+  }
+
+  // Fisher-Yates shuffle using ESPHome's random helper
+  for (size_t i = ps.shuffle_indices.size() - 1; i > 0; i--) {
+    size_t j = random_uint32() % (i + 1);
+    std::swap(ps.shuffle_indices[i], ps.shuffle_indices[j]);
+  }
+
+  // Move current track to current position (so playback continues seamlessly)
+  if (ps.playlist_index < ps.shuffle_indices.size()) {
+    for (size_t i = 0; i < ps.shuffle_indices.size(); i++) {
+      if (ps.shuffle_indices[i] == current_actual) {
+        std::swap(ps.shuffle_indices[i], ps.shuffle_indices[ps.playlist_index]);
+        break;
+      }
+    }
+  }
+}
+
+void SpeakerSourceMediaPlayer::unshuffle_playlist_(uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (!ps.shuffle_indices.empty() && ps.playlist_index < ps.shuffle_indices.size()) {
+    ps.playlist_index = ps.shuffle_indices[ps.playlist_index];
+  }
+  ps.shuffle_indices.clear();
+}
+
+}  // namespace speaker_source
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -640,7 +640,8 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
 
   // Determine which pipeline to use based on announcement flag, falling back if the preferred pipeline
   // is not configured
-  if (call.get_announcement().has_value() && call.get_announcement().value()) {
+  auto announcement = call.get_announcement();
+  if (announcement.has_value() && announcement.value()) {
     if (this->pipelines_[ANNOUNCEMENT_PIPELINE].is_configured()) {
       control_command.pipeline = ANNOUNCEMENT_PIPELINE;
     } else {
@@ -654,9 +655,10 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
     }
   }
 
-  if (call.get_media_url().has_value()) {
-    bool enqueue =
-        call.get_command().has_value() && call.get_command().value() == media_player::MEDIA_PLAYER_COMMAND_ENQUEUE;
+  auto media_url = call.get_media_url();
+  if (media_url.has_value()) {
+    auto command = call.get_command();
+    bool enqueue = command.has_value() && command.value() == media_player::MEDIA_PLAYER_COMMAND_ENQUEUE;
 
     if (enqueue) {
       control_command.type = MediaPlayerControlCommand::ENQUEUE_URI;
@@ -666,7 +668,7 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
     // Heap allocation is unavoidable: URIs from Home Assistant are arbitrary-length (media URLs with tokens
     // can easily exceed 500 bytes). Deleted in process_control_queue_() after the command is consumed. FreeRTOS queues
     // require items to be copyable, so we store a pointer to the string in the queue rather than the string itself.
-    control_command.data.uri = new std::string(call.get_media_url().value());
+    control_command.data.uri = new std::string(media_url.value());
     if (xQueueSend(this->media_control_command_queue_, &control_command, 0) != pdTRUE) {
       delete control_command.data.uri;
       ESP_LOGE(TAG, "Queue full, URI dropped");
@@ -674,14 +676,16 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
     return;
   }
 
-  if (call.get_volume().has_value()) {
-    this->set_volume_(call.get_volume().value());
+  auto volume = call.get_volume();
+  if (volume.has_value()) {
+    this->set_volume_(volume.value());
     this->publish_state();
     return;
   }
 
-  if (call.get_command().has_value()) {
-    switch (call.get_command().value()) {
+  auto cmd = call.get_command();
+  if (cmd.has_value()) {
+    switch (cmd.value()) {
       case media_player::MEDIA_PLAYER_COMMAND_MUTE:
         this->set_mute_state_(true);
         this->publish_state();
@@ -703,7 +707,7 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
     }
 
     control_command.type = MediaPlayerControlCommand::SEND_COMMAND;
-    control_command.data.command = call.get_command().value();
+    control_command.data.command = cmd.value();
     if (xQueueSend(this->media_control_command_queue_, &control_command, 0) != pdTRUE) {
       ESP_LOGE(TAG, "Queue full, command dropped");
     }

--- a/esphome/components/speaker_source/speaker_source_media_player.h
+++ b/esphome/components/speaker_source/speaker_source_media_player.h
@@ -1,0 +1,238 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/components/audio/audio.h"
+#include "esphome/components/media_source/media_source.h"
+#include "esphome/components/media_player/media_player.h"
+#include "esphome/components/speaker/speaker.h"
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+
+#include <array>
+#include <atomic>
+#include <memory>
+#include <vector>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+
+namespace esphome {
+namespace speaker_source {
+
+enum Pipeline : uint8_t {
+  MEDIA_PIPELINE = 0,
+  ANNOUNCEMENT_PIPELINE = 1,
+};
+
+enum RepeatMode : uint8_t {
+  REPEAT_OFF = 0,
+  REPEAT_ONE = 1,
+  REPEAT_ALL = 2,
+};
+
+// Forward declaration
+class SpeakerSourceMediaPlayer;
+
+/// @brief Per-source listener binding that captures the source pointer at registration time.
+/// Each binding implements MediaSourceListener and forwards callbacks to the player with the source identified.
+/// Defined before PipelineContext so pipelines can own their bindings directly.
+struct SourceBinding : public media_source::MediaSourceListener {
+  SourceBinding(SpeakerSourceMediaPlayer *player, media_source::MediaSource *source, uint8_t pipeline)
+      : player(player), source(source), pipeline(pipeline) {}
+  SpeakerSourceMediaPlayer *player;
+  media_source::MediaSource *source;
+  uint8_t pipeline;
+
+  // Implementations are in the .cpp file because SpeakerSourceMediaPlayer is only forward-declared here
+  size_t write_audio(const uint8_t *data, size_t length, uint32_t timeout_ms,
+                     const audio::AudioStreamInfo &stream_info) override;
+  void report_state(media_source::MediaSourceState state) override;
+  void request_volume(float volume) override;
+  void request_mute(bool is_muted) override;
+  void request_play_uri(const std::string &uri) override;
+};
+
+struct PipelineContext {
+  /// @brief Timeout IDs for playlist delay, indexed by Pipeline enum
+  static constexpr const char *const TIMEOUT_IDS[] = {"next_media", "next_ann"};
+
+  speaker::Speaker *speaker{nullptr};
+  optional<media_player::MediaPlayerSupportedFormat> format;
+
+  std::atomic<media_source::MediaSource *> active_source{nullptr};
+  media_source::MediaSource *last_source{nullptr};
+  media_source::MediaSource *stopping_source{nullptr};  // Source we've asked to stop, awaiting IDLE
+  media_source::MediaSource *pending_source{nullptr};   // Source we've asked to play, awaiting PLAYING
+
+  // Each SourceBinding pairs a MediaSource* with its listener implementation.
+  // Uses unique_ptr so binding addresses are stable and set_listener() can be called in add_media_source().
+  // Uses std::vector because the count varies across instances (multiple speaker_source media players may exist).
+  std::vector<std::unique_ptr<SourceBinding>> sources;
+
+  // Dynamic allocation is unavoidable here: URIs from Home Assistant are arbitrary-length strings
+  // (media URLs with tokens can easily exceed 500 bytes), and playlist size is unbounded.
+  // Pre-allocating fixed buffers would waste significant RAM when idle without covering worst cases.
+  std::vector<std::string> playlist;
+  size_t playlist_index{0};
+  RepeatMode repeat_mode{REPEAT_OFF};
+  uint32_t playlist_delay_ms{0};
+
+  // When non-empty, playlist_index indexes into these vectors
+  // which contain the actual playlist indices in shuffled order
+  std::vector<size_t> shuffle_indices;
+
+  // Track frames sent to speaker to correlate with playback callbacks.
+  // Atomic because it is written from the main loop/source tasks and read/decremented from the speaker playback
+  // callback.
+  std::atomic<uint32_t> pending_frames{0};
+
+  /// @brief Check if this pipeline is configured (has a speaker assigned)
+  bool is_configured() const { return this->speaker != nullptr; }
+};
+
+struct MediaPlayerControlCommand {
+  enum Type : uint8_t {
+    PLAY_URI,          // Clear playlist, reset index, add URI, queue PLAY_CURRENT
+    ENQUEUE_URI,       // Add URI to playlist, queue PLAY_CURRENT if idle
+    PLAYLIST_ADVANCE,  // Advance index (or wrap for repeat_all), queue PLAY_CURRENT if more items
+    PLAY_CURRENT,      // Play item at current playlist index (can retry if speaker not ready)
+    SEND_COMMAND,      // Send command to active source
+  };
+  Type type;
+  uint8_t pipeline;  // MEDIA_PIPELINE or ANNOUNCEMENT_PIPELINE
+
+  union {
+    std::string *uri;  // Owned pointer, must delete after xQueueReceive (for PLAY_URI and ENQUEUE_URI)
+    media_player::MediaPlayerCommand command;
+  } data;
+};
+
+struct VolumeRestoreState {
+  float volume;
+  bool is_muted;
+};
+
+class SpeakerSourceMediaPlayer : public Component, public media_player::MediaPlayer {
+  friend struct SourceBinding;
+
+ public:
+  float get_setup_priority() const override { return esphome::setup_priority::PROCESSOR; }
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  // MediaPlayer implementations
+  media_player::MediaPlayerTraits get_traits() override;
+  bool is_muted() const override { return this->is_muted_; }
+
+  // Percentage to increase or decrease the volume for volume up or volume down commands
+  void set_volume_increment(float volume_increment) { this->volume_increment_ = volume_increment; }
+
+  // Volume used initially on first boot when no volume had been previously saved
+  void set_volume_initial(float volume_initial) { this->volume_initial_ = volume_initial; }
+
+  void set_volume_max(float volume_max) { this->volume_max_ = volume_max; }
+  void set_volume_min(float volume_min) { this->volume_min_ = volume_min; }
+
+  /// @brief Adds a media source to a pipeline and registers this player as its listener
+  void add_media_source(uint8_t pipeline, media_source::MediaSource *media_source);
+
+  void set_speaker(uint8_t pipeline, speaker::Speaker *speaker) { this->pipelines_[pipeline].speaker = speaker; }
+  void set_format(uint8_t pipeline, const media_player::MediaPlayerSupportedFormat &format) {
+    this->pipelines_[pipeline].format = format;
+  }
+
+  Trigger<> *get_mute_trigger() { return &this->mute_trigger_; }
+  Trigger<> *get_unmute_trigger() { return &this->unmute_trigger_; }
+  Trigger<float> *get_volume_trigger() { return &this->volume_trigger_; }
+
+  void set_playlist_delay_ms(uint8_t pipeline, uint32_t delay_ms);
+
+ protected:
+  // Callbacks from source bindings (pipeline index is captured at binding creation time)
+  size_t handle_media_output_(uint8_t pipeline, media_source::MediaSource *source, const uint8_t *data, size_t length,
+                              uint32_t timeout_ms, const audio::AudioStreamInfo &stream_info);
+  void handle_media_state_changed_(uint8_t pipeline, media_source::MediaSource *source,
+                                   media_source::MediaSourceState state);
+  void handle_volume_request_(float volume);
+  void handle_mute_request_(bool is_muted);
+  void handle_play_uri_request_(uint8_t pipeline, const std::string &uri);
+
+  void handle_speaker_playback_callback_(uint32_t frames, int64_t timestamp, uint8_t pipeline);
+
+  // Receives commands from HA or from the voice assistant component
+  // Sends commands to the media_control_command_queue_
+  void control(const media_player::MediaPlayerCall &call) override;
+
+  /// @brief Updates this->volume and saves volume/mute state to flash for restoration if publish is true.
+  void set_volume_(float volume, bool publish = true);
+
+  /// @brief Sets the mute state.
+  /// @param mute_state If true, audio will be muted. If false, audio will be unmuted
+  /// @param publish If true, saves volume/mute state to flash for restoration
+  void set_mute_state_(bool mute_state, bool publish = true);
+
+  /// @brief Saves the current volume and mute state to the flash for restoration.
+  void save_volume_restore_state_();
+
+  /// @brief Determine media player state from the media pipeline's active source
+  /// @param media_source Active source for the media pipeline (may be nullptr)
+  /// @param playlist_active Whether the media pipeline's playlist is in progress
+  /// @param old_state Previous media player state (used for transition smoothing)
+  /// @return The appropriate MediaPlayerState
+  media_player::MediaPlayerState get_media_pipeline_state_(media_source::MediaSource *media_source,
+                                                           bool playlist_active,
+                                                           media_player::MediaPlayerState old_state) const;
+
+  void process_control_queue_();
+  bool try_execute_play_uri_(const std::string &uri, uint8_t pipeline);
+  media_source::MediaSource *find_source_for_uri_(const std::string &uri, uint8_t pipeline);
+  void queue_command_(MediaPlayerControlCommand::Type type, uint8_t pipeline);
+  void queue_play_current_(uint8_t pipeline, uint32_t delay_ms = 0);
+
+  /// @brief Maps playlist_index through shuffle indices if shuffle is active
+  size_t get_playlist_position_(uint8_t pipeline) const;
+
+  /// @brief Generates shuffled indices for the playlist, keeping current track at current position
+  void shuffle_playlist_(uint8_t pipeline);
+
+  /// @brief Clears shuffle indices and adjusts playlist_index to maintain current track
+  void unshuffle_playlist_(uint8_t pipeline);
+
+  QueueHandle_t media_control_command_queue_;
+
+  // Pipeline context for media (index 0) and announcement (index 1) pipelines
+  // Threading: Most pipeline access is from the main loop thread (loop, process_control_queue_,
+  // handle_media_state_changed_ via the media source listener contract). Two callbacks cross threads:
+  //   - handle_media_output_: called from media source tasks (writes audio to speaker)
+  //   - handle_speaker_playback_callback_: called from the speaker callback task
+  // These only touch active_source and pending_frames, both atomic. No mutex needed.
+  std::array<PipelineContext, 2> pipelines_;
+
+  // Used to save volume/mute state for restoration on reboot
+  ESPPreferenceObject pref_;
+
+  Trigger<> mute_trigger_;
+  Trigger<> unmute_trigger_;
+  Trigger<float> volume_trigger_;
+
+  // The amount to change the volume on volume up/down commands
+  float volume_increment_;
+
+  // The initial volume used by Setup when no previous volume was saved
+  float volume_initial_;
+
+  float volume_max_;
+  float volume_min_;
+
+  bool is_muted_{false};
+};
+
+}  // namespace speaker_source
+}  // namespace esphome
+
+#endif  // USE_ESP32

--- a/tests/components/speaker_source/common.yaml
+++ b/tests/components/speaker_source/common.yaml
@@ -1,0 +1,65 @@
+i2s_audio:
+  i2s_lrclk_pin: ${i2s_bclk_pin}
+  i2s_bclk_pin: ${i2s_lrclk_pin}
+  i2s_mclk_pin: ${i2s_mclk_pin}
+
+speaker:
+  - platform: i2s_audio
+    id: speaker_id
+    dac_type: external
+    i2s_dout_pin: ${i2s_dout_pin}
+    sample_rate: 48000
+    num_channels: 2
+  - platform: mixer
+    output_speaker: speaker_id
+    source_speakers:
+      - id: announcement_mixer_speaker_id
+      - id: media_mixer_speaker_id
+
+audio_file:
+
+network:
+
+http_request:
+
+media_source:
+  - platform: http_request
+    id: announcement_http_source
+    buffer_size: 50000
+  - platform: http_request
+    id: media_http_source
+    buffer_size: 100000
+  - platform: audio_file
+    id: announcement_audio_file_source
+
+media_player:
+  - platform: speaker_source
+    id: media_player_id
+    name: Media Player
+    volume_increment: 0.02
+    volume_initial: 0.75
+    volume_max: 0.95
+    volume_min: 0.0
+    announcement_pipeline:
+      speaker: announcement_mixer_speaker_id
+      format: FLAC
+      num_channels: 1
+      sources:
+        - announcement_http_source
+        - announcement_audio_file_source
+    media_pipeline:
+      speaker: media_mixer_speaker_id
+      format: NONE
+      sources:
+        - media_http_source
+    on_mute:
+      - media_player.pause:
+          id: media_player_id
+    on_unmute:
+      - media_player.play:
+          id: media_player_id
+    on_volume:
+      - speaker_source.set_playlist_delay:
+          id: media_player_id
+          pipeline: media
+          delay: 500ms

--- a/tests/components/speaker_source/test.esp32-idf.yaml
+++ b/tests/components/speaker_source/test.esp32-idf.yaml
@@ -1,0 +1,9 @@
+substitutions:
+  scl_pin: GPIO16
+  sda_pin: GPIO17
+  i2s_bclk_pin: GPIO27
+  i2s_lrclk_pin: GPIO26
+  i2s_mclk_pin: GPIO25
+  i2s_dout_pin: GPIO23
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new media player that orchestrates ``media_source`` platform components. This allows the media player to support new media sources in the future; e.g., a color noise generator or Sendspin.

It has all the features of the existing speaker media player and more. For example, it has full internal playlist support including repeating (one or all) and shuffling. The API doesn't support these commands though, so, for now, support is limited to using native media player actions. For smart media sources with their own internal playlists; e.g., Sendspin, those commands are forwarded to the source if it is active.

All sources are started by the ``media_player.play_media`` action. You select the source by adjusting the prefix. So for example, to use the ``audio_file`` media source you do this:

```yaml
     on_*:
        - media_player.play_media:
            media_url: "audio-file://test_audio"
```

Regular HTTP urls will be forwarded to the ``http_request`` media source if configured for the pipeline.

It supports one or both announcement and media pipelines. You can use a ``mixer`` speaker component to combine the audio from two different pipelines (just like how the ``speaker`` media player works). You can configure a preferred format that is sent to HA and MA to audio (via the ``http_request``) component will be transcoded to an easy format to decode/process. You can specify a ``NONE`` preferred format and you will receive the original audio.

Each media source is unique to a pipeline. This lets you configure different settings for different pipelines, like using a smaller buffer for an announcement pipeline compared to the media pipeline. If you want to play ``audio_file`` files on both pipelines, you will need two different pipelines defined! (They can play the same files from the universal ``audio_file`` registry.

Note tests will fail until #14510 is merged.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker_source
    name: Media Player
    announcement_pipeline:
      speaker: announcement_mixer_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 1
      sources:
        - announcement_http_source
        - announcement_file_source
    media_pipeline:
      speaker: media_mixer_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 2
      sources:
        - media_http_source

audio_file:
  - id: test_audio
    file: /Users/kahrendt/Downloads/beethoven_opus_test.opus

http_request:
  buffer_size_rx: 2048

media_source:
  - platform: http_request
    id: announcement_http_source
    buffer_size: 100000
  - platform: http_request
    id: media_http_source
    buffer_size: 500000
  - platform: audio_file
    id: announcement_file_source

speaker:
  - platform: i2s_audio
    id: box_speaker
    i2s_dout_pin: GPIOXX
    dac_type: external
    sample_rate: 48000
    bits_per_sample: 16bit
    buffer_duration: 100ms
  - platform: mixer
    output_speaker: box_speaker
    source_speakers:
      - id: announcement_mixer_speaker
      - id: media_mixer_speaker

external_components:
  - source: github://pr#14510
    components: [http_request]
  - source: github://pr##14646
    components: [speaker_source]

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
