### PR TITLE
[light] Fix binary light spamming 'brightness not supported' warning with strobe effect

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -214,8 +214,14 @@ LightColorValues LightCall::validate_() {
   if (this->has_brightness() && this->brightness_ == 0.0f) {
     this->state_ = false;
     this->set_flag_(FLAG_HAS_STATE);
-    this->clear_flag_(FLAG_HAS_BRIGHTNESS);
-    this->brightness_ = 1.0f;
+    if (color_mode & ColorCapability::BRIGHTNESS) {
+      // Reset brightness so the light has nonzero brightness when turned back on.
+      this->brightness_ = 1.0f;
+    } else {
+      // Light doesn't support brightness; clear the flag to avoid a spurious
+      // "brightness not supported" warning during capability validation.
+      this->clear_flag_(FLAG_HAS_BRIGHTNESS);
+    }
   }
 
   // Set color brightness to 100% if currently zero and a color is set.

--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -214,6 +214,7 @@ LightColorValues LightCall::validate_() {
   if (this->has_brightness() && this->brightness_ == 0.0f) {
     this->state_ = false;
     this->set_flag_(FLAG_HAS_STATE);
+    this->clear_flag_(FLAG_HAS_BRIGHTNESS);
     this->brightness_ = 1.0f;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes binary lights spamming `'<name>': brightness not supported` warnings in the log when using the strobe effect.

The strobe effect uses `set_brightness(0.0f)` to simulate turning off without actually stopping the effect. In `LightCall::validate_()`, the brightness-to-zero business logic converts this to a turn-off (`state_ = false`) and resets brightness to 1.0f (so the light has nonzero brightness when turned back on). However, since the `FLAG_HAS_BRIGHTNESS` flag remains set, the subsequent capability validation sees `has_brightness() && brightness > 0.0f` on a light that doesn't support brightness (like binary lights), and logs the warning.

The fix conditionally handles the two cases:
- **Dimmable lights** (support `BRIGHTNESS` capability): brightness is reset to 1.0f as before, preserving existing behavior so the light has nonzero brightness when turned back on.
- **Non-brightness lights** (e.g. binary): `FLAG_HAS_BRIGHTNESS` is cleared instead, since the brightness value was only used as a signal to turn off — not an actual brightness setting to apply. This prevents the spurious warning during capability validation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/11261

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: binary
    id: status_led_power
    output: output_led_power
    effects:
      - strobe:
          name: not_polling
          colors:
            - state: true
              duration: 500ms
            - state: false
              duration: 1500ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).