### PR TITLE
[dashboard] Use sys.executable for dashboard subprocess commands

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -74,6 +74,8 @@ from esphome.util import (
 
 _LOGGER = logging.getLogger(__name__)
 
+ESPHOME_COMMAND = [sys.executable, "-m", "esphome"]
+
 # Maximum buffer size for serial log reading to prevent unbounded memory growth
 SERIAL_BUFFER_MAX_SIZE = 65536
 
@@ -1307,28 +1309,10 @@ def command_update_all(args: ArgsProtocol) -> int | None:
     files = list_yaml_files(args.configuration)
 
     def build_command(f):
+        cmd = [*ESPHOME_COMMAND]
         if CORE.dashboard:
-            return [
-                sys.executable,
-                "-m",
-                "esphome",
-                "--dashboard",
-                "run",
-                f,
-                "--no-logs",
-                "--device",
-                "OTA",
-            ]
-        return [
-            sys.executable,
-            "-m",
-            "esphome",
-            "run",
-            f,
-            "--no-logs",
-            "--device",
-            "OTA",
-        ]
+            cmd.append("--dashboard")
+        return [*cmd, "run", f, "--no-logs", "--device", "OTA"]
 
     return run_multiple_configs(files, build_command)
 
@@ -1477,7 +1461,7 @@ def command_rename(args: ArgsProtocol, config: ConfigType) -> int | None:
 
     new_path.write_text(new_raw, encoding="utf-8")
 
-    rc = run_external_process(sys.executable, "-m", "esphome", "config", str(new_path))
+    rc = run_external_process(*ESPHOME_COMMAND, "config", str(new_path))
     if rc != 0:
         print(color(AnsiFore.BOLD_RED, "Rename failed. Reverting changes."))
         new_path.unlink()
@@ -1495,7 +1479,7 @@ def command_rename(args: ArgsProtocol, config: ConfigType) -> int | None:
         cli_args.insert(0, "--dashboard")
 
     try:
-        rc = run_external_process(sys.executable, "-m", "esphome", *cli_args)
+        rc = run_external_process(*ESPHOME_COMMAND, *cli_args)
     except KeyboardInterrupt:
         rc = 1
     if rc != 0:
@@ -1892,7 +1876,7 @@ def run_esphome(argv):
         # argv[0] is the program path, skip it since we prefix with "esphome"
         def build_command(f):
             return (
-                [sys.executable, "-m", "esphome"]
+                [*ESPHOME_COMMAND]
                 + [arg for arg in argv[1:] if arg not in args.configuration]
                 + [str(f)]
             )

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1309,10 +1309,17 @@ def command_update_all(args: ArgsProtocol) -> int | None:
     files = list_yaml_files(args.configuration)
 
     def build_command(f):
-        cmd = [*ESPHOME_COMMAND]
         if CORE.dashboard:
-            cmd.append("--dashboard")
-        return [*cmd, "run", f, "--no-logs", "--device", "OTA"]
+            return [
+                *ESPHOME_COMMAND,
+                "--dashboard",
+                "run",
+                f,
+                "--no-logs",
+                "--device",
+                "OTA",
+            ]
+        return [*ESPHOME_COMMAND, "run", f, "--no-logs", "--device", "OTA"]
 
     return run_multiple_configs(files, build_command)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1308,8 +1308,27 @@ def command_update_all(args: ArgsProtocol) -> int | None:
 
     def build_command(f):
         if CORE.dashboard:
-            return [sys.executable, "-m", "esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"]
-        return [sys.executable, "-m", "esphome", "run", f, "--no-logs", "--device", "OTA"]
+            return [
+                sys.executable,
+                "-m",
+                "esphome",
+                "--dashboard",
+                "run",
+                f,
+                "--no-logs",
+                "--device",
+                "OTA",
+            ]
+        return [
+            sys.executable,
+            "-m",
+            "esphome",
+            "run",
+            f,
+            "--no-logs",
+            "--device",
+            "OTA",
+        ]
 
     return run_multiple_configs(files, build_command)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1308,8 +1308,8 @@ def command_update_all(args: ArgsProtocol) -> int | None:
 
     def build_command(f):
         if CORE.dashboard:
-            return ["esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"]
-        return ["esphome", "run", f, "--no-logs", "--device", "OTA"]
+            return [sys.executable, "-m", "esphome", "--dashboard", "run", f, "--no-logs", "--device", "OTA"]
+        return [sys.executable, "-m", "esphome", "run", f, "--no-logs", "--device", "OTA"]
 
     return run_multiple_configs(files, build_command)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1309,17 +1309,8 @@ def command_update_all(args: ArgsProtocol) -> int | None:
     files = list_yaml_files(args.configuration)
 
     def build_command(f):
-        if CORE.dashboard:
-            return [
-                *ESPHOME_COMMAND,
-                "--dashboard",
-                "run",
-                f,
-                "--no-logs",
-                "--device",
-                "OTA",
-            ]
-        return [*ESPHOME_COMMAND, "run", f, "--no-logs", "--device", "OTA"]
+        dashboard = ["--dashboard"] if CORE.dashboard else []
+        return [*ESPHOME_COMMAND, *dashboard, "run", f, "--no-logs", "--device", "OTA"]
 
     return run_multiple_configs(files, build_command)
 

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1458,7 +1458,7 @@ def command_rename(args: ArgsProtocol, config: ConfigType) -> int | None:
 
     new_path.write_text(new_raw, encoding="utf-8")
 
-    rc = run_external_process("esphome", "config", str(new_path))
+    rc = run_external_process(sys.executable, "-m", "esphome", "config", str(new_path))
     if rc != 0:
         print(color(AnsiFore.BOLD_RED, "Rename failed. Reverting changes."))
         new_path.unlink()
@@ -1476,7 +1476,7 @@ def command_rename(args: ArgsProtocol, config: ConfigType) -> int | None:
         cli_args.insert(0, "--dashboard")
 
     try:
-        rc = run_external_process("esphome", *cli_args)
+        rc = run_external_process(sys.executable, "-m", "esphome", *cli_args)
     except KeyboardInterrupt:
         rc = 1
     if rc != 0:
@@ -1873,7 +1873,7 @@ def run_esphome(argv):
         # argv[0] is the program path, skip it since we prefix with "esphome"
         def build_command(f):
             return (
-                ["esphome"]
+                [sys.executable, "-m", "esphome"]
                 + [arg for arg in argv[1:] if arg not in args.configuration]
                 + [str(f)]
             )

--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -28,4 +28,5 @@ MAX_EXECUTOR_WORKERS = 48
 
 SENTINEL = object()
 
-DASHBOARD_COMMAND = [sys.executable, "-m", "esphome", "--dashboard"]
+ESPHOME_COMMAND = [sys.executable, "-m", "esphome"]
+DASHBOARD_COMMAND = [*ESPHOME_COMMAND, "--dashboard"]

--- a/esphome/dashboard/const.py
+++ b/esphome/dashboard/const.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+
 from esphome.enum import StrEnum
 
 
@@ -26,4 +28,4 @@ MAX_EXECUTOR_WORKERS = 48
 
 SENTINEL = object()
 
-DASHBOARD_COMMAND = ["esphome", "--dashboard"]
+DASHBOARD_COMMAND = [sys.executable, "-m", "esphome", "--dashboard"]

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -52,7 +52,7 @@ from esphome.util import get_serial_ports, shlex_quote
 from esphome.yaml_util import FastestAvailableSafeLoader
 
 from ..helpers import write_file
-from .const import DASHBOARD_COMMAND, DashboardEvent
+from .const import DASHBOARD_COMMAND, ESPHOME_COMMAND, DashboardEvent
 from .core import DASHBOARD, ESPHomeDashboard, Event
 from .entries import UNKNOWN_STATE, DashboardEntry, entry_state_to_bool
 from .models import build_device_list_response
@@ -1079,7 +1079,7 @@ class DownloadBinaryRequestHandler(BaseHandler):
             return
 
         if not path.is_file():
-            args = ["esphome", "idedata", settings.rel_path(configuration)]
+            args = [*ESPHOME_COMMAND, "idedata", settings.rel_path(configuration)]
             rc, stdout, _ = await async_run_system_command(args)
 
             if rc != 0:
@@ -1462,7 +1462,7 @@ class JsonConfigRequestHandler(BaseHandler):
             self.send_error(404)
             return
 
-        args = ["esphome", "config", str(filename), "--show-secrets"]
+        args = [*ESPHOME_COMMAND, "config", str(filename), "--show-secrets"]
 
         rc, stdout, stderr = await async_run_system_command(args)
 


### PR DESCRIPTION
# What does this implement/fix?

The dashboard spawns `esphome` subprocesses (compile, validate, run, etc.) using `subprocess.Popen` with `"esphome"` as the command, which requires `esphome` to be on `PATH`. This fails in embedded Python environments where the bundled Python interpreter may not have `esphome` on `PATH`.

Changed `DASHBOARD_COMMAND` to use `sys.executable -m esphome` instead, which always resolves to the correct Python interpreter regardless of `PATH` configuration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome-desktop/issues/3
- related https://github.com/esphome/esphome-desktop/pull/22

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - dashboard internal change, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).