### PR TITLE
[speaker_source] Reshuffle playlist on repeat all restart

### DIFF
--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -457,10 +457,10 @@ void SpeakerSourceMediaPlayer::process_control_queue_() {
       if (ps.playlist_index < ps.playlist.size()) {
         this->queue_play_current_(pipeline, ps.playlist_delay_ms);
       } else if (ps.repeat_mode == REPEAT_ALL && !ps.playlist.empty()) {
-        ps.playlist_index = 0;
         if (!ps.shuffle_indices.empty()) {
           this->shuffle_playlist_(pipeline);
         }
+        ps.playlist_index = 0;
         this->queue_play_current_(pipeline, ps.playlist_delay_ms);
       }
       command_executed = true;

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -458,6 +458,9 @@ void SpeakerSourceMediaPlayer::process_control_queue_() {
         this->queue_play_current_(pipeline, ps.playlist_delay_ms);
       } else if (ps.repeat_mode == REPEAT_ALL && !ps.playlist.empty()) {
         ps.playlist_index = 0;
+        if (!ps.shuffle_indices.empty()) {
+          this->shuffle_playlist_(pipeline);
+        }
         this->queue_play_current_(pipeline, ps.playlist_delay_ms);
       }
       command_executed = true;


### PR DESCRIPTION
## What does this implement/fix?

When a playlist finishes and restarts due to repeat all mode, the shuffle order is now reshuffled. Previously, the playlist would repeat in the same shuffled order every time, which is unexpected behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

This is a little tedious to test since we don't have an enqueue action, and we don't have the API messages for repeat modes/shuffling so you can't just use the media player controls in HA.


```yaml
audio_file:
  - id: timer_sound
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
  - id: timer_a
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
  - id: timer_b
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_double_press.flac
  - id: timer_c
    file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_triple_press.flac

speaker:
  - platform: i2s_audio
    id: box_speaker
    # ... i2s config ...

media_player:
  - platform: speaker_source
    id: external_media_player
    name: Media Player
    media_pipeline:
      speaker: box_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 2
      sources:
        - media_file_source

media_source:
  - platform: audio_file
    id: media_file_source

button:
  - platform: template
    name: Build queue
    on_press:
      then:
        - media_player.play_media:
            media_url: "audio-file://timer_sound"
        - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_media_url("audio-file://timer_a")
              .set_command("enqueue")
              .perform();
        - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_media_url("audio-file://timer_b")
              .set_command("enqueue")
              .perform();
        - lambda: |-
            id(external_media_player)
              ->make_call()
              .set_media_url("audio-file://timer_c")
              .set_command("enqueue")
              .perform();
  - platform: template
    name: Repeat all
    on_press:
      then:
        - media_player.repeat_all:
  - platform: template
    name: Shuffle
    on_press:
      then:
        - media_player.shuffle:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).