### PR TITLE
[OTA] Stage exact uploaded size for ESP8266 web OTA (gzip fix)

### DIFF
--- a/esphome/components/ota/ota_backend_esp8266.cpp
+++ b/esphome/components/ota/ota_backend_esp8266.cpp
@@ -105,6 +105,7 @@ OTAResponseTypes ESP8266OTABackend::begin(size_t image_size) {
 
   this->current_address_ = this->start_address_;
   this->image_size_ = image_size;
+  this->bytes_received_ = 0;
   this->buffer_len_ = 0;
   this->md5_set_ = false;
 
@@ -140,6 +141,7 @@ OTAResponseTypes ESP8266OTABackend::write(uint8_t *data, size_t len) {
     size_t to_buffer = std::min(len - written, this->buffer_size_ - this->buffer_len_);
     memcpy(this->buffer_.get() + this->buffer_len_, data + written, to_buffer);
     this->buffer_len_ += to_buffer;
+    this->bytes_received_ += to_buffer;
     written += to_buffer;
 
     // If buffer is full, write to flash
@@ -252,8 +254,8 @@ OTAResponseTypes ESP8266OTABackend::end() {
     }
   }
 
-  // Calculate actual bytes written
-  size_t actual_size = this->current_address_ - this->start_address_;
+  // Calculate actual bytes written (exact uploaded size, excluding flash write padding)
+  size_t actual_size = this->bytes_received_;
 
   // Check if any data was written
   if (actual_size == 0) {
@@ -304,6 +306,7 @@ void ESP8266OTABackend::abort() {
   this->buffer_.reset();
   this->buffer_len_ = 0;
   this->image_size_ = 0;
+  this->bytes_received_ = 0;
   esp8266::preferences_prevent_write(false);
 }
 

--- a/esphome/components/ota/ota_backend_esp8266.h
+++ b/esphome/components/ota/ota_backend_esp8266.h
@@ -48,6 +48,7 @@ class ESP8266OTABackend final {
   uint32_t start_address_{0};
   uint32_t current_address_{0};
   size_t image_size_{0};
+  size_t bytes_received_{0};
 
   md5::MD5Digest md5_{};
   uint8_t expected_md5_[16];  // Fixed-size buffer for 128-bit (16-byte) MD5 digest


### PR DESCRIPTION
# What does this implement/fix?

Fixes ESP8266 web OTA handling for compressed (`.gz`) firmware uploads when upload size is unknown (`begin(0)` multipart flow).

The ESP8266 OTA backend was staging the padded flash-write size (4-byte alignment) into the eboot copy command. For gzip images, eboot uses the staged size to read the gzip footer, so using padded size can cause reboot-time apply failures even though upload reports success.

This change tracks exact uploaded bytes and stages that exact size for eboot, while still keeping flash writes padded/aligned as required.

Tested and this fixed gzip uploading for me.  Used ChatGPT Codex for this if it matters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
  web_server:
    ota: true

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
