### PR TITLE
[modbus] Fix buffer overflow in modbus

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -125,8 +125,6 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   // Byte 0: modbus address (match all)
   if (at == 0)
     return true;
-  uint8_t address = raw[0];
-  uint8_t function_code = raw[1];
   // Byte 1: function code
   if (at == 1)
     return true;
@@ -134,6 +132,9 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   // See also https://en.wikipedia.org/wiki/Modbus
   if (at == 2)
     return true;
+
+  uint8_t address = raw[0];
+  uint8_t function_code = raw[1];
 
   uint8_t data_len = raw[2];
   uint8_t data_offset = 3;
@@ -148,10 +149,6 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     // installed, but wait, there is the CRC, and if we get a hit there is a good
     // chance that this is a complete message ... admittedly there is a small chance is
     // isn't but that is quite small given the purpose of the CRC in the first place
-
-    // Fewer than 2 bytes can't calc CRC
-    if (at < 2)
-      return true;
 
     data_len = at - 2;
     data_offset = 1;

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -127,6 +127,9 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     return true;
   uint8_t address = raw[0];
   uint8_t function_code = raw[1];
+  // Byte 1: function code
+  if (at == 1)
+    return true;
   // Byte 2: Size (with modbus rtu function code 4/3)
   // See also https://en.wikipedia.org/wiki/Modbus
   if (at == 2)

--- a/tests/components/modbus/modbus_test.cpp
+++ b/tests/components/modbus/modbus_test.cpp
@@ -20,6 +20,7 @@ class MockDevice : public ModbusDevice {
 
 TEST(ModbusTest, TwoByteRegressionTest) {
   TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
   // First byte (at=0)
   EXPECT_TRUE(modbus.test_parse_modbus_byte(0x01));
   // Second byte (at=1)
@@ -33,6 +34,7 @@ TEST(ModbusTest, TestValidFrame) {
   modbus.set_role(ModbusRole::CLIENT);
 
   MockDevice device;
+  device.set_parent(&modbus);
   device.set_address(0x01);
   modbus.register_device(&device);
   modbus.set_waiting(0x01);

--- a/tests/components/modbus/modbus_test.cpp
+++ b/tests/components/modbus/modbus_test.cpp
@@ -1,0 +1,57 @@
+#include <gtest/gtest.h>
+#include "esphome/components/modbus/modbus.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::modbus {
+
+// Exposes protected methods for testing.
+class TestModbus : public Modbus {
+ public:
+  bool test_parse_modbus_byte(uint8_t byte) { return this->parse_modbus_byte_(byte); }
+  void test_clear_rx_buffer() { this->rx_buffer_.clear(); }
+  void set_waiting(uint8_t addr) { this->waiting_for_response_ = addr; }
+};
+
+class MockDevice : public ModbusDevice {
+ public:
+  void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_received = true; }
+  bool data_received{false};
+};
+
+TEST(ModbusTest, TwoByteRegressionTest) {
+  TestModbus modbus;
+  // First byte (at=0)
+  EXPECT_TRUE(modbus.test_parse_modbus_byte(0x01));
+  // Second byte (at=1)
+  // This used to reach raw[2] because it skipped the if(at==2) check, causing a
+  // buffer overflow.
+  EXPECT_TRUE(modbus.test_parse_modbus_byte(0x03));
+}
+
+TEST(ModbusTest, TestValidFrame) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // Address 1, Function 3, Length 2, Data 0x1234
+  uint8_t frame_data[] = {0x01, 0x03, 0x02, 0x12, 0x34};
+  uint16_t crc = esphome::crc16(frame_data, sizeof(frame_data));
+
+  std::vector<uint8_t> frame;
+  for (uint8_t b : frame_data)
+    frame.push_back(b);
+  frame.push_back(crc & 0xFF);
+  frame.push_back((crc >> 8) & 0xFF);
+
+  for (size_t i = 0; i < frame.size(); i++) {
+    bool result = modbus.test_parse_modbus_byte(frame[i]);
+    EXPECT_TRUE(result) << "Failed at byte " << i << " (0x" << std::hex << (int) frame[i] << ")";
+  }
+  EXPECT_TRUE(device.data_received);
+}
+
+}  // namespace esphome::modbus


### PR DESCRIPTION
# What does this implement/fix?

This fixes a buffer overflow bug in the modbus component. It adds unit test coverage for the bug (a regression test), as well as a test case for happy-path modbus parsing.

This is an issue found by enabling the sanitizers for the C++ integration tests, #14718.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

#14718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
