### PR TITLE
[api] Inline force-variant ProtoSize calc methods

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -602,7 +602,7 @@ class ProtoSize {
   static constexpr uint32_t calc_sint32(uint32_t field_id_size, int32_t value) {
     return value ? field_id_size + varint(encode_zigzag32(value)) : 0;
   }
-  static constexpr uint32_t calc_sint32_force(uint32_t field_id_size, int32_t value) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_sint32_force(uint32_t field_id_size, int32_t value) {
     return field_id_size + varint(encode_zigzag32(value));
   }
   static constexpr uint32_t calc_int64(uint32_t field_id_size, int64_t value) {
@@ -614,13 +614,13 @@ class ProtoSize {
   static constexpr uint32_t calc_uint64(uint32_t field_id_size, uint64_t value) {
     return value ? field_id_size + varint(value) : 0;
   }
-  static constexpr uint32_t calc_uint64_force(uint32_t field_id_size, uint64_t value) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_uint64_force(uint32_t field_id_size, uint64_t value) {
     return field_id_size + varint(value);
   }
   static constexpr uint32_t calc_length(uint32_t field_id_size, size_t len) {
     return len ? field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len) : 0;
   }
-  static constexpr uint32_t calc_length_force(uint32_t field_id_size, size_t len) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_length_force(uint32_t field_id_size, size_t len) {
     return field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len);
   }
   static constexpr uint32_t calc_sint64(uint32_t field_id_size, int64_t value) {
@@ -638,7 +638,8 @@ class ProtoSize {
   static constexpr uint32_t calc_message(uint32_t field_id_size, uint32_t nested_size) {
     return nested_size ? field_id_size + varint(nested_size) + nested_size : 0;
   }
-  static constexpr uint32_t calc_message_force(uint32_t field_id_size, uint32_t nested_size) {
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_message_force(uint32_t field_id_size,
+                                                                            uint32_t nested_size) {
     return field_id_size + varint(nested_size) + nested_size;
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

Force-inline `calc_uint64_force`, `calc_sint32_force`, `calc_length_force`, and `calc_message_force` in `ProtoSize` so the varint fast path (`value < 128 → return 1`) is expanded at each call site instead of going through a function call.

These four methods are specifically the ones used by BLE proxy messages on the hot path:
- `BluetoothLERawAdvertisement::calculate_size()` calls `calc_uint64_force` (address), `calc_sint32_force` (rssi), `calc_length_force` (data)
- `BluetoothLERawAdvertisementsResponse::calculate_size()` calls `calc_message_force` for each sub-message
- `BluetoothGATTService/Characteristic/Descriptor::calculate_size()` call `calc_uint64_force` (uuid) and `calc_message_force` (nested messages)

These are called 12× per advertisement batch in the BLE proxy hot path.

**Benchmark results** (ESP32, 12-advertisement batches, 10k iterations):

| Operation | Before | After | Change |
|-----------|--------|-------|--------|
| `calculate_size` | 10,381 ns/op | 9,718 ns/op | **-6.4%** |
| `encode` | 38,038 ns/op | 37,874 ns/op | unchanged |
| `calc+encode` | 49,886 ns/op | 47,599 ns/op | **-4.6%** |

**Flash impact:**
- ESP32 IDF: +40 bytes
- ESP8266: +64 bytes

The non-force variants (which include a `value == 0` zero-skip check) are intentionally left alone — they have ~30 call sites and inlining them costs +700 bytes with no measurable benefit.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).