### PR TITLE
[bl0940] Fix reset_calibration() declaration missing from header

### DIFF
--- a/esphome/components/bl0940/bl0940.h
+++ b/esphome/components/bl0940/bl0940.h
@@ -69,10 +69,8 @@ class BL0940 : public PollingComponent, public uart::UARTDevice {
   void set_energy_calibration_number(number::Number *num) { this->energy_calibration_number_ = num; }
 #endif
 
-#ifdef USE_BUTTON
-  // Resets all calibration values to defaults (can be triggered by a button)
+  // Resets all calibration values to defaults
   void reset_calibration();
-#endif
 
   // Core component methods
   void loop() override;


### PR DESCRIPTION
## What does this implement/fix?

Fixes #14674

The `reset_calibration()` method was implemented in `bl0940.cpp` but its declaration in `bl0940.h` was incorrectly guarded by `#ifdef USE_BUTTON`, while the implementation uses `#ifdef USE_NUMBER`. This mismatch caused a compilation error on both esp-idf and arduino frameworks.

## Problem

The compilation error occurs because:
- Header declaration was guarded by `#ifdef USE_BUTTON` 
- Implementation in cpp file is guarded by `#ifdef USE_NUMBER`
- When `USE_NUMBER` is defined but `USE_BUTTON` is not, the method implementation has no matching declaration

Error message:
```
src/esphome/components/bl0940/bl0940.cpp:129:6: error:
no declaration matches 'void esphome::bl0940::BL0940::reset_calibration()'
```

## Solution

Removed the incorrect `#ifdef USE_BUTTON` guard from the declaration in `bl0940.h`, making the method always available. The method's implementation already handles the `USE_NUMBER` dependency correctly with its internal `#ifdef USE_NUMBER` guards.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

Not applicable - this is a compilation fix that doesn't change functionality or configuration.

## Checklist:

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)