### PR TITLE
[audio] Bump microOpus to v0.3.5

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -214,4 +214,4 @@ async def to_code(config):
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
     if data.opus_support:
         cg.add_define("USE_AUDIO_OPUS_SUPPORT")
-        add_idf_component(name="esphome/micro-opus", ref="0.3.4")
+        add_idf_component(name="esphome/micro-opus", ref="0.3.5")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   esphome/esp-audio-libs:
     version: 2.0.3
   esphome/micro-opus:
-    version: 0.3.4
+    version: 0.3.5
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the microOpus library ([Github](https://github.com/esphome-libs/micro-opus), [IDF Component Registry](https://components.espressif.com/components/esphome/micro-opus/versions/0.3.5/readme)) to v0.3.5.

It has several improvements:

- Builds library with O2 instead of O3
  - Saves 14764 bytes of flash on an S3
  - Decodes 7-8% faster
- Uses latest microOggDemuxer library ([Github](https://github.com/esphome-libs/micro-ogg-demuxer)) internally
  - Eliminates an extra heap allocation
  - Internal Opus packet buffer doesn't try to grow to store the metadata packet (which is immediately discarded), reducing the total size of the allocation

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: box_speaker
      format: OPUS
      sample_rate: 48000
      num_channels: 1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
