### PR TITLE
[serial_proxy] Reduce loop() overhead by disabling when idle and splitting read path

### DIFF
--- a/esphome/components/serial_proxy/serial_proxy.cpp
+++ b/esphome/components/serial_proxy/serial_proxy.cpp
@@ -28,25 +28,38 @@ void SerialProxy::setup() {
   // instance_index_ is fixed at registration time; pre-set it so loop() only needs to update data
   this->outgoing_msg_.instance = this->instance_index_;
 #endif
+  // No subscriber at startup; disable loop until a client subscribes
+  this->disable_loop();
 }
 
 void SerialProxy::loop() {
 #ifdef USE_API
-  // Detect subscriber disconnect
-  if (this->api_connection_ != nullptr && (this->api_connection_->is_marked_for_removal() ||
-                                           !this->api_connection_->is_connection_setup() || !api_is_connected())) {
-    ESP_LOGW(TAG, "Subscriber disconnected");
-    this->api_connection_ = nullptr;
+  // Safety check — loop should only run when subscribed, but guard against races
+  if (this->api_connection_ == nullptr) [[unlikely]] {
+    this->disable_loop();
+    return;
   }
 
-  if (this->api_connection_ == nullptr)
+  // Detect subscriber disconnect
+  if (this->api_connection_->is_marked_for_removal() || !this->api_connection_->is_connection_setup() ||
+      !api_is_connected()) {
+    ESP_LOGW(TAG, "Subscriber disconnected");
+    this->api_connection_ = nullptr;
+    this->disable_loop();
     return;
+  }
 
   // Read available data from UART and forward to subscribed client
   size_t available = this->available();
   if (available == 0)
     return;
 
+  this->read_and_send_(available);
+#endif
+}
+
+#ifdef USE_API
+void __attribute__((noinline)) SerialProxy::read_and_send_(size_t available) {
   // Read in chunks up to SERIAL_PROXY_MAX_READ_SIZE
   uint8_t buffer[SERIAL_PROXY_MAX_READ_SIZE];
   size_t to_read = std::min(available, sizeof(buffer));
@@ -56,8 +69,8 @@ void SerialProxy::loop() {
 
   this->outgoing_msg_.set_data(buffer, to_read);
   this->api_connection_->send_serial_proxy_data(this->outgoing_msg_);
-#endif
 }
+#endif
 
 void SerialProxy::dump_config() {
   ESP_LOGCONFIG(TAG,
@@ -166,6 +179,7 @@ void SerialProxy::serial_proxy_request(api::APIConnection *api_connection, api::
         return;
       }
       this->api_connection_ = api_connection;
+      this->enable_loop();
       ESP_LOGV(TAG, "API connection subscribed to serial proxy [%u]", this->instance_index_);
       break;
     case api::enums::SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE:
@@ -174,6 +188,7 @@ void SerialProxy::serial_proxy_request(api::APIConnection *api_connection, api::
         return;
       }
       this->api_connection_ = nullptr;
+      this->disable_loop();
       ESP_LOGV(TAG, "API connection unsubscribed from serial proxy [%u]", this->instance_index_);
       break;
     default:

--- a/esphome/components/serial_proxy/serial_proxy.h
+++ b/esphome/components/serial_proxy/serial_proxy.h
@@ -101,8 +101,10 @@ class SerialProxy : public uart::UARTDevice, public Component {
   void set_dtr_pin(GPIOPin *pin) { this->dtr_pin_ = pin; }
 
  protected:
+#ifdef USE_API
   /// Read from UART and send to API client (slow path with 256-byte stack buffer)
   void read_and_send_(size_t available);
+#endif
 
   /// Instance index for identifying this proxy in API messages
   uint32_t instance_index_{0};

--- a/esphome/components/serial_proxy/serial_proxy.h
+++ b/esphome/components/serial_proxy/serial_proxy.h
@@ -101,6 +101,9 @@ class SerialProxy : public uart::UARTDevice, public Component {
   void set_dtr_pin(GPIOPin *pin) { this->dtr_pin_ = pin; }
 
  protected:
+  /// Read from UART and send to API client (slow path with 256-byte stack buffer)
+  void read_and_send_(size_t available);
+
   /// Instance index for identifying this proxy in API messages
   uint32_t instance_index_{0};
 


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `SerialProxy::loop()` in two ways:

1. **Disable loop when no subscriber**: Uses `disable_loop()`/`enable_loop()` so the scheduler skips `SerialProxy` entirely when no API client is subscribed. Previously, `loop()` ran every cycle just to check a null pointer and return.

2. **Split read buffer into noinline helper**: Moves the 256-byte stack buffer (`uint8_t buffer[SERIAL_PROXY_MAX_READ_SIZE]`) into a separate `read_and_send_()` method marked `__attribute__((noinline))`. On Xtensa, `entry` allocates the full stack frame before any checks, so the original `loop()` consumed 288 bytes of stack every call even when no data was available.

### Disassembly analysis (ESP32, Xtensa, ESP-IDF)

| | Before | After |
|---|---|---|
| `loop()` stack frame | 288 B (`entry a1, 0x120`) | **32 B** (`entry a1, 32`) |
| `loop()` code size | 107 B | 87 B |
| `loop()` calls when idle | Every cycle | **Zero** (loop disabled) |
| `serial_proxy_request()` | 69 B | 83 B (+14 B for enable/disable calls) |
| `setup()` | 55 B | 63 B (+8 B for initial disable_loop) |

### Flow

- `setup()` → `disable_loop()` (no subscriber yet)
- `serial_proxy_request(SUBSCRIBE)` → `enable_loop()` (start polling UART)
- `serial_proxy_request(UNSUBSCRIBE)` → `disable_loop()` (stop polling)
- `loop()` disconnect detection → `disable_loop()` (subscriber gone)
- `loop()` null safety guard → `disable_loop()` (shouldn't happen, but safe)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  - id: device_uart
    tx_pin: GPIO4
    rx_pin: GPIO5
    baud_rate: 9600

api:

serial_proxy:
  - id: device_serial
    uart_id: device_uart
    name: "TTL Device"
    port_type: TTL
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).