### PR TITLE
[ethernet] ESP32-S3 Ethernet compilation fix

### DIFF
--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -11,11 +11,14 @@
 
 #include "esp_eth.h"
 #include "esp_eth_mac.h"
+#include "esp_eth_mac_esp.h"
 #include "esp_netif.h"
 #include "esp_mac.h"
 #include "esp_idf_version.h"
 
+#if CONFIG_ETH_USE_ESP32_EMAC
 extern "C" eth_esp32_emac_config_t eth_esp32_emac_default_config(void);
+#endif
 
 namespace esphome::ethernet {
 

--- a/esphome/components/ethernet/ethernet_helpers.c
+++ b/esphome/components/ethernet/ethernet_helpers.c
@@ -3,6 +3,8 @@
 // ETH_ESP32_EMAC_DEFAULT_CONFIG() uses out-of-order designated initializers
 // which are valid in C but not in C++. This wrapper allows C++ code to get
 // the default config without replicating the macro's contents.
+#if CONFIG_ETH_USE_ESP32_EMAC
 eth_esp32_emac_config_t eth_esp32_emac_default_config(void) {
   return (eth_esp32_emac_config_t) ETH_ESP32_EMAC_DEFAULT_CONFIG();
 }
+#endif

--- a/tests/components/ethernet/common-w5500.yaml
+++ b/tests/components/ethernet/common-w5500.yaml
@@ -2,10 +2,10 @@ ethernet:
   type: W5500
   clk_pin: 19
   mosi_pin: 21
-  miso_pin: 23
+  miso_pin: 17
   cs_pin: 18
   interrupt_pin: 36
-  reset_pin: 22
+  reset_pin: 12
   clock_speed: 10Mhz
   manual_ip:
     static_ip: 192.168.178.56

--- a/tests/components/ethernet/test.esp32-s3-idf.yaml
+++ b/tests/components/ethernet/test.esp32-s3-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-w5500.yaml


### PR DESCRIPTION
# What does this implement/fix?

#14714 fixed P4 builds but broke S3 (and possibly other) builds -- this PR adds some guards to ensure everything builds as expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
