### PR TITLE
[core] Fix memory leaks in host-based unit tests

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -58,6 +58,15 @@ namespace esphome {
 
 static const char *const TAG = "app";
 
+#ifdef USE_HOST
+Application::~Application() {
+  for (auto *comp : this->components_) {
+    delete comp;
+  }
+  this->components_.clear();
+}
+#endif
+
 // Helper function for insertion sort of components by priority
 // Using insertion sort instead of std::stable_sort saves ~1.3KB of flash
 // by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -141,6 +141,9 @@ static constexpr uint32_t TEARDOWN_TIMEOUT_REBOOT_MS = 1000;  // 1 second for qu
 
 class Application {
  public:
+#ifdef USE_HOST
+  virtual ~Application();
+#endif
 #ifdef ESPHOME_NAME_ADD_MAC_SUFFIX
   // Called before Logger::pre_setup() — must not log (global_logger is not yet set).
   /// Pre-setup with MAC suffix: overwrites placeholder in mutable static buffers with actual MAC.

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -93,6 +93,10 @@ class Component {
    */
   virtual void setup();
 
+#ifdef USE_HOST
+  virtual ~Component() = default;
+#endif
+
   /** This method will be called repeatedly.
    *
    * Analogous to Arduino's loop(). setup() is guaranteed to be called before this.

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -300,15 +300,9 @@ template<typename T> class StatefulEntityBase : public EntityBase {
   void invalidate_state() { this->set_new_state({}); }
 
   void add_full_state_callback(std::function<void(optional<T> previous, optional<T> current)> &&callback) {
-    if (this->full_state_callbacks_ == nullptr)
-      this->full_state_callbacks_ = new CallbackManager<void(optional<T> previous, optional<T> current)>();  // NOLINT
-    this->full_state_callbacks_->add(std::move(callback));
+    this->full_state_callbacks_.add(std::move(callback));
   }
-  void add_on_state_callback(std::function<void(T)> &&callback) {
-    if (this->state_callbacks_ == nullptr)
-      this->state_callbacks_ = new CallbackManager<void(T)>();  // NOLINT
-    this->state_callbacks_->add(std::move(callback));
-  }
+  void add_on_state_callback(std::function<void(T)> &&callback) { this->state_callbacks_.add(std::move(callback)); }
 
   void set_trigger_on_initial_state(bool trigger_on_initial_state) {
     this->trigger_on_initial_state_ = trigger_on_initial_state;
@@ -325,21 +319,20 @@ template<typename T> class StatefulEntityBase : public EntityBase {
   virtual bool set_new_state(const optional<T> &new_state) {
     if (this->state_ != new_state) {
       // call the full state callbacks with the previous and new state
-      if (this->full_state_callbacks_ != nullptr)
-        this->full_state_callbacks_->call(this->state_, new_state);
+      this->full_state_callbacks_.call(this->state_, new_state);
       // trigger legacy callbacks only if the new state is valid and either the trigger on initial state is enabled or
       // the previous state was valid
       auto had_state = this->has_state();
       this->state_ = new_state;
-      if (this->state_callbacks_ != nullptr && new_state.has_value() && (this->trigger_on_initial_state_ || had_state))
-        this->state_callbacks_->call(new_state.value());
+      if (new_state.has_value() && (this->trigger_on_initial_state_ || had_state))
+        this->state_callbacks_.call(new_state.value());
       return true;
     }
     return false;
   }
   bool trigger_on_initial_state_{true};
   // callbacks with full state and previous state
-  CallbackManager<void(optional<T> previous, optional<T> current)> *full_state_callbacks_{};
-  CallbackManager<void(T)> *state_callbacks_{};
+  LazyCallbackManager<void(optional<T> previous, optional<T> current)> full_state_callbacks_{};
+  LazyCallbackManager<void(T)> state_callbacks_{};
 };
 }  // namespace esphome

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1646,8 +1646,12 @@ template<typename... Ts> class LazyCallbackManager<void(Ts...)> {
  public:
   LazyCallbackManager() = default;
   /// Destructor - clean up allocated CallbackManager if any.
-  /// In practice this never runs (entities live for device lifetime) but included for correctness.
-  ~LazyCallbackManager() { delete this->callbacks_; }
+  /// In practice this never runs on embedded (entities live for device lifetime).
+  ~LazyCallbackManager() {
+#ifdef USE_HOST
+    delete this->callbacks_;
+#endif
+  }
 
   // Non-copyable and non-movable (entities are never copied or moved)
   LazyCallbackManager(const LazyCallbackManager &) = delete;

--- a/tests/components/main.cpp
+++ b/tests/components/main.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
-
+#include <vector>
 #include "esphome/components/logger/logger.h"
+#include "esphome/core/application.h"
 
 /*
 This special main.cpp replaces the default one.
@@ -10,24 +11,47 @@ See README.md for more information
 
 // Auto generated code by esphome
 // ========== AUTO GENERATED INCLUDE BLOCK BEGIN ===========
-// ========== AUTO GENERATED INCLUDE BLOCK END ==========="
+// ========== AUTO GENERATED INCLUDE BLOCK END ===========
+
+// Components registered during individual unit tests.
+static std::vector<esphome::Component *> &get_test_components() {
+  static std::vector<esphome::Component *> test_components;
+  return test_components;
+}
+
+void register_component(esphome::Component *comp) { get_test_components().push_back(comp); }
 
 void original_setup() {
-  // This function won't be run.
-
+  // This function won't be run by the test runner.
+  // It's here for the codegen markers.
   // ========== AUTO GENERATED CODE BEGIN ===========
   // =========== AUTO GENERATED CODE END ============
 }
 
 void setup() {
+  // Construct App via placement new — see application.cpp for storage details.
+  new (&esphome::App) esphome::Application();
+
   // Log functions call global_logger->log_vprintf_() without a null check,
-  // so we must set up a Logger before any test that triggers logging.
   static esphome::logger::Logger test_logger(0);
   test_logger.set_log_level(ESPHOME_LOG_LEVEL);
   test_logger.pre_setup();
 
   ::testing::InitGoogleTest();
   int exit_code = RUN_ALL_TESTS();
+
+  // Register all components gathered during tests with App,
+  // so App.~Application() will delete them.
+  // We do this here because setup() is a friend of Application.
+  for (auto *comp : get_test_components()) {
+    esphome::App.register_component_(comp);
+  }
+  get_test_components().clear();
+
+  // On host/tests, App is a placement-newed object.
+  // We must call its destructor explicitly to trigger cleanup (deleting components).
+  esphome::App.~Application();
+
   exit(exit_code);
 }
 


### PR DESCRIPTION
This change resolves false-positive memory leaks reported by LeakSanitizer (LSan) when running ESPHome unit tests on the host platform.

1. Refactored StatefulEntityBase to use LazyCallbackManager instead of manually allocating CallbackManager on the heap with raw pointers. This ensures that callback managers are properly deleted when the entity is destroyed, matching the pattern already used in the Sensor class.

2. Implemented a host-only teardown mechanism for the global Application object and its components.
   - Added virtual destructors to Component and Application, gated by USE_HOST to ensure zero overhead on embedded targets.
   - The Application destructor now explicitly deletes all registered components to trigger their cleanup chains.

3. Updated the unit test runner (tests/components/main.cpp) to properly initialize the global App object (ensuring valid vtables for polymorphic types) and call its destructor before exit.

These changes allow for a "clean exit" in unit tests, enabling the use of ASan/LSan to catch real memory regressions without being overwhelmed by intentional program-lifetime objects.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
