### PR TITLE
[pid] Replace std::deque with FixedRingBuffer

### DIFF
--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_KD_MULTIPLIER, default=0.0): cv.float_,
                     cv.Optional(
                         CONF_DEADBAND_OUTPUT_AVERAGING_SAMPLES, default=1
-                    ): cv.int_,
+                    ): cv.positive_int,
                 }
             ),
             cv.Required(CONF_CONTROL_PARAMETERS): cv.Schema(
@@ -68,8 +68,12 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_STARTING_INTEGRAL_TERM, default=0.0): cv.float_,
                     cv.Optional(CONF_MIN_INTEGRAL, default=-1): cv.float_,
                     cv.Optional(CONF_MAX_INTEGRAL, default=1): cv.float_,
-                    cv.Optional(CONF_DERIVATIVE_AVERAGING_SAMPLES, default=1): cv.int_,
-                    cv.Optional(CONF_OUTPUT_AVERAGING_SAMPLES, default=1): cv.int_,
+                    cv.Optional(
+                        CONF_DERIVATIVE_AVERAGING_SAMPLES, default=1
+                    ): cv.positive_int,
+                    cv.Optional(
+                        CONF_OUTPUT_AVERAGING_SAMPLES, default=1
+                    ): cv.positive_int,
                 }
             ),
         }

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_KD_MULTIPLIER, default=0.0): cv.float_,
                     cv.Optional(
                         CONF_DEADBAND_OUTPUT_AVERAGING_SAMPLES, default=1
-                    ): cv.positive_int,
+                    ): cv.positive_not_null_int,
                 }
             ),
             cv.Required(CONF_CONTROL_PARAMETERS): cv.Schema(
@@ -70,10 +70,10 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_MAX_INTEGRAL, default=1): cv.float_,
                     cv.Optional(
                         CONF_DERIVATIVE_AVERAGING_SAMPLES, default=1
-                    ): cv.positive_int,
+                    ): cv.positive_not_null_int,
                     cv.Optional(
                         CONF_OUTPUT_AVERAGING_SAMPLES, default=1
-                    ): cv.positive_int,
+                    ): cv.positive_not_null_int,
                 }
             ),
         }

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -106,13 +106,15 @@ async def to_code(config):
     cg.add(var.set_starting_integral_term(params[CONF_STARTING_INTEGRAL_TERM]))
     cg.add(var.set_derivative_samples(params[CONF_DERIVATIVE_AVERAGING_SAMPLES]))
 
-    cg.add(var.set_output_samples(params[CONF_OUTPUT_AVERAGING_SAMPLES]))
+    output_samples = params[CONF_OUTPUT_AVERAGING_SAMPLES]
+    cg.add(var.set_output_samples(output_samples))
 
     if CONF_MIN_INTEGRAL in params:
         cg.add(var.set_min_integral(params[CONF_MIN_INTEGRAL]))
     if CONF_MAX_INTEGRAL in params:
         cg.add(var.set_max_integral(params[CONF_MAX_INTEGRAL]))
 
+    deadband_output_samples = 1
     if CONF_DEADBAND_PARAMETERS in config:
         params = config[CONF_DEADBAND_PARAMETERS]
         cg.add(var.set_threshold_low(params[CONF_THRESHOLD_LOW]))
@@ -120,11 +122,11 @@ async def to_code(config):
         cg.add(var.set_kp_multiplier(params[CONF_KP_MULTIPLIER]))
         cg.add(var.set_ki_multiplier(params[CONF_KI_MULTIPLIER]))
         cg.add(var.set_kd_multiplier(params[CONF_KD_MULTIPLIER]))
