### PR TITLE
[socket] Fix use-after-free in LWIP PCB close/abort path

### DIFF
--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -138,13 +138,41 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
+// Clear LWIP callbacks and abort a PCB.
+// Must be called before destroying the object that `tcp_arg` points to.
+// tcp_abort() triggers the err callback synchronously — without clearing
+// first, it would call back into a partially-destroyed object, corrupting
+// freed memory.
+static void pcb_detach_abort(struct tcp_pcb *pcb) {
+  tcp_arg(pcb, nullptr);
+  tcp_recv(pcb, nullptr);
+  tcp_err(pcb, nullptr);
+  tcp_abort(pcb);
+}
+
+// Clear LWIP callbacks and gracefully close a PCB.
+// After tcp_close(), the PCB remains alive during the TCP close handshake
+// (FIN_WAIT, TIME_WAIT states). Without clearing callbacks first, LWIP
+// would call recv/err on a destroyed socket object, corrupting the heap.
+// Returns ERR_OK on success; on failure the PCB is aborted instead.
+static err_t pcb_detach_close(struct tcp_pcb *pcb) {
+  tcp_arg(pcb, nullptr);
+  tcp_recv(pcb, nullptr);
+  tcp_err(pcb, nullptr);
+  err_t err = tcp_close(pcb);
+  if (err != ERR_OK) {
+    tcp_abort(pcb);
+  }
+  return err;
+}
+
 // ---- LWIPRawCommon methods ----
 
 LWIPRawCommon::~LWIPRawCommon() {
   LWIP_LOCK();
   if (this->pcb_ != nullptr) {
     LWIP_LOG("tcp_abort(%p)", this->pcb_);
-    tcp_abort(this->pcb_);
+    pcb_detach_abort(this->pcb_);
     this->pcb_ = nullptr;
   }
 }
@@ -222,15 +250,13 @@ int LWIPRawCommon::close() {
     return -1;
   }
   LWIP_LOG("tcp_close(%p)", this->pcb_);
-  err_t err = tcp_close(this->pcb_);
+  err_t err = pcb_detach_close(this->pcb_);
+  this->pcb_ = nullptr;
   if (err != ERR_OK) {
     LWIP_LOG("  -> err %d", err);
-    tcp_abort(this->pcb_);
-    this->pcb_ = nullptr;
     errno = err == ERR_MEM ? ENOMEM : EIO;
     return -1;
   }
-  this->pcb_ = nullptr;
   return 0;
 }
 
