### PR TITLE
[api] Optimize plaintext varint encoding and devirtualize write_protobuf_packet

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -12,6 +12,7 @@
 #include "esphome/components/socket/socket.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
+#include "proto.h"
 
 namespace esphome::api {
 
@@ -36,8 +37,6 @@ static constexpr uint16_t RX_BUF_NULL_TERMINATOR = 1;
 // Maximum number of messages to batch in a single write operation
 // Must be >= MAX_INITIAL_PER_BATCH in api_connection.h (enforced by static_assert there)
 static constexpr size_t MAX_MESSAGES_PER_BATCH = 34;
-
-class ProtoWriteBuffer;
 
 // Max client name length (e.g., "Home Assistant 2026.1.0.dev0" = 28 chars)
 static constexpr size_t CLIENT_INFO_NAME_MAX_LEN = 32;
@@ -161,7 +160,14 @@ class APIFrameHelper {
       this->nodelay_state_++;
     }
   }
-  virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
+  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
+    // Resize buffer to include footer space if needed (e.g. Noise MAC)
+    if (frame_footer_size_)
+      buffer.get_buffer()->resize(buffer.get_buffer()->size() + frame_footer_size_);
+    MessageInfo msg{type, 0,
+                    static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_)};
+    return write_protobuf_messages(buffer, std::span<const MessageInfo>(&msg, 1));
+  }
   // Write multiple protobuf messages in a single operation
   // messages contains (message_type, offset, length) for each message in the buffer
   // The buffer contains all messages with appropriate padding before each

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -450,14 +450,6 @@ APIError APINoiseFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   buffer->type = type;
   return APIError::OK;
 }
