### PR TITLE
[wifi] Reject EAP/WPA2 Enterprise config on unsupported platforms

### DIFF
--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -166,6 +166,7 @@ TTLS_PHASE_2 = {
 }
 
 EAP_AUTH_SCHEMA = cv.All(
+    cv.only_on([Platform.ESP32, Platform.ESP8266]),
     cv.Schema(
         {
             cv.Optional(CONF_IDENTITY): cv.string_strict,


### PR DESCRIPTION
# What does this implement/fix?

WPA2 Enterprise (EAP) authentication is only implemented for ESP32 and ESP8266, but the configuration schema accepted it on all platforms without validation. On RP2040 this caused a bootloop at runtime with no useful error message.

Now rejects EAP configuration at validation time on unsupported platforms (RP2040, LibreTiny, etc.) with a clear error message.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14743

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This now correctly fails validation on RP2040:
wifi:
  ssid: "TestNetwork"
  eap:
    identity: "user"
    username: "user"
    password: "pass"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).