### PR TITLE
[select] Fix -Wmaybe-uninitialized warnings on ESP8266

### DIFF
--- a/esphome/components/select/select_call.cpp
+++ b/esphome/components/select/select_call.cpp
@@ -41,7 +41,7 @@ SelectCall &SelectCall::with_index(size_t index) {
   this->operation_ = SELECT_OP_SET;
   if (index >= this->parent_->size()) {
     ESP_LOGW(TAG, "'%s' - Index value %zu out of bounds", this->parent_->get_name().c_str(), index);
-    this->index_ = {};  // Store nullopt for invalid index
+    this->index_ = nullopt;  // Store nullopt for invalid index
   } else {
     this->index_ = index;
   }
@@ -52,7 +52,7 @@ optional<size_t> SelectCall::calculate_target_index_(const char *name) {
   const auto &options = this->parent_->traits.get_options();
   if (options.empty()) {
     ESP_LOGW(TAG, "'%s' - Select has no options", name);
-    return {};
+    return nullopt;
   }
 
   if (this->operation_ == SELECT_OP_FIRST) {
@@ -67,7 +67,7 @@ optional<size_t> SelectCall::calculate_target_index_(const char *name) {
     ESP_LOGD(TAG, "'%s' - Setting", name);
     if (!this->index_.has_value()) {
       ESP_LOGW(TAG, "'%s' - No option set", name);
-      return {};
+      return nullopt;
     }
     return this->index_;
   }
@@ -96,7 +96,7 @@ optional<size_t> SelectCall::calculate_target_index_(const char *name) {
     return active_index + 1;
   }
 
-  return {};  // Can't navigate further without cycling
+  return nullopt;  // Can't navigate further without cycling
 }
 
 void SelectCall::perform() {


### PR DESCRIPTION
# What does this implement/fix?

Fix `-Wmaybe-uninitialized` compiler warnings in `select_call.cpp` on ESP8266. Older GCC versions used by the ESP8266 toolchain falsely warn about uninitialized values when using brace-initialization `return {}` for `optional<size_t>`. Replace with explicit `nullopt`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).