### PR TITLE
[ci] Dont run codeowners workflows on release or beta PRs

### DIFF
--- a/.github/workflows/codeowner-approved-label-update.yml
+++ b/.github/workflows/codeowner-approved-label-update.yml
@@ -10,6 +10,9 @@ name: Codeowner Approved Label
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+    branches-ignore:
+      - release
+      - beta
 
 permissions:
   issues: write

--- a/.github/workflows/codeowner-review-request.yml
+++ b/.github/workflows/codeowner-review-request.yml
@@ -13,6 +13,9 @@ on:
   # Needs to be pull_request_target to get write permissions
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+    branches-ignore:
+      - release
+      - beta
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
# What does this implement/fix?

This workflow is not needed for releases, no need to use more runners/runtime

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
