### PR TITLE
[dlms_meter] WIP new parser

### DIFF
--- a/esphome/components/dlms_meter/__init__.py
+++ b/esphome/components/dlms_meter/__init__.py
@@ -9,8 +9,10 @@ DEPENDENCIES = ["uart"]
 CONF_DLMS_METER_ID = "dlms_meter_id"
 CONF_DECRYPTION_KEY = "decryption_key"
 CONF_PROVIDER = "provider"
+CONF_TRANSPORT = "transport"
 
 PROVIDERS = {"generic": 0, "netznoe": 1}
+TRANSPORTS = {"mbus": 0, "raw": 1}
 
 dlms_meter_component_ns = cg.esphome_ns.namespace("dlms_meter")
 DlmsMeterComponent = dlms_meter_component_ns.class_(
@@ -32,9 +34,12 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DlmsMeterComponent),
-            cv.Required(CONF_DECRYPTION_KEY): validate_key,
+            cv.Optional(CONF_DECRYPTION_KEY): validate_key,
             cv.Optional(CONF_PROVIDER, default="generic"): cv.enum(
                 PROVIDERS, lower=True
+            ),
+            cv.Optional(CONF_TRANSPORT, default="mbus"): cv.enum(
+                TRANSPORTS, lower=True
             ),
         }
     )
@@ -43,15 +48,17 @@ CONFIG_SCHEMA = cv.All(
     cv.only_on([PLATFORM_ESP8266, PLATFORM_ESP32]),
 )
 
-FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
-    "dlms_meter", baud_rate=2400, require_rx=True
-)
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema("dlms_meter", require_rx=True)
 
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
-    key = ", ".join(str(b) for b in config[CONF_DECRYPTION_KEY])
-    cg.add(var.set_decryption_key(cg.RawExpression(f"{{{key}}}")))
+
+    if CONF_DECRYPTION_KEY in config:
+        key = ", ".join(str(b) for b in config[CONF_DECRYPTION_KEY])
+        cg.add(var.set_decryption_key(cg.RawExpression(f"{{{key}}}")))
+
     cg.add(var.set_provider(PROVIDERS[config[CONF_PROVIDER]]))
+    cg.add(var.set_transport(TRANSPORTS[config[CONF_TRANSPORT]]))

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -63,6 +63,85 @@ void DlmsMeterComponent::loop() {
       this->payload_ = this->receive_buffer_;
     }
 
+    MeterData data{};
+    DlmsParser parser;
+
+    auto callback = [&data](const char *obis_code, float float_val, const char *str_val, bool is_numeric) {
+      int parts[6] = {0};
+      int count = 0;
+      const char *ptr = obis_code;
+
+      // Extract parts of the OBIS code using strtol to avoid the sscanf flash size penalty
+      while (*ptr && count < 6) {
+        char *endptr;
+        parts[count++] = strtol(ptr, &endptr, 10);
+        if (*endptr == '.') {
+          ptr = endptr + 1;  // Skip the dot for the next number
+        } else {
+          break;  // Reached the end of the string or an invalid format
+        }
+      }
+
+      // If we successfully parsed all 6 groups (A.B.C.D.E.F)
+      if (count == 6) {
+        // Extract C and D to match the original enums in obis.h
+        uint16_t obis_cd = (parts[2] << 8) | parts[3];
+
+        if (is_numeric) {
+          switch (obis_cd) {
+            case OBIS_VOLTAGE_L1:
+              data.voltage_l1 = float_val;
+              break;
+            case OBIS_VOLTAGE_L2:
+              data.voltage_l2 = float_val;
+              break;
+            case OBIS_VOLTAGE_L3:
+              data.voltage_l3 = float_val;
+              break;
+            case OBIS_CURRENT_L1:
+              data.current_l1 = float_val;
+              break;
+            case OBIS_CURRENT_L2:
+              data.current_l2 = float_val;
+              break;
+            case OBIS_CURRENT_L3:
+              data.current_l3 = float_val;
+              break;
+            case OBIS_ACTIVE_POWER_PLUS:
+              data.active_power_plus = float_val;
+              break;
+            case OBIS_ACTIVE_POWER_MINUS:
+              data.active_power_minus = float_val;
+              break;
+            case OBIS_ACTIVE_ENERGY_PLUS:
+              data.active_energy_plus = float_val;
+              break;
+            case OBIS_ACTIVE_ENERGY_MINUS:
+              data.active_energy_minus = float_val;
+              break;
+            case OBIS_REACTIVE_ENERGY_PLUS:
+              data.reactive_energy_plus = float_val;
+              break;
+            case OBIS_REACTIVE_ENERGY_MINUS:
+              data.reactive_energy_minus = float_val;
+              break;
+            case OBIS_POWER_FACTOR:
+              data.power_factor = float_val;
+              break;
+            default:
+              ESP_LOGV(TAG, "Unsupported numeric OBIS code %s", obis_code);
+          }
+        } else {
+          // Handling strings and dates
+          if (obis_cd == OBIS_TIMESTAMP) {
+            snprintf(data.timestamp, sizeof(data.timestamp), "%s", str_val);
+          } else if (obis_cd == OBIS_SERIAL_NUMBER || obis_cd == OBIS_DEVICE_NAME) {
+            snprintf(data.meternumber, sizeof(data.meternumber), "%s", str_val);
+          }
+        }
+      }
+    };
+
     if (this->has_decryption_key_) {
       uint16_t message_length;
       uint8_t systitle_length;
@@ -79,11 +158,18 @@ void DlmsMeterComponent::loop() {
       // Decrypt in place and then decode the OBIS codes
       if (!this->decrypt_(this->payload_, message_length, systitle_length, header_offset))
         return;
-      this->decode_obis_(&this->payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+
+      parser.parse(&this->payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length, callback, true);
     } else {
       // If no decryption key is provided, decode the parsed payload directly assuming unencrypted APDU.
-      this->decode_obis_(this->payload_.data(), this->payload_.size());
+      parser.parse(this->payload_.data(), this->payload_.size(), callback, true);
     }
+
+    this->receive_buffer_.clear();
+
+    ESP_LOGI(TAG, "Received valid data");
+    this->publish_sensors(data);
+    this->status_clear_warning();
   }
 }
 
@@ -276,217 +362,6 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
   }
   ESP_LOGV(TAG, "Decrypted payload: %d bytes", message_length);
   return true;
