### PR TITLE
[output] Inline trivial FloatOutput accessors

### DIFF
--- a/esphome/components/output/float_output.cpp
+++ b/esphome/components/output/float_output.cpp
@@ -11,15 +11,9 @@ void FloatOutput::set_max_power(float max_power) {
   this->max_power_ = clamp(max_power, this->min_power_, 1.0f);  // Clamp to MIN>=MAX>=1.0
 }
 
-float FloatOutput::get_max_power() const { return this->max_power_; }
-
 void FloatOutput::set_min_power(float min_power) {
   this->min_power_ = clamp(min_power, 0.0f, this->max_power_);  // Clamp to 0.0>=MIN>=MAX
 }
-
-void FloatOutput::set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero_means_zero; }
-
-float FloatOutput::get_min_power() const { return this->min_power_; }
 
 void FloatOutput::set_level(float state) {
   state = clamp(state, 0.0f, 1.0f);

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -48,7 +48,7 @@ class FloatOutput : public BinaryOutput {
 
   /** Sets this output to ignore min_power for a 0 state
    *
-   * @param zero True if a 0 state should mean 0 and not min_power.
+   * @param zero_means_zero True if a 0 state should mean 0 and not min_power.
    */
   void set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero_means_zero; }
 

--- a/esphome/components/output/float_output.h
+++ b/esphome/components/output/float_output.h
@@ -50,7 +50,7 @@ class FloatOutput : public BinaryOutput {
    *
    * @param zero True if a 0 state should mean 0 and not min_power.
    */
-  void set_zero_means_zero(bool zero_means_zero);
+  void set_zero_means_zero(bool zero_means_zero) { this->zero_means_zero_ = zero_means_zero; }
 
   /** Set the level of this float output, this is called from the front-end.
    *
@@ -70,10 +70,10 @@ class FloatOutput : public BinaryOutput {
   // (In most use cases you won't need these)
 
   /// Get the maximum power output.
-  float get_max_power() const;
+  float get_max_power() const { return this->max_power_; }
 
   /// Get the minimum power output.
-  float get_min_power() const;
+  float get_min_power() const { return this->min_power_; }
 
  protected:
   /// Implement BinarySensor's write_enabled; this should never be called.


### PR DESCRIPTION
# What does this implement/fix?

Move `get_min_power()`, `get_max_power()`, and `set_zero_means_zero()` definitions from `float_output.cpp` into the class body in `float_output.h` so the compiler can inline these trivial member accessors.

Identified using the inlining candidates analysis from #14779.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).