### PR TITLE
[core] Fix std::isnan conflict with picolibc on ESP-IDF 6.0

### DIFF
--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -589,7 +589,10 @@ async def _add_looping_components() -> None:
 async def to_code(config: ConfigType) -> None:
     cg.add_global(cg.global_ns.namespace("esphome").using)
     # These can be used by user lambdas, put them to default scope
+    # picolibc (IDF 6.0+) declares isnan in global scope, conflicting with using std::isnan
+    cg.add_global(cg.RawStatement("#ifndef __PICOLIBC__"))
     cg.add_global(cg.RawExpression("using std::isnan"))
+    cg.add_global(cg.RawStatement("#endif"))
     cg.add_global(cg.RawExpression("using std::min"))
     cg.add_global(cg.RawExpression("using std::max"))
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation error with ESP-IDF 6.0 which uses picolibc instead of newlib. picolibc declares `extern int isnan(double)` in the global namespace, which conflicts with `using std::isnan` in the generated `main.cpp`. Guard the using declaration with `#ifndef __PICOLIBC__` since picolibc already provides `isnan` globally for user lambdas.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a core build fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).