-APIError APINoiseFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
-  // Resize to include MAC space (required for Noise encryption)
-  buffer.get_buffer()->resize(buffer.get_buffer()->size() + frame_footer_size_);
-  MessageInfo msg{type, 0,
-                  static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_ - frame_footer_size_)};
-  return write_protobuf_messages(buffer, std::span<const MessageInfo>(&msg, 1));
-}
-
 APIError APINoiseFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffer, std::span<const MessageInfo> messages) {
   APIError aerr = this->check_data_state_();
   if (aerr != APIError::OK)

--- a/esphome/components/api/api_frame_helper_noise.h
+++ b/esphome/components/api/api_frame_helper_noise.h
@@ -22,7 +22,6 @@ class APINoiseFrameHelper final : public APIFrameHelper {
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_messages(ProtoWriteBuffer buffer, std::span<const MessageInfo> messages) override;
 
  protected:

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -253,9 +253,10 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
 
   for (const auto &msg : messages) {
     // Calculate varint sizes for header layout using inline ternary to avoid varint_slow call overhead
-    uint8_t size_varint_len =
-        msg.payload_size < ProtoSize::VARINT_MAX_1_BYTE ? 1 : (msg.payload_size < ProtoSize::VARINT_MAX_2_BYTE ? 2 : 3);
-    uint8_t type_varint_len = msg.message_type < ProtoSize::VARINT_MAX_1_BYTE ? 1 : 2;
+    uint8_t size_varint_len = msg.payload_size < ProtoSize::VARINT_THRESHOLD_1_BYTE
+                                  ? 1
+                                  : (msg.payload_size < ProtoSize::VARINT_THRESHOLD_2_BYTE ? 2 : 3);
+    uint8_t type_varint_len = msg.message_type < ProtoSize::VARINT_THRESHOLD_1_BYTE ? 1 : 2;
     uint8_t total_header_len = 1 + size_varint_len + type_varint_len;
 
     // Calculate where to start writing the header

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -255,8 +255,7 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
     // Calculate varint sizes for header layout using inline ternary to avoid varint_slow call overhead
     uint8_t size_varint_len =
         msg.payload_size < ProtoSize::VARINT_MAX_1_BYTE ? 1 : (msg.payload_size < ProtoSize::VARINT_MAX_2_BYTE ? 2 : 3);
-    uint8_t type_varint_len =
-        msg.message_type < ProtoSize::VARINT_MAX_1_BYTE ? 1 : (msg.message_type < ProtoSize::VARINT_MAX_2_BYTE ? 2 : 3);
+    uint8_t type_varint_len = msg.message_type < ProtoSize::VARINT_MAX_1_BYTE ? 1 : 2;
     uint8_t total_header_len = 1 + size_varint_len + type_varint_len;
 
     // Calculate where to start writing the header
@@ -290,10 +289,8 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
     // Write the plaintext header
     buf_start[header_offset] = 0x00;  // indicator
 
-    // Encode payload size varint
+    // Encode varints directly into buffer
     encode_varint_to_buffer(msg.payload_size, buf_start + header_offset + 1);
-
-    // Encode message type varint
     encode_varint_to_buffer(msg.message_type, buf_start + header_offset + 1 + size_varint_len);
 
     // Add iovec for this message (header + payload)

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -235,11 +235,6 @@ APIError APIPlaintextFrameHelper::read_packet(ReadPacketBuffer *buffer) {
   buffer->type = this->rx_header_parsed_type_;
   return APIError::OK;
 }
-APIError APIPlaintextFrameHelper::write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) {
-  MessageInfo msg{type, 0, static_cast<uint16_t>(buffer.get_buffer()->size() - frame_header_padding_)};
-  return write_protobuf_messages(buffer, std::span<const MessageInfo>(&msg, 1));
-}
-
 APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffer,
                                                           std::span<const MessageInfo> messages) {
   APIError aerr = this->check_data_state_();
@@ -257,9 +252,11 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
   uint16_t total_write_len = 0;
 
   for (const auto &msg : messages) {
-    // Calculate varint sizes for header layout
-    uint8_t size_varint_len = api::ProtoSize::varint(static_cast<uint32_t>(msg.payload_size));
-    uint8_t type_varint_len = api::ProtoSize::varint(static_cast<uint32_t>(msg.message_type));
+    // Calculate varint sizes for header layout using inline ternary to avoid varint_slow call overhead
+    uint8_t size_varint_len =
+        msg.payload_size < ProtoSize::VARINT_MAX_1_BYTE ? 1 : (msg.payload_size < ProtoSize::VARINT_MAX_2_BYTE ? 2 : 3);
+    uint8_t type_varint_len =
+        msg.message_type < ProtoSize::VARINT_MAX_1_BYTE ? 1 : (msg.message_type < ProtoSize::VARINT_MAX_2_BYTE ? 2 : 3);
     uint8_t total_header_len = 1 + size_varint_len + type_varint_len;
 
     // Calculate where to start writing the header
@@ -281,8 +278,8 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
     //
     // Example 3 (large values): total_header_len = 6, header_offset = 6 - 6 = 0
     // [0]    - 0x00 indicator byte
-    // [1-3]  - Payload size varint (3 bytes, for sizes 16384-2097151)
-    // [4-5]  - Message type varint (2 bytes, for types 128-32767)
+    // [1-3]  - Payload size varint (3 bytes, for sizes 16384-65535)
+    // [4-5]  - Message type varint (2 bytes, for types 128-16383)
     // [6...] - Actual payload data
     //
     // The message starts at offset + frame_header_padding_
@@ -293,8 +290,10 @@ APIError APIPlaintextFrameHelper::write_protobuf_messages(ProtoWriteBuffer buffe
     // Write the plaintext header
     buf_start[header_offset] = 0x00;  // indicator
 
-    // Encode varints directly into buffer
+    // Encode payload size varint
     encode_varint_to_buffer(msg.payload_size, buf_start + header_offset + 1);
+
+    // Encode message type varint
     encode_varint_to_buffer(msg.message_type, buf_start + header_offset + 1 + size_varint_len);
 
     // Add iovec for this message (header + payload)

--- a/esphome/components/api/api_frame_helper_plaintext.h
+++ b/esphome/components/api/api_frame_helper_plaintext.h
@@ -19,7 +19,6 @@ class APIPlaintextFrameHelper final : public APIFrameHelper {
   APIError init() override;
   APIError loop() override;
   APIError read_packet(ReadPacketBuffer *buffer) override;
-  APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) override;
   APIError write_protobuf_messages(ProtoWriteBuffer buffer, std::span<const MessageInfo> messages) override;
 
  protected:

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -474,10 +474,10 @@ class ProtoDecodableMessage : public ProtoMessage {
 class ProtoSize {
  public:
   // Varint encoding thresholds: values below each threshold fit in N bytes
-  static constexpr uint32_t VARINT_MAX_1_BYTE = 1 << 7;   // 128
-  static constexpr uint32_t VARINT_MAX_2_BYTE = 1 << 14;  // 16384
-  static constexpr uint32_t VARINT_MAX_3_BYTE = 1 << 21;  // 2097152
-  static constexpr uint32_t VARINT_MAX_4_BYTE = 1 << 28;  // 268435456
+  static constexpr uint32_t VARINT_THRESHOLD_1_BYTE = 1 << 7;   // 128
+  static constexpr uint32_t VARINT_THRESHOLD_2_BYTE = 1 << 14;  // 16384
+  static constexpr uint32_t VARINT_THRESHOLD_3_BYTE = 1 << 21;  // 2097152
+  static constexpr uint32_t VARINT_THRESHOLD_4_BYTE = 1 << 28;  // 268435456
 
   /**
    * @brief Calculates the size in bytes needed to encode a uint32_t value as a varint
@@ -486,7 +486,7 @@ class ProtoSize {
    * @return The number of bytes needed to encode the value
    */
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint(uint32_t value) {
-    if (value < VARINT_MAX_1_BYTE) [[likely]]
+    if (value < VARINT_THRESHOLD_1_BYTE) [[likely]]
       return 1;  // Fast path: 7 bits, most common case
     if (__builtin_is_constant_evaluated())
       return varint_wide(value);
@@ -498,11 +498,11 @@ class ProtoSize {
   static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
   // Shared cascade for values >= 128 (used by both constexpr and noinline paths)
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint_wide(uint32_t value) {
-    if (value < VARINT_MAX_2_BYTE)
+    if (value < VARINT_THRESHOLD_2_BYTE)
       return 2;
-    if (value < VARINT_MAX_3_BYTE)
+    if (value < VARINT_THRESHOLD_3_BYTE)
       return 3;
-    if (value < VARINT_MAX_4_BYTE)
+    if (value < VARINT_THRESHOLD_4_BYTE)
       return 4;
     return 5;
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -473,6 +473,12 @@ class ProtoDecodableMessage : public ProtoMessage {
 
 class ProtoSize {
  public:
+  // Varint encoding thresholds: values below each threshold fit in N bytes
+  static constexpr uint32_t VARINT_MAX_1_BYTE = 1 << 7;   // 128
+  static constexpr uint32_t VARINT_MAX_2_BYTE = 1 << 14;  // 16384
+  static constexpr uint32_t VARINT_MAX_3_BYTE = 1 << 21;  // 2097152
+  static constexpr uint32_t VARINT_MAX_4_BYTE = 1 << 28;  // 268435456
+
   /**
    * @brief Calculates the size in bytes needed to encode a uint32_t value as a varint
    *
@@ -480,7 +486,7 @@ class ProtoSize {
    * @return The number of bytes needed to encode the value
    */
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint(uint32_t value) {
-    if (value < 128) [[likely]]
+    if (value < VARINT_MAX_1_BYTE) [[likely]]
       return 1;  // Fast path: 7 bits, most common case
     if (__builtin_is_constant_evaluated())
       return varint_wide(value);
@@ -492,11 +498,11 @@ class ProtoSize {
   static uint32_t varint_slow(uint32_t value) __attribute__((noinline));
   // Shared cascade for values >= 128 (used by both constexpr and noinline paths)
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE varint_wide(uint32_t value) {
-    if (value < 16384)
+    if (value < VARINT_MAX_2_BYTE)
       return 2;
-    if (value < 2097152)
+    if (value < VARINT_MAX_3_BYTE)
       return 3;
-    if (value < 268435456)
+    if (value < VARINT_MAX_4_BYTE)
       return 4;
     return 5;
   }


### PR DESCRIPTION
# What does this implement/fix?

Reduces code size on the API plaintext write path through two optimizations:

1. **Inline varint length calculations**: Replaces both `ProtoSize::varint()` calls in the `write_protobuf_messages` loop with inline ternaries using named constants. For `payload_size` (uint16_t), a 3-way ternary covers 1/2/3-byte varints. For `message_type` (uint8_t, max 255), a simpler 2-way ternary suffices (max 2-byte varint). This eliminates the `noinline` `varint_slow` function calls and associated register spill/restore overhead on Xtensa. Also fixes incorrect ranges in the header layout comments (payload size capped at 65535 not 2097151, message type 2-byte varint max is 16383 not 32767).

2. **Devirtualize `write_protobuf_packet`**: Moves it from a pure virtual method with per-subclass overrides to a non-virtual inline method on the base class. The plaintext and noise implementations only differed in footer handling — noise needs to resize the buffer for MAC space. This is now unified with a conditional resize based on `frame_footer_size_` (which is 0 for plaintext, so the branch is optimized away). Eliminates one vtable slot and allows the compiler to fully inline the thin wrapper into callers.

**Note on compile test measurements:** The CI compile tests define both `USE_API_PLAINTEXT` and `USE_API_NOISE`, so both `APIPlaintextFrameHelper` and `APINoiseFrameHelper` are compiled into the same binary. With both subclasses present, the compiler cannot devirtualize calls to `write_protobuf_packet` through the base class pointer — it sees two possible targets and must emit an indirect call. Making the method non-virtual eliminates this overhead regardless of which protocol variants are compiled in.

Also adds named varint threshold constants (`VARINT_MAX_1_BYTE`, `VARINT_MAX_2_BYTE`, etc.) to `ProtoSize`, replacing magic numbers in both `varint()` and `varint_wide()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).