### PR TITLE
[config] Allow !extend/!remove on components without id in schema

### DIFF
--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -175,6 +175,12 @@ class _Schema(vol.Schema):
                 else:
                     if self.extra == vol.ALLOW_EXTRA:
                         out[key] = value
+                    elif key == "id":
+                        # Silently drop 'id' on any dict so that
+                        # !extend / !remove work on every list-based
+                        # config without requiring each component to
+                        # declare an id in its schema.
+                        pass
                     elif self.extra != vol.REMOVE_EXTRA:
                         if isinstance(key, str) and key_names:
                             matches = difflib.get_close_matches(key, key_names)

--- a/tests/components/external_components/common.yaml
+++ b/tests/components/external_components/common.yaml
@@ -1,6 +1,8 @@
 external_components:
-  - source: github://esphome/esphome@dev
+  - id: my_ext
+    source: github://esphome/esphome@dev
     refresh: 1d
     components: [bh1750]
-  - source: ../../../esphome/components
+  - id: my_local
+    source: ../../../esphome/components
     components: [sntp]

--- a/tests/components/external_components/test.esp32-idf.yaml
+++ b/tests/components/external_components/test.esp32-idf.yaml
@@ -1,1 +1,5 @@
+# WARNING: Using !extend or !remove prevents automatic component grouping in CI, making builds slower.
 <<: !include common.yaml
+
+external_components:
+  - id: !remove my_local

--- a/tests/unit_tests/test_voluptuous_schema.py
+++ b/tests/unit_tests/test_voluptuous_schema.py
@@ -1,0 +1,86 @@
+"""Tests for voluptuous_schema.py."""
+
+import pytest
+import voluptuous as vol
+
+from esphome.voluptuous_schema import _Schema
+
+
+class TestIdKeyDropping:
+    """Test that 'id' keys are silently dropped in PREVENT_EXTRA schemas."""
+
+    def test_id_key_silently_dropped(self):
+        """Schema without 'id' should accept and drop 'id' key from input."""
+        schema = _Schema(
+            {
+                vol.Required("name"): str,
+                vol.Optional("value", default=0): int,
+            }
+        )
+        result = schema({"name": "test", "value": 42, "id": "my_id"})
+        assert result == {"name": "test", "value": 42}
+        assert "id" not in result
+
+    def test_id_key_dropped_with_only_required(self):
+        """Schema with only required keys should still drop 'id'."""
+        schema = _Schema(
+            {
+                vol.Required("source"): str,
+            }
+        )
+        result = schema({"source": "github://test", "id": "my_component"})
+        assert result == {"source": "github://test"}
+
+    def test_other_extra_keys_still_rejected(self):
+        """Non-'id' extra keys should still raise errors."""
+        schema = _Schema(
+            {
+                vol.Required("name"): str,
+            }
+        )
+        with pytest.raises(vol.MultipleInvalid, match="extra keys not allowed"):
+            schema({"name": "test", "unknown_key": "value"})
+
+    def test_id_key_not_dropped_when_in_schema(self):
+        """When 'id' is declared in the schema, it should be validated normally."""
+        schema = _Schema(
+            {
+                vol.Required("id"): str,
+                vol.Required("name"): str,
+            }
+        )
+        result = schema({"id": "my_id", "name": "test"})
+        assert result == {"id": "my_id", "name": "test"}
+
+    def test_id_key_not_dropped_with_allow_extra(self):
+        """With ALLOW_EXTRA, 'id' should be kept (not dropped)."""
+        schema = _Schema(
+            {
+                vol.Required("name"): str,
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+        result = schema({"name": "test", "id": "my_id"})
+        assert result == {"name": "test", "id": "my_id"}
+
+    def test_id_key_dropped_with_remove_extra(self):
+        """With REMOVE_EXTRA, 'id' should be removed along with other extras."""
+        schema = _Schema(
+            {
+                vol.Required("name"): str,
+            },
+            extra=vol.REMOVE_EXTRA,
+        )
+        result = schema({"name": "test", "id": "my_id", "other": "value"})
+        assert result == {"name": "test"}
+
+    def test_without_id_no_extra_keys(self):
+        """Normal validation without 'id' key should work as before."""
+        schema = _Schema(
+            {
+                vol.Required("name"): str,
+                vol.Optional("value", default=0): int,
+            }
+        )
+        result = schema({"name": "test"})
+        assert result == {"name": "test", "value": 0}


### PR DESCRIPTION
# What does this implement/fix?

Silently drops the `id` key during schema validation for any component that doesn't declare `id` in its schema. This enables `!extend` and `!remove` to work universally on all list-based configs (like `external_components`) without requiring each component to add a dummy id field to its schema.

The `id` key is used by `resolve_extend_remove()` for matching (step 1.2 of config processing), but by the time schema validation runs (step 4), the `id` has already served its purpose. For schemas that don't declare `id`, it's now silently dropped instead of raising an "extra keys not allowed" error.

The drop is placed after the `ALLOW_EXTRA` check so schemas that explicitly allow extra keys (like `mipi_dsi`'s inner schema) still pass `id` through normally.

Supersedes https://github.com/esphome/esphome/pull/13929

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/backlog/issues/73

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# In a package file:
external_components:
  - id: my_ext
    source: github://esphome/esphome@dev
    refresh: 1d
    components: [bh1750]

# In the main config, extend without needing id in external_components schema:
external_components:
  - id: !extend my_ext
    refresh: 0s

# Or remove an entry:
external_components:
  - id: !remove my_ext
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).