### PR TITLE
[multiple] Convert static function locals to member variables

### DIFF
--- a/esphome/components/daikin_arc/daikin_arc.cpp
+++ b/esphome/components/daikin_arc/daikin_arc.cpp
@@ -91,11 +91,10 @@ void DaikinArcClimate::transmit_state() {
   remote_state[5] = this->operation_mode_() | 0x08;
   remote_state[6] = this->temperature_();
   remote_state[7] = this->humidity_();
-  static uint8_t last_humidity = 0x66;
-  if (remote_state[7] != last_humidity && this->mode != climate::CLIMATE_MODE_OFF) {
+  if (remote_state[7] != this->last_humidity_ && this->mode != climate::CLIMATE_MODE_OFF) {
     ESP_LOGD(TAG, "Set Humditiy: %d, %d\n", (int) this->target_humidity, (int) remote_state[7]);
     remote_header[9] |= 0x10;
-    last_humidity = remote_state[7];
+    this->last_humidity_ = remote_state[7];
   }
   uint16_t fan_speed = this->fan_speed_();
   remote_state[8] = fan_speed >> 8;

--- a/esphome/components/daikin_arc/daikin_arc.h
+++ b/esphome/components/daikin_arc/daikin_arc.h
@@ -70,6 +70,7 @@ class DaikinArcClimate : public climate_ir::ClimateIR {
   // Handle received IR Buffer
   bool on_receive(remote_base::RemoteReceiveData data) override;
   bool parse_state_frame_(const uint8_t frame[]);
+  uint8_t last_humidity_{0x66};
 };
 
 }  // namespace daikin_arc

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -1375,9 +1375,8 @@ void HonClimate::process_protocol_reset() {
 
 bool HonClimate::should_get_big_data_() {
   if (this->big_data_sensors_ > 0) {
-    static uint8_t counter = 0;
-    counter = (counter + 1) % 3;
-    return counter == 1;
+    this->big_data_counter_ = (this->big_data_counter_ + 1) % 3;
+    return this->big_data_counter_ == 1;
   }
   return false;
 }

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -188,6 +188,7 @@ class HonClimate : public HaierClimateBase {
   float active_alarm_count_{NAN};
   std::chrono::steady_clock::time_point last_alarm_request_;
   int big_data_sensors_{0};
+  uint8_t big_data_counter_{0};
   esphome::optional<hon_protocol::VerticalSwingMode> current_vertical_swing_{};
   esphome::optional<hon_protocol::HorizontalSwingMode> current_horizontal_swing_{};
   HonSettings settings_{};

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -572,16 +572,17 @@ bool INA2XX::write_unsigned_16_(uint8_t reg, uint16_t val) {
 }
 
 bool INA2XX::read_unsigned_(uint8_t reg, uint8_t reg_size, uint64_t &data_out) {
-  if (reg_size > sizeof(this->read_buf_)) {
+  uint8_t rx_buf[5];
+  if (reg_size > sizeof(rx_buf)) {
     return false;
   }
 
-  auto ret = this->read_ina_register(reg, this->read_buf_, reg_size);
+  auto ret = this->read_ina_register(reg, rx_buf, reg_size);
 
   // Combine bytes
-  data_out = this->read_buf_[0];
+  data_out = rx_buf[0];
   for (uint8_t i = 1; i < reg_size; i++) {
-    data_out = (data_out << 8) | this->read_buf_[i];
+    data_out = (data_out << 8) | rx_buf[i];
   }
   ESP_LOGV(TAG, "read_unsigned_ reg=0x%02X, ret=%s, len=%d, val=0x%" PRIX64, reg, OKFAILED(ret), reg_size, data_out);
 

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -572,18 +572,16 @@ bool INA2XX::write_unsigned_16_(uint8_t reg, uint16_t val) {
 }
 
 bool INA2XX::read_unsigned_(uint8_t reg, uint8_t reg_size, uint64_t &data_out) {
-  static uint8_t rx_buf[5] = {0};  // max buffer size
-
-  if (reg_size > 5) {
+  if (reg_size > sizeof(this->read_buf_)) {
     return false;
   }
 
-  auto ret = this->read_ina_register(reg, rx_buf, reg_size);
+  auto ret = this->read_ina_register(reg, this->read_buf_, reg_size);
 
   // Combine bytes
-  data_out = rx_buf[0];
+  data_out = this->read_buf_[0];
   for (uint8_t i = 1; i < reg_size; i++) {
-    data_out = (data_out << 8) | rx_buf[i];
+    data_out = (data_out << 8) | this->read_buf_[i];
   }
   ESP_LOGV(TAG, "read_unsigned_ reg=0x%02X, ret=%s, len=%d, val=0x%" PRIX64, reg, OKFAILED(ret), reg_size, data_out);
 

--- a/esphome/components/ina2xx_base/ina2xx_base.cpp
+++ b/esphome/components/ina2xx_base/ina2xx_base.cpp
@@ -572,7 +572,7 @@ bool INA2XX::write_unsigned_16_(uint8_t reg, uint16_t val) {
 }
 
 bool INA2XX::read_unsigned_(uint8_t reg, uint8_t reg_size, uint64_t &data_out) {
-  uint8_t rx_buf[5];
+  uint8_t rx_buf[5]{};
   if (reg_size > sizeof(rx_buf)) {
     return false;
   }

--- a/esphome/components/ina2xx_base/ina2xx_base.h
+++ b/esphome/components/ina2xx_base/ina2xx_base.h
@@ -238,7 +238,6 @@ class INA2XX : public PollingComponent {
   //
   // Register read/write
   //
-  uint8_t read_buf_[5]{};
   bool read_unsigned_(uint8_t reg, uint8_t reg_size, uint64_t &data_out);
   bool read_unsigned_16_(uint8_t reg, uint16_t &out);
   bool write_unsigned_16_(uint8_t reg, uint16_t val);

--- a/esphome/components/ina2xx_base/ina2xx_base.h
+++ b/esphome/components/ina2xx_base/ina2xx_base.h
@@ -238,6 +238,7 @@ class INA2XX : public PollingComponent {
   //
   // Register read/write
   //
+  uint8_t read_buf_[5]{};
   bool read_unsigned_(uint8_t reg, uint8_t reg_size, uint64_t &data_out);
   bool read_unsigned_16_(uint8_t reg, uint16_t &out);
   bool write_unsigned_16_(uint8_t reg, uint16_t val);

--- a/esphome/components/ltr_als_ps/ltr_als_ps.cpp
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.cpp
@@ -137,7 +137,6 @@ void LTRAlsPsComponent::update() {
 
 void LTRAlsPsComponent::loop() {
   ErrorCode err = i2c::ERROR_OK;
-  static uint8_t tries{0};
 
   switch (this->state_) {
     case State::DELAYED_SETUP:
@@ -166,20 +165,20 @@ void LTRAlsPsComponent::loop() {
 
     case State::WAITING_FOR_DATA:
       if (this->is_als_data_ready_(this->als_readings_) == LtrDataAvail::LTR_DATA_OK) {
-        tries = 0;
+        this->read_data_tries_ = 0;
         ESP_LOGV(TAG, "Reading sensor data having gain = %.0fx, time = %d ms", get_gain_coeff(this->als_readings_.gain),
                  get_itime_ms(this->als_readings_.integration_time));
         this->read_sensor_data_(this->als_readings_);
         this->state_ = State::DATA_COLLECTED;
         this->apply_lux_calculation_(this->als_readings_);
-      } else if (tries >= MAX_TRIES) {
+      } else if (this->read_data_tries_ >= MAX_TRIES) {
         ESP_LOGW(TAG, "Can't get data after several tries.");
-        tries = 0;
+        this->read_data_tries_ = 0;
         this->status_set_warning();
         this->state_ = State::IDLE;
         return;
       } else {
-        tries++;
+        this->read_data_tries_++;
       }
       break;
 
@@ -221,21 +220,21 @@ void LTRAlsPsComponent::loop() {
 }
 
 void LTRAlsPsComponent::check_and_trigger_ps_() {
-  static uint32_t last_high_trigger_time{0};
-  static uint32_t last_low_trigger_time{0};
   uint16_t ps_data = this->read_ps_data_();
   uint32_t now = millis();
 
   if (ps_data != this->ps_readings_) {
     this->ps_readings_ = ps_data;
     // Higher values - object is closer to sensor
-    if (ps_data > this->ps_threshold_high_ && now - last_high_trigger_time >= this->ps_cooldown_time_s_ * 1000) {
-      last_high_trigger_time = now;
+    if (ps_data > this->ps_threshold_high_ &&
+        now - this->last_ps_high_trigger_time_ >= this->ps_cooldown_time_s_ * 1000) {
+      this->last_ps_high_trigger_time_ = now;
       ESP_LOGV(TAG, "Proximity high threshold triggered. Value = %d, Trigger level = %d", ps_data,
                this->ps_threshold_high_);
       this->on_ps_high_trigger_callback_.call();
-    } else if (ps_data < this->ps_threshold_low_ && now - last_low_trigger_time >= this->ps_cooldown_time_s_ * 1000) {
-      last_low_trigger_time = now;
+    } else if (ps_data < this->ps_threshold_low_ &&
+               now - this->last_ps_low_trigger_time_ >= this->ps_cooldown_time_s_ * 1000) {
+      this->last_ps_low_trigger_time_ = now;
       ESP_LOGV(TAG, "Proximity low threshold triggered. Value = %d, Trigger level = %d", ps_data,
                this->ps_threshold_low_);
       this->on_ps_low_trigger_callback_.call();

--- a/esphome/components/ltr_als_ps/ltr_als_ps.h
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.h
@@ -126,13 +126,13 @@ class LTRAlsPsComponent : public PollingComponent, public i2c::I2CDevice {
   MeasurementRepeatRate repeat_rate_{MeasurementRepeatRate::REPEAT_RATE_500MS};
   float glass_attenuation_factor_{1.0};
 
-  uint16_t ps_cooldown_time_s_{5};
-  PsGain ps_gain_{PsGain::PS_GAIN_16};
-  uint16_t ps_threshold_high_{0xffff};
-  uint16_t ps_threshold_low_{0x0000};
   uint32_t last_ps_high_trigger_time_{0};
   uint32_t last_ps_low_trigger_time_{0};
+  uint16_t ps_cooldown_time_s_{5};
+  uint16_t ps_threshold_high_{0xffff};
+  uint16_t ps_threshold_low_{0x0000};
   uint8_t read_data_tries_{0};
+  PsGain ps_gain_{PsGain::PS_GAIN_16};
 
   //
   //   Sensors for publishing data

--- a/esphome/components/ltr_als_ps/ltr_als_ps.h
+++ b/esphome/components/ltr_als_ps/ltr_als_ps.h
@@ -130,6 +130,9 @@ class LTRAlsPsComponent : public PollingComponent, public i2c::I2CDevice {
   PsGain ps_gain_{PsGain::PS_GAIN_16};
   uint16_t ps_threshold_high_{0xffff};
   uint16_t ps_threshold_low_{0x0000};
+  uint32_t last_ps_high_trigger_time_{0};
+  uint32_t last_ps_low_trigger_time_{0};
+  uint8_t read_data_tries_{0};
 
   //
   //   Sensors for publishing data

--- a/esphome/components/matrix_keypad/matrix_keypad.cpp
+++ b/esphome/components/matrix_keypad/matrix_keypad.cpp
@@ -27,8 +27,6 @@ void MatrixKeypad::setup() {
 }
 
 void MatrixKeypad::loop() {
-  static uint32_t active_start = 0;
-  static int active_key = -1;
   uint32_t now = App.get_loop_component_start_time();
   int key = -1;
   bool error = false;
@@ -54,8 +52,8 @@ void MatrixKeypad::loop() {
   if (error)
     return;
 
-  if (key != active_key) {
-    if ((active_key != -1) && (this->pressed_key_ == active_key)) {
+  if (key != this->active_key_) {
+    if ((this->active_key_ != -1) && (this->pressed_key_ == this->active_key_)) {
       row = this->pressed_key_ / this->columns_.size();
       col = this->pressed_key_ % this->columns_.size();
       ESP_LOGD(TAG, "key @ row %d, col %d released", row, col);
@@ -70,13 +68,13 @@ void MatrixKeypad::loop() {
       this->pressed_key_ = -1;
     }
 
-    active_key = key;
+    this->active_key_ = key;
     if (key == -1)
       return;
-    active_start = now;
+    this->active_start_ = now;
   }
 
-  if ((this->pressed_key_ == key) || (now - active_start < this->debounce_time_))
+  if ((this->pressed_key_ == key) || (now - this->active_start_ < this->debounce_time_))
     return;
 
   row = key / this->columns_.size();

--- a/esphome/components/matrix_keypad/matrix_keypad.h
+++ b/esphome/components/matrix_keypad/matrix_keypad.h
@@ -44,6 +44,8 @@ class MatrixKeypad : public key_provider::KeyProvider, public Component {
   bool has_diodes_{false};
   bool has_pulldowns_{false};
   int pressed_key_ = -1;
+  uint32_t active_start_{0};
+  int active_key_{-1};
 
   std::vector<MatrixKeypadListener *> listeners_{};
   std::vector<MatrixKeyTrigger *> key_triggers_;

--- a/esphome/components/mqtt/mqtt_backend_esp32.cpp
+++ b/esphome/components/mqtt/mqtt_backend_esp32.cpp
@@ -150,17 +150,16 @@ void MQTTBackendESP32::mqtt_event_handler_(const Event &event) {
       this->on_publish_.call((int) event.msg_id);
       break;
     case MQTT_EVENT_DATA: {
-      static std::string topic;
       if (!event.topic.empty()) {
         // When a single message arrives as multiple chunks, the topic will be empty
         // on any but the first message, leading to event.topic being an empty string.
         // To ensure handlers get the correct topic, cache the last seen topic to
         // simulate always receiving the topic from underlying library
-        topic = event.topic;
+        this->cached_topic_ = event.topic;
       }
-      ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", topic.c_str());
-      this->on_message_.call(topic.c_str(), event.data.data(), event.data.size(), event.current_data_offset,
-                             event.total_data_len);
+      ESP_LOGV(TAG, "MQTT_EVENT_DATA %s", this->cached_topic_.c_str());
+      this->on_message_.call(this->cached_topic_.c_str(), event.data.data(), event.data.size(),
+                             event.current_data_offset, event.total_data_len);
     } break;
     case MQTT_EVENT_ERROR:
       ESP_LOGE(TAG, "MQTT_EVENT_ERROR");

--- a/esphome/components/mqtt/mqtt_backend_esp32.h
+++ b/esphome/components/mqtt/mqtt_backend_esp32.h
@@ -265,6 +265,7 @@ class MQTTBackendESP32 final : public MQTTBackend {
   CallbackManager<on_unsubscribe_callback_t> on_unsubscribe_;
   CallbackManager<on_message_callback_t> on_message_;
   CallbackManager<on_publish_user_callback_t> on_publish_;
+  std::string cached_topic_;
   std::queue<Event> mqtt_events_;
 
 #if defined(USE_MQTT_IDF_ENQUEUE)

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -124,6 +124,7 @@ void SGP4xComponent::self_test_() {
     }
 
     this->self_test_complete_ = true;
+    this->nox_conditioning_start_ = millis();
     ESP_LOGD(TAG, "Self-test complete");
   });
 }
@@ -161,7 +162,6 @@ void SGP4xComponent::update_gas_indices_() {
 
 void SGP4xComponent::measure_raw_() {
   float humidity = NAN;
-  static uint32_t nox_conditioning_start = millis();
 
   if (!this->self_test_complete_) {
     ESP_LOGW(TAG, "Self-test incomplete");
@@ -191,7 +191,7 @@ void SGP4xComponent::measure_raw_() {
     response_words = 1;
   } else {
     // SGP41 sensor must use NOx conditioning command for the first 10 seconds
-    if (millis() - nox_conditioning_start < 10000) {
+    if (millis() - this->nox_conditioning_start_ < 10000) {
       command = SGP41_CMD_NOX_CONDITIONING;
       response_words = 1;
     } else {

--- a/esphome/components/sgp4x/sgp4x.cpp
+++ b/esphome/components/sgp4x/sgp4x.cpp
@@ -191,10 +191,11 @@ void SGP4xComponent::measure_raw_() {
     response_words = 1;
   } else {
     // SGP41 sensor must use NOx conditioning command for the first 10 seconds
-    if (millis() - this->nox_conditioning_start_ < 10000) {
+    if (this->nox_conditioning_start_.has_value() && millis() - *this->nox_conditioning_start_ < 10000) {
       command = SGP41_CMD_NOX_CONDITIONING;
       response_words = 1;
     } else {
+      this->nox_conditioning_start_.reset();
       command = SGP41_CMD_MEASURE_RAW;
       response_words = 2;
     }

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -127,10 +127,9 @@ class SGP4xComponent : public PollingComponent, public sensor::Sensor, public se
   uint16_t measure_time_;
   uint8_t samples_read_ = 0;
   uint8_t samples_to_stabilize_ = static_cast<int8_t>(GasIndexAlgorithm_INITIAL_BLACKOUT) * 2;
-
-  uint32_t nox_conditioning_start_{0};
-
   bool store_baseline_;
+
+  optional<uint32_t> nox_conditioning_start_{};
   ESPPreferenceObject pref_;
   uint32_t seconds_since_last_store_;
   SGP4xBaselines voc_baselines_storage_;

--- a/esphome/components/sgp4x/sgp4x.h
+++ b/esphome/components/sgp4x/sgp4x.h
@@ -128,6 +128,8 @@ class SGP4xComponent : public PollingComponent, public sensor::Sensor, public se
   uint8_t samples_read_ = 0;
   uint8_t samples_to_stabilize_ = static_cast<int8_t>(GasIndexAlgorithm_INITIAL_BLACKOUT) * 2;
 
+  uint32_t nox_conditioning_start_{0};
+
   bool store_baseline_;
   ESPPreferenceObject pref_;
   uint32_t seconds_since_last_store_;


### PR DESCRIPTION
# What does this implement/fix?

Static local variables inside member functions are shared across all instances of a class. This causes bugs when multiple component instances exist (e.g., two matrix keypads share debounce state, two LTR-ALS-PS sensors share retry counters and trigger cooldown times, two Haier units share a request counter).

This PR converts static function locals to member variables across 8 components:
- **daikin_arc**: `last_humidity` in `transmit_state()`
- **matrix_keypad**: `active_start`/`active_key` in `loop()` — multi-instance bug
- **mqtt**: `topic` in event handler — persistent heap allocation converted to member
- **ltr_als_ps**: `tries` in `loop()`, `last_high/low_trigger_time` in `check_and_trigger_ps_()` — multi-instance bug
- **sgp4x**: `nox_conditioning_start` in `measure_raw_()` — now uses `optional<uint32_t>` to prevent re-triggering conditioning after `millis()` wraps (~49.7 days)
- **haier**: `counter` in `should_get_big_data_()` — multi-instance bug
- **ina2xx_base**: `rx_buf` in `read_unsigned_()` — converted to plain stack variable (no persistence needed)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).