### PR TITLE
[water_heater] Set OPERATION_MODE feature flag when modes are configured

### DIFF
--- a/esphome/components/template/water_heater/template_water_heater.cpp
+++ b/esphome/components/template/water_heater/template_water_heater.cpp
@@ -26,6 +26,7 @@ water_heater::WaterHeaterTraits TemplateWaterHeater::traits() {
 
   if (!this->supported_modes_.empty()) {
     traits.set_supported_modes(this->supported_modes_);
+    traits.add_feature_flags(water_heater::WATER_HEATER_SUPPORTS_OPERATION_MODE);
   }
 
   traits.set_supports_current_temperature(true);

--- a/tests/integration/test_water_heater_template.py
+++ b/tests/integration/test_water_heater_template.py
@@ -102,7 +102,11 @@ async def test_water_heater_template(
             f"Expected target temp 60.0, got {initial_state.target_temperature}"
         )
 
-        # Verify supported features: away mode and on/off (fixture has away + is_on lambdas)
+        # Verify supported features: operation mode, away mode, and on/off
+        assert (
+            test_water_heater.supported_features
+            & WaterHeaterFeature.SUPPORTS_OPERATION_MODE
+        ) != 0, "Expected SUPPORTS_OPERATION_MODE in supported_features"
         assert (
             test_water_heater.supported_features & WaterHeaterFeature.SUPPORTS_AWAY_MODE
         ) != 0, "Expected SUPPORTS_AWAY_MODE in supported_features"


### PR DESCRIPTION
# What does this implement/fix?

The template water_heater component sets the supported modes list via `set_supported_modes()` but never sets the `WATER_HEATER_SUPPORTS_OPERATION_MODE` feature flag. This means the feature bitmask sent to Home Assistant via the API is missing the operation mode bit, even though the device does support mode selection.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14605

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
water_heater:
  - platform: template
    name: "Kettle"
    optimistic: true
    supported_modes:
      - "OFF"
      - ELECTRIC
    set_action:
      - logger.log: "Set action triggered"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).