### PR TITLE
[ci] Add PR title check for unescaped angle brackets

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -65,6 +65,18 @@ jobs:
               return;
             }
 
+            // Check for angle brackets not wrapped in backticks.
+            // Astro docs MDX treats bare < as JSX component opening tags.
+            const stripped = title.replace(/`[^`]*`/g, '');
+            if (/[<>]/.test(stripped)) {
+              core.setFailed(
+                'PR title contains `<` or `>` not wrapped in backticks.\n' +
+                'Astro docs MDX interprets bare `<` as JSX components.\n' +
+                'Please wrap angle brackets with backticks, e.g.: [component] Add `<feature>` support'
+              );
+              return;
+            }
+
             // Check title starts with [tag] prefix
             const bracketPattern = /^\[\w+\]/;
             if (!bracketPattern.test(title)) {


### PR DESCRIPTION
# What does this implement/fix?

Adds a check to the PR title validation workflow that rejects titles containing bare `<` or `>` characters not wrapped in backticks. Astro docs MDX files interpret bare `<` as JSX component opening tags, which breaks rendering in the changelog/release notes.

Examples:
- `[i2c] Add <something> support` — **fails**
- `` [i2c] Add `<something>` support `` — **passes**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# n/a - CI workflow change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).