### PR TITLE
[rp2040] Use full flash for sketch in testing mode

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -203,7 +203,12 @@ async def to_code(config):
             cg.add_build_flag(f"-Wl,--wrap={symbol}")
 
     cg.add_platformio_option("board_build.core", "earlephilhower")
-    cg.add_platformio_option("board_build.filesystem_size", "1m")
+    # In testing mode, use all flash for sketch to allow linking grouped component tests.
+    # Real RP2040 hardware uses 1MB filesystem + 1MB sketch, but CI tests may combine
+    # many components that exceed the 1MB sketch partition.
+    cg.add_platformio_option(
+        "board_build.filesystem_size", "0m" if CORE.testing_mode else "1m"
+    )
 
     ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
     cg.add_define(


### PR DESCRIPTION
# What does this implement/fix?

In testing mode (`--testing-mode`), set `board_build.filesystem_size` to `0m` so the full 2MB flash is available for the sketch partition. This prevents linker overflow ("region 'FLASH' overflowed by 2512 bytes") when CI groups many components into a single RP2040 build.

This matches the approach used by ESP8266's testing mode, which patches linker scripts to allow larger builds for CI component grouping.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - only affects testing mode builds
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).