### PR TITLE
[scheduler] Use integer math for interval offset calculation

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -105,10 +105,11 @@ static void validate_static_string(const char *name) {
 // avoid the main thread modifying the list while it is being accessed.
 
 // Calculate random offset for interval timers
-// Extracted from set_timer_common_ to reduce code size - float math + random_float()
-// only needed for intervals, not timeouts
+// Extracted from set_timer_common_ to reduce code size - only needed for intervals, not timeouts
 uint32_t Scheduler::calculate_interval_offset_(uint32_t delay) {
-  return static_cast<uint32_t>(std::min(delay / 2, MAX_INTERVAL_DELAY) * random_float());
+  uint32_t max_offset = std::min(delay / 2, MAX_INTERVAL_DELAY);
+  // Multiply-and-shift: uniform random in [0, max_offset) without floating point
+  return static_cast<uint32_t>((static_cast<uint64_t>(random_uint32()) * max_offset) >> 32);
 }
 
 // Check if a retry was already cancelled in items_ or to_add_


### PR DESCRIPTION
# What does this implement/fix?

Replace floating-point random offset calculation in `Scheduler::calculate_interval_offset_()` with integer multiply-and-shift, eliminating soft-float calls on ESP8266 and FPU instructions on ESP32/RP2040.

The integer version uses `(uint64_t(random_uint32()) * max_offset) >> 32` to produce a uniform random value in `[0, max_offset)` — functionally equivalent to the original `max_offset * random_float()` (at most off by 1 due to float rounding, which is negligible for a random stagger offset).

**Code size savings for `calculate_interval_offset_`:**

| Platform | Before | After | Saved |
|---|---|---|---|
| RP2040 (ARM Thumb-2) | 54 B | 26 B | -28 B (-52%) |
| ESP8266 (Xtensa LX106) | 65 B | 45 B | -20 B (-31%) |

**Runtime benchmark (real hardware):**

| Platform | Old (float) | New (integer) | Speedup |
|---|---|---|---|
| ESP32 (Xtensa LX6, HW FPU) | 1011 ns/call | 870 ns/call | 1.16x |
| ESP8266 (Xtensa LX106, soft-float) | 4602 ns/call | 1521 ns/call | 3.03x |

On ESP8266 the soft-float emulation for `random_float()` + float multiply costs 3x more than the integer multiply-and-shift path.

**ESP32-IDF flash impact (CI):**

`calculate_interval_offset_` shrinks from 48 B → 28 B (-42%), and `random_float()` (25 B) is eliminated entirely — net **-100 B flash** on ESP32-IDF.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).