### PR TITLE
[dlms_meter] optional key, optional mbus, remove 2400 uart baud requirement

### DIFF
--- a/esphome/components/dlms_meter/__init__.py
+++ b/esphome/components/dlms_meter/__init__.py
@@ -9,8 +9,10 @@ DEPENDENCIES = ["uart"]
 CONF_DLMS_METER_ID = "dlms_meter_id"
 CONF_DECRYPTION_KEY = "decryption_key"
 CONF_PROVIDER = "provider"
+CONF_TRANSPORT = "transport"
 
 PROVIDERS = {"generic": 0, "netznoe": 1}
+TRANSPORTS = {"mbus": 0, "raw": 1}
 
 dlms_meter_component_ns = cg.esphome_ns.namespace("dlms_meter")
 DlmsMeterComponent = dlms_meter_component_ns.class_(
@@ -32,9 +34,12 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DlmsMeterComponent),
-            cv.Required(CONF_DECRYPTION_KEY): validate_key,
+            cv.Optional(CONF_DECRYPTION_KEY): validate_key,
             cv.Optional(CONF_PROVIDER, default="generic"): cv.enum(
                 PROVIDERS, lower=True
+            ),
+            cv.Optional(CONF_TRANSPORT, default="mbus"): cv.enum(
+                TRANSPORTS, lower=True
             ),
         }
     )
@@ -43,15 +48,17 @@ CONFIG_SCHEMA = cv.All(
     cv.only_on([PLATFORM_ESP8266, PLATFORM_ESP32]),
 )
 
-FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "dlms_meter", baud_rate=2400, require_rx=True
-)
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema("dlms_meter", require_rx=True)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    key = ", ".join(str(b) for b in config[CONF_DECRYPTION_KEY])
-    cg.add(var.set_decryption_key(cg.RawExpression(f"{{{key}}}")))
+
+    if CONF_DECRYPTION_KEY in config:
+        key = ", ".join(str(b) for b in config[CONF_DECRYPTION_KEY])
+        cg.add(var.set_decryption_key(cg.RawExpression(f"{{{key}}}")))
+
     cg.add(var.set_provider(PROVIDERS[config[CONF_PROVIDER]]))
+    cg.add(var.set_transport(TRANSPORTS[config[CONF_TRANSPORT]]))

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -13,11 +13,14 @@ static constexpr const char *TAG = "dlms_meter";
 
 void DlmsMeterComponent::dump_config() {
   const char *provider_name = this->provider_ == PROVIDER_NETZNOE ? "Netz NOE" : "Generic";
+  const char *transport_name = this->transport_ == TRANSPORT_MBUS ? "M-Bus" : "Raw";
   ESP_LOGCONFIG(TAG,
                 "DLMS Meter:\n"
                 "  Provider: %s\n"
+                "  Transport: %s\n"
+                "  Decryption Enabled: %s\n"
                 "  Read Timeout: %u ms",
-                provider_name, this->read_timeout_);
+                provider_name, transport_name, this->has_decryption_key_ ? "YES" : "NO", this->read_timeout_);
 #define DLMS_METER_LOG_SENSOR(s) LOG_SENSOR("  ", #s, this->s##_sensor_);
   DLMS_METER_SENSOR_LIST(DLMS_METER_LOG_SENSOR, )
 #define DLMS_METER_LOG_TEXT_SENSOR(s) LOG_TEXT_SENSOR("  ", #s, this->s##_text_sensor_);
