### PR TITLE
[socket] Fast path for TCP_NODELAY bypasses lwip_setsockopt overhead

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef USE_LWIP_FAST_SELECT
-struct lwip_sock;
+#include "esphome/core/lwip_fast_select.h"
 #endif
 
 namespace esphome::socket {

--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -59,7 +59,7 @@ class BSDSocketImpl {
 #if defined(USE_LWIP_FAST_SELECT) && defined(CONFIG_LWIP_TCPIP_CORE_LOCKING)
     // Fast path for TCP_NODELAY: directly set the pcb flag under the TCPIP core lock,
     // bypassing lwip_setsockopt overhead (socket lookups, hook, switch cascade, refcounting).
-    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int)) {
+    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int) && optval != nullptr) {
       LwIPLock lock;
       if (esphome_lwip_set_nodelay(this->cached_sock_, *reinterpret_cast<const int *>(optval) != 0))
         return 0;

--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -56,6 +56,15 @@ class BSDSocketImpl {
     return ::getsockopt(this->fd_, level, optname, optval, optlen);
   }
   int setsockopt(int level, int optname, const void *optval, socklen_t optlen) {
+#if defined(USE_LWIP_FAST_SELECT) && defined(CONFIG_LWIP_TCPIP_CORE_LOCKING)
+    // Fast path for TCP_NODELAY: directly set the pcb flag under the TCPIP core lock,
+    // bypassing lwip_setsockopt overhead (socket lookups, hook, switch cascade, refcounting).
+    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int)) {
+      LwIPLock lock;
+      if (esphome_lwip_set_nodelay(this->cached_sock_, *reinterpret_cast<const int *>(optval) != 0))
+        return 0;
+    }
+#endif
     return ::setsockopt(this->fd_, level, optname, optval, optlen);
   }
   int listen(int backlog) { return ::listen(this->fd_, backlog); }

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -10,7 +10,7 @@
 #include "headers.h"
 
 #ifdef USE_LWIP_FAST_SELECT
