### PR TITLE
[uart] Allow hardware UART with single pin on RP2040

### DIFF
--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -107,16 +107,21 @@ void RP2040UartComponent::setup() {
 
   // Determine which hardware UART to use. A pin that is not specified
   // should not prevent hardware UART selection — one-way UART is valid.
-  // Both pins must map to the same UART when both are specified.
+  // When both pins are configured, both must be HW-capable and agree on UART number.
+  // When only one pin is configured (nullptr other), use that pin's HW UART.
+  // If a pin is configured but not HW-capable (inverted/invalid), fall back to SerialPIO.
   int8_t hw_uart = -1;
-  if (tx_hw != -1 && rx_hw != -1) {
-    // Both pins specified — they must agree on the UART number
-    if (tx_hw == rx_hw) {
+  const bool tx_configured = (this->tx_pin_ != nullptr);
+  const bool rx_configured = (this->rx_pin_ != nullptr);
+
+  if (tx_configured && rx_configured) {
+    // Both pins configured — both must map to the same hardware UART
+    if (tx_hw != -1 && rx_hw != -1 && tx_hw == rx_hw) {
       hw_uart = tx_hw;
     }
-  } else if (tx_hw != -1) {
+  } else if (tx_configured) {
     hw_uart = tx_hw;
-  } else if (rx_hw != -1) {
+  } else if (rx_configured) {
     hw_uart = rx_hw;
   }
 

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -105,15 +105,29 @@ void RP2040UartComponent::setup() {
     }
   }
 
+  // Determine which hardware UART to use. A pin that is not specified
+  // should not prevent hardware UART selection — one-way UART is valid.
+  // Both pins must map to the same UART when both are specified.
+  int8_t hw_uart = -1;
+  if (tx_hw != -1 && rx_hw != -1) {
+    // Both pins specified — they must agree on the UART number
+    if (tx_hw == rx_hw) {
+      hw_uart = tx_hw;
+    }
+  } else if (tx_hw != -1) {
+    hw_uart = tx_hw;
+  } else if (rx_hw != -1) {
+    hw_uart = rx_hw;
+  }
+
 #ifdef USE_LOGGER
-  if (tx_hw == rx_hw && logger::global_logger->get_uart() == tx_hw) {
-    ESP_LOGD(TAG, "Using SerialPIO as UART%d is taken by the logger", tx_hw);
-    tx_hw = -1;
-    rx_hw = -1;
+  if (hw_uart != -1 && logger::global_logger->get_uart() == hw_uart) {
+    ESP_LOGD(TAG, "Using SerialPIO as UART%d is taken by the logger", hw_uart);
+    hw_uart = -1;
   }
 #endif
 
-  if (tx_hw == -1 || rx_hw == -1 || tx_hw != rx_hw) {
+  if (hw_uart == -1) {
     ESP_LOGV(TAG, "Using SerialPIO");
     pin_size_t tx = this->tx_pin_ == nullptr ? NOPIN : this->tx_pin_->get_pin();
     pin_size_t rx = this->rx_pin_ == nullptr ? NOPIN : this->rx_pin_->get_pin();
@@ -127,13 +141,15 @@ void RP2040UartComponent::setup() {
   } else {
     ESP_LOGV(TAG, "Using Hardware Serial");
     SerialUART *serial;
-    if (tx_hw == 0) {
+    if (hw_uart == 0) {
       serial = &Serial1;
     } else {
       serial = &Serial2;
     }
-    serial->setTX(this->tx_pin_->get_pin());
-    serial->setRX(this->rx_pin_->get_pin());
+    if (this->tx_pin_ != nullptr)
+      serial->setTX(this->tx_pin_->get_pin());
+    if (this->rx_pin_ != nullptr)
+      serial->setRX(this->rx_pin_->get_pin());
     serial->setFIFOSize(this->rx_buffer_size_);
     serial->begin(this->baud_rate_, config);
     this->serial_ = serial;

--- a/tests/components/uart/test.rp2040-ard.yaml
+++ b/tests/components/uart/test.rp2040-ard.yaml
@@ -23,3 +23,6 @@ uart:
     baud_rate: 115200
     debug:
       debug_prefix: "[UART1] "
+  - id: uart_rx_only
+    rx_pin: 17
+    baud_rate: 1200


### PR DESCRIPTION
# What does this implement/fix?

When only `rx_pin` or only `tx_pin` is specified for a UART on RP2040, the component incorrectly fell back to software SerialPIO even when the pin maps to a valid hardware UART. One-way UART communication is common (e.g., reading a water meter with RX only).

The root cause was line 116: `if (tx_hw == -1 || rx_hw == -1 || tx_hw != rx_hw)` — this required *both* pins to be specified and map to the same HW UART, otherwise it always used SerialPIO.

The fix determines the hardware UART number based on whether pins are configured (`nullptr` check) and HW-capable:
- Both pins configured → both must be HW-capable and map to the same UART number (unchanged behavior)
- Only TX configured (no RX pin) → use the UART that TX maps to (if HW-capable)
- Only RX configured (no TX pin) → use the UART that RX maps to (if HW-capable)
- Neither, conflict, or configured but not HW-capable (inverted/invalid GPIO) → fall back to SerialPIO

The distinction between "pin not configured" (`nullptr`) and "pin configured but not HW-capable" (`*_hw == -1`) is important: if a pin is specified but can't use hardware UART (e.g., inverted or not in the valid pin set), we must fall back to SerialPIO which supports inversion via `gpio_set_outover`/`gpio_set_inover`. Without this distinction, an inverted pin could be incorrectly routed to a hardware UART that doesn't support inversion.

When only one pin is set, only that pin's `setTX()`/`setRX()` is called on the `SerialUART`. The other direction uses the `SerialUART`'s default pin, which is safe since `begin()` always configures both directions internally.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Code quality improvements to existing code or addition of tests
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/13889

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# RX-only UART (e.g., water meter reader)
uart:
  rx_pin:
    number: GPIO17
    mode:
      input: true
      pullup: true
  baud_rate: 1200
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).