### PR TITLE
[debug] Fix missing reset reason for RP2040/RP2350

### DIFF
--- a/esphome/components/debug/debug_rp2040.cpp
+++ b/esphome/components/debug/debug_rp2040.cpp
@@ -1,23 +1,77 @@
 #include "debug_component.h"
 #ifdef USE_RP2040
+#include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 #include <Arduino.h>
+#include <hardware/watchdog.h>
+#if defined(PICO_RP2350)
+#include <hardware/structs/powman.h>
+#else
+#include <hardware/structs/vreg_and_chip_reset.h>
+#endif
+#ifdef USE_RP2040_CRASH_HANDLER
+#include "esphome/components/rp2040/crash_handler.h"
+#endif
 namespace esphome {
 namespace debug {
 
 static const char *const TAG = "debug";
 
-const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
+const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) {
+  char *buf = buffer.data();
+  const size_t size = RESET_REASON_BUFFER_SIZE;
+  size_t pos = 0;
+
+#if defined(PICO_RP2350)
+  uint32_t chip_reset = powman_hw->chip_reset;
+  if (chip_reset & 0x04000000)  // HAD_GLITCH_DETECT
+    pos = buf_append_str(buf, size, pos, "Power supply glitch|");
+  if (chip_reset & 0x00040000)  // HAD_RUN_LOW
+    pos = buf_append_str(buf, size, pos, "RUN pin|");
+  if (chip_reset & 0x00020000)  // HAD_BOR
+    pos = buf_append_str(buf, size, pos, "Brown-out|");
+  if (chip_reset & 0x00010000)  // HAD_POR
+    pos = buf_append_str(buf, size, pos, "Power-on reset|");
+#else
+  uint32_t chip_reset = vreg_and_chip_reset_hw->chip_reset;
+  if (chip_reset & 0x00010000)  // HAD_RUN
+    pos = buf_append_str(buf, size, pos, "RUN pin|");
+  if (chip_reset & 0x00000100)  // HAD_POR
+    pos = buf_append_str(buf, size, pos, "Power-on reset|");
+#endif
+
+  if (watchdog_caused_reboot()) {
+#ifdef USE_RP2040_CRASH_HANDLER
+    if (rp2040::crash_handler_has_data()) {
+      pos = buf_append_str(buf, size, pos, "Crash (HardFault)|");
+    } else
+#endif
+        if (watchdog_enable_caused_reboot()) {
+      pos = buf_append_str(buf, size, pos, "Watchdog timeout|");
+    } else {
+      pos = buf_append_str(buf, size, pos, "Software reset|");
+    }
+  }
+
+  // Remove trailing '|'
+  if (pos > 0 && buf[pos - 1] == '|') {
+    buf[pos - 1] = '\0';
+  } else if (pos == 0) {
+    return "Unknown";
+  }
+
+  return buf;
+}
 
 const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
 
-uint32_t DebugComponent::get_free_heap_() { return rp2040.getFreeHeap(); }
+uint32_t DebugComponent::get_free_heap_() { return ::rp2040.getFreeHeap(); }
 
 size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE> buffer, size_t pos) {
   constexpr size_t size = DEVICE_INFO_BUFFER_SIZE;
   char *buf = buffer.data();
 
-  uint32_t cpu_freq = rp2040.f_cpu();
+  uint32_t cpu_freq = ::rp2040.f_cpu();
   ESP_LOGD(TAG, "CPU Frequency: %" PRIu32, cpu_freq);
   pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32, cpu_freq);
 

--- a/esphome/components/debug/debug_rp2040.cpp
+++ b/esphome/components/debug/debug_rp2040.cpp
@@ -41,15 +41,19 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
 #endif
 
   if (watchdog_caused_reboot()) {
+    bool handled = false;
 #ifdef USE_RP2040_CRASH_HANDLER
     if (rp2040::crash_handler_has_data()) {
       pos = buf_append_str(buf, size, pos, "Crash (HardFault)|");
-    } else
+      handled = true;
+    }
 #endif
-        if (watchdog_enable_caused_reboot()) {
-      pos = buf_append_str(buf, size, pos, "Watchdog timeout|");
-    } else {
-      pos = buf_append_str(buf, size, pos, "Software reset|");
+    if (!handled) {
+      if (watchdog_enable_caused_reboot()) {
+        pos = buf_append_str(buf, size, pos, "Watchdog timeout|");
+      } else {
+        pos = buf_append_str(buf, size, pos, "Software reset|");
+      }
     }
   }
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -947,7 +947,7 @@ __attribute__((format(printf, 4, 5))) inline size_t buf_append_printf(char *buf,
 /// @param buf Output buffer
 /// @param size Total buffer size
 /// @param pos Current position in buffer
-/// @param str String to append
+/// @param str String to append (must not be null)
 /// @return New position after appending (capped at size on overflow)
 inline size_t buf_append_str(char *buf, size_t size, size_t pos, const char *str) {
   if (pos >= size) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -942,6 +942,28 @@ __attribute__((format(printf, 4, 5))) inline size_t buf_append_printf(char *buf,
 }
 #endif
 
+/// Safely append a string to buffer without format parsing, returning new position (capped at size).
+/// More efficient than buf_append_printf for plain string literals.
+/// @param buf Output buffer
+/// @param size Total buffer size
+/// @param pos Current position in buffer
+/// @param str String to append
+/// @return New position after appending (capped at size on overflow)
+inline size_t buf_append_str(char *buf, size_t size, size_t pos, const char *str) {
+  if (pos >= size) {
+    return size;
+  }
+  size_t remaining = size - pos - 1;  // reserve space for null terminator
+  size_t len = strlen(str);
+  if (len > remaining) {
+    len = remaining;
+  }
+  memcpy(buf + pos, str, len);
+  pos += len;
+  buf[pos] = '\0';
+  return pos;
+}
+
 /// Concatenate a name with a separator and suffix using an efficient stack-based approach.
 /// This avoids multiple heap allocations during string construction.
 /// Maximum name length supported is 120 characters for friendly names.


### PR DESCRIPTION
# What does this implement/fix?

Fix the debug component's reset reason text sensor returning an empty string on RP2040 and RP2350 platforms. Reads the chip reset hardware registers to report the actual reset source.

- **RP2040**: Reads `VREG_AND_CHIP_RESET` register for power-on reset and RUN pin
- **RP2350**: Reads `POWMAN` chip_reset register for power-on reset, brown-out, RUN pin, and power supply glitch
- **Both**: Checks `watchdog_caused_reboot()` from the Pico SDK, and distinguishes between crash (HardFault), watchdog timeout, and software reset by consulting the crash handler data

Also adds a `buf_append_str()` helper to `helpers.h` for efficient plain string buffer appends without format parsing overhead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
debug:
  update_interval: 5s

text_sensor:
  - platform: debug
    reset_reason:
      name: "Reset Reason"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).