### PR TITLE
[ethernet] ESP32-P4 Ethernet compilation fix

### DIFF
--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -21,22 +21,6 @@
 
 namespace esphome::ethernet {
 
-#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 4, 2)
-// work around IDF compile issue on P4 https://github.com/espressif/esp-idf/pull/15637
-#ifdef USE_ESP32_VARIANT_ESP32P4
-#undef ETH_ESP32_EMAC_DEFAULT_CONFIG
-#define ETH_ESP32_EMAC_DEFAULT_CONFIG() \
-  { \
-    .smi_gpio = {.mdc_num = 31, .mdio_num = 52}, .interface = EMAC_DATA_INTERFACE_RMII, \
-    .clock_config = {.rmii = {.clock_mode = EMAC_CLK_EXT_IN, .clock_gpio = (emac_rmii_clock_gpio_t) 50}}, \
-    .dma_burst_len = ETH_DMA_BURST_LEN_32, .intr_priority = 0, \
-    .emac_dataif_gpio = \
-        {.rmii = {.tx_en_num = 49, .txd0_num = 34, .txd1_num = 35, .crs_dv_num = 28, .rxd0_num = 29, .rxd1_num = 30}}, \
-    .clock_config_out_in = {.rmii = {.clock_mode = EMAC_CLK_EXT_IN, .clock_gpio = (emac_rmii_clock_gpio_t) -1}}, \
-  }
-#endif
-#endif
-
 static const char *const TAG = "ethernet";
 
 // PHY register size for hex logging
@@ -162,7 +146,33 @@ void EthernetComponent::setup() {
   phy_config.phy_addr = this->phy_addr_;
   phy_config.reset_gpio_num = this->power_pin_;
 
-  eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+  eth_esp32_emac_config_t esp32_emac_config{};
+#if CONFIG_IDF_TARGET_ESP32P4
+  // Avoid ETH_ESP32_EMAC_DEFAULT_CONFIG() on ESP32-P4 because some ESP-IDF releases
+  // use out-of-order designated initializers, which fail in C++ mode.
+  esp32_emac_config.smi_gpio.mdc_num = 31;
+  esp32_emac_config.smi_gpio.mdio_num = 52;
+  esp32_emac_config.interface = EMAC_DATA_INTERFACE_RMII;
+  esp32_emac_config.clock_config.rmii.clock_mode = EMAC_CLK_EXT_IN;
+  esp32_emac_config.clock_config.rmii.clock_gpio = (emac_rmii_clock_gpio_t) 50;
+  esp32_emac_config.dma_burst_len = ETH_DMA_BURST_LEN_32;
+  esp32_emac_config.intr_priority = 0;
+#if SOC_EMAC_USE_MULTI_IO_MUX || SOC_EMAC_MII_USE_GPIO_MATRIX
+  esp32_emac_config.emac_dataif_gpio.rmii.tx_en_num = 49;
+  esp32_emac_config.emac_dataif_gpio.rmii.txd0_num = 34;
+  esp32_emac_config.emac_dataif_gpio.rmii.txd1_num = 35;
+  esp32_emac_config.emac_dataif_gpio.rmii.crs_dv_num = 28;
+  esp32_emac_config.emac_dataif_gpio.rmii.rxd0_num = 29;
+  esp32_emac_config.emac_dataif_gpio.rmii.rxd1_num = 30;
+#endif
+#if !SOC_EMAC_RMII_CLK_OUT_INTERNAL_LOOPBACK
+  esp32_emac_config.clock_config_out_in.rmii.clock_mode = EMAC_CLK_EXT_IN;
+  esp32_emac_config.clock_config_out_in.rmii.clock_gpio = (emac_rmii_clock_gpio_t) -1;
+#endif
+  esp32_emac_config.mdc_freq_hz = 0;
+#else
+  esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+#endif
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
   esp32_emac_config.smi_gpio.mdc_num = this->mdc_pin_;
   esp32_emac_config.smi_gpio.mdio_num = this->mdio_pin_;

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -146,33 +146,7 @@ void EthernetComponent::setup() {
   phy_config.phy_addr = this->phy_addr_;
   phy_config.reset_gpio_num = this->power_pin_;
 
-  eth_esp32_emac_config_t esp32_emac_config{};
-#if CONFIG_IDF_TARGET_ESP32P4
-  // Avoid ETH_ESP32_EMAC_DEFAULT_CONFIG() on ESP32-P4 because some ESP-IDF releases
-  // use out-of-order designated initializers, which fail in C++ mode.
-  esp32_emac_config.smi_gpio.mdc_num = 31;
-  esp32_emac_config.smi_gpio.mdio_num = 52;
-  esp32_emac_config.interface = EMAC_DATA_INTERFACE_RMII;
-  esp32_emac_config.clock_config.rmii.clock_mode = EMAC_CLK_EXT_IN;
-  esp32_emac_config.clock_config.rmii.clock_gpio = (emac_rmii_clock_gpio_t) 50;
-  esp32_emac_config.dma_burst_len = ETH_DMA_BURST_LEN_32;
-  esp32_emac_config.intr_priority = 0;
-#if SOC_EMAC_USE_MULTI_IO_MUX || SOC_EMAC_MII_USE_GPIO_MATRIX
-  esp32_emac_config.emac_dataif_gpio.rmii.tx_en_num = 49;
-  esp32_emac_config.emac_dataif_gpio.rmii.txd0_num = 34;
-  esp32_emac_config.emac_dataif_gpio.rmii.txd1_num = 35;
-  esp32_emac_config.emac_dataif_gpio.rmii.crs_dv_num = 28;
-  esp32_emac_config.emac_dataif_gpio.rmii.rxd0_num = 29;
-  esp32_emac_config.emac_dataif_gpio.rmii.rxd1_num = 30;
-#endif
-#if !SOC_EMAC_RMII_CLK_OUT_INTERNAL_LOOPBACK
-  esp32_emac_config.clock_config_out_in.rmii.clock_mode = EMAC_CLK_EXT_IN;
-  esp32_emac_config.clock_config_out_in.rmii.clock_gpio = (emac_rmii_clock_gpio_t) -1;
-#endif
-  esp32_emac_config.mdc_freq_hz = 0;
-#else
-  esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
-#endif
+  eth_esp32_emac_config_t esp32_emac_config = eth_esp32_emac_default_config();
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
   esp32_emac_config.smi_gpio.mdc_num = this->mdc_pin_;
   esp32_emac_config.smi_gpio.mdio_num = this->mdio_pin_;

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -15,6 +15,8 @@
 #include "esp_mac.h"
 #include "esp_idf_version.h"
 
+extern "C" eth_esp32_emac_config_t eth_esp32_emac_default_config(void);
+
 namespace esphome::ethernet {
 
 #ifdef USE_ETHERNET_IP_STATE_LISTENERS

--- a/esphome/components/ethernet/ethernet_helpers.c
+++ b/esphome/components/ethernet/ethernet_helpers.c
@@ -1,4 +1,4 @@
-#include "esp_eth_mac.h"
+#include "esp_eth_mac_esp.h"
 
 // ETH_ESP32_EMAC_DEFAULT_CONFIG() uses out-of-order designated initializers
 // which are valid in C but not in C++. This wrapper allows C++ code to get

--- a/esphome/components/ethernet/ethernet_helpers.c
+++ b/esphome/components/ethernet/ethernet_helpers.c
@@ -1,0 +1,8 @@
+#include "esp_eth_mac.h"
+
+// ETH_ESP32_EMAC_DEFAULT_CONFIG() uses out-of-order designated initializers
+// which are valid in C but not in C++. This wrapper allows C++ code to get
+// the default config without replicating the macro's contents.
+eth_esp32_emac_config_t eth_esp32_emac_default_config(void) {
+  return (eth_esp32_emac_config_t) ETH_ESP32_EMAC_DEFAULT_CONFIG();
+}

--- a/tests/components/ethernet/test.esp32-p4-idf.yaml
+++ b/tests/components/ethernet/test.esp32-p4-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-ip101.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes ESP32-P4 Ethernet compilation when building with ESP-IDF versions where `ETH_ESP32_EMAC_DEFAULT_CONFIG()` uses out-of-order designated initializers in C++ mode.  
For `CONFIG_IDF_TARGET_ESP32P4`, the EMAC config is now initialized via explicit field assignment (in declaration-safe order), while other targets continue using `ETH_ESP32_EMAC_DEFAULT_CONFIG()`.

```
In file included from /Users/kburzinski/.platformio/packages/framework-espidf/components/esp_eth/include/esp_eth_driver.h:13,
                 from /Users/kburzinski/.platformio/packages/framework-espidf/components/esp_eth/include/esp_eth.h:15,
                 from src/esphome/components/ethernet/ethernet_component.h:12,
                 from src/esphome/components/ethernet/ethernet_component.cpp:1:
src/esphome/components/ethernet/ethernet_component.cpp: In member function 'virtual void esphome::ethernet::EthernetComponent::setup()':
/Users/kburzinski/.platformio/packages/framework-espidf/components/esp_eth/include/esp_eth_mac_esp.h:303:5: error: designator order for field 'eth_esp32_emac_config_t::emac_dataif_gpio' does not match declaration order in 'eth_esp32_emac_config_t'
  303 |     }
      |     ^
src/esphome/components/ethernet/ethernet_component.cpp:165:47: note: in expansion of macro 'ETH_ESP32_EMAC_DEFAULT_CONFIG'
  165 |   eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
      |                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (no issue link)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal compile fix, no user-facing config/API changes)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp32p4-ethernet-test

esp32:
  variant: esp32p4
  framework:
    type: esp-idf

ethernet:
  type: LAN8720
  mdc_pin: 31
  mdio_pin: 52
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
