### PR TITLE
[logger] Fix UART selection not applied before `pre_setup()`

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -337,6 +337,16 @@ async def to_code(config):
     )
     if CORE.is_esp32:
         cg.add(log.create_pthread_key())
+    # set_uart_selection() must be called before pre_setup() because
+    # pre_setup() switches on uart_ to decide which hardware to initialize
+    # (e.g. UART0 vs USB_SERIAL_JTAG). Without this, uart_ is still the
+    # default UART_SELECTION_UART0 and the wrong hardware gets initialized.
+    if CONF_HARDWARE_UART in config:
+        cg.add(
+            log.set_uart_selection(
+                HARDWARE_UART_TO_UART_SELECTION[config[CONF_HARDWARE_UART]]
+            )
+        )
     # pre_setup() must be called before init_log_buffer() because
     # init_log_buffer() calls disable_loop() which may log at VV level,
     # and global_logger must be set before any logging occurs.
@@ -354,12 +364,6 @@ async def to_code(config):
         cg.add(log.init_log_buffer(64))  # Fixed 64 slots for host
 
     cg.add(log.set_log_level(initial_level))
-    if CONF_HARDWARE_UART in config:
-        cg.add(
-            log.set_uart_selection(
-                HARDWARE_UART_TO_UART_SELECTION[config[CONF_HARDWARE_UART]]
-            )
-        )
 
     # Enable runtime tag levels if logs are configured or explicitly enabled
     logs_config = config[CONF_LOGS]


### PR DESCRIPTION
# What does this implement/fix?

Commit 4d2ef09a (#14538) moved `Logger::pre_setup()` earlier in the generated code to ensure `global_logger` is set before any logging occurs. However, it was moved **before** `set_uart_selection()`, so `pre_setup()` always sees the default `UART_SELECTION_UART0` instead of the configured value.

On platforms where the default logger UART is not `UART0` (e.g. `USB_SERIAL_JTAG` on ESP32-C3, C5, C6, C61, H2, P4, S3), `pre_setup()` initializes the wrong hardware. For `USB_SERIAL_JTAG`, the driver is never installed, which causes a NULL pointer crash in `improv_serial` when it calls `usb_serial_jtag_read_bytes()` on the first `loop()` iteration.

The fix moves `set_uart_selection()` before `pre_setup()`. Since `set_uart_selection()` is a simple field setter with no side effects (no logging, no hardware access), it is safe to call before the logger is fully initialized.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression introduced by #14538

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any ESP32-C6 config with improv_serial and default logger settings triggers the crash:
esp32:
  board: esp32-c6-devkitm-1
  framework:
    type: esp-idf

logger:

improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


Made with [Cursor](https://cursor.com)