### PR TITLE
[analyze-memory] Add function call frequency analysis

### DIFF
--- a/esphome/analyze_memory/__init__.py
+++ b/esphome/analyze_memory/__init__.py
@@ -46,7 +46,7 @@ _READELF_SECTION_PATTERN = re.compile(
 #   ARM:    bl/blx <addr> <symbol>
 # Captures the mangled symbol name inside angle brackets.
 _CALL_TARGET_PATTERN = re.compile(
-    r"\t(?:call[x]?[048c]|call12|callx12|bl[x]?)\s+[\da-fA-F]+ <([^>]+)>"
+    r"\t(?:call(?:0|4|8|12)|callx(?:0|4|8|12)|blx?)\s+[\da-fA-F]+ <([^>]+)>"
 )
 
 # Component category prefixes

--- a/esphome/analyze_memory/__init__.py
+++ b/esphome/analyze_memory/__init__.py
@@ -1,6 +1,6 @@
 """Memory usage analyzer for ESPHome compiled binaries."""
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 import logging
 from pathlib import Path
@@ -38,6 +38,15 @@ _LIBC_PRINTF_SCANF_FAMILY = frozenset(["printf", "fprintf", "sprintf", "scanf"])
 # Format: [ #] name type addr off size
 _READELF_SECTION_PATTERN = re.compile(
     r"\s*\[\s*\d+\]\s+([\.\w]+)\s+\w+\s+[\da-fA-F]+\s+[\da-fA-F]+\s+([\da-fA-F]+)"
+)
+
+# Regex for extracting call targets from objdump disassembly
+# Matches direct call instructions across architectures:
+#   Xtensa: call0/call4/call8/call12/callx0/callx4/callx8/callx12 <addr> <symbol>
+#   ARM:    bl/blx <addr> <symbol>
+# Captures the mangled symbol name inside angle brackets.
+_CALL_TARGET_PATTERN = re.compile(
+    r"\t(?:call[x]?[048c]|call12|callx12|bl[x]?)\s+[\da-fA-F]+ <([^>]+)>"
 )
 
 # Component category prefixes
@@ -197,6 +206,8 @@ class MemoryAnalyzer:
         self._lib_hash_to_name: dict[str, str] = {}
         # Heuristic category to library redirect: "mdns_lib" -> "[lib]mdns"
         self._heuristic_to_lib: dict[str, str] = {}
+        # Function call counts: mangled_name -> call_count
+        self._function_call_counts: Counter[str] = Counter()
 
     def analyze(self) -> dict[str, ComponentMemory]:
         """Analyze the ELF file and return component memory usage."""
@@ -206,6 +217,7 @@ class MemoryAnalyzer:
         self._categorize_symbols()
         self._analyze_cswtch_symbols()
         self._analyze_sdk_libraries()
+        self._analyze_function_calls()
         return dict(self.components)
 
     def _parse_sections(self) -> None:
@@ -384,8 +396,9 @@ class MemoryAnalyzer:
             return
 
         _LOGGER.info("Demangling %d symbols", len(symbols))
-        self._demangle_cache = batch_demangle(symbols, objdump_path=self.objdump_path)
-        _LOGGER.info("Successfully demangled %d symbols", len(self._demangle_cache))
+        demangled = batch_demangle(symbols, objdump_path=self.objdump_path)
+        self._demangle_cache.update(demangled)
+        _LOGGER.info("Successfully demangled %d symbols", len(demangled))
 
     def _demangle_symbol(self, symbol: str) -> str:
         """Get demangled C++ symbol name from cache."""
@@ -1009,6 +1022,43 @@ class MemoryAnalyzer:
             "CSWTCH analysis: %d symbols, %d bytes total",
             len(self._cswtch_symbols),
             total_size,
+        )
+
+    def _analyze_function_calls(self) -> None:
+        """Count function call sites by parsing disassembly output.
+
+        Parses direct call instructions (call0/call8/bl/blx) from objdump -d
+        to count how many times each function is called. This helps identify
+        inlining candidates — frequently called small functions benefit most
+        from inlining.
+        """
+        result = run_tool(
+            [self.objdump_path, "-d", str(self.elf_path)],
+            timeout=60,
+        )
+        if result is None or result.returncode != 0:
+            _LOGGER.debug("Failed to disassemble ELF for function call analysis")
+            return
+
+        self._function_call_counts = Counter(
+            match.group(1)
+            for line in result.stdout.splitlines()
+            if (match := _CALL_TARGET_PATTERN.search(line))
+        )
+
+        # Demangle any call targets not already in the cache
+        missing = [
+            name
+            for name in self._function_call_counts
+            if name not in self._demangle_cache
+        ]
+        if missing:
+            self._batch_demangle_symbols(missing)
+
+        _LOGGER.debug(
+            "Function call analysis: %d unique targets, %d total calls",
+            len(self._function_call_counts),
+            sum(self._function_call_counts.values()),
         )
 
     def get_unattributed_ram(self) -> tuple[int, int, int]:

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -231,6 +231,52 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
                     lines.append(f"    {size:>6,} B  {sym_name}")
             lines.append("")
 
