### PR TITLE
[rp2040] Add HardFault crash handler with backtrace

### DIFF
--- a/esphome/components/logger/logger_rp2040.cpp
+++ b/esphome/components/logger/logger_rp2040.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_RP2040
 #include "logger.h"
+#include "esphome/components/rp2040/crash_handler.h"
 #include "esphome/core/log.h"
 
 namespace esphome::logger {
@@ -25,6 +26,7 @@ void Logger::pre_setup() {
   }
   global_logger = this;
   ESP_LOGI(TAG, "Log initialized");
+  rp2040::crash_handler_log();
 }
 
 void HOT Logger::write_msg_(const char *msg, uint16_t len) {

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -301,7 +301,7 @@ def process_stacktrace(config, line: str, backtrace_state: bool) -> bool:
 
             idedata = get_idedata(config)
             if idedata.addr2line_path:
-                elf = CORE.relative_pioenvs_path(CORE.name, "firmware.elf")
+                elf = idedata.firmware_elf_path
                 if elf.exists():
                     decoded = _addr2line(idedata.addr2line_path, elf, match.group(1))
                     _LOGGER.error("  %s => %s", match.group(1), decoded)

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -285,7 +285,7 @@ def _addr2line(tool: str, elf: Path, addr: str) -> str:
             check=True,
         )
         return result.stdout.strip()
-    except Exception:  # pylint: disable=broad-except
+    except (OSError, subprocess.CalledProcessError):
         return f"{addr} (decode failed)"
 
 

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -1,6 +1,8 @@
 import logging
 from pathlib import Path
+import re
 from string import ascii_letters, digits
+import subprocess
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -264,3 +266,48 @@ def copy_files():
         path = CORE.relative_src_path("esphome.h")
         content = read_file(path).rstrip("\n")
         write_file_if_changed(path, content + '\n#include "pio_includes.h"\n')
+
+
+# RP2040 crash handler stacktrace decoding
+# Matches output from esphome/components/rp2040/crash_handler.cpp
+_CRASH_RE = re.compile(r"CRASH DETECTED ON PREVIOUS BOOT")
+_CRASH_ADDR_RE = re.compile(
+    r"(?:PC|LR|BT\d):\s+(0x[0-9a-fA-F]{8})\s+\((?:fault location|return address|stack backtrace)\)"
+)
+
+
+def _addr2line(tool: str, elf: Path, addr: str) -> str:
+    try:
+        result = subprocess.run(
+            [tool, "-pfiaC", "-e", str(elf), addr],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except Exception:  # pylint: disable=broad-except
+        return f"{addr} (decode failed)"
+
+
+def process_stacktrace(config, line: str, backtrace_state: bool) -> bool:
+    """Decode RP2040 crash handler output using addr2line."""
+    if _CRASH_RE.search(line):
+        _LOGGER.error("RP2040 crash detected - decoding addresses")
+        return True
+
+    if backtrace_state:
+        if match := _CRASH_ADDR_RE.search(line):
+            from esphome.platformio_api import get_idedata
+
+            idedata = get_idedata(config)
+            if idedata.addr2line_path:
+                elf = CORE.relative_pioenvs_path(CORE.name, "firmware.elf")
+                if elf.exists():
+                    decoded = _addr2line(idedata.addr2line_path, elf, match.group(1))
+                    _LOGGER.error("  %s => %s", match.group(1), decoded)
+
+        # Stop backtrace state after addr2line hint (last line of crash dump)
+        if "addr2line" in line:
+            return False
+
+    return backtrace_state

--- a/esphome/components/rp2040/core.cpp
+++ b/esphome/components/rp2040/core.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_RP2040
 
 #include "core.h"
+#include "crash_handler.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -24,6 +25,7 @@ void arch_restart() {
 }
 
 void arch_init() {
+  rp2040::crash_handler_read_and_clear();
 #if USE_RP2040_WATCHDOG_TIMEOUT > 0
   watchdog_enable(USE_RP2040_WATCHDOG_TIMEOUT, false);
 #endif

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -69,6 +69,11 @@ void crash_handler_read_and_clear() {
   }
 }
 
