### PR TITLE
midea: bidirectional Fahrenheit translation for accurate F display in HA

### DIFF
--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -25,7 +25,7 @@ template<typename T> void update_property(T &property, const T &value, bool &fla
 
 void AirConditioner::on_status_change() {
   bool need_publish = false;
-  update_property(this->target_temperature, this->base_.getTargetTemp(), need_publish);
+  update_property(this->target_temperature, this->ac_celsius_to_ha_celsius(this->base_.getTargetTemp()), need_publish);
   update_property(this->current_temperature, this->base_.getIndoorTemp(), need_publish);
   auto mode = Converters::to_climate_mode(this->base_.getMode());
   update_property(this->mode, mode, need_publish);
@@ -58,7 +58,7 @@ void AirConditioner::control(const ClimateCall &call) {
   dudanov::midea::ac::Control ctrl{};
   auto target_temp_val = call.get_target_temperature();
   if (target_temp_val.has_value())
-    ctrl.targetTemp = *target_temp_val;
+    ctrl.targetTemp = this->ha_celsius_to_ac_celsius(*target_temp_val);
   auto swing_mode_val = call.get_swing_mode();
   if (swing_mode_val.has_value())
     ctrl.swingMode = Converters::to_midea_swing_mode(*swing_mode_val);
@@ -85,9 +85,17 @@ void AirConditioner::control(const ClimateCall &call) {
 ClimateTraits AirConditioner::traits() {
   auto traits = ClimateTraits();
   traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-  traits.set_visual_min_temperature(17);
-  traits.set_visual_max_temperature(30);
-  traits.set_visual_temperature_step(0.5);
+  if (this->use_fahrenheit_) {
+    // Set min/max/step so HA displays clean integer F (60-86)
+    traits.set_visual_min_temperature((F_MIN - 32.0f) / 1.8f - 0.001f);  // 60F = 15.556C
+    traits.set_visual_max_temperature((F_MAX - 32.0f) / 1.8f);  // 86F = 30.0C
+    traits.set_visual_target_temperature_step(1.0f);             // 1F step
+    traits.set_visual_current_temperature_step(0.5f);          // match stock
+  } else {
+    traits.set_visual_min_temperature(17);
+    traits.set_visual_max_temperature(30);
+    traits.set_visual_temperature_step(0.5);
+  }
   traits.set_supported_modes(this->supported_modes_);
   traits.set_supported_swing_modes(this->supported_swing_modes_);
   traits.set_supported_presets(this->supported_presets_);

--- a/esphome/components/midea/air_conditioner.h
+++ b/esphome/components/midea/air_conditioner.h
@@ -7,6 +7,7 @@
 
 #include "appliance_base.h"
 #include "esphome/components/sensor/sensor.h"
+#include <cmath>
 
 namespace esphome {
 namespace midea {
@@ -48,6 +49,7 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   void set_supported_presets(ClimatePresetMask presets) { this->supported_presets_ = presets; }
   void set_custom_presets(std::initializer_list<const char *> presets) { this->supported_custom_presets_ = presets; }
   void set_custom_fan_modes(std::initializer_list<const char *> modes) { this->supported_custom_fan_modes_ = modes; }
+  void set_use_fahrenheit(bool state) { this->use_fahrenheit_ = state; }
 
  protected:
   void control(const ClimateCall &call) override;
@@ -60,6 +62,47 @@ class AirConditioner : public ApplianceBase<dudanov::midea::ac::AirConditioner>,
   Sensor *outdoor_sensor_{nullptr};
   Sensor *humidity_sensor_{nullptr};
   Sensor *power_sensor_{nullptr};
+  bool use_fahrenheit_{false};
+
+  // AC's canonical Celsius values for each integer F (60-86).
+  // Derived empirically by setting each F on the IR remote and reading
+  // the Celsius value the AC reports back over UART.
+  // Index 0 = 60F, Index 26 = 86F.
+  static constexpr int F_MIN = 60;
+  static constexpr int F_MAX = 86;
+  static constexpr int F_COUNT = F_MAX - F_MIN + 1;
+  static constexpr float AC_CELSIUS[F_COUNT] = {
+    16.0f, 16.5f, 17.0f, 17.5f, 18.0f, 18.5f, 19.0f, 19.5f, 20.0f,  // 60-68
+    20.5f, 21.0f, 21.5f, 22.0f, 23.0f, 23.5f, 24.0f, 24.5f, 25.0f,  // 69-77
+    25.5f, 26.0f, 26.5f, 27.0f, 28.0f, 28.5f, 29.0f, 29.5f, 30.0f   // 78-86
+  };
+
+  /// INBOUND (HA -> AC): Convert HA's precise Celsius to the AC's canonical
+  /// 0.5C value. HA sends (F-32)/1.8 which doesn't land on 0.5C steps.
+  float ha_celsius_to_ac_celsius(float celsius) {
+    if (!this->use_fahrenheit_)
+      return celsius;
+    int f = static_cast<int>(std::round(celsius * 1.8f + 32.0f));
+    if (f < F_MIN) f = F_MIN;
+    if (f > F_MAX) f = F_MAX;
+    return AC_CELSIUS[f - F_MIN];
+  }
+
+  /// OUTBOUND (AC -> HA): Convert the AC's canonical 0.5C value to the
+  /// precise Celsius that HA will display as a clean integer F.
+  float ac_celsius_to_ha_celsius(float celsius) {
+    if (!this->use_fahrenheit_)
+      return celsius;
+    // Find this value in the AC table
+    for (int i = 0; i < F_COUNT; i++) {
+      if (std::abs(AC_CELSIUS[i] - celsius) < 0.01f) {
+        int f = F_MIN + i;
+        return (f - 32.0f) / 1.8f;
+      }
+    }
+    // Not in table, pass through unchanged
+    return celsius;
+  }
 };
 
 }  // namespace ac

--- a/esphome/components/midea/climate.py
+++ b/esphome/components/midea/climate.py
@@ -53,7 +53,9 @@ def templatize(value):
 
 def register_action(name, type_, schema):
     validator = templatize(schema).extend(MIDEA_ACTION_BASE_SCHEMA)
-    registerer = automation.register_action(f"midea_ac.{name}", type_, validator)
+    registerer = automation.register_action(
+        f"midea_ac.{name}", type_, validator
+    )
 
     def decorator(func):
         async def new_func(config, action_id, template_arg, args):
@@ -114,6 +116,7 @@ CONFIG_SCHEMA = cv.All(
                 remote_transmitter.RemoteTransmitterComponent
             ),
             cv.Optional(CONF_BEEPER, default=False): cv.boolean,
+            cv.Optional(CONF_USE_FAHRENHEIT, default=False): cv.boolean,
             cv.Optional(CONF_AUTOCONF, default=True): cv.boolean,
             cv.Optional(CONF_SUPPORTED_MODES): cv.ensure_list(validate_modes),
             cv.Optional(CONF_SUPPORTED_SWING_MODES): cv.ensure_list(
@@ -270,6 +273,7 @@ async def to_code(config):
         transmitter_ = await cg.get_variable(config[CONF_TRANSMITTER_ID])
         cg.add(var.set_transmitter(transmitter_))
     cg.add(var.set_beeper_feedback(config[CONF_BEEPER]))
+    cg.add(var.set_use_fahrenheit(config[CONF_USE_FAHRENHEIT]))
     cg.add(var.set_autoconf(config[CONF_AUTOCONF]))
     if CONF_SUPPORTED_MODES in config:
         cg.add(var.set_supported_modes(config[CONF_SUPPORTED_MODES]))


### PR DESCRIPTION
When use_fahrenheit is enabled, translates between the AC's internal 0.5C-step setpoint table and the precise Celsius values that produce clean integer F readings in Home Assistant.

INBOUND (HA->AC): Rounds to nearest integer F, looks up the AC's canonical Celsius value from an empirically-derived table.

OUTBOUND (AC->HA): Maps the AC's 0.5C value back to precise Celsius so HA displays the correct integer F.

Visual traits automatically set to 60-86F range with 1F steps.

Lookup table derived by setting each F step via IR remote and reading the Celsius value reported back over UART.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
