### PR TITLE
[api] Fix heap-buffer-overflow in protobuf message dump for StringRef

### DIFF
--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -13,7 +13,7 @@ namespace esphome::api {
 static inline void append_quoted_string(DumpBuffer &out, const StringRef &ref) {
   out.append("'");
   if (!ref.empty()) {
-    out.append(ref.c_str());
+    out.append(ref.c_str(), ref.size());
   }
   out.append("'");
 }

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -642,7 +642,7 @@ class StringType(TypeInfo):
         # For SOURCE_BOTH, check if StringRef is set (sending) or use string (received)
         return (
             f"if (!this->{self.field_name}_ref_.empty()) {{"
-            f'  out.append("\'").append(this->{self.field_name}_ref_.c_str()).append("\'");'
+            f'  out.append("\'").append(this->{self.field_name}_ref_.c_str(), this->{self.field_name}_ref_.size()).append("\'");'
             f"}} else {{"
             f'  out.append("\'").append(this->{self.field_name}).append("\'");'
             f"}}"
@@ -2705,7 +2705,7 @@ namespace esphome::api {
 static inline void append_quoted_string(DumpBuffer &out, const StringRef &ref) {
   out.append("'");
   if (!ref.empty()) {
-    out.append(ref.c_str());
+    out.append(ref.c_str(), ref.size());
   }
   out.append("'");
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a heap-buffer-overflow in `DumpBuffer::append` when dumping protobuf messages containing `StringRef` fields.

`StringRef` fields decoded from protobuf point into the receive buffer and are **not** null-terminated. `DumpBuffer::append(const char*)` calls `strlen()` which reads past the allocated buffer. This uses the `append(const char*, size_t)` overload instead.

**Note:** This is a real safety bug, but only triggers with `VERY_VERBOSE` logging enabled, which activates the protobuf message dump code path (`HAS_PROTO_MESSAGE_DUMP`).

The fix is in the protobuf code generator (`script/api_protobuf/api_protobuf.py`) and the regenerated output.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Found by AddressSanitizer in #14718.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — this is a bug fix in the API protocol debug logging path.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).