### PR TITLE
[dlms_meter] Add Kamstrup OMNIPOWER DLMS support and parser refactor

### DIFF
--- a/esphome/components/dlms_meter/__init__.py
+++ b/esphome/components/dlms_meter/__init__.py
@@ -8,9 +8,10 @@ DEPENDENCIES = ["uart"]
 
 CONF_DLMS_METER_ID = "dlms_meter_id"
 CONF_DECRYPTION_KEY = "decryption_key"
+CONF_AUTHENTICATION_KEY = "authentication_key"
 CONF_PROVIDER = "provider"
 
-PROVIDERS = {"generic": 0, "netznoe": 1}
+PROVIDERS = {"generic": 0, "netznoe": 1, "kamstrup-omnipower": 2}
 
 dlms_meter_component_ns = cg.esphome_ns.namespace("dlms_meter")
 DlmsMeterComponent = dlms_meter_component_ns.class_(
@@ -21,11 +22,11 @@ DlmsMeterComponent = dlms_meter_component_ns.class_(
 def validate_key(value):
     value = cv.string_strict(value)
     if len(value) != 32:
-        raise cv.Invalid("Decryption key must be 32 hex characters (16 bytes)")
+        raise cv.Invalid("Key must be 32 hex characters (16 bytes)")
     try:
         return [int(value[i : i + 2], 16) for i in range(0, 32, 2)]
     except ValueError as exc:
-        raise cv.Invalid("Decryption key must be hex values from 00 to FF") from exc
+        raise cv.Invalid("Key must be hex values from 00 to FF") from exc
 
 
 CONFIG_SCHEMA = cv.All(
@@ -33,6 +34,7 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(): cv.declare_id(DlmsMeterComponent),
             cv.Required(CONF_DECRYPTION_KEY): validate_key,
+            cv.Optional(CONF_AUTHENTICATION_KEY): validate_key,
             cv.Optional(CONF_PROVIDER, default="generic"): cv.enum(
                 PROVIDERS, lower=True
             ),
@@ -54,4 +56,7 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     key = ", ".join(str(b) for b in config[CONF_DECRYPTION_KEY])
     cg.add(var.set_decryption_key(cg.RawExpression(f"{{{key}}}")))
+    if CONF_AUTHENTICATION_KEY in config:
+        auth_key = ", ".join(str(b) for b in config[CONF_AUTHENTICATION_KEY])
+        cg.add(var.set_authentication_key(cg.RawExpression(f"{{{auth_key}}}")))
     cg.add(var.set_provider(PROVIDERS[config[CONF_PROVIDER]]))

--- a/esphome/components/dlms_meter/dlms.h
+++ b/esphome/components/dlms_meter/dlms.h
@@ -30,21 +30,25 @@ namespace esphome::dlms_meter {
 +-------------------------------+
 |                               |
 ~                               ~
-        Encrypted Payload
+           Ciphertext
 ~                               ~
 |                               |
++-------------------------------+
+|     Authentication Tag        | (12 Bytes, if authentication bit is set)
 +-------------------------------+
 
 Ciphering Service: 0xDB (General-Glo-Ciphering)
 System Title Length: 0x08
 System Title: Unique ID of meter
-Length: 1 Byte=Length <= 127, 3 Bytes=Length > 127 (0x82 & 2 Bytes length)
+Length: 1 Byte=Length <= 127, 3 Bytes=Length > 127 (0x82 + 2 length bytes)
 Security Control Byte:
 - Bit 3…0: Security_Suite_Id
 - Bit 4: "A" subfield: indicates that authentication is applied
 - Bit 5: "E" subfield: indicates that encryption is applied
 - Bit 6: Key_Set subfield: 0 = Unicast, 1 = Broadcast
 - Bit 7: Indicates the use of compression.
+The payload after the frame counter is ciphertext. If authentication is enabled, a trailing 12-byte
+authentication tag is appended to the ciphertext.
  */
 
 static constexpr uint8_t DLMS_HEADER_LENGTH = 16;
@@ -58,10 +62,16 @@ static constexpr uint8_t DLMS_SECBYTE_OFFSET = 11;
 static constexpr uint8_t DLMS_FRAMECOUNTER_OFFSET = 12;
 static constexpr uint8_t DLMS_FRAMECOUNTER_LENGTH = 4;
 static constexpr uint8_t DLMS_PAYLOAD_OFFSET = 16;
+static constexpr uint8_t DLMS_AUTH_TAG_LENGTH = 12;
 static constexpr uint8_t GLO_CIPHERING = 0xDB;
 static constexpr uint8_t DATA_NOTIFICATION = 0x0F;
 static constexpr uint8_t TIMESTAMP_DATETIME = 0x0C;
 static constexpr uint16_t MAX_MESSAGE_LENGTH = 512;  // Maximum size of message (when having 2 bytes length in header).
+static constexpr uint8_t DLMS_SECURITY_SUITE_MASK = 0x0F;
+static constexpr uint8_t DLMS_SECURITY_AUTHENTICATION = 0x10;
+static constexpr uint8_t DLMS_SECURITY_ENCRYPTION = 0x20;
+static constexpr uint8_t DLMS_SECURITY_SUPPORTED_SUITE_0 = 0x00;
+static constexpr uint8_t DLMS_SECURITY_SUPPORTED_SUITE_1 = 0x01;
 
 // Provider specific quirks
 static constexpr uint8_t NETZ_NOE_MAGIC_BYTE = 0x81;  // Magic length byte used by Netz NOE

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -12,28 +12,38 @@ namespace esphome::dlms_meter {
 static constexpr const char *TAG = "dlms_meter";
 
 void DlmsMeterComponent::dump_config() {
-  const char *provider_name = this->provider_ == PROVIDER_NETZNOE ? "Netz NOE" : "Generic";
+  const char *provider_name = "Generic";
+  if (this->provider_ == PROVIDER_NETZNOE) {
+    provider_name = "Netz NOE";
+  } else if (this->provider_ == PROVIDER_KAMSTRUP_OMNIPOWER) {
+    provider_name = "Kamstrup";
+  }
   ESP_LOGCONFIG(TAG,
                 "DLMS Meter:\n"
                 "  Provider: %s\n"
-                "  Read Timeout: %u ms",
-                provider_name, this->read_timeout_);
+                "  Read Timeout: %u ms\n"
+                "  Authentication Key: %s",
+                provider_name, this->read_timeout_, this->has_authentication_key_ ? "configured" : "not configured");
 #define DLMS_METER_LOG_SENSOR(s) LOG_SENSOR("  ", #s, this->s##_sensor_);
   DLMS_METER_SENSOR_LIST(DLMS_METER_LOG_SENSOR, )
 #define DLMS_METER_LOG_TEXT_SENSOR(s) LOG_TEXT_SENSOR("  ", #s, this->s##_text_sensor_);
   DLMS_METER_TEXT_SENSOR_LIST(DLMS_METER_LOG_TEXT_SENSOR, )
 }
 
+void DlmsMeterComponent::publish_parsed_data_(MeterData &data) {
+  this->receive_buffer_.clear();
+  ESP_LOGI(TAG, "Received valid data");
+  this->publish_sensors(data);
+  this->status_clear_warning();
+}
+
 void DlmsMeterComponent::loop() {
-  // Read while data is available, netznoe uses two frames so allow 2x max frame length
   size_t avail = this->available();
   if (avail > 0) {
-    size_t remaining = MBUS_MAX_FRAME_LENGTH * 2 - this->receive_buffer_.size();
+    size_t remaining = this->max_receive_length_() - this->receive_buffer_.size();
     if (remaining == 0) {
       ESP_LOGW(TAG, "Receive buffer full, dropping remaining bytes");
     } else {
-      // Read all available bytes in batches to reduce UART call overhead.
-      // Cap reads to remaining buffer capacity.
       if (avail > remaining) {
         avail = remaining;
       }
@@ -51,15 +61,26 @@ void DlmsMeterComponent::loop() {
   }
 
   if (!this->receive_buffer_.empty() && millis() - this->last_read_ > this->read_timeout_) {
-    this->mbus_payload_.clear();
-    if (!this->parse_mbus_(this->mbus_payload_))
+    const TransportType transport = this->detect_transport_();
+    if (transport == TransportType::UNKNOWN) {
+      ESP_LOGE(TAG, "Unable to determine transport type from received data");
+      this->receive_buffer_.clear();
       return;
+    }
+
+    this->dlms_payload_.clear();
+    const bool frame_ok = transport == TransportType::HDLC ? this->parse_hdlc_(this->dlms_payload_)
+                                                           : this->parse_mbus_(this->dlms_payload_);
+    if (!frame_ok) {
+      return;
+    }
 
     uint16_t message_length;
     uint8_t systitle_length;
     uint16_t header_offset;
-    if (!this->parse_dlms_(this->mbus_payload_, message_length, systitle_length, header_offset))
+    if (!this->parse_dlms_(this->dlms_payload_, message_length, systitle_length, header_offset)) {
       return;
+    }
 
     if (message_length < DECODER_START_OFFSET || message_length > MAX_MESSAGE_LENGTH) {
       ESP_LOGE(TAG, "DLMS: Message length invalid: %u", message_length);
@@ -67,151 +88,81 @@ void DlmsMeterComponent::loop() {
       return;
     }
 
-    // Decrypt in place and then decode the OBIS codes
-    if (!this->decrypt_(this->mbus_payload_, message_length, systitle_length, header_offset))
+    if (!this->decrypt_(this->dlms_payload_, message_length, systitle_length, header_offset)) {
       return;
-    this->decode_obis_(&this->mbus_payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+    }
+    this->decode_obis_(&this->dlms_payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
   }
 }
 
-bool DlmsMeterComponent::parse_mbus_(std::vector<uint8_t> &mbus_payload) {
-  ESP_LOGV(TAG, "Parsing M-Bus frames");
-  uint16_t frame_offset = 0;  // Offset is used if the M-Bus message is split into multiple frames
-
-  while (frame_offset < this->receive_buffer_.size()) {
-    // Ensure enough bytes remain for the minimal intro header before accessing indices
-    if (this->receive_buffer_.size() - frame_offset < MBUS_HEADER_INTRO_LENGTH) {
-      ESP_LOGE(TAG, "MBUS: Not enough data for frame header (need %d, have %d)", MBUS_HEADER_INTRO_LENGTH,
-               (this->receive_buffer_.size() - frame_offset));
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    // Check start bytes
-    if (this->receive_buffer_[frame_offset + MBUS_START1_OFFSET] != START_BYTE_LONG_FRAME ||
-        this->receive_buffer_[frame_offset + MBUS_START2_OFFSET] != START_BYTE_LONG_FRAME) {
-      ESP_LOGE(TAG, "MBUS: Start bytes do not match");
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    // Both length bytes must be identical
-    if (this->receive_buffer_[frame_offset + MBUS_LENGTH1_OFFSET] !=
-        this->receive_buffer_[frame_offset + MBUS_LENGTH2_OFFSET]) {
-      ESP_LOGE(TAG, "MBUS: Length bytes do not match");
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    uint8_t frame_length = this->receive_buffer_[frame_offset + MBUS_LENGTH1_OFFSET];  // Get length of this frame
-
-    // Check if received data is enough for the given frame length
-    if (this->receive_buffer_.size() - frame_offset <
-        frame_length + 3) {  // length field inside packet does not account for second start- + checksum- + stop- byte
-      ESP_LOGE(TAG, "MBUS: Frame too big for received data");
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    // Ensure we have full frame (header + payload + checksum + stop byte) before accessing stop byte
-    size_t required_total =
-        frame_length + MBUS_HEADER_INTRO_LENGTH + MBUS_FOOTER_LENGTH;  // payload + header + 2 footer bytes
-    if (this->receive_buffer_.size() - frame_offset < required_total) {
-      ESP_LOGE(TAG, "MBUS: Incomplete frame (need %d, have %d)", (unsigned int) required_total,
-               this->receive_buffer_.size() - frame_offset);
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    if (this->receive_buffer_[frame_offset + frame_length + MBUS_HEADER_INTRO_LENGTH + MBUS_FOOTER_LENGTH - 1] !=
-        STOP_BYTE) {
-      ESP_LOGE(TAG, "MBUS: Invalid stop byte");
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    // Verify checksum: sum of all bytes starting at MBUS_HEADER_INTRO_LENGTH, take last byte
-    uint8_t checksum = 0;  // use uint8_t so only the 8 least significant bits are stored
-    for (uint16_t i = 0; i < frame_length; i++) {
-      checksum += this->receive_buffer_[frame_offset + MBUS_HEADER_INTRO_LENGTH + i];
-    }
-    if (checksum != this->receive_buffer_[frame_offset + frame_length + MBUS_HEADER_INTRO_LENGTH]) {
-      ESP_LOGE(TAG, "MBUS: Invalid checksum: %x != %x", checksum,
-               this->receive_buffer_[frame_offset + frame_length + MBUS_HEADER_INTRO_LENGTH]);
-      this->receive_buffer_.clear();
-      return false;
-    }
-
-    mbus_payload.insert(mbus_payload.end(), &this->receive_buffer_[frame_offset + MBUS_FULL_HEADER_LENGTH],
-                        &this->receive_buffer_[frame_offset + MBUS_HEADER_INTRO_LENGTH + frame_length]);
-
-    frame_offset += MBUS_HEADER_INTRO_LENGTH + frame_length + MBUS_FOOTER_LENGTH;
-  }
-  return true;
-}
-
-bool DlmsMeterComponent::parse_dlms_(const std::vector<uint8_t> &mbus_payload, uint16_t &message_length,
+bool DlmsMeterComponent::parse_dlms_(const std::vector<uint8_t> &dlms_payload, uint16_t &message_length,
                                      uint8_t &systitle_length, uint16_t &header_offset) {
   ESP_LOGV(TAG, "Parsing DLMS header");
-  if (mbus_payload.size() < DLMS_HEADER_LENGTH + DLMS_HEADER_EXT_OFFSET) {
+  if (dlms_payload.size() < DLMS_HEADER_LENGTH + DLMS_HEADER_EXT_OFFSET) {
     ESP_LOGE(TAG, "DLMS: Payload too short");
     this->receive_buffer_.clear();
     return false;
   }
 
-  if (mbus_payload[DLMS_CIPHER_OFFSET] != GLO_CIPHERING) {  // Only general-glo-ciphering is supported (0xDB)
+  if (dlms_payload[DLMS_CIPHER_OFFSET] != GLO_CIPHERING) {
     ESP_LOGE(TAG, "DLMS: Unsupported cipher");
     this->receive_buffer_.clear();
     return false;
   }
 
-  systitle_length = mbus_payload[DLMS_SYST_OFFSET];
-
-  if (systitle_length != 0x08) {  // Only system titles with length of 8 are supported
+  systitle_length = dlms_payload[DLMS_SYST_OFFSET];
+  if (systitle_length != 0x08) {
     ESP_LOGE(TAG, "DLMS: Unsupported system title length");
     this->receive_buffer_.clear();
     return false;
   }
 
-  message_length = mbus_payload[DLMS_LENGTH_OFFSET];
+  message_length = dlms_payload[DLMS_LENGTH_OFFSET];
   header_offset = 0;
 
   if (this->provider_ == PROVIDER_NETZNOE) {
-    // for some reason EVN seems to set the standard "length" field to 0x81 and then the actual length is in the next
-    // byte. Check some bytes to see if received data still matches expectation
     if (message_length == NETZ_NOE_MAGIC_BYTE &&
-        mbus_payload[DLMS_LENGTH_OFFSET + 1] == NETZ_NOE_EXPECTED_MESSAGE_LENGTH &&
-        mbus_payload[DLMS_LENGTH_OFFSET + 2] == NETZ_NOE_EXPECTED_SECURITY_CONTROL_BYTE) {
-      message_length = mbus_payload[DLMS_LENGTH_OFFSET + 1];
+        dlms_payload[DLMS_LENGTH_OFFSET + 1] == NETZ_NOE_EXPECTED_MESSAGE_LENGTH &&
+        dlms_payload[DLMS_LENGTH_OFFSET + 2] == NETZ_NOE_EXPECTED_SECURITY_CONTROL_BYTE) {
+      message_length = dlms_payload[DLMS_LENGTH_OFFSET + 1];
       header_offset = 1;
     } else {
       ESP_LOGE(TAG, "Wrong Length - Security Control Byte sequence detected for provider EVN");
     }
-  } else {
-    if (message_length == TWO_BYTE_LENGTH) {
-      message_length = encode_uint16(mbus_payload[DLMS_LENGTH_OFFSET + 1], mbus_payload[DLMS_LENGTH_OFFSET + 2]);
-      header_offset = DLMS_HEADER_EXT_OFFSET;
-    }
+  } else if (message_length == TWO_BYTE_LENGTH) {
+    message_length = encode_uint16(dlms_payload[DLMS_LENGTH_OFFSET + 1], dlms_payload[DLMS_LENGTH_OFFSET + 2]);
+    header_offset = DLMS_HEADER_EXT_OFFSET;
   }
+
   if (message_length < DLMS_LENGTH_CORRECTION) {
     ESP_LOGE(TAG, "DLMS: Message length too short: %u", message_length);
     this->receive_buffer_.clear();
     return false;
   }
-  message_length -= DLMS_LENGTH_CORRECTION;  // Correct message length due to part of header being included in length
+  message_length -= DLMS_LENGTH_CORRECTION;
 
-  if (mbus_payload.size() - DLMS_HEADER_LENGTH - header_offset != message_length) {
-    ESP_LOGV(TAG, "DLMS: Length mismatch - payload=%d, header=%d, offset=%d, message=%d", mbus_payload.size(),
+  if (dlms_payload.size() - DLMS_HEADER_LENGTH - header_offset != message_length) {
+    ESP_LOGV(TAG, "DLMS: Length mismatch - payload=%d, header=%d, offset=%d, message=%d", dlms_payload.size(),
              DLMS_HEADER_LENGTH, header_offset, message_length);
     ESP_LOGE(TAG, "DLMS: Message has invalid length");
     this->receive_buffer_.clear();
     return false;
   }
 
-  if (mbus_payload[header_offset + DLMS_SECBYTE_OFFSET] != 0x21 &&
-      mbus_payload[header_offset + DLMS_SECBYTE_OFFSET] !=
-          0x20) {  // Only certain security suite is supported (0x21 || 0x20)
-    ESP_LOGE(TAG, "DLMS: Unsupported security control byte");
+  const uint8_t security_control = dlms_payload[header_offset + DLMS_SECBYTE_OFFSET];
+  const uint8_t security_suite = security_control & DLMS_SECURITY_SUITE_MASK;
+  if (this->provider_ == PROVIDER_KAMSTRUP_OMNIPOWER && security_suite != DLMS_SECURITY_SUPPORTED_SUITE_0) {
+    ESP_LOGE(TAG, "DLMS: Kamstrup provider only supports security suite 0, got 0x%02X", security_control);
+    this->receive_buffer_.clear();
+    return false;
+  }
+  if ((security_control & DLMS_SECURITY_ENCRYPTION) == 0) {
+    ESP_LOGE(TAG, "DLMS: Unsupported security control byte 0x%02X, encryption bit not set", security_control);
+    this->receive_buffer_.clear();
+    return false;
+  }
+  if (security_suite != DLMS_SECURITY_SUPPORTED_SUITE_0 && security_suite != DLMS_SECURITY_SUPPORTED_SUITE_1) {
+    ESP_LOGE(TAG, "DLMS: Unsupported security suite in security control byte 0x%02X", security_control);
     this->receive_buffer_.clear();
     return false;
   }
@@ -219,17 +170,38 @@ bool DlmsMeterComponent::parse_dlms_(const std::vector<uint8_t> &mbus_payload, u
   return true;
 }
 
-bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t message_length, uint8_t systitle_length,
+bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &dlms_payload, uint16_t message_length, uint8_t systitle_length,
                                   uint16_t header_offset) {
   ESP_LOGV(TAG, "Decrypting payload");
-  uint8_t iv[12];  // Reserve space for the IV, always 12 bytes
-  // Copy system title to IV (System title is before length; no header offset needed!)
-  // Add 1 to the offset in order to skip the system title length byte
-  memcpy(&iv[0], &mbus_payload[DLMS_SYST_OFFSET + 1], systitle_length);
-  memcpy(&iv[8], &mbus_payload[header_offset + DLMS_FRAMECOUNTER_OFFSET],
-         DLMS_FRAMECOUNTER_LENGTH);  // Copy frame counter to IV
+  const uint8_t security_control = dlms_payload[header_offset + DLMS_SECBYTE_OFFSET];
+  const bool has_authentication = (security_control & DLMS_SECURITY_AUTHENTICATION) != 0;
+  uint8_t iv[12];
+  memcpy(&iv[0], &dlms_payload[DLMS_SYST_OFFSET + 1], systitle_length);
+  memcpy(&iv[8], &dlms_payload[header_offset + DLMS_FRAMECOUNTER_OFFSET], DLMS_FRAMECOUNTER_LENGTH);
 
-  uint8_t *payload_ptr = &mbus_payload[header_offset + DLMS_PAYLOAD_OFFSET];
+  uint8_t *payload_ptr = &dlms_payload[header_offset + DLMS_PAYLOAD_OFFSET];
+  size_t ciphertext_length = message_length;
+  const uint8_t *tag_ptr = nullptr;
+  uint8_t aad[17];
+  size_t aad_length = 0;
+
+  if (has_authentication) {
+    if (!this->has_authentication_key_) {
+      ESP_LOGE(TAG, "DLMS: Authentication key required but not configured");
+      this->receive_buffer_.clear();
+      return false;
+    }
+    if (message_length < DLMS_AUTH_TAG_LENGTH) {
+      ESP_LOGE(TAG, "DLMS: Authenticated payload too short: %u", message_length);
+      this->receive_buffer_.clear();
+      return false;
+    }
+    ciphertext_length -= DLMS_AUTH_TAG_LENGTH;
+    tag_ptr = payload_ptr + ciphertext_length;
+    aad[0] = security_control;
+    memcpy(&aad[1], this->authentication_key_.data(), this->authentication_key_.size());
+    aad_length = sizeof(aad);
+  }
 
 #if defined(USE_ESP8266_FRAMEWORK_ARDUINO)
   br_gcm_context gcm_ctx;
@@ -237,23 +209,56 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
   br_aes_ct_ctr_init(&bc, this->decryption_key_.data(), this->decryption_key_.size());
   br_gcm_init(&gcm_ctx, &bc.vtable, br_ghash_ctmul32);
   br_gcm_reset(&gcm_ctx, iv, sizeof(iv));
+  if (has_authentication) {
+    br_gcm_aad_inject(&gcm_ctx, aad, aad_length);
+  }
   br_gcm_flip(&gcm_ctx);
-  br_gcm_run(&gcm_ctx, 0, payload_ptr, message_length);
+  br_gcm_run(&gcm_ctx, 0, payload_ptr, ciphertext_length);
+  if (has_authentication && br_gcm_check_tag_trunc(&gcm_ctx, tag_ptr, DLMS_AUTH_TAG_LENGTH) == 0) {
+    ESP_LOGE(TAG, "Decryption failed: authentication tag mismatch");
+    this->receive_buffer_.clear();
+    return false;
+  }
 #elif defined(USE_ESP32)
-  size_t outlen = 0;
   mbedtls_gcm_context gcm_ctx;
   mbedtls_gcm_init(&gcm_ctx);
-  mbedtls_gcm_setkey(&gcm_ctx, MBEDTLS_CIPHER_ID_AES, this->decryption_key_.data(), this->decryption_key_.size() * 8);
-  mbedtls_gcm_starts(&gcm_ctx, MBEDTLS_GCM_DECRYPT, iv, sizeof(iv));
-  auto ret = mbedtls_gcm_update(&gcm_ctx, payload_ptr, message_length, payload_ptr, message_length, &outlen);
+  int ret = mbedtls_gcm_setkey(&gcm_ctx, MBEDTLS_CIPHER_ID_AES, this->decryption_key_.data(),
+                               this->decryption_key_.size() * 8);
+  if (ret != 0) {
+    mbedtls_gcm_free(&gcm_ctx);
+    ESP_LOGE(TAG, "DLMS: Failed to initialize GCM key: %d", ret);
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  if (has_authentication) {
+    ret = mbedtls_gcm_auth_decrypt(&gcm_ctx, ciphertext_length, iv, sizeof(iv), aad, aad_length, tag_ptr,
+                                   DLMS_AUTH_TAG_LENGTH, payload_ptr, payload_ptr);
+  } else {
+    size_t outlen = 0;
+    ret = mbedtls_gcm_starts(&gcm_ctx, MBEDTLS_GCM_DECRYPT, iv, sizeof(iv));
+    if (ret == 0) {
+      ret = mbedtls_gcm_update_ad(&gcm_ctx, nullptr, 0);
+    }
+    if (ret == 0) {
+      ret = mbedtls_gcm_update(&gcm_ctx, payload_ptr, ciphertext_length, payload_ptr, ciphertext_length, &outlen);
+      if (ret == 0 && outlen != ciphertext_length) {
+        ret = -1;
+      }
+    }
+    if (ret == 0) {
+      ret = mbedtls_gcm_finish(&gcm_ctx, nullptr, 0, &outlen, nullptr, 0);
+      if (ret == 0 && outlen != 0) {
+        ret = -1;
+      }
+    }
+  }
   mbedtls_gcm_free(&gcm_ctx);
   if (ret != 0) {
     ESP_LOGE(TAG, "Decryption failed with error: %d", ret);
     this->receive_buffer_.clear();
     return false;
   }
-#else
-#error "Invalid Platform"
 #endif
 
   if (payload_ptr[0] != DATA_NOTIFICATION || payload_ptr[5] != TIMESTAMP_DATETIME) {
@@ -263,217 +268,6 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
   }
   ESP_LOGV(TAG, "Decrypted payload: %d bytes", message_length);
   return true;
-}
-
-void DlmsMeterComponent::decode_obis_(uint8_t *plaintext, uint16_t message_length) {
-  ESP_LOGV(TAG, "Decoding payload");
-  MeterData data{};
-  uint16_t current_position = DECODER_START_OFFSET;
-  bool power_factor_found = false;
-
-  while (current_position + OBIS_CODE_OFFSET <= message_length) {
-    if (plaintext[current_position + OBIS_TYPE_OFFSET] != DataType::OCTET_STRING) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header type: %x", plaintext[current_position + OBIS_TYPE_OFFSET]);
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    uint8_t obis_code_length = plaintext[current_position + OBIS_LENGTH_OFFSET];
-    if (obis_code_length != OBIS_CODE_LENGTH_STANDARD && obis_code_length != OBIS_CODE_LENGTH_EXTENDED) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header length: %x", obis_code_length);
-      this->receive_buffer_.clear();
-      return;
-    }
-    if (current_position + OBIS_CODE_OFFSET + obis_code_length > message_length) {
-      ESP_LOGE(TAG, "OBIS: Buffer too short for OBIS code");
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    uint8_t *obis_code = &plaintext[current_position + OBIS_CODE_OFFSET];
-    uint8_t obis_medium = obis_code[OBIS_A];
-    uint16_t obis_cd = encode_uint16(obis_code[OBIS_C], obis_code[OBIS_D]);
-
-    bool timestamp_found = false;
-    bool meter_number_found = false;
-    if (this->provider_ == PROVIDER_NETZNOE) {
-      // Do not advance Position when reading the Timestamp at DECODER_START_OFFSET
-      if ((obis_code_length == OBIS_CODE_LENGTH_EXTENDED) && (current_position == DECODER_START_OFFSET)) {
-        timestamp_found = true;
-      } else if (power_factor_found) {
-        meter_number_found = true;
-        power_factor_found = false;
-      } else {
-        current_position += obis_code_length + OBIS_CODE_OFFSET;  // Advance past code and position
-      }
-    } else {
-      current_position += obis_code_length + OBIS_CODE_OFFSET;  // Advance past code, position and type
-    }
-    if (!timestamp_found && !meter_number_found && obis_medium != Medium::ELECTRICITY &&
-        obis_medium != Medium::ABSTRACT) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS medium: %x", obis_medium);
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    if (current_position >= message_length) {
-      ESP_LOGE(TAG, "OBIS: Buffer too short for data type");
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    float value = 0.0f;
-    uint8_t value_size = 0;
-    uint8_t data_type = plaintext[current_position];
-    current_position++;
-
-    switch (data_type) {
-      case DataType::DOUBLE_LONG_UNSIGNED: {
-        value_size = 4;
-        if (current_position + value_size > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for DOUBLE_LONG_UNSIGNED");
-          this->receive_buffer_.clear();
-          return;
-        }
-        value = encode_uint32(plaintext[current_position + 0], plaintext[current_position + 1],
-                              plaintext[current_position + 2], plaintext[current_position + 3]);
-        current_position += value_size;
-        break;
-      }
-      case DataType::LONG_UNSIGNED: {
-        value_size = 2;
-        if (current_position + value_size > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for LONG_UNSIGNED");
-          this->receive_buffer_.clear();
-          return;
-        }
-        value = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
-        current_position += value_size;
-        break;
-      }
-      case DataType::OCTET_STRING: {
-        uint8_t data_length = plaintext[current_position];
-        current_position++;  // Advance past string length
-        if (current_position + data_length > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for OCTET_STRING");
-          this->receive_buffer_.clear();
-          return;
-        }
-        // Handle timestamp (normal OBIS code or NETZNOE special case)
-        if (obis_cd == OBIS_TIMESTAMP || timestamp_found) {
-          if (data_length < 8) {
-            ESP_LOGE(TAG, "OBIS: Timestamp data too short: %u", data_length);
-            this->receive_buffer_.clear();
-            return;
-          }
-          uint16_t year = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
-          uint8_t month = plaintext[current_position + 2];
-          uint8_t day = plaintext[current_position + 3];
-          uint8_t hour = plaintext[current_position + 5];
-          uint8_t minute = plaintext[current_position + 6];
-          uint8_t second = plaintext[current_position + 7];
-          if (year > 9999 || month > 12 || day > 31 || hour > 23 || minute > 59 || second > 59) {
-            ESP_LOGE(TAG, "Invalid timestamp values: %04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour, minute,
-                     second);
-            this->receive_buffer_.clear();
-            return;
-          }
-          snprintf(data.timestamp, sizeof(data.timestamp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour,
-                   minute, second);
-        } else if (meter_number_found) {
-          snprintf(data.meternumber, sizeof(data.meternumber), "%.*s", data_length, &plaintext[current_position]);
-        }
-        current_position += data_length;
-        break;
-      }
-      default:
-        ESP_LOGE(TAG, "OBIS: Unsupported OBIS data type: %x", data_type);
-        this->receive_buffer_.clear();
-        return;
-    }
-
-    // Skip break after data
-    if (this->provider_ == PROVIDER_NETZNOE) {
-      // Don't skip the break on the first timestamp, as there's none
-      if (!timestamp_found) {
-        current_position += 2;
-      }
-    } else {
-      current_position += 2;
-    }
-
-    // Check for additional data (scaler-unit structure)
-    if (current_position < message_length && plaintext[current_position] == DataType::INTEGER) {
-      // Apply scaler: real_value = raw_value × 10^scaler
-      if (current_position + 1 < message_length) {
-        int8_t scaler = static_cast<int8_t>(plaintext[current_position + 1]);
-        if (scaler != 0) {
-          value *= pow10_int(scaler);
-        }
-      }
-
-      // on EVN Meters there is no additional break
-      if (this->provider_ == PROVIDER_NETZNOE) {
-        current_position += 4;
-      } else {
-        current_position += 6;
-      }
-    }
-
-    // Handle numeric values (LONG_UNSIGNED and DOUBLE_LONG_UNSIGNED)
-    if (value_size > 0) {
-      switch (obis_cd) {
-        case OBIS_VOLTAGE_L1:
-          data.voltage_l1 = value;
-          break;
-        case OBIS_VOLTAGE_L2:
-          data.voltage_l2 = value;
-          break;
-        case OBIS_VOLTAGE_L3:
-          data.voltage_l3 = value;
-          break;
-        case OBIS_CURRENT_L1:
-          data.current_l1 = value;
-          break;
-        case OBIS_CURRENT_L2:
-          data.current_l2 = value;
-          break;
-        case OBIS_CURRENT_L3:
-          data.current_l3 = value;
-          break;
-        case OBIS_ACTIVE_POWER_PLUS:
-          data.active_power_plus = value;
-          break;
-        case OBIS_ACTIVE_POWER_MINUS:
-          data.active_power_minus = value;
-          break;
-        case OBIS_ACTIVE_ENERGY_PLUS:
-          data.active_energy_plus = value;
-          break;
-        case OBIS_ACTIVE_ENERGY_MINUS:
-          data.active_energy_minus = value;
-          break;
-        case OBIS_REACTIVE_ENERGY_PLUS:
-          data.reactive_energy_plus = value;
-          break;
-        case OBIS_REACTIVE_ENERGY_MINUS:
-          data.reactive_energy_minus = value;
-          break;
-        case OBIS_POWER_FACTOR:
-          data.power_factor = value;
-          power_factor_found = true;
-          break;
-        default:
-          ESP_LOGW(TAG, "Unsupported OBIS code 0x%04X", obis_cd);
-      }
-    }
-  }
-
-  this->receive_buffer_.clear();
-
-  ESP_LOGI(TAG, "Received valid data");
-  this->publish_sensors(data);
-  this->status_clear_warning();
 }
 
 }  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/dlms_meter.h
+++ b/esphome/components/dlms_meter/dlms_meter.h
@@ -29,27 +29,48 @@ namespace esphome::dlms_meter {
 #endif
 
 struct MeterData {
-  float voltage_l1 = 0.0f;             // Voltage L1
-  float voltage_l2 = 0.0f;             // Voltage L2
-  float voltage_l3 = 0.0f;             // Voltage L3
-  float current_l1 = 0.0f;             // Current L1
-  float current_l2 = 0.0f;             // Current L2
-  float current_l3 = 0.0f;             // Current L3
-  float active_power_plus = 0.0f;      // Active power taken from grid
-  float active_power_minus = 0.0f;     // Active power put into grid
-  float active_energy_plus = 0.0f;     // Active energy taken from grid
-  float active_energy_minus = 0.0f;    // Active energy put into grid
-  float reactive_energy_plus = 0.0f;   // Reactive energy taken from grid
-  float reactive_energy_minus = 0.0f;  // Reactive energy put into grid
-  char timestamp[27]{};                // Text sensor for the timestamp value
+  float voltage_l1 = 0.0f;              // Voltage L1
+  float voltage_l2 = 0.0f;              // Voltage L2
+  float voltage_l3 = 0.0f;              // Voltage L3
+  float current_l1 = 0.0f;              // Current L1
+  float current_l2 = 0.0f;              // Current L2
+  float current_l3 = 0.0f;              // Current L3
+  float active_power_plus = 0.0f;       // Active power taken from grid
+  float active_power_minus = 0.0f;      // Active power put into grid
+  float active_power_plus_l1 = 0.0f;    // Active power taken from grid on L1
+  float active_power_minus_l1 = 0.0f;   // Active power put into grid on L1
+  float active_power_plus_l2 = 0.0f;    // Active power taken from grid on L2
+  float active_power_minus_l2 = 0.0f;   // Active power put into grid on L2
+  float active_power_plus_l3 = 0.0f;    // Active power taken from grid on L3
+  float active_power_minus_l3 = 0.0f;   // Active power put into grid on L3
+  float reactive_power_plus = 0.0f;     // Reactive power taken from grid
+  float reactive_power_minus = 0.0f;    // Reactive power put into grid
+  float active_energy_plus = 0.0f;      // Active energy taken from grid
+  float active_energy_minus = 0.0f;     // Active energy put into grid
+  float active_energy_plus_l1 = 0.0f;   // Active energy taken from grid on L1
+  float active_energy_minus_l1 = 0.0f;  // Active energy put into grid on L1
+  float active_energy_plus_l2 = 0.0f;   // Active energy taken from grid on L2
+  float active_energy_minus_l2 = 0.0f;  // Active energy put into grid on L2
+  float active_energy_plus_l3 = 0.0f;   // Active energy taken from grid on L3
+  float active_energy_minus_l3 = 0.0f;  // Active energy put into grid on L3
+  float reactive_energy_plus = 0.0f;    // Reactive energy taken from grid
+  float reactive_energy_minus = 0.0f;   // Reactive energy put into grid
+  char timestamp[27]{};                 // Text sensor for the timestamp value
 
   // Netz NOE
   float power_factor = 0.0f;  // Power Factor
-  char meternumber[13]{};     // Text sensor for the meterNumber value
+  float power_factor_l1 = 0.0f;
+  float power_factor_l2 = 0.0f;
+  float power_factor_l3 = 0.0f;
+  float power_factor_total = 0.0f;
+  char meternumber[13]{};   // Text sensor for the meterNumber value
+  char meter_number[17]{};  // Kamstrup meter number
+  char obis_list_version[17]{};
 };
 
 // Provider constants
-enum Providers : uint32_t { PROVIDER_GENERIC = 0x00, PROVIDER_NETZNOE = 0x01 };
+enum Providers : uint32_t { PROVIDER_GENERIC = 0x00, PROVIDER_NETZNOE = 0x01, PROVIDER_KAMSTRUP_OMNIPOWER = 0x02 };
+enum class TransportType : uint8_t { UNKNOWN = 0x00, MBUS = 0x01, HDLC = 0x02 };
 
 class DlmsMeterComponent : public Component, public uart::UARTDevice {
  public:
@@ -59,6 +80,10 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
   void loop() override;
 
   void set_decryption_key(const std::array<uint8_t, 16> &key) { this->decryption_key_ = key; }
+  void set_authentication_key(const std::array<uint8_t, 16> &key) {
+    this->authentication_key_ = key;
+    this->has_authentication_key_ = true;
+  }
   void set_provider(uint32_t provider) { this->provider_ = provider; }
 
   void publish_sensors(MeterData &data) {
@@ -78,19 +103,28 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
 
  protected:
   bool parse_mbus_(std::vector<uint8_t> &mbus_payload);
-  bool parse_dlms_(const std::vector<uint8_t> &mbus_payload, uint16_t &message_length, uint8_t &systitle_length,
+  bool parse_hdlc_(std::vector<uint8_t> &dlms_payload);
+  bool parse_dlms_(const std::vector<uint8_t> &dlms_payload, uint16_t &message_length, uint8_t &systitle_length,
                    uint16_t &header_offset);
-  bool decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t message_length, uint8_t systitle_length,
+  bool decrypt_(std::vector<uint8_t> &dlms_payload, uint16_t message_length, uint8_t systitle_length,
                 uint16_t header_offset);
+  MeterData parse_kamstrup_omnipower_data_(uint8_t *plaintext, uint16_t message_length);
+  void decode_kamstrup_omnipower_obis_(uint8_t *plaintext, uint16_t message_length);
   void decode_obis_(uint8_t *plaintext, uint16_t message_length);
+  TransportType detect_transport_() const;
+  bool uses_hdlc_transport_() const;
+  size_t max_receive_length_() const;
+  void publish_parsed_data_(MeterData &data);
 
   std::vector<uint8_t> receive_buffer_;  // Stores the packet currently being received
-  std::vector<uint8_t> mbus_payload_;    // Parsed M-Bus payload, reused to avoid heap churn
+  std::vector<uint8_t> dlms_payload_;    // Parsed DLMS payload, reused to avoid heap churn
   uint32_t last_read_ = 0;               // Timestamp when data was last read
   uint32_t read_timeout_ = 1000;         // Time to wait after last byte before considering data complete
 
   uint32_t provider_ = PROVIDER_GENERIC;  // Provider of the meter / your grid operator
   std::array<uint8_t, 16> decryption_key_;
+  std::array<uint8_t, 16> authentication_key_{};
+  bool has_authentication_key_{false};
 };
 
 }  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/dlms_meter_kamstrup_omnipower.cpp
+++ b/esphome/components/dlms_meter/dlms_meter_kamstrup_omnipower.cpp
@@ -1,0 +1,129 @@
+#include "dlms_meter.h"
+
+#include <algorithm>
+
+namespace esphome::dlms_meter {
+
+static constexpr const char *TAG = "dlms_meter";
+
+void DlmsMeterComponent::decode_kamstrup_omnipower_obis_(uint8_t *plaintext, uint16_t message_length) {
+  ESP_LOGV(TAG, "Decoding Kamstrup OMNIPOWER payload");
+  MeterData data = this->parse_kamstrup_omnipower_data_(plaintext, message_length);
+  this->publish_parsed_data_(data);
+}
+
+MeterData DlmsMeterComponent::parse_kamstrup_omnipower_data_(uint8_t *plaintext, uint16_t message_length) {
+  MeterData data{};
+
+  if (message_length < 15) {
+    return data;
+  }
+
+  if (plaintext[0] == DATA_NOTIFICATION && plaintext[5] == TIMESTAMP_DATETIME) {
+    uint16_t year = encode_uint16(plaintext[6], plaintext[7]);
+    uint8_t month = plaintext[8];
+    uint8_t day = plaintext[9];
+    uint8_t hour = plaintext[11];
+    uint8_t minute = plaintext[12];
+    uint8_t second = plaintext[13];
+    if (year <= 9999 && month <= 12 && day <= 31 && hour <= 23 && minute <= 59 && second <= 59) {
+      snprintf(data.timestamp, sizeof(data.timestamp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour, minute,
+               second);
+    }
+  }
+
+  const auto find_obis = [&](uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e, uint8_t f) -> const uint8_t * {
+    const std::array<uint8_t, 8> needle = {DataType::OCTET_STRING, OBIS_CODE_LENGTH_STANDARD, a, b, c, d, e, f};
+    auto *const it = std::search(plaintext, plaintext + message_length, needle.begin(), needle.end());
+    if (it == plaintext + message_length) {
+      return nullptr;
+    }
+    return it + needle.size();
+  };
+
+  const auto read_u16 = [&](uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e, uint8_t f, float &target,
+                            float multiplier = 1.0f) {
+    const uint8_t *value = find_obis(a, b, c, d, e, f);
+    if (value == nullptr || value + 3 > plaintext + message_length || value[0] != DataType::LONG_UNSIGNED) {
+      return;
+    }
+    target = static_cast<float>(encode_uint16(value[1], value[2])) * multiplier;
+  };
+
+  const auto read_u32 = [&](uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e, uint8_t f, float &target,
+                            float multiplier = 1.0f) {
+    const uint8_t *value = find_obis(a, b, c, d, e, f);
+    if (value == nullptr || value + 5 > plaintext + message_length || value[0] != DataType::DOUBLE_LONG_UNSIGNED) {
+      return;
+    }
+    target = static_cast<float>(encode_uint32(value[1], value[2], value[3], value[4])) * multiplier;
+  };
+
+  const auto read_string = [&](uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e, uint8_t f, char *target,
+                               size_t target_size) {
+    const uint8_t *value = find_obis(a, b, c, d, e, f);
+    if (value == nullptr || value + 2 > plaintext + message_length) {
+      return;
+    }
+    if (value[0] != DataType::OCTET_STRING && value[0] != DataType::VISIBLE_STRING) {
+      return;
+    }
+    const uint8_t length = value[1];
+    if (value + 2 + length > plaintext + message_length) {
+      return;
+    }
+    snprintf(target, target_size, "%.*s", length, reinterpret_cast<const char *>(value + 2));
+  };
+
+  const auto read_u32_string = [&](uint8_t a, uint8_t b, uint8_t c, uint8_t d, uint8_t e, uint8_t f, char *target,
+                                   size_t target_size) {
+    const uint8_t *value = find_obis(a, b, c, d, e, f);
+    if (value == nullptr || value + 5 > plaintext + message_length || value[0] != DataType::DOUBLE_LONG_UNSIGNED) {
+      return;
+    }
+    snprintf(target, target_size, "%lu",
+             static_cast<unsigned long>(encode_uint32(value[1], value[2], value[3], value[4])));
+  };
+
+  read_u32_string(0x01, 0x01, 0x00, 0x00, 0x01, 0xFF, data.meter_number, sizeof(data.meter_number));
+  read_string(0x01, 0x01, 0x00, 0x02, 0x81, 0xFF, data.obis_list_version, sizeof(data.obis_list_version));
+
+  read_u32(0x01, 0x01, 0x01, 0x07, 0x00, 0xFF, data.active_power_plus);
+  read_u32(0x01, 0x01, 0x02, 0x07, 0x00, 0xFF, data.active_power_minus);
+  read_u32(0x01, 0x01, 0x03, 0x07, 0x00, 0xFF, data.reactive_power_plus);
+  read_u32(0x01, 0x01, 0x04, 0x07, 0x00, 0xFF, data.reactive_power_minus);
+  read_u32(0x01, 0x01, 0x15, 0x07, 0x00, 0xFF, data.active_power_plus_l1);
+  read_u32(0x01, 0x01, 0x16, 0x07, 0x00, 0xFF, data.active_power_minus_l1);
+  read_u32(0x01, 0x01, 0x29, 0x07, 0x00, 0xFF, data.active_power_plus_l2);
+  read_u32(0x01, 0x01, 0x2A, 0x07, 0x00, 0xFF, data.active_power_minus_l2);
+  read_u32(0x01, 0x01, 0x3D, 0x07, 0x00, 0xFF, data.active_power_plus_l3);
+  read_u32(0x01, 0x01, 0x3E, 0x07, 0x00, 0xFF, data.active_power_minus_l3);
+
+  read_u16(0x01, 0x01, 0x20, 0x07, 0x00, 0xFF, data.voltage_l1);
+  read_u16(0x01, 0x01, 0x34, 0x07, 0x00, 0xFF, data.voltage_l2);
+  read_u16(0x01, 0x01, 0x48, 0x07, 0x00, 0xFF, data.voltage_l3);
+
+  read_u32(0x01, 0x01, 0x1F, 0x07, 0x00, 0xFF, data.current_l1, 0.01f);
+  read_u32(0x01, 0x01, 0x33, 0x07, 0x00, 0xFF, data.current_l2, 0.01f);
+  read_u32(0x01, 0x01, 0x47, 0x07, 0x00, 0xFF, data.current_l3, 0.01f);
+
+  read_u32(0x01, 0x01, 0x01, 0x08, 0x00, 0xFF, data.active_energy_plus, 10.0f);
+  read_u32(0x01, 0x01, 0x02, 0x08, 0x00, 0xFF, data.active_energy_minus, 10.0f);
+  read_u32(0x01, 0x01, 0x03, 0x08, 0x00, 0xFF, data.reactive_energy_plus, 10.0f);
+  read_u32(0x01, 0x01, 0x04, 0x08, 0x00, 0xFF, data.reactive_energy_minus, 10.0f);
+  read_u32(0x01, 0x01, 0x15, 0x08, 0x00, 0xFF, data.active_energy_plus_l1, 10.0f);
+  read_u32(0x01, 0x01, 0x16, 0x08, 0x00, 0xFF, data.active_energy_minus_l1, 10.0f);
+  read_u32(0x01, 0x01, 0x29, 0x08, 0x00, 0xFF, data.active_energy_plus_l2, 10.0f);
+  read_u32(0x01, 0x01, 0x2A, 0x08, 0x00, 0xFF, data.active_energy_minus_l2, 10.0f);
+  read_u32(0x01, 0x01, 0x3D, 0x08, 0x00, 0xFF, data.active_energy_plus_l3, 10.0f);
+  read_u32(0x01, 0x01, 0x3E, 0x08, 0x00, 0xFF, data.active_energy_minus_l3, 10.0f);
+
+  read_u16(0x01, 0x01, 0x21, 0x07, 0x00, 0xFF, data.power_factor_l1);
+  read_u16(0x01, 0x01, 0x35, 0x07, 0x00, 0xFF, data.power_factor_l2);
+  read_u16(0x01, 0x01, 0x49, 0x07, 0x00, 0xFF, data.power_factor_l3);
+  read_u16(0x01, 0x01, 0x0D, 0x07, 0x00, 0xFF, data.power_factor_total);
+
+  return data;
+}
+
+}  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/dlms_meter_obis.cpp
+++ b/esphome/components/dlms_meter/dlms_meter_obis.cpp
@@ -1,0 +1,321 @@
+#include "dlms_meter.h"
+
+namespace esphome::dlms_meter {
+
+static constexpr const char *TAG = "dlms_meter";
+
+namespace {
+
+void assign_numeric_obis_value(MeterData &data, uint16_t obis_cd, float value, bool &power_factor_found) {
+  switch (obis_cd) {
+    case OBIS_VOLTAGE_L1:
+      data.voltage_l1 = value;
+      break;
+    case OBIS_VOLTAGE_L2:
+      data.voltage_l2 = value;
+      break;
+    case OBIS_VOLTAGE_L3:
+      data.voltage_l3 = value;
+      break;
+    case OBIS_CURRENT_L1:
+      data.current_l1 = value;
+      break;
+    case OBIS_CURRENT_L2:
+      data.current_l2 = value;
+      break;
+    case OBIS_CURRENT_L3:
+      data.current_l3 = value;
+      break;
+    case OBIS_ACTIVE_POWER_PLUS:
+      data.active_power_plus = value;
+      break;
+    case OBIS_ACTIVE_POWER_MINUS:
+      data.active_power_minus = value;
+      break;
+    case OBIS_ACTIVE_POWER_PLUS_L1:
+      data.active_power_plus_l1 = value;
+      break;
+    case OBIS_ACTIVE_POWER_MINUS_L1:
+      data.active_power_minus_l1 = value;
+      break;
+    case OBIS_ACTIVE_POWER_PLUS_L2:
+      data.active_power_plus_l2 = value;
+      break;
+    case OBIS_ACTIVE_POWER_MINUS_L2:
+      data.active_power_minus_l2 = value;
+      break;
+    case OBIS_ACTIVE_POWER_PLUS_L3:
+      data.active_power_plus_l3 = value;
+      break;
+    case OBIS_ACTIVE_POWER_MINUS_L3:
+      data.active_power_minus_l3 = value;
+      break;
+    case OBIS_REACTIVE_POWER_PLUS:
+      data.reactive_power_plus = value;
+      break;
+    case OBIS_REACTIVE_POWER_MINUS:
+      data.reactive_power_minus = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_PLUS:
+      data.active_energy_plus = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_MINUS:
+      data.active_energy_minus = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_PLUS_L1:
+      data.active_energy_plus_l1 = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_MINUS_L1:
+      data.active_energy_minus_l1 = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_PLUS_L2:
+      data.active_energy_plus_l2 = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_MINUS_L2:
+      data.active_energy_minus_l2 = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_PLUS_L3:
+      data.active_energy_plus_l3 = value;
+      break;
+    case OBIS_ACTIVE_ENERGY_MINUS_L3:
+      data.active_energy_minus_l3 = value;
+      break;
+    case OBIS_REACTIVE_ENERGY_PLUS:
+      data.reactive_energy_plus = value;
+      break;
+    case OBIS_REACTIVE_ENERGY_MINUS:
+      data.reactive_energy_minus = value;
+      break;
+    case OBIS_POWER_FACTOR:
+      data.power_factor = value;
+      data.power_factor_total = value;
+      power_factor_found = true;
+      break;
+    case OBIS_POWER_FACTOR_L1:
+      data.power_factor_l1 = value;
+      break;
+    case OBIS_POWER_FACTOR_L2:
+      data.power_factor_l2 = value;
+      break;
+    case OBIS_POWER_FACTOR_L3:
+      data.power_factor_l3 = value;
+      break;
+    default:
+      ESP_LOGW(TAG, "Unsupported OBIS code 0x%04X", obis_cd);
+      break;
+  }
+}
+
+void copy_string_value(char *target, size_t target_size, uint8_t data_length, const uint8_t *value) {
+  snprintf(target, target_size, "%.*s", data_length, value);
+}
+
+}  // namespace
+
+void DlmsMeterComponent::decode_obis_(uint8_t *plaintext, uint16_t message_length) {
+  if (this->provider_ == PROVIDER_KAMSTRUP_OMNIPOWER) {
+    this->decode_kamstrup_omnipower_obis_(plaintext, message_length);
+    return;
+  }
+
+  ESP_LOGV(TAG, "Decoding payload");
+  MeterData data{};
+  uint16_t current_position = DECODER_START_OFFSET;
+  bool power_factor_found = false;
+  bool has_break_after_data = true;
+
+  while (current_position + OBIS_CODE_OFFSET <= message_length) {
+    has_break_after_data = true;
+    if (plaintext[current_position + OBIS_TYPE_OFFSET] != DataType::OCTET_STRING) {
+      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header type: %x", plaintext[current_position + OBIS_TYPE_OFFSET]);
+      this->receive_buffer_.clear();
+      return;
+    }
+
+    uint8_t obis_code_length = plaintext[current_position + OBIS_LENGTH_OFFSET];
+    if (obis_code_length != OBIS_CODE_LENGTH_STANDARD && obis_code_length != OBIS_CODE_LENGTH_EXTENDED) {
+      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header length: %x", obis_code_length);
+      this->receive_buffer_.clear();
+      return;
+    }
+    if (current_position + OBIS_CODE_OFFSET + obis_code_length > message_length) {
+      ESP_LOGE(TAG, "OBIS: Buffer too short for OBIS code");
+      this->receive_buffer_.clear();
+      return;
+    }
+
+    uint8_t *obis_code = &plaintext[current_position + OBIS_CODE_OFFSET];
+    uint8_t obis_medium = obis_code[OBIS_A];
+    uint16_t obis_cd = encode_uint16(obis_code[OBIS_C], obis_code[OBIS_D]);
+    uint32_t obis_cde = encode_obis_cde(obis_code[OBIS_C], obis_code[OBIS_D], obis_code[OBIS_E]);
+
+    bool timestamp_found = false;
+    bool meter_number_found = false;
+    bool kamstrup_omnipower_meter_number_found = false;
+    bool kamstrup_omnipower_obis_list_version_found = false;
+    if (this->provider_ == PROVIDER_NETZNOE) {
+      if ((obis_code_length == OBIS_CODE_LENGTH_EXTENDED) && (current_position == DECODER_START_OFFSET)) {
+        timestamp_found = true;
+      } else if (power_factor_found) {
+        meter_number_found = true;
+        power_factor_found = false;
+      } else {
+        current_position += obis_code_length + OBIS_CODE_OFFSET;
+      }
+    } else {
+      current_position += obis_code_length + OBIS_CODE_OFFSET;
+    }
+    if (this->provider_ == PROVIDER_KAMSTRUP_OMNIPOWER) {
+      kamstrup_omnipower_meter_number_found = obis_cde == OBIS_METER_NUMBER;
+      kamstrup_omnipower_obis_list_version_found = obis_cde == OBIS_LIST_VERSION_IDENTIFIER;
+    }
+    if (!timestamp_found && !meter_number_found && obis_medium != Medium::ELECTRICITY &&
+        obis_medium != Medium::ABSTRACT) {
+      ESP_LOGE(TAG, "OBIS: Unsupported OBIS medium: %x", obis_medium);
+      this->receive_buffer_.clear();
+      return;
+    }
+
+    if (current_position >= message_length) {
+      ESP_LOGE(TAG, "OBIS: Buffer too short for data type");
+      this->receive_buffer_.clear();
+      return;
+    }
+
+    float value = 0.0f;
+    uint8_t value_size = 0;
+    uint8_t data_type = plaintext[current_position];
+    current_position++;
+
+    switch (data_type) {
+      case DataType::DOUBLE_LONG_UNSIGNED: {
+        constexpr uint8_t read_size = 4;
+        value_size = read_size;
+        if (current_position + read_size > message_length) {
+          ESP_LOGE(TAG, "OBIS: Buffer too short for DOUBLE_LONG_UNSIGNED");
+          this->receive_buffer_.clear();
+          return;
+        }
+        uint32_t raw_value = encode_uint32(plaintext[current_position + 0], plaintext[current_position + 1],
+                                           plaintext[current_position + 2], plaintext[current_position + 3]);
+        value = raw_value;
+        if (kamstrup_omnipower_meter_number_found) {
+          snprintf(data.meter_number, sizeof(data.meter_number), "%lu", static_cast<unsigned long>(raw_value));
+          value_size = 0;
+        }
+        current_position += read_size;
+        break;
+      }
+      case DataType::LONG_UNSIGNED: {
+        constexpr uint8_t read_size = 2;
+        value_size = read_size;
+        if (current_position + read_size > message_length) {
+          ESP_LOGE(TAG, "OBIS: Buffer too short for LONG_UNSIGNED");
+          this->receive_buffer_.clear();
+          return;
+        }
+        uint16_t raw_value = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
+        value = raw_value;
+        if (kamstrup_omnipower_meter_number_found) {
+          snprintf(data.meter_number, sizeof(data.meter_number), "%u", raw_value);
+          value_size = 0;
+        }
+        current_position += read_size;
+        break;
+      }
+      case DataType::OCTET_STRING: {
+        uint8_t data_length = plaintext[current_position];
+        current_position++;
+        if (current_position + data_length > message_length) {
+          ESP_LOGE(TAG, "OBIS: Buffer too short for OCTET_STRING");
+          this->receive_buffer_.clear();
+          return;
+        }
+        if (obis_cd == OBIS_TIMESTAMP || timestamp_found) {
+          if (data_length < 8) {
+            ESP_LOGE(TAG, "OBIS: Timestamp data too short: %u", data_length);
+            this->receive_buffer_.clear();
+            return;
+          }
+          uint16_t year = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
+          uint8_t month = plaintext[current_position + 2];
+          uint8_t day = plaintext[current_position + 3];
+          uint8_t hour = plaintext[current_position + 5];
+          uint8_t minute = plaintext[current_position + 6];
+          uint8_t second = plaintext[current_position + 7];
+          if (year > 9999 || month > 12 || day > 31 || hour > 23 || minute > 59 || second > 59) {
+            ESP_LOGE(TAG, "Invalid timestamp values: %04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour, minute,
+                     second);
+            this->receive_buffer_.clear();
+            return;
+          }
+          snprintf(data.timestamp, sizeof(data.timestamp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour,
+                   minute, second);
+        } else if (meter_number_found) {
+          copy_string_value(data.meternumber, sizeof(data.meternumber), data_length, &plaintext[current_position]);
+        } else if (kamstrup_omnipower_meter_number_found) {
+          copy_string_value(data.meter_number, sizeof(data.meter_number), data_length, &plaintext[current_position]);
+        } else if (kamstrup_omnipower_obis_list_version_found) {
+          copy_string_value(data.obis_list_version, sizeof(data.obis_list_version), data_length,
+                            &plaintext[current_position]);
+        }
+        current_position += data_length;
+        has_break_after_data = false;
+        break;
+      }
+      case DataType::VISIBLE_STRING: {
+        uint8_t data_length = plaintext[current_position];
+        current_position++;
+        if (current_position + data_length > message_length) {
+          ESP_LOGE(TAG, "OBIS: Buffer too short for VISIBLE_STRING");
+          this->receive_buffer_.clear();
+          return;
+        }
+        if (kamstrup_omnipower_meter_number_found) {
+          copy_string_value(data.meter_number, sizeof(data.meter_number), data_length, &plaintext[current_position]);
+        } else if (kamstrup_omnipower_obis_list_version_found) {
+          copy_string_value(data.obis_list_version, sizeof(data.obis_list_version), data_length,
+                            &plaintext[current_position]);
+        }
+        current_position += data_length;
+        has_break_after_data = false;
+        break;
+      }
+      default:
+        ESP_LOGE(TAG, "OBIS: Unsupported OBIS data type: %x", data_type);
+        this->receive_buffer_.clear();
+        return;
+    }
+
+    if (has_break_after_data && this->provider_ == PROVIDER_NETZNOE) {
+      if (!timestamp_found) {
+        current_position += 2;
+      }
+    } else if (has_break_after_data) {
+      current_position += 2;
+    }
+
+    if (current_position < message_length && plaintext[current_position] == DataType::INTEGER) {
+      if (current_position + 1 < message_length) {
+        int8_t scaler = static_cast<int8_t>(plaintext[current_position + 1]);
+        if (scaler != 0) {
+          value *= pow10_int(scaler);
+        }
+      }
+
+      if (this->provider_ == PROVIDER_NETZNOE) {
+        current_position += 4;
+      } else {
+        current_position += 6;
+      }
+    }
+
+    if (value_size > 0) {
+      assign_numeric_obis_value(data, obis_cd, value, power_factor_found);
+    }
+  }
+
+  this->publish_parsed_data_(data);
+}
+
+}  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/dlms_meter_transport.cpp
+++ b/esphome/components/dlms_meter/dlms_meter_transport.cpp
@@ -1,0 +1,199 @@
+#include "dlms_meter.h"
+
+#include <algorithm>
+
+namespace esphome::dlms_meter {
+
+static constexpr const char *TAG = "dlms_meter";
+static constexpr uint8_t HDLC_FLAG = 0x7E;
+static constexpr size_t HDLC_HEADER_FORMAT_OFFSET = 1;
+static constexpr size_t HDLC_MIN_FRAME_BYTES = 5;
+static constexpr uint8_t HDLC_LLC_DEST = 0xE6;
+static constexpr uint8_t HDLC_LLC_SRC = 0xE7;
+static constexpr uint8_t HDLC_LLC_QUALITY = 0x00;
+static constexpr size_t HDLC_LLC_LENGTH = 3;
+static constexpr size_t HDLC_FCS_LENGTH = 2;
+static constexpr uint16_t HDLC_LENGTH_MASK = 0x07FF;
+static constexpr size_t HDLC_MAX_RECEIVE_LENGTH = 600;
+
+TransportType DlmsMeterComponent::detect_transport_() const {
+  if (this->receive_buffer_.empty()) {
+    return TransportType::UNKNOWN;
+  }
+
+  if (this->receive_buffer_[0] == START_BYTE_LONG_FRAME) {
+    if (this->receive_buffer_.size() < MBUS_HEADER_INTRO_LENGTH) {
+      return TransportType::UNKNOWN;
+    }
+    if (this->receive_buffer_[MBUS_START2_OFFSET] == START_BYTE_LONG_FRAME &&
+        this->receive_buffer_[MBUS_LENGTH1_OFFSET] == this->receive_buffer_[MBUS_LENGTH2_OFFSET]) {
+      return TransportType::MBUS;
+    }
+  }
+
+  if (this->receive_buffer_[0] == HDLC_FLAG) {
+    if (this->receive_buffer_.size() < HDLC_MIN_FRAME_BYTES) {
+      return TransportType::UNKNOWN;
+    }
+
+    const uint8_t format_type = this->receive_buffer_[HDLC_HEADER_FORMAT_OFFSET] & 0xF0;
+    if (format_type != 0xA0 && format_type != 0xA1) {
+      return TransportType::UNKNOWN;
+    }
+
+    const uint16_t frame_length = encode_uint16(this->receive_buffer_[HDLC_HEADER_FORMAT_OFFSET],
+                                                this->receive_buffer_[HDLC_HEADER_FORMAT_OFFSET + 1]) &
+                                  HDLC_LENGTH_MASK;
+    if (frame_length <= HDLC_LLC_LENGTH + HDLC_FCS_LENGTH || frame_length + 1 > HDLC_MAX_RECEIVE_LENGTH) {
+      return TransportType::UNKNOWN;
+    }
+    return TransportType::HDLC;
+  }
+
+  return TransportType::UNKNOWN;
+}
+
+bool DlmsMeterComponent::uses_hdlc_transport_() const { return this->detect_transport_() == TransportType::HDLC; }
+
+size_t DlmsMeterComponent::max_receive_length_() const {
+  switch (this->detect_transport_()) {
+    case TransportType::HDLC:
+      return HDLC_MAX_RECEIVE_LENGTH;
+    case TransportType::MBUS:
+      return MBUS_MAX_FRAME_LENGTH * 2;
+    case TransportType::UNKNOWN:
+    default:
+      return std::max(HDLC_MAX_RECEIVE_LENGTH, static_cast<size_t>(MBUS_MAX_FRAME_LENGTH * 2));
+  }
+}
+
+bool DlmsMeterComponent::parse_mbus_(std::vector<uint8_t> &mbus_payload) {
+  ESP_LOGV(TAG, "Parsing M-Bus frames");
+  uint16_t frame_offset = 0;
+
+  while (frame_offset < this->receive_buffer_.size()) {
+    if (this->receive_buffer_.size() - frame_offset < MBUS_HEADER_INTRO_LENGTH) {
+      ESP_LOGE(TAG, "MBUS: Not enough data for frame header (need %d, have %d)", MBUS_HEADER_INTRO_LENGTH,
+               (this->receive_buffer_.size() - frame_offset));
+      this->receive_buffer_.clear();
+      return false;
+    }
+
+    if (this->receive_buffer_[frame_offset + MBUS_START1_OFFSET] != START_BYTE_LONG_FRAME ||
+        this->receive_buffer_[frame_offset + MBUS_START2_OFFSET] != START_BYTE_LONG_FRAME) {
+      frame_offset++;
+      continue;
+    }
+
+    if (this->receive_buffer_[frame_offset + MBUS_LENGTH1_OFFSET] !=
+        this->receive_buffer_[frame_offset + MBUS_LENGTH2_OFFSET]) {
+      frame_offset++;
+      continue;
+    }
+
+    uint8_t frame_length = this->receive_buffer_[frame_offset + MBUS_LENGTH1_OFFSET];
+    if (this->receive_buffer_.size() - frame_offset < frame_length + 3) {
+      ESP_LOGE(TAG, "MBUS: Frame too big for received data");
+      this->receive_buffer_.clear();
+      return false;
+    }
+
+    size_t required_total = frame_length + MBUS_HEADER_INTRO_LENGTH + MBUS_FOOTER_LENGTH;
+    if (this->receive_buffer_.size() - frame_offset < required_total) {
+      ESP_LOGE(TAG, "MBUS: Incomplete frame (need %d, have %d)", (unsigned int) required_total,
+               this->receive_buffer_.size() - frame_offset);
+      this->receive_buffer_.clear();
+      return false;
+    }
+
+    if (this->receive_buffer_[frame_offset + frame_length + MBUS_HEADER_INTRO_LENGTH + MBUS_FOOTER_LENGTH - 1] !=
+        STOP_BYTE) {
+      frame_offset++;
+      continue;
+    }
+
+    uint8_t checksum = 0;
+    for (uint16_t i = 0; i < frame_length; i++) {
+      checksum += this->receive_buffer_[frame_offset + MBUS_HEADER_INTRO_LENGTH + i];
+    }
+    if (checksum != this->receive_buffer_[frame_offset + frame_length + MBUS_HEADER_INTRO_LENGTH]) {
+      frame_offset++;
+      continue;
+    }
+
+    mbus_payload.insert(mbus_payload.end(), &this->receive_buffer_[frame_offset + MBUS_FULL_HEADER_LENGTH],
+                        &this->receive_buffer_[frame_offset + MBUS_HEADER_INTRO_LENGTH + frame_length]);
+    frame_offset += MBUS_HEADER_INTRO_LENGTH + frame_length + MBUS_FOOTER_LENGTH;
+  }
+
+  if (mbus_payload.empty()) {
+    ESP_LOGE(TAG, "MBUS: No valid frame found");
+    this->receive_buffer_.clear();
+    return false;
+  }
+  return true;
+}
+
+bool DlmsMeterComponent::parse_hdlc_(std::vector<uint8_t> &dlms_payload) {
+  ESP_LOGV(TAG, "Parsing HDLC frame");
+  static constexpr std::array<uint8_t, HDLC_LLC_LENGTH> HDLC_LLC_HEADER = {HDLC_LLC_DEST, HDLC_LLC_SRC,
+                                                                           HDLC_LLC_QUALITY};
+
+  const auto frame_start = std::find(this->receive_buffer_.begin(), this->receive_buffer_.end(), HDLC_FLAG);
+  if (frame_start == this->receive_buffer_.end()) {
+    ESP_LOGE(TAG, "HDLC: Start flag not found");
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  const size_t frame_start_offset = std::distance(this->receive_buffer_.begin(), frame_start);
+  if (this->receive_buffer_.size() - frame_start_offset < HDLC_MIN_FRAME_BYTES) {
+    ESP_LOGE(TAG, "HDLC: Not enough data for header");
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  const uint16_t frame_length =
+      encode_uint16(this->receive_buffer_[frame_start_offset + HDLC_HEADER_FORMAT_OFFSET],
+                    this->receive_buffer_[frame_start_offset + HDLC_HEADER_FORMAT_OFFSET + 1]) &
+      HDLC_LENGTH_MASK;
+  if (frame_length <= HDLC_LLC_LENGTH + HDLC_FCS_LENGTH) {
+    ESP_LOGE(TAG, "HDLC: Invalid frame length %u", frame_length);
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  const size_t frame_end_offset = frame_start_offset + frame_length + 1;
+  if (frame_end_offset >= this->receive_buffer_.size()) {
+    ESP_LOGE(TAG, "HDLC: Incomplete frame (need %u bytes, have %u)", static_cast<unsigned int>(frame_end_offset + 1),
+             static_cast<unsigned int>(this->receive_buffer_.size()));
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  if (this->receive_buffer_[frame_end_offset] != HDLC_FLAG) {
+    ESP_LOGE(TAG, "HDLC: End flag missing at expected offset %u", static_cast<unsigned int>(frame_end_offset));
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  const auto frame_end = this->receive_buffer_.begin() + static_cast<std::ptrdiff_t>(frame_end_offset);
+  const auto llc = std::search(frame_start + 1, frame_end, HDLC_LLC_HEADER.begin(), HDLC_LLC_HEADER.end());
+  if (llc == frame_end) {
+    ESP_LOGE(TAG, "HDLC: LLC header not found");
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  const auto payload_start = llc + HDLC_LLC_LENGTH;
+  if (frame_end - payload_start <= static_cast<std::ptrdiff_t>(HDLC_FCS_LENGTH)) {
+    ESP_LOGE(TAG, "HDLC: No DLMS payload after LLC header");
+    this->receive_buffer_.clear();
+    return false;
+  }
+
+  dlms_payload.assign(payload_start, frame_end - HDLC_FCS_LENGTH);
+  return true;
+}
+
+}  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/obis.h
+++ b/esphome/components/dlms_meter/obis.h
@@ -61,8 +61,14 @@ static constexpr uint8_t OBIS_D = 3;
 static constexpr uint8_t OBIS_E = 4;
 static constexpr uint8_t OBIS_F = 5;
 
+constexpr uint32_t encode_obis_cde(uint8_t c, uint8_t d, uint8_t e) {
+  return (static_cast<uint32_t>(c) << 16) | (static_cast<uint32_t>(d) << 8) | e;
+}
+
 // Metadata
 static constexpr uint16_t OBIS_TIMESTAMP = 0x0100;
+static constexpr uint32_t OBIS_LIST_VERSION_IDENTIFIER = 0x000281;
+static constexpr uint32_t OBIS_METER_NUMBER = 0x000001;
 static constexpr uint16_t OBIS_SERIAL_NUMBER = 0x6001;
 static constexpr uint16_t OBIS_DEVICE_NAME = 0x2A00;
 
@@ -79,16 +85,33 @@ static constexpr uint16_t OBIS_CURRENT_L3 = 0x4707;
 // Power
 static constexpr uint16_t OBIS_ACTIVE_POWER_PLUS = 0x0107;
 static constexpr uint16_t OBIS_ACTIVE_POWER_MINUS = 0x0207;
+static constexpr uint16_t OBIS_REACTIVE_POWER_PLUS = 0x0307;
+static constexpr uint16_t OBIS_REACTIVE_POWER_MINUS = 0x0407;
+static constexpr uint16_t OBIS_ACTIVE_POWER_PLUS_L1 = 0x1507;
+static constexpr uint16_t OBIS_ACTIVE_POWER_MINUS_L1 = 0x1607;
+static constexpr uint16_t OBIS_ACTIVE_POWER_PLUS_L2 = 0x2907;
+static constexpr uint16_t OBIS_ACTIVE_POWER_MINUS_L2 = 0x2A07;
+static constexpr uint16_t OBIS_ACTIVE_POWER_PLUS_L3 = 0x3D07;
+static constexpr uint16_t OBIS_ACTIVE_POWER_MINUS_L3 = 0x3E07;
 
 // Active energy
 static constexpr uint16_t OBIS_ACTIVE_ENERGY_PLUS = 0x0108;
 static constexpr uint16_t OBIS_ACTIVE_ENERGY_MINUS = 0x0208;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_PLUS_L1 = 0x1508;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_MINUS_L1 = 0x1608;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_PLUS_L2 = 0x2908;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_MINUS_L2 = 0x2A08;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_PLUS_L3 = 0x3D08;
+static constexpr uint16_t OBIS_ACTIVE_ENERGY_MINUS_L3 = 0x3E08;
 
 // Reactive energy
 static constexpr uint16_t OBIS_REACTIVE_ENERGY_PLUS = 0x0308;
 static constexpr uint16_t OBIS_REACTIVE_ENERGY_MINUS = 0x0408;
 
-// Netz NOE specific
+// Power Factor
 static constexpr uint16_t OBIS_POWER_FACTOR = 0x0D07;
+static constexpr uint16_t OBIS_POWER_FACTOR_L1 = 0x2107;
+static constexpr uint16_t OBIS_POWER_FACTOR_L2 = 0x3507;
+static constexpr uint16_t OBIS_POWER_FACTOR_L3 = 0x4907;
 
 }  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/sensor/__init__.py
+++ b/esphome/components/dlms_meter/sensor/__init__.py
@@ -12,6 +12,8 @@ from esphome.const import (
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_VOLT,
+    UNIT_VOLT_AMPS_REACTIVE,
+    UNIT_VOLT_AMPS_REACTIVE_HOURS,
     UNIT_WATT,
     UNIT_WATT_HOURS,
 )
@@ -71,6 +73,52 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
+        cv.Optional("active_power_plus_l1"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("active_power_minus_l1"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("active_power_plus_l2"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("active_power_minus_l2"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("active_power_plus_l3"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("active_power_minus_l3"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("reactive_power_plus"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("reactive_power_minus"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
         cv.Optional("active_energy_plus"): sensor.sensor_schema(
             unit_of_measurement=UNIT_WATT_HOURS,
             accuracy_decimals=0,
@@ -83,20 +131,76 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_ENERGY,
             state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
-        cv.Optional("reactive_energy_plus"): sensor.sensor_schema(
+        cv.Optional("active_energy_plus_l1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_WATT_HOURS,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_ENERGY,
             state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
-        cv.Optional("reactive_energy_minus"): sensor.sensor_schema(
+        cv.Optional("active_energy_minus_l1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_WATT_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("active_energy_plus_l2"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("active_energy_minus_l2"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("active_energy_plus_l3"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("active_energy_minus_l3"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("reactive_energy_plus"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE_HOURS,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_ENERGY,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional("reactive_energy_minus"): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=0,
             device_class=DEVICE_CLASS_ENERGY,
             state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         # Netz NOE
         cv.Optional("power_factor"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            device_class=DEVICE_CLASS_POWER_FACTOR,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("power_factor_l1"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            device_class=DEVICE_CLASS_POWER_FACTOR,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("power_factor_l2"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            device_class=DEVICE_CLASS_POWER_FACTOR,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("power_factor_l3"): sensor.sensor_schema(
+            accuracy_decimals=3,
+            device_class=DEVICE_CLASS_POWER_FACTOR,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional("power_factor_total"): sensor.sensor_schema(
             accuracy_decimals=3,
             device_class=DEVICE_CLASS_POWER_FACTOR,
             state_class=STATE_CLASS_MEASUREMENT,

--- a/esphome/components/dlms_meter/text_sensor/__init__.py
+++ b/esphome/components/dlms_meter/text_sensor/__init__.py
@@ -13,6 +13,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional("timestamp"): text_sensor.text_sensor_schema(),
         # Netz NOE
         cv.Optional("meternumber"): text_sensor.text_sensor_schema(),
+        cv.Optional("meter_number"): text_sensor.text_sensor_schema(),
+        cv.Optional("obis_list_version"): text_sensor.text_sensor_schema(),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/tests/components/dlms_meter/common-generic-auth.yaml
+++ b/tests/components/dlms_meter/common-generic-auth.yaml
@@ -1,0 +1,12 @@
+dlms_meter:
+  decryption_key: "36C66639E48A8CA4D6BC8B282A793BBB"
+  authentication_key: "00112233445566778899AABBCCDDEEFF"
+
+sensor:
+  - platform: dlms_meter
+    reactive_energy_plus:
+      name: "Reactive energy taken from grid"
+    reactive_energy_minus:
+      name: "Reactive energy put into grid"
+
+<<: !include common.yaml

--- a/tests/components/dlms_meter/common-kamstrup.yaml
+++ b/tests/components/dlms_meter/common-kamstrup.yaml
@@ -1,0 +1,52 @@
+dlms_meter:
+  decryption_key: "36C66639E48A8CA4D6BC8B282A793BBB"
+  authentication_key: "00112233445566778899AABBCCDDEEFF"
+  provider: kamstrup-omnipower
+
+sensor:
+  - platform: dlms_meter
+    active_power_plus_l1:
+      name: "Active power taken from grid on L1"
+    active_power_minus_l1:
+      name: "Active power put into grid on L1"
+    active_power_plus_l2:
+      name: "Active power taken from grid on L2"
+    active_power_minus_l2:
+      name: "Active power put into grid on L2"
+    active_power_plus_l3:
+      name: "Active power taken from grid on L3"
+    active_power_minus_l3:
+      name: "Active power put into grid on L3"
+    reactive_power_plus:
+      name: "Reactive power taken from grid"
+    reactive_power_minus:
+      name: "Reactive power put into grid"
+    power_factor_l1:
+      name: "Power factor L1"
+    power_factor_l2:
+      name: "Power factor L2"
+    power_factor_l3:
+      name: "Power factor L3"
+    power_factor_total:
+      name: "Power factor total"
+    active_energy_plus_l1:
+      name: "Active energy taken from grid on L1"
+    active_energy_minus_l1:
+      name: "Active energy put into grid on L1"
+    active_energy_plus_l2:
+      name: "Active energy taken from grid on L2"
+    active_energy_minus_l2:
+      name: "Active energy put into grid on L2"
+    active_energy_plus_l3:
+      name: "Active energy taken from grid on L3"
+    active_energy_minus_l3:
+      name: "Active energy put into grid on L3"
+
+text_sensor:
+  - platform: dlms_meter
+    meter_number:
+      name: "Meter number"
+    obis_list_version:
+      name: "OBIS list version"
+
+<<: !include common.yaml

--- a/tests/components/dlms_meter/test-auth.esp32-ard.yaml
+++ b/tests/components/dlms_meter/test-auth.esp32-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp32-ard.yaml
+
+<<: !include common-generic-auth.yaml

--- a/tests/components/dlms_meter/test-auth.esp32-idf.yaml
+++ b/tests/components/dlms_meter/test-auth.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp32-idf.yaml
+
+<<: !include common-generic-auth.yaml

--- a/tests/components/dlms_meter/test-auth.esp8266-ard.yaml
+++ b/tests/components/dlms_meter/test-auth.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp8266-ard.yaml
+
+<<: !include common-generic-auth.yaml

--- a/tests/components/dlms_meter/test-kamstrup.esp32-idf.yaml
+++ b/tests/components/dlms_meter/test-kamstrup.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  uart_2400: !include ../../test_build_components/common/uart_2400/esp32-idf.yaml
+
+<<: !include common-kamstrup.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds authenticated dual-key DLMS support to `dlms_meter` and extends the component with support for Danish Kamstrup OMNIPOWER HAN meters.

The change adds:
- optional `authentication_key` support for meters using separate encryption and authentication keys
- a `kamstrup-omnipower` provider with Kamstrup-specific sensor/text-sensor decoding
- direct HDLC transport support for OMNIPOWER HAN frames
- automatic transport detection from received frame bytes
- internal refactoring to split transport, generic OBIS decoding, and Kamstrup-specific decoding into separate files

It keeps the existing generic and `netznoe` decoding paths intact. (Untested, as I do not have access to any other meter)

## Types of changes

- [] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/feature-requests/issues/1401#issuecomment-3993779867

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6264

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  rx_pin: GPIO13
  baud_rate: 2400
  rx_buffer_size: 1024

dlms_meter:
  provider: kamstrup-omnipower
  decryption_key: "00112233445566778899AABBCCDDEEFF"
  authentication_key: "FFEEDDCCBBAA99887766554433221100"

sensor:
  - platform: dlms_meter
    voltage_l1:
      name: Voltage L1
    active_power_plus:
      name: Active power import
    active_energy_plus:
      name: Active energy import

text_sensor:
  - platform: dlms_meter
    timestamp:
      name: Timestamp
    meter_number:
      name: Meter number
    obis_list_version:
      name: OBIS list version
```


## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