+// Intentionally uses separate ESP_LOGE calls per line instead of combining into
+// one multi-line log message. This ensures each address appears as its own line
+// on the serial console (miniterm), making it possible to see partial output if
+// the device crashes again during boot, and allowing the CLI's process_stacktrace
+// to match and decode each address individually.
 void crash_handler_log() {
   if (!s_crash_data.valid)
     return;

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -133,6 +133,17 @@ static void __attribute__((used)) hard_fault_handler_c(uint32_t *frame, uint32_t
 // Naked asm wrapper - Cortex-M0+ compatible (no ITE/conditional execution).
 // Determines active stack pointer and branches to C handler.
 // Uses literal pool (.word) for addresses since M0+ has limited immediate encoding.
+//
+// Based on the standard Cortex-M0+ HardFault handler pattern described in:
+// - ARM Application Note AN209: "Using Cortex-M3/M4/M7 Fault Exceptions"
+//   (adapted for M0+ which lacks conditional execution instructions)
+// - Memfault: "How to debug a HardFault on an ARM Cortex-M MCU"
+//   https://interrupt.memfault.com/blog/cortex-m-hardfault-debug
+// - Raspberry Pi Forums: "Cortex-M0+ Hard Fault handler porting"
+//   https://www.eevblog.com/forum/microcontrollers/cortex-m0-hard-fault-handler-porting/
+//
+// The key M0+ adaptation: replaces ITE/MRSEQ/MRSNE (Cortex-M3+) with
+// MOVS+TST+BEQ branch sequence, and uses a literal pool for the C handler address.
 extern "C" void __attribute__((naked, used)) isr_hardfault() {
   __asm volatile("movs r0, #4          \n"  // Prepare bit 2 mask
                  "mov  r1, lr          \n"  // r1 = EXC_RETURN

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -116,7 +116,7 @@ void crash_handler_log() {
 //   RP2040: 0x20000000 - 0x20042000 (264KB)
 //   RP2350: 0x20000000 - 0x20082000 (520KB)
 static inline bool is_valid_sram_ptr(const uint32_t *ptr) {
-  auto addr = (uint32_t) ptr;
+  auto addr = reinterpret_cast<uintptr_t>(ptr);
   // Exception frame is 8 words (32 bytes), so frame+7 must also be in SRAM.
   // Check alignment (must be word-aligned) and that the full frame fits.
   return (addr % 4 == 0) && addr >= SRAM_BASE && (addr + 32) <= SRAM_END;
@@ -133,9 +133,9 @@ static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame
   // crash marker so we at least know a crash occurred.
   if (!is_valid_sram_ptr(frame)) {
     watchdog_hw->scratch[0] = CRASH_MAGIC;
-    watchdog_hw->scratch[1] = 0;                 // PC unknown
-    watchdog_hw->scratch[2] = 0;                 // LR unknown
-    watchdog_hw->scratch[3] = (uint32_t) frame;  // Record the bad SP for diagnosis
+    watchdog_hw->scratch[1] = 0;                                   // PC unknown
+    watchdog_hw->scratch[2] = 0;                                   // LR unknown
+    watchdog_hw->scratch[3] = reinterpret_cast<uintptr_t>(frame);  // Record the bad SP for diagnosis
     for (uint32_t i = 0; i < MAX_BACKTRACE; i++) {
       watchdog_hw->scratch[4 + i] = 0;
     }
@@ -145,8 +145,13 @@ static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame
   }
 
   // Pre-fault SP: the exception frame is 8 words pushed onto the stack,
-  // so the SP before the fault was frame + 8 words.
-  uint32_t pre_fault_sp = (uint32_t) (frame + 8);
+  // so the SP before the fault was frame + 8 words. If xPSR bit 9 is set,
+  // the hardware pushed an extra alignment word to maintain 8-byte stack
+  // alignment (ARMv6-M/ARMv7-M spec), so add 1 more word.
+  static constexpr uint32_t EF_XPSR = 7;
+  uint32_t extra_align = (frame[EF_XPSR] & (1u << 9)) ? 1 : 0;
+  uint32_t *post_frame = frame + 8 + extra_align;
+  uint32_t pre_fault_sp = reinterpret_cast<uintptr_t>(post_frame);
 
   // Write key registers
   watchdog_hw->scratch[0] = CRASH_MAGIC;
@@ -155,11 +160,11 @@ static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame
   watchdog_hw->scratch[3] = pre_fault_sp;
 
   // Scan stack for code addresses to build a deeper backtrace.
-  // The exception frame is 8 words (32 bytes) at 'frame'. The pre-fault
-  // stack starts at frame+8. Walk up to 64 words looking for return addresses.
-  uint32_t *scan_start = frame + 8;  // Past exception frame
+  // The exception frame is 8 words (32 bytes) at 'frame', plus an optional
+  // alignment word. Walk up to 64 words looking for return addresses.
+  uint32_t *scan_start = post_frame;
   // SRAM_END is chip-specific: 0x20042000 (RP2040) or 0x20082000 (RP2350)
-  uint32_t *stack_top = (uint32_t *) SRAM_END;
+  uint32_t *stack_top = reinterpret_cast<uint32_t *>(SRAM_END);
   uint32_t bt_count = 0;
 
   for (uint32_t *p = scan_start; p < stack_top && p < scan_start + 64 && bt_count < MAX_BACKTRACE; p++) {

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -3,6 +3,7 @@
 #include "crash_handler.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
 #include <hardware/structs/watchdog.h>
 #include <hardware/watchdog.h>
 
@@ -24,13 +25,18 @@ static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
 // [4..7] = up to 4 additional code addresses found by scanning the stack
 //          (return addresses from callers, giving a deeper backtrace)
 
-// RP2040 flash is mapped at 0x10000000 with up to 16MB address space.
-// We use 2MB as the upper bound — large enough for any typical ESPHome firmware
-// while keeping false positives low during stack scanning. Wider ranges would
-// match more stale data on the stack that happens to look like code addresses.
+// Flash is mapped at 0x10000000. RP2040 supports up to 16MB, RP2350 up to 32MB.
+// We use a conservative upper bound to keep false positives low during stack scanning.
+// Wider ranges would match more stale data on the stack that happens to look like code addresses.
+#if defined(PICO_RP2350)
+static constexpr uint32_t FLASH_END = 0x10400000;  // 4MB — RP2350 typical max
+#else
+static constexpr uint32_t FLASH_END = 0x10200000;  // 2MB — RP2040 typical max
+#endif
+
 static inline bool is_code_addr(uint32_t val) {
   uint32_t cleared = val & ~1u;  // Clear Thumb bit
-  return cleared >= 0x10000000 && cleared < 0x10200000;
+  return cleared >= 0x10000000 && cleared < FLASH_END;
 }
 
 static constexpr size_t MAX_BACKTRACE = 4;
@@ -85,7 +91,14 @@ void crash_handler_log() {
   for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
     ESP_LOGE(TAG, "  BT%d: 0x%08X  (stack backtrace)", i, s_crash_data.backtrace[i]);
   }
-  ESP_LOGE(TAG, "Use addr2line -e firmware.elf 0x%08X 0x%08X to decode", s_crash_data.pc, s_crash_data.lr);
+  // Build addr2line hint with all captured addresses for easy copy-paste
+  char hint[160];
+  int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32 " 0x%08" PRIX32,
+                     s_crash_data.pc, s_crash_data.lr);
+  for (uint8_t i = 0; i < s_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
+    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_crash_data.backtrace[i]);
+  }
+  ESP_LOGE(TAG, "%s", hint);
 }
 
 }  // namespace esphome::rp2040
@@ -98,7 +111,7 @@ void crash_handler_log() {
 // (which survive watchdog reboot), then trigger a reboot.
 
 // C handler called from the asm wrapper with the exception frame pointer.
-static void __attribute__((used)) hard_fault_handler_c(uint32_t *frame, uint32_t exc_return) {
+static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame, uint32_t /*exc_return*/) {
   // watchdog_reboot() overwrites scratch[4]-[7], so we must call it first
   // then write ALL our data after. The 10ms timeout gives us plenty of time.
   watchdog_reboot(0, 0, 10);
@@ -113,8 +126,12 @@ static void __attribute__((used)) hard_fault_handler_c(uint32_t *frame, uint32_t
   // The exception frame is 8 words (32 bytes) at 'frame'. The pre-fault
   // stack starts at frame+8. Walk up to 64 words looking for return addresses.
   uint32_t *scan_start = frame + 8;  // Past exception frame
-  // RP2040 RAM ends at 0x20042000 (264KB SRAM)
-  uint32_t *stack_top = (uint32_t *) 0x20042000;
+  // SRAM end address differs by chip variant
+#if defined(PICO_RP2350)
+  uint32_t *stack_top = (uint32_t *) 0x20082000;  // RP2350: 520KB SRAM
+#else
+  uint32_t *stack_top = (uint32_t *) 0x20042000;   // RP2040: 264KB SRAM
+#endif
   uint32_t bt_count = 0;
 
   for (uint32_t *p = scan_start; p < stack_top && p < scan_start + 64 && bt_count < MAX_BACKTRACE; p++) {

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -8,8 +8,8 @@
 
 // Cortex-M0+ exception frame offsets (words)
 // When a fault occurs, the CPU pushes: R0, R1, R2, R3, R12, LR, PC, xPSR
-#define EF_LR 5
-#define EF_PC 6
+static constexpr uint32_t EF_LR = 5;
+static constexpr uint32_t EF_PC = 6;
 
 static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
 

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/log.h"
 
 #include <cinttypes>
+#include <hardware/regs/addressmap.h>
 #include <hardware/structs/watchdog.h>
 #include <hardware/watchdog.h>
 
@@ -25,18 +26,18 @@ static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
 // [4..7] = up to 4 additional code addresses found by scanning the stack
 //          (return addresses from callers, giving a deeper backtrace)
 
-// Flash is mapped at 0x10000000. RP2040 supports up to 16MB, RP2350 up to 32MB.
-// We use a conservative upper bound to keep false positives low during stack scanning.
-// Wider ranges would match more stale data on the stack that happens to look like code addresses.
+// Flash is mapped at XIP_BASE (0x10000000). We use a conservative upper bound
+// to keep false positives low during stack scanning. Wider ranges would match
+// more stale data on the stack that happens to look like code addresses.
 #if defined(PICO_RP2350)
-static constexpr uint32_t FLASH_END = 0x10400000;  // 4MB — RP2350 typical max
+static constexpr uint32_t FLASH_SCAN_END = XIP_BASE + 0x400000;  // 4MB — RP2350 typical max
 #else
-static constexpr uint32_t FLASH_END = 0x10200000;  // 2MB — RP2040 typical max
+static constexpr uint32_t FLASH_SCAN_END = XIP_BASE + 0x200000;  // 2MB — RP2040 typical max
 #endif
 
 static inline bool is_code_addr(uint32_t val) {
   uint32_t cleared = val & ~1u;  // Clear Thumb bit
-  return cleared >= 0x10000000 && cleared < FLASH_END;
+  return cleared >= XIP_BASE && cleared < FLASH_SCAN_END;
 }
 
 static constexpr size_t MAX_BACKTRACE = 4;
@@ -126,12 +127,8 @@ static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame
   // The exception frame is 8 words (32 bytes) at 'frame'. The pre-fault
   // stack starts at frame+8. Walk up to 64 words looking for return addresses.
   uint32_t *scan_start = frame + 8;  // Past exception frame
-  // SRAM end address differs by chip variant
-#if defined(PICO_RP2350)
-  uint32_t *stack_top = (uint32_t *) 0x20082000;  // RP2350: 520KB SRAM
-#else
-  uint32_t *stack_top = (uint32_t *) 0x20042000;   // RP2040: 264KB SRAM
-#endif
+  // SRAM_END is chip-specific: 0x20042000 (RP2040) or 0x20082000 (RP2350)
+  uint32_t *stack_top = (uint32_t *) SRAM_END;
   uint32_t bt_count = 0;
 
   for (uint32_t *p = scan_start; p < stack_top && p < scan_start + 64 && bt_count < MAX_BACKTRACE; p++) {

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -1,0 +1,157 @@
+#ifdef USE_RP2040
+
+#include "crash_handler.h"
+#include "esphome/core/log.h"
+
+#include <hardware/structs/watchdog.h>
+#include <hardware/watchdog.h>
+
+// Cortex-M0+ exception frame offsets (words)
+// When a fault occurs, the CPU pushes: R0, R1, R2, R3, R12, LR, PC, xPSR
+#define EF_LR 5
+#define EF_PC 6
+
+static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
+
+// We only have 8 scratch registers (32 bytes) that survive watchdog reboot.
+// Use them for the most important data, then scan the stack for code addresses.
+//
+// Scratch register layout:
+// [0] = magic (CRASH_MAGIC)
+// [1] = PC (program counter at fault)
+// [2] = LR (link register from exception frame)
+// [3] = SP (stack pointer at fault)
+// [4..7] = up to 4 additional code addresses found by scanning the stack
+//          (return addresses from callers, giving a deeper backtrace)
+
+// RP2040 flash is mapped at 0x10000000, code lives in first 1MB typically
+static inline bool is_code_addr(uint32_t val) {
+  // Thumb addresses have bit 0 set, but addr2line wants them without it.
+  // Accept anything in flash range 0x10000000-0x10100000 (1MB)
+  uint32_t cleared = val & ~1u;
+  return cleared >= 0x10000000 && cleared < 0x10100000;
+}
+
+static constexpr size_t MAX_BACKTRACE = 4;
+
+namespace esphome {
+namespace rp2040 {
+
+static const char *const TAG = "rp2040.crash";
+
+static struct {
+  bool valid{false};
+  uint32_t pc;
+  uint32_t lr;
+  uint32_t sp;
+  uint32_t backtrace[MAX_BACKTRACE];
+  uint8_t backtrace_count;
+} s_crash_data;
+
+void crash_handler_read_and_clear() {
+  if (watchdog_hw->scratch[0] == CRASH_MAGIC) {
+    s_crash_data.valid = true;
+    s_crash_data.pc = watchdog_hw->scratch[1];
+    s_crash_data.lr = watchdog_hw->scratch[2];
+    s_crash_data.sp = watchdog_hw->scratch[3];
+    s_crash_data.backtrace_count = 0;
+    for (size_t i = 0; i < MAX_BACKTRACE; i++) {
+      uint32_t addr = watchdog_hw->scratch[4 + i];
+      if (addr == 0)
+        break;
+      s_crash_data.backtrace[i] = addr;
+      s_crash_data.backtrace_count++;
+    }
+  }
+  // Clear scratch registers regardless
+  for (int i = 0; i < 8; i++) {
+    watchdog_hw->scratch[i] = 0;
+  }
+}
+
+void crash_handler_log() {
+  if (!s_crash_data.valid)
+    return;
+
+  ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
+  ESP_LOGE(TAG, "  PC:  0x%08X  (fault location)", s_crash_data.pc);
+  ESP_LOGE(TAG, "  LR:  0x%08X  (return address)", s_crash_data.lr);
+  ESP_LOGE(TAG, "  SP:  0x%08X", s_crash_data.sp);
+  for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
+    ESP_LOGE(TAG, "  BT%d: 0x%08X  (stack backtrace)", i, s_crash_data.backtrace[i]);
+  }
+  ESP_LOGE(TAG, "Use addr2line -e firmware.elf 0x%08X 0x%08X to decode", s_crash_data.pc, s_crash_data.lr);
+}
+
+}  // namespace rp2040
+}  // namespace esphome
+
+// --- HardFault handler ---
+// Overrides the weak isr_hardfault from arduino-pico's crt0.S.
+// On Cortex-M0+, the CPU pushes {R0,R1,R2,R3,R12,LR,PC,xPSR} onto the
+// active stack (MSP or PSP). We determine which stack was active,
+// extract key registers, store them in watchdog scratch registers
+// (which survive watchdog reboot), then trigger a reboot.
+
+// C handler called from the asm wrapper with the exception frame pointer.
+static void __attribute__((used)) hard_fault_handler_c(uint32_t *frame, uint32_t exc_return) {
+  // watchdog_reboot() overwrites scratch[4]-[7], so we must call it first
+  // then write ALL our data after. The 10ms timeout gives us plenty of time.
+  watchdog_reboot(0, 0, 10);
+
+  // Write key registers
+  watchdog_hw->scratch[0] = CRASH_MAGIC;
+  watchdog_hw->scratch[1] = frame[EF_PC];
+  watchdog_hw->scratch[2] = frame[EF_LR];
+  watchdog_hw->scratch[3] = (uint32_t) frame;  // SP at fault
+
+  // Scan stack for code addresses to build a deeper backtrace.
+  // The exception frame is 8 words (32 bytes) at 'frame'. The pre-fault
+  // stack starts at frame+8. Walk up to 64 words looking for return addresses.
+  uint32_t *scan_start = frame + 8;  // Past exception frame
+  // RP2040 RAM ends at 0x20042000 (264KB SRAM)
+  uint32_t *stack_top = (uint32_t *) 0x20042000;
+  uint32_t bt_count = 0;
+
+  for (uint32_t *p = scan_start; p < stack_top && p < scan_start + 64 && bt_count < MAX_BACKTRACE; p++) {
+    uint32_t val = *p;
+    // Check if this looks like a code address in flash
+    // Skip if it's the same as PC or LR we already saved
+    if (is_code_addr(val) && val != frame[EF_PC] && val != frame[EF_LR]) {
+      watchdog_hw->scratch[4 + bt_count] = val;
+      bt_count++;
+    }
+  }
+  // Zero remaining slots
+  for (uint32_t i = bt_count; i < MAX_BACKTRACE; i++) {
+    watchdog_hw->scratch[4 + i] = 0;
+  }
+
+  while (true) {
+    __asm volatile("nop");
+  }
+}
+
+// Naked asm wrapper - Cortex-M0+ compatible (no ITE/conditional execution).
+// Determines active stack pointer and branches to C handler.
+// Uses literal pool (.word) for addresses since M0+ has limited immediate encoding.
+extern "C" void __attribute__((naked, used)) isr_hardfault() {
+  __asm volatile("movs r0, #4          \n"  // Prepare bit 2 mask
+                 "mov  r1, lr          \n"  // r1 = EXC_RETURN
+                 "tst  r1, r0          \n"  // Test bit 2
+                 "beq  1f              \n"  // If 0, was using MSP
+                 "mrs  r0, psp         \n"  // Bit 2 set = PSP was active
+                 "b    2f              \n"
+                 "1:                   \n"
+                 "mrs  r0, msp         \n"  // Bit 2 clear = MSP was active
+                 "2:                   \n"
+                 // r0 = exception frame pointer, r1 = EXC_RETURN (still in r1)
+                 "ldr  r2, 3f          \n"  // Load C handler address from literal pool
+                 "bx   r2              \n"  // Branch to handler (r0=frame, r1=exc_return)
+                 ".align 2             \n"
+                 "3: .word %c0         \n"  // Literal pool: address of C handler
+                 :
+                 : "i"(hard_fault_handler_c));
+}
+
+#endif  // USE_RP2040

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -24,12 +24,13 @@ static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
 // [4..7] = up to 4 additional code addresses found by scanning the stack
 //          (return addresses from callers, giving a deeper backtrace)
 
-// RP2040 flash is mapped at 0x10000000, code lives in first 1MB typically
+// RP2040 flash is mapped at 0x10000000 with up to 16MB address space.
+// We use 2MB as the upper bound — large enough for any typical ESPHome firmware
+// while keeping false positives low during stack scanning. Wider ranges would
+// match more stale data on the stack that happens to look like code addresses.
 static inline bool is_code_addr(uint32_t val) {
-  // Thumb addresses have bit 0 set, but addr2line wants them without it.
-  // Accept anything in flash range 0x10000000-0x10100000 (1MB)
-  uint32_t cleared = val & ~1u;
-  return cleared >= 0x10000000 && cleared < 0x10100000;
+  uint32_t cleared = val & ~1u;  // Clear Thumb bit
+  return cleared >= 0x10000000 && cleared < 0x10200000;
 }
 
 static constexpr size_t MAX_BACKTRACE = 4;

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -111,17 +111,48 @@ void crash_handler_log() {
 // extract key registers, store them in watchdog scratch registers
 // (which survive watchdog reboot), then trigger a reboot.
 
+// Check if a pointer falls within SRAM (valid for stack access).
+// SRAM_BASE and SRAM_END are chip-specific SDK defines:
+//   RP2040: 0x20000000 - 0x20042000 (264KB)
+//   RP2350: 0x20000000 - 0x20082000 (520KB)
+static inline bool is_valid_sram_ptr(const uint32_t *ptr) {
+  auto addr = (uint32_t) ptr;
+  // Exception frame is 8 words (32 bytes), so frame+7 must also be in SRAM.
+  // Check alignment (must be word-aligned) and that the full frame fits.
+  return (addr % 4 == 0) && addr >= SRAM_BASE && (addr + 32) <= SRAM_END;
+}
+
 // C handler called from the asm wrapper with the exception frame pointer.
 static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame, uint32_t /*exc_return*/) {
   // watchdog_reboot() overwrites scratch[4]-[7], so we must call it first
   // then write ALL our data after. The 10ms timeout gives us plenty of time.
   watchdog_reboot(0, 0, 10);
 
+  // Validate frame pointer before dereferencing. If the HardFault was caused
+  // by a stacking error or corrupted SP, frame may be invalid. Write a minimal
+  // crash marker so we at least know a crash occurred.
+  if (!is_valid_sram_ptr(frame)) {
+    watchdog_hw->scratch[0] = CRASH_MAGIC;
+    watchdog_hw->scratch[1] = 0;                 // PC unknown
+    watchdog_hw->scratch[2] = 0;                 // LR unknown
+    watchdog_hw->scratch[3] = (uint32_t) frame;  // Record the bad SP for diagnosis
+    for (uint32_t i = 0; i < MAX_BACKTRACE; i++) {
+      watchdog_hw->scratch[4 + i] = 0;
+    }
+    while (true) {
+      __asm volatile("nop");
+    }
+  }
+
+  // Pre-fault SP: the exception frame is 8 words pushed onto the stack,
+  // so the SP before the fault was frame + 8 words.
+  uint32_t pre_fault_sp = (uint32_t) (frame + 8);
+
   // Write key registers
   watchdog_hw->scratch[0] = CRASH_MAGIC;
   watchdog_hw->scratch[1] = frame[EF_PC];
   watchdog_hw->scratch[2] = frame[EF_LR];
-  watchdog_hw->scratch[3] = (uint32_t) frame;  // SP at fault
+  watchdog_hw->scratch[3] = pre_fault_sp;
 
   // Scan stack for code addresses to build a deeper backtrace.
   // The exception frame is 8 words (32 bytes) at 'frame'. The pre-fault

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -34,8 +34,7 @@ static inline bool is_code_addr(uint32_t val) {
 
 static constexpr size_t MAX_BACKTRACE = 4;
 
-namespace esphome {
-namespace rp2040 {
+namespace esphome::rp2040 {
 
 static const char *const TAG = "rp2040.crash";
 
@@ -83,8 +82,7 @@ void crash_handler_log() {
   ESP_LOGE(TAG, "Use addr2line -e firmware.elf 0x%08X 0x%08X to decode", s_crash_data.pc, s_crash_data.lr);
 }
 
-}  // namespace rp2040
-}  // namespace esphome
+}  // namespace esphome::rp2040
 
 // --- HardFault handler ---
 // Overrides the weak isr_hardfault from arduino-pico's crt0.S.

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -46,16 +46,19 @@ namespace esphome::rp2040 {
 
 static const char *const TAG = "rp2040.crash";
 
+// Placed in .noinit so BSS zero-init cannot race with crash_handler_read_and_clear().
+// The valid field is explicitly cleared in crash_handler_read_and_clear() instead.
 static struct {
-  bool valid{false};
+  bool valid;
   uint32_t pc;
   uint32_t lr;
   uint32_t sp;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-} s_crash_data;
+} __attribute__((section(".noinit"))) s_crash_data;
 
 void crash_handler_read_and_clear() {
+  s_crash_data.valid = false;
   if (watchdog_hw->scratch[0] == CRASH_MAGIC) {
     s_crash_data.valid = true;
     s_crash_data.pc = watchdog_hw->scratch[1];
@@ -86,11 +89,11 @@ void crash_handler_log() {
     return;
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
-  ESP_LOGE(TAG, "  PC:  0x%08X  (fault location)", s_crash_data.pc);
-  ESP_LOGE(TAG, "  LR:  0x%08X  (return address)", s_crash_data.lr);
-  ESP_LOGE(TAG, "  SP:  0x%08X", s_crash_data.sp);
+  ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_crash_data.pc);
+  ESP_LOGE(TAG, "  LR:  0x%08" PRIX32 "  (return address)", s_crash_data.lr);
+  ESP_LOGE(TAG, "  SP:  0x%08" PRIX32, s_crash_data.sp);
   for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
-    ESP_LOGE(TAG, "  BT%d: 0x%08X  (stack backtrace)", i, s_crash_data.backtrace[i]);
+    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (stack backtrace)", i, s_crash_data.backtrace[i]);
   }
   // Build addr2line hint with all captured addresses for easy copy-paste
   char hint[160];
@@ -165,6 +168,8 @@ static void __attribute__((used, noreturn)) hard_fault_handler_c(uint32_t *frame
   uint32_t *scan_start = post_frame;
   // SRAM_END is chip-specific: 0x20042000 (RP2040) or 0x20082000 (RP2350)
   uint32_t *stack_top = reinterpret_cast<uint32_t *>(SRAM_END);
+  // Scan up to 64 words (256 bytes) — covers typical nested call frames
+  // without scanning too much stale stack data that could produce false positives.
   uint32_t bt_count = 0;
 
   for (uint32_t *p = scan_start; p < stack_top && p < scan_start + 64 && bt_count < MAX_BACKTRACE; p++) {

--- a/esphome/components/rp2040/crash_handler.h
+++ b/esphome/components/rp2040/crash_handler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifdef USE_RP2040
+
+#include <cstdint>
+
+namespace esphome {
+namespace rp2040 {
+
+/// Read crash data from watchdog scratch registers and clear them.
+void crash_handler_read_and_clear();
+
+/// Log crash data if a crash was detected on previous boot.
+void crash_handler_log();
+
+}  // namespace rp2040
+}  // namespace esphome
+
+#endif  // USE_RP2040

--- a/esphome/components/rp2040/crash_handler.h
+++ b/esphome/components/rp2040/crash_handler.h
@@ -4,8 +4,7 @@
 
 #include <cstdint>
 
-namespace esphome {
-namespace rp2040 {
+namespace esphome::rp2040 {
 
 /// Read crash data from watchdog scratch registers and clear them.
 void crash_handler_read_and_clear();
@@ -13,7 +12,6 @@ void crash_handler_read_and_clear();
 /// Log crash data if a crash was detected on previous boot.
 void crash_handler_log();
 
-}  // namespace rp2040
-}  // namespace esphome
+}  // namespace esphome::rp2040
 
 #endif  // USE_RP2040


### PR DESCRIPTION
# What does this implement/fix?

Add a crash handler for RP2040 that captures register state and stack backtrace when a HardFault occurs. The crash data is stored in the RP2040's watchdog scratch registers (which survive watchdog reboot) and logged on the next boot immediately after logger initialization.

This makes RP2040 crash debugging practical without a hardware debugger — previously, HardFaults caused a silent reboot with no diagnostic information.

This crash handler has already proven useful — it helped identify the heap corruption bug fixed in #14687.

**How it works:**
1. `isr_hardfault` (Cortex-M0+ compatible naked asm) determines MSP vs PSP and extracts the exception frame
2. C handler saves PC, LR, SP to watchdog scratch registers, then scans the stack for additional return addresses (up to 4) to provide a deeper backtrace
3. Triggers watchdog reboot (writing scratch registers after `watchdog_reboot()` to avoid SDK clobbering scratch[4-7])
4. On next boot, `arch_init()` reads and clears the scratch registers
5. After logger init, crash data is logged with register values
6. The CLI's serial log viewer auto-decodes addresses using `addr2line`

**Example 1: Use-after-free in API connection on RP2040 (triggered by rapid connect/disconnect stress testing)**

Device serial output:
```
[13:20:11.138][I][logger:028]: Log initialized
[13:20:11.144][E][rp2040.crash:076]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[13:20:11.154][E][rp2040.crash:077]:   PC:  0x100045A8  (fault location)
[13:20:11.172][E][rp2040.crash:078]:   LR:  0x10003A01  (return address)
[13:20:11.172][E][rp2040.crash:079]:   SP:  0x20041EE8
[13:20:11.172][E][rp2040.crash:081]:   BT0: 0x1000570B  (stack backtrace)
[13:20:11.202][E][rp2040.crash:081]:   BT1: 0x100286F9  (stack backtrace)
[13:20:11.202][E][rp2040.crash:081]:   BT2: 0x1000BDBD  (stack backtrace)
[13:20:11.202][E][rp2040.crash:081]:   BT3: 0x1003608C  (stack backtrace)
[13:20:11.202][E][rp2040.crash:083]: Use addr2line -e firmware.elf 0x100045A8 0x10003A01 to decode
```

With `esphome logs` on serial, addresses are auto-decoded inline:
```
ERROR RP2040 crash detected - decoding addresses
ERROR   0x100045A8 => esphome::api::APIFrameHelper::get_peername_to(std::span<char, 16u>) const at ??:?
ERROR   0x10003A01 => esphome::api::APIConnection::start() at ??:?
ERROR   0x1000570B => esphome::api::APIServer::accept_new_connections_() at ??:?
ERROR   0x100286F9 => _free_r at /workdir/repo/newlib/newlib/libc/stdlib/_mallocr.c:2736
ERROR   0x1000BDBD => esphome::Scheduler::call(unsigned long) at ??:?
```

This immediately revealed a use-after-free crash in the API connection accept path under rapid connect/disconnect load.

**Example 2: Heap corruption from malloc in lwip accept callback on RP2040 (led to #14687)**

```
[14:19:31.664][I][logger:028]: Log initialized
[14:19:31.669][E][rp2040.crash:088]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[14:19:31.680][E][rp2040.crash:089]:   PC:  0x10027112  (fault location)
[14:19:31.696][E][rp2040.crash:090]:   LR:  0x10031891  (return address)
[14:19:31.696][E][rp2040.crash:091]:   SP:  0x20041E90
[14:19:31.711][E][rp2040.crash:093]:   BT0: 0x10031ADB  (stack backtrace)
[14:19:31.711][E][rp2040.crash:093]:   BT1: 0x100289D3  (stack backtrace)
[14:19:31.711][E][rp2040.crash:093]:   BT2: 0x1001BB2F  (stack backtrace)
[14:19:31.750][E][rp2040.crash:093]:   BT3: 0x10023467  (stack backtrace)
[14:19:31.750][E][rp2040.crash:102]: Use: addr2line -pfiaC -e firmware.elf 0x10027112 0x10031891 0x10031ADB 0x100289D3 0x1001BB2F 0x10023467
```

Decoded:
```
ERROR RP2040 crash detected - decoding addresses
ERROR   0x10027112 => _malloc_r at /workdir/repo/newlib/newlib/libc/stdlib/_mallocr.c:2520
ERROR   0x10031891 => __retarget_lock_acquire_recursive at ??:?
ERROR   0x10031ADB => lock_release at async_context_threadsafe_background.c:?
ERROR   0x100289D3 => malloc at /workdir/repo/newlib/newlib/libc/stdlib/malloc.c:165
ERROR   0x1001BB2F => __wrap_malloc at ??:?
ERROR   0x10023467 => operator new(unsigned int) at /workdir/repo/gcc-gnu/libstdc++-v3/libsupc++/new_op.cc:50
```

This revealed heap corruption caused by calling malloc from the lwip accept callback (interrupt context), leading to the fix in #14687.

**Example 3: Same heap corruption on RP2350 (confirming cross-chip compatibility)**

```
[14:24:36.689][I][logger:028]: Log initialized
[14:24:36.695][E][rp2040.crash:088]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[14:24:36.705][E][rp2040.crash:089]:   PC:  0x100276F6  (fault location)
[14:24:36.725][E][rp2040.crash:090]:   LR:  0x10027739  (return address)
[14:24:36.725][E][rp2040.crash:091]:   SP:  0x20081EF0
[14:24:36.725][E][rp2040.crash:093]:   BT0: 0x1002FCEB  (stack backtrace)
[14:24:36.752][E][rp2040.crash:093]:   BT1: 0x1002FD01  (stack backtrace)
[14:24:36.752][E][rp2040.crash:093]:   BT2: 0x1000B355  (stack backtrace)
[14:24:36.752][E][rp2040.crash:093]:   BT3: 0x1000B991  (stack backtrace)
[14:24:36.752][E][rp2040.crash:102]: Use: addr2line -pfiaC -e firmware.elf 0x100276F6 0x10027739 0x1002FCEB 0x1002FD01 0x1000B355 0x1000B991
```

Decoded:
```
ERROR RP2040 crash detected - decoding addresses
ERROR   0x100276F6 => __malloc_update_mallinfo at /workdir/repo/newlib/newlib/libc/stdlib/_mallocr.c:3463
ERROR   0x10027739 => _mallinfo_r at /workdir/repo/newlib/newlib/libc/stdlib/_mallocr.c:3576
ERROR   0x1002FCEB => lock_release at async_context_threadsafe_background.c:?
ERROR   0x1002FD01 => async_context_threadsafe_background_release_lock at async_context_threadsafe_background.c:?
ERROR   0x1000B355 => esphome::Scheduler::SchedulerItem::cmp(...)
ERROR   0x1000B991 => std::__adjust_heap<...>(...)
```

Note the SP at `0x20081EF0` — within the RP2350's larger 520KB SRAM range (vs RP2040's 264KB), confirming the chip-specific `SRAM_END` define works correctly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration; always active on RP2040)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration needed - crash handler is always active on RP2040.
# Any RP2040 config will include it automatically.
esphome:
  name: my-rp2040

rp2040:
  board: rpipicow

logger:
  hardware_uart: UART0
  baud_rate: 115200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).