### PR TITLE
[runtime_image][st7701s] Fix BMP decoder and LCD init bugs

### DIFF
--- a/esphome/components/runtime_image/bmp_decoder.cpp
+++ b/esphome/components/runtime_image/bmp_decoder.cpp
@@ -63,7 +63,8 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
 
     switch (this->bits_per_pixel_) {
       case 1:
-        this->width_bytes_ = (this->width_ % 8 == 0) ? (this->width_ / 8) : (this->width_ / 8 + 1);
+        this->width_bytes_ = (this->width_ + 7) / 8;
+        this->padding_bytes_ = (4 - (this->width_bytes_ % 4)) % 4;
         break;
       case 24:
         this->width_bytes_ = this->width_ * 3;
@@ -92,15 +93,26 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
     case 1: {
       while (index < size) {
         uint8_t current_byte = buffer[index];
+        bool end_of_row = false;
         for (uint8_t i = 0; i < 8; i++) {
-          size_t x = (this->paint_index_ % static_cast<size_t>(this->width_)) + i;
+          size_t x = this->paint_index_ % static_cast<size_t>(this->width_);
           size_t y = static_cast<size_t>(this->height_ - 1) - (this->paint_index_ / static_cast<size_t>(this->width_));
           Color c = (current_byte & (1 << (7 - i))) ? display::COLOR_ON : display::COLOR_OFF;
           this->draw(x, y, 1, 1, c);
+          this->paint_index_++;
+          // End of pixel row: skip remaining bits in this byte
+          if (x + 1 >= static_cast<size_t>(this->width_)) {
+            end_of_row = true;
+            break;
+          }
         }
-        this->paint_index_ += 8;
         this->current_index_++;
         index++;
+        // End of pixel row: skip row padding bytes (4-byte alignment)
+        if (end_of_row && this->padding_bytes_ > 0) {
+          index += this->padding_bytes_;
+          this->current_index_ += this->padding_bytes_;
+        }
       }
       break;
     }

--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -36,11 +36,13 @@ void ST7701S::setup() {
   config.de_gpio_num = this->de_pin_->get_pin();
   config.pclk_gpio_num = this->pclk_pin_->get_pin();
   esp_err_t err = esp_lcd_new_rgb_panel(&config, &this->handle_);
-  ESP_ERROR_CHECK(esp_lcd_panel_reset(this->handle_));
-  ESP_ERROR_CHECK(esp_lcd_panel_init(this->handle_));
   if (err != ESP_OK) {
     esph_log_e(TAG, "lcd_new_rgb_panel failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
   }
+  ESP_ERROR_CHECK(esp_lcd_panel_reset(this->handle_));
+  ESP_ERROR_CHECK(esp_lcd_panel_init(this->handle_));
 }
 
 void ST7701S::loop() {


### PR DESCRIPTION
# What does this implement/fix?

Fixes two bugs in separate components:

**runtime_image (BMP decoder):** The 1-bit BMP decoder did not handle row padding correctly. BMP rows are padded to 4-byte alignment, and for image widths that aren't multiples of 8, the remaining bits in the last byte of a row need to be skipped. The decoder was processing all 8 bits of every byte including padding bits, causing pixel misalignment for non-multiple-of-8 widths. Pre-calculates `width_bytes_` and `padding_bytes_` (matching the 24-bit path) and breaks out of the bit loop at end-of-row, then skips padding bytes.

**st7701s:** `esp_lcd_panel_reset()` and `esp_lcd_panel_init()` were called after `esp_lcd_new_rgb_panel()` without checking the return value first. If panel creation failed, the code would call these functions with an invalid handle. Moved the error check to immediately after panel creation and added `mark_failed()` + early return on failure.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# runtime_image - 1-bit BMP with non-multiple-of-8 width
online_image:
  - url: "http://example.com/image.bmp"
    format: BMP
    id: my_bmp
    type: BINARY

# st7701s - no config change needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).