### PR TITLE
[core] Inline Mutex on all embedded platforms

### DIFF
--- a/esphome/components/esp32/helpers.cpp
+++ b/esphome/components/esp32/helpers.cpp
@@ -20,12 +20,6 @@ bool random_bytes(uint8_t *data, size_t len) {
   return true;
 }
 
-Mutex::Mutex() { handle_ = xSemaphoreCreateMutex(); }
-Mutex::~Mutex() {}
-void Mutex::lock() { xSemaphoreTake(this->handle_, portMAX_DELAY); }
-bool Mutex::try_lock() { return xSemaphoreTake(this->handle_, 0) == pdTRUE; }
-void Mutex::unlock() { xSemaphoreGive(this->handle_); }
-
 // only affects the executing core
 // so should not be used as a mutex lock, only to get accurate timing
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }

--- a/esphome/components/esp8266/helpers.cpp
+++ b/esphome/components/esp8266/helpers.cpp
@@ -12,12 +12,7 @@ namespace esphome {
 uint32_t random_uint32() { return os_random(); }
 bool random_bytes(uint8_t *data, size_t len) { return os_get_random(data, len) == 0; }
 
-// ESP8266 doesn't have mutexes, but that shouldn't be an issue as it's single-core and non-preemptive OS.
-Mutex::Mutex() {}
-Mutex::~Mutex() {}
-void Mutex::lock() {}
-bool Mutex::try_lock() { return true; }
-void Mutex::unlock() {}
+// ESP8266 Mutex is defined inline in helpers.h when ESPHOME_THREAD_SINGLE is set.
 
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = xt_rsil(15); }
 IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(state_); }

--- a/esphome/components/esp8266/helpers.cpp
+++ b/esphome/components/esp8266/helpers.cpp
@@ -12,7 +12,8 @@ namespace esphome {
 uint32_t random_uint32() { return os_random(); }
 bool random_bytes(uint8_t *data, size_t len) { return os_get_random(data, len) == 0; }
 
-// ESP8266 Mutex is defined inline in helpers.h when ESPHOME_THREAD_SINGLE is set.
+// ESP8266 Mutex is defined inline as a no-op in helpers.h when USE_ESP8266 (or USE_RP2040) is set,
+// independent of the ESPHOME_THREAD_SINGLE thread model define.
 
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = xt_rsil(15); }
 IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(state_); }

--- a/esphome/components/libretiny/helpers.cpp
+++ b/esphome/components/libretiny/helpers.cpp
@@ -15,12 +15,6 @@ bool random_bytes(uint8_t *data, size_t len) {
   return true;
 }
 
-Mutex::Mutex() { handle_ = xSemaphoreCreateMutex(); }
-Mutex::~Mutex() {}
-void Mutex::lock() { xSemaphoreTake(this->handle_, portMAX_DELAY); }
-bool Mutex::try_lock() { return xSemaphoreTake(this->handle_, 0) == pdTRUE; }
-void Mutex::unlock() { xSemaphoreGive(this->handle_); }
-
 // only affects the executing core
 // so should not be used as a mutex lock, only to get accurate timing
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }

--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -35,7 +35,7 @@ bool random_bytes(uint8_t *data, size_t len) {
   return true;
 }
 