@@ -51,26 +54,36 @@ void DlmsMeterComponent::loop() {
   }
 
   if (!this->receive_buffer_.empty() && millis() - this->last_read_ > this->read_timeout_) {
-    this->mbus_payload_.clear();
-    if (!this->parse_mbus_(this->mbus_payload_))
-      return;
+    this->payload_.clear();
 
-    uint16_t message_length;
-    uint8_t systitle_length;
-    uint16_t header_offset;
-    if (!this->parse_dlms_(this->mbus_payload_, message_length, systitle_length, header_offset))
-      return;
-
-    if (message_length < DECODER_START_OFFSET || message_length > MAX_MESSAGE_LENGTH) {
-      ESP_LOGE(TAG, "DLMS: Message length invalid: %u", message_length);
-      this->receive_buffer_.clear();
-      return;
+    if (this->transport_ == TRANSPORT_MBUS) {
+      if (!this->parse_mbus_(this->payload_))
+        return;
+    } else {
+      this->payload_ = this->receive_buffer_;
     }
 
-    // Decrypt in place and then decode the OBIS codes
-    if (!this->decrypt_(this->mbus_payload_, message_length, systitle_length, header_offset))
-      return;
-    this->decode_obis_(&this->mbus_payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+    if (this->has_decryption_key_) {
+      uint16_t message_length;
+      uint8_t systitle_length;
+      uint16_t header_offset;
+      if (!this->parse_dlms_(this->payload_, message_length, systitle_length, header_offset))
+        return;
+
+      if (message_length < DECODER_START_OFFSET || message_length > MAX_MESSAGE_LENGTH) {
+        ESP_LOGE(TAG, "DLMS: Message length invalid: %u", message_length);
+        this->receive_buffer_.clear();
+        return;
+      }
+
+      // Decrypt in place and then decode the OBIS codes
+      if (!this->decrypt_(this->payload_, message_length, systitle_length, header_offset))
+        return;
+      this->decode_obis_(&this->payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+    } else {
+      // If no decryption key is provided, decode the parsed payload directly assuming unencrypted APDU.
+      this->decode_obis_(this->payload_.data(), this->payload_.size());
+    }
   }
 }
 

--- a/esphome/components/dlms_meter/dlms_meter.h
+++ b/esphome/components/dlms_meter/dlms_meter.h
@@ -50,6 +50,8 @@ struct MeterData {
 
 // Provider constants
 enum Providers : uint32_t { PROVIDER_GENERIC = 0x00, PROVIDER_NETZNOE = 0x01 };
+// Transport constants
+enum Transports : uint32_t { TRANSPORT_MBUS = 0x00, TRANSPORT_RAW = 0x01 };
 
 class DlmsMeterComponent : public Component, public uart::UARTDevice {
  public:
@@ -58,8 +60,12 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
   void dump_config() override;
   void loop() override;
 
-  void set_decryption_key(const std::array<uint8_t, 16> &key) { this->decryption_key_ = key; }
+  void set_decryption_key(const std::array<uint8_t, 16> &key) {
+    this->decryption_key_ = key;
+    this->has_decryption_key_ = true;
+  }
   void set_provider(uint32_t provider) { this->provider_ = provider; }
+  void set_transport(uint32_t transport) { this->transport_ = transport; }
 
   void publish_sensors(MeterData &data) {
 #define DLMS_METER_PUBLISH_SENSOR(s) \
@@ -85,11 +91,14 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
   void decode_obis_(uint8_t *plaintext, uint16_t message_length);
 
   std::vector<uint8_t> receive_buffer_;  // Stores the packet currently being received
-  std::vector<uint8_t> mbus_payload_;    // Parsed M-Bus payload, reused to avoid heap churn
+  std::vector<uint8_t> payload_;         // Parsed payload, reused to avoid heap churn
   uint32_t last_read_ = 0;               // Timestamp when data was last read
   uint32_t read_timeout_ = 1000;         // Time to wait after last byte before considering data complete
 
   uint32_t provider_ = PROVIDER_GENERIC;  // Provider of the meter / your grid operator
+  uint32_t transport_ = TRANSPORT_MBUS;   // Transport protocol used
+
+  bool has_decryption_key_{false};
   std::array<uint8_t, 16> decryption_key_;
 };
 

--- a/tests/components/dlms_meter/common-generic.yaml
+++ b/tests/components/dlms_meter/common-generic.yaml
@@ -1,5 +1,6 @@
 dlms_meter:
   decryption_key: "36C66639E48A8CA4D6BC8B282A793BBB"   # change this to your decryption key!
+  transport: raw
 
 sensor:
   - platform: dlms_meter


### PR DESCRIPTION
# What does this implement/fix?

Makes `decryption_key` optional - If no decryption key is provided, decode the parsed payload directly assuming unencrypted APDU
Adds optional configuration value `transport` that can be `mbus` or `raw` - some meters broadcast raw and unencrypted
Removes the requirement for 2400 uart baud rate

I have not been able to test the changes on my meter, because of the rigid, flat parser (parser does not work on my meter). I will open more pull requests to implement a full recursive AXDR parser.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome#14604

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6274

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
dlms_meter:
  transport: raw

sensor:
  - platform: dlms_meter
    active_power_plus:
      name: Active power import
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
