### PR TITLE
[adc] Fix PICO_VSYS_PIN compile error on RP2350 boards

### DIFF
--- a/esphome/components/adc/adc_sensor_rp2040.cpp
+++ b/esphome/components/adc/adc_sensor_rp2040.cpp
@@ -8,6 +8,13 @@
 #endif  // CYW43_USES_VSYS_PIN
 #include <hardware/adc.h>
 
+// PICO_VSYS_PIN is defined in pico-sdk board headers (e.g. boards/pico2.h),
+// but the Arduino framework's config_autogen.h includes a generic board header
+// that doesn't define it. Provide the standard value (pin 29) as a fallback.
+#ifndef PICO_VSYS_PIN
+#define PICO_VSYS_PIN 29  // NOLINT(cppcoreguidelines-macro-usage)
+#endif
+
 namespace esphome {
 namespace adc {
 

--- a/tests/components/adc/test.rp2040-pico2-ard.yaml
+++ b/tests/components/adc/test.rp2040-pico2-ard.yaml
@@ -1,0 +1,11 @@
+sensor:
+  - id: my_sensor
+    platform: adc
+    pin: VCC
+    name: ADC Test sensor
+    update_interval: "1:01"
+    unit_of_measurement: "°C"
+    icon: "mdi:water-percent"
+    accuracy_decimals: 5
+    setup_priority: -100
+    force_update: true

--- a/tests/components/spi/test.rp2040-pico2-ard.yaml
+++ b/tests/components/spi/test.rp2040-pico2-ard.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  clk_pin: GPIO2
+  mosi_pin: GPIO3
+  miso_pin: GPIO4
+
+<<: !include common.yaml

--- a/tests/test_build_components/build_components_base.rp2040-pico2-ard.yaml
+++ b/tests/test_build_components/build_components_base.rp2040-pico2-ard.yaml
@@ -1,0 +1,15 @@
+esphome:
+  name: componenttestrp2040pico2ard
+  friendly_name: $component_name
+
+rp2040:
+  board: rpipico2
+
+logger:
+  level: VERY_VERBOSE
+
+packages:
+  component_under_test: !include
+    file: $component_test_file
+    vars:
+      component_test_file: $component_test_file

--- a/tests/test_build_components/common/spi/rp2040-pico2-ard.yaml
+++ b/tests/test_build_components/common/spi/rp2040-pico2-ard.yaml
@@ -1,0 +1,12 @@
+# Common SPI configuration for RP2040 Pico 2 (RP2350) Arduino tests
+
+substitutions:
+  clk_pin: GPIO18
+  mosi_pin: GPIO19
+  miso_pin: GPIO16
+
+spi:
+  - id: spi_bus
+    clk_pin: ${clk_pin}
+    mosi_pin: ${mosi_pin}
+    miso_pin: ${miso_pin}


### PR DESCRIPTION
# What does this implement/fix?

`PICO_VSYS_PIN` is defined in pico-sdk board headers (e.g. `boards/pico2.h`), but the Arduino framework's `config_autogen.h` for RP2350 includes a generic board header (`solderparty_rp2350_stamp_xl.h`) that doesn't define it. This causes a compile failure on non-W RP2350 boards like `rpipico2`.

The fix adds a fallback `#define PICO_VSYS_PIN 29` so the VSYS voltage divider coefficient (3x) works correctly on all Pico boards. `PICO_VSYS_PIN` is the only define from `pico2.h` that ESPHome references — the other defines (UART, LED, I2C, SPI defaults, flash config) are handled by the Arduino variant's `pins_arduino.h`.

Also adds the `rp2040-pico2-ard` compile test target (`board: rpipico2`) with ADC and SPI component tests to catch RP2350-specific build issues going forward.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10146

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a build fix
rp2040:
  board: rpipico2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).