### PR TITLE
[media_player] Add enqueue action

### DIFF
--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -91,6 +91,9 @@ _STATE_CONDITIONS = [
 PlayMediaAction = media_player_ns.class_(
     "PlayMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
+EnqueueMediaAction = media_player_ns.class_(
+    "EnqueueMediaAction", automation.Action, cg.Parented.template(MediaPlayer)
+)
 VolumeSetAction = media_player_ns.class_(
     "VolumeSetAction", automation.Action, cg.Parented.template(MediaPlayer)
 )
@@ -180,6 +183,29 @@ MEDIA_PLAYER_CONDITION_SCHEMA = automation.maybe_simple_id(
     synchronous=True,
 )
 async def media_player_play_media_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)
+    announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
+    cg.add(var.set_media_url(media_url))
+    cg.add(var.set_announcement(announcement))
+    return var
+
+
+@automation.register_action(
+    "media_player.enqueue",
+    EnqueueMediaAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(MediaPlayer),
+            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.url),
+            cv.Optional(CONF_ANNOUNCEMENT, default=False): cv.templatable(cv.boolean),
+        },
+        key=CONF_MEDIA_URL,
+    ),
+    synchronous=True,
+)
+async def media_player_enqueue_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -169,50 +169,39 @@ MEDIA_PLAYER_CONDITION_SCHEMA = automation.maybe_simple_id(
 )
 
 
-@automation.register_action(
+_MEDIA_URL_ACTION_SCHEMA = cv.maybe_simple_value(
+    {
+        cv.GenerateID(): cv.use_id(MediaPlayer),
+        cv.Required(CONF_MEDIA_URL): cv.templatable(cv.url),
+        cv.Optional(CONF_ANNOUNCEMENT, default=False): cv.templatable(cv.boolean),
+    },
+    key=CONF_MEDIA_URL,
+)
+
+
+async def _media_action_handler(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)
+    announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
+    cg.add(var.set_media_url(media_url))
+    cg.add(var.set_announcement(announcement))
+    return var
+
+
+automation.register_action(
     "media_player.play_media",
     PlayMediaAction,
-    cv.maybe_simple_value(
-        {
-            cv.GenerateID(): cv.use_id(MediaPlayer),
-            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.url),
-            cv.Optional(CONF_ANNOUNCEMENT, default=False): cv.templatable(cv.boolean),
-        },
-        key=CONF_MEDIA_URL,
-    ),
+    _MEDIA_URL_ACTION_SCHEMA,
     synchronous=True,
-)
-async def media_player_play_media_action(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)
-    announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
-    cg.add(var.set_media_url(media_url))
-    cg.add(var.set_announcement(announcement))
-    return var
+)(_media_action_handler)
 
-
-@automation.register_action(
+automation.register_action(
     "media_player.enqueue",
     EnqueueMediaAction,
-    cv.maybe_simple_value(
-        {
-            cv.GenerateID(): cv.use_id(MediaPlayer),
-            cv.Required(CONF_MEDIA_URL): cv.templatable(cv.url),
-            cv.Optional(CONF_ANNOUNCEMENT, default=False): cv.templatable(cv.boolean),
-        },
-        key=CONF_MEDIA_URL,
-    ),
+    _MEDIA_URL_ACTION_SCHEMA,
     synchronous=True,
-)
-async def media_player_enqueue_action(config, action_id, template_arg, args):
-    var = cg.new_Pvariable(action_id, template_arg)
-    await cg.register_parented(var, config[CONF_ID])
-    media_url = await cg.templatable(config[CONF_MEDIA_URL], args, cg.std_string)
-    announcement = await cg.templatable(config[CONF_ANNOUNCEMENT], args, cg.bool_)
-    cg.add(var.set_media_url(media_url))
-    cg.add(var.set_announcement(announcement))
-    return var
+)(_media_action_handler)
 
 
 def _snake_to_camel(name):

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -55,28 +55,22 @@ using GroupJoinAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYE
 template<typename... Ts>
 using ClearPlaylistAction = MediaPlayerCommandAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_CLEAR_PLAYLIST, Ts...>;
 
