### PR TITLE
[core] Inline trivial EntityBase accessors

### DIFF
--- a/esphome/core/entity_base.cpp
+++ b/esphome/core/entity_base.cpp
@@ -8,9 +8,6 @@ namespace esphome {
 
 static const char *const TAG = "entity_base";
 
-// Entity Name
-const StringRef &EntityBase::get_name() const { return this->name_; }
-
 void EntityBase::configure_entity_(const char *name, uint32_t object_id_hash, uint32_t entity_fields) {
   this->name_ = StringRef(name);
   if (this->name_.empty()) {
@@ -175,8 +172,6 @@ StringRef EntityBase::get_object_id_to(std::span<char, OBJECT_ID_MAX_LEN> buf) c
   size_t len = this->write_object_id_to(buf.data(), buf.size());
   return StringRef(buf.data(), len);
 }
-
-uint32_t EntityBase::get_object_id_hash() { return this->object_id_hash_; }
 
 // Migrate preference data from old_key to new_key if they differ.
 // This helper is exposed so callers with custom key computation (like TextPrefs)

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -68,7 +68,7 @@ static constexpr uint8_t ENTITY_FIELD_ENTITY_CATEGORY_SHIFT = 26;
 class EntityBase {
  public:
   // Get the name of this Entity
-  const StringRef &get_name() const;
+  const StringRef &get_name() const { return this->name_; }
 
   // Get whether this Entity has its own name or it should use the device friendly_name.
   bool has_own_name() const { return this->flags_.has_own_name; }
@@ -86,7 +86,7 @@ class EntityBase {
   std::string get_object_id() const;
 
   // Get the unique Object ID of this Entity
-  uint32_t get_object_id_hash();
+  uint32_t get_object_id_hash() { return this->object_id_hash_; }
 
   /// Get object_id with zero heap allocation
   /// For static case: returns StringRef to internal storage (buffer unused)

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -86,7 +86,7 @@ class EntityBase {
   std::string get_object_id() const;
 
   // Get the unique Object ID of this Entity
-  uint32_t get_object_id_hash() { return this->object_id_hash_; }
+  uint32_t get_object_id_hash() const { return this->object_id_hash_; }
 
   /// Get object_id with zero heap allocation
   /// For static case: returns StringRef to internal storage (buffer unused)


### PR DESCRIPTION
# What does this implement/fix?

Move `get_name()` and `get_object_id_hash()` definitions from `entity_base.cpp` into the class body in `entity_base.h` so the compiler can inline these trivial member accessors.

Both functions are single-statement member returns (4-5 bytes compiled) called from many call sites across the codebase. Defining them in the header eliminates the function call overhead at each site.

Identified using the inlining candidates analysis from #14779.

ESP8266 measured savings: **352 bytes flash**.

Note: CI memory impact analysis likely won't show improvement since the test configs don't have enough entities to exercise these accessors.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).