### PR TITLE
[tests] Disable LeakSanitizer in C++ unit tests

### DIFF
--- a/script/cpp_unit_test.py
+++ b/script/cpp_unit_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 from functools import partial
+import os
 from pathlib import Path
 import sys
 
@@ -35,6 +36,7 @@ PLATFORMIO_OPTIONS = {
 
 
 def run_tests(selected_components: list[str]) -> int:
+    os.environ["ASAN_OPTIONS"] = "detect_leaks=0"
     return build_and_run(
         selected_components=selected_components,
         tests_dir=COMPONENTS_TESTS_DIR,


### PR DESCRIPTION
## What does this implement/fix?

Disables LeakSanitizer (LSAN) in the C++ unit test suite by setting `ASAN_OPTIONS=detect_leaks=0` before running tests.

ESPHome uses intentional permanent allocations — objects created with `new` that are never freed because they must outlive the program. Under AddressSanitizer + LeakSanitizer (enabled in the C++ unit test suite) these show up as false-positive leaks and fail the test run.

This globally disables leak detection for all C++ unit tests.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

N/A — LSan false positives surfaced during internal C++ unit test development.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

All 190 C++ unit tests pass (`./script/cpp_unit_test.py --all`) with LeakSanitizer disabled. No changes to firmware builds.

## Example entry for `config.yaml`:

```yaml
# No user-facing configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).