### PR TITLE
[time] Fix settimeofday() failure on ESP8266

### DIFF
--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -88,13 +88,13 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
   struct timeval timev {
     .tv_sec = static_cast<time_t>(epoch), .tv_usec = 0,
   };
+#ifdef USE_ESP8266
+  // ESP8266 settimeofday() requires tz to be nullptr
+  int ret = settimeofday(&timev, nullptr);
+#else
   struct timezone tz = {0, 0};
   int ret = settimeofday(&timev, &tz);
-  if (ret != 0 && errno == EINVAL) {
-    // Some ESP8266 frameworks abort when timezone parameter is not NULL
-    // while ESP32 expects it not to be NULL
-    ret = settimeofday(&timev, nullptr);
-  }
+#endif
 
   if (ret != 0) {
     ESP_LOGW(TAG, "setimeofday() failed with code %d", ret);

--- a/esphome/components/time/real_time_clock.cpp
+++ b/esphome/components/time/real_time_clock.cpp
@@ -97,7 +97,7 @@ void RealTimeClock::synchronize_epoch_(uint32_t epoch) {
 #endif
 
   if (ret != 0) {
-    ESP_LOGW(TAG, "setimeofday() failed with code %d", ret);
+    ESP_LOGW(TAG, "settimeofday() failed with code %d", ret);
   }
 #endif
   auto time = this->now();


### PR DESCRIPTION
# What does this implement/fix?

Fix `settimeofday()` failing with EINVAL (error code 22) on ESP8266, which prevented time synchronization from working.

ESP8266's Arduino core `settimeofday()` implementation returns `EINVAL` (22) directly as the return value when the timezone parameter is non-NULL, rather than following POSIX convention of returning -1 and setting `errno`. The previous fallback code checked `errno == EINVAL` which never matched because `errno` was never set by the ESP8266 implementation, so the retry with `nullptr` never triggered.

From the [ESP8266 Arduino core source](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/time.cpp#L294):
```cpp
if (tz || !tv)
    // tz is obsolete (cf. man settimeofday)
    return EINVAL;
```

Fix by always passing `nullptr` for the timezone parameter on ESP8266 since the platform requires it.

Before:
```
[09:34:28.513][W][time:100]: setimeofday() failed with code 22
[09:34:28.513][D][time:104]: Synchronized time: 1969-12-31 14:00:14
```

After:
```
[09:39:24.002][C][time:055]: Current time: 2026-03-11 09:39:23
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: homeassistant
    id: ha_time
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).