### PR TITLE
[esp32] Add crash handler to capture and report backtrace across reboots

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -14,6 +14,9 @@
 #include "api_server.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
+#ifdef USE_ESP32
+#include "esphome/components/esp32/crash_handler.h"
+#endif
 #include "esphome/core/entity_base.h"
 #include "esphome/core/string_ref.h"
 
@@ -235,6 +238,9 @@ class APIConnection final : public APIServerConnectionBase {
     this->flags_.log_subscription = msg.level;
     if (msg.dump_config)
       App.schedule_dump_config();
+#ifdef USE_ESP32
+    esp32::crash_handler_log();
+#endif
   }
 #ifdef USE_API_HOMEASSISTANT_SERVICES
   void on_subscribe_homeassistant_services_request() override { this->flags_.service_call_subscription = true; }

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -14,7 +14,7 @@
 #include "api_server.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
-#ifdef USE_ESP32
+#ifdef USE_ESP32_CRASH_HANDLER
 #include "esphome/components/esp32/crash_handler.h"
 #endif
 #include "esphome/core/entity_base.h"
@@ -238,7 +238,7 @@ class APIConnection final : public APIServerConnectionBase {
     this->flags_.log_subscription = msg.level;
     if (msg.dump_config)
       App.schedule_dump_config();
-#ifdef USE_ESP32
+#ifdef USE_ESP32_CRASH_HANDLER
     esp32::crash_handler_log();
 #endif
   }

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -79,12 +79,15 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
         )
         for parsed_msg in parse_log_message(text, timestamp):
             print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
-        if platform_process_stacktrace:
-            backtrace_state = platform_process_stacktrace(config, text, backtrace_state)
-        else:
-            backtrace_state = process_stacktrace(
-                config, text, backtrace_state=backtrace_state
-            )
+        for raw_line in text.splitlines():
+            if platform_process_stacktrace:
+                backtrace_state = platform_process_stacktrace(
+                    config, raw_line, backtrace_state
+                )
+            else:
+                backtrace_state = process_stacktrace(
+                    config, raw_line, backtrace_state=backtrace_state
+                )
 
     stop = await async_run(cli, on_log, name=name)
     try:

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
+import importlib
 import logging
 from typing import TYPE_CHECKING, Any
 import warnings
@@ -18,6 +19,7 @@ import contextlib
 
 from esphome.const import CONF_KEY, CONF_PORT, __version__
 from esphome.core import CORE
+from esphome.platformio_api import process_stacktrace
 
 from . import CONF_ENCRYPTION
 
@@ -55,9 +57,19 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
         addresses=addresses,  # Pass all addresses for automatic retry
     )
     dashboard = CORE.dashboard
+    backtrace_state = False
+
+    # Try platform-specific stacktrace handler first, fall back to generic
+    platform_process_stacktrace = None
+    try:
+        module = importlib.import_module("esphome.components." + CORE.target_platform)
+        platform_process_stacktrace = getattr(module, "process_stacktrace")
+    except (AttributeError, ImportError):
+        pass
 
     def on_log(msg: SubscribeLogsResponse) -> None:
         """Handle a new log message."""
+        nonlocal backtrace_state
         time_ = datetime.now()
         message: bytes = msg.message
         text = message.decode("utf8", "backslashreplace")
@@ -67,6 +79,12 @@ async def async_run_logs(config: dict[str, Any], addresses: list[str]) -> None:
         )
         for parsed_msg in parse_log_message(text, timestamp):
             print(parsed_msg.replace("\033", "\\033") if dashboard else parsed_msg)
+        if platform_process_stacktrace:
+            backtrace_state = platform_process_stacktrace(config, text, backtrace_state)
+        else:
+            backtrace_state = process_stacktrace(
+                config, text, backtrace_state=backtrace_state
+            )
 
     stop = await async_run(cli, on_log, name=name)
     try:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1442,7 +1442,11 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("USE_NATIVE_64BIT_TIME")
     cg.add_build_flag("-Wl,-z,noexecstack")
-    cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
+    # Arduino already wraps esp_panic_handler for its own backtrace handler,
+    # so only add our wrap when using ESP-IDF framework to avoid linker conflicts.
+    if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+        cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
+        cg.add_define("USE_ESP32_CRASH_HANDLER")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     variant = config[CONF_VARIANT]
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1442,6 +1442,7 @@ async def to_code(config):
     cg.add_build_flag("-DUSE_ESP32")
     cg.add_define("USE_NATIVE_64BIT_TIME")
     cg.add_build_flag("-Wl,-z,noexecstack")
+    cg.add_build_flag("-Wl,--wrap=esp_panic_handler")
     cg.add_define("ESPHOME_BOARD", config[CONF_BOARD])
     variant = config[CONF_VARIANT]
     cg.add_build_flag(f"-DUSE_ESP32_VARIANT_{variant}")

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -1,7 +1,7 @@
 #ifdef USE_ESP32
 
-#include "crash_handler.h"
 #include "esphome/core/defines.h"