-        cg.add(
-            var.set_deadband_output_samples(
-                params[CONF_DEADBAND_OUTPUT_AVERAGING_SAMPLES]
-            )
-        )
+        deadband_output_samples = params[CONF_DEADBAND_OUTPUT_AVERAGING_SAMPLES]
+        cg.add(var.set_deadband_output_samples(deadband_output_samples))
+
+    # Single shared output buffer sized to max of both modes
+    cg.add(var.init_output_buffer(max(output_samples, deadband_output_samples)))
 
     cg.add(var.set_default_target_temperature(config[CONF_DEFAULT_TARGET_TEMPERATURE]))
 

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -27,10 +27,7 @@ class PIDClimate : public climate::Climate, public Component {
   void set_kd(float kd) { controller_.kd_ = kd; }
   void set_min_integral(float min_integral) { controller_.min_integral_ = min_integral; }
   void set_max_integral(float max_integral) { controller_.max_integral_ = max_integral; }
-  void set_output_samples(int in) {
-    controller_.output_samples_ = in;
-    controller_.output_window_.init(in);
-  }
+  void set_output_samples(int in) { controller_.output_samples_ = in; }
   void set_derivative_samples(int in) {
     controller_.derivative_samples_ = in;
     controller_.derivative_window_.init(in);
@@ -43,10 +40,8 @@ class PIDClimate : public climate::Climate, public Component {
   void set_kd_multiplier(float in) { controller_.kd_multiplier_ = in; }
   void set_starting_integral_term(float in) { controller_.set_starting_integral_term(in); }
 
-  void set_deadband_output_samples(int in) {
-    controller_.deadband_output_samples_ = in;
-    controller_.deadband_output_window_.init(in);
-  }
+  void set_deadband_output_samples(int in) { controller_.deadband_output_samples_ = in; }
+  void init_output_buffer(int size) { controller_.output_window_.init(size); }
 
   float get_output_value() const { return output_value_; }
   float get_error_value() const { return controller_.error_; }

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -27,8 +27,14 @@ class PIDClimate : public climate::Climate, public Component {
   void set_kd(float kd) { controller_.kd_ = kd; }
   void set_min_integral(float min_integral) { controller_.min_integral_ = min_integral; }
   void set_max_integral(float max_integral) { controller_.max_integral_ = max_integral; }
-  void set_output_samples(int in) { controller_.output_samples_ = in; }
-  void set_derivative_samples(int in) { controller_.derivative_samples_ = in; }
+  void set_output_samples(int in) {
+    controller_.output_samples_ = in;
+    controller_.output_window_.init(in);
+  }
+  void set_derivative_samples(int in) {
+    controller_.derivative_samples_ = in;
+    controller_.derivative_window_.init(in);
+  }
 
   void set_threshold_low(float in) { controller_.threshold_low_ = in; }
   void set_threshold_high(float in) { controller_.threshold_high_ = in; }
@@ -37,7 +43,10 @@ class PIDClimate : public climate::Climate, public Component {
   void set_kd_multiplier(float in) { controller_.kd_multiplier_ = in; }
   void set_starting_integral_term(float in) { controller_.set_starting_integral_term(in); }
 
-  void set_deadband_output_samples(int in) { controller_.deadband_output_samples_ = in; }
+  void set_deadband_output_samples(int in) {
+    controller_.deadband_output_samples_ = in;
+    controller_.deadband_output_window_.init(in);
+  }
 
   float get_output_value() const { return output_value_; }
   float get_error_value() const { return controller_.error_; }

--- a/esphome/components/pid/pid_climate.h
+++ b/esphome/components/pid/pid_climate.h
@@ -30,7 +30,8 @@ class PIDClimate : public climate::Climate, public Component {
   void set_output_samples(int in) { controller_.output_samples_ = in; }
   void set_derivative_samples(int in) {
     controller_.derivative_samples_ = in;
-    controller_.derivative_window_.init(in);
+    if (in > 1)  // No allocation needed when samples=1 (ring_buffer_average_ short-circuits)
+      controller_.derivative_window_.init(in);
   }
 
   void set_threshold_low(float in) { controller_.threshold_low_ = in; }
@@ -41,7 +42,10 @@ class PIDClimate : public climate::Climate, public Component {
   void set_starting_integral_term(float in) { controller_.set_starting_integral_term(in); }
 
   void set_deadband_output_samples(int in) { controller_.deadband_output_samples_ = in; }
-  void init_output_buffer(int size) { controller_.output_window_.init(size); }
+  void init_output_buffer(int size) {
+    if (size > 1)  // No allocation needed when samples=1 (ring_buffer_average_ short-circuits)
+      controller_.output_window_.init(size);
+  }
 
   float get_output_value() const { return output_value_; }
   float get_error_value() const { return controller_.error_; }

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -100,13 +100,11 @@ float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new
     return new_value;
   }
 
-  // Use push_overwrite for sliding window behavior (overwrites oldest when full)
-  buf.push_overwrite(new_value);
-
-  // When buffer has more entries than the current mode needs (shared buffer may be
-  // sized larger for the other mode), trim oldest entries to match max_samples
-  while (buf.size() > static_cast<size_t>(max_samples))
+  // Trim oldest entries to make room (handles mode-switching where buffer
+  // may have more entries than the current mode needs)
+  while (buf.size() >= static_cast<size_t>(max_samples))
     buf.pop();
+  buf.push(new_value);
 
   float sum = 0;
   for (auto val : buf)

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -21,12 +21,9 @@ float PIDController::update(float setpoint, float process_value) {
   // u(t) := p(t) + i(t) + d(t)
   float output = proportional_term_ + integral_term_ + derivative_term_;
 
-  // smooth/sample the output using appropriate buffer for current mode
-  if (in_deadband()) {
-    return ring_buffer_average_(deadband_output_window_, output, deadband_output_samples_);
-  } else {
-    return ring_buffer_average_(output_window_, output, output_samples_);
-  }
+  // smooth/sample the output using shared buffer with mode-appropriate sample count
+  int samples = in_deadband() ? deadband_output_samples_ : output_samples_;
+  return ring_buffer_average_(output_window_, output, samples);
 }
 
 bool PIDController::in_deadband() {
@@ -106,7 +103,11 @@ float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new
   // Use push_overwrite for sliding window behavior (overwrites oldest when full)
   buf.push_overwrite(new_value);
 
-  // Buffer is always initialized via init_buffers() before this is called
+  // When buffer has more entries than the current mode needs (shared buffer may be
+  // sized larger for the other mode), trim oldest entries to match max_samples
+  while (buf.size() > static_cast<size_t>(max_samples))
+    buf.pop();
+
   float sum = 0;
   for (auto val : buf)
     sum += val;

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -94,8 +94,8 @@ void PIDController::calculate_derivative_term_(float setpoint) {
 }
 
 float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples) {
-  // if only 1 sample needed, clear the buffer and return
-  if (max_samples == 1) {
+  // if only 1 sample needed (or invalid), clear the buffer and return
+  if (max_samples <= 1) {
     buf.clear();
     return new_value;
   }

--- a/esphome/components/pid/pid_controller.cpp
+++ b/esphome/components/pid/pid_controller.cpp
@@ -21,9 +21,12 @@ float PIDController::update(float setpoint, float process_value) {
   // u(t) := p(t) + i(t) + d(t)
   float output = proportional_term_ + integral_term_ + derivative_term_;
 
-  // smooth/sample the output
-  int samples = in_deadband() ? deadband_output_samples_ : output_samples_;
-  return weighted_average_(output_list_, output, samples);
+  // smooth/sample the output using appropriate buffer for current mode
+  if (in_deadband()) {
+    return ring_buffer_average_(deadband_output_window_, output, deadband_output_samples_);
+  } else {
+    return ring_buffer_average_(output_window_, output, output_samples_);
+  }
 }
 
 bool PIDController::in_deadband() {
@@ -83,7 +86,7 @@ void PIDController::calculate_derivative_term_(float setpoint) {
   previous_setpoint_ = setpoint;
 
   // smooth the derivative samples
-  derivative = weighted_average_(derivative_list_, derivative, derivative_samples_);
+  derivative = ring_buffer_average_(derivative_window_, derivative, derivative_samples_);
 
   derivative_term_ = kd_ * derivative;
 
@@ -93,25 +96,21 @@ void PIDController::calculate_derivative_term_(float setpoint) {
   }
 }
 
-float PIDController::weighted_average_(std::deque<float> &list, float new_value, int samples) {
-  // if only 1 sample needed, clear the list and return
-  if (samples == 1) {
-    list.clear();
+float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples) {
+  // if only 1 sample needed, clear the buffer and return
+  if (max_samples == 1) {
+    buf.clear();
     return new_value;
   }
 
-  // add the new item to the list
-  list.push_front(new_value);
+  // Use push_overwrite for sliding window behavior (overwrites oldest when full)
+  buf.push_overwrite(new_value);
 
-  // keep only 'samples' readings, by popping off the back of the list
-  while (samples > 0 && list.size() > static_cast<size_t>(samples))
-    list.pop_back();
-
-  // calculate and return the average of all values in the list
+  // Buffer is always initialized via init_buffers() before this is called
   float sum = 0;
-  for (auto &elem : list)
-    sum += elem;
-  return sum / list.size();
+  for (auto val : buf)
+    sum += val;
+  return sum / buf.size();
 }
 
 float PIDController::calculate_relative_time_() {

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -1,6 +1,7 @@
 #pragma once
+
 #include "esphome/core/hal.h"
-#include <deque>
+#include "esphome/core/helpers.h"
 #include <cmath>
 
 namespace esphome {
@@ -50,7 +51,10 @@ struct PIDController {
   void calculate_proportional_term_();
   void calculate_integral_term_();
   void calculate_derivative_term_(float setpoint);
-  float weighted_average_(std::deque<float> &list, float new_value, int samples);
+
+  /// Ring buffer smoothing using FixedRingBuffer (single allocation at setup)
+  float ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples);
+
   float calculate_relative_time_();
 
   /// Error from previous update used for derivative term
@@ -60,12 +64,15 @@ struct PIDController {
   float accumulated_integral_ = 0;
   uint32_t last_time_ = 0;
 
-  // this is a list of derivative values for smoothing.
-  std::deque<float> derivative_list_;
+  // Ring buffer for derivative smoothing
+  FixedRingBuffer<float> derivative_window_;
 
-  // this is a list of output values for smoothing.
-  std::deque<float> output_list_;
+  // Ring buffer for output smoothing (normal mode)
+  FixedRingBuffer<float> output_window_;
 
-};  // Struct PID Controller
+  // Ring buffer for output smoothing (deadband mode)
+  FixedRingBuffer<float> deadband_output_window_;
+
+};  // Struct PIDController
 }  // namespace pid
 }  // namespace esphome

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -26,7 +26,7 @@ struct PIDController {
   float kd_ = 0;
 
   // smooth the derivative value using an average over X samples
-  int derivative_samples_ = 8;
+  int derivative_samples_ = 1;
 
   /// smooth the output value using an average over X values
   int output_samples_ = 1;

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -67,11 +67,8 @@ struct PIDController {
   // Ring buffer for derivative smoothing
   FixedRingBuffer<float> derivative_window_;
 
-  // Ring buffer for output smoothing (normal mode)
+  // Ring buffer for output smoothing (shared between normal and deadband modes)
   FixedRingBuffer<float> output_window_;
-
-  // Ring buffer for output smoothing (deadband mode)
-  FixedRingBuffer<float> deadband_output_window_;
 
 };  // Struct PIDController
 }  // namespace pid

--- a/esphome/components/pid/pid_controller.h
+++ b/esphome/components/pid/pid_controller.h
@@ -25,10 +25,10 @@ struct PIDController {
   /// Differential gain K_d.
   float kd_ = 0;
 
-  // smooth the derivative value using a weighted average over X samples
+  // smooth the derivative value using an average over X samples
   int derivative_samples_ = 8;
 
-  /// smooth the output value using a weighted average over X values
+  /// smooth the output value using an average over X values
   int output_samples_ = 1;
 
   float threshold_low_ = 0.0f;


### PR DESCRIPTION
# What does this implement/fix?

Replaces `std::deque` with `FixedRingBuffer` in the PID controller. `std::deque` allocates 512-byte blocks regardless of element size, causing memory issues on ESP devices.

**Benefits:**
- Eliminates heap allocation after `setup()`
- Removes STL reallocation machinery (`_M_realloc_insert`) from the binary
- No 512-byte block allocation overhead
- Uses separate ring buffers for normal and deadband output modes
- Same behavior with better memory efficiency
- No configuration limits (previously had max=16)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A - Internal implementation change, no documentation updates needed.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal implementation only

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

N/A - No user-exposed changes.