-}
-
-void DlmsMeterComponent::decode_obis_(uint8_t *plaintext, uint16_t message_length) {
-  ESP_LOGV(TAG, "Decoding payload");
-  MeterData data{};
-  uint16_t current_position = DECODER_START_OFFSET;
-  bool power_factor_found = false;
-
-  while (current_position + OBIS_CODE_OFFSET <= message_length) {
-    if (plaintext[current_position + OBIS_TYPE_OFFSET] != DataType::OCTET_STRING) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header type: %x", plaintext[current_position + OBIS_TYPE_OFFSET]);
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    uint8_t obis_code_length = plaintext[current_position + OBIS_LENGTH_OFFSET];
-    if (obis_code_length != OBIS_CODE_LENGTH_STANDARD && obis_code_length != OBIS_CODE_LENGTH_EXTENDED) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS header length: %x", obis_code_length);
-      this->receive_buffer_.clear();
-      return;
-    }
-    if (current_position + OBIS_CODE_OFFSET + obis_code_length > message_length) {
-      ESP_LOGE(TAG, "OBIS: Buffer too short for OBIS code");
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    uint8_t *obis_code = &plaintext[current_position + OBIS_CODE_OFFSET];
-    uint8_t obis_medium = obis_code[OBIS_A];
-    uint16_t obis_cd = encode_uint16(obis_code[OBIS_C], obis_code[OBIS_D]);
-
-    bool timestamp_found = false;
-    bool meter_number_found = false;
-    if (this->provider_ == PROVIDER_NETZNOE) {
-      // Do not advance Position when reading the Timestamp at DECODER_START_OFFSET
-      if ((obis_code_length == OBIS_CODE_LENGTH_EXTENDED) && (current_position == DECODER_START_OFFSET)) {
-        timestamp_found = true;
-      } else if (power_factor_found) {
-        meter_number_found = true;
-        power_factor_found = false;
-      } else {
-        current_position += obis_code_length + OBIS_CODE_OFFSET;  // Advance past code and position
-      }
-    } else {
-      current_position += obis_code_length + OBIS_CODE_OFFSET;  // Advance past code, position and type
-    }
-    if (!timestamp_found && !meter_number_found && obis_medium != Medium::ELECTRICITY &&
-        obis_medium != Medium::ABSTRACT) {
-      ESP_LOGE(TAG, "OBIS: Unsupported OBIS medium: %x", obis_medium);
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    if (current_position >= message_length) {
-      ESP_LOGE(TAG, "OBIS: Buffer too short for data type");
-      this->receive_buffer_.clear();
-      return;
-    }
-
-    float value = 0.0f;
-    uint8_t value_size = 0;
-    uint8_t data_type = plaintext[current_position];
-    current_position++;
-
-    switch (data_type) {
-      case DataType::DOUBLE_LONG_UNSIGNED: {
-        value_size = 4;
-        if (current_position + value_size > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for DOUBLE_LONG_UNSIGNED");
-          this->receive_buffer_.clear();
-          return;
-        }
-        value = encode_uint32(plaintext[current_position + 0], plaintext[current_position + 1],
-                              plaintext[current_position + 2], plaintext[current_position + 3]);
-        current_position += value_size;
-        break;
-      }
-      case DataType::LONG_UNSIGNED: {
-        value_size = 2;
-        if (current_position + value_size > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for LONG_UNSIGNED");
-          this->receive_buffer_.clear();
-          return;
-        }
-        value = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
-        current_position += value_size;
-        break;
-      }
-      case DataType::OCTET_STRING: {
-        uint8_t data_length = plaintext[current_position];
-        current_position++;  // Advance past string length
-        if (current_position + data_length > message_length) {
-          ESP_LOGE(TAG, "OBIS: Buffer too short for OCTET_STRING");
-          this->receive_buffer_.clear();
-          return;
-        }
-        // Handle timestamp (normal OBIS code or NETZNOE special case)
-        if (obis_cd == OBIS_TIMESTAMP || timestamp_found) {
-          if (data_length < 8) {
-            ESP_LOGE(TAG, "OBIS: Timestamp data too short: %u", data_length);
-            this->receive_buffer_.clear();
-            return;
-          }
-          uint16_t year = encode_uint16(plaintext[current_position + 0], plaintext[current_position + 1]);
-          uint8_t month = plaintext[current_position + 2];
-          uint8_t day = plaintext[current_position + 3];
-          uint8_t hour = plaintext[current_position + 5];
-          uint8_t minute = plaintext[current_position + 6];
-          uint8_t second = plaintext[current_position + 7];
-          if (year > 9999 || month > 12 || day > 31 || hour > 23 || minute > 59 || second > 59) {
-            ESP_LOGE(TAG, "Invalid timestamp values: %04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour, minute,
-                     second);
-            this->receive_buffer_.clear();
-            return;
-          }
-          snprintf(data.timestamp, sizeof(data.timestamp), "%04u-%02u-%02uT%02u:%02u:%02uZ", year, month, day, hour,
-                   minute, second);
-        } else if (meter_number_found) {
-          snprintf(data.meternumber, sizeof(data.meternumber), "%.*s", data_length, &plaintext[current_position]);
-        }
-        current_position += data_length;
-        break;
-      }
-      default:
-        ESP_LOGE(TAG, "OBIS: Unsupported OBIS data type: %x", data_type);
-        this->receive_buffer_.clear();
-        return;
-    }
-
-    // Skip break after data
-    if (this->provider_ == PROVIDER_NETZNOE) {
-      // Don't skip the break on the first timestamp, as there's none
-      if (!timestamp_found) {
-        current_position += 2;
-      }
-    } else {
-      current_position += 2;
-    }
-
-    // Check for additional data (scaler-unit structure)
-    if (current_position < message_length && plaintext[current_position] == DataType::INTEGER) {
-      // Apply scaler: real_value = raw_value × 10^scaler
-      if (current_position + 1 < message_length) {
-        int8_t scaler = static_cast<int8_t>(plaintext[current_position + 1]);
-        if (scaler != 0) {
-          value *= pow10_int(scaler);
-        }
-      }
-
-      // on EVN Meters there is no additional break
-      if (this->provider_ == PROVIDER_NETZNOE) {
-        current_position += 4;
-      } else {
-        current_position += 6;
-      }
-    }
-
-    // Handle numeric values (LONG_UNSIGNED and DOUBLE_LONG_UNSIGNED)
-    if (value_size > 0) {
-      switch (obis_cd) {
-        case OBIS_VOLTAGE_L1:
-          data.voltage_l1 = value;
-          break;
-        case OBIS_VOLTAGE_L2:
-          data.voltage_l2 = value;
-          break;
-        case OBIS_VOLTAGE_L3:
-          data.voltage_l3 = value;
-          break;
-        case OBIS_CURRENT_L1:
-          data.current_l1 = value;
-          break;
-        case OBIS_CURRENT_L2:
-          data.current_l2 = value;
-          break;
-        case OBIS_CURRENT_L3:
-          data.current_l3 = value;
-          break;
-        case OBIS_ACTIVE_POWER_PLUS:
-          data.active_power_plus = value;
-          break;
-        case OBIS_ACTIVE_POWER_MINUS:
-          data.active_power_minus = value;
-          break;
-        case OBIS_ACTIVE_ENERGY_PLUS:
-          data.active_energy_plus = value;
-          break;
-        case OBIS_ACTIVE_ENERGY_MINUS:
-          data.active_energy_minus = value;
-          break;
-        case OBIS_REACTIVE_ENERGY_PLUS:
-          data.reactive_energy_plus = value;
-          break;
-        case OBIS_REACTIVE_ENERGY_MINUS:
-          data.reactive_energy_minus = value;
-          break;
-        case OBIS_POWER_FACTOR:
-          data.power_factor = value;
-          power_factor_found = true;
-          break;
-        default:
-          ESP_LOGW(TAG, "Unsupported OBIS code 0x%04X", obis_cd);
-      }
-    }
-  }
-
-  this->receive_buffer_.clear();
-
-  ESP_LOGI(TAG, "Received valid data");
-  this->publish_sensors(data);
-  this->status_clear_warning();
 }
 
 }  // namespace esphome::dlms_meter

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -13,11 +13,14 @@ static constexpr const char *TAG = "dlms_meter";
 
 void DlmsMeterComponent::dump_config() {
   const char *provider_name = this->provider_ == PROVIDER_NETZNOE ? "Netz NOE" : "Generic";
+  const char *transport_name = this->transport_ == TRANSPORT_MBUS ? "M-Bus" : "Raw";
   ESP_LOGCONFIG(TAG,
                 "DLMS Meter:\n"
                 "  Provider: %s\n"
+                "  Transport: %s\n"
+                "  Decryption Enabled: %s\n"
                 "  Read Timeout: %u ms",
-                provider_name, this->read_timeout_);
+                provider_name, transport_name, this->has_decryption_key_ ? "YES" : "NO", this->read_timeout_);
 #define DLMS_METER_LOG_SENSOR(s) LOG_SENSOR("  ", #s, this->s##_sensor_);
   DLMS_METER_SENSOR_LIST(DLMS_METER_LOG_SENSOR, )
 #define DLMS_METER_LOG_TEXT_SENSOR(s) LOG_TEXT_SENSOR("  ", #s, this->s##_text_sensor_);
