### PR TITLE
[speaker_source] Add shuffle support

### DIFF
--- a/esphome/components/speaker_source/media_player.py
+++ b/esphome/components/speaker_source/media_player.py
@@ -57,14 +57,6 @@ FORMAT_MAPPING = {
 }
 
 
-FORMAT_MAPPING = {
-    "FLAC": "flac",
-    "MP3": "mp3",
-    "OPUS": "opus",
-    "WAV": "wav",
-}
-
-
 # Returns a media_player.MediaPlayerSupportedFormat struct with the configured
 # format, sample rate, number of channels, purpose, and bytes per sample
 def _get_supported_format_struct(pipeline: ConfigType):

--- a/esphome/components/speaker_source/media_player.py
+++ b/esphome/components/speaker_source/media_player.py
@@ -57,6 +57,14 @@ FORMAT_MAPPING = {
 }
 
 
+FORMAT_MAPPING = {
+    "FLAC": "flac",
+    "MP3": "mp3",
+    "OPUS": "opus",
+    "WAV": "wav",
+}
+
+
 # Returns a media_player.MediaPlayerSupportedFormat struct with the configured
 # format, sample rate, number of channels, purpose, and bytes per sample
 def _get_supported_format_struct(pipeline: ConfigType):

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -5,6 +5,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <algorithm>
+
 namespace esphome::speaker_source {
 
 static constexpr uint32_t MEDIA_CONTROLS_QUEUE_LENGTH = 20;
@@ -383,7 +385,8 @@ void SpeakerSourceMediaPlayer::process_control_queue_() {
       // Always use our local playlist to start playback
       this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
       ps.playlist.clear();
-      ps.playlist_index = 0;  // Reset index
+      ps.shuffle_indices.clear();  // Clear shuffle when starting fresh playlist
+      ps.playlist_index = 0;       // Reset index
       ps.playlist.push_back(*control_command.data.uri);
 
       // Queue PLAY_CURRENT to initiate playback
@@ -395,6 +398,11 @@ void SpeakerSourceMediaPlayer::process_control_queue_() {
     case MediaPlayerControlCommand::ENQUEUE_URI: {
       // Always add to our local playlist
       ps.playlist.push_back(*control_command.data.uri);
+
+      // If shuffle is active, add the new item to the end of the shuffle order
+      if (!ps.shuffle_indices.empty()) {
+        ps.shuffle_indices.push_back(ps.playlist.size() - 1);
+      }
 
       // If nothing is playing and no upcoming items are queued, start the new item.
       bool nothing_playing =
@@ -425,9 +433,10 @@ void SpeakerSourceMediaPlayer::process_control_queue_() {
     }
 
     case MediaPlayerControlCommand::PLAY_CURRENT: {
-      // Play the item at current playlist index
+      // Play the item at current playlist index (mapped through shuffle if active)
       if (ps.playlist_index < ps.playlist.size()) {
-        command_executed = this->try_execute_play_uri_(ps.playlist[ps.playlist_index], pipeline);
+        size_t actual_position = this->get_playlist_position_(pipeline);
+        command_executed = this->try_execute_play_uri_(ps.playlist[actual_position], pipeline);
       } else {
         command_executed = true;  // Index out of bounds or empty playlist
       }
@@ -521,6 +530,7 @@ void SpeakerSourceMediaPlayer::handle_player_command_(media_player::MediaPlayerC
       if (!has_internal_playlist) {
         this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
         ps.playlist.clear();
+        ps.shuffle_indices.clear();
         ps.playlist_index = 0;
       }
       if (target_source != nullptr) {
@@ -589,21 +599,39 @@ void SpeakerSourceMediaPlayer::handle_player_command_(media_player::MediaPlayerC
       if (!has_internal_playlist) {
         this->cancel_timeout(PipelineContext::TIMEOUT_IDS[pipeline]);
         if (ps.playlist_index < ps.playlist.size()) {
-          ps.playlist[0] = std::move(ps.playlist[ps.playlist_index]);
+          size_t actual_position = this->get_playlist_position_(pipeline);
+          ps.playlist[0] = std::move(ps.playlist[actual_position]);
           ps.playlist.resize(1);
           ps.playlist_index = 0;
         } else {
           ps.playlist.clear();
           ps.playlist_index = 0;
         }
+        ps.shuffle_indices.clear();
       } else if (target_source != nullptr) {
         target_source->handle_command(media_source::MediaSourceCommand::CLEAR_PLAYLIST);
       }
       break;
     }
 
+    case media_player::MEDIA_PLAYER_COMMAND_SHUFFLE:
+      if (!has_internal_playlist) {
+        this->shuffle_playlist_(pipeline);
+      } else if (target_source != nullptr) {
+        target_source->handle_command(media_source::MediaSourceCommand::SHUFFLE);
+      }
+      break;
+
+    case media_player::MEDIA_PLAYER_COMMAND_UNSHUFFLE:
+      if (!has_internal_playlist) {
+        this->unshuffle_playlist_(pipeline);
+      } else if (target_source != nullptr) {
+        target_source->handle_command(media_source::MediaSourceCommand::UNSHUFFLE);
+      }
+      break;
+
     default:
-      // TURN_ON, TURN_OFF, ENQUEUE (handled separately with URL), SHUFFLE/UNSHUFFLE (PR3) are no-ops
+      // TURN_ON, TURN_OFF, ENQUEUE (handled separately with URL) are no-ops
       break;
   }
 }
@@ -764,6 +792,58 @@ void SpeakerSourceMediaPlayer::set_volume_(float volume, bool publish) {
   }
 
   this->defer([this, volume]() { this->volume_trigger_.trigger(volume); });
+}
+
+size_t SpeakerSourceMediaPlayer::get_playlist_position_(uint8_t pipeline) const {
+  const PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (ps.shuffle_indices.empty() || ps.playlist_index >= ps.shuffle_indices.size()) {
+    return ps.playlist_index;
+  }
+  return ps.shuffle_indices[ps.playlist_index];
+}
+
+void SpeakerSourceMediaPlayer::shuffle_playlist_(uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (ps.playlist.size() <= 1) {
+    ps.shuffle_indices.clear();
+    return;
+  }
+
+  // Capture current actual position BEFORE modifying shuffle_indices
+  size_t current_actual = this->get_playlist_position_(pipeline);
+
+  // Build indices vector
+  ps.shuffle_indices.resize(ps.playlist.size());
+  for (size_t i = 0; i < ps.playlist.size(); i++) {
+    ps.shuffle_indices[i] = i;
+  }
+
+  // Fisher-Yates shuffle using ESPHome's random helper
+  for (size_t i = ps.shuffle_indices.size() - 1; i > 0; i--) {
+    size_t j = random_uint32() % (i + 1);
+    std::swap(ps.shuffle_indices[i], ps.shuffle_indices[j]);
+  }
+
+  // Move current track to current position (so playback continues seamlessly)
+  if (ps.playlist_index < ps.shuffle_indices.size()) {
+    for (size_t i = 0; i < ps.shuffle_indices.size(); i++) {
+      if (ps.shuffle_indices[i] == current_actual) {
+        std::swap(ps.shuffle_indices[i], ps.shuffle_indices[ps.playlist_index]);
+        break;
+      }
+    }
+  }
+}
+
+void SpeakerSourceMediaPlayer::unshuffle_playlist_(uint8_t pipeline) {
+  PipelineContext &ps = this->pipelines_[pipeline];
+
+  if (!ps.shuffle_indices.empty() && ps.playlist_index < ps.shuffle_indices.size()) {
+    ps.playlist_index = ps.shuffle_indices[ps.playlist_index];
+  }
+  ps.shuffle_indices.clear();
 }
 
 }  // namespace esphome::speaker_source

--- a/esphome/components/speaker_source/speaker_source_media_player.h
+++ b/esphome/components/speaker_source/speaker_source_media_player.h
@@ -110,6 +110,10 @@ struct PipelineContext {
   RepeatMode repeat_mode{REPEAT_OFF};
   uint32_t playlist_delay_ms{0};
 
+  // When non-empty, playlist_index indexes into these vectors
+  // which contain the actual playlist indices in shuffled order
+  std::vector<size_t> shuffle_indices;
+
   // Track frames sent to speaker to correlate with playback callbacks.
   // Atomic because it is written from the main loop/source tasks and read/decremented from the speaker playback
   // callback.
@@ -219,6 +223,15 @@ class SpeakerSourceMediaPlayer : public Component, public media_player::MediaPla
   media_source::MediaSource *find_source_for_uri_(const std::string &uri, uint8_t pipeline);
   void queue_command_(MediaPlayerControlCommand::Type type, uint8_t pipeline);
   void queue_play_current_(uint8_t pipeline, uint32_t delay_ms = 0);
+
+  /// @brief Maps playlist_index through shuffle indices if shuffle is active
+  size_t get_playlist_position_(uint8_t pipeline) const;
+
+  /// @brief Generates shuffled indices for the playlist, keeping current track at current position
+  void shuffle_playlist_(uint8_t pipeline);
+
+  /// @brief Clears shuffle indices and adjusts playlist_index to maintain current track
+  void unshuffle_playlist_(uint8_t pipeline);
 
   QueueHandle_t media_control_command_queue_;
 

--- a/tests/components/speaker_source/common.yaml
+++ b/tests/components/speaker_source/common.yaml
@@ -36,10 +36,10 @@ media_player:
       sources:
         - audio_file_source
     on_mute:
-      - media_player.pause:
+      - media_player.shuffle:
           id: media_player_id
     on_unmute:
-      - media_player.play:
+      - media_player.unshuffle:
           id: media_player_id
     on_volume:
       - speaker_source.set_playlist_delay:


### PR DESCRIPTION
# What does this implement/fix?

Adds shuffle and unshuffle support to the `speaker_source` media player. This builds on #14652 (playlist management).

Features added:
- Shuffle command using Fisher-Yates algorithm with an indirect index mapping (`shuffle_indices` vector)
- Current track position is preserved when toggling shuffle on or off
- Unshuffle restores the original playlist order, adjusting the current index to match
- Shuffle indices are cleared on new playlist, stop, or clear playlist commands
- New items enqueued during shuffle are appended to the end of the shuffle order
- Smart source forwarding: shuffle/unshuffle commands are forwarded to the active source if it has internal playlist management

Depends on #14652.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) -- [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) -- [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6246 (one doc PR for entire chain)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
media_player:
  - platform: speaker_source
    name: Media Player
    media_pipeline:
      speaker: media_mixer_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 2
      sources:
        - media_http_source

# Shuffle via automation
on_press:
  - media_player.shuffle:
  - media_player.unshuffle:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).