### PR TITLE
[rp2040] Add CI check for boards.py freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
           script/build_codeowners.py --check
           script/build_language_schema.py --check
           script/generate-esp32-boards.py --check
+          script/generate-rp2040-boards.py --check
 
   pytest:
     name: Run pytest

--- a/esphome/components/rp2040/generate_boards.py
+++ b/esphome/components/rp2040/generate_boards.py
@@ -6,6 +6,7 @@ Usage: python esphome/components/rp2040/generate_boards.py <arduino-pico-path>
 import json
 from pathlib import Path
 import re
+import subprocess
 import sys
 
 from jinja2 import Environment, FileSystemLoader
@@ -157,13 +158,22 @@ def generate(arduino_pico_path: Path) -> str:
     board_pins, boards = load_boards(arduino_pico_path)
 
     template = _jinja_env.get_template("boards.jinja2")
-    return template.render(
+    content = template.render(
         cyw43_gpio_offset=CYW43_GPIO_OFFSET,
         cyw43_max_gpio=CYW43_GPIO_OFFSET + CYW43_GPIO_COUNT - 1,
         default_max_pin=DEFAULT_MAX_PIN,
         board_pins=sorted(board_pins.items()),
         boards=sorted(boards.items()),
     )
+
+    # Format output to match pre-commit ruff formatting
+    result = subprocess.run(
+        ["ruff", "format", "--stdin-filename", "boards.py"],
+        input=content.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.decode()
 
 
 def main():

--- a/esphome/components/rp2040/generate_boards.py
+++ b/esphome/components/rp2040/generate_boards.py
@@ -168,7 +168,7 @@ def generate(arduino_pico_path: Path) -> str:
 
     # Format output to match pre-commit ruff formatting
     result = subprocess.run(
-        ["ruff", "format", "--stdin-filename", "boards.py"],
+        [sys.executable, "-m", "ruff", "format", "--stdin-filename", "boards.py"],
         input=content.encode(),
         capture_output=True,
         check=True,

--- a/script/generate-rp2040-boards.py
+++ b/script/generate-rp2040-boards.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+from esphome.components.rp2040 import RECOMMENDED_ARDUINO_FRAMEWORK_VERSION
+from esphome.components.rp2040.generate_boards import generate
+from esphome.helpers import write_file_if_changed
+
+ver = RECOMMENDED_ARDUINO_FRAMEWORK_VERSION
+version_tag: str = f"{ver.major}.{ver.minor}.{ver.patch}"
+root: Path = Path(__file__).parent.parent
+boards_file_path: Path = root / "esphome" / "components" / "rp2040" / "boards.py"
+
+
+def main(check: bool) -> None:
+    with tempfile.TemporaryDirectory() as tempdir:
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "-q",
+                "-c",
+                "advice.detachedHead=false",
+                "--depth",
+                "1",
+                "--branch",
+                version_tag,
+                "https://github.com/earlephilhower/arduino-pico",
+                tempdir,
+            ],
+            check=True,
+        )
+
+        content: str = generate(Path(tempdir))
+
+    if check:
+        existing_content: str = boards_file_path.read_text(encoding="utf-8")
+        if existing_content != content:
+            print("esphome/components/rp2040/boards.py is not up to date.")
+            print("Please run `script/generate-rp2040-boards.py`")
+            sys.exit(1)
+        print("esphome/components/rp2040/boards.py is up to date")
+    elif write_file_if_changed(boards_file_path, content):
+        print("RP2040 boards updated successfully.")
+
+
+if __name__ == "__main__":
+    parser: argparse.ArgumentParser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        help="Check if the boards.py file is up to date.",
+        action="store_true",
+    )
+    args: argparse.Namespace = parser.parse_args()
+    main(args.check)


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #14528 as suggested by swoboda1337.

Adds a `script/generate-rp2040-boards.py` script that clones the arduino-pico repository at the recommended framework version and regenerates `boards.py`, then adds a `--check` mode to CI that verifies the checked-in file is up to date. This matches the existing `script/generate-esp32-boards.py --check` pattern.

This ensures `boards.py` stays in sync whenever the arduino-pico framework version is bumped.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14528

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — CI-only change, no user-facing docs needed.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — CI script only, no config.yaml changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).