+#include "crash_handler.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "preferences.h"
@@ -37,8 +37,10 @@ void arch_restart() {
 }
 
 void arch_init() {
+#ifdef USE_ESP32_CRASH_HANDLER
   // Read crash data from previous boot before anything else
   esp32::crash_handler_read_and_clear();
+#endif
 
   // Enable the task watchdog only on the loop task (from which we're currently running)
   esp_task_wdt_add(nullptr);

--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -1,5 +1,6 @@
 #ifdef USE_ESP32
 
+#include "crash_handler.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
@@ -36,6 +37,9 @@ void arch_restart() {
 }
 
 void arch_init() {
+  // Read crash data from previous boot before anything else
+  esp32::crash_handler_read_and_clear();
+
   // Enable the task watchdog only on the loop task (from which we're currently running)
   esp_task_wdt_add(nullptr);
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -17,7 +17,7 @@
 #endif
 
 static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
-static constexpr size_t MAX_BACKTRACE = 8;
+static constexpr size_t MAX_BACKTRACE = 16;
 
 // Check if an address looks like code (flash-mapped or IRAM).
 // Must be safe to call from panic context (no flash access needed).

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -30,6 +30,8 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 // Validated by magic marker. Static linkage since it's only used within this file.
 // Version field is first so future firmware can always identify the struct layout.
 // Magic is second to validate the data. Remaining fields can change between versions.
+// Version is uint32_t because it would be padded to 4 bytes anyway before the next
+// uint32_t field, so we use the full width rather than wasting 3 bytes of padding.
 static constexpr uint32_t CRASH_DATA_VERSION = 1;
 struct RawCrashData {
   uint32_t version;

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -33,13 +33,22 @@ static inline bool is_return_addr(uint32_t addr) {
   if (!is_code_addr(addr) || addr < 4)
     return false;
   // A return address on the stack points to the instruction after a call.
-  // Read the 4-byte instruction immediately before this address.
+  // Check for 4-byte JAL/JALR call instruction before this address.
   uint32_t inst = *(uint32_t *) (addr - 4);
   // RISC-V instruction encoding: bits [6:0] = opcode, bits [11:7] = rd
   uint32_t opcode = inst & 0x7f;  // Extract 7-bit opcode
   uint32_t rd = inst & 0xf80;     // Extract rd field (bits 11:7)
   // Match JAL (0x6f) or JALR (0x67) with rd=ra (x1, encoded as 0x80 = 1<<7)
-  return (opcode == 0x6f || opcode == 0x67) && rd == 0x80;
+  if ((opcode == 0x6f || opcode == 0x67) && rd == 0x80)
+    return true;
+  // Check for 2-byte compressed c.jalr before this address (C extension).
+  // c.jalr saves to ra implicitly: funct4=1001, rs1!=0, rs2=0, op=10
+  if (addr >= 2) {
+    uint16_t c_inst = *(uint16_t *) (addr - 2);
+    if ((c_inst & 0xf07f) == 0x9002 && (c_inst & 0x0f80) != 0)
+      return true;
+  }
+  return false;
 }
 #endif
 
@@ -56,6 +65,7 @@ struct RawCrashData {
   uint32_t magic;
   uint32_t pc;
   uint8_t backtrace_count;
+  uint8_t reg_frame_count;  // Number of entries from registers (not stack-scanned)
   uint32_t backtrace[MAX_BACKTRACE];
 };
 static RawCrashData __attribute__((section(".noinit")))
@@ -71,9 +81,11 @@ static const char *const TAG = "esp32.crash";
 void crash_handler_read_and_clear() {
   if (s_raw_crash_data.magic == CRASH_MAGIC && s_raw_crash_data.version == CRASH_DATA_VERSION) {
     s_crash_data_valid = true;
-    // Clamp backtrace count to prevent out-of-bounds reads from corrupt .noinit data
+    // Clamp counts to prevent out-of-bounds reads from corrupt .noinit data
     if (s_raw_crash_data.backtrace_count > MAX_BACKTRACE)
       s_raw_crash_data.backtrace_count = MAX_BACKTRACE;
+    if (s_raw_crash_data.reg_frame_count > s_raw_crash_data.backtrace_count)
+      s_raw_crash_data.reg_frame_count = s_raw_crash_data.backtrace_count;
   }
   // Clear magic regardless so we don't re-report on next normal reboot
   s_raw_crash_data.magic = 0;
@@ -96,9 +108,8 @@ void crash_handler_log() {
   for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count; i++) {
     uint32_t addr = s_raw_crash_data.backtrace[i];
 #if CONFIG_IDF_TARGET_ARCH_RISCV
-    // Filter stack-scanned addresses: skip values that aren't preceded by a
-    // JAL/JALR call instruction. Safe to check here since flash cache is up.
-    if (!is_return_addr(addr))
+    // Register-sourced entries (MEPC/RA) are trusted; only filter stack-scanned ones.
+    if (i >= s_raw_crash_data.reg_frame_count && !is_return_addr(addr))
       continue;
 #endif
     ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", bt_num++, addr);
@@ -109,7 +120,7 @@ void crash_handler_log() {
   for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
     uint32_t addr = s_raw_crash_data.backtrace[i];
 #if CONFIG_IDF_TARGET_ARCH_RISCV
-    if (!is_return_addr(addr))
+    if (i >= s_raw_crash_data.reg_frame_count && !is_return_addr(addr))
       continue;
 #endif
     pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, addr);
@@ -132,6 +143,7 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   // Save the faulting PC
   s_raw_crash_data.pc = (uint32_t) info->addr;
   s_raw_crash_data.backtrace_count = 0;
+  s_raw_crash_data.reg_frame_count = 0;
 
 #if CONFIG_IDF_TARGET_ARCH_XTENSA
   // Xtensa: walk the backtrace using the public API
@@ -176,6 +188,10 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
     if (is_code_addr(rv_frame->ra) && rv_frame->ra != rv_frame->mepc) {
       s_raw_crash_data.backtrace[count++] = rv_frame->ra;
     }
+
+    // Track how many entries came from registers (MEPC/RA) so we can
+    // skip return-address validation for them at log time.
+    s_raw_crash_data.reg_frame_count = count;
 
     // Scan stack for code addresses — captures broadly during panic,
     // filtered by is_return_addr() at log time when flash is accessible.

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -114,9 +114,6 @@ void crash_handler_log() {
     pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, addr);
   }
   ESP_LOGE(TAG, "%s", hint);
-#if CONFIG_IDF_TARGET_ARCH_RISCV
-  ESP_LOGE(TAG, "RISC-V backtrace is best-effort. Check serial console for full register dump.");
-#endif
 }
 
 }  // namespace esphome::esp32

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -116,7 +116,12 @@ void crash_handler_log() {
     if (i >= s_raw_crash_data.reg_frame_count && !is_return_addr(addr))
       continue;
 #endif
-    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", bt_num++, addr);
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+    const char *source = (i < s_raw_crash_data.reg_frame_count) ? "backtrace" : "stack scan";
+#else
+    const char *source = "backtrace";
+#endif
+    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (%s)", bt_num++, addr, source);
   }
   // Build addr2line hint with all captured addresses for easy copy-paste
   char hint[256];

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -28,12 +28,13 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 // Raw crash data written by the panic handler wrapper.
 // Lives in .noinit so it survives software reset but contains garbage after power cycle.
 // Validated by magic marker. Static linkage since it's only used within this file.
-static struct {
+struct RawCrashData {
   uint32_t magic;
   uint32_t pc;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-} __attribute__((section(".noinit"))) s_raw_crash_data;
+};
+static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
 
 namespace esphome::esp32 {
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -63,7 +63,7 @@ static inline bool is_return_addr(uint32_t addr) {
 // Magic is second to validate the data. Remaining fields can change between versions.
 // Version is uint32_t because it would be padded to 4 bytes anyway before the next
 // uint32_t field, so we use the full width rather than wasting 3 bytes of padding.
-static constexpr uint32_t CRASH_DATA_VERSION = 2;
+static constexpr uint32_t CRASH_DATA_VERSION = 1;
 struct RawCrashData {
   uint32_t version;
   uint32_t magic;

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -28,12 +28,15 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 // Raw crash data written by the panic handler wrapper.
 // Lives in .noinit so it survives software reset but contains garbage after power cycle.
 // Validated by magic marker. Static linkage since it's only used within this file.
-// Field order matters: magic, pc, and backtrace_count are at fixed offsets
+// Field order matters: magic, version, pc, and backtrace_count are at fixed offsets
 // so the struct remains readable even if MAX_BACKTRACE changes between versions.
+static constexpr uint8_t CRASH_DATA_VERSION = 1;
 struct RawCrashData {
   uint32_t magic;
   uint32_t pc;
+  uint8_t version;
   uint8_t backtrace_count;
+  // 2 bytes padding here, then backtrace array
   uint32_t backtrace[MAX_BACKTRACE];
 };
 static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
@@ -46,7 +49,7 @@ namespace esphome::esp32 {
 static const char *const TAG = "esp32.crash";
 
 void crash_handler_read_and_clear() {
-  if (s_raw_crash_data.magic == CRASH_MAGIC) {
+  if (s_raw_crash_data.magic == CRASH_MAGIC && s_raw_crash_data.version == CRASH_DATA_VERSION) {
     s_crash_data_valid = true;
     // Clamp backtrace count to prevent out-of-bounds reads from corrupt .noinit data
     if (s_raw_crash_data.backtrace_count > MAX_BACKTRACE)
@@ -151,7 +154,8 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   }
 #endif
 
-  // Write magic last — ensures all data is written before we mark it valid
+  // Write version and magic last — ensures all data is written before we mark it valid
+  s_raw_crash_data.version = CRASH_DATA_VERSION;
   s_raw_crash_data.magic = CRASH_MAGIC;
 
   // Call the real panic handler (prints to UART, does core dump, reboots, etc.)

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -1,0 +1,177 @@
+#ifdef USE_ESP32
+
+#include "crash_handler.h"
+#include "esphome/core/log.h"
+
+#include <cinttypes>
+#include <esp_attr.h>
+#include <esp_private/panic_internal.h>
+#include <soc/soc.h>
+
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+#include <esp_cpu_utils.h>
+#include <esp_debug_helpers.h>
+#include <xtensa_context.h>
+#elif CONFIG_IDF_TARGET_ARCH_RISCV
+#include <riscv/rvruntime-frames.h>
+#endif
+
+static constexpr uint32_t CRASH_MAGIC = 0xDEADBEEF;
+static constexpr size_t MAX_BACKTRACE = 8;
+
+// Check if an address looks like code (flash-mapped or IRAM).
+// Must be safe to call from panic context (no flash access needed).
+static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
+  return (addr >= SOC_IROM_LOW && addr < SOC_IROM_HIGH) || (addr >= SOC_IRAM_LOW && addr < SOC_IRAM_HIGH);
+}
+
+// Raw crash data written by the panic handler wrapper.
+// Lives in .noinit so it survives software reset.
+// Defined at file scope (outside any namespace) because both the namespace
+// functions and the extern "C" panic handler wrapper need to access it.
+struct RawCrashData {
+  uint32_t magic;
+  uint32_t pc;
+  uint32_t backtrace[MAX_BACKTRACE];
+  uint8_t backtrace_count;
+};
+extern RawCrashData s_raw_crash_data;
+
+namespace esphome::esp32 {
+
+static const char *const TAG = "esp32.crash";
+
+// Validated crash data — populated by crash_handler_read_and_clear() from the
+// raw NOINIT data written by the panic handler wrapper.
+static struct {
+  bool valid;
+  uint32_t pc;
+  uint32_t backtrace[MAX_BACKTRACE];
+  uint8_t backtrace_count;
+} s_crash_data;
+
+void crash_handler_read_and_clear() {
+  s_crash_data.valid = false;
+  if (s_raw_crash_data.magic == CRASH_MAGIC) {
+    s_crash_data.valid = true;
+    s_crash_data.pc = s_raw_crash_data.pc;
+    s_crash_data.backtrace_count = s_raw_crash_data.backtrace_count;
+    if (s_crash_data.backtrace_count > MAX_BACKTRACE)
+      s_crash_data.backtrace_count = MAX_BACKTRACE;
+    for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
+      s_crash_data.backtrace[i] = s_raw_crash_data.backtrace[i];
+    }
+  }
+  // Clear magic regardless so we don't re-report on next normal reboot
+  s_raw_crash_data.magic = 0;
+}
+
+bool crash_handler_has_data() { return s_crash_data.valid; }
+
+// Intentionally uses separate ESP_LOGE calls per line instead of combining into
+// one multi-line log message. This ensures each address appears as its own line
+// on the serial console, making it possible to see partial output if the device
+// crashes again during boot, and allowing the CLI's process_stacktrace to match
+// and decode each address individually.
+void crash_handler_log() {
+  if (!s_crash_data.valid)
+    return;
+
+  ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
+  ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_crash_data.pc);
+  for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
+    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", i, s_crash_data.backtrace[i]);
+  }
+  // Build addr2line hint with all captured addresses for easy copy-paste
+  char hint[256];
+  int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_crash_data.pc);
+  for (uint8_t i = 0; i < s_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
+    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_crash_data.backtrace[i]);
+  }
+  ESP_LOGE(TAG, "%s", hint);
+}
+
+}  // namespace esphome::esp32
+
+// --- Panic handler wrapper ---
+// Intercepts esp_panic_handler() via --wrap linker flag to capture crash data
+// into NOINIT memory before the normal panic handler runs.
+//
+// The raw crash data struct must be separate from the read-side struct to avoid
+// BSS initialization conflicts. It lives in .noinit so it survives software reset.
+
+RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
+
+extern "C" {
+extern void __real_esp_panic_handler(panic_info_t *info);
+
+void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
+  // Save the faulting PC
+  s_raw_crash_data.pc = (uint32_t) info->addr;
+  s_raw_crash_data.backtrace_count = 0;
+
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+  // Xtensa: walk the backtrace using the public API
+  if (info->frame != nullptr) {
+    auto *xt_frame = (XtExcFrame *) info->frame;
+    esp_backtrace_frame_t bt_frame = {
+        .pc = (uint32_t) xt_frame->pc,
+        .sp = (uint32_t) xt_frame->a1,
+        .next_pc = (uint32_t) xt_frame->a0,
+        .exc_frame = xt_frame,
+    };
+
+    uint8_t count = 0;
+    // First frame PC
+    if (is_code_addr(esp_cpu_process_stack_pc(bt_frame.pc))) {
+      s_raw_crash_data.backtrace[count++] = esp_cpu_process_stack_pc(bt_frame.pc);
+    }
+    // Walk remaining frames
+    while (count < MAX_BACKTRACE && bt_frame.next_pc != 0) {
+      if (!esp_backtrace_get_next_frame(&bt_frame)) {
+        break;
+      }
+      uint32_t pc = esp_cpu_process_stack_pc(bt_frame.pc);
+      if (is_code_addr(pc)) {
+        s_raw_crash_data.backtrace[count++] = pc;
+      }
+    }
+    s_raw_crash_data.backtrace_count = count;
+  }
+
+#elif CONFIG_IDF_TARGET_ARCH_RISCV
+  // RISC-V: capture MEPC + RA, then scan stack for code addresses
+  if (info->frame != nullptr) {
+    auto *rv_frame = (RvExcFrame *) info->frame;
+    uint8_t count = 0;
+
+    // Save MEPC (fault PC) and RA (return address)
+    if (is_code_addr(rv_frame->mepc)) {
+      s_raw_crash_data.backtrace[count++] = rv_frame->mepc;
+    }
+    if (is_code_addr(rv_frame->ra) && rv_frame->ra != rv_frame->mepc) {
+      s_raw_crash_data.backtrace[count++] = rv_frame->ra;
+    }
+
+    // Scan stack for additional code addresses (like RP2040 approach)
+    auto *scan_start = (uint32_t *) rv_frame->sp;
+    for (uint32_t i = 0; i < 64 && count < MAX_BACKTRACE; i++) {
+      uint32_t val = scan_start[i];
+      if (is_code_addr(val) && val != rv_frame->mepc && val != rv_frame->ra) {
+        s_raw_crash_data.backtrace[count++] = val;
+      }
+    }
+    s_raw_crash_data.backtrace_count = count;
+  }
+#endif
+
+  // Write magic last — ensures all data is written before we mark it valid
+  s_raw_crash_data.magic = CRASH_MAGIC;
+
+  // Call the real panic handler (prints to UART, does core dump, reboots, etc.)
+  __real_esp_panic_handler(info);
+}
+
+}  // extern "C"
+
+#endif  // USE_ESP32

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -63,14 +63,17 @@ static inline bool is_return_addr(uint32_t addr) {
 // Magic is second to validate the data. Remaining fields can change between versions.
 // Version is uint32_t because it would be padded to 4 bytes anyway before the next
 // uint32_t field, so we use the full width rather than wasting 3 bytes of padding.
-static constexpr uint32_t CRASH_DATA_VERSION = 1;
+static constexpr uint32_t CRASH_DATA_VERSION = 2;
 struct RawCrashData {
   uint32_t version;
   uint32_t magic;
   uint32_t pc;
   uint8_t backtrace_count;
   uint8_t reg_frame_count;  // Number of entries from registers (not stack-scanned)
+  uint8_t exception;        // panic_exception_t enum (FAULT/ABORT/IWDT/TWDT/DEBUG)
+  uint8_t pseudo_excause;   // Whether cause is a pseudo exception (Xtensa SoC-level panic)
   uint32_t backtrace[MAX_BACKTRACE];
+  uint32_t cause;  // Architecture-specific: exccause (Xtensa) or mcause (RISC-V)
 };
 static RawCrashData __attribute__((section(".noinit")))
 s_raw_crash_data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -90,12 +93,121 @@ void crash_handler_read_and_clear() {
       s_raw_crash_data.backtrace_count = MAX_BACKTRACE;
     if (s_raw_crash_data.reg_frame_count > s_raw_crash_data.backtrace_count)
       s_raw_crash_data.reg_frame_count = s_raw_crash_data.backtrace_count;
+    if (s_raw_crash_data.exception > 4)  // panic_exception_t max value
+      s_raw_crash_data.exception = 4;    // Default to PANIC_EXCEPTION_FAULT
+    if (s_raw_crash_data.pseudo_excause > 1)
+      s_raw_crash_data.pseudo_excause = 0;
   }
   // Clear magic regardless so we don't re-report on next normal reboot
   s_raw_crash_data.magic = 0;
 }
 
 bool crash_handler_has_data() { return s_crash_data_valid; }
+
+// Look up the exception cause as a human-readable string.
+// Tables mirror ESP-IDF's panic_arch_fill_info() which uses local static arrays
+// not exposed via any public API.
+static const char *get_exception_reason() {
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+  if (s_raw_crash_data.pseudo_excause) {
+    // SoC-level panic: watchdog, cache error, etc.
+    // Keep in sync with ESP-IDF's PANIC_RSN_* defines
+    static const char *const pseudo_reason[] = {
+        "Unknown reason",                 // 0
+        "Unhandled debug exception",      // 1
+        "Double exception",               // 2
+        "Unhandled kernel exception",     // 3
+        "Coprocessor exception",          // 4
+        "Interrupt wdt timeout on CPU0",  // 5
+        "Interrupt wdt timeout on CPU1",  // 6
+        "Cache error",                    // 7
+    };
+    uint32_t cause = s_raw_crash_data.cause;
+    if (cause < sizeof(pseudo_reason) / sizeof(pseudo_reason[0]))
+      return pseudo_reason[cause];
+    return pseudo_reason[0];
+  }
+  // Real Xtensa exception
+  static const char *const reason[] = {
+      "IllegalInstruction",
+      "Syscall",
+      "InstructionFetchError",
+      "LoadStoreError",
+      "Level1Interrupt",
+      "Alloca",
+      "IntegerDivideByZero",
+      "PCValue",
+      "Privileged",
+      "LoadStoreAlignment",
+      nullptr,
+      nullptr,
+      "InstrPDAddrError",
+      "LoadStorePIFDataError",
+      "InstrPIFAddrError",
+      "LoadStorePIFAddrError",
+      "InstTLBMiss",
+      "InstTLBMultiHit",
+      "InstFetchPrivilege",
+      nullptr,
+      "InstrFetchProhibited",
+      nullptr,
+      nullptr,
+      nullptr,
+      "LoadStoreTLBMiss",
+      "LoadStoreTLBMultihit",
+      "LoadStorePrivilege",
+      nullptr,
+      "LoadProhibited",
+      "StoreProhibited",
+  };
+  uint32_t cause = s_raw_crash_data.cause;
+  if (cause < sizeof(reason) / sizeof(reason[0]) && reason[cause] != nullptr)
+    return reason[cause];
+#elif CONFIG_IDF_TARGET_ARCH_RISCV
+  // For SoC-level panics (watchdog, cache error), mcause holds IDF-internal
+  // interrupt numbers, not standard RISC-V cause codes. The exception type
+  // field already identifies these, so just return null to use the type name.
+  if (s_raw_crash_data.pseudo_excause)
+    return nullptr;
+  static const char *const reason[] = {
+      "Instruction address misaligned",
+      "Instruction access fault",
+      "Illegal instruction",
+      "Breakpoint",
+      "Load address misaligned",
+      "Load access fault",
+      "Store address misaligned",
+      "Store access fault",
+      "Environment call from U-mode",
+      "Environment call from S-mode",
+      nullptr,
+      "Environment call from M-mode",
+      "Instruction page fault",
+      "Load page fault",
+      nullptr,
+      "Store page fault",
+  };
+  uint32_t cause = s_raw_crash_data.cause;
+  if (cause < sizeof(reason) / sizeof(reason[0]) && reason[cause] != nullptr)
+    return reason[cause];
+#endif
+  return "Unknown";
+}
+
+// Exception type names matching panic_exception_t enum
+static const char *get_exception_type() {
+  static const char *const types[] = {
+      "Debug exception",  // PANIC_EXCEPTION_DEBUG
+      "Interrupt wdt",    // PANIC_EXCEPTION_IWDT
+      "Task wdt",         // PANIC_EXCEPTION_TWDT
+      "Abort",            // PANIC_EXCEPTION_ABORT
+      "Fault",            // PANIC_EXCEPTION_FAULT
+  };
+  uint8_t exc = s_raw_crash_data.exception;
+  if (exc < sizeof(types) / sizeof(types[0]))
+    return types[exc];
+  return "Unknown";
+}
 
 // Intentionally uses separate ESP_LOGE calls per line instead of combining into
 // one multi-line log message. This ensures each address appears as its own line
@@ -107,6 +219,12 @@ void crash_handler_log() {
     return;
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
+  const char *reason = get_exception_reason();
+  if (reason != nullptr) {
+    ESP_LOGE(TAG, "  Reason: %s - %s", get_exception_type(), reason);
+  } else {
+    ESP_LOGE(TAG, "  Reason: %s", get_exception_type());
+  }
   ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_raw_crash_data.pc);
   uint8_t bt_num = 0;
   for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count; i++) {
@@ -149,15 +267,18 @@ extern "C" {
 extern void __real_esp_panic_handler(panic_info_t *info);
 
 void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
-  // Save the faulting PC
+  // Save the faulting PC and exception info
   s_raw_crash_data.pc = (uint32_t) info->addr;
   s_raw_crash_data.backtrace_count = 0;
   s_raw_crash_data.reg_frame_count = 0;
+  s_raw_crash_data.exception = (uint8_t) info->exception;
+  s_raw_crash_data.pseudo_excause = info->pseudo_excause ? 1 : 0;
 
 #if CONFIG_IDF_TARGET_ARCH_XTENSA
   // Xtensa: walk the backtrace using the public API
   if (info->frame != nullptr) {
     auto *xt_frame = (XtExcFrame *) info->frame;
+    s_raw_crash_data.cause = xt_frame->exccause;
     esp_backtrace_frame_t bt_frame = {
         .pc = (uint32_t) xt_frame->pc,
         .sp = (uint32_t) xt_frame->a1,
@@ -188,6 +309,7 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   // RISC-V: capture MEPC + RA, then scan stack for code addresses
   if (info->frame != nullptr) {
     auto *rv_frame = (RvExcFrame *) info->frame;
+    s_raw_crash_data.cause = rv_frame->mcause;
     uint8_t count = 0;
 
     // Save MEPC (fault PC) and RA (return address)

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -89,6 +89,8 @@ void crash_handler_log() {
     pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_crash_data.backtrace[i]);
   }
   ESP_LOGE(TAG, "%s", hint);
+  // Clear so we don't re-log on subsequent API reconnects
+  s_crash_data.valid = false;
 }
 
 }  // namespace esphome::esp32
@@ -123,8 +125,9 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
 
     uint8_t count = 0;
     // First frame PC
-    if (is_code_addr(esp_cpu_process_stack_pc(bt_frame.pc))) {
-      s_raw_crash_data.backtrace[count++] = esp_cpu_process_stack_pc(bt_frame.pc);
+    uint32_t first_pc = esp_cpu_process_stack_pc(bt_frame.pc);
+    if (is_code_addr(first_pc)) {
+      s_raw_crash_data.backtrace[count++] = first_pc;
     }
     // Walk remaining frames
     while (count < MAX_BACKTRACE && bt_frame.next_pc != 0) {

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -114,6 +114,9 @@ void crash_handler_log() {
     pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, addr);
   }
   ESP_LOGE(TAG, "%s", hint);
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+  ESP_LOGE(TAG, "RISC-V backtrace is best-effort. Check serial console for full register dump.");
+#endif
 }
 
 }  // namespace esphome::esp32

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -28,11 +28,13 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 // Raw crash data written by the panic handler wrapper.
 // Lives in .noinit so it survives software reset but contains garbage after power cycle.
 // Validated by magic marker. Static linkage since it's only used within this file.
+// Field order matters: magic, pc, and backtrace_count are at fixed offsets
+// so the struct remains readable even if MAX_BACKTRACE changes between versions.
 struct RawCrashData {
   uint32_t magic;
   uint32_t pc;
-  uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
+  uint32_t backtrace[MAX_BACKTRACE];
 };
 static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -26,16 +26,14 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 }
 
 // Raw crash data written by the panic handler wrapper.
