### PR TITLE
[ci] Make codeowner label update non-fatal for fork PRs

### DIFF
--- a/.github/workflows/codeowner-approved-label-update.yml
+++ b/.github/workflows/codeowner-approved-label-update.yml
@@ -55,18 +55,24 @@ jobs:
               return;
             }
 
-            if (action === LabelAction.ADD) {
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: pr_number, labels: [LABEL_NAME]
-              });
-              console.log(`Added '${LABEL_NAME}' label`);
-            } else if (action === LabelAction.REMOVE) {
-              try {
+            try {
+              if (action === LabelAction.ADD) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: pr_number, labels: [LABEL_NAME]
+                });
+                console.log(`Added '${LABEL_NAME}' label`);
+              } else if (action === LabelAction.REMOVE) {
                 await github.rest.issues.removeLabel({
                   owner, repo, issue_number: pr_number, name: LABEL_NAME
                 });
                 console.log(`Removed '${LABEL_NAME}' label`);
-              } catch (error) {
-                if (error.status !== 404) throw error;
+              }
+            } catch (error) {
+              if (error.status === 403) {
+                console.log(`Warning: insufficient permissions to update label (expected for fork PRs)`);
+              } else if (error.status === 404) {
+                console.log(`Label '${LABEL_NAME}' not present, nothing to remove`);
+              } else {
+                throw error;
               }
             }


### PR DESCRIPTION
# What does this implement/fix?

Since the [Dec 2025 GitHub change to `pull_request_target`](https://github.blog/changelog/2025-11-07-actions-pull_request_target-and-environment-branch-protections-changes/), the `GITHUB_TOKEN` is restricted for fork PRs even when the workflow declares `issues: write` permission. This causes a 403 "Resource not accessible by integration" error when the codeowner approval workflow tries to add/remove labels on fork PRs (e.g. https://github.com/esphome/esphome/actions/runs/22876851344/job/66370464148?pr=14655).

Previous runs that "succeeded" on fork PRs simply never needed to change the label. Every run that actually attempted to add a label failed with 403.

This wraps the label add/remove operations in a try/catch so the workflow succeeds gracefully. The label will be applied on the next event where the token has write access (e.g. a non-fork PR update or when a maintainer triggers the workflow).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).