### PR TITLE
[rp2040] Fix compiler warnings in crash_handler and mdns

### DIFF
--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -8,17 +8,11 @@
 #include "mdns_component.h"
 
 // Arduino-Pico's PolledTimeout.h (pulled in by ESP8266mDNS.h) redefines IRAM_ATTR to empty.
-// Save the current definition (from hal.h), undef before include to avoid a redefinition warning,
-// then restore the original value afterwards.
-#ifdef IRAM_ATTR
-#define ESPHOME_SAVED_IRAM_ATTR IRAM_ATTR
+// Save and restore our definition around the include to avoid a redefinition warning.
+#pragma push_macro("IRAM_ATTR")
 #undef IRAM_ATTR
-#endif
 #include <ESP8266mDNS.h>
-#ifdef ESPHOME_SAVED_IRAM_ATTR
-#define IRAM_ATTR ESPHOME_SAVED_IRAM_ATTR
-#undef ESPHOME_SAVED_IRAM_ATTR
-#endif
+#pragma pop_macro("IRAM_ATTR")
 
 namespace esphome::mdns {
 

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -7,7 +7,12 @@
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
+// Arduino-Pico's PolledTimeout.h redefines IRAM_ATTR to empty;
+// undef before include to avoid macro redefinition warning, then restore from hal.h.
+#undef IRAM_ATTR
 #include <ESP8266mDNS.h>
+#undef IRAM_ATTR
+#include "esphome/core/hal.h"
 
 namespace esphome::mdns {
 

--- a/esphome/components/mdns/mdns_rp2040.cpp
+++ b/esphome/components/mdns/mdns_rp2040.cpp
@@ -7,12 +7,18 @@
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
-// Arduino-Pico's PolledTimeout.h redefines IRAM_ATTR to empty;
-// undef before include to avoid macro redefinition warning, then restore from hal.h.
+// Arduino-Pico's PolledTimeout.h (pulled in by ESP8266mDNS.h) redefines IRAM_ATTR to empty.
+// Save the current definition (from hal.h), undef before include to avoid a redefinition warning,
+// then restore the original value afterwards.
+#ifdef IRAM_ATTR
+#define ESPHOME_SAVED_IRAM_ATTR IRAM_ATTR
 #undef IRAM_ATTR
+#endif
 #include <ESP8266mDNS.h>
-#undef IRAM_ATTR
-#include "esphome/core/hal.h"
+#ifdef ESPHOME_SAVED_IRAM_ATTR
+#define IRAM_ATTR ESPHOME_SAVED_IRAM_ATTR
+#undef ESPHOME_SAVED_IRAM_ATTR
+#endif
 
 namespace esphome::mdns {
 

--- a/esphome/components/rp2040/crash_handler.cpp
+++ b/esphome/components/rp2040/crash_handler.cpp
@@ -57,14 +57,14 @@ static const char *const TAG = "rp2040.crash";
 
 // Placed in .noinit so BSS zero-init cannot race with crash_handler_read_and_clear().
 // The valid field is explicitly cleared in crash_handler_read_and_clear() instead.
-static struct {
+static struct CrashData {
   bool valid;
   uint32_t pc;
   uint32_t lr;
   uint32_t sp;
   uint32_t backtrace[MAX_BACKTRACE];
   uint8_t backtrace_count;
-} __attribute__((section(".noinit"))) s_crash_data;
+} s_crash_data __attribute__((section(".noinit")));
 
 bool crash_handler_has_data() { return s_crash_data.valid; }
 


### PR DESCRIPTION

# What does this implement/fix?

Fix two GCC warnings on RP2040 builds:

1. **crash_handler.cpp** (`-Wattributes`): `__attribute__((section(".noinit")))` was placed between the struct definition and the variable name, causing GCC to interpret it as a type attribute. Moved it after the variable name and named the anonymous struct.

2. **mdns_rp2040.cpp** (macro redefinition): Arduino-Pico's `PolledTimeout.h` (included via `ESP8266mDNS.h`) redefines `IRAM_ATTR` to empty, conflicting with ESPHome's definition in `hal.h`. Fixed by `#undef`-ing before the framework include, then restoring from `hal.h` after.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - compiler warning fixes only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