-// Lives in .noinit so it survives software reset.
-// Defined at file scope (outside any namespace) because both the namespace
-// functions and the extern "C" panic handler wrapper need to access it.
-struct RawCrashData {
+// Lives in .noinit so it survives software reset but contains garbage after power cycle.
+// Validated by magic marker. Static linkage since it's only used within this file.
+static struct {
   uint32_t magic;
   uint32_t pc;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-};
-extern RawCrashData s_raw_crash_data;
+} __attribute__((section(".noinit"))) s_raw_crash_data;
 
 namespace esphome::esp32 {
 
@@ -89,8 +87,6 @@ void crash_handler_log() {
     pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_crash_data.backtrace[i]);
   }
   ESP_LOGE(TAG, "%s", hint);
-  // Clear so we don't re-log on subsequent API reconnects
-  s_crash_data.valid = false;
 }
 
 }  // namespace esphome::esp32
@@ -99,11 +95,6 @@ void crash_handler_log() {
 // Intercepts esp_panic_handler() via --wrap linker flag to capture crash data
 // into NOINIT memory before the normal panic handler runs.
 //
-// The raw crash data struct must be separate from the read-side struct to avoid
-// BSS initialization conflicts. It lives in .noinit so it survives software reset.
-
-RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
-
 extern "C" {
 extern void __real_esp_panic_handler(panic_info_t *info);
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -32,10 +32,14 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 static inline bool is_return_addr(uint32_t addr) {
   if (!is_code_addr(addr) || addr < 4)
     return false;
+  // A return address on the stack points to the instruction after a call.
+  // Read the 4-byte instruction immediately before this address.
   uint32_t inst = *(uint32_t *) (addr - 4);
-  uint32_t opcode = inst & 0x7f;
-  // JAL (opcode 0x6f) or JALR (opcode 0x67) with rd=x1 (ra)
-  return (opcode == 0x6f || opcode == 0x67) && (inst & 0xf80) == 0x80;
+  // RISC-V instruction encoding: bits [6:0] = opcode, bits [11:7] = rd
+  uint32_t opcode = inst & 0x7f;  // Extract 7-bit opcode
+  uint32_t rd = inst & 0xf80;     // Extract rd field (bits 11:7)
+  // Match JAL (0x6f) or JALR (0x67) with rd=ra (x1, encoded as 0x80 = 1<<7)
+  return (opcode == 0x6f || opcode == 0x67) && rd == 0x80;
 }
 #endif
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -112,7 +112,7 @@ static const char *get_exception_reason() {
   if (s_raw_crash_data.pseudo_excause) {
     // SoC-level panic: watchdog, cache error, etc.
     // Keep in sync with ESP-IDF's PANIC_RSN_* defines
-    static const char *const pseudo_reason[] = {
+    static const char *const PSEUDO_REASON[] = {
         "Unknown reason",                 // 0
         "Unhandled debug exception",      // 1
         "Double exception",               // 2
@@ -123,12 +123,12 @@ static const char *get_exception_reason() {
         "Cache error",                    // 7
     };
     uint32_t cause = s_raw_crash_data.cause;
-    if (cause < sizeof(pseudo_reason) / sizeof(pseudo_reason[0]))
-      return pseudo_reason[cause];
-    return pseudo_reason[0];
+    if (cause < sizeof(PSEUDO_REASON) / sizeof(PSEUDO_REASON[0]))
+      return PSEUDO_REASON[cause];
+    return PSEUDO_REASON[0];
   }
   // Real Xtensa exception
-  static const char *const reason[] = {
+  static const char *const REASON[] = {
       "IllegalInstruction",
       "Syscall",
       "InstructionFetchError",
@@ -161,15 +161,15 @@ static const char *get_exception_reason() {
       "StoreProhibited",
   };
   uint32_t cause = s_raw_crash_data.cause;
-  if (cause < sizeof(reason) / sizeof(reason[0]) && reason[cause] != nullptr)
-    return reason[cause];
+  if (cause < sizeof(REASON) / sizeof(reason[0]) && REASON[cause] != nullptr)
+    return REASON[cause];
 #elif CONFIG_IDF_TARGET_ARCH_RISCV
   // For SoC-level panics (watchdog, cache error), mcause holds IDF-internal
   // interrupt numbers, not standard RISC-V cause codes. The exception type
   // field already identifies these, so just return null to use the type name.
   if (s_raw_crash_data.pseudo_excause)
     return nullptr;
-  static const char *const reason[] = {
+  static const char *const REASON[] = {
       "Instruction address misaligned",
       "Instruction access fault",
       "Illegal instruction",
@@ -188,15 +188,15 @@ static const char *get_exception_reason() {
       "Store page fault",
   };
   uint32_t cause = s_raw_crash_data.cause;
-  if (cause < sizeof(reason) / sizeof(reason[0]) && reason[cause] != nullptr)
-    return reason[cause];
+  if (cause < sizeof(REASON) / sizeof(reason[0]) && REASON[cause] != nullptr)
+    return REASON[cause];
 #endif
   return "Unknown";
 }
 
 // Exception type names matching panic_exception_t enum
 static const char *get_exception_type() {
-  static const char *const types[] = {
+  static const char *const TYPES[] = {
       "Debug exception",  // PANIC_EXCEPTION_DEBUG
       "Interrupt wdt",    // PANIC_EXCEPTION_IWDT
       "Task wdt",         // PANIC_EXCEPTION_TWDT
@@ -204,8 +204,8 @@ static const char *get_exception_type() {
       "Fault",            // PANIC_EXCEPTION_FAULT
   };
   uint8_t exc = s_raw_crash_data.exception;
-  if (exc < sizeof(types) / sizeof(types[0]))
-    return types[exc];
+  if (exc < sizeof(TYPES) / sizeof(TYPES[0]))
+    return TYPES[exc];
   return "Unknown";
 }
 

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -161,7 +161,7 @@ static const char *get_exception_reason() {
       "StoreProhibited",
   };
   uint32_t cause = s_raw_crash_data.cause;
-  if (cause < sizeof(REASON) / sizeof(reason[0]) && REASON[cause] != nullptr)
+  if (cause < sizeof(REASON) / sizeof(REASON[0]) && REASON[cause] != nullptr)
     return REASON[cause];
 #elif CONFIG_IDF_TARGET_ARCH_RISCV
   // For SoC-level panics (watchdog, cache error), mcause holds IDF-internal
@@ -188,7 +188,7 @@ static const char *get_exception_reason() {
       "Store page fault",
   };
   uint32_t cause = s_raw_crash_data.cause;
-  if (cause < sizeof(REASON) / sizeof(reason[0]) && REASON[cause] != nullptr)
+  if (cause < sizeof(REASON) / sizeof(REASON[0]) && REASON[cause] != nullptr)
     return REASON[cause];
 #endif
   return "Unknown";

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -36,36 +36,25 @@ struct RawCrashData {
 };
 static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
 
+// Whether crash data was found and validated this boot.
+static bool s_crash_data_valid = false;
+
 namespace esphome::esp32 {
 
 static const char *const TAG = "esp32.crash";
 
-// Validated crash data — populated by crash_handler_read_and_clear() from the
-// raw NOINIT data written by the panic handler wrapper.
-static struct {
-  bool valid;
-  uint32_t pc;
-  uint32_t backtrace[MAX_BACKTRACE];
-  uint8_t backtrace_count;
-} s_crash_data;
-
 void crash_handler_read_and_clear() {
-  s_crash_data.valid = false;
   if (s_raw_crash_data.magic == CRASH_MAGIC) {
-    s_crash_data.valid = true;
-    s_crash_data.pc = s_raw_crash_data.pc;
-    s_crash_data.backtrace_count = s_raw_crash_data.backtrace_count;
-    if (s_crash_data.backtrace_count > MAX_BACKTRACE)
-      s_crash_data.backtrace_count = MAX_BACKTRACE;
-    for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
-      s_crash_data.backtrace[i] = s_raw_crash_data.backtrace[i];
-    }
+    s_crash_data_valid = true;
+    // Clamp backtrace count to prevent out-of-bounds reads from corrupt .noinit data
+    if (s_raw_crash_data.backtrace_count > MAX_BACKTRACE)
+      s_raw_crash_data.backtrace_count = MAX_BACKTRACE;
   }
   // Clear magic regardless so we don't re-report on next normal reboot
   s_raw_crash_data.magic = 0;
 }
 
-bool crash_handler_has_data() { return s_crash_data.valid; }
+bool crash_handler_has_data() { return s_crash_data_valid; }
 
 // Intentionally uses separate ESP_LOGE calls per line instead of combining into
 // one multi-line log message. This ensures each address appears as its own line
@@ -73,19 +62,19 @@ bool crash_handler_has_data() { return s_crash_data.valid; }
 // crashes again during boot, and allowing the CLI's process_stacktrace to match
 // and decode each address individually.
 void crash_handler_log() {
-  if (!s_crash_data.valid)
+  if (!s_crash_data_valid)
     return;
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
-  ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_crash_data.pc);
-  for (uint8_t i = 0; i < s_crash_data.backtrace_count; i++) {
-    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", i, s_crash_data.backtrace[i]);
+  ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_raw_crash_data.pc);
+  for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count; i++) {
+    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", i, s_raw_crash_data.backtrace[i]);
   }
   // Build addr2line hint with all captured addresses for easy copy-paste
   char hint[256];
-  int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_crash_data.pc);
-  for (uint8_t i = 0; i < s_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
-    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_crash_data.backtrace[i]);
+  int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_raw_crash_data.pc);
+  for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
+    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_raw_crash_data.backtrace[i]);
   }
   ESP_LOGE(TAG, "%s", hint);
 }

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -25,6 +25,20 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
   return (addr >= SOC_IROM_LOW && addr < SOC_IROM_HIGH) || (addr >= SOC_IRAM_LOW && addr < SOC_IRAM_HIGH);
 }
 
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+// Check if a code address is a real return address by verifying the preceding
+// instruction is a JAL or JALR with rd=ra (x1). Called at log time (not during
+// panic) so flash cache is available and both IRAM and IROM are safely readable.
+static inline bool is_return_addr(uint32_t addr) {
+  if (!is_code_addr(addr) || addr < 4)
+    return false;
+  uint32_t inst = *(uint32_t *) (addr - 4);
+  uint32_t opcode = inst & 0x7f;
+  // JAL (opcode 0x6f) or JALR (opcode 0x67) with rd=x1 (ra)
+  return (opcode == 0x6f || opcode == 0x67) && (inst & 0xf80) == 0x80;
+}
+#endif
+
 // Raw crash data written by the panic handler wrapper.
 // Lives in .noinit so it survives software reset but contains garbage after power cycle.
 // Validated by magic marker. Static linkage since it's only used within this file.
@@ -73,14 +87,27 @@ void crash_handler_log() {
 
   ESP_LOGE(TAG, "*** CRASH DETECTED ON PREVIOUS BOOT ***");
   ESP_LOGE(TAG, "  PC:  0x%08" PRIX32 "  (fault location)", s_raw_crash_data.pc);
+  uint8_t bt_num = 0;
   for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count; i++) {
-    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", i, s_raw_crash_data.backtrace[i]);
+    uint32_t addr = s_raw_crash_data.backtrace[i];
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+    // Filter stack-scanned addresses: skip values that aren't preceded by a
+    // JAL/JALR call instruction. Safe to check here since flash cache is up.
+    if (!is_return_addr(addr))
+      continue;
+#endif
+    ESP_LOGE(TAG, "  BT%d: 0x%08" PRIX32 "  (backtrace)", bt_num++, addr);
   }
   // Build addr2line hint with all captured addresses for easy copy-paste
   char hint[256];
   int pos = snprintf(hint, sizeof(hint), "Use: addr2line -pfiaC -e firmware.elf 0x%08" PRIX32, s_raw_crash_data.pc);
   for (uint8_t i = 0; i < s_raw_crash_data.backtrace_count && pos < (int) sizeof(hint) - 12; i++) {
-    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, s_raw_crash_data.backtrace[i]);
+    uint32_t addr = s_raw_crash_data.backtrace[i];
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+    if (!is_return_addr(addr))
+      continue;
+#endif
+    pos += snprintf(hint + pos, sizeof(hint) - pos, " 0x%08" PRIX32, addr);
   }
   ESP_LOGE(TAG, "%s", hint);
 }
@@ -143,7 +170,8 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
       s_raw_crash_data.backtrace[count++] = rv_frame->ra;
     }
 
