### PR TITLE
[const] Add CONF_CLIMATE_ID for climate component sub-entities

### DIFF
--- a/esphome/components/const/__init__.py
+++ b/esphome/components/const/__init__.py
@@ -2,8 +2,8 @@
 
 CODEOWNERS = ["@esphome/core"]
 
-CONF_CLIMATE_ID = "climate_id"
 CONF_BYTE_ORDER = "byte_order"
+CONF_CLIMATE_ID = "climate_id"
 BYTE_ORDER_LITTLE = "little_endian"
 BYTE_ORDER_BIG = "big_endian"
 

--- a/esphome/components/const/__init__.py
+++ b/esphome/components/const/__init__.py
@@ -2,6 +2,7 @@
 
 CODEOWNERS = ["@esphome/core"]
 
+CONF_CLIMATE_ID = "climate_id"
 CONF_BYTE_ORDER = "byte_order"
 BYTE_ORDER_LITTLE = "little_endian"
 BYTE_ORDER_BIG = "big_endian"

--- a/esphome/components/pid/sensor/__init__.py
+++ b/esphome/components/pid/sensor/__init__.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.const import CONF_CLIMATE_ID
 import esphome.config_validation as cv
 from esphome.const import CONF_TYPE, ICON_GAUGE, STATE_CLASS_MEASUREMENT, UNIT_PERCENT
 
@@ -21,7 +22,6 @@ PID_CLIMATE_SENSOR_TYPES = {
     "KD": PIDClimateSensorType.PID_SENSOR_TYPE_KD,
 }
 
-CONF_CLIMATE_ID = "climate_id"
 CONFIG_SCHEMA = (
     sensor.sensor_schema(
         PIDClimateSensor,


### PR DESCRIPTION
# What does this implement/fix?

Adds `CONF_CLIMATE_ID` constant for use by climate component sub-entities that need to reference their parent climate device.

## Why this is needed

Per [ESPHome coding conventions](https://developers.esphome.io/contributing/code/#python):

> Configuration keys (those that appear as keys in YAML):
> - Should be defined as constants--even if used only once--in the form CONF_XYZ
> - If a key is used in **two or more components**, it should be migrated to `esphome/components/const/__init__.py`
> - If a key appears in **three or more components**, it must be migrated there or CI checks will fail

Multiple components define `climate_id` configuration keys for sub-entities that reference a parent climate device:

- **equitherm** (#14738): number, sensor, binary_sensor, text_sensor sub-components
- **pid**: sensor sub-component (existing component)

## Changes

- Add `CONF_CLIMATE_ID = "climate_id"` to `esphome/components/const/__init__.py`
- Update `pid` sensor component to import from shared const

## Related PRs

- esphome/esphome#14738 - equitherm climate component (consumer of this constant)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other (constant migration)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Follows ESPHome coding conventions for constant placement.