-struct lwip_sock;
+#include "esphome/core/lwip_fast_select.h"
 #endif
 
 namespace esphome::socket {

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -52,6 +52,15 @@ class LwIPSocketImpl {
     return lwip_getsockopt(this->fd_, level, optname, optval, optlen);
   }
   int setsockopt(int level, int optname, const void *optval, socklen_t optlen) {
+#if defined(USE_LWIP_FAST_SELECT) && defined(CONFIG_LWIP_TCPIP_CORE_LOCKING)
+    // Fast path for TCP_NODELAY: directly set the pcb flag under the TCPIP core lock,
+    // bypassing lwip_setsockopt overhead (socket lookups, hook, switch cascade, refcounting).
+    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int)) {
+      LwIPLock lock;
+      if (esphome_lwip_set_nodelay(this->cached_sock_, *reinterpret_cast<const int *>(optval) != 0))
+        return 0;
+    }
+#endif
     return lwip_setsockopt(this->fd_, level, optname, optval, optlen);
   }
   int listen(int backlog) { return lwip_listen(this->fd_, backlog); }

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -55,7 +55,7 @@ class LwIPSocketImpl {
 #if defined(USE_LWIP_FAST_SELECT) && defined(CONFIG_LWIP_TCPIP_CORE_LOCKING)
     // Fast path for TCP_NODELAY: directly set the pcb flag under the TCPIP core lock,
     // bypassing lwip_setsockopt overhead (socket lookups, hook, switch cascade, refcounting).
-    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int)) {
+    if (level == IPPROTO_TCP && optname == TCP_NODELAY && optlen == sizeof(int) && optval != nullptr) {
       LwIPLock lock;
       if (esphome_lwip_set_nodelay(this->cached_sock_, *reinterpret_cast<const int *>(optval) != 0))
         return 0;

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -218,9 +218,11 @@ void esphome_lwip_hook_socket(struct lwip_sock *sock) {
 }
 
 bool esphome_lwip_set_nodelay(struct lwip_sock *sock, bool enable) {
-  if (sock == NULL || sock->conn == NULL || sock->conn->pcb.tcp == NULL)
+  if (sock == NULL || sock->conn == NULL)
     return false;
   if (NETCONNTYPE_GROUP(sock->conn->type) != NETCONN_TCP)
+    return false;
+  if (sock->conn->pcb.tcp == NULL)
     return false;
   if (enable) {
     tcp_nagle_disable(sock->conn->pcb.tcp);

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -220,6 +220,8 @@ void esphome_lwip_hook_socket(struct lwip_sock *sock) {
 bool esphome_lwip_set_nodelay(struct lwip_sock *sock, bool enable) {
   if (sock == NULL || sock->conn == NULL || sock->conn->pcb.tcp == NULL)
     return false;
+  if (NETCONNTYPE_GROUP(sock->conn->type) != NETCONN_TCP)
+    return false;
   if (enable) {
     tcp_nagle_disable(sock->conn->pcb.tcp);
   } else {

--- a/esphome/core/lwip_fast_select.c
+++ b/esphome/core/lwip_fast_select.c
@@ -112,6 +112,7 @@
 // LwIP headers must come first — they define netconn_callback, struct lwip_sock, etc.
 #include <lwip/api.h>
 #include <lwip/priv/sockets_priv.h>
+#include <lwip/tcp.h>
 // FreeRTOS include paths differ: ESP-IDF uses freertos/ prefix, LibreTiny does not
 #ifdef USE_ESP32
 #include <freertos/FreeRTOS.h>
@@ -214,6 +215,17 @@ void esphome_lwip_hook_socket(struct lwip_sock *sock) {
   // Replace with our wrapper. Atomic on all supported platforms (32-bit aligned pointer write).
   // TCP/IP thread sees either old or new pointer — both are valid.
   sock->conn->callback = esphome_socket_event_callback;
+}
+
+bool esphome_lwip_set_nodelay(struct lwip_sock *sock, bool enable) {
+  if (sock == NULL || sock->conn == NULL || sock->conn->pcb.tcp == NULL)
+    return false;
+  if (enable) {
+    tcp_nagle_disable(sock->conn->pcb.tcp);
+  } else {
+    tcp_nagle_enable(sock->conn->pcb.tcp);
+  }
+  return true;
 }
 
 // Wake the main loop from another FreeRTOS task. NOT ISR-safe.

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -66,6 +66,13 @@ void esphome_lwip_wake_main_loop(void);
 /// @param px_higher_priority_task_woken Set to pdTRUE if a context switch is needed.
 void esphome_lwip_wake_main_loop_from_isr(int *px_higher_priority_task_woken);
 
+/// Set or clear TCP_NODELAY on a socket's tcp_pcb directly.
+/// Must be called with the TCPIP core lock held (LwIPLock in C++).
+/// This bypasses lwip_setsockopt() overhead (socket lookups, switch cascade,
+/// hooks, refcounting) — just a direct pcb->flags bit set/clear.
+/// Returns true if successful, false if sock/conn/pcb is NULL.
+bool esphome_lwip_set_nodelay(struct lwip_sock *sock, bool enable);
+
 /// Wake the main loop task from any context (ISR, thread, or main loop).
 /// ESP32-only: uses xPortInIsrContext() to detect ISR context.
 /// LibreTiny lacks IRAM_ATTR support needed for ISR-safe paths.

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -70,7 +70,7 @@ void esphome_lwip_wake_main_loop_from_isr(int *px_higher_priority_task_woken);
 /// Must be called with the TCPIP core lock held (LwIPLock in C++).
 /// This bypasses lwip_setsockopt() overhead (socket lookups, switch cascade,
 /// hooks, refcounting) — just a direct pcb->flags bit set/clear.
-/// Returns true if successful, false if sock/conn/pcb is NULL.
+/// Returns true if successful, false if sock/conn/pcb is NULL or the socket is not TCP.
 bool esphome_lwip_set_nodelay(struct lwip_sock *sock, bool enable);
 
 /// Wake the main loop task from any context (ISR, thread, or main loop).


### PR DESCRIPTION
# What does this implement/fix?

On ESP32 with `CONFIG_LWIP_TCPIP_CORE_LOCKING`, bypass `lwip_setsockopt()` for `TCP_NODELAY` by directly modifying `tcp_pcb->flags` under the TCPIP core lock. This eliminates ~1091 bytes of overhead per call (socket lookups, hook, switch cascade, refcounting) for what is just a single bit flip.

The API frame helper toggles Nagle's algorithm on every message send via `set_nodelay_for_message()`, making this a hot path. The fast path reduces `set_nodelay_raw_` from calling the full `lwip_setsockopt` to just acquiring the mutex, loading 3 pointers, and flipping the `TF_NODELAY` bit.

### Benchmark results (ESP32, Olimex ESP32-PoE-ISO)

10,000 iterations, toggling NODELAY on and off (20,000 calls total):

| Path | Time per call | Total |
|------|--------------|-------|
| `lwip_setsockopt()` | 41,280 ns | 825,605 µs |
| Fast path (LwIPLock + direct pcb flag) | 9,141 ns | 182,812 µs |
| **Speedup** | **4.5x** | |

Each API message send toggles Nagle via `set_nodelay_for_message()`, so this saves ~32 µs per message on the hot path.

### Platform coverage

- **ESP32 (IDF):** Optimized — fast path enabled when both `USE_LWIP_FAST_SELECT` and `CONFIG_LWIP_TCPIP_CORE_LOCKING` are available
- **ESP8266 / RP2040:** Not affected — these use the raw TCP socket implementation which stores nodelay as a local `bool` and calls `tcp_output()` after writes, never going through `lwip_setsockopt` at all
- **LibreTiny (BK72xx, RTL87xx, LN882x):** Not optimized — lacks `CONFIG_LWIP_TCPIP_CORE_LOCKING` (uses message-passing via `tcpip_callback` instead), so the fast path is excluded at compile time and falls back to the standard `lwip_setsockopt`. Tested and confirmed same performance as before.

### What lwip_setsockopt does (and why we bypass it)

A single `lwip_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, ...)` call goes through:
1. `get_socket()` — lookup fd in socket table + refcount increment
2. ESP-IDF hook (`lwip_setsockopt_impl_ext`) — extension point check
3. Level/optname switch cascade — walks through all socket option levels
4. `LOCK_TCPIP_CORE()` / `UNLOCK_TCPIP_CORE()` — acquires the core lock
5. `tcp_nagle_disable/enable()` — the actual bit flip (one instruction)
6. `done_socket()` — refcount decrement + cleanup
7. errno setting

The fast path does only steps 4-5: acquire lock, flip bit, release lock.

### Safety

- Guarded by `#if defined(USE_LWIP_FAST_SELECT) && defined(CONFIG_LWIP_TCPIP_CORE_LOCKING)` — only compiles in when both the cached socket pointer and real mutex protection are available
- `TF_NODELAY` shares a 16-bit flags word with bits modified by the TCPIP thread (`TF_ACK_DELAY`, `TF_ACK_NOW`, etc.), so the TCPIP core lock is required for safe read-modify-write
- Falls back to the standard `setsockopt()` call if the cached socket pointer is NULL or the connection is gone

### Benchmark code

To reproduce, add this button to a test device config:

```yaml
button:
  - platform: template
    name: "Benchmark TCP_NODELAY"
    on_press:
      - lambda: |-
          static const char *TAG = "bench_nodelay";

          int fd = lwip_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
          if (fd < 0) {
            ESP_LOGE(TAG, "Failed to create socket");
            return;
          }

          struct lwip_sock *sock = esphome_lwip_get_sock(fd);
          if (sock == nullptr) {
            ESP_LOGE(TAG, "Failed to get lwip_sock");
            lwip_close(fd);
            return;
          }

          const int iterations = 10000;
          int val;

          // Warm up
          val = 1;
          lwip_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
          val = 0;
          lwip_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
          {
            esphome::LwIPLock lock;
            esphome_lwip_set_nodelay(sock, true);
          }
          {
            esphome::LwIPLock lock;
            esphome_lwip_set_nodelay(sock, false);
          }

          App.feed_wdt();

          // Benchmark slow path: lwip_setsockopt
          uint32_t t0 = micros();
          for (int i = 0; i < iterations; i++) {
            val = 1;
            lwip_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
            val = 0;
            lwip_setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(int));
          }
          uint32_t slow_us = micros() - t0;

          App.feed_wdt();

          // Benchmark fast path: esphome_lwip_set_nodelay under LwIPLock
          t0 = micros();
          for (int i = 0; i < iterations; i++) {
            {
              esphome::LwIPLock lock;
              esphome_lwip_set_nodelay(sock, true);
            }
            {
              esphome::LwIPLock lock;
              esphome_lwip_set_nodelay(sock, false);
            }
          }
          uint32_t fast_us = micros() - t0;

          float slow_ns = (float) slow_us / (iterations * 2) * 1000.0f;
          float fast_ns = (float) fast_us / (iterations * 2) * 1000.0f;

          ESP_LOGW(TAG, "TCP_NODELAY setsockopt benchmark (%d iterations, 2 calls each):", iterations);
          ESP_LOGW(TAG, "  lwip_setsockopt: %u us (%.1f ns/call)", slow_us, slow_ns);
          ESP_LOGW(TAG, "  fast path:       %u us (%.1f ns/call)", fast_us, fast_ns);
          ESP_LOGW(TAG, "  speedup:         %.1fx", (float) slow_us / (float) fast_us);

          lwip_close(fd);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - this is an internal optimization
# that applies automatically on ESP32 with CONFIG_LWIP_TCPIP_CORE_LOCKING
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).