### PR TITLE
[api] Increase log Nagle coalescing on all platforms except ESP8266

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -139,11 +139,11 @@ class APIFrameHelper {
   // holding data too long waiting for Nagle's timer causes buffer exhaustion
   // and dropped messages.
   //
-  // ESP32 (TCP_SND_BUF=64KB) / RP2040 (8×MSS): 4 logs per cycle
-  // ESP8266 / LibreTiny: 3 logs per cycle (tighter buffers)
+  // ESP32 (TCP_SND_BUF=4×MSS+) / RP2040 (8×MSS) / LibreTiny (4×MSS): 4 logs per cycle
+  // ESP8266 (2×MSS): 3 logs per cycle (tightest buffers)
   //
-  // Flow (ESP32/RP2040): Log 1 (Nagle on) -> Log 2 -> Log 3 -> Log 4 (NODELAY, flush)
-  // Flow (other):        Log 1 (Nagle on) -> Log 2 -> Log 3 (NODELAY, flush all)
+  // Flow (ESP32/RP2040/LT): Log 1 (Nagle on) -> Log 2 -> Log 3 -> Log 4 (NODELAY, flush)
+  // Flow (ESP8266):         Log 1 (Nagle on) -> Log 2 -> Log 3 (NODELAY, flush all)
   //
   void set_nodelay_for_message(bool is_log_message) {
     if (!is_log_message) {
@@ -261,13 +261,13 @@ class APIFrameHelper {
   // Nagle batching state for log messages. NODELAY_ON (-1) means NODELAY is enabled
   // (immediate send). Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
   // After LOG_NAGLE_COUNT logs, we switch to NODELAY to flush and reset.
-  // ESP32 and RP2040 have larger TCP send buffers and can coalesce more;
-  // ESP8266 and LibreTiny have tighter buffers.
+  // ESP8266 has the tightest TCP send buffer (2×MSS) and needs conservative batching.
+  // ESP32 (4×MSS+), RP2040 (8×MSS), and LibreTiny (4×MSS) can coalesce more.
   static constexpr int8_t NODELAY_ON = -1;
-#if defined(USE_ESP32) || defined(USE_RP2040)
-  static constexpr int8_t LOG_NAGLE_COUNT = 3;
-#else
+#ifdef USE_ESP8266
   static constexpr int8_t LOG_NAGLE_COUNT = 2;
+#else
+  static constexpr int8_t LOG_NAGLE_COUNT = 3;
 #endif
   int8_t nodelay_state_{NODELAY_ON};
 

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -154,7 +154,7 @@ class APIFrameHelper {
       return;
     }
 
-    // Log messages 1-3: state transitions -1 -> 1 -> 2 -> -1 (flush on 3rd)
+    // Log messages: state transitions -1 -> 1 -> ... -> LOG_NAGLE_COUNT -> -1 (flush)
     if (this->nodelay_state_ == NODELAY_ON) {
       this->set_nodelay_raw_(false);
       this->nodelay_state_ = 1;

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -134,12 +134,16 @@ class APIFrameHelper {
   //
   // For log messages: Use Nagle to coalesce multiple small log packets into
   // fewer larger packets, reducing WiFi overhead. However, we limit batching
-  // to 3 messages to avoid excessive LWIP buffer pressure on memory-constrained
-  // devices like ESP8266. LWIP's TCP_OVERSIZE option coalesces the data into
-  // shared pbufs, but holding data too long waiting for Nagle's timer causes
-  // buffer exhaustion and dropped messages.
+  // to avoid excessive LWIP buffer pressure on memory-constrained devices.
+  // LWIP's TCP_OVERSIZE option coalesces the data into shared pbufs, but
+  // holding data too long waiting for Nagle's timer causes buffer exhaustion
+  // and dropped messages.
   //
-  // Flow: Log 1 (Nagle on) -> Log 2 (Nagle on) -> Log 3 (NODELAY, flush all)
+  // ESP32 (TCP_SND_BUF=64KB) / RP2040 (8×MSS): 4 logs per cycle
+  // ESP8266 / LibreTiny: 3 logs per cycle (tighter buffers)
+  //
+  // Flow (ESP32/RP2040): Log 1 (Nagle on) -> Log 2 -> Log 3 -> Log 4 (NODELAY, flush)
+  // Flow (other):        Log 1 (Nagle on) -> Log 2 -> Log 3 (NODELAY, flush all)
   //
   void set_nodelay_for_message(bool is_log_message) {
     if (!is_log_message) {
@@ -255,10 +259,16 @@ class APIFrameHelper {
   uint8_t tx_buf_tail_{0};
   uint8_t tx_buf_count_{0};
   // Nagle batching state for log messages. NODELAY_ON (-1) means NODELAY is enabled
-  // (immediate send). Values 1-2 count log messages in the current Nagle batch.
+  // (immediate send). Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
   // After LOG_NAGLE_COUNT logs, we switch to NODELAY to flush and reset.
+  // ESP32 and RP2040 have larger TCP send buffers and can coalesce more;
+  // ESP8266 and LibreTiny have tighter buffers.
   static constexpr int8_t NODELAY_ON = -1;
+#if defined(USE_ESP32) || defined(USE_RP2040)
+  static constexpr int8_t LOG_NAGLE_COUNT = 3;
+#else
   static constexpr int8_t LOG_NAGLE_COUNT = 2;
+#endif
   int8_t nodelay_state_{NODELAY_ON};
 
   // Internal helper to set TCP_NODELAY socket option


### PR DESCRIPTION
# What does this implement/fix?

Fixes unnecessary heap allocations on ESP32, RP2040, and LibreTiny caused by an overly conservative Nagle batching limit.

PR #13439 fixed LWIP buffer exhaustion on ESP8266 by limiting log message Nagle batching to `LOG_NAGLE_COUNT=2` (3 logs per flush cycle). The fix was correct for ESP8266 (`TCP_SND_BUF=2×MSS = ~2.9KB`), but was applied globally to all platforms as a conservative measure since we lacked visibility into actual buffering behavior at the time. This inadvertently caused a performance regression on platforms with larger TCP send buffers:

- **ESP32**: `4×MSS = 5760` default, `65534` with high-perf networking
- **RP2040**: `8×MSS = 11680`
- **LibreTiny**: `4×MSS = 5840` (set in `libretiny/__init__.py`)

On these platforms, the overly aggressive flushing caused ~15% of log writes to hit EWOULDBLOCK, each triggering a `buffer_data_from_iov_()` call that heap-allocates (`std::make_unique<SendBuffer>` + `std::make_unique<uint8_t[]>`). This heap churn is especially harmful during `dump_config()` at startup, where a burst of log messages is forwarded to connected clients, and contributes to heap fragmentation on long-running devices.

This PR increases `LOG_NAGLE_COUNT` from 2 to 3 on all platforms except ESP8266, coalescing 4 log messages per Nagle cycle instead of 3. Fewer write calls means fewer EWOULDBLOCK hits, which eliminates the unnecessary heap allocations.

## Testing methodology

Instrumented `write_raw_()` in `api_frame_helper.cpp` with counters to track write outcomes over 30-second intervals. Stats were logged from `APIConnection::loop()` (outside the write path to avoid re-entrancy with the API log subscriber). Counters tracked:

- **direct**: writes that went straight to the socket successfully
- **buffered**: writes where socket returned EWOULDBLOCK (full send buffer)
- **partial**: writes where socket accepted some bytes but not all
- **prior_buf**: writes queued because prior buffered data was still pending
- **total_bytes** / **buffered_bytes**: byte-level breakdown
- **buf_size_min** / **buf_size_max**: smallest/largest single buffered write

Key finding: buffering only occurs on the **log subscriber** connection (ESPHome Logs client), not on the Home Assistant state connection. The HA connection (sensor updates, batched messages) consistently shows zero buffered writes. This is expected — log messages are bursty (multiple sensor readings fire in quick succession, each generating a forwarded log line).

### ESP32 results

**LOG_NAGLE_COUNT=2 (baseline):**
```
Home Assistant 2026.4.0.dev0: write stats (30s): direct=38 buffered=0 partial=0 prior_buf=0 total_bytes=13446 buffered_bytes=0
ESPHome Logs 2026.4.0-dev: write stats (30s): direct=114 buffered=21 partial=0 prior_buf=0 total_bytes=12455 buffered_bytes=2104
```

```
Home Assistant 2026.4.0.dev0: write stats (30s): direct=6 buffered=0 partial=0 prior_buf=0 total_bytes=99 buffered_bytes=0
ESPHome Logs 2026.4.0-dev: write stats (30s): direct=80 buffered=13 partial=0 prior_buf=0 total_bytes=9162 buffered_bytes=1320 buf_size_min=96 buf_size_max=112
```

**LOG_NAGLE_COUNT=3:**
```
Home Assistant 2026.4.0.dev0: write stats (30s): direct=6 buffered=0 partial=0 prior_buf=0 total_bytes=102 buffered_bytes=0 buf_size_min=0 buf_size_max=0
ESPHome Logs 2026.4.0-dev: write stats (30s): direct=129 buffered=0 partial=4 prior_buf=0 total_bytes=13076 buffered_bytes=213 buf_size_min=9 buf_size_max=96
```

**LOG_NAGLE_COUNT=4 (too aggressive):**
```
Home Assistant 2026.4.0.dev0: write stats (30s): direct=6 buffered=0 partial=0 prior_buf=0 total_bytes=102 buffered_bytes=0 buf_size_min=0 buf_size_max=0
ESPHome Logs 2026.4.0-dev: write stats (30s): direct=134 buffered=0 partial=5 prior_buf=0 total_bytes=13658 buffered_bytes=367 buf_size_min=57 buf_size_max=87
```

### RP2040 results

**LOG_NAGLE_COUNT=2 (baseline):**
```
Home Assistant 2026.4.0.dev0: write stats (30s): direct=6 buffered=0 partial=0 prior_buf=0 total_bytes=102 buffered_bytes=0 buf_size_min=0 buf_size_max=0
ESPHome Logs 2026.4.0-dev: write stats (30s): direct=101 buffered=9 partial=1 prior_buf=0 total_bytes=10864 buffered_bytes=974 buf_size_min=79 buf_size_max=105
```

### Summary

| ESP32 Metric | count=2 | count=3 | count=4 |
|--------|---------|---------|---------|
| buffered writes | 21 (15.6%) | 0 (0%) | 0 (0%) |
| partial writes | 0 | 4 | 5 |
| buffered bytes | 2,104 | 213 | 367 |

`LOG_NAGLE_COUNT=3` is the sweet spot — eliminates all full EWOULDBLOCK blocks with minimal partials. Count=4 shows slightly more partials and buffered bytes as the larger coalesced writes are more likely to exceed remaining send buffer space.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #13439

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change — internal tuning only
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
