### PR TITLE
[api] Fix undefined behavior in noise handshake with empty rx buffer

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -258,10 +258,13 @@ APIError APINoiseFrameHelper::state_action_() {
     // ignore contents, may be used in future for flags
     // Resize for: existing prologue + 2 size bytes + frame data
     size_t old_size = this->prologue_.size();
-    this->prologue_.resize(old_size + 2 + this->rx_buf_.size());
-    this->prologue_[old_size] = (uint8_t) (this->rx_buf_.size() >> 8);
-    this->prologue_[old_size + 1] = (uint8_t) this->rx_buf_.size();
-    std::memcpy(this->prologue_.data() + old_size + 2, this->rx_buf_.data(), this->rx_buf_.size());
+    size_t rx_size = this->rx_buf_.size();
+    this->prologue_.resize(old_size + 2 + rx_size);
+    this->prologue_[old_size] = (uint8_t) (rx_size >> 8);
+    this->prologue_[old_size + 1] = (uint8_t) rx_size;
+    if (rx_size > 0) {
+      std::memcpy(this->prologue_.data() + old_size + 2, this->rx_buf_.data(), rx_size);
+    }
 
     state_ = State::SERVER_HELLO;
   }


### PR DESCRIPTION
# What does this implement/fix?

Fixes undefined behavior in the noise protocol handshake. When `rx_buf_` is empty during the client hello phase, `rx_buf_.data()` can return `nullptr`. Passing `nullptr` to `std::memcpy` as the source argument is undefined behavior even when the size is 0. This adds a guard to skip the `memcpy` when the buffer is empty.

**Note:** This is a correctness fix, not a safety fix. In practice `memcpy(dst, nullptr, 0)` is a no-op on every real implementation, but UndefinedBehaviorSanitizer correctly flags it per the C++ standard. This fix is needed to enable sanitizers in CI (#14718) without false positives.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Found by UndefinedBehaviorSanitizer in #14718.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — this is a bug fix in the noise protocol handshake path.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).