### PR TITLE
[wifi][captive_portal][heatpumpir][es8388] Fix wrong behavior in 4 components

### DIFF
--- a/esphome/components/captive_portal/dns_server_esp32_idf.cpp
+++ b/esphome/components/captive_portal/dns_server_esp32_idf.cpp
@@ -14,6 +14,7 @@ static const char *const TAG = "captive_portal.dns";
 // DNS constants
 static constexpr uint16_t DNS_PORT = 53;
 static constexpr uint16_t DNS_QR_FLAG = 1 << 15;
+static constexpr uint16_t DNS_AA_FLAG = 1 << 10;
 static constexpr uint16_t DNS_OPCODE_MASK = 0x7800;
 static constexpr uint16_t DNS_QTYPE_A = 0x0001;
 static constexpr uint16_t DNS_QCLASS_IN = 0x0001;
@@ -162,8 +163,8 @@ void DNSServer::process_next_request() {
   }
 
   // Build DNS response by modifying the request in-place
-  header->flags = htons(DNS_QR_FLAG | 0x8000);  // Response + Authoritative
-  header->an_count = htons(1);                  // One answer
+  header->flags = htons(DNS_QR_FLAG | DNS_AA_FLAG);  // Response + Authoritative
+  header->an_count = htons(1);                       // One answer
 
   // Add answer section after the question
   size_t question_len = (ptr + sizeof(DNSQuestion)) - this->buffer_ - sizeof(DNSHeader);

--- a/esphome/components/es8388/es8388.cpp
+++ b/esphome/components/es8388/es8388.cpp
@@ -152,7 +152,7 @@ void ES8388::dump_config() {
 
 bool ES8388::set_volume(float volume) {
   volume = clamp(volume, 0.0f, 1.0f);
-  uint8_t value = remap<uint8_t, float>(volume, 0.0f, 1.0f, -96, 0);
+  uint8_t value = remap<uint8_t, float>(volume, 0.0f, 1.0f, 192, 0);
   ESP_LOGD(TAG, "Setting ES8388_DACCONTROL4 / ES8388_DACCONTROL5 to 0x%02X (volume: %f)", value, volume);
   ES8388_ERROR_CHECK(this->write_byte(ES8388_DACCONTROL4, value));
   ES8388_ERROR_CHECK(this->write_byte(ES8388_DACCONTROL5, value));
@@ -163,7 +163,7 @@ bool ES8388::set_volume(float volume) {
 float ES8388::volume() {
   uint8_t value;
   ES8388_ERROR_CHECK(this->read_byte(ES8388_DACCONTROL4, &value));
-  return remap<float, uint8_t>(value, -96, 0, 0.0f, 1.0f);
+  return remap<float, uint8_t>(value, 192, 0, 0.0f, 1.0f);
 }
 
 bool ES8388::set_mute_state_(bool mute_state) {

--- a/esphome/components/heatpumpir/heatpumpir.cpp
+++ b/esphome/components/heatpumpir/heatpumpir.cpp
@@ -114,7 +114,7 @@ void HeatpumpIRClimate::setup() {
       this->current_temperature = state;
 
       IRSenderESPHome esp_sender(this->transmitter_);
-      this->heatpump_ir_->send(esp_sender, uint8_t(lround(this->current_temperature + 0.5)));
+      this->heatpump_ir_->send(esp_sender, uint8_t(lround(this->current_temperature)));
 
       // current temperature changed, publish state
       this->publish_state();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -638,8 +638,6 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   return WiFiSTAConnectStatus::IDLE;
 }
 bool WiFiComponent::wifi_scan_start_(bool passive) {
-  static bool first_scan = false;
-
   // enable STA
   if (!this->wifi_mode_(true, {}))
     return false;
@@ -656,23 +654,13 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   config.show_hidden = 1;
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 4, 0)
   config.scan_type = passive ? WIFI_SCAN_TYPE_PASSIVE : WIFI_SCAN_TYPE_ACTIVE;
-  if (first_scan) {
-    if (passive) {
-      config.scan_time.passive = 200;
-    } else {
-      config.scan_time.active.min = 100;
-      config.scan_time.active.max = 200;
-    }
+  if (passive) {
+    config.scan_time.passive = 500;
   } else {
-    if (passive) {
-      config.scan_time.passive = 500;
-    } else {
-      config.scan_time.active.min = 400;
-      config.scan_time.active.max = 500;
-    }
+    config.scan_time.active.min = 400;
+    config.scan_time.active.max = 500;
   }
 #endif
-  first_scan = false;
   bool ret = wifi_station_scan(&config, &WiFiComponent::s_wifi_scan_done_callback);
   if (!ret) {
     ESP_LOGV(TAG, "wifi_station_scan failed");


### PR DESCRIPTION
# What does this implement/fix?

Fix incorrect behavior in 4 components found during systematic code review:

- **wifi** (ESP8266): `first_scan` static was initialized to `false` but never set `true`, making the shorter first-scan timeout branch dead code. Removed the dead `first_scan` code path entirely, keeping only the standard scan timeouts.
- **captive_portal**: DNS response flags used `DNS_QR_FLAG | 0x8000` which is redundant (DNS_QR_FLAG already is 0x8000). The comment says "Authoritative" but the AA bit was never set. Added `DNS_AA_FLAG` constant and set it correctly.
- **heatpumpir**: `lround()` already rounds to nearest integer, but `+ 0.5` was added before it, causing double-rounding (e.g. 20.3°C → 21°C instead of 20°C). Removed the redundant `+ 0.5`.
- **es8388**: `remap<uint8_t>(-96, 0, ...)` wraps -96 to 160 due to unsigned narrowing. The ES8388 DAC register uses 0=0dB and 192=-96dB in 0.5dB steps. Changed remap to use register values directly (192→0).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - these are internal bug fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).