### PR TITLE
[ledc] Fix high-pressure crash & recovery

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -145,7 +145,7 @@ void LEDCOutput::write_state(float state) {
 
 void LEDCOutput::setup() {
   if (!ledc_peripheral_reset_done) {
-    ESP_LOGI(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
+    ESP_LOGV(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
     periph_module_reset(PERIPH_LEDC_MODULE);
     ledc_peripheral_reset_done = true;
   }

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -37,6 +37,21 @@ inline ledc_mode_t get_speed_mode(uint8_t) { return LEDC_LOW_SPEED_MODE; }
 #endif
 
 #if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+// Classic ESP32 (currently the only target without SOC_LEDC_SUPPORT_FADE_STOP) can block in
+// ledc_ll_set_duty_start() while duty_start is set. We check the same conf1.duty_start bit here
+// to defer updates and avoid entering IDF's unbounded wait loop.
+//
+// This intentionally depends on the classic ESP32 LEDC register layout used by IDF's own LL HAL.
+// If another target without SOC_LEDC_SUPPORT_FADE_STOP is introduced, revisit this helper.
+static_assert(
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    true,
+#else
+    false,
+#endif
+    "LEDC duty_start pending check assumes classic ESP32 register layout; "
+    "re-evaluate for this target");
+
 static bool ledc_duty_update_pending(ledc_mode_t speed_mode, ledc_channel_t chan_num) {
   auto *hw = LEDC_LL_GET_HW();
   return hw->channel_group[speed_mode].channel[chan_num].conf1.duty_start != 0;

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -7,6 +7,9 @@
 #include <cinttypes>
 #ifdef USE_ESP_IDF
 #include <esp_private/periph_ctrl.h>
+#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+#include <hal/ledc_ll.h>
+#endif
 #endif
 
 #define CLOCK_FREQUENCY 80e6f
@@ -22,7 +25,9 @@ static const uint8_t SETUP_ATTEMPT_COUNT_MAX = 5;
 namespace esphome::ledc {
 
 static const char *const TAG = "ledc.output";
+#ifdef USE_ESP_IDF
 static bool ledc_peripheral_reset_done = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#endif
 
 static const int MAX_RES_BITS = LEDC_TIMER_BIT_MAX - 1;
 #if SOC_LEDC_SUPPORT_HS_MODE
@@ -33,6 +38,13 @@ inline ledc_mode_t get_speed_mode(uint8_t channel) { return channel < 8 ? LEDC_H
 // See
 // https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/ledc.html#functionality-overview
 inline ledc_mode_t get_speed_mode(uint8_t) { return LEDC_LOW_SPEED_MODE; }
+#endif
+
+#if defined(USE_ESP_IDF) && !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+static bool ledc_duty_update_pending(ledc_mode_t speed_mode, ledc_channel_t chan_num) {
+  auto *hw = LEDC_LL_GET_HW();
+  return hw->channel_group[speed_mode].channel[chan_num].conf1.duty_start != 0;
+}
 #endif
 
 float ledc_max_frequency_for_bit_depth(uint8_t bit_depth) {
@@ -119,11 +131,20 @@ void LEDCOutput::write_state(float state) {
   int hpoint = ledc_angle_to_htop(this->phase_angle_, this->bit_depth_);
   if (duty == max_duty) {
     ledc_stop(speed_mode, chan_num, 1);
+    this->last_duty_ = duty;
   } else if (duty == 0) {
     ledc_stop(speed_mode, chan_num, 0);
+    this->last_duty_ = duty;
   } else {
+#if defined(USE_ESP_IDF) && !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+    if (ledc_duty_update_pending(speed_mode, chan_num)) {
+      ESP_LOGV(TAG, "Skipping LEDC duty update on channel %u while previous duty_start is still set", this->channel_);
+      return;
+    }
+#endif
     ledc_set_duty_with_hpoint(speed_mode, chan_num, duty, hpoint);
     ledc_update_duty(speed_mode, chan_num);
+    this->last_duty_ = duty;
   }
 }
 

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -5,6 +5,9 @@
 
 #include <driver/ledc.h>
 #include <cinttypes>
+#ifdef USE_ESP_IDF
+#include <esp_private/periph_ctrl.h>
+#endif
 
 #define CLOCK_FREQUENCY 80e6f
 
@@ -16,10 +19,10 @@
 
 static const uint8_t SETUP_ATTEMPT_COUNT_MAX = 5;
 
-namespace esphome {
-namespace ledc {
+namespace esphome::ledc {
 
 static const char *const TAG = "ledc.output";
+static bool ledc_peripheral_reset_done = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 static const int MAX_RES_BITS = LEDC_TIMER_BIT_MAX - 1;
 #if SOC_LEDC_SUPPORT_HS_MODE
@@ -105,6 +108,11 @@ void LEDCOutput::write_state(float state) {
   const uint32_t max_duty = (uint32_t(1) << this->bit_depth_) - 1;
   const float duty_rounded = roundf(state * max_duty);
   auto duty = static_cast<uint32_t>(duty_rounded);
+  if (duty == this->last_duty_) {
+    return;
+  }
+  this->last_duty_ = duty;
+
   ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
   auto speed_mode = get_speed_mode(this->channel_);
   auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
@@ -120,6 +128,14 @@ void LEDCOutput::write_state(float state) {
 }
 
 void LEDCOutput::setup() {
+#ifdef USE_ESP_IDF
+  if (!ledc_peripheral_reset_done) {
+    ESP_LOGI(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
+    periph_module_reset(PERIPH_LEDC_MODULE);
+    ledc_peripheral_reset_done = true;
+  }
+#endif
+
   auto speed_mode = get_speed_mode(this->channel_);
   auto timer_num = static_cast<ledc_timer_t>((this->channel_ % 8) / 2);
   auto chan_num = static_cast<ledc_channel_t>(this->channel_ % 8);
@@ -207,12 +223,12 @@ void LEDCOutput::update_frequency(float frequency) {
   this->status_clear_error();
 
   // re-apply duty
+  this->last_duty_ = UINT32_MAX;
   this->write_state(this->duty_);
 }
 
 uint8_t next_ledc_channel = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-}  // namespace ledc
-}  // namespace esphome
+}  // namespace esphome::ledc
 
 #endif

--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -5,11 +5,9 @@
 
 #include <driver/ledc.h>
 #include <cinttypes>
-#ifdef USE_ESP_IDF
 #include <esp_private/periph_ctrl.h>
 #if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
 #include <hal/ledc_ll.h>
-#endif
 #endif
 
 #define CLOCK_FREQUENCY 80e6f
@@ -25,9 +23,7 @@ static const uint8_t SETUP_ATTEMPT_COUNT_MAX = 5;
 namespace esphome::ledc {
 
 static const char *const TAG = "ledc.output";
-#ifdef USE_ESP_IDF
 static bool ledc_peripheral_reset_done = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-#endif
 
 static const int MAX_RES_BITS = LEDC_TIMER_BIT_MAX - 1;
 #if SOC_LEDC_SUPPORT_HS_MODE
@@ -40,7 +36,7 @@ inline ledc_mode_t get_speed_mode(uint8_t channel) { return channel < 8 ? LEDC_H
 inline ledc_mode_t get_speed_mode(uint8_t) { return LEDC_LOW_SPEED_MODE; }
 #endif
 
-#if defined(USE_ESP_IDF) && !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
 static bool ledc_duty_update_pending(ledc_mode_t speed_mode, ledc_channel_t chan_num) {
   auto *hw = LEDC_LL_GET_HW();
   return hw->channel_group[speed_mode].channel[chan_num].conf1.duty_start != 0;
@@ -123,7 +119,6 @@ void LEDCOutput::write_state(float state) {
   if (duty == this->last_duty_) {
     return;
   }
-  this->last_duty_ = duty;
 
   ESP_LOGV(TAG, "Setting duty: %" PRIu32 " on channel %u", duty, this->channel_);
   auto speed_mode = get_speed_mode(this->channel_);
@@ -136,7 +131,7 @@ void LEDCOutput::write_state(float state) {
     ledc_stop(speed_mode, chan_num, 0);
     this->last_duty_ = duty;
   } else {
-#if defined(USE_ESP_IDF) && !defined(SOC_LEDC_SUPPORT_FADE_STOP)
+#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
     if (ledc_duty_update_pending(speed_mode, chan_num)) {
       ESP_LOGV(TAG, "Skipping LEDC duty update on channel %u while previous duty_start is still set", this->channel_);
       return;
@@ -149,13 +144,11 @@ void LEDCOutput::write_state(float state) {
 }
 
 void LEDCOutput::setup() {
-#ifdef USE_ESP_IDF
   if (!ledc_peripheral_reset_done) {
     ESP_LOGI(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
     periph_module_reset(PERIPH_LEDC_MODULE);
     ledc_peripheral_reset_done = true;
   }
-#endif
 
   auto speed_mode = get_speed_mode(this->channel_);
   auto timer_num = static_cast<ledc_timer_t>((this->channel_ % 8) / 2);

--- a/esphome/components/ledc/ledc_output.h
+++ b/esphome/components/ledc/ledc_output.h
@@ -4,11 +4,11 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/automation.h"
 #include "esphome/components/output/float_output.h"
+#include <cstdint>
 
 #ifdef USE_ESP32
 
-namespace esphome {
-namespace ledc {
+namespace esphome::ledc {
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 extern uint8_t next_ledc_channel;
@@ -39,6 +39,7 @@ class LEDCOutput : public output::FloatOutput, public Component {
   float phase_angle_{0.0f};
   float frequency_{};
   float duty_{0.0f};
+  uint32_t last_duty_{UINT32_MAX};
   bool initialized_ = false;
 };
 
@@ -56,7 +57,6 @@ template<typename... Ts> class SetFrequencyAction : public Action<Ts...> {
   LEDCOutput *parent_;
 };
 
-}  // namespace ledc
-}  // namespace esphome
+}  // namespace esphome::ledc
 
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes an ESP32 LEDC crash/reboot-loop scenario seen with high LEDC update pressure (for example, with many channels with (slow) transitions) on recent ESP-IDF versions. Recent ESPHome improvements have reduced loop times, exasperating the issue.

This PR adds three targeted mitigations in ledc_output:

- Skip redundant writes by caching last applied duty and avoiding unnecessary LEDC updates.
- Reset LEDC peripheral once during setup to clear stale hardware state after crash reboot, preventing repeated setup-time boot loops.
- Avoid entering IDF’s unbounded `duty_start` wait path on classic ESP32 by checking whether the previous duty update is still pending and deferring the update to a later loop iteration instead of blocking.

## Why

Crash traces consistently point to `ledc_update_duty()` / `ledc_ll_set_duty_start()` under transition load.

The setup-time loop was also reproducible after a software-reset crash, indicating stale LEDC peripheral state across reboot.

These mitigations reduce LEDC call pressure, improve recovery behavior, and avoid the most problematic busy-wait path without changing user-facing configuration.

## Scope / Safety

- Changes are limited to `esphome/components/ledc/ledc_output.*`.
- Pending-duty guard is applied only where relevant (classic ESP32 behavior).
- On deferred updates, duty is retried next loop (no permanent suppression).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
