### PR TITLE
[multiple] Fix crashes from malformed external input (batch 2)

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -514,6 +514,11 @@ void ESPBTDevice::parse_adv_(const uint8_t *payload, uint8_t len) {
       continue;  // Possible zero padded advertisement data
     }
 
+    // Validate field fits in remaining payload
+    if (offset + field_length > len) {
+      break;
+    }
+
     // first byte of adv record is adv record type
     const uint8_t record_type = payload[offset++];
     const uint8_t *record = &payload[offset];

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -200,6 +200,12 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
       this->send_error(function_code, ModbusExceptionCode::ILLEGAL_DATA_VALUE);
       return;
     }
+    if (data.size() < 5 + payload_size) {
+      ESP_LOGW(TAG, "Write multiple registers payload truncated (%zu bytes, expected %u)", data.size(),
+               5 + payload_size);
+      this->send_error(function_code, ModbusExceptionCode::ILLEGAL_DATA_VALUE);
+      return;
+    }
     payload_offset = 5;
   } else if (function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER) {
     if (data.size() < 4) {

--- a/esphome/components/modbus_controller/modbus_controller.cpp
+++ b/esphome/components/modbus_controller/modbus_controller.cpp
@@ -59,6 +59,10 @@ bool ModbusController::send_next_command_() {
 
 // Queue incoming response
 void ModbusController::on_modbus_data(const std::vector<uint8_t> &data) {
+  if (this->command_queue_.empty()) {
+    ESP_LOGW(TAG, "Received modbus data but command queue is empty");
+    return;
+  }
   auto &current_command = this->command_queue_.front();
   if (current_command != nullptr) {
     if (this->module_offline_) {
@@ -92,6 +96,9 @@ void ModbusController::process_modbus_data_(const ModbusCommandItem *response) {
 
 void ModbusController::on_modbus_error(uint8_t function_code, uint8_t exception_code) {
   ESP_LOGE(TAG, "Modbus error function code: 0x%X exception: %d ", function_code, exception_code);
+  if (this->command_queue_.empty()) {
+    return;
+  }
   // Remove pending command waiting for a response
   auto &current_command = this->command_queue_.front();
   if (current_command != nullptr) {
@@ -175,6 +182,11 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
   uint16_t payload_offset;
 
   if (function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
+    if (data.size() < 5) {
+      ESP_LOGW(TAG, "Write multiple registers data too short (%zu bytes)", data.size());
+      this->send_error(function_code, ModbusExceptionCode::ILLEGAL_DATA_VALUE);
+      return;
+    }
     number_of_registers = uint16_t(data[3]) | (uint16_t(data[2]) << 8);
     if (number_of_registers == 0 || number_of_registers > modbus::MAX_NUM_OF_REGISTERS_TO_WRITE) {
       ESP_LOGW(TAG, "Invalid number of registers %d. Sending exception response.", number_of_registers);
@@ -190,6 +202,11 @@ void ModbusController::on_modbus_write_registers(uint8_t function_code, const st
     }
     payload_offset = 5;
   } else if (function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER) {
+    if (data.size() < 4) {
+      ESP_LOGW(TAG, "Write single register data too short (%zu bytes)", data.size());
+      this->send_error(function_code, ModbusExceptionCode::ILLEGAL_DATA_VALUE);
+      return;
+    }
     number_of_registers = 1;
     payload_offset = 2;
   } else {

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -86,6 +86,12 @@ int Nextion::upload_by_chunks_(HTTPClient &http_client, uint32_t &range_start) {
       ESP_LOGD(TAG, "Upload: %0.2f%% (%" PRIu32 " left, heap: %" PRIu32 ")", upload_percentage, this->content_length_,
                EspClass::getFreeHeap());
       upload_first_chunk_sent_ = true;
+      if (recv_string.empty()) {
+        ESP_LOGW(TAG, "No response from display during upload");
+        allocator.deallocate(buffer, 4096);
+        buffer = nullptr;
+        return -1;
+      }
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
         char hex_buf[format_hex_pretty_size(NEXTION_MAX_RESPONSE_LOG_BYTES)];
         ESP_LOGD(

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -108,6 +108,12 @@ int Nextion::upload_by_chunks_(esp_http_client_handle_t http_client, uint32_t &r
                static_cast<uint32_t>(esp_get_free_heap_size()));
 #endif
       upload_first_chunk_sent_ = true;
+      if (recv_string.empty()) {
+        ESP_LOGW(TAG, "No response from display during upload");
+        allocator.deallocate(buffer, 4096);
+        buffer = nullptr;
+        return -1;
+      }
       if (recv_string[0] == 0x08 && recv_string.size() == 5) {  // handle partial upload request
         char hex_buf[format_hex_pretty_size(NEXTION_MAX_RESPONSE_LOG_BYTES)];
         ESP_LOGD(

--- a/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/esphome/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -199,7 +199,7 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
       }
       break;
     case DISTANCE_TYPE_BUFFER:
-      if (data[0] != 0) {
+      if (length >= 1 && data[0] != 0) {
         if (this->distance_sensor_ != nullptr && length >= 8) {
           uint32_t current_distance_int = encode_uint32(data[7], data[6], data[5], data[4]);
           float distance_float;

--- a/esphome/components/usb_host/usb_host_client.cpp
+++ b/esphome/components/usb_host/usb_host_client.cpp
@@ -492,6 +492,11 @@ bool USBClient::transfer_in(uint8_t ep_address, const transfer_cb_t &callback, u
     ESP_LOGE(TAG, "Too many requests queued");
     return false;
   }
+  if (length > trq->transfer->data_buffer_size) {
+    ESP_LOGE(TAG, "transfer_in: data length %u exceeds buffer size %u", length, trq->transfer->data_buffer_size);
+    this->release_trq(trq);
+    return false;
+  }
   trq->callback = callback;
   trq->transfer->callback = transfer_callback;
   trq->transfer->bEndpointAddress = ep_address | USB_DIR_IN;


### PR DESCRIPTION
# What does this implement/fix?

Fixes crashes and undefined behavior triggered by malformed external input in 5 components, found during a systematic code audit.

**esp32_ble_tracker** — `parse_adv_()` reads `field_length` from BLE advertisement data but doesn't validate it fits within the remaining payload. A malformed advertisement with an inflated length field causes out-of-bounds reads. Added `if (offset + field_length > len) break;` after reading the field length.

**modbus_controller** — Three issues:
1. `on_modbus_data()` and `on_modbus_error()` call `command_queue_.front()` without checking if the queue is empty. A stale or unexpected Modbus response when the queue is empty causes undefined behavior. Added empty checks.
2. `on_modbus_write_registers()` accesses `data[0..4]` without checking `data.size()`. A truncated response causes out-of-bounds reads. Added size validation for both WRITE_MULTIPLE and WRITE_SINGLE register responses.

**seeed_mr60bha2** — The DISTANCE_TYPE_BUFFER handler accesses `data[0]` without checking that `length >= 1`. A zero-length payload causes an out-of-bounds read. Added length check.

**usb_host** — `transfer_in()` uses the device-reported `length` without bounds checking against `data_buffer_size` (64 bytes). The matching `transfer_out()` already has this check. Added the same bounds validation.

**nextion** — During firmware upload, `recv_string[0]` is accessed without checking if `recv_string` is empty. A timeout that returns an empty string causes an out-of-bounds access. Added empty checks in both the ESP32 and Arduino upload paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (found during systematic code audit)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required — these are runtime bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).