-    // Scan stack for additional code addresses (like RP2040 approach)
+    // Scan stack for code addresses — captures broadly during panic,
+    // filtered by is_return_addr() at log time when flash is accessible.
     auto *scan_start = (uint32_t *) rv_frame->sp;
     for (uint32_t i = 0; i < 64 && count < MAX_BACKTRACE; i++) {
       uint32_t val = scan_start[i];

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -4,6 +4,7 @@
 #include "esphome/core/log.h"
 
 #include <cinttypes>
+#include <cstring>
 #include <esp_attr.h>
 #include <esp_private/panic_internal.h>
 #include <soc/soc.h>
@@ -34,7 +35,10 @@ static inline bool is_return_addr(uint32_t addr) {
     return false;
   // A return address on the stack points to the instruction after a call.
   // Check for 4-byte JAL/JALR call instruction before this address.
-  uint32_t inst = *(uint32_t *) (addr - 4);
+  // Use memcpy for alignment safety — RISC-V C extension means code addresses
+  // are only 2-byte aligned, so addr-4 may not be 4-byte aligned.
+  uint32_t inst;
+  memcpy(&inst, (const void *) (addr - 4), sizeof(inst));
   // RISC-V instruction encoding: bits [6:0] = opcode, bits [11:7] = rd
   uint32_t opcode = inst & 0x7f;  // Extract 7-bit opcode
   uint32_t rd = inst & 0xf80;     // Extract rd field (bits 11:7)

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -58,10 +58,11 @@ struct RawCrashData {
   uint8_t backtrace_count;
   uint32_t backtrace[MAX_BACKTRACE];
 };
-static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;
+static RawCrashData __attribute__((section(".noinit")))
+s_raw_crash_data;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 // Whether crash data was found and validated this boot.
-static bool s_crash_data_valid = false;
+static bool s_crash_data_valid = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 namespace esphome::esp32 {
 
@@ -123,6 +124,8 @@ void crash_handler_log() {
 // into NOINIT memory before the normal panic handler runs.
 //
 extern "C" {
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+// Names are mandated by the --wrap linker mechanism
 extern void __real_esp_panic_handler(panic_info_t *info);
 
 void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
@@ -195,6 +198,7 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
   __real_esp_panic_handler(info);
 }
 
+// NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 }  // extern "C"
 
 #endif  // USE_ESP32

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -28,15 +28,14 @@ static inline bool IRAM_ATTR is_code_addr(uint32_t addr) {
 // Raw crash data written by the panic handler wrapper.
 // Lives in .noinit so it survives software reset but contains garbage after power cycle.
 // Validated by magic marker. Static linkage since it's only used within this file.
-// Field order matters: magic, version, pc, and backtrace_count are at fixed offsets
-// so the struct remains readable even if MAX_BACKTRACE changes between versions.
-static constexpr uint8_t CRASH_DATA_VERSION = 1;
+// Version field is first so future firmware can always identify the struct layout.
+// Magic is second to validate the data. Remaining fields can change between versions.
+static constexpr uint32_t CRASH_DATA_VERSION = 1;
 struct RawCrashData {
+  uint32_t version;
   uint32_t magic;
   uint32_t pc;
-  uint8_t version;
   uint8_t backtrace_count;
-  // 2 bytes padding here, then backtrace array
   uint32_t backtrace[MAX_BACKTRACE];
 };
 static RawCrashData __attribute__((section(".noinit"))) s_raw_crash_data;

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -1,5 +1,8 @@
 #ifdef USE_ESP32
 
+#include "esphome/core/defines.h"
+#ifdef USE_ESP32_CRASH_HANDLER
+
 #include "crash_handler.h"
 #include "esphome/core/log.h"
 
@@ -348,4 +351,5 @@ void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t *info) {
 // NOLINTEND(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 }  // extern "C"
 
+#endif  // USE_ESP32_CRASH_HANDLER
 #endif  // USE_ESP32

--- a/esphome/components/esp32/crash_handler.h
+++ b/esphome/components/esp32/crash_handler.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_ESP32
+#ifdef USE_ESP32_CRASH_HANDLER
 
 namespace esphome::esp32 {
 
@@ -15,4 +15,4 @@ bool crash_handler_has_data();
 
 }  // namespace esphome::esp32
 
-#endif  // USE_ESP32
+#endif  // USE_ESP32_CRASH_HANDLER

--- a/esphome/components/esp32/crash_handler.h
+++ b/esphome/components/esp32/crash_handler.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef USE_ESP32
+
+#include <cstdint>
+
+namespace esphome::esp32 {
+
+/// Read crash data from NOINIT memory and clear the magic marker.
+void crash_handler_read_and_clear();
+
+/// Log crash data if a crash was detected on previous boot.
+void crash_handler_log();
+
+/// Returns true if crash data was found this boot.
+bool crash_handler_has_data();
+
+}  // namespace esphome::esp32
+
+#endif  // USE_ESP32

--- a/esphome/components/esp32/crash_handler.h
+++ b/esphome/components/esp32/crash_handler.h
@@ -2,8 +2,6 @@
 
 #ifdef USE_ESP32
 
-#include <cstdint>
-
 namespace esphome::esp32 {
 
 /// Read crash data from NOINIT memory and clear the magic marker.

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -118,7 +118,9 @@ void Logger::pre_setup() {
   esp_log_set_vprintf(esp_idf_log_vprintf_);
 
   ESP_LOGI(TAG, "Log initialized");
+#ifdef USE_ESP32_CRASH_HANDLER
   esp32::crash_handler_log();
+#endif
 }
 
 void HOT Logger::write_msg_(const char *msg, uint16_t len) {

--- a/esphome/components/logger/logger_esp32.cpp
+++ b/esphome/components/logger/logger_esp32.cpp
@@ -1,6 +1,7 @@
 #ifdef USE_ESP32
 #include "logger.h"
 
+#include "esphome/components/esp32/crash_handler.h"
 #include <esp_log.h>
 
 #include <driver/uart.h>
@@ -117,6 +118,7 @@ void Logger::pre_setup() {
   esp_log_set_vprintf(esp_idf_log_vprintf_);
 
   ESP_LOGI(TAG, "Log initialized");
+  esp32::crash_handler_log();
 }
 
 void HOT Logger::write_msg_(const char *msg, uint16_t len) {

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -195,6 +195,7 @@
 
 // ESP32-specific feature flags
 #ifdef USE_ESP32
+#define USE_ESP32_CRASH_HANDLER
 #define USE_MQTT_IDF_ENQUEUE
 #define USE_ESPHOME_TASK_LOG_BUFFER
 #define USE_OTA_ROLLBACK

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -340,6 +340,8 @@ STACKTRACE_ESP32_BACKTRACE_RE = re.compile(
     r"Backtrace:(?:\s*0x[0-9a-fA-F]{8}:0x[0-9a-fA-F]{8})+"
 )
 STACKTRACE_ESP32_BACKTRACE_PC_RE = re.compile(r"4[0-9a-f]{7}")
+# ESP32 crash handler (stored backtrace from previous boot)
+STACKTRACE_ESP32_CRASH_BT_RE = re.compile(r"BT\d+:\s*0x([0-9a-fA-F]{8})")
 STACKTRACE_ESP8266_BACKTRACE_PC_RE = re.compile(r"4[0-9a-f]{7}")
 
 
@@ -369,6 +371,11 @@ def process_stacktrace(config, line, backtrace_state):
         _LOGGER.warning(
             "Memory allocation of %s bytes failed at %s", match.group(2), match.group(1)
         )
+        _decode_pc(config, match.group(1))
+
+    # ESP32 crash handler backtrace (from previous boot)
+    match = re.search(STACKTRACE_ESP32_CRASH_BT_RE, line)
+    if match is not None:
         _decode_pc(config, match.group(1))
 
     # ESP32 single-line backtrace

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -673,6 +673,34 @@ def test_process_stacktrace_bad_alloc(
     assert state is False
 
 
+def test_process_stacktrace_esp32_crash_handler(
+    setup_core: Path, mock_decode_pc: Mock
+) -> None:
+    """Test process_stacktrace handles ESP32 crash handler backtrace lines."""
+    config = {"name": "test"}
+
+    # Simulate crash handler log lines as they appear from the API/serial
+    line_pc = "[E][esp32.crash:078]:   PC:  0x400D1234  (fault location)"
+    state = platformio_api.process_stacktrace(config, line_pc, False)
+    # PC line is matched by existing STACKTRACE_ESP32_PC_RE
+    mock_decode_pc.assert_called_with(config, "400D1234")
+    assert state is False
+
+    mock_decode_pc.reset_mock()
+
+    line_bt0 = "[E][esp32.crash:080]:   BT0: 0x400D5678  (backtrace)"
+    state = platformio_api.process_stacktrace(config, line_bt0, False)
+    mock_decode_pc.assert_called_once_with(config, "400D5678")
+    assert state is False
+
+    mock_decode_pc.reset_mock()
+
+    line_bt1 = "[E][esp32.crash:080]:   BT1: 0x42005ABC  (backtrace)"
+    state = platformio_api.process_stacktrace(config, line_bt1, False)
+    mock_decode_pc.assert_called_once_with(config, "42005ABC")
+    assert state is False
+
+
 def test_patch_file_downloader_succeeds_first_try() -> None:
     """Test patch_file_downloader succeeds on first attempt."""
     mock_exception_cls = type("PackageException", (Exception,), {})


### PR DESCRIPTION
# What does this implement/fix?

When an ESP32 device crashes, the backtrace is printed to UART during the panic handler and then lost. Users without a serial cable connected never see this diagnostic information, making it very difficult to debug crashes on deployed devices.

This PR adds a crash handler for the **ESP-IDF framework** that captures the backtrace during a panic, stores it in `.noinit` memory (survives software reset), and logs it:
1. **At boot** via `ESP_LOGE` on the serial console
2. **When Home Assistant subscribes to logs** so it appears in the HA log viewer without needing a serial cable

The CLI's `process_stacktrace` has been updated to decode the new `BT\d+:` format automatically, so addresses are resolved inline.

### Memory cost

+92 bytes RAM, +1,092 bytes flash. The RAM is one 84-byte `.noinit` struct for crash data plus a single bool for validation state. The flash covers the full panic wrapper, backtrace walker, exception cause lookup tables, log formatting, and addr2line hint builder. A worthwhile trade for crash diagnostics without a serial cable.

### How it works

- Uses the `--wrap=esp_panic_handler` linker flag to intercept the ESP-IDF panic handler
- In the wrapper, extracts the faulting PC, backtrace, and exception cause from the exception frame
- Stores crash data in a `.noinit` section with a magic marker and version field for validation
- On next boot, reads and validates the stored data, then logs it with human-readable exception reasons
- **Xtensa** (ESP32/S2/S3): Walks the backtrace using `esp_backtrace_get_next_frame()` (public, IRAM-safe API)
- **RISC-V** (C3/C6/H2/C2): Captures MEPC + RA, then scans the stack for code addresses. Stack-scanned entries are validated at log time by checking the preceding instruction is a JAL/JALR/c.jalr call, and labeled `(stack scan)` to distinguish from trusted register-sourced `(backtrace)` entries.

### Forward compatibility

The `.noinit` struct starts with a `version` field (uint32_t) at offset 0, followed by the magic marker. This ensures future firmware can always identify the struct layout by reading the first word, even if the rest of the struct changes completely. The version is uint32_t rather than uint8_t because alignment would pad it to 4 bytes anyway. If a future version needs to change the struct layout (e.g., adding task name), it bumps the version and the reader can handle both formats or skip unrecognized versions.

### Limitations

- Captures up to **16 backtrace frames** (ESP-IDF's built-in panic handler walks up to 100). In practice 16 is sufficient — real-world crashes typically produce 8-15 frames. Increasing to 100 would cost an additional 336 bytes of RAM.
- Only survives **software reset**, not power cycle (`.noinit` memory contains garbage after power loss, validated by magic marker).
- **ESP-IDF framework only** — the Arduino framework already wraps `esp_panic_handler` in `esp32-hal-misc.c`, so this feature is not available when using the Arduino framework.
- **RISC-V** backtrace is best-effort via stack scanning (no frame pointer chain), so some frames may be missed or spurious. Return addresses are validated at log time by checking that the preceding instruction is a JAL/JALR/c.jalr call, which filters many false positives. Stack-scanned entries are labeled `(stack scan)` in the output to distinguish them from trusted register-sourced entries labeled `(backtrace)`, so users can tell which frames to trust. Note: our crash handler actually provides a *better* RISC-V backtrace than ESP-IDF's built-in panic output, which only dumps raw stack memory without any address decoding.

### Example: Xtensa (ESP32) — `esphome logs` over API after a null-pointer crash

```
INFO Starting log output from ol.local using esphome API
INFO Successfully connected to ol @ 192.168.107.62 in 0.004s
INFO Successful handshake with ol @ 192.168.107.62 in 0.012s
[12:31:55][E][esp32.crash:221]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[12:31:55][E][esp32.crash:224]:   Reason: Fault - StoreProhibited
[12:31:55][E][esp32.crash:228]:   PC:  0x4011AD40  (fault location)
WARNING Decoded 0x4011ad40: setup()::{lambda()#1}::_FUN() at ol.yaml:89
[12:31:55][E][esp32.crash:242]:   BT0: 0x4011AD3D  (backtrace)
WARNING Decoded 0x4011ad3d: setup()::{lambda()#1}::_FUN() at ol.yaml:89
[12:31:55][E][esp32.crash:242]:   BT1: 0x4011AD95  (backtrace)
WARNING Decoded 0x4011ad95: esphome::StatelessLambdaAction<>::play()
[12:31:56][E][esp32.crash:242]:   BT2: 0x4011AD77  (backtrace)
WARNING Decoded 0x4011ad77: esphome::Action<>::play_complex()
[12:31:56][E][esp32.crash:242]:   BT3: 0x4011AE6D  (backtrace)
WARNING Decoded 0x4011ae6d: esphome::ActionList<>::play()
[12:31:56][E][esp32.crash:242]:   BT4: 0x400D6C7E  (backtrace)
WARNING Decoded 0x400d6c7e: esphome::button::Button::press()
[12:31:56][E][esp32.crash:242]:   BT5: 0x400D385C  (backtrace)
WARNING Decoded 0x400d385c: esphome::api::APIConnection::on_button_command_request()
[12:31:56][E][esp32.crash:242]:   BT6: 0x400D6251  (backtrace)
WARNING Decoded 0x400d6251: esphome::api::APIServerConnectionBase::read_message()
[12:31:56][E][esp32.crash:242]:   BT7: 0x400D4A08  (backtrace)
WARNING Decoded 0x400d4a08: esphome::api::APIConnection::loop()
[12:31:56][E][esp32.crash:242]:   BT8: 0x400D687C  (backtrace)
WARNING Decoded 0x400d687c: esphome::api::APIServer::loop()
[12:31:56][E][esp32.crash:242]:   BT9: 0x400E122D  (backtrace)
WARNING Decoded 0x400e122d: esphome::Application::loop()
[12:31:56][E][esp32.crash:242]:   BT10: 0x400E3A66  (backtrace)
WARNING Decoded 0x400e3a66: loop() at ol.yaml:1609
[12:31:56][E][esp32.crash:242]:   BT11: 0x400D78F2  (backtrace)
WARNING Decoded 0x400d78f2: esphome::loop_task(void*)
[12:31:56][E][esp32.crash:255]: Use: addr2line -pfiaC -e firmware.elf 0x4011AD40 0x4011AD3D 0x4011AD95 0x4011AD77 0x4011AE6D 0x400D6C7E 0x400D385C 0x400D6251 0x400D4A08 0x400D687C 0x400E122D 0x400E3A66 0x400D78F2
```

### Example: RISC-V (ESP32-C3) — null-pointer crash

```
[12:32:04][E][esp32.crash:221]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[12:32:04][E][esp32.crash:224]:   Reason: Fault - Store access fault
[12:32:04][E][esp32.crash:228]:   PC:  0x4200C35C  (fault location)
WARNING Decoded 0x4200c35c: setup()::{lambda()#1}::_FUN() at c3test.yaml:38
[12:32:04][E][esp32.crash:242]:   BT0: 0x4200C35C  (backtrace)
WARNING Decoded 0x4200c35c: setup()::{lambda()#1}::_FUN() at c3test.yaml:38
[12:32:05][E][esp32.crash:242]:   BT1: 0x4200C386  (backtrace)
WARNING Decoded 0x4200c386: esphome::Action<>::play_complex()
[12:32:05][E][esp32.crash:242]:   BT2: 0x42003356  (stack scan)
WARNING Decoded 0x42003356: esphome::button::Button::press()
[12:32:05][E][esp32.crash:242]:   BT3: 0x42002914  (stack scan)
WARNING Decoded 0x42002914: esphome::api::APIServerConnectionBase::read_message()
[12:32:05][E][esp32.crash:242]:   BT4: 0x42001E6E  (stack scan)
WARNING Decoded 0x42001e6e: esphome::api::APIPlaintextFrameHelper::try_read_frame_()
[12:32:05][E][esp32.crash:242]:   BT5: 0x420014B8  (stack scan)
WARNING Decoded 0x420014b8: esphome::api::APIConnection::loop()
[12:32:05][E][esp32.crash:242]:   BT6: 0x42003068  (stack scan)
WARNING Decoded 0x42003068: esphome::api::APIServer::loop()
[12:32:05][E][esp32.crash:242]:   BT7: 0x4200A74A  (stack scan)
WARNING Decoded 0x4200a74a: esphome::Application::loop()
[12:32:05][E][esp32.crash:255]: Use: addr2line -pfiaC -e firmware.elf 0x4200C35C 0x4200C35C 0x4200C386 0x42003356 0x42002914 0x42001E6E 0x420014B8 0x42003068 0x4200A74A
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6258

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Compiled and verified on ESP32 (Xtensa), ESP32-S3 (Xtensa), and ESP32-C3 (RISC-V).

## Example entry for `config.yaml`:

No configuration needed — the crash handler is automatically enabled for all ESP32 devices using the ESP-IDF framework (the default). Crash data from the previous boot (if any) will appear in the serial log at boot and in the HA log viewer when the API connects. Not available when using the Arduino framework.

To test the crash handler, add a button that triggers a null pointer crash:

```yaml
button:
  - platform: template
    name: "Crash: Null Pointer"
    on_press:
      - lambda: |-
          volatile int *p = nullptr;
          *p = 42;
```

Press the button from Home Assistant, then run `esphome logs` to see the captured crash data after reboot.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).