### PR TITLE
[core] Fix waiting for port indefinitely

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -920,7 +920,9 @@ def _wait_for_serial_port(
 
     def _port_found() -> bool:
         if port is not None:
-            return os.path.exists(port)
+          if os.name == "posix":
+              return os.path.exists(port)
+          return any(p.path == port for p in get_serial_ports())
         ports = get_serial_ports()
         if known_ports is not None:
             return any(p.path not in known_ports for p in ports)

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -920,9 +920,9 @@ def _wait_for_serial_port(
 
     def _port_found() -> bool:
         if port is not None:
-          if os.name == "posix":
-              return os.path.exists(port)
-          return any(p.path == port for p in get_serial_ports())
+            if os.name == "posix":
+                return os.path.exists(port)
+            return any(p.path == port for p in get_serial_ports())
         ports = get_serial_ports()
         if known_ports is not None:
             return any(p.path not in known_ports for p in ports)

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -919,9 +919,9 @@ def _wait_for_serial_port(
     """
 
     def _port_found() -> bool:
-        ports = get_serial_ports()
         if port is not None:
-            return any(p.path == port for p in ports)
+            return os.path.exists(port)
+        ports = get_serial_ports()
         if known_ports is not None:
             return any(p.path not in known_ports for p in ports)
         return bool(ports)


### PR DESCRIPTION
# What does this implement/fix?

In macOS, prior to this fix, my console gets stuck after:
```
Hard resetting via RTS pin...
INFO Successfully uploaded program.
INFO Waiting for /dev/tty.usbmodem1101 to come online...
```
The port is back online but logs never start. This PR is a small patch which fixes the issue. Likely fallout from #14483

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