@@ -51,26 +54,36 @@ void DlmsMeterComponent::loop() {
   }
 
   if (!this->receive_buffer_.empty() && millis() - this->last_read_ > this->read_timeout_) {
-    this->mbus_payload_.clear();
-    if (!this->parse_mbus_(this->mbus_payload_))
-      return;
+    this->payload_.clear();
 
-    uint16_t message_length;
-    uint8_t systitle_length;
-    uint16_t header_offset;
-    if (!this->parse_dlms_(this->mbus_payload_, message_length, systitle_length, header_offset))
-      return;
-
-    if (message_length < DECODER_START_OFFSET || message_length > MAX_MESSAGE_LENGTH) {
-      ESP_LOGE(TAG, "DLMS: Message length invalid: %u", message_length);
-      this->receive_buffer_.clear();
-      return;
+    if (this->transport_ == TRANSPORT_MBUS) {
+      if (!this->parse_mbus_(this->payload_))
+        return;
+    } else {
+      this->payload_ = this->receive_buffer_;
     }
 
-    // Decrypt in place and then decode the OBIS codes
-    if (!this->decrypt_(this->mbus_payload_, message_length, systitle_length, header_offset))
-      return;
-    this->decode_obis_(&this->mbus_payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+    if (this->has_decryption_key_) {
+      uint16_t message_length;
+      uint8_t systitle_length;
+      uint16_t header_offset;
+      if (!this->parse_dlms_(this->payload_, message_length, systitle_length, header_offset))
+        return;
+
+      if (message_length < DECODER_START_OFFSET || message_length > MAX_MESSAGE_LENGTH) {
+        ESP_LOGE(TAG, "DLMS: Message length invalid: %u", message_length);
+        this->receive_buffer_.clear();
+        return;
+      }
+
+      // Decrypt in place and then decode the OBIS codes
+      if (!this->decrypt_(this->payload_, message_length, systitle_length, header_offset))
+        return;
+      this->decode_obis_(&this->payload_[header_offset + DLMS_PAYLOAD_OFFSET], message_length);
+    } else {
+      // If no decryption key is provided, decode the parsed payload directly assuming unencrypted APDU.
+      this->decode_obis_(this->payload_.data(), this->payload_.size());
+    }
   }
 }
 

--- a/esphome/components/dlms_meter/dlms_meter.h
+++ b/esphome/components/dlms_meter/dlms_meter.h
@@ -50,6 +50,8 @@ struct MeterData {
 
 // Provider constants
 enum Providers : uint32_t { PROVIDER_GENERIC = 0x00, PROVIDER_NETZNOE = 0x01 };
+// Transport constants
+enum Transports : uint32_t { TRANSPORT_MBUS = 0x00, TRANSPORT_RAW = 0x01 };
 
 class DlmsMeterComponent : public Component, public uart::UARTDevice {
  public:
@@ -58,8 +60,12 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
   void dump_config() override;
   void loop() override;
 
-  void set_decryption_key(const std::array<uint8_t, 16> &key) { this->decryption_key_ = key; }
+  void set_decryption_key(const std::array<uint8_t, 16> &key) {
+    this->decryption_key_ = key;
+    this->has_decryption_key_ = true;
+  }
   void set_provider(uint32_t provider) { this->provider_ = provider; }
+  void set_transport(uint32_t transport) { this->transport_ = transport; }
 
   void publish_sensors(MeterData &data) {
 #define DLMS_METER_PUBLISH_SENSOR(s) \
@@ -85,11 +91,14 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
   void decode_obis_(uint8_t *plaintext, uint16_t message_length);
 
   std::vector<uint8_t> receive_buffer_;  // Stores the packet currently being received
-  std::vector<uint8_t> mbus_payload_;    // Parsed M-Bus payload, reused to avoid heap churn
+  std::vector<uint8_t> payload_;         // Parsed payload, reused to avoid heap churn
   uint32_t last_read_ = 0;               // Timestamp when data was last read
   uint32_t read_timeout_ = 1000;         // Time to wait after last byte before considering data complete
 
   uint32_t provider_ = PROVIDER_GENERIC;  // Provider of the meter / your grid operator
+  uint32_t transport_ = TRANSPORT_MBUS;   // Transport protocol used
+
+  bool has_decryption_key_{false};
   std::array<uint8_t, 16> decryption_key_;
 };
 

--- a/esphome/components/dlms_meter/dlms_meter.h
+++ b/esphome/components/dlms_meter/dlms_meter.h
@@ -14,6 +14,7 @@
 #include "mbus.h"
 #include "dlms.h"
 #include "obis.h"
+#include "dlms_parser.h"
 
 #include <array>
 #include <vector>
@@ -88,7 +89,6 @@ class DlmsMeterComponent : public Component, public uart::UARTDevice {
                    uint16_t &header_offset);
   bool decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t message_length, uint8_t systitle_length,
                 uint16_t header_offset);
-  void decode_obis_(uint8_t *plaintext, uint16_t message_length);
 
   std::vector<uint8_t> receive_buffer_;  // Stores the packet currently being received
   std::vector<uint8_t> payload_;         // Parsed payload, reused to avoid heap churn

--- a/esphome/components/dlms_meter/dlms_parser.cpp
+++ b/esphome/components/dlms_meter/dlms_parser.cpp
@@ -1,0 +1,842 @@
+#include "dlms_parser.h"
+
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <utility>
+
+namespace esphome {
+namespace dlms_meter {
+
+static const char *const TAG = "dlms_parser";
+
+DlmsParser::DlmsParser() { this->load_default_patterns_(); }
+
+void DlmsParser::load_default_patterns_() {
+  this->register_pattern_dsl_("T1", "TC,TO,TS,TV", 10);
+  this->register_pattern_dsl_("T2", "TO,TV,TSU", 10);
+  this->register_pattern_dsl_("T3", "TV,TC,TSU,TO", 10);
+  this->register_pattern_dsl_("U.ZPA", "F,C,O,A,TV", 10);
+}
+
+void DlmsParser::register_custom_pattern(const std::string &dsl) {
+  this->register_pattern_dsl_("CUSTOM", dsl, 0);  // Priority 0 to try this first
+}
+
+size_t DlmsParser::parse(const uint8_t *buffer, size_t length, DlmsDataCallback callback, bool show_log) {
+  if (buffer == nullptr || length == 0) {
+    if (show_log)
+      ESP_LOGV(TAG, "Buffer is null or empty");
+    return 0;
+  }
+
+  this->buffer_ = buffer;
+  this->buffer_len_ = length;
+  this->pos_ = 0;
+  this->callback_ = std::move(callback);
+  this->show_log_ = show_log;
+  this->objects_found_ = 0;
+
+  if (this->show_log_)
+    ESP_LOGD(TAG, "Starting to parse buffer of length %zu", length);
+
+  // Skip to notification flag 0x0F
+  while (this->pos_ < this->buffer_len_) {
+    if (this->read_byte_() == 0x0F) {
+      if (this->show_log_)
+        ESP_LOGD(TAG, "Found notification flag 0x0F at position %zu", this->pos_ - 1);
+      break;
+    }
+  }
+
+  // Strictly skip Invoke-ID/Priority (5 bytes)
+  for (int i = 0; i < 5 && this->pos_ < this->buffer_len_; i++) {
+    this->pos_++;
+  }
+
+  // Check for datetime object before the data and skip it if present
+  if (this->test_if_date_time_12b_()) {
+    if (this->show_log_)
+      ESP_LOGV(TAG, "Skipping datetime object at position %zu", this->pos_);
+    this->pos_ += 12;
+  }
+
+  // First byte after flag should be the data type (usually Structure or Array)
+  uint8_t start_type = this->read_byte_();
+  if (start_type != DLMS_DATA_TYPE_STRUCTURE && start_type != DLMS_DATA_TYPE_ARRAY) {
+    if (this->show_log_) {
+      ESP_LOGW(TAG, "Expected STRUCTURE or ARRAY after header, found type %02X at position %zu", start_type,
+               this->pos_ - 1);
+    }
+
+    return 0;
+  }
+
+  // Trigger recursive parsing
+  bool success = this->parse_element_(start_type, 0);
+  if (!success && this->show_log_) {
+    ESP_LOGV(TAG, "Some errors occurred parsing DLMS data, or unexpected end of buffer.");
+  }
+
+  if (this->show_log_) {
+    ESP_LOGD(TAG, "Parsing completed. Processed %zu bytes, found %zu objects", this->pos_, this->objects_found_);
+  }
+
+  return this->objects_found_;
+}
+
+uint8_t DlmsParser::read_byte_() {
+  if (this->pos_ >= this->buffer_len_)
+    return 0xFF;
+  return this->buffer_[this->pos_++];
+}
+
+uint16_t DlmsParser::read_u16_() {
+  if (this->pos_ + 1 >= this->buffer_len_)
+    return 0xFFFF;
+  uint16_t val = (this->buffer_[this->pos_] << 8) | this->buffer_[this->pos_ + 1];
+  this->pos_ += 2;
+  return val;
+}
+
+uint32_t DlmsParser::read_u32_() {
+  if (this->pos_ + 3 >= this->buffer_len_)
+    return 0xFFFFFFFF;
+  uint32_t val = (this->buffer_[this->pos_] << 24) | (this->buffer_[this->pos_ + 1] << 16) |
+                 (this->buffer_[this->pos_ + 2] << 8) | this->buffer_[this->pos_ + 3];
+  this->pos_ += 4;
+  return val;
+}
+
+bool DlmsParser::test_if_date_time_12b_() {
+  if (this->pos_ + 12 > this->buffer_len_)
+    return false;
+  const uint8_t *buf = &this->buffer_[this->pos_];
+
+  uint16_t year = (buf[0] << 8) | buf[1];
+  if (year != 0x0000 && (year < 1970 || year > 2100))
+    return false;
+  if (buf[2] != 0xFF && (buf[2] < 1 || buf[2] > 12))
+    return false;
+  if (buf[3] != 0xFF && (buf[3] < 1 || buf[3] > 31))
+    return false;
+  if (buf[4] != 0xFF && (buf[4] < 1 || buf[4] > 7))
+    return false;
+  if (buf[5] != 0xFF && buf[5] > 23)
+    return false;
+  if (buf[6] != 0xFF && buf[6] > 59)
+    return false;
+  if (buf[7] != 0xFF && buf[7] > 59)
+    return false;
+
+  // Hundredths of second
+  uint8_t ms = buf[8];
+  if (ms != 0xFF && ms > 99)
+    return false;
+
+  // Deviation (timezone offset, signed, 2 bytes)
+  uint16_t u_dev = (buf[9] << 8) | buf[10];
+  int16_t s_dev = (int16_t) u_dev;
+  return s_dev == (int16_t) 0x8000 || (s_dev >= -720 && s_dev <= 720);
+}
+
+int DlmsParser::get_data_type_size_(DlmsDataType type) {
+  switch (type) {
+    case DLMS_DATA_TYPE_NONE:
+      return 0;
+    case DLMS_DATA_TYPE_BOOLEAN:
+    case DLMS_DATA_TYPE_INT8:
+    case DLMS_DATA_TYPE_UINT8:
+    case DLMS_DATA_TYPE_ENUM:
+      return 1;
+    case DLMS_DATA_TYPE_INT16:
+    case DLMS_DATA_TYPE_UINT16:
+      return 2;
+    case DLMS_DATA_TYPE_INT32:
+    case DLMS_DATA_TYPE_UINT32:
+    case DLMS_DATA_TYPE_FLOAT32:
+      return 4;
+    case DLMS_DATA_TYPE_INT64:
+    case DLMS_DATA_TYPE_UINT64:
+    case DLMS_DATA_TYPE_FLOAT64:
+      return 8;
+    case DLMS_DATA_TYPE_DATETIME:
+      return 12;
+    case DLMS_DATA_TYPE_DATE:
+      return 5;
+    case DLMS_DATA_TYPE_TIME:
+      return 4;
+    default:
+      return -1;  // Variable or complex
+  }
+}
+
+bool DlmsParser::is_value_data_type_(DlmsDataType type) {
+  switch (type) {
+    case DLMS_DATA_TYPE_ARRAY:
+    case DLMS_DATA_TYPE_STRUCTURE:
+    case DLMS_DATA_TYPE_COMPACT_ARRAY:
+      return false;
+    case DLMS_DATA_TYPE_NONE:
+    case DLMS_DATA_TYPE_BOOLEAN:
+    case DLMS_DATA_TYPE_BIT_STRING:
+    case DLMS_DATA_TYPE_INT32:
+    case DLMS_DATA_TYPE_UINT32:
+    case DLMS_DATA_TYPE_OCTET_STRING:
+    case DLMS_DATA_TYPE_STRING:
+    case DLMS_DATA_TYPE_BINARY_CODED_DESIMAL:
+    case DLMS_DATA_TYPE_STRING_UTF8:
+    case DLMS_DATA_TYPE_INT8:
+    case DLMS_DATA_TYPE_INT16:
+    case DLMS_DATA_TYPE_UINT8:
+    case DLMS_DATA_TYPE_UINT16:
+    case DLMS_DATA_TYPE_INT64:
+    case DLMS_DATA_TYPE_UINT64:
+    case DLMS_DATA_TYPE_ENUM:
+    case DLMS_DATA_TYPE_FLOAT32:
+    case DLMS_DATA_TYPE_FLOAT64:
+    case DLMS_DATA_TYPE_DATETIME:
+    case DLMS_DATA_TYPE_DATE:
+    case DLMS_DATA_TYPE_TIME:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool DlmsParser::skip_data_(uint8_t type) {
+  int data_size = this->get_data_type_size_((DlmsDataType) type);
+
+  if (data_size == 0)
+    return true;
+  if (data_size > 0) {
+    if (this->pos_ + data_size > this->buffer_len_)
+      return false;
+    this->pos_ += data_size;
+  } else {
+    uint8_t first_byte = this->read_byte_();
+    if (first_byte == 0xFF)
+      return false;
+
+    uint32_t length = first_byte;
+    // Handle DLMS multi-byte length fields
+    if (first_byte > 127) {
+      uint8_t num_bytes = first_byte & 0x7F;
+      length = 0;
+      for (int i = 0; i < num_bytes; i++) {
+        uint8_t b = this->read_byte_();
+        if (b == 0xFF && this->pos_ >= this->buffer_len_)
+          return false;
+        length = (length << 8) | b;
+      }
+    }
+
+    uint32_t skip_bytes = length;
+    // DLMS Bit strings designate their length in bits, so we must adjust the byte skip
+    if (type == DLMS_DATA_TYPE_BIT_STRING) {
+      skip_bytes = (length + 7) / 8;
+    }
+
+    if (this->pos_ + skip_bytes > this->buffer_len_)
+      return false;
+
+    if (this->show_log_) {
+      ESP_LOGVV(TAG, "Skipping variable data of type %s (bytes: %u) at position %zu",
+                this->dlms_data_type_to_string_((DlmsDataType) type), skip_bytes, this->pos_);
+    }
+    this->pos_ += skip_bytes;
+  }
+  return true;
+}
+
+bool DlmsParser::parse_element_(uint8_t type, uint8_t depth) {
+  if (type == DLMS_DATA_TYPE_STRUCTURE || type == DLMS_DATA_TYPE_ARRAY) {
+    return this->parse_sequence_(type, depth);
+  }
+  return this->skip_data_(type);
+}
+
+bool DlmsParser::parse_sequence_(uint8_t type, uint8_t depth) {
+  uint8_t elements_count = this->read_byte_();
+  if (elements_count == 0xFF) {
+    if (this->show_log_)
+      ESP_LOGVV(TAG, "Invalid sequence length at position %zu", this->pos_ - 1);
+    return false;
+  }
+
+  if (this->show_log_) {
+    ESP_LOGD(TAG, "Parsing %s with %d elements at position %zu (depth %d)",
+             type == DLMS_DATA_TYPE_STRUCTURE ? "STRUCTURE" : "ARRAY", elements_count, this->pos_ - 1, depth);
+  }
+
+  uint8_t elements_consumed = 0;
+  while (elements_consumed < elements_count) {
+    size_t original_position = this->pos_;
+
+    if (this->try_match_patterns_(elements_consumed)) {
+      elements_consumed += this->last_pattern_elements_consumed_ ? this->last_pattern_elements_consumed_ : 1;
+      this->last_pattern_elements_consumed_ = 0;
+      continue;
+    }
+
+    if (this->pos_ >= this->buffer_len_) {
+      if (this->show_log_) {
+        ESP_LOGV(TAG, "Unexpected end while reading element %d of %s", elements_consumed + 1,
+                 type == DLMS_DATA_TYPE_STRUCTURE ? "STRUCTURE" : "ARRAY");
+      }
+
+      return false;
+    }
+
+    uint8_t elem_type = this->read_byte_();
+    if (!this->parse_element_(elem_type, depth + 1))
+      return false;
+    elements_consumed++;
+
+    if (this->pos_ == original_position) {
+      if (this->show_log_) {
+        ESP_LOGV(TAG, "No progress parsing element %d at position %zu, aborting to avoid infinite loop",
+                 elements_consumed, original_position);
+      }
+
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DlmsParser::capture_generic_value_(AxdrCaptures &c) {
+  uint8_t vt = this->read_byte_();
+  if (!this->is_value_data_type_((DlmsDataType) vt))
+    return false;
+
+  int ds = this->get_data_type_size_((DlmsDataType) vt);
+  if (ds > 0) {
+    if (this->pos_ + ds > this->buffer_len_)
+      return false;
+    c.value_ptr = &this->buffer_[this->pos_];
+    c.value_len = ds;
+    this->pos_ += ds;
+  } else if (ds == 0) {
+    c.value_ptr = nullptr;
+    c.value_len = 0;
+  } else {
+    uint8_t first_byte = this->read_byte_();
+    if (first_byte == 0xFF)
+      return false;
+
+    uint32_t length = first_byte;
+    if (first_byte > 127) {
+      uint8_t num_bytes = first_byte & 0x7F;
+      length = 0;
+      for (int i = 0; i < num_bytes; i++) {
+        uint8_t b = this->read_byte_();
+        if (b == 0xFF && this->pos_ >= this->buffer_len_)
+          return false;
+        length = (length << 8) | b;
+      }
+    }
+
+    uint32_t data_bytes = length;
+    if (vt == DLMS_DATA_TYPE_BIT_STRING) {
+      data_bytes = (length + 7) / 8;
+    }
+
+    if (this->pos_ + data_bytes > this->buffer_len_)
+      return false;
+    c.value_ptr = &this->buffer_[this->pos_];
+    c.value_len = data_bytes > 255 ? 255 : data_bytes;
+    this->pos_ += data_bytes;
+  }
+  c.value_type = (DlmsDataType) vt;
+  return true;
+}
+
+bool DlmsParser::try_match_patterns_(uint8_t elem_idx) {
+  for (const auto &p : this->patterns_) {
+    uint8_t consumed = 0;
+    size_t saved_position = this->pos_;
+    if (this->match_pattern_(elem_idx, p, consumed)) {
+      this->last_pattern_elements_consumed_ = consumed;
+      return true;
+    }
+    this->pos_ = saved_position;  // Backtrack if match failed
+  }
+  return false;
+}
+
+bool DlmsParser::match_pattern_(uint8_t elem_idx, const AxdrDescriptorPattern &pat,
+                                uint8_t &elements_consumed_at_level0) {
+  AxdrCaptures cap{};
+  elements_consumed_at_level0 = 0;
+  uint8_t level = 0;
+  auto consume_one = [&]() {
+    if (level == 0)
+      elements_consumed_at_level0++;
+  };
+  size_t initial_position = this->pos_;
+
+  for (const auto &step : pat.steps) {
+    switch (step.type) {
+      case AxdrTokenType::EXPECT_TO_BE_FIRST:
+        if (elem_idx != 0)
+          return false;
+        break;
+      case AxdrTokenType::EXPECT_TYPE_EXACT:
+        if (this->read_byte_() != step.param_u8_a)
+          return false;
+        consume_one();
+        break;
+      case AxdrTokenType::EXPECT_TYPE_U_I_8: {
+        uint8_t t = this->read_byte_();
+        if (t != DLMS_DATA_TYPE_INT8 && t != DLMS_DATA_TYPE_UINT8)
+          return false;
+        consume_one();
+        break;
+      }
+      case AxdrTokenType::EXPECT_CLASS_ID_UNTAGGED: {
+        uint16_t v = this->read_u16_();
+        if (v > 0x00FF)
+          return false;  // Match max typical class ID
+        cap.class_id = v;
+        break;
+      }
+      case AxdrTokenType::EXPECT_OBIS6_TAGGED:
+        if (this->read_byte_() != DLMS_DATA_TYPE_OCTET_STRING)
+          return false;
+        if (this->read_byte_() != 6)
+          return false;
+        if (this->pos_ + 6 > this->buffer_len_)
+          return false;
+        cap.obis = &this->buffer_[this->pos_];
+        this->pos_ += 6;
+        consume_one();
+        break;
+      case AxdrTokenType::EXPECT_OBIS6_UNTAGGED:
+        if (this->pos_ + 6 > this->buffer_len_)
+          return false;
+        cap.obis = &this->buffer_[this->pos_];
+        this->pos_ += 6;
+        break;
+      case AxdrTokenType::EXPECT_ATTR8_UNTAGGED:
+        if (this->read_byte_() == 0)
+          return false;
+        break;
+      case AxdrTokenType::EXPECT_VALUE_GENERIC:
+        if (!this->capture_generic_value_(cap))
+          return false;
+        consume_one();
+        break;
+      case AxdrTokenType::EXPECT_STRUCTURE_N:
+        if (this->read_byte_() != DLMS_DATA_TYPE_STRUCTURE)
+          return false;
+        if (this->read_byte_() != step.param_u8_a)
+          return false;
+        consume_one();
+        break;
+      case AxdrTokenType::EXPECT_SCALER_TAGGED:
+        if (this->read_byte_() != DLMS_DATA_TYPE_INT8)
+          return false;
+        cap.scaler = (int8_t) this->read_byte_();
+        cap.has_scaler_unit = true;
+        consume_one();
+        break;
+      case AxdrTokenType::EXPECT_UNIT_ENUM_TAGGED:
+        if (this->read_byte_() != DLMS_DATA_TYPE_ENUM)
+          return false;
+        cap.unit_enum = this->read_byte_();
+        cap.has_scaler_unit = true;
+        consume_one();
+        break;
+      case AxdrTokenType::GOING_DOWN:
+        level++;
+        break;
+      case AxdrTokenType::GOING_UP:
+        level--;
+        break;
+    }
+  }
+
+  if (elements_consumed_at_level0 == 0)
+    elements_consumed_at_level0 = 1;
+  cap.elem_idx = initial_position;
+  this->emit_object_(pat, cap);
+  return true;
+}
+
+void DlmsParser::emit_object_(const AxdrDescriptorPattern &pat, const AxdrCaptures &c) {
+  if (!c.obis || !this->callback_)
+    return;
+
+  // Use stack-allocated buffer for OBIS to avoid heap allocation
+  char obis_str_buf[32];
+  this->obis_to_string_(c.obis, obis_str_buf, sizeof(obis_str_buf));
+
+  float raw_val_f = this->data_as_float_(c.value_type, c.value_ptr, c.value_len);
+  float val_f = raw_val_f;
+
+  // Use stack-allocated buffer for formatting data
+  char val_s_buf[128];
+  this->data_to_string_(c.value_type, c.value_ptr, c.value_len, val_s_buf, sizeof(val_s_buf));
+
+  bool is_numeric = (c.value_type != DLMS_DATA_TYPE_OCTET_STRING && c.value_type != DLMS_DATA_TYPE_STRING &&
+                     c.value_type != DLMS_DATA_TYPE_STRING_UTF8);
+
+  if (c.has_scaler_unit && is_numeric) {
+    val_f *= std::pow(10, c.scaler);
+  }
+
+  if (this->show_log_) {
+    ESP_LOGD(TAG, "Pattern match '%s' at idx %u ===============", pat.name.c_str(), c.elem_idx);
+    uint16_t cid = c.class_id ? c.class_id : pat.default_class_id;
+
+    ESP_LOGI(TAG, "Found attribute descriptor: class_id=%d, obis=%s", cid, obis_str_buf);
+
+    if (c.has_scaler_unit) {
+      ESP_LOGI(TAG, "Value type: %s, len %d, scaler %d, unit %d", this->dlms_data_type_to_string_(c.value_type),
+               c.value_len, c.scaler, c.unit_enum);
+    } else {
+      ESP_LOGI(TAG, "Value type: %s, len %d", this->dlms_data_type_to_string_(c.value_type), c.value_len);
+    }
+
+    if (c.value_ptr && c.value_len > 0) {
+      char hex_buf[512];
+      esphome::format_hex_pretty_to(hex_buf, sizeof(hex_buf), c.value_ptr, c.value_len);
+      ESP_LOGI(TAG, " as hex dump : %s", hex_buf);
+    }
+    ESP_LOGI(TAG, " as string   :'%s'", val_s_buf);
+    ESP_LOGI(TAG, " as number   : %f", raw_val_f);
+
+    if (c.has_scaler_unit && is_numeric) {
+      ESP_LOGI(TAG, " as number * scaler  : %f", val_f);
+    }
+  }
+
+  this->callback_(obis_str_buf, val_f, val_s_buf, is_numeric);
+  this->objects_found_++;
+}
+
+float DlmsParser::data_as_float_(DlmsDataType value_type, const uint8_t *ptr, uint8_t len) {
+  if (!ptr || len == 0)
+    return 0.0f;
+
+  auto be16 = [](const uint8_t *p) { return (uint16_t) ((p[0] << 8) | p[1]); };
+  auto be32 = [](const uint8_t *p) {
+    return ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) | ((uint32_t) p[2] << 8) | (uint32_t) p[3];
+  };
+  auto be64 = [](const uint8_t *p) {
+    return ((uint64_t) p[0] << 56) | ((uint64_t) p[1] << 48) | ((uint64_t) p[2] << 40) | ((uint64_t) p[3] << 32) |
+           ((uint64_t) p[4] << 24) | ((uint64_t) p[5] << 16) | ((uint64_t) p[6] << 8) | (uint64_t) p[7];
+  };
+
+  switch (value_type) {
+    case DLMS_DATA_TYPE_BOOLEAN:
+    case DLMS_DATA_TYPE_ENUM:
+    case DLMS_DATA_TYPE_UINT8:
+      return static_cast<float>(ptr[0]);
+    case DLMS_DATA_TYPE_INT8:
+      return static_cast<float>(static_cast<int8_t>(ptr[0]));
+    case DLMS_DATA_TYPE_BIT_STRING:
+      return (len > 0 && ptr) ? static_cast<float>(ptr[0]) : 0.0f;
+    case DLMS_DATA_TYPE_UINT16:
+      return len >= 2 ? static_cast<float>(be16(ptr)) : 0.0f;
+    case DLMS_DATA_TYPE_INT16:
+      return len >= 2 ? static_cast<float>(static_cast<int16_t>(be16(ptr))) : 0.0f;
+    case DLMS_DATA_TYPE_UINT32:
+      return len >= 4 ? static_cast<float>(be32(ptr)) : 0.0f;
+    case DLMS_DATA_TYPE_INT32:
+      return len >= 4 ? static_cast<float>(static_cast<int32_t>(be32(ptr))) : 0.0f;
+    case DLMS_DATA_TYPE_UINT64:
+      return len >= 8 ? static_cast<float>(be64(ptr)) : 0.0f;
+    case DLMS_DATA_TYPE_INT64:
+      return len >= 8 ? static_cast<float>(static_cast<int64_t>(be64(ptr))) : 0.0f;
+    case DLMS_DATA_TYPE_FLOAT32: {
+      if (len < 4)
+        return 0.0f;
+      uint32_t i32 = be32(ptr);
+      float f;
+      std::memcpy(&f, &i32, sizeof(float));
+      return f;
+    }
+    case DLMS_DATA_TYPE_FLOAT64: {
+      if (len < 8)
+        return 0.0f;
+      uint64_t i64 = be64(ptr);
+      double d;
+      std::memcpy(&d, &i64, sizeof(double));
+      return static_cast<float>(d);
+    }
+    default:
+      return 0.0f;
+  }
+}
+
+void DlmsParser::data_to_string_(DlmsDataType value_type, const uint8_t *ptr, uint8_t len, char *buffer,
+                                 size_t max_len) {
+  if (max_len > 0)
+    buffer[0] = '\0';
+  if (!ptr || len == 0 || max_len == 0)
+    return;
+
+  auto hex_of = [](const uint8_t *p, uint8_t l, char *out, size_t max_out) {
+    if (max_out == 0)
+      return;
+    out[0] = '\0';
+    size_t pos = 0;
+    for (uint8_t i = 0; i < l && pos + 2 < max_out; i++) {
+      pos += snprintf(out + pos, max_out - pos, "%02x", p[i]);
+    }
+  };
+
+  auto be16 = [](const uint8_t *p) { return (uint16_t) ((p[0] << 8) | p[1]); };
+  auto be32 = [](const uint8_t *p) {
+    return ((uint32_t) p[0] << 24) | ((uint32_t) p[1] << 16) | ((uint32_t) p[2] << 8) | (uint32_t) p[3];
+  };
+  auto be64 = [](const uint8_t *p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++)
+      v = (v << 8) | p[i];
+    return v;
+  };
+
+  switch (value_type) {
+    case DLMS_DATA_TYPE_OCTET_STRING:
+    case DLMS_DATA_TYPE_STRING:
+    case DLMS_DATA_TYPE_STRING_UTF8: {
+      size_t copy_len = std::min((size_t) len, max_len - 1);
+      std::memcpy(buffer, ptr, copy_len);
+      buffer[copy_len] = '\0';
+      break;
+    }
+
+    case DLMS_DATA_TYPE_BIT_STRING:
+    case DLMS_DATA_TYPE_BINARY_CODED_DESIMAL:
+    case DLMS_DATA_TYPE_DATETIME:
+    case DLMS_DATA_TYPE_DATE:
+    case DLMS_DATA_TYPE_TIME:
+      hex_of(ptr, len, buffer, max_len);
+      break;
+
+    case DLMS_DATA_TYPE_BOOLEAN:
+    case DLMS_DATA_TYPE_ENUM:
+    case DLMS_DATA_TYPE_UINT8:
+      snprintf(buffer, max_len, "%u", static_cast<unsigned>(ptr[0]));
+      break;
+
+    case DLMS_DATA_TYPE_INT8:
+      snprintf(buffer, max_len, "%d", static_cast<int>(static_cast<int8_t>(ptr[0])));
+      break;
+
+    case DLMS_DATA_TYPE_UINT16:
+      if (len >= 2)
+        snprintf(buffer, max_len, "%u", be16(ptr));
+      break;
+
+    case DLMS_DATA_TYPE_INT16:
+      if (len >= 2)
+        snprintf(buffer, max_len, "%d", static_cast<int16_t>(be16(ptr)));
+      break;
+
+    case DLMS_DATA_TYPE_UINT32:
+      if (len >= 4)
+        snprintf(buffer, max_len, "%lu", (unsigned long) be32(ptr));
+      break;
+
+    case DLMS_DATA_TYPE_INT32:
+      if (len >= 4)
+        snprintf(buffer, max_len, "%ld", (long) static_cast<int32_t>(be32(ptr)));
+      break;
+
+    case DLMS_DATA_TYPE_UINT64:
+      if (len >= 8)
+        snprintf(buffer, max_len, "%llu", (unsigned long long) be64(ptr));
+      break;
+
+    case DLMS_DATA_TYPE_INT64:
+      if (len >= 8)
+        snprintf(buffer, max_len, "%lld", (long long) static_cast<int64_t>(be64(ptr)));
+      break;
+
+    case DLMS_DATA_TYPE_FLOAT32:
+    case DLMS_DATA_TYPE_FLOAT64: {
+      snprintf(buffer, max_len, "%f", this->data_as_float_(value_type, ptr, len));
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+void DlmsParser::obis_to_string_(const uint8_t *obis, char *buffer, size_t max_len) {
+  if (max_len > 0)
+    buffer[0] = '\0';
+  if (!obis || max_len == 0)
+    return;
+  snprintf(buffer, max_len, "%u.%u.%u.%u.%u.%u", obis[0], obis[1], obis[2], obis[3], obis[4], obis[5]);
+}
+
+const char *DlmsParser::dlms_data_type_to_string_(DlmsDataType vt) {
+  switch (vt) {
+    case DLMS_DATA_TYPE_NONE:
+      return "NONE";
+    case DLMS_DATA_TYPE_ARRAY:
+      return "ARRAY";
+    case DLMS_DATA_TYPE_STRUCTURE:
+      return "STRUCTURE";
+    case DLMS_DATA_TYPE_BOOLEAN:
+      return "BOOLEAN";
+    case DLMS_DATA_TYPE_BIT_STRING:
+      return "BIT_STRING";
+    case DLMS_DATA_TYPE_INT32:
+      return "INT32";
+    case DLMS_DATA_TYPE_UINT32:
+      return "UINT32";
+    case DLMS_DATA_TYPE_OCTET_STRING:
+      return "OCTET_STRING";
+    case DLMS_DATA_TYPE_STRING:
+      return "STRING";
+    case DLMS_DATA_TYPE_STRING_UTF8:
+      return "STRING_UTF8";
+    case DLMS_DATA_TYPE_BINARY_CODED_DESIMAL:
+      return "BINARY_CODED_DESIMAL";
+    case DLMS_DATA_TYPE_INT8:
+      return "INT8";
+    case DLMS_DATA_TYPE_INT16:
+      return "INT16";
+    case DLMS_DATA_TYPE_UINT8:
+      return "UINT8";
+    case DLMS_DATA_TYPE_UINT16:
+      return "UINT16";
+    case DLMS_DATA_TYPE_COMPACT_ARRAY:
+      return "COMPACT_ARRAY";
+    case DLMS_DATA_TYPE_INT64:
+      return "INT64";
+    case DLMS_DATA_TYPE_UINT64:
+      return "UINT64";
+    case DLMS_DATA_TYPE_ENUM:
+      return "ENUM";
+    case DLMS_DATA_TYPE_FLOAT32:
+      return "FLOAT32";
+    case DLMS_DATA_TYPE_FLOAT64:
+      return "FLOAT64";
+    case DLMS_DATA_TYPE_DATETIME:
+      return "DATETIME";
+    case DLMS_DATA_TYPE_DATE:
+      return "DATE";
+    case DLMS_DATA_TYPE_TIME:
+      return "TIME";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void DlmsParser::register_pattern_dsl_(const std::string &name, const std::string &dsl, int priority) {
+  AxdrDescriptorPattern pat{name, priority, {}, 0};
+
+  auto trim = [](const std::string &s) {
+    size_t b = s.find_first_not_of(" \t\r\n");
+    size_t e = s.find_last_not_of(" \t\r\n");
+    if (b == std::string::npos)
+      return std::string();
+    return s.substr(b, e - b + 1);
+  };
+
+  std::vector<std::string> tokens;
+  std::string current;
+  int paren = 0;
+  for (char c : dsl) {
+    if (c == '(') {
+      paren++;
+      current.push_back(c);
+    } else if (c == ')') {
+      paren--;
+      current.push_back(c);
+    } else if (c == ',' && paren == 0) {
+      tokens.push_back(trim(current));
+      current.clear();
+    } else {
+      current.push_back(c);
+    }
+  }
+  if (!current.empty())
+    tokens.push_back(trim(current));
+
+  for (size_t i = 0; i < tokens.size(); i++) {
+    std::string tok = tokens[i];
+    if (tok.empty())
+      continue;
+
+    if (tok == "F") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_TO_BE_FIRST});
+    } else if (tok == "C") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_CLASS_ID_UNTAGGED});
+    } else if (tok == "TC") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_TYPE_EXACT, DLMS_DATA_TYPE_UINT16});
+      pat.steps.push_back({AxdrTokenType::EXPECT_CLASS_ID_UNTAGGED});
+    } else if (tok == "O") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_OBIS6_UNTAGGED});
+    } else if (tok == "TO") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_OBIS6_TAGGED});
+    } else if (tok == "A") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_ATTR8_UNTAGGED});
+    } else if (tok == "TA") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_TYPE_U_I_8});
+      pat.steps.push_back({AxdrTokenType::EXPECT_ATTR8_UNTAGGED});
+    } else if (tok == "TS") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_SCALER_TAGGED});
+    } else if (tok == "TU") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_UNIT_ENUM_TAGGED});
+    } else if (tok == "TSU") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_STRUCTURE_N, 2});
+      pat.steps.push_back({AxdrTokenType::GOING_DOWN});
+      pat.steps.push_back({AxdrTokenType::EXPECT_SCALER_TAGGED});
+      pat.steps.push_back({AxdrTokenType::EXPECT_UNIT_ENUM_TAGGED});
+      pat.steps.push_back({AxdrTokenType::GOING_UP});
+    } else if (tok == "V" || tok == "TV") {
+      pat.steps.push_back({AxdrTokenType::EXPECT_VALUE_GENERIC});
+    } else if (tok.size() >= 2 && tok.substr(0, 2) == "S(") {
+      size_t l = tok.find('(');
+      size_t r = tok.rfind(')');
+      if (l != std::string::npos && r != std::string::npos && r > l + 1) {
+        std::string inner = tok.substr(l + 1, r - l - 1);
+        std::vector<std::string> inner_tokens;
+        std::string cur;
+        for (char c2 : inner) {
+          if (c2 == ',') {
+            inner_tokens.push_back(trim(cur));
+            cur.clear();
+          } else {
+            cur.push_back(c2);
+          }
+        }
+        if (!cur.empty())
+          inner_tokens.push_back(trim(cur));
+
+        if (!inner_tokens.empty()) {
+          pat.steps.push_back({AxdrTokenType::EXPECT_STRUCTURE_N, static_cast<uint8_t>(inner_tokens.size())});
+          inner_tokens.insert(inner_tokens.begin(), "DN");
+          inner_tokens.emplace_back("UP");
+          tokens.insert(tokens.begin() + i + 1, inner_tokens.begin(), inner_tokens.end());
+        }
+      }
+    } else if (tok == "DN") {
+      pat.steps.push_back({AxdrTokenType::GOING_DOWN});
+    } else if (tok == "UP") {
+      pat.steps.push_back({AxdrTokenType::GOING_UP});
+    }
+  }
+
+  // Insert maintaining priority sort order
+  auto it = std::upper_bound(
+      this->patterns_.begin(), this->patterns_.end(), pat,
+      [](const AxdrDescriptorPattern &a, const AxdrDescriptorPattern &b) { return a.priority < b.priority; });
+  this->patterns_.insert(it, pat);
+}
+
+}  // namespace dlms_meter
+}  // namespace esphome

