### PR TITLE
[mipi_dsi] Fix ESP-IDF 6.0 compatibility for LCD color format

### DIFF
--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -54,16 +54,16 @@ void MIPI_DSI::setup() {
     this->smark_failed(LOG_STR("new_panel_io_dbi failed"), err);
     return;
   }
+  // clang-format off
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   auto color_format = LCD_COLOR_FMT_RGB565;
   if (this->color_depth_ == display::COLOR_BITNESS_888) {
     color_format = LCD_COLOR_FMT_RGB888;
   }
-  esp_lcd_dpi_panel_config_t dpi_config =
-  {.virtual_channel = 0,
-   .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
-   .dpi_clock_freq_mhz = this->pclk_frequency_,
-   .in_color_format = color_format,
+  esp_lcd_dpi_panel_config_t dpi_config = {.virtual_channel = 0,
+                                           .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
+                                           .dpi_clock_freq_mhz = this->pclk_frequency_,
+                                           .in_color_format = color_format,
 #else
   auto pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565;
   if (this->color_depth_ == display::COLOR_BITNESS_888) {
@@ -74,21 +74,22 @@ void MIPI_DSI::setup() {
                                            .dpi_clock_freq_mhz = this->pclk_frequency_,
                                            .pixel_format = pixel_format,
 #endif
-   .num_fbs = 1,  // number of frame buffers to allocate
-   .video_timing =
-       {
-           .h_size = this->width_,
-           .v_size = this->height_,
-           .hsync_pulse_width = this->hsync_pulse_width_,
-           .hsync_back_porch = this->hsync_back_porch_,
-           .hsync_front_porch = this->hsync_front_porch_,
-           .vsync_pulse_width = this->vsync_pulse_width_,
-           .vsync_back_porch = this->vsync_back_porch_,
-           .vsync_front_porch = this->vsync_front_porch_,
-       },
-   .flags = {
-       .use_dma2d = true,
-   } };
+                                           .num_fbs = 1,  // number of frame buffers to allocate
+                                           .video_timing =
+                                               {
+                                                   .h_size = this->width_,
+                                                   .v_size = this->height_,
+                                                   .hsync_pulse_width = this->hsync_pulse_width_,
+                                                   .hsync_back_porch = this->hsync_back_porch_,
+                                                   .hsync_front_porch = this->hsync_front_porch_,
+                                                   .vsync_pulse_width = this->vsync_pulse_width_,
+                                                   .vsync_back_porch = this->vsync_back_porch_,
+                                                   .vsync_front_porch = this->vsync_front_porch_,
+                                               },
+                                           .flags = {
+                                               .use_dma2d = true,
+                                           }};
+  // clang-format on
   err = esp_lcd_new_panel_dpi(this->bus_handle_, &dpi_config, &this->handle_);
   if (err != ESP_OK) {
     this->smark_failed(LOG_STR("esp_lcd_new_panel_dpi failed"), err);

--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -54,6 +54,17 @@ void MIPI_DSI::setup() {
     this->smark_failed(LOG_STR("new_panel_io_dbi failed"), err);
     return;
   }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  auto color_format = LCD_COLOR_FMT_RGB565;
+  if (this->color_depth_ == display::COLOR_BITNESS_888) {
+    color_format = LCD_COLOR_FMT_RGB888;
+  }
+  esp_lcd_dpi_panel_config_t dpi_config =
+  {.virtual_channel = 0,
+   .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
+   .dpi_clock_freq_mhz = this->pclk_frequency_,
+   .in_color_format = color_format,
+#else
   auto pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565;
   if (this->color_depth_ == display::COLOR_BITNESS_888) {
     pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB888;
@@ -62,21 +73,22 @@ void MIPI_DSI::setup() {
                                            .dpi_clk_src = MIPI_DSI_DPI_CLK_SRC_DEFAULT,
                                            .dpi_clock_freq_mhz = this->pclk_frequency_,
                                            .pixel_format = pixel_format,
-                                           .num_fbs = 1,  // number of frame buffers to allocate
-                                           .video_timing =
-                                               {
-                                                   .h_size = this->width_,
-                                                   .v_size = this->height_,
-                                                   .hsync_pulse_width = this->hsync_pulse_width_,
-                                                   .hsync_back_porch = this->hsync_back_porch_,
-                                                   .hsync_front_porch = this->hsync_front_porch_,
-                                                   .vsync_pulse_width = this->vsync_pulse_width_,
-                                                   .vsync_back_porch = this->vsync_back_porch_,
-                                                   .vsync_front_porch = this->vsync_front_porch_,
-                                               },
-                                           .flags = {
-                                               .use_dma2d = true,
-                                           }};
+#endif
+   .num_fbs = 1,  // number of frame buffers to allocate
+   .video_timing =
+       {
+           .h_size = this->width_,
+           .v_size = this->height_,
+           .hsync_pulse_width = this->hsync_pulse_width_,
+           .hsync_back_porch = this->hsync_back_porch_,
+           .hsync_front_porch = this->hsync_front_porch_,
+           .vsync_pulse_width = this->vsync_pulse_width_,
+           .vsync_back_porch = this->vsync_back_porch_,
+           .vsync_front_porch = this->vsync_front_porch_,
+       },
+   .flags = {
+       .use_dma2d = true,
+   } };
   err = esp_lcd_new_panel_dpi(this->bus_handle_, &dpi_config, &this->handle_);
   if (err != ESP_OK) {
     this->smark_failed(LOG_STR("esp_lcd_new_panel_dpi failed"), err);


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 renamed the LCD color format enums and struct fields:
- `LCD_COLOR_PIXEL_FORMAT_RGB565` → `LCD_COLOR_FMT_RGB565`
- `LCD_COLOR_PIXEL_FORMAT_RGB888` → `LCD_COLOR_FMT_RGB888`
- `esp_lcd_dpi_panel_config_t.pixel_format` → `.in_color_format`

Added `#if` guards to support both IDF 5.x and 6.0.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (ESP-IDF 6.0 forward compatibility)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal IDF compatibility fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).