### PR TITLE
[light] Fix ambiguous set_effect overload for const char*

### DIFF
--- a/esphome/components/addressable_light/addressable_light_display.h
+++ b/esphome/components/addressable_light/addressable_light_display.h
@@ -33,7 +33,7 @@ class AddressableLightDisplay : public display::DisplayBuffer {
         // - Save the current effect index.
         this->last_effect_index_ = light_state_->get_current_effect_index();
         // - Disable any current effect.
-        light_state_->make_call().set_effect(0).perform();
+        light_state_->make_call().set_effect(uint32_t{0}).perform();
       }
     }
     enabled_ = enabled;

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -506,7 +506,7 @@ color_mode_bitmask_t LightCall::get_suitable_color_modes_mask_() {
 
 LightCall &LightCall::set_effect(const char *effect, size_t len) {
   if (len == 4 && strncasecmp(effect, "none", 4) == 0) {
-    this->set_effect(0);
+    this->set_effect(uint32_t{0});
     return *this;
   }
 

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -130,6 +130,8 @@ class LightCall {
   LightCall &set_effect(optional<std::string> effect);
   /// Set the effect of the light by its name.
   LightCall &set_effect(const std::string &effect) { return this->set_effect(effect.data(), effect.size()); }
+  /// Set the effect of the light by its name (const char * overload to resolve ambiguity).
+  LightCall &set_effect(const char *effect) { return this->set_effect(effect, strlen(effect)); }
   /// Set the effect of the light by its name and length (zero-copy from API).
   LightCall &set_effect(const char *effect, size_t len);
   /// Set the effect of the light by its internal index number (only for internal use).

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -60,6 +60,12 @@ esphome:
             }
           }
 
+      # Test set_effect with const char* doesn't cause ambiguous overload (issue #14728)
+      - lambda: |-
+          auto call = id(test_monochromatic_light).turn_on();
+          call.set_effect("None");
+          call.perform();
+
       - light.toggle: test_binary_light
       - light.turn_off: test_rgb_light
       - light.turn_on:


### PR DESCRIPTION
# What does this implement/fix?

When calling `set_effect("None")` from a lambda, the compiler cannot choose between `set_effect(optional<std::string>)` and `set_effect(const std::string&)` since both require one implicit conversion from `const char*`. This adds an explicit `const char*` overload to resolve the ambiguity.

Internal callers that used `set_effect(0)` (integer index) are updated to `set_effect(uint32_t{0})` since the literal `0` is ambiguous between `const char*` (null pointer) and `uint32_t`. In practice, lambda users call `set_effect("EffectName")` not by numeric index, so the impact is minimal.

## Migration guide

If you have a lambda that calls `set_effect(0)` to disable effects by index, you will get an ambiguous overload error. Change it to use an explicit cast:

```cpp
// Before (no longer compiles)
call.set_effect(0);

// After (option 1: explicit cast)
call.set_effect(uint32_t(0));

// After (option 2: use the string form)
call.set_effect("None");
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14728

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: neopixelbus
    id: my_light
    # ...
    effects:
      - addressable_lambda:
          name: "Test"
          lambda: |-
            auto call = id(my_light).turn_on();
            call.set_effect("None");  // Previously caused ambiguous overload error
            call.perform();
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).