### PR TITLE
[multiple] Remove unnecessary heap allocations in 4 components

### DIFF
--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -350,8 +350,8 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     valid_daikin_frame = true;
     size_t bytes_count = data.size() / 2 / 8;
-    size_t buf_size = bytes_count * 3 + 1;
-    std::unique_ptr<char[]> buf(new char[buf_size]());  // value-initialize (zero-fill)
+    char buf[DAIKIN_STATE_FRAME_SIZE * 3 + 1] = {};
+    constexpr size_t buf_size = sizeof(buf);
     size_t buf_pos = 0;
     for (size_t i = 0; i < bytes_count; i++) {
       uint8_t byte = 0;
@@ -363,9 +363,9 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
           break;
         }
       }
-      buf_pos = buf_append_printf(buf.get(), buf_size, buf_pos, "%02x ", byte);
+      buf_pos = buf_append_printf(buf, buf_size, buf_pos, "%02x ", byte);
     }
-    ESP_LOGD(TAG, "WHOLE FRAME %s  size: %d", buf.get(), data.size());
+    ESP_LOGD(TAG, "WHOLE FRAME %s  size: %d", buf, data.size());
   }
   if (!valid_daikin_frame) {
     char sbuf[16 * 10 + 1] = {0};

--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -350,7 +350,8 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     valid_daikin_frame = true;
     size_t bytes_count = data.size() / 2 / 8;
-    char buf[DAIKIN_STATE_FRAME_SIZE * 3 + 1] = {};
+    // Enough for 42 decoded bytes; truncates gracefully via buf_append_printf
+    char buf[128] = {};
     constexpr size_t buf_size = sizeof(buf);
     size_t buf_pos = 0;
     for (size_t i = 0; i < bytes_count; i++) {

--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -350,8 +350,8 @@ bool DaikinArcClimate::on_receive(remote_base::RemoteReceiveData data) {
   if (data.expect_item(DAIKIN_HEADER_MARK, DAIKIN_HEADER_SPACE)) {
     valid_daikin_frame = true;
     size_t bytes_count = data.size() / 2 / 8;
-    // Enough for 42 decoded bytes; truncates gracefully via buf_append_printf
-    char buf[128] = {};
+    // Header (20) + state (19) = 39 bytes max; truncates gracefully via buf_append_printf
+    char buf[40 * 3 + 1] = {};
     constexpr size_t buf_size = sizeof(buf);
     size_t buf_pos = 0;
     for (size_t i = 0; i < bytes_count; i++) {

--- a/esphome/components/pn7150_i2c/pn7150_i2c.cpp
+++ b/esphome/components/pn7150_i2c/pn7150_i2c.cpp
@@ -34,7 +34,8 @@ uint8_t PN7150I2C::read_nfcc(nfc::NciMessage &rx, const uint16_t timeout) {
 }
 
 uint8_t PN7150I2C::write_nfcc(nfc::NciMessage &tx) {
-  if (this->write(tx.encode().data(), tx.encode().size()) == i2c::ERROR_OK) {
+  auto encoded = tx.encode();
+  if (this->write(encoded.data(), encoded.size()) == i2c::ERROR_OK) {
     return nfc::STATUS_OK;
   }
   return nfc::STATUS_FAILED;

--- a/esphome/components/pn7160_i2c/pn7160_i2c.cpp
+++ b/esphome/components/pn7160_i2c/pn7160_i2c.cpp
@@ -34,7 +34,8 @@ uint8_t PN7160I2C::read_nfcc(nfc::NciMessage &rx, const uint16_t timeout) {
 }
 
 uint8_t PN7160I2C::write_nfcc(nfc::NciMessage &tx) {
-  if (this->write(tx.encode().data(), tx.encode().size()) == i2c::ERROR_OK) {
+  auto encoded = tx.encode();
+  if (this->write(encoded.data(), encoded.size()) == i2c::ERROR_OK) {
     return nfc::STATUS_OK;
   }
   return nfc::STATUS_FAILED;

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -951,10 +951,10 @@ void ToshibaClimate::transmit_ras_2819t_() {
 }
 
 uint8_t ToshibaClimate::is_valid_rac_pt1411hwru_header_(const uint8_t *message) {
-  const std::vector<uint8_t> header{RAC_PT1411HWRU_MESSAGE_HEADER0, RAC_PT1411HWRU_CS_HEADER,
-                                    RAC_PT1411HWRU_SWING_HEADER};
+  static constexpr uint8_t HEADERS[] = {RAC_PT1411HWRU_MESSAGE_HEADER0, RAC_PT1411HWRU_CS_HEADER,
+                                        RAC_PT1411HWRU_SWING_HEADER};
 
-  for (auto i : header) {
+  for (auto i : HEADERS) {
     if ((message[0] == i) && (message[1] == static_cast<uint8_t>(~i)))
       return i;
   }


### PR DESCRIPTION
# What does this implement/fix?

Remove unnecessary runtime heap allocations in 4 components:

- **toshiba**: Replace `std::vector` with `static constexpr` array in `is_valid_rac_pt1411hwru_header_()`, which is called on every IR receive
- **pn7160_i2c**: Save `tx.encode()` result to a local variable instead of calling it twice (two vector copies per NFC write)
- **pn7150_i2c**: Same fix as pn7160_i2c
- **daikin_arc**: Replace heap-allocated `char[]` buffer with stack buffer in `on_receive()` debug logging

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).