### PR TITLE
[i2c] Fix RP2040 I2C bus selection based on pin assignment

### DIFF
--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -93,11 +93,25 @@ def _bus_declare_type(value):
     raise NotImplementedError
 
 
+def _rp2040_i2c_controller(pin):
+    """Return the I2C controller number (0 or 1) for a given RP2040/RP2350 GPIO pin."""
+    return (pin // 2) % 2
+
+
 def validate_config(config):
     if CORE.is_esp32:
         return cv.require_framework_version(
             esp_idf=cv.Version(5, 4, 2), esp32_arduino=cv.Version(3, 2, 1)
         )(config)
+    if CORE.is_rp2040:
+        sda_controller = _rp2040_i2c_controller(config[CONF_SDA])
+        scl_controller = _rp2040_i2c_controller(config[CONF_SCL])
+        if sda_controller != scl_controller:
+            raise cv.Invalid(
+                f"SDA pin GPIO{config[CONF_SDA]} is on I2C{sda_controller} but "
+                f"SCL pin GPIO{config[CONF_SCL]} is on I2C{scl_controller}. "
+                f"Both pins must be on the same I2C controller."
+            )
     return config
 
 
@@ -146,6 +160,22 @@ def _final_validate(config):
     full_config = fv.full_config.get()[CONF_I2C]
     if CORE.using_zephyr and len(full_config) > 1:
         raise cv.Invalid("Second i2c is not implemented on Zephyr yet")
+    if CORE.is_rp2040:
+        if len(full_config) > 2:
+            raise cv.Invalid(
+                "The maximum number of I2C interfaces for RP2040/RP2350 is 2"
+            )
+        if len(full_config) > 1:
+            controllers = [
+                _rp2040_i2c_controller(conf[CONF_SDA]) for conf in full_config
+            ]
+            if len(set(controllers)) != len(controllers):
+                raise cv.Invalid(
+                    "Multiple I2C buses are configured to use the same I2C controller. "
+                    "Each bus must use pins on a different controller "
+                    "(I2C0: SDA on GPIO 0,4,8,12,16,20,24,28; "
+                    "I2C1: SDA on GPIO 2,6,10,14,18,22,26)."
+                )
     if CORE.is_esp32 and get_esp32_variant() in ESP32_I2C_CAPABILITIES:
         variant = get_esp32_variant()
         max_num = ESP32_I2C_CAPABILITIES[variant]["NUM"]

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -94,7 +94,13 @@ def _bus_declare_type(value):
 
 
 def _rp2040_i2c_controller(pin):
-    """Return the I2C controller number (0 or 1) for a given RP2040/RP2350 GPIO pin."""
+    """Return the I2C controller number (0 or 1) for a given RP2040/RP2350 GPIO pin.
+
+    See RP2040 datasheet Table 2 (section 1.4.3, "GPIO Functions"):
+    https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf
+    See RP2350 datasheet Table 7 (section 9.4, "Function Select"):
+    https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf
+    """
     return (pin // 2) % 2
 
 

--- a/esphome/components/i2c/__init__.py
+++ b/esphome/components/i2c/__init__.py
@@ -178,9 +178,10 @@ def _final_validate(config):
             if len(set(controllers)) != len(controllers):
                 raise cv.Invalid(
                     "Multiple I2C buses are configured to use the same I2C controller. "
-                    "Each bus must use pins on a different controller "
-                    "(I2C0: SDA on GPIO 0,4,8,12,16,20,24,28; "
-                    "I2C1: SDA on GPIO 2,6,10,14,18,22,26)."
+                    "Each bus must use pins on a different controller. "
+                    "The I2C controller is determined by (gpio / 2) % 2: "
+                    "even pin pairs (0-1, 4-5, 8-9, ...) use I2C0, "
+                    "odd pin pairs (2-3, 6-7, 10-11, ...) use I2C1."
                 )
     if CORE.is_esp32 and get_esp32_variant() in ESP32_I2C_CAPABILITIES:
         variant = get_esp32_variant()

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -22,7 +22,8 @@ void ArduinoI2CBus::setup() {
 #elif defined(USE_RP2040)
   // Select Wire instance based on pin assignment, not definition order.
   // RP2040 I2C controller is determined by GPIO: (pin / 2) % 2
-  // I2C0 SDA: GPIO 0,4,8,12,16,20,24,28  I2C1 SDA: GPIO 2,6,10,14,18,22,26
+  // See RP2040 datasheet Table 2 (section 1.4.3): https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf
+  // See RP2350 datasheet Table 7 (section 9.4): https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf
   if ((this->sda_pin_ / 2) % 2 == 0) {
     wire_ = &Wire;
   } else {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -21,9 +21,9 @@ void ArduinoI2CBus::setup() {
   wire_ = new TwoWire();  // NOLINT(cppcoreguidelines-owning-memory)
 #elif defined(USE_RP2040)
   // Select Wire instance based on pin assignment, not definition order.
-  // RP2040 I2C controller is determined by GPIO: (pin / 2) % 2
-  // See RP2040 datasheet Table 2 (section 1.4.3): https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf
-  // See RP2350 datasheet Table 7 (section 9.4): https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf
+  // I2C controller = (gpio / 2) % 2: even pairs (0-1,4-5,...) → I2C0, odd pairs (2-3,6-7,...) → I2C1
+  // RP2040 datasheet Table 2 (section 1.4.3): https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf
+  // RP2350 datasheet Table 7 (section 9.4): https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf
   if ((this->sda_pin_ / 2) % 2 == 0) {
     wire_ = &Wire;
   } else {

--- a/esphome/components/i2c/i2c_bus_arduino.cpp
+++ b/esphome/components/i2c/i2c_bus_arduino.cpp
@@ -20,12 +20,13 @@ void ArduinoI2CBus::setup() {
 #if defined(USE_ESP8266)
   wire_ = new TwoWire();  // NOLINT(cppcoreguidelines-owning-memory)
 #elif defined(USE_RP2040)
-  static bool first = true;
-  if (first) {
+  // Select Wire instance based on pin assignment, not definition order.
+  // RP2040 I2C controller is determined by GPIO: (pin / 2) % 2
+  // I2C0 SDA: GPIO 0,4,8,12,16,20,24,28  I2C1 SDA: GPIO 2,6,10,14,18,22,26
+  if ((this->sda_pin_ / 2) % 2 == 0) {
     wire_ = &Wire;
-    first = false;
   } else {
-    wire_ = &Wire1;  // NOLINT(cppcoreguidelines-owning-memory)
+    wire_ = &Wire1;
   }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

The RP2040 I2C bus was assigned `Wire` (I2C0) or `Wire1` (I2C1) based on the order I2C buses were defined in YAML configuration, not based on which GPIO pins were actually used. This caused I2C1 to silently not work when only a single bus was configured using I2C1 pins (e.g., GPIO6/GPIO7), because the code always assigned `Wire` (I2C0) to the first-defined bus.

Now selects the correct `Wire` instance using the RP2040/RP2350 GPIO pin mapping: `(pin / 2) % 2`.

Pin-to-controller mapping per the datasheets:
- [RP2040 datasheet](https://datasheets.raspberrypi.com/rp2040/rp2040-datasheet.pdf) — Table 2, section 1.4.3 "GPIO Functions"
- [RP2350 datasheet](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf) — Table 7, section 9.4 "Function Select"

Also adds Python-side config validation to catch:
- SDA and SCL pins on different I2C controllers
- Multiple buses configured on the same I2C controller
- More than 2 I2C buses (hardware limit)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14742

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Single I2C bus on I2C1 pins - previously broken, now works
i2c:
  sda: GPIO6
  scl: GPIO7
  scan: true

# Dual I2C bus configuration
i2c:
  - id: bus_i2c0
    sda: GPIO0
    scl: GPIO1
  - id: bus_i2c1
    sda: GPIO2
    scl: GPIO3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).