### PR TITLE
[captive_portal] Fix captive portal inaccessible when web_server auth is configured

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -61,7 +61,7 @@ void CaptivePortal::handle_wifisave(AsyncWebServerRequest *request) {
   // Defer save to main loop thread to avoid NVS operations from HTTP thread
   this->defer([ssid, psk]() { wifi::global_wifi_component->save_wifi_sta(ssid.c_str(), psk.c_str()); });
 #endif
-  request->redirect(ESPHOME_F("/?save"));
+  request->send(200, ESPHOME_F("text/plain"), ESPHOME_F("Saved. Connecting..."));
 }
 
 void CaptivePortal::setup() {
@@ -71,7 +71,7 @@ void CaptivePortal::setup() {
 void CaptivePortal::start() {
   this->base_->init();
   if (!this->initialized_) {
-    this->base_->add_handler(this);
+    this->base_->add_handler_without_auth(this);
   }
 
   network::IPAddress ip = wifi::global_wifi_component->wifi_soft_ap_ip();

--- a/esphome/components/web_server_base/web_server_base.cpp
+++ b/esphome/components/web_server_base/web_server_base.cpp
@@ -11,6 +11,10 @@ void WebServerBase::add_handler(AsyncWebHandler *handler) {
     handler = new internal::AuthMiddlewareHandler(handler, &credentials_);
   }
 #endif
+  this->add_handler_without_auth(handler);
+}
+
+void WebServerBase::add_handler_without_auth(AsyncWebHandler *handler) {
   this->handlers_.push_back(handler);
   if (this->server_ != nullptr) {
     this->server_->addHandler(handler);

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -122,6 +122,13 @@ class WebServerBase {
 #endif
 
   void add_handler(AsyncWebHandler *handler);
+  /**
+   * WARNING: Registers a handler that bypasses the USE_WEBSERVER_AUTH middleware.
+   *
+   * This should only be used for endpoints that are intentionally unauthenticated
+   * (for example, captive portal or very limited-status endpoints). For normal
+   * endpoints that should respect web server authentication, use add_handler().
+   */
   void add_handler_without_auth(AsyncWebHandler *handler);
 
   void set_port(uint16_t port) { port_ = port; }

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -122,6 +122,7 @@ class WebServerBase {
 #endif
 
   void add_handler(AsyncWebHandler *handler);
+  void add_handler_without_auth(AsyncWebHandler *handler);
 
   void set_port(uint16_t port) { port_ = port; }
   uint16_t get_port() const { return port_; }


### PR DESCRIPTION
# What does this implement/fix?

When `web_server: auth:` is configured, the `WebServerBase::add_handler()` wraps **all** handlers with `AuthMiddlewareHandler`, including the captive portal. This makes the captive portal require HTTP Basic Auth credentials that users don't know when connecting to the fallback AP to configure WiFi.

This PR:
1. Adds `add_handler_without_auth()` to `WebServerBase` so handlers can opt out of auth wrapping
2. Uses it in the captive portal so it's always accessible without authentication
3. Replaces the `/?save` redirect with a plain text response, since the redirect would hit the auth-protected web server

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/12710

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: "mynetwork"
  password: "mypassword"
  ap:
    ssid: "FallbackAP"
    password: ""

captive_portal:

web_server:
  auth:
    username: "admin"
    password: "admin"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).