### PR TITLE
[ci] Skip YAML anchor keys in integration fixture component extraction

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -706,7 +706,7 @@ def get_components_from_integration_fixtures() -> set[str]:
             continue
 
         # Add all top-level component keys (skip YAML anchor keys starting with '.')
-        components.update(k for k in config if not k.startswith("."))
+        components.update(k for k in config if isinstance(k, str) and not k.startswith("."))
 
         # Add platform components (e.g., output.template)
         for value in config.values():

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -705,8 +705,8 @@ def get_components_from_integration_fixtures() -> set[str]:
         if not config:
             continue
 
-        # Add all top-level component keys
-        components.update(config.keys())
+        # Add all top-level component keys (skip YAML anchor keys starting with '.')
+        components.update(k for k in config if not k.startswith("."))
 
         # Add platform components (e.g., output.template)
         for value in config.values():

--- a/script/helpers.py
+++ b/script/helpers.py
@@ -706,7 +706,9 @@ def get_components_from_integration_fixtures() -> set[str]:
             continue
 
         # Add all top-level component keys (skip YAML anchor keys starting with '.')
-        components.update(k for k in config if isinstance(k, str) and not k.startswith("."))
+        components.update(
+            k for k in config if isinstance(k, str) and not k.startswith(".")
+        )
 
         # Add platform components (e.g., output.template)
         for value in config.values():

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1057,6 +1057,30 @@ def test_get_components_from_integration_fixtures() -> None:
         assert components == expected_components
 
 
+def test_get_components_from_integration_fixtures_skips_yaml_anchors() -> None:
+    """Test that YAML anchor keys (starting with '.') are excluded."""
+    yaml_content = {
+        "sensor": [{"platform": "template", "name": "test"}],
+        "esphome": {"name": "test"},
+        ".sensor_filters": {"filters": [{"timeout": "50ms"}]},
+        ".binary_filters": {"filters": [{"settle": "50ms"}]},
+    }
+
+    mock_yaml_file = Mock()
+
+    with (
+        patch("pathlib.Path.glob") as mock_glob,
+        patch("esphome.yaml_util.load_yaml", return_value=yaml_content),
+    ):
+        mock_glob.return_value = [mock_yaml_file]
+
+        components = helpers.get_components_from_integration_fixtures()
+
+        assert ".sensor_filters" not in components
+        assert ".binary_filters" not in components
+        assert components == {"sensor", "esphome", "template"}
+
+
 @pytest.mark.parametrize(
     "output,expected",
     [


### PR DESCRIPTION
# What does this implement/fix?

`get_components_from_integration_fixtures()` was including YAML anchor keys (starting with `.`) like `.sensor_filters` as component names. These keys contain dots, which triggers `assert "." not in domain` in `get_component()`, causing pytest failures.

This filters out keys starting with `.` before adding them to the component set.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes pytest failures introduced by integration test fixtures using YAML anchors (e.g. #14643)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).