### PR TITLE
[hmc5883l][mmc5603][honeywellabp2][xgzp68xx][max9611] Fix uninitialized members

### DIFF
--- a/esphome/components/hmc5883l/hmc5883l.h
+++ b/esphome/components/hmc5883l/hmc5883l.h
@@ -61,7 +61,7 @@ class HMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
     NONE = 0,
     COMMUNICATION_FAILED,
     ID_REGISTERS,
-  } error_code_;
+  } error_code_{NONE};
   HighFrequencyLoopRequester high_freq_;
 };
 

--- a/esphome/components/honeywellabp2_i2c/honeywellabp2.h
+++ b/esphome/components/honeywellabp2_i2c/honeywellabp2.h
@@ -45,8 +45,8 @@ class HONEYWELLABP2Sensor : public PollingComponent, public i2c::I2CDevice {
   const float max_count_b_ = 11744051.2;  // (70% of 2^24 counts or 0xB33333)
   const float min_count_b_ = 5033164.8;   // (30% of 2^24 counts or 0x4CCCCC)
 
-  float max_count_;
-  float min_count_;
+  float max_count_{max_count_a_};
+  float min_count_{min_count_a_};
   bool measurement_running_ = false;
 
   uint8_t raw_data_[7];                      // holds output data

--- a/esphome/components/max9611/sensor.py
+++ b/esphome/components/max9611/sensor.py
@@ -35,7 +35,9 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(MAX9611Component),
-            cv.Required(CONF_SHUNT_RESISTANCE): cv.resistance,
+            cv.Required(CONF_SHUNT_RESISTANCE): cv.All(
+                cv.resistance, cv.Range(min=1e-6)
+            ),
             cv.Required(CONF_GAIN): cv.enum(MAX9611_GAIN, upper=True),
             cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_VOLT,

--- a/esphome/components/mmc5603/mmc5603.h
+++ b/esphome/components/mmc5603/mmc5603.h
@@ -27,7 +27,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
   void set_auto_set_reset(bool auto_set_reset) { auto_set_reset_ = auto_set_reset; }
 
  protected:
-  MMC5603Datarate datarate_;
+  MMC5603Datarate datarate_{MMC5603_DATARATE_75_0_HZ};
   sensor::Sensor *x_sensor_{nullptr};
   sensor::Sensor *y_sensor_{nullptr};
   sensor::Sensor *z_sensor_{nullptr};
@@ -37,7 +37,7 @@ class MMC5603Component : public PollingComponent, public i2c::I2CDevice {
     NONE = 0,
     COMMUNICATION_FAILED,
     ID_REGISTERS,
-  } error_code_;
+  } error_code_{NONE};
 };
 
 }  // namespace mmc5603

--- a/esphome/components/xgzp68xx/sensor.py
+++ b/esphome/components/xgzp68xx/sensor.py
@@ -56,7 +56,7 @@ CONFIG_SCHEMA = (
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
-            cv.Optional(CONF_K_VALUE, default=4096): cv.uint16_t,
+            cv.Optional(CONF_K_VALUE, default=4096): cv.int_range(min=1, max=65535),
         }
     )
     .extend(cv.polling_component_schema("60s"))


### PR DESCRIPTION
# What does this implement/fix?

Fix uninitialized member variables and missing schema validation in 5 components found during systematic code review:

- **hmc5883l**: `error_code_` uninitialized; `dump_config()` reads indeterminate value (UB). Added `{NONE}` initializer.
- **mmc5603**: `datarate_` and `error_code_` uninitialized; `dump_config()` reads indeterminate enum values (UB). Added default initializers.
- **honeywellabp2_i2c**: `max_count_`/`min_count_` uninitialized but used as divisors in pressure calculation. Initialized to transfer function A defaults.
- **xgzp68xx**: `k_value_` used as divisor; schema accepted 0 which would cause division by zero. Changed `cv.uint16_t` to `cv.int_range(min=1, max=65535)`.
- **max9611**: `current_resistor_` used as divisor with no zero guard; inf/NaN on 0Ω config. Added `cv.Range(min=1e-6)` to schema validation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - these are internal bug fixes
# xgzp68xx k_value now requires min=1 (was already defaulting to 4096)
# max9611 shunt_resistance now requires a positive value
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).