### PR TITLE
[mdns] Fix RP2040 mDNS not restarting after WiFi reconnect

### DIFF
--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -130,6 +130,10 @@ class MDNSComponent final : public Component {
 #ifdef USE_MDNS_STORE_SERVICES
   StaticVector<MDNSService, MDNS_SERVICE_COUNT> services_{};
 #endif
+#ifdef USE_RP2040
+  bool was_connected_{false};
+  bool initialized_{false};
+#endif
   void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf);
 };
 

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -43,9 +43,10 @@ void MDNSComponent::setup() {
   // safely run directly since netif status callbacks fire from IRQ context
   // (PICO_CYW43_ARCH_THREADSAFE_BACKGROUND) while _restart() allocates UDP sockets.
   //
-  // Workaround: defer MDNS.begin() and service registration until WiFi is connected
-  // (has an IP), then call notifyAPChange() on subsequent reconnects to restart
-  // mDNS probing and announcing — all from main loop context so it's thread-safe.
+  // Workaround: defer MDNS.begin() and service registration until the network is
+  // connected (has an IP), then call notifyAPChange() on subsequent reconnects to
+  // restart mDNS probing and announcing — all from main loop context so it's
+  // thread-safe.
   this->set_interval(MDNS_UPDATE_INTERVAL_MS, [this]() {
     bool connected = network::is_connected();
     if (connected && !this->was_connected_) {

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -36,12 +36,31 @@ static void register_rp2040(MDNSComponent *, StaticVector<MDNSService, MDNS_SERV
 }
 
 void MDNSComponent::setup() {
-  this->setup_buffers_and_register_(register_rp2040);
-  // Schedule MDNS.update() via set_interval() instead of overriding loop().
-  // This removes the component from the per-iteration loop list entirely,
-  // eliminating virtual dispatch overhead on every main loop cycle.
-  // See MDNS_UPDATE_INTERVAL_MS comment in mdns_component.h for safety analysis.
-  this->set_interval(MDNS_UPDATE_INTERVAL_MS, []() { MDNS.update(); });
+  // RP2040's LEAmDNS library registers a LwipIntf::stateUpCB() callback to restart
+  // mDNS when the network interface reconnects. However, stateUpCB() is stubbed out
+  // in arduino-pico's LwipIntfCB.cpp because the original ESP8266 implementation used
+  // schedule_function() which doesn't exist in arduino-pico, and the callback can't
+  // safely run directly since netif status callbacks fire from IRQ context
+  // (PICO_CYW43_ARCH_THREADSAFE_BACKGROUND) while _restart() allocates UDP sockets.
+  //
+  // Workaround: defer MDNS.begin() and service registration until WiFi is connected
+  // (has an IP), then call notifyAPChange() on subsequent reconnects to restart
+  // mDNS probing and announcing — all from main loop context so it's thread-safe.
+  this->set_interval(MDNS_UPDATE_INTERVAL_MS, [this]() {
+    bool connected = network::is_connected();
+    if (connected && !this->was_connected_) {
+      if (!this->initialized_) {
+        this->setup_buffers_and_register_(register_rp2040);
+        this->initialized_ = true;
+      } else {
+        MDNS.notifyAPChange();
+      }
+    }
+    this->was_connected_ = connected;
+    if (this->initialized_) {
+      MDNS.update();
+    }
+  });
 }
 
 void MDNSComponent::on_shutdown() {

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -562,13 +562,6 @@ async def to_code(config):
         cg.add_library("ESP8266WiFi", None)
     elif CORE.is_rp2040:
         cg.add_library("WiFi", None)
-        # RP2040's mDNS library (LEAmDNS) relies on LwipIntf::stateUpCB() to restart
-        # mDNS when the network interface reconnects. However, this callback is disabled
-        # in the arduino-pico framework. As a workaround, we block component setup until
-        # WiFi is connected via can_proceed(), ensuring mDNS.begin() is called with an
-        # active connection. This define enables the loop priority sorting infrastructure
-        # used during the setup blocking phase.
-        cg.add_define("USE_LOOP_PRIORITY")
 
     if CORE.is_esp32:
         if config[CONF_ENABLE_BTM] or config[CONF_ENABLE_RRM]:

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2109,20 +2109,6 @@ void WiFiComponent::retry_connect() {
   }
 }
 
-#ifdef USE_RP2040
-// RP2040's mDNS library (LEAmDNS) relies on LwipIntf::stateUpCB() to restart
-// mDNS when the network interface reconnects. However, this callback is disabled
-// in the arduino-pico framework. As a workaround, we block component setup until
-// WiFi is connected, ensuring mDNS.begin() is called with an active connection.
-
-bool WiFiComponent::can_proceed() {
-  if (!this->has_sta() || this->state_ == WIFI_COMPONENT_STATE_DISABLED || this->ap_setup_) {
-    return true;
-  }
-  return this->is_connected_();
-}
-#endif
-
 void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 bool WiFiComponent::is_connected_() const {
   return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -437,10 +437,6 @@ class WiFiComponent : public Component {
 
   void retry_connect();
 
-#ifdef USE_RP2040
-  bool can_proceed() override;
-#endif
-
   void set_reboot_timeout(uint32_t reboot_timeout);
 
   bool is_connected() const { return this->connected_; }


### PR DESCRIPTION
# What does this implement/fix?

Fix RP2040 mDNS not working on initial boot or after WiFi reconnects.

The RP2040's LEAmDNS library registers a `LwipIntf::stateUpCB()` callback to restart mDNS when the network interface reconnects. However, `stateUpCB()` is [stubbed out](https://github.com/earlephilhower/arduino-pico/blob/33694a1fccd46f1b1086b94b09638566718191cc/libraries/lwIP_Ethernet/src/LwipIntfCB.cpp#L53-L67) in the arduino-pico framework — it was commented out from day one because the original ESP8266 implementation used `schedule_function()` which doesn't exist in arduino-pico, and the callback can't safely run directly since netif status callbacks fire from IRQ context (`PICO_CYW43_ARCH_THREADSAFE_BACKGROUND`) while `_restart()` allocates UDP sockets.

The previous workaround blocked all component setup via `can_proceed()` until WiFi connected. This only helped on initial boot but had two problems:
1. `MDNS.begin()` was called before the device had an IP address
2. mDNS would silently break after any WiFi disconnection/reconnection cycle

This replaces the workaround with a proper fix:
- Defer `MDNS.begin()` and service registration until WiFi is fully connected (has an IP address)
- Detect WiFi reconnection from the existing 50ms mDNS update interval (main loop context, so thread-safe) and call `MDNS.notifyAPChange()` to restart mDNS probing and announcing
- Remove the `can_proceed()` override and the `USE_LOOP_PRIORITY` define that were only added for the old workaround

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal bug fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).