+    # Number of top called functions to show
+    TOP_CALLS_LIMIT: int = 50
+
+    def _add_function_call_analysis(self, lines: list[str]) -> None:
+        """Add function call frequency analysis section.
+
+        Shows the most frequently called functions by call site count,
+        helping identify inlining candidates. Includes function size
+        when available from the symbol table.
+        """
+        self._add_section_header(lines, "Top Called Functions (inlining candidates)")
+
+        # Build a size lookup from all component symbols: mangled_name -> size
+        symbol_sizes: dict[str, int] = {
+            symbol: size
+            for symbols in self._component_symbols.values()
+            for symbol, _, size, _ in symbols
+        }
+
+        # Sort by call count descending
+        sorted_calls = sorted(
+            self._function_call_counts.items(), key=lambda x: x[1], reverse=True
+        )
+
+        lines.append(f"{'#':>3}  {'Calls':>5}  {'Size':>7}  Function")
+        lines.append(f"{'---':>3}  {'-----':>5}  {'-------':>7}  {'-' * 60}")
+
+        for i, (mangled, count) in enumerate(sorted_calls[: self.TOP_CALLS_LIMIT]):
+            # Look up demangled name
+            demangled = self._demangle_cache.get(mangled, mangled)
+            # Truncate long names
+            if len(demangled) > 80:
+                demangled = f"{demangled[:77]}..."
+            # Look up size
+            size = symbol_sizes.get(mangled)
+            size_str = f"{size:>5,} B" if size is not None else "      ?"
+            lines.append(f"{i + 1:>3}  {count:>5}  {size_str}  {demangled}")
+
+        total_calls = sum(self._function_call_counts.values())
+        lines.append("")
+        lines.append(
+            f"Total: {len(self._function_call_counts)} unique targets, "
+            f"{total_calls:,} call sites"
+        )
+        lines.append("")
+
     def generate_report(self, detailed: bool = False) -> str:
         """Generate a formatted memory report."""
         components = sorted(
@@ -532,6 +578,10 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
         # CSWTCH (GCC switch table) analysis
         if self._cswtch_symbols:
             self._add_cswtch_analysis(lines)
+
+        # Function call frequency analysis
+        if self._function_call_counts:
+            self._add_function_call_analysis(lines)
 
         lines.append(
             "Note: This analysis covers symbols in the ELF file. Some runtime allocations may not be included."

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -233,47 +233,105 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
 
     # Number of top called functions to show
     TOP_CALLS_LIMIT: int = 50
+    # Number of inlining candidates to show
+    INLINE_CANDIDATES_LIMIT: int = 25
+    # Maximum function size in bytes to consider for inlining
+    INLINE_SIZE_THRESHOLD: int = 16
 
-    def _add_function_call_analysis(self, lines: list[str]) -> None:
-        """Add function call frequency analysis section.
-
-        Shows the most frequently called functions by call site count,
-        helping identify inlining candidates. Includes function size
-        when available from the symbol table.
-        """
-        self._add_section_header(lines, "Top Called Functions (inlining candidates)")
-
-        # Build a size lookup from all component symbols: mangled_name -> size
-        symbol_sizes: dict[str, int] = {
+    def _build_symbol_sizes(self) -> dict[str, int]:
+        """Build a size lookup from all component symbols: mangled_name -> size."""
+        return {
             symbol: size
             for symbols in self._component_symbols.values()
             for symbol, _, size, _ in symbols
         }
+
+    def _format_call_row(
+        self, index: int, mangled: str, count: int, symbol_sizes: dict[str, int]
+    ) -> str:
+        """Format a single row for call frequency tables."""
+        demangled = self._demangle_cache.get(mangled, mangled)
+        if len(demangled) > 80:
+            demangled = f"{demangled[:77]}..."
+        size = symbol_sizes.get(mangled)
+        size_str = f"{size:>5,} B" if size is not None else "      ?"
+        return f"{index:>3}  {count:>5}  {size_str}  {demangled}"
+
+    def _add_call_table_header(self, lines: list[str]) -> None:
+        """Add the header row for call frequency tables."""
+        lines.append(f"{'#':>3}  {'Calls':>5}  {'Size':>7}  Function")
+        lines.append(f"{'---':>3}  {'-----':>5}  {'-------':>7}  {'-' * 60}")
+
+    def _add_function_call_analysis(self, lines: list[str]) -> None:
+        """Add function call frequency analysis section.
+
+        Shows the most frequently called functions by call site count.
+        """
+        self._add_section_header(lines, "Top Called Functions")
+
+        symbol_sizes = self._build_symbol_sizes()
 
         # Sort by call count descending
         sorted_calls = sorted(
             self._function_call_counts.items(), key=lambda x: x[1], reverse=True
         )
 
-        lines.append(f"{'#':>3}  {'Calls':>5}  {'Size':>7}  Function")
-        lines.append(f"{'---':>3}  {'-----':>5}  {'-------':>7}  {'-' * 60}")
+        self._add_call_table_header(lines)
 
         for i, (mangled, count) in enumerate(sorted_calls[: self.TOP_CALLS_LIMIT]):
-            # Look up demangled name
-            demangled = self._demangle_cache.get(mangled, mangled)
-            # Truncate long names
-            if len(demangled) > 80:
-                demangled = f"{demangled[:77]}..."
-            # Look up size
-            size = symbol_sizes.get(mangled)
-            size_str = f"{size:>5,} B" if size is not None else "      ?"
-            lines.append(f"{i + 1:>3}  {count:>5}  {size_str}  {demangled}")
+            lines.append(self._format_call_row(i + 1, mangled, count, symbol_sizes))
 
         total_calls = sum(self._function_call_counts.values())
         lines.append("")
         lines.append(
             f"Total: {len(self._function_call_counts)} unique targets, "
             f"{total_calls:,} call sites"
+        )
+        lines.append("")
+
+    def _add_inline_candidates(self, lines: list[str]) -> None:
+        """Add inlining candidates section.
+
+        Shows frequently called functions that are small enough to benefit
+        from inlining (< 16 bytes). These are the best candidates for
+        reducing call overhead.
+        """
+        self._add_section_header(
+            lines,
+            f"Inlining Candidates (<{self.INLINE_SIZE_THRESHOLD} B, by call count)",
+        )
+
+        symbol_sizes = self._build_symbol_sizes()
+
+        # Filter to small functions with known size, sort by call count
+        candidates = sorted(
+            (
+                (mangled, count)
+                for mangled, count in self._function_call_counts.items()
+                if mangled in symbol_sizes
+                and symbol_sizes[mangled] < self.INLINE_SIZE_THRESHOLD
+            ),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+
+        if not candidates:
+            lines.append("No candidates found.")
+            lines.append("")
+            return
+
+        self._add_call_table_header(lines)
+
+        for i, (mangled, count) in enumerate(
+            candidates[: self.INLINE_CANDIDATES_LIMIT]
+        ):
+            lines.append(self._format_call_row(i + 1, mangled, count, symbol_sizes))
+
+        lines.append("")
+        lines.append(
+            f"Showing top {min(len(candidates), self.INLINE_CANDIDATES_LIMIT)} "
+            f"of {len(candidates)} functions under "
+            f"{self.INLINE_SIZE_THRESHOLD} B"
         )
         lines.append("")
 
@@ -582,6 +640,7 @@ class MemoryAnalyzerCLI(MemoryAnalyzer):
         # Function call frequency analysis
         if self._function_call_counts:
             self._add_function_call_analysis(lines)
+            self._add_inline_candidates(lines)
 
         lines.append(
             "Note: This analysis covers symbols in the ELF file. Some runtime allocations may not be included."


### PR DESCRIPTION
# What does this implement/fix?

Add a "Top Called Functions (inlining candidates)" section to the `esphome analyze-memory` report. This shows the 50 most frequently called functions by call site count, alongside their code size when available from the symbol table.

This helps identify functions that would benefit most from inlining — frequently called small functions are the best candidates for reducing call overhead and code size.

The analysis works by:
- Parsing `objdump -d` disassembly output to count call instructions
- Supporting both Xtensa (`call0/call4/call8/call12/callx0-callx12`) and ARM (`bl/blx`) architectures
- Demangling call target symbols for readable output
- Cross-referencing with symbol table sizes

Also fixes `_batch_demangle_symbols` to merge into the existing cache instead of replacing it (which caused demangled names to be lost on subsequent calls).

Example output (ESP8266):

```
  #  Calls     Size  Function
---  -----  -------  ------------------------------------------------------------
  1    287        ?  std::_Function_base::~_Function_base()
  2    271     51 B  operator new(unsigned int)
  3    223     56 B  esphome::esp_log_printf_(...)
  4    139     40 B  String::invalidate()
  5    110      6 B  operator delete(void*, unsigned int)
  ...
 50     18     34 B  __assert_func

Total: 2835 unique targets, 8,958 call sites
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a developer tool
# Usage: esphome analyze-memory <config.yaml>
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).