-// RP2040 Mutex is defined inline in helpers.h when ESPHOME_THREAD_SINGLE is set.
+// RP2040 Mutex is defined inline in helpers.h for RP2040/ESP8266 builds.
 
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = save_and_disable_interrupts(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { restore_interrupts(state_); }

--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -35,12 +35,7 @@ bool random_bytes(uint8_t *data, size_t len) {
   return true;
 }
 
-// RP2040 doesn't have mutexes, but that shouldn't be an issue as it's single-core and non-preemptive OS.
-Mutex::Mutex() {}
-Mutex::~Mutex() {}
-void Mutex::lock() {}
-bool Mutex::try_lock() { return true; }
-void Mutex::unlock() {}
+// RP2040 Mutex is defined inline in helpers.h when ESPHOME_THREAD_SINGLE is set.
 
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = save_and_disable_interrupts(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { restore_interrupts(state_); }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1876,6 +1876,16 @@ class Mutex {
   void lock() {}
   bool try_lock() { return true; }
   void unlock() {}
+#elif defined(USE_ESP32) || defined(USE_LIBRETINY)
+  // FreeRTOS platforms: inline to avoid out-of-line call overhead.
+  Mutex() { handle_ = xSemaphoreCreateMutex(); }
+  ~Mutex() = default;
+  void lock() { xSemaphoreTake(this->handle_, portMAX_DELAY); }
+  bool try_lock() { return xSemaphoreTake(this->handle_, 0) == pdTRUE; }
+  void unlock() { xSemaphoreGive(this->handle_); }
+
+ private:
+  SemaphoreHandle_t handle_;
 #else
   Mutex();
   ~Mutex();
@@ -1884,13 +1894,9 @@ class Mutex {
   void unlock();
 
  private:
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
-  SemaphoreHandle_t handle_;
-#else
   // d-pointer to store private data on new platforms
   void *handle_;  // NOLINT(clang-diagnostic-unused-private-field)
 #endif
-#endif  // single-threaded check
 };
 
 /** Helper class that wraps a mutex with a RAII-style API.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1737,14 +1737,22 @@ template<typename T> class Parented {
  */
 class Mutex {
  public:
-  Mutex();
   Mutex(const Mutex &) = delete;
+  Mutex &operator=(const Mutex &) = delete;
+
+#if defined(USE_ESP8266) || defined(USE_RP2040)
+  // Single-threaded platforms: inline no-ops so the compiler eliminates all call overhead.
+  Mutex() = default;
+  ~Mutex() = default;
+  void lock() {}
+  bool try_lock() { return true; }
+  void unlock() {}
+#else
+  Mutex();
   ~Mutex();
   void lock();
   bool try_lock();
   void unlock();
-
-  Mutex &operator=(const Mutex &) = delete;
 
  private:
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
@@ -1753,6 +1761,7 @@ class Mutex {
   // d-pointer to store private data on new platforms
   void *handle_;  // NOLINT(clang-diagnostic-unused-private-field)
 #endif
+#endif  // single-threaded check
 };
 
 /** Helper class that wraps a mutex with a RAII-style API.


### PR DESCRIPTION
# What does this implement/fix?

Moves Mutex methods inline into `helpers.h` for all embedded platforms, eliminating out-of-line definitions in platform-specific `.cpp` files.

**Single-threaded platforms (ESP8266, RP2040):** Mutex becomes inline no-ops, allowing the compiler to completely eliminate all lock/unlock overhead.

**FreeRTOS platforms (ESP32, LibreTiny):** Mutex methods are inlined as direct calls to `xSemaphoreTake`/`xSemaphoreGive`. The primary benefit here is not flash savings but **call indirection elimination**: GCC's ISRA (Interprocedural Scalar Replacement of Aggregates) pass hoists the `handle_` load into callers and generates tail-call clones. This collapses the call chain from `caller → LockGuard → Mutex::lock → xQueueSemaphoreTake` (3 levels) to `caller → Mutex::lock$isra → xQueueSemaphoreTake` (1 real call frame via tail call). `LockGuard` constructor/destructor are fully inlined at all call sites.

**Scheduler hot path code size (ESP8266, disassembled from ELF):**

| Platform | Before | After | Saved |
|---|---|---|---|
| ESP8266 (Xtensa LX106) | 2,023 B | 1,736 B | **-287 B (-14.2%)** |
| RP2040 Pico2 (ARM Thumb-2) | 1,560 B | 1,474 B | **-86 B (-5.5%)** |

Key improvements on ESP8266:
- `Mutex::lock`, `Mutex::unlock`, `LockGuard::~LockGuard` symbols eliminated entirely
- `cancel_item_` (86 B wrapper) eliminated — inlined by compiler once lock overhead removed
- `cancel_item_locked_` shrunk from 135 B to 25 B
- `Scheduler::call` shrunk from 323 B to 283 B

**Application main loop hot path code size (FreeRTOS, disassembled from ELF):**

| Platform | Before | After | Saved |
|---|---|---|---|
| ESP32 (Xtensa) | 1,304 B | 1,270 B | **-34 B** |
| BK72xx (ARM M4) | 1,400 B | 1,396 B | **-4 B** |
| RTL87xx (ARM M33) | 1,248 B | 1,246 B | **-2 B** |
| ESP32-C3 (RISC-V) | 1,498 B | 1,494 B | **-4 B** |

Host platform continues using the existing out-of-line Mutex with `std::mutex`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).