### PR TITLE
[ble_scanner] Escape special characters in JSON output

### DIFF
--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -16,12 +16,22 @@ namespace ble_scanner {
 class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESPBTDeviceListener, public Component {
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
-    // Format JSON using stack buffer to avoid heap allocations from string concatenation
-    char buf[128];
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+    // Escape quotes and backslashes in the device name for valid JSON
+    const char *name = device.get_name().c_str();
+    char escaped_name[128];
+    size_t pos = 0;
+    for (; *name != '\0' && pos < sizeof(escaped_name) - 2; name++) {
+      if (*name == '"' || *name == '\\') {
+        escaped_name[pos++] = '\\';
+      }
+      escaped_name[pos++] = *name;
+    }
+    escaped_name[pos] = '\0';
+
+    char buf[256];
     snprintf(buf, sizeof(buf), "{\"timestamp\":%" PRId64 ",\"address\":\"%s\",\"rssi\":%d,\"name\":\"%s\"}",
-             static_cast<int64_t>(::time(nullptr)), device.address_str_to(addr_buf), device.get_rssi(),
-             device.get_name().c_str());
+             static_cast<int64_t>(::time(nullptr)), device.address_str_to(addr_buf), device.get_rssi(), escaped_name);
     this->publish_state(buf);
     return true;
   }

--- a/esphome/components/ble_scanner/ble_scanner.h
+++ b/esphome/components/ble_scanner/ble_scanner.h
@@ -17,15 +17,20 @@ class BLEScanner : public text_sensor::TextSensor, public esp32_ble_tracker::ESP
  public:
   bool parse_device(const esp32_ble_tracker::ESPBTDevice &device) override {
     char addr_buf[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
-    // Escape quotes and backslashes in the device name for valid JSON
+    // Escape special characters in the device name for valid JSON
     const char *name = device.get_name().c_str();
     char escaped_name[128];
     size_t pos = 0;
-    for (; *name != '\0' && pos < sizeof(escaped_name) - 2; name++) {
-      if (*name == '"' || *name == '\\') {
+    for (; *name != '\0' && pos < sizeof(escaped_name) - 7; name++) {
+      uint8_t c = static_cast<uint8_t>(*name);
+      if (c == '"' || c == '\\') {
         escaped_name[pos++] = '\\';
+        escaped_name[pos++] = c;
+      } else if (c < 0x20) {
+        pos += snprintf(escaped_name + pos, sizeof(escaped_name) - pos, "\\u%04x", c);
+      } else {
+        escaped_name[pos++] = c;
       }
-      escaped_name[pos++] = *name;
     }
     escaped_name[pos] = '\0';
 


### PR DESCRIPTION
# What does this implement/fix?

The BLE scanner component builds JSON manually using `snprintf` to publish device advertisements. If a BLE device name contains `"` or `\` characters, the resulting JSON string is malformed since these characters are not escaped. While uncommon, BLE device names can contain arbitrary characters, and with enough devices in range this will eventually be encountered.

This fix adds JSON escaping for `"` and `\` characters in the device name before inserting it into the JSON string. The buffer is also increased from 128 to 256 bytes to accommodate the escaped characters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_tracker:

text_sensor:
  - platform: ble_scanner
    name: "BLE Devices"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).