--- a/esphome/components/dlms_meter/dlms_parser.h
+++ b/esphome/components/dlms_meter/dlms_parser.h
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace esphome {
+namespace dlms_meter {
+
+enum DlmsDataType : uint8_t {
+  DLMS_DATA_TYPE_NONE = 0,
+  DLMS_DATA_TYPE_ARRAY = 1,
+  DLMS_DATA_TYPE_STRUCTURE = 2,
+  DLMS_DATA_TYPE_BOOLEAN = 3,
+  DLMS_DATA_TYPE_BIT_STRING = 4,
+  DLMS_DATA_TYPE_INT32 = 5,
+  DLMS_DATA_TYPE_UINT32 = 6,
+  DLMS_DATA_TYPE_OCTET_STRING = 9,
+  DLMS_DATA_TYPE_STRING = 10,
+  DLMS_DATA_TYPE_STRING_UTF8 = 12,
+  DLMS_DATA_TYPE_BINARY_CODED_DESIMAL = 13,
+  DLMS_DATA_TYPE_INT8 = 15,
+  DLMS_DATA_TYPE_INT16 = 16,
+  DLMS_DATA_TYPE_UINT8 = 17,
+  DLMS_DATA_TYPE_UINT16 = 18,
+  DLMS_DATA_TYPE_COMPACT_ARRAY = 19,
+  DLMS_DATA_TYPE_INT64 = 20,
+  DLMS_DATA_TYPE_UINT64 = 21,
+  DLMS_DATA_TYPE_ENUM = 22,
+  DLMS_DATA_TYPE_FLOAT32 = 23,
+  DLMS_DATA_TYPE_FLOAT64 = 24,
+  DLMS_DATA_TYPE_DATETIME = 25,
+  DLMS_DATA_TYPE_DATE = 26,
+  DLMS_DATA_TYPE_TIME = 27
+};
+
+// Callback for the hub: OBIS code (e.g. "1.0.1.8.0.255"), numeric value, string value, is_numeric flag
+using DlmsDataCallback =
+    std::function<void(const char *obis_code, float float_val, const char *str_val, bool is_numeric)>;
+
+// --- Pattern Matching Enums & Structs ---
+enum class AxdrTokenType : uint8_t {
+  EXPECT_TO_BE_FIRST,
+  EXPECT_TYPE_EXACT,
+  EXPECT_TYPE_U_I_8,
+  EXPECT_CLASS_ID_UNTAGGED,
+  EXPECT_OBIS6_TAGGED,
+  EXPECT_OBIS6_UNTAGGED,
+  EXPECT_ATTR8_UNTAGGED,
+  EXPECT_VALUE_GENERIC,
+  EXPECT_STRUCTURE_N,
+  EXPECT_SCALER_TAGGED,
+  EXPECT_UNIT_ENUM_TAGGED,
+  GOING_DOWN,
+  GOING_UP,
+};
+
+struct AxdrPatternStep {
+  AxdrTokenType type;
+  uint8_t param_u8_a{0};
+};
+
+struct AxdrDescriptorPattern {
+  std::string name;
+  int priority{0};
+  std::vector<AxdrPatternStep> steps;
+  uint16_t default_class_id{0};
+};
+
+struct AxdrCaptures {
+  uint32_t elem_idx{0};
+  uint16_t class_id{0};
+  const uint8_t *obis{nullptr};
+  DlmsDataType value_type{DlmsDataType::DLMS_DATA_TYPE_NONE};
+  const uint8_t *value_ptr{nullptr};
+  uint8_t value_len{0};
+
+  bool has_scaler_unit{false};
+  int8_t scaler{0};
+  uint8_t unit_enum{0};
+};
+
+class DlmsParser {
+ public:
+  DlmsParser();
+
+  // Registers a custom parsing pattern from the YAML config
+  void register_custom_pattern(const std::string &dsl);
+
+  // Parses the buffer and fires callbacks for each found sensor value
+  size_t parse(const uint8_t *buffer, size_t length, DlmsDataCallback callback, bool show_log);
+
+ private:
+  void register_pattern_dsl_(const std::string &name, const std::string &dsl, int priority);
+  void load_default_patterns_();
+
+  uint8_t read_byte_();
+  uint16_t read_u16_();
+  uint32_t read_u32_();
+
+  bool test_if_date_time_12b_();
+  int get_data_type_size_(DlmsDataType type);
+  bool is_value_data_type_(DlmsDataType type);
+
+  bool skip_data_(uint8_t type);
+  bool parse_element_(uint8_t type, uint8_t depth = 0);
+  bool parse_sequence_(uint8_t type, uint8_t depth = 0);
+
+  bool capture_generic_value_(AxdrCaptures &c);
+  bool try_match_patterns_(uint8_t elem_idx);
+  bool match_pattern_(uint8_t elem_idx, const AxdrDescriptorPattern &pat, uint8_t &elements_consumed_at_level0);
+  void emit_object_(const AxdrDescriptorPattern &pat, const AxdrCaptures &c);
+
+  float data_as_float_(DlmsDataType value_type, const uint8_t *ptr, uint8_t len);
+  void data_to_string_(DlmsDataType value_type, const uint8_t *ptr, uint8_t len, char *buffer, size_t max_len);
+  void obis_to_string_(const uint8_t *obis, char *buffer, size_t max_len);
+  const char *dlms_data_type_to_string_(DlmsDataType vt);
+
+  const uint8_t *buffer_{nullptr};
+  size_t buffer_len_{0};
+
+  size_t pos_{0};
+  DlmsDataCallback callback_;
+  bool show_log_{false};
+  size_t objects_found_{0};
+  uint8_t last_pattern_elements_consumed_{0};
+
+  std::vector<AxdrDescriptorPattern> patterns_;
+};
+
+}  // namespace dlms_meter
+}  // namespace esphome