-template<typename... Ts> class PlayMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
+template<MediaPlayerCommand Command, typename... Ts>
+class MediaPlayerMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(std::string, media_url)
   TEMPLATABLE_VALUE(bool, announcement)
   void play(const Ts &...x) override {
-    this->parent_->make_call()
-        .set_media_url(this->media_url_.value(x...))
-        .set_announcement(this->announcement_.value(x...))
-        .perform();
+    auto call = this->parent_->make_call();
+    if constexpr (Command != MediaPlayerCommand::MEDIA_PLAYER_COMMAND_PLAY)
+      call.set_command(Command);
+    call.set_media_url(this->media_url_.value(x...)).set_announcement(this->announcement_.value(x...)).perform();
   }
 };
 
-template<typename... Ts> class EnqueueMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
-  TEMPLATABLE_VALUE(std::string, media_url)
-  TEMPLATABLE_VALUE(bool, announcement)
-  void play(const Ts &...x) override {
-    this->parent_->make_call()
-        .set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
-        .set_media_url(this->media_url_.value(x...))
-        .set_announcement(this->announcement_.value(x...))
-        .perform();
-  }
-};
+template<typename... Ts>
+using PlayMediaAction = MediaPlayerMediaAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_PLAY, Ts...>;
+template<typename... Ts>
+using EnqueueMediaAction = MediaPlayerMediaAction<MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE, Ts...>;
 
 template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(float, volume)

--- a/esphome/components/media_player/automation.h
+++ b/esphome/components/media_player/automation.h
@@ -66,6 +66,18 @@ template<typename... Ts> class PlayMediaAction : public Action<Ts...>, public Pa
   }
 };
 
+template<typename... Ts> class EnqueueMediaAction : public Action<Ts...>, public Parented<MediaPlayer> {
+  TEMPLATABLE_VALUE(std::string, media_url)
+  TEMPLATABLE_VALUE(bool, announcement)
+  void play(const Ts &...x) override {
+    this->parent_->make_call()
+        .set_command(MediaPlayerCommand::MEDIA_PLAYER_COMMAND_ENQUEUE)
+        .set_media_url(this->media_url_.value(x...))
+        .set_announcement(this->announcement_.value(x...))
+        .perform();
+  }
+};
+
 template<typename... Ts> class VolumeSetAction : public Action<Ts...>, public Parented<MediaPlayer> {
   TEMPLATABLE_VALUE(float, volume)
   void play(const Ts &...x) override { this->parent_->make_call().set_volume(this->volume_.value(x...)).perform(); }

--- a/tests/components/media_player/common.yaml
+++ b/tests/components/media_player/common.yaml
@@ -61,3 +61,8 @@ media_player:
       - media_player.volume_up:
       - media_player.volume_down:
       - media_player.volume_set: 50%
+      - media_player.enqueue: http://localhost/media.mp3
+      - media_player.enqueue: !lambda 'return "http://localhost/media.mp3";'
+      - media_player.enqueue:
+          media_url: http://localhost/media.mp3
+          announcement: true


### PR DESCRIPTION
# What does this implement/fix?

Adds a `media_player.enqueue` action to the media player platform component. The C++ `MEDIA_PLAYER_COMMAND_ENQUEUE` and protobuf definitions already existed, but there was no YAML automation action to use them. This adds the action so users can enqueue media URLs from automations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) -- [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) -- [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6276

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Simple form
on_...:
  - media_player.enqueue: 'http://media-url/media.mp3'

# Full form
on_...:
  - media_player.enqueue:
      media_url: 'http://media-url/media.mp3'
      announcement: true

# Lambda form
on_...:
  - media_player.enqueue: !lambda 'return "http://media-url/media.mp3";'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).