### PR TITLE
[esp32_rmt_led_strip][remote_transmitter][remote_receiver] Fix ESP-IDF 6.0 RMT compatibility

### DIFF
--- a/esphome/components/esp32_rmt_led_strip/led_strip.cpp
+++ b/esphome/components/esp32_rmt_led_strip/led_strip.cpp
@@ -99,8 +99,6 @@ void ESP32RMTLEDStripLightOutput::setup() {
   channel.gpio_num = gpio_num_t(this->pin_);
   channel.mem_block_symbols = this->rmt_symbols_;
   channel.trans_queue_depth = 1;
-  channel.flags.io_loop_back = 0;
-  channel.flags.io_od_mode = 0;
   channel.flags.invert_out = this->invert_out_;
   channel.flags.with_dma = this->use_dma_;
   channel.intr_priority = 0;

--- a/esphome/components/remote_receiver/remote_receiver_rmt.cpp
+++ b/esphome/components/remote_receiver/remote_receiver_rmt.cpp
@@ -44,7 +44,6 @@ void RemoteReceiverComponent::setup() {
   channel.intr_priority = 0;
   channel.flags.invert_in = 0;
   channel.flags.with_dma = this->with_dma_;
-  channel.flags.io_loop_back = 0;
   esp_err_t error = rmt_new_rx_channel(&channel, &this->channel_);
   if (error != ESP_OK) {
     this->error_code_ = error;

--- a/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
+++ b/esphome/components/remote_transmitter/remote_transmitter_rmt.cpp
@@ -120,11 +120,13 @@ void RemoteTransmitterComponent::configure_rmt_() {
     channel.gpio_num = gpio_num_t(this->pin_->get_pin());
     channel.mem_block_symbols = this->rmt_symbols_;
     channel.trans_queue_depth = 1;
-    channel.flags.io_loop_back = open_drain;
-    channel.flags.io_od_mode = open_drain;
     channel.flags.invert_out = 0;
     channel.flags.with_dma = this->with_dma_;
     channel.intr_priority = 0;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
+    channel.flags.io_loop_back = open_drain;
+    channel.flags.io_od_mode = open_drain;
+#endif
     error = rmt_new_tx_channel(&channel, &this->channel_);
     if (error != ESP_OK) {
       this->error_code_ = error;
@@ -136,6 +138,13 @@ void RemoteTransmitterComponent::configure_rmt_() {
       this->mark_failed();
       return;
     }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    if (open_drain) {
+      gpio_num_t gpio = gpio_num_t(this->pin_->get_pin());
+      gpio_od_enable(gpio);
+      gpio_input_enable(gpio);
+    }
+#endif
     if (this->pin_->get_flags() & gpio::FLAG_PULLUP) {
       gpio_pullup_en(gpio_num_t(this->pin_->get_pin()));
     } else {


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 removed `io_loop_back` and `io_od_mode` flags from `rmt_tx_channel_config_t` and `rmt_rx_channel_config_t`.

- **esp32_rmt_led_strip**: Removed `io_loop_back = 0` and `io_od_mode = 0` assignments (no-ops since the struct is already zeroed by `memset`)
- **remote_receiver**: Removed `io_loop_back = 0` assignment (same, no-op)
- **remote_transmitter**: Wrapped `io_loop_back`/`io_od_mode` in `#if IDF < 6.0` guard. For IDF 6.0+, open-drain mode is configured via `gpio_od_enable()` and `gpio_input_enable()` after channel creation, since `gpio_od_enable` is new in IDF 6.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (ESP-IDF 6.0 forward compatibility)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal IDF compatibility fix
light:
  - platform: esp32_rmt_led_strip
    pin: GPIO2
    num_leds: 10
    chipset: WS2812
    rgb_order: GRB
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).