### PR TITLE
[esp32_hosted] Bump esp_hosted to 2.12.1

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -105,7 +105,7 @@ async def to_code(config):
     if framework_ver >= cv.Version(5, 5, 0):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.4.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.4")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.0")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.1")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -20,7 +20,7 @@ dependencies:
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.12.0
+    version: 2.12.1
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:


### PR DESCRIPTION
# What does this implement/fix?

Bumps esp_hosted from 2.12.0 to 2.12.1 to fix slave OTA validation failure.

See https://github.com/espressif/esp-hosted-mcu/issues/165

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/espressif/esp-hosted-mcu/issues/165

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_hosted:
  variant: ESP32C6
  active_high: true
  reset_pin: 7
  clk_pin: 43
  cmd_pin: 44
  d0_pin: 39
  d1_pin: 40
  d2_pin: 41
  d3_pin: 42
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).