### PR TITLE
[socket] Fix RP2040 heap corruption from malloc in lwip accept callback

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -425,7 +425,7 @@ LWIPRawImpl::~LWIPRawImpl() {
   // Base class destructor handles pcb_ cleanup via tcp_abort
 }
 
-void LWIPRawImpl::init(struct pbuf *initial_rx) {
+void LWIPRawImpl::init(struct pbuf *initial_rx, bool initial_rx_closed) {
   LWIP_LOCK();
   LWIP_LOG("init(%p)", this->pcb_);
   tcp_arg(this->pcb_, this);
@@ -435,6 +435,7 @@ void LWIPRawImpl::init(struct pbuf *initial_rx) {
     this->rx_buf_ = initial_rx;
     this->rx_buf_offset_ = 0;
   }
+  this->rx_closed_ = initial_rx_closed;
 }
 
 void LWIPRawImpl::s_err_fn(void *arg, err_t err) {
@@ -670,7 +671,7 @@ LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
   // Abort any queued PCBs that were never accepted by the main loop.
   // Clear the error callback first — tcp_abort triggers it, and we don't
-  // want s_accepted_pcb_err_fn writing to slots during destruction.
+  // want s_queued_err_fn writing to slots during destruction.
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
     auto &entry = this->accepted_pcbs_[i];
     if (entry.pcb != nullptr) {
@@ -775,11 +776,7 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     // Create socket wrapper on the main loop (not in accept callback) to avoid
     // heap allocation in IRQ context on RP2040. Transfer any data received while queued.
     auto sock = make_unique<LWIPRawImpl>(this->family_, entry.pcb);
-    sock->init(entry.rx_buf);
-    if (entry.rx_closed) {
-      // Remote closed while queued — mark so read() returns EOF after buffered data
-      sock->rx_closed_ = true;
-    }
+    sock->init(entry.rx_buf, entry.rx_closed);
     if (addr != nullptr) {
       sock->getpeername(addr, addrlen);
     }

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -748,48 +748,46 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     errno = EBADF;
     return nullptr;
   }
-  if (this->accepted_socket_count_ == 0) {
-    errno = EWOULDBLOCK;
-    return nullptr;
-  }
-  // Take entry from front of queue
-  QueuedPcb entry = this->accepted_pcbs_[0];
-  // Shift remaining entries forward
-  for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
-    this->accepted_pcbs_[i - 1] = this->accepted_pcbs_[i];
-  }
-  this->accepted_pcbs_[this->accepted_socket_count_ - 1] = {};
-  this->accepted_socket_count_--;
-  // Update tcp_arg for remaining queued PCBs — their array slots shifted by one.
-  // Safe because we hold LWIP_LOCK, so err/recv callbacks can't fire during the update.
-  for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
-    if (this->accepted_pcbs_[i].pcb != nullptr) {
-      tcp_arg(this->accepted_pcbs_[i].pcb, &this->accepted_pcbs_[i]);
+  // Dequeue front entry, skipping any null entries (PCBs freed by lwip while queued).
+  // The error callback nulled their pcb pointers; clean up buffered data and discard.
+  while (this->accepted_socket_count_ > 0) {
+    QueuedPcb entry = this->accepted_pcbs_[0];
+    // Shift remaining entries forward and update tcp_arg pointers (slots shifted by one).
+    // Safe because we hold LWIP_LOCK, so err/recv callbacks can't fire during the update.
+    for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
+      this->accepted_pcbs_[i - 1] = this->accepted_pcbs_[i];
     }
-  }
-  LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
-  if (entry.pcb == nullptr) {
-    // PCB was freed by lwip (RST/timeout) while queued — the temporary error callback
-    // nulled our pointer. Free any buffered data and return EWOULDBLOCK.
-    if (entry.rx_buf != nullptr) {
-      pbuf_free(entry.rx_buf);
+    this->accepted_pcbs_[this->accepted_socket_count_ - 1] = {};
+    this->accepted_socket_count_--;
+    for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
+      if (this->accepted_pcbs_[i].pcb != nullptr) {
+        tcp_arg(this->accepted_pcbs_[i].pcb, &this->accepted_pcbs_[i]);
+      }
     }
-    errno = EWOULDBLOCK;
-    return nullptr;
+    if (entry.pcb == nullptr) {
+      // PCB was freed by lwip (RST/timeout) while queued — discard and try next
+      if (entry.rx_buf != nullptr) {
+        pbuf_free(entry.rx_buf);
+      }
+      continue;
+    }
+    LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
+    // Create socket wrapper on the main loop (not in accept callback) to avoid
+    // heap allocation in IRQ context on RP2040. Transfer any data received while queued.
+    auto sock = make_unique<LWIPRawImpl>(this->family_, entry.pcb);
+    sock->init(entry.rx_buf);
+    if (entry.rx_closed) {
+      // Remote closed while queued — mark so read() returns EOF after buffered data
+      sock->rx_closed_ = true;
+    }
+    if (addr != nullptr) {
+      sock->getpeername(addr, addrlen);
+    }
+    LWIP_LOG("accept(%p)", sock.get());
+    return sock;
   }
-  // Create socket wrapper on the main loop (not in accept callback) to avoid
-  // heap allocation in IRQ context on RP2040. Transfer any data received while queued.
-  auto sock = make_unique<LWIPRawImpl>(this->family_, entry.pcb);
-  sock->init(entry.rx_buf);
-  if (entry.rx_closed) {
-    // Remote closed while queued — mark so read() returns EOF after buffered data
-    sock->rx_closed_ = true;
-  }
-  if (addr != nullptr) {
-    sock->getpeername(addr, addrlen);
-  }
-  LWIP_LOG("accept(%p)", sock.get());
-  return sock;
+  errno = EWOULDBLOCK;
+  return nullptr;
 }
 
 int LWIPRawListenImpl::listen(int backlog) {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -664,9 +664,12 @@ ssize_t LWIPRawImpl::writev(const struct iovec *iov, int iovcnt) {
 
 LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
-  // Abort any queued PCBs that were never accepted by the main loop
+  // Abort any queued PCBs that were never accepted by the main loop.
+  // Clear the error callback first — tcp_abort triggers it, and we don't
+  // want s_accepted_pcb_err_fn writing to slots during destruction.
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
     if (this->accepted_pcbs_[i] != nullptr) {
+      tcp_err(this->accepted_pcbs_[i], nullptr);
       tcp_abort(this->accepted_pcbs_[i]);
       this->accepted_pcbs_[i] = nullptr;
     }

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -439,11 +439,10 @@ void LWIPRawImpl::init(struct pbuf *initial_rx, bool initial_rx_closed) {
 }
 
 void LWIPRawImpl::s_err_fn(void *arg, err_t err) {
-  // Called by lwip core which already holds the async_context lock on RP2040.
-  // No LWIP_LOCK() needed — acquiring it would be redundant (recursive mutex).
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
+  // No LWIP_LOCK() needed — lwip core already holds the async_context lock.
   //
-  // "If a connection is aborted because of an error, the application is alerted of this event by
-  // the err callback."
   // pcb is already freed when this callback is called
   // ERR_RST: connection was reset by remote host
   // ERR_ABRT: aborted through tcp_abort or TCP timer
@@ -458,7 +457,8 @@ err_t LWIPRawImpl::s_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, er
 }
 
 err_t LWIPRawImpl::recv_fn(struct pbuf *pb, err_t err) {
-  // Called by lwip core which already holds the async_context lock on RP2040.
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   LWIP_LOG("recv(pb=%p err=%d)", pb, err);
   if (err != 0) {
     // "An error code if there has been an error receiving Only return ERR_ABRT if you have
@@ -704,13 +704,16 @@ void LWIPRawListenImpl::init() {
 }
 
 void LWIPRawListenImpl::s_err_fn(void *arg, err_t err) {
-  // Called by lwip core which already holds the async_context lock on RP2040.
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   auto *arg_this = reinterpret_cast<LWIPRawListenImpl *>(arg);
   ESP_LOGVV(TAG, "socket %p: err(err=%d)", arg_this, err);
   arg_this->pcb_ = nullptr;
 }
 
 void LWIPRawListenImpl::s_queued_err_fn(void *arg, err_t err) {
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   // Called when a queued (not yet accepted) PCB errors — e.g., remote sent RST.
   // The PCB is already freed by lwip. Null our pointer so accept() skips it.
   (void) err;
@@ -720,6 +723,8 @@ void LWIPRawListenImpl::s_queued_err_fn(void *arg, err_t err) {
 }
 
 err_t LWIPRawListenImpl::s_queued_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err) {
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   // Temporary recv callback for PCBs queued between accept_fn_ and accept().
   // Without this, lwip's default tcp_recv_null handler would ACK and drop the data,
   // causing the API handshake to silently fail (client sends Hello, server never sees it).
@@ -812,7 +817,8 @@ int LWIPRawListenImpl::listen(int backlog) {
 }
 
 err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
-  // Called by lwip core which already holds the async_context lock on RP2040.
+  // LWIP CALLBACK — runs from IRQ context on RP2040 (low-priority user IRQ).
+  // No heap allocation allowed — malloc is not IRQ-safe (see #14687).
   LWIP_LOG("accept(newpcb=%p err=%d)", newpcb, err);
   if (err != ERR_OK || newpcb == nullptr) {
     // "An error code if there has been an error accepting. Only return ERR_ABRT if you have

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -463,6 +463,9 @@ err_t LWIPRawImpl::recv_fn(struct pbuf *pb, err_t err) {
   if (err != 0) {
     // "An error code if there has been an error receiving Only return ERR_ABRT if you have
     // called tcp_abort from within the callback function!"
+    if (pb != nullptr) {
+      pbuf_free(pb);
+    }
     this->rx_closed_ = true;
     return ERR_OK;
   }
@@ -732,9 +735,13 @@ err_t LWIPRawListenImpl::s_queued_recv_fn(void *arg, struct tcp_pcb *pcb, struct
   auto *entry = reinterpret_cast<QueuedPcb *>(arg);
   if (pb == nullptr || err != ERR_OK) {
     // Remote closed or error
+    if (pb != nullptr) {
+      pbuf_free(pb);
+    }
     entry->rx_closed = true;
     return ERR_OK;
   }
+  // Buffer the data — tcp_recved() is deferred to read() after accept() creates the socket.
   if (entry->rx_buf == nullptr) {
     entry->rx_buf = pb;
   } else {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -753,18 +753,16 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
   // The error callback nulled their pcb pointers; clean up buffered data and discard.
   while (this->accepted_socket_count_ > 0) {
     QueuedPcb entry = this->accepted_pcbs_[0];
-    // Shift remaining entries forward and update tcp_arg pointers (slots shifted by one).
+    // Shift remaining entries forward, updating tcp_arg pointers as we go.
     // Safe because we hold LWIP_LOCK, so err/recv callbacks can't fire during the update.
     for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
       this->accepted_pcbs_[i - 1] = this->accepted_pcbs_[i];
+      if (this->accepted_pcbs_[i - 1].pcb != nullptr) {
+        tcp_arg(this->accepted_pcbs_[i - 1].pcb, &this->accepted_pcbs_[i - 1]);
+      }
     }
     this->accepted_pcbs_[this->accepted_socket_count_ - 1] = {};
     this->accepted_socket_count_--;
-    for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
-      if (this->accepted_pcbs_[i].pcb != nullptr) {
-        tcp_arg(this->accepted_pcbs_[i].pcb, &this->accepted_pcbs_[i]);
-      }
-    }
     if (entry.pcb == nullptr) {
       // PCB was freed by lwip (RST/timeout) while queued — discard and try next
       if (entry.rx_buf != nullptr) {

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -664,7 +664,6 @@ ssize_t LWIPRawImpl::writev(const struct iovec *iov, int iovcnt) {
 
 LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
-#ifdef USE_RP2040
   // Abort any queued PCBs that were never accepted by the main loop
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
     if (this->accepted_pcbs_[i] != nullptr) {
@@ -673,7 +672,6 @@ LWIPRawListenImpl::~LWIPRawListenImpl() {
     }
   }
   this->accepted_socket_count_ = 0;
-#endif
   // Listen PCBs must use tcp_close(), not tcp_abort().
   // tcp_abandon() asserts pcb->state != LISTEN and would access
   // fields that don't exist in the smaller tcp_pcb_listen struct.
@@ -699,7 +697,6 @@ void LWIPRawListenImpl::s_err_fn(void *arg, err_t err) {
   arg_this->pcb_ = nullptr;
 }
 
-#ifdef USE_RP2040
 void LWIPRawListenImpl::s_accepted_pcb_err_fn(void *arg, err_t err) {
   // Called when a queued (not yet accepted) PCB errors — e.g., remote sent RST.
   // The PCB is already freed by lwip. Null our pointer so accept() skips it.
@@ -707,7 +704,6 @@ void LWIPRawListenImpl::s_accepted_pcb_err_fn(void *arg, err_t err) {
   auto *slot = reinterpret_cast<struct tcp_pcb **>(arg);
   *slot = nullptr;
 }
-#endif
 
 err_t LWIPRawListenImpl::s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err) {
   auto *arg_this = reinterpret_cast<LWIPRawListenImpl *>(arg);
@@ -724,9 +720,7 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     errno = EWOULDBLOCK;
     return nullptr;
   }
-#ifdef USE_RP2040
-  // On RP2040, the accept callback stored raw PCBs to avoid heap allocation in IRQ context.
-  // Create the LWIPRawImpl here on the main loop where malloc is safe.
+  // Take raw PCB from front of queue
   struct tcp_pcb *pcb = this->accepted_pcbs_[0];
   // Shift remaining PCBs forward
   for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
@@ -748,18 +742,10 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     errno = EWOULDBLOCK;
     return nullptr;
   }
+  // Create socket wrapper on the main loop (not in accept callback) to avoid
+  // heap allocation in IRQ context on RP2040.
   auto sock = make_unique<LWIPRawImpl>(this->family_, pcb);
   sock->init();
-#else
-  // Take from front for FIFO ordering
-  std::unique_ptr<LWIPRawImpl> sock = std::move(this->accepted_sockets_[0]);
-  // Shift remaining sockets forward
-  for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
-    this->accepted_sockets_[i - 1] = std::move(this->accepted_sockets_[i]);
-  }
-  this->accepted_socket_count_--;
-  LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
-#endif
   if (addr != nullptr) {
     sock->getpeername(addr, addrlen);
   }
@@ -811,11 +797,8 @@ err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
     // Must return ERR_ABRT since we called tcp_abort()
     return ERR_ABRT;
   }
-#ifdef USE_RP2040
-  // On RP2040, this callback runs from IRQ context (async_context_threadsafe_background).
-  // Heap allocation here is unsafe — newlib's malloc recursive mutex doesn't prevent
-  // IRQ re-entry on the same core, causing heap corruption under rapid connect/disconnect.
-  // Store the raw PCB and defer LWIPRawImpl creation to the main-loop accept().
+  // Store the raw PCB — LWIPRawImpl creation is deferred to the main-loop accept().
+  // This avoids heap allocation in this callback, which is unsafe from IRQ context on RP2040.
   uint8_t idx = this->accepted_socket_count_++;
   this->accepted_pcbs_[idx] = newpcb;
   // Register a temporary error callback so that if the connection errors (RST, timeout)
@@ -823,11 +806,6 @@ err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
   // tcp_arg points to our array slot; accept() updates these pointers after shifting.
   tcp_arg(newpcb, &this->accepted_pcbs_[idx]);
   tcp_err(newpcb, LWIPRawListenImpl::s_accepted_pcb_err_fn);
-#else
-  auto sock = make_unique<LWIPRawImpl>(this->family_, newpcb);
-  sock->init();
-  this->accepted_sockets_[this->accepted_socket_count_++] = std::move(sock);
-#endif
   LWIP_LOG("Accepted connection, queue size: %d", this->accepted_socket_count_);
 #if (defined(USE_ESP8266) || defined(USE_RP2040))
   // Wake the main loop immediately so it can accept the new connection.

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -699,6 +699,16 @@ void LWIPRawListenImpl::s_err_fn(void *arg, err_t err) {
   arg_this->pcb_ = nullptr;
 }
 
+#ifdef USE_RP2040
+void LWIPRawListenImpl::s_accepted_pcb_err_fn(void *arg, err_t err) {
+  // Called when a queued (not yet accepted) PCB errors — e.g., remote sent RST.
+  // The PCB is already freed by lwip. Null our pointer so accept() skips it.
+  (void) err;
+  auto *slot = reinterpret_cast<struct tcp_pcb **>(arg);
+  *slot = nullptr;
+}
+#endif
+
 err_t LWIPRawListenImpl::s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err) {
   auto *arg_this = reinterpret_cast<LWIPRawListenImpl *>(arg);
   return arg_this->accept_fn_(newpcb, err);
@@ -724,7 +734,20 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
   }
   this->accepted_pcbs_[this->accepted_socket_count_ - 1] = nullptr;
   this->accepted_socket_count_--;
+  // Update tcp_arg for remaining queued PCBs — their array slots shifted by one.
+  // Safe because we hold LWIP_LOCK, so err callbacks can't fire during the update.
+  for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
+    if (this->accepted_pcbs_[i] != nullptr) {
+      tcp_arg(this->accepted_pcbs_[i], &this->accepted_pcbs_[i]);
+    }
+  }
   LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
+  if (pcb == nullptr) {
+    // PCB was freed by lwip (RST/timeout) while queued — the temporary error callback
+    // nulled our pointer. Return EWOULDBLOCK so the caller retries next loop.
+    errno = EWOULDBLOCK;
+    return nullptr;
+  }
   auto sock = make_unique<LWIPRawImpl>(this->family_, pcb);
   sock->init();
 #else
@@ -793,7 +816,13 @@ err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
   // Heap allocation here is unsafe — newlib's malloc recursive mutex doesn't prevent
   // IRQ re-entry on the same core, causing heap corruption under rapid connect/disconnect.
   // Store the raw PCB and defer LWIPRawImpl creation to the main-loop accept().
-  this->accepted_pcbs_[this->accepted_socket_count_++] = newpcb;
+  uint8_t idx = this->accepted_socket_count_++;
+  this->accepted_pcbs_[idx] = newpcb;
+  // Register a temporary error callback so that if the connection errors (RST, timeout)
+  // before accept() picks it up, we null our pointer instead of leaving a dangling reference.
+  // tcp_arg points to our array slot; accept() updates these pointers after shifting.
+  tcp_arg(newpcb, &this->accepted_pcbs_[idx]);
+  tcp_err(newpcb, LWIPRawListenImpl::s_accepted_pcb_err_fn);
 #else
   auto sock = make_unique<LWIPRawImpl>(this->family_, newpcb);
   sock->init();

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -664,6 +664,16 @@ ssize_t LWIPRawImpl::writev(const struct iovec *iov, int iovcnt) {
 
 LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
+#ifdef USE_RP2040
+  // Abort any queued PCBs that were never accepted by the main loop
+  for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
+    if (this->accepted_pcbs_[i] != nullptr) {
+      tcp_abort(this->accepted_pcbs_[i]);
+      this->accepted_pcbs_[i] = nullptr;
+    }
+  }
+  this->accepted_socket_count_ = 0;
+#endif
   // Listen PCBs must use tcp_close(), not tcp_abort().
   // tcp_abandon() asserts pcb->state != LISTEN and would access
   // fields that don't exist in the smaller tcp_pcb_listen struct.
@@ -704,6 +714,20 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     errno = EWOULDBLOCK;
     return nullptr;
   }
+#ifdef USE_RP2040
+  // On RP2040, the accept callback stored raw PCBs to avoid heap allocation in IRQ context.
+  // Create the LWIPRawImpl here on the main loop where malloc is safe.
+  struct tcp_pcb *pcb = this->accepted_pcbs_[0];
+  // Shift remaining PCBs forward
+  for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
+    this->accepted_pcbs_[i - 1] = this->accepted_pcbs_[i];
+  }
+  this->accepted_pcbs_[this->accepted_socket_count_ - 1] = nullptr;
+  this->accepted_socket_count_--;
+  LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
+  auto sock = make_unique<LWIPRawImpl>(this->family_, pcb);
+  sock->init();
+#else
   // Take from front for FIFO ordering
   std::unique_ptr<LWIPRawImpl> sock = std::move(this->accepted_sockets_[0]);
   // Shift remaining sockets forward
@@ -712,6 +736,7 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
   }
   this->accepted_socket_count_--;
   LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
+#endif
   if (addr != nullptr) {
     sock->getpeername(addr, addrlen);
   }
@@ -763,9 +788,17 @@ err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
     // Must return ERR_ABRT since we called tcp_abort()
     return ERR_ABRT;
   }
+#ifdef USE_RP2040
+  // On RP2040, this callback runs from IRQ context (async_context_threadsafe_background).
+  // Heap allocation here is unsafe — newlib's malloc recursive mutex doesn't prevent
+  // IRQ re-entry on the same core, causing heap corruption under rapid connect/disconnect.
+  // Store the raw PCB and defer LWIPRawImpl creation to the main-loop accept().
+  this->accepted_pcbs_[this->accepted_socket_count_++] = newpcb;
+#else
   auto sock = make_unique<LWIPRawImpl>(this->family_, newpcb);
   sock->init();
   this->accepted_sockets_[this->accepted_socket_count_++] = std::move(sock);
+#endif
   LWIP_LOG("Accepted connection, queue size: %d", this->accepted_socket_count_);
 #if (defined(USE_ESP8266) || defined(USE_RP2040))
   // Wake the main loop immediately so it can accept the new connection.

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -425,12 +425,16 @@ LWIPRawImpl::~LWIPRawImpl() {
   // Base class destructor handles pcb_ cleanup via tcp_abort
 }
 
-void LWIPRawImpl::init() {
+void LWIPRawImpl::init(struct pbuf *initial_rx) {
   LWIP_LOCK();
   LWIP_LOG("init(%p)", this->pcb_);
   tcp_arg(this->pcb_, this);
   tcp_recv(this->pcb_, LWIPRawImpl::s_recv_fn);
   tcp_err(this->pcb_, LWIPRawImpl::s_err_fn);
+  if (initial_rx != nullptr) {
+    this->rx_buf_ = initial_rx;
+    this->rx_buf_offset_ = 0;
+  }
 }
 
 void LWIPRawImpl::s_err_fn(void *arg, err_t err) {
@@ -666,9 +670,14 @@ LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
   // Abort any queued PCBs that were never accepted by the main loop
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
-    if (this->accepted_pcbs_[i] != nullptr) {
-      tcp_abort(this->accepted_pcbs_[i]);
-      this->accepted_pcbs_[i] = nullptr;
+    auto &entry = this->accepted_pcbs_[i];
+    if (entry.pcb != nullptr) {
+      tcp_abort(entry.pcb);
+      entry.pcb = nullptr;
+    }
+    if (entry.rx_buf != nullptr) {
+      pbuf_free(entry.rx_buf);
+      entry.rx_buf = nullptr;
     }
   }
   this->accepted_socket_count_ = 0;
@@ -697,12 +706,32 @@ void LWIPRawListenImpl::s_err_fn(void *arg, err_t err) {
   arg_this->pcb_ = nullptr;
 }
 
-void LWIPRawListenImpl::s_accepted_pcb_err_fn(void *arg, err_t err) {
+void LWIPRawListenImpl::s_queued_err_fn(void *arg, err_t err) {
   // Called when a queued (not yet accepted) PCB errors — e.g., remote sent RST.
   // The PCB is already freed by lwip. Null our pointer so accept() skips it.
   (void) err;
-  auto *slot = reinterpret_cast<struct tcp_pcb **>(arg);
-  *slot = nullptr;
+  auto *entry = reinterpret_cast<QueuedPcb *>(arg);
+  entry->pcb = nullptr;
+  // Don't free rx_buf here — accept() will clean it up when it sees pcb==nullptr
+}
+
+err_t LWIPRawListenImpl::s_queued_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err) {
+  // Temporary recv callback for PCBs queued between accept_fn_ and accept().
+  // Without this, lwip's default tcp_recv_null handler would ACK and drop the data,
+  // causing the API handshake to silently fail (client sends Hello, server never sees it).
+  (void) pcb;
+  auto *entry = reinterpret_cast<QueuedPcb *>(arg);
+  if (pb == nullptr || err != ERR_OK) {
+    // Remote closed or error
+    entry->rx_closed = true;
+    return ERR_OK;
+  }
+  if (entry->rx_buf == nullptr) {
+    entry->rx_buf = pb;
+  } else {
+    pbuf_cat(entry->rx_buf, pb);
+  }
+  return ERR_OK;
 }
 
 err_t LWIPRawListenImpl::s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err) {
@@ -720,32 +749,39 @@ std::unique_ptr<LWIPRawImpl> LWIPRawListenImpl::accept(struct sockaddr *addr, so
     errno = EWOULDBLOCK;
     return nullptr;
   }
-  // Take raw PCB from front of queue
-  struct tcp_pcb *pcb = this->accepted_pcbs_[0];
-  // Shift remaining PCBs forward
+  // Take entry from front of queue
+  QueuedPcb entry = this->accepted_pcbs_[0];
+  // Shift remaining entries forward
   for (uint8_t i = 1; i < this->accepted_socket_count_; i++) {
     this->accepted_pcbs_[i - 1] = this->accepted_pcbs_[i];
   }
-  this->accepted_pcbs_[this->accepted_socket_count_ - 1] = nullptr;
+  this->accepted_pcbs_[this->accepted_socket_count_ - 1] = {};
   this->accepted_socket_count_--;
   // Update tcp_arg for remaining queued PCBs — their array slots shifted by one.
-  // Safe because we hold LWIP_LOCK, so err callbacks can't fire during the update.
+  // Safe because we hold LWIP_LOCK, so err/recv callbacks can't fire during the update.
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
-    if (this->accepted_pcbs_[i] != nullptr) {
-      tcp_arg(this->accepted_pcbs_[i], &this->accepted_pcbs_[i]);
+    if (this->accepted_pcbs_[i].pcb != nullptr) {
+      tcp_arg(this->accepted_pcbs_[i].pcb, &this->accepted_pcbs_[i]);
     }
   }
   LWIP_LOG("Connection accepted by application, queue size: %d", this->accepted_socket_count_);
-  if (pcb == nullptr) {
+  if (entry.pcb == nullptr) {
     // PCB was freed by lwip (RST/timeout) while queued — the temporary error callback
-    // nulled our pointer. Return EWOULDBLOCK so the caller retries next loop.
+    // nulled our pointer. Free any buffered data and return EWOULDBLOCK.
+    if (entry.rx_buf != nullptr) {
+      pbuf_free(entry.rx_buf);
+    }
     errno = EWOULDBLOCK;
     return nullptr;
   }
   // Create socket wrapper on the main loop (not in accept callback) to avoid
-  // heap allocation in IRQ context on RP2040.
-  auto sock = make_unique<LWIPRawImpl>(this->family_, pcb);
-  sock->init();
+  // heap allocation in IRQ context on RP2040. Transfer any data received while queued.
+  auto sock = make_unique<LWIPRawImpl>(this->family_, entry.pcb);
+  sock->init(entry.rx_buf);
+  if (entry.rx_closed) {
+    // Remote closed while queued — mark so read() returns EOF after buffered data
+    sock->rx_closed_ = true;
+  }
   if (addr != nullptr) {
     sock->getpeername(addr, addrlen);
   }
@@ -800,12 +836,15 @@ err_t LWIPRawListenImpl::accept_fn_(struct tcp_pcb *newpcb, err_t err) {
   // Store the raw PCB — LWIPRawImpl creation is deferred to the main-loop accept().
   // This avoids heap allocation in this callback, which is unsafe from IRQ context on RP2040.
   uint8_t idx = this->accepted_socket_count_++;
-  this->accepted_pcbs_[idx] = newpcb;
-  // Register a temporary error callback so that if the connection errors (RST, timeout)
-  // before accept() picks it up, we null our pointer instead of leaving a dangling reference.
-  // tcp_arg points to our array slot; accept() updates these pointers after shifting.
+  this->accepted_pcbs_[idx] = {newpcb, nullptr, false};
+  // Register temporary callbacks so that while the PCB is queued:
+  // - err: nulls our pointer if the connection errors (RST, timeout)
+  // - recv: buffers any data that arrives before accept() creates the LWIPRawImpl
+  //   (without this, lwip's default tcp_recv_null would ACK and drop the data)
+  // tcp_arg points to our queue entry; accept() updates these pointers after shifting.
   tcp_arg(newpcb, &this->accepted_pcbs_[idx]);
-  tcp_err(newpcb, LWIPRawListenImpl::s_accepted_pcb_err_fn);
+  tcp_err(newpcb, LWIPRawListenImpl::s_queued_err_fn);
+  tcp_recv(newpcb, LWIPRawListenImpl::s_queued_recv_fn);
   LWIP_LOG("Accepted connection, queue size: %d", this->accepted_socket_count_);
 #if (defined(USE_ESP8266) || defined(USE_RP2040))
   // Wake the main loop immediately so it can accept the new connection.

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -177,30 +177,20 @@ class LWIPRawListenImpl : public LWIPRawCommon {
   int loop() { return 0; }
 
   static void s_err_fn(void *arg, err_t err);
-#ifdef USE_RP2040
   static void s_accepted_pcb_err_fn(void *arg, err_t err);
-#endif
 
  private:
   err_t accept_fn_(struct tcp_pcb *newpcb, err_t err);
   static err_t s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err);
 
-  // Accept queue - temporary holding area between lwip callbacks and main loop.
+  // Accept queue — stores raw tcp_pcb pointers instead of heap-allocated LWIPRawImpl objects.
+  // LWIPRawImpl creation is deferred to the main-loop accept() call. This avoids:
+  // - Heap allocation in the accept callback (unsafe from IRQ context on RP2040)
+  // - Dangling LWIPRawImpl if the connection errors before accept() picks it up
   // 3 slots is plenty since connections are pulled out quickly by the event loop.
-  //
-  // On RP2040, the accept callback runs from IRQ context (async_context_threadsafe_background),
-  // so it must NOT allocate heap memory — newlib's malloc recursive mutex doesn't prevent
-  // IRQ re-entry on the same core, causing heap corruption under rapid connect/disconnect.
-  // We store raw tcp_pcb pointers and defer LWIPRawImpl creation to the main-loop accept().
-  //
-  // On ESP8266, lwip callbacks run cooperatively (SYS context), so malloc is safe in callbacks.
   static constexpr size_t MAX_ACCEPTED_SOCKETS = 3;
-#ifdef USE_RP2040
   std::array<struct tcp_pcb *, MAX_ACCEPTED_SOCKETS> accepted_pcbs_{};
-#else
-  std::array<std::unique_ptr<LWIPRawImpl>, MAX_ACCEPTED_SOCKETS> accepted_sockets_;
-#endif
-  uint8_t accepted_socket_count_ = 0;  // Number of entries currently in queue
+  uint8_t accepted_socket_count_ = 0;  // Number of PCBs currently in queue
 };
 
 }  // namespace esphome::socket

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -187,8 +187,8 @@ class LWIPRawListenImpl : public LWIPRawCommon {
   // LWIPRawImpl creation is deferred to the main-loop accept() call. This avoids:
   // - Heap allocation in the accept callback (unsafe from IRQ context on RP2040)
   // - Dangling LWIPRawImpl if the connection errors before accept() picks it up
-  // 3 slots is plenty since connections are pulled out quickly by the event loop.
-  static constexpr size_t MAX_ACCEPTED_SOCKETS = 3;
+  // 2 slots is plenty since the main loop drains the queue every iteration.
+  static constexpr size_t MAX_ACCEPTED_SOCKETS = 2;
   std::array<struct tcp_pcb *, MAX_ACCEPTED_SOCKETS> accepted_pcbs_{};
   uint8_t accepted_socket_count_ = 0;  // Number of PCBs currently in queue
 };

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -177,6 +177,9 @@ class LWIPRawListenImpl : public LWIPRawCommon {
   int loop() { return 0; }
 
   static void s_err_fn(void *arg, err_t err);
+#ifdef USE_RP2040
+  static void s_accepted_pcb_err_fn(void *arg, err_t err);
+#endif
 
  private:
   err_t accept_fn_(struct tcp_pcb *newpcb, err_t err);

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -66,7 +66,7 @@ class LWIPRawImpl : public LWIPRawCommon {
   using LWIPRawCommon::LWIPRawCommon;
   ~LWIPRawImpl();
 
-  void init(struct pbuf *initial_rx = nullptr);
+  void init(struct pbuf *initial_rx = nullptr, bool initial_rx_closed = false);
 
   // Non-listening sockets return error
   std::unique_ptr<LWIPRawImpl> accept(struct sockaddr *, socklen_t *) {
@@ -120,8 +120,6 @@ class LWIPRawImpl : public LWIPRawCommon {
 
   static void s_err_fn(void *arg, err_t err);
   static err_t s_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err);
-
-  friend class LWIPRawListenImpl;  // accept() transfers queued rx data
 
  protected:
   ssize_t internal_write_(const void *buf, size_t len);

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -66,7 +66,7 @@ class LWIPRawImpl : public LWIPRawCommon {
   using LWIPRawCommon::LWIPRawCommon;
   ~LWIPRawImpl();
 
-  void init();
+  void init(struct pbuf *initial_rx = nullptr);
 
   // Non-listening sockets return error
   std::unique_ptr<LWIPRawImpl> accept(struct sockaddr *, socklen_t *) {
@@ -120,6 +120,8 @@ class LWIPRawImpl : public LWIPRawCommon {
 
   static void s_err_fn(void *arg, err_t err);
   static err_t s_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err);
+
+  friend class LWIPRawListenImpl;  // accept() transfers queued rx data
 
  protected:
   ssize_t internal_write_(const void *buf, size_t len);
@@ -177,20 +179,33 @@ class LWIPRawListenImpl : public LWIPRawCommon {
   int loop() { return 0; }
 
   static void s_err_fn(void *arg, err_t err);
-  static void s_accepted_pcb_err_fn(void *arg, err_t err);
 
  private:
   err_t accept_fn_(struct tcp_pcb *newpcb, err_t err);
   static err_t s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err);
 
-  // Accept queue — stores raw tcp_pcb pointers instead of heap-allocated LWIPRawImpl objects.
+  // Temporary callbacks for queued PCBs (between accept_fn_ and accept())
+  static void s_queued_err_fn(void *arg, err_t err);
+  static err_t s_queued_recv_fn(void *arg, struct tcp_pcb *pcb, struct pbuf *pb, err_t err);
+
+  // Accept queue entry — stores a raw tcp_pcb and any data received while queued.
+  // lwip's default tcp_recv_null handler drops data and ACKs it, so we must register
+  // a temporary recv callback to buffer any data that arrives between accept_fn_
+  // (which stores the PCB) and accept() (which creates the LWIPRawImpl).
+  struct QueuedPcb {
+    struct tcp_pcb *pcb{nullptr};
+    struct pbuf *rx_buf{nullptr};  // Data received while queued (before accept() picks it up)
+    bool rx_closed{false};         // Remote sent FIN while queued
+  };
+
+  // Accept queue — stores raw tcp_pcb entries instead of heap-allocated LWIPRawImpl objects.
   // LWIPRawImpl creation is deferred to the main-loop accept() call. This avoids:
   // - Heap allocation in the accept callback (unsafe from IRQ context on RP2040)
   // - Dangling LWIPRawImpl if the connection errors before accept() picks it up
   // 2 slots is plenty since the main loop drains the queue every iteration.
   static constexpr size_t MAX_ACCEPTED_SOCKETS = 2;
-  std::array<struct tcp_pcb *, MAX_ACCEPTED_SOCKETS> accepted_pcbs_{};
-  uint8_t accepted_socket_count_ = 0;  // Number of PCBs currently in queue
+  std::array<QueuedPcb, MAX_ACCEPTED_SOCKETS> accepted_pcbs_{};
+  uint8_t accepted_socket_count_ = 0;  // Number of entries currently in queue
 };
 
 }  // namespace esphome::socket

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -182,23 +182,22 @@ class LWIPRawListenImpl : public LWIPRawCommon {
   err_t accept_fn_(struct tcp_pcb *newpcb, err_t err);
   static err_t s_accept_fn(void *arg, struct tcp_pcb *newpcb, err_t err);
 
-  // Accept queue - holds incoming connections briefly until the event loop calls accept()
-  // This is NOT a connection pool - just a temporary queue between LWIP callbacks and the main loop
-  // 3 slots is plenty since connections are pulled out quickly by the event loop
+  // Accept queue - temporary holding area between lwip callbacks and main loop.
+  // 3 slots is plenty since connections are pulled out quickly by the event loop.
   //
-  // Memory analysis: std::array<3> vs original std::queue implementation:
-  // - std::queue uses std::deque internally which on 32-bit systems needs:
-  //   24 bytes (deque object) + 32+ bytes (map array) + heap allocations
-  //   Total: ~56+ bytes minimum, plus heap fragmentation
-  // - std::array<3>: 12 bytes fixed (3 pointers × 4 bytes)
-  // Saves ~44+ bytes RAM per listening socket + avoids ALL heap allocations
-  // Used on ESP8266 and RP2040 (platforms using LWIP_TCP implementation)
+  // On RP2040, the accept callback runs from IRQ context (async_context_threadsafe_background),
+  // so it must NOT allocate heap memory — newlib's malloc recursive mutex doesn't prevent
+  // IRQ re-entry on the same core, causing heap corruption under rapid connect/disconnect.
+  // We store raw tcp_pcb pointers and defer LWIPRawImpl creation to the main-loop accept().
   //
-  // By using a separate listening socket class, regular connected sockets save
-  // 16 bytes (12 bytes array + 1 byte count + 3 bytes padding) of memory overhead on 32-bit systems
+  // On ESP8266, lwip callbacks run cooperatively (SYS context), so malloc is safe in callbacks.
   static constexpr size_t MAX_ACCEPTED_SOCKETS = 3;
+#ifdef USE_RP2040
+  std::array<struct tcp_pcb *, MAX_ACCEPTED_SOCKETS> accepted_pcbs_{};
+#else
   std::array<std::unique_ptr<LWIPRawImpl>, MAX_ACCEPTED_SOCKETS> accepted_sockets_;
-  uint8_t accepted_socket_count_ = 0;  // Number of sockets currently in queue
+#endif
+  uint8_t accepted_socket_count_ = 0;  // Number of entries currently in queue
 };
 
 }  // namespace esphome::socket


### PR DESCRIPTION
# What does this implement/fix?

Fixes heap corruption crashes on RP2040/RP2350 (Pico W) caused by `malloc` in lwip's IRQ context during TCP accept.

### The bug

`accept_fn_()` runs from lwip's low-priority IRQ context (`async_context_threadsafe_background`) and called `make_unique<LWIPRawImpl>()` — which calls `operator new` → `malloc`. Newlib's malloc uses a recursive mutex (`__retarget_lock_acquire_recursive`) that **does not prevent IRQ re-entry on the same core**. When the main loop is mid-malloc (e.g., constructing an `APIConnection`) and the lwip IRQ fires to accept a new connection, malloc's internal data structures get corrupted.

### The fix

Defer `LWIPRawImpl` creation from the accept callback to the main-loop `accept()` call. The accept callback now stores raw `tcp_pcb*` pointers in a fixed-size `QueuedPcb` array (no heap allocation). The main loop drains the queue every iteration, creating `LWIPRawImpl` objects safely outside IRQ context.

This required handling two edge cases in the queued PCB window:

1. **Connection errors while queued**: A temporary `s_queued_err_fn` callback nulls the PCB pointer when a queued connection errors (RST, timeout). Without this, lwip frees the PCB silently, leaving a dangling pointer. `accept()` checks for null and skips these entries.

2. **Data arriving while queued**: A temporary `s_queued_recv_fn` callback buffers any data received before `accept()` picks up the PCB. Without this, lwip's default `tcp_recv_null` handler ACKs incoming data but silently drops it. On ESP8266, where lwip processes TCP segments in batches, the SYN completion and first data packet can arrive together — the API Hello would be ACKed at TCP level but never delivered to the application. The buffered data is transferred to the new socket via `init(initial_rx)`.

### Crash manifestations

Under stress testing (4 concurrent clients, 500 iterations of rapid connect/disconnect), the IRQ-context malloc corruption manifested as various crashes:

1. **Double-free in `~APIFrameHelper`** — destroying already-freed `unique_ptr<uint8_t[]>`
2. **Crash in `_malloc_r` during `APIConnection()` constructor** — heap metadata corrupted
3. **Crash in `_malloc_r` with `lock_release` from `async_context_threadsafe_background`** — IRQ re-entry during allocation
4. **Crash in `_free_r` during `operator delete[]`** — freeing corrupted heap block

Example crash backtrace (captured via the RP2040 crash handler from #14685):

```
PC:  0x100270C6  => _malloc_r at _mallocr.c:2508
LR:  0x1003187D  => __retarget_lock_acquire_recursive
BT0: 0x100289BF  => malloc at malloc.c:165
BT1: 0x1001BB1B  => __wrap_malloc
BT2: 0x10023453  => operator new(unsigned int) at new_op.cc:50
BT3: 0x10004407  => APIConnection::APIConnection(...)
```

### Stress test results

Verified on real hardware with 500 iterations, 4 concurrent clients:

| Platform | Before PR | After PR |
|----------|-----------|----------|
| RP2040 (Pico W) | Crashes at 3-4 iterations | 500/500 pass |
| RP2350 (Pico 2 W) | Crashes at 3-4 iterations | 500/500 pass |
| ESP8266 | N/A (no IRQ context) | 500/500 pass |
| ESP32-S3 (IDF) | 500/500 pass (baseline, uses BSD sockets) | 500/500 pass |

Stress test script (requires `aioesphomeapi`):

```python
"""Rapid connect/disconnect stress test for ESPHome native API."""

import asyncio
import sys
import time

from aioesphomeapi import APIClient


HOST = "192.168.1.100"
PORT = 6053
PASSWORD = ""
NOISE_PSK = None
ITERATIONS = 500
CONCURRENCY = 4  # simultaneous connection attempts


async def connect_disconnect(client_id: int, iteration: int) -> tuple[int, bool, str]:
    """Connect and immediately disconnect."""
    cli = APIClient(HOST, PORT, PASSWORD, noise_psk=NOISE_PSK)
    try:
        await asyncio.wait_for(cli.connect(login=True), timeout=10)
        await cli.disconnect()
        return iteration, True, ""
    except Exception as e:
        return iteration, False, f"client{client_id} iter{iteration}: {type(e).__name__}: {e}"
    finally:
        await cli.disconnect(force=True)


async def main() -> None:
    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else ITERATIONS
    concurrency = int(sys.argv[2]) if len(sys.argv) > 2 else CONCURRENCY

    print(f"Stress testing {HOST}:{PORT}")
    print(f"Iterations: {iterations}, Concurrency: {concurrency}")
    print()

    success = 0
    fail = 0
    errors: list[str] = []
    start = time.monotonic()

    sem = asyncio.Semaphore(concurrency)

    async def run(client_id: int, iteration: int) -> tuple[int, bool, str]:
        async with sem:
            return await connect_disconnect(client_id, iteration)

    tasks = [
        asyncio.create_task(run(i % concurrency, i)) for i in range(iterations)
    ]

    for coro in asyncio.as_completed(tasks):
        iteration, ok, err = await coro
        if ok:
            success += 1
        else:
            fail += 1
            errors.append(err)
        total = success + fail
        if total % 10 == 0 or not ok:
            elapsed = time.monotonic() - start
            rate = total / elapsed if elapsed > 0 else 0
            print(f"[{total}/{iterations}] ok={success} fail={fail} ({rate:.1f}/s)")
            if err:
                print(f"  ERROR: {err}")

    elapsed = time.monotonic() - start
    print()
    print(f"Done in {elapsed:.1f}s")
    print(f"Success: {success}, Failed: {fail}, Rate: {iterations/elapsed:.1f}/s")

    if errors:
        print(f"\nLast 10 errors:")
        for e in errors[-10:]:
            print(f"  {e}")

    sys.exit(1 if fail > 0 else 0)


if __name__ == "__main__":
    asyncio.run(main())
```

### Changes

- **`lwip_raw_tcp_impl.h`**: Accept queue changed from `std::array<std::unique_ptr<LWIPRawImpl>, 3>` to `std::array<QueuedPcb, 2>` (struct with `pcb`, `rx_buf`, `rx_closed`). Added `s_queued_err_fn` and `s_queued_recv_fn` declarations.
- **`lwip_raw_tcp_impl.cpp`**:
  - `accept_fn_()`: Stores raw `tcp_pcb*` in a `QueuedPcb` entry and registers temporary err/recv callbacks via `tcp_arg` pointing to the queue entry.
  - `accept()`: Creates `LWIPRawImpl` on the main loop. Transfers any buffered rx data via `init(initial_rx)`. Checks for null PCBs (freed by lwip while queued). Updates `tcp_arg` pointers for remaining queued entries after array shift.
  - `s_queued_err_fn()`: Nulls the PCB pointer when a queued connection errors.
  - `s_queued_recv_fn()`: Buffers data into the `QueuedPcb.rx_buf` chain, preventing lwip's default `tcp_recv_null` from dropping it.
  - `~LWIPRawListenImpl()`: Aborts any queued PCBs that were never accepted.

This is a follow-up to #14679 which added lwip locking but didn't address the malloc-in-IRQ issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14679

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal bugfix.
# Any RP2040 Pico W config using the native API exercises the fixed code path:
esphome:
  name: pico-w-test

rp2040:
  board: rpipicow

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