@@ -673,13 +699,10 @@ ssize_t LWIPRawImpl::writev(const struct iovec *iov, int iovcnt) {
 LWIPRawListenImpl::~LWIPRawListenImpl() {
   LWIP_LOCK();
   // Abort any queued PCBs that were never accepted by the main loop.
-  // Clear the error callback first — tcp_abort triggers it, and we don't
-  // want s_queued_err_fn writing to slots during destruction.
   for (uint8_t i = 0; i < this->accepted_socket_count_; i++) {
     auto &entry = this->accepted_pcbs_[i];
     if (entry.pcb != nullptr) {
-      tcp_err(entry.pcb, nullptr);
-      tcp_abort(entry.pcb);
+      pcb_detach_abort(entry.pcb);
       entry.pcb = nullptr;
     }
     if (entry.rx_buf != nullptr) {
@@ -693,7 +716,7 @@ LWIPRawListenImpl::~LWIPRawListenImpl() {
   // fields that don't exist in the smaller tcp_pcb_listen struct.
   // Close here and null pcb_ so the base destructor skips tcp_abort.
   if (this->pcb_ != nullptr) {
-    tcp_close(this->pcb_);
+    pcb_detach_close(this->pcb_);
     this->pcb_ = nullptr;
   }
 }

--- a/esphome/components/socket/lwip_raw_tcp_impl.cpp
+++ b/esphome/components/socket/lwip_raw_tcp_impl.cpp
@@ -138,11 +138,13 @@ static const char *const TAG = "socket.lwip";
 #define LWIP_LOG(msg, ...)
 #endif
 
-// Clear LWIP callbacks and abort a PCB.
-// Must be called before destroying the object that `tcp_arg` points to.
-// tcp_abort() triggers the err callback synchronously — without clearing
-// first, it would call back into a partially-destroyed object, corrupting
-// freed memory.
+// Clear arg, recv, and err callbacks, then abort a connected PCB.
+// Only valid for full tcp_pcb (not tcp_pcb_listen).
+// Must be called before destroying the object that tcp_arg points to —
+// tcp_abort() triggers the err callback synchronously, which would
+// otherwise call back into a partially-destroyed object.
+// tcp_sent/tcp_poll are not cleared because this implementation
+// never registers them.
 static void pcb_detach_abort(struct tcp_pcb *pcb) {
   tcp_arg(pcb, nullptr);
   tcp_recv(pcb, nullptr);
@@ -150,10 +152,13 @@ static void pcb_detach_abort(struct tcp_pcb *pcb) {
   tcp_abort(pcb);
 }
 
-// Clear LWIP callbacks and gracefully close a PCB.
+// Clear arg, recv, and err callbacks, then gracefully close a connected PCB.
+// Only valid for full tcp_pcb (not tcp_pcb_listen).
 // After tcp_close(), the PCB remains alive during the TCP close handshake
 // (FIN_WAIT, TIME_WAIT states). Without clearing callbacks first, LWIP
 // would call recv/err on a destroyed socket object, corrupting the heap.
+// tcp_sent/tcp_poll are not cleared because this implementation
+// never registers them.
 // Returns ERR_OK on success; on failure the PCB is aborted instead.
 static err_t pcb_detach_close(struct tcp_pcb *pcb) {
   tcp_arg(pcb, nullptr);
@@ -714,9 +719,13 @@ LWIPRawListenImpl::~LWIPRawListenImpl() {
   // Listen PCBs must use tcp_close(), not tcp_abort().
   // tcp_abandon() asserts pcb->state != LISTEN and would access
   // fields that don't exist in the smaller tcp_pcb_listen struct.
+  // Don't use pcb_detach_close() here — tcp_recv()/tcp_err() also access
+  // fields that only exist in the full tcp_pcb, not tcp_pcb_listen.
+  // tcp_close() on a listen PCB is synchronous (frees immediately),
+  // so there are no async callbacks to worry about.
   // Close here and null pcb_ so the base destructor skips tcp_abort.
   if (this->pcb_ != nullptr) {
-    pcb_detach_close(this->pcb_);
+    tcp_close(this->pcb_);
     this->pcb_ = nullptr;
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix a use-after-free bug in the LWIP raw TCP socket implementation that causes heap corruption and crashes on ESP8266 during rapid API client connect/disconnect cycles.

When `tcp_close()` is called, the PCB remains alive during the TCP close handshake (FIN_WAIT, TIME_WAIT states). If the socket object (`LWIPRawImpl`) is destroyed before the handshake completes, LWIP's `recv`/`err` callbacks fire with a dangling `arg` pointer, writing to freed memory and corrupting the heap. This manifests as `umm_malloc_core` crashes (LoadStoreError) when the corrupted free-list is next traversed.

The fix extracts two helpers — `pcb_detach_abort()` and `pcb_detach_close()` — that clear all LWIP callbacks (`tcp_arg`, `tcp_recv`, `tcp_err`) before closing or aborting the PCB. All close/abort call sites now use these helpers to ensure callbacks are consistently cleared first.

## Stress test used to reproduce and verify

<details>
<summary>stress_test_connect.py</summary>

```python
"""Rapid connect/disconnect stress test for ESPHome native API."""

import asyncio
import sys
import time

from aioesphomeapi import APIClient


HOST = "192.168.x.x"
PORT = 6053
PASSWORD = ""
NOISE_PSK = None
ITERATIONS = 500
CONCURRENCY = 4  # simultaneous connection attempts


async def connect_disconnect(client_id: int, iteration: int) -> tuple[int, bool, str]:
    """Connect and immediately disconnect."""
    cli = APIClient(HOST, PORT, PASSWORD, noise_psk=NOISE_PSK)
    try:
        await asyncio.wait_for(cli.connect(login=True), timeout=10)
        await cli.disconnect()
        return iteration, True, ""
    except Exception as e:
        return iteration, False, f"client{client_id} iter{iteration}: {type(e).__name__}: {e}"
    finally:
        await cli.disconnect(force=True)


async def main() -> None:
    iterations = int(sys.argv[1]) if len(sys.argv) > 1 else ITERATIONS
    concurrency = int(sys.argv[2]) if len(sys.argv) > 2 else CONCURRENCY

    print(f"Stress testing {HOST}:{PORT}")
    print(f"Iterations: {iterations}, Concurrency: {concurrency}")
    print()

    success = 0
    fail = 0
    errors: list[str] = []
    start = time.monotonic()

    sem = asyncio.Semaphore(concurrency)

    async def run(client_id: int, iteration: int) -> tuple[int, bool, str]:
        async with sem:
            return await connect_disconnect(client_id, iteration)

    tasks = [
        asyncio.create_task(run(i % concurrency, i)) for i in range(iterations)
    ]

    for coro in asyncio.as_completed(tasks):
        iteration, ok, err = await coro
        if ok:
            success += 1
        else:
            fail += 1
            errors.append(err)
        total = success + fail
        if total % 10 == 0 or not ok:
            elapsed = time.monotonic() - start
            rate = total / elapsed if elapsed > 0 else 0
            print(f"[{total}/{iterations}] ok={success} fail={fail} ({rate:.1f}/s)")
            if err:
                print(f"  ERROR: {err}")

    elapsed = time.monotonic() - start
    print()
    print(f"Done in {elapsed:.1f}s")
    print(f"Success: {success}, Failed: {fail}, Rate: {iterations/elapsed:.1f}/s")

    if errors:
        print(f"\nLast 10 errors:")
        for e in errors[-10:]:
            print(f"  {e}")

    sys.exit(1 if fail > 0 else 0)


if __name__ == "__main__":
    asyncio.run(main())
```

</details>

**Before fix:** crashes within ~50 iterations with `umm_malloc_core` LoadStoreError.
**After fix:** 490/500 success, 10 connection resets from overload (expected on ESP8266).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — internal bug fix, no user-facing config changes.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal socket layer fix.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).