--- a/tests/components/dlms_meter/common-generic.yaml
+++ b/tests/components/dlms_meter/common-generic.yaml
@@ -1,5 +1,6 @@
 dlms_meter:
   decryption_key: "36C66639E48A8CA4D6BC8B282A793BBB"   # change this to your decryption key!
+  transport: raw
 
 sensor:
   - platform: dlms_meter


### PR DESCRIPTION
# What does this implement/fix?

This PR replaces the fragile, offset-based byte skipping in the `dlms_meter` component with a robust DLMS ASN.1 parser.

Previously, the `decode_obis_` function relied on hardcoded byte offsets, which required fragile, provider-specific hacks (such as the EVN workarounds) to function correctly. By introducing `DlmsParser` (`dlms_parser.cpp` and `dlms_parser.h`), the component now genuinely navigates the DLMS ASN.1 data structures (arrays, structures, scalers, etc.)

Maps parsed standard OBIS strings back to the original `MeterData` struct internally to maintain 100% backward compatibility with existing user YAML configurations.

I have tested the new parser and it can now read data from my meter!

Slowly implementing features from:

- esphome/esphome/pull/14604
- https://github.com/Tomer27cz/xt211

Original parser comes from:

- https://github.com/latonita/esphome-dlms-cosem

Merge after these are merged

- esphome/esphome/pull/14750

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- esphome/esphome/pull/14750

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
