### PR TITLE
[core] Inline LwIPLock as no-op on platforms without lwIP core locking

### DIFF
--- a/esphome/components/esp8266/helpers.cpp
+++ b/esphome/components/esp8266/helpers.cpp
@@ -22,9 +22,7 @@ void Mutex::unlock() {}
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = xt_rsil(15); }
 IRAM_ATTR InterruptLock::~InterruptLock() { xt_wsr_ps(state_); }
 
-// ESP8266 doesn't support lwIP core locking, so this is a no-op
-LwIPLock::LwIPLock() {}
-LwIPLock::~LwIPLock() {}
+// ESP8266 LwIPLock is defined inline as a no-op in helpers.h
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
   wifi_get_macaddr(STATION_IF, mac);

--- a/esphome/components/libretiny/helpers.cpp
+++ b/esphome/components/libretiny/helpers.cpp
@@ -26,9 +26,7 @@ void Mutex::unlock() { xSemaphoreGive(this->handle_); }
 IRAM_ATTR InterruptLock::InterruptLock() { portDISABLE_INTERRUPTS(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { portENABLE_INTERRUPTS(); }
 
-// LibreTiny doesn't support lwIP core locking, so this is a no-op
-LwIPLock::LwIPLock() {}
-LwIPLock::~LwIPLock() {}
+// LibreTiny LwIPLock is defined inline as a no-op in helpers.h
 
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
   WiFi.macAddress(mac);

--- a/esphome/components/zephyr/core.cpp
+++ b/esphome/components/zephyr/core.cpp
@@ -76,9 +76,7 @@ void Mutex::unlock() { k_mutex_unlock(static_cast<k_mutex *>(this->handle_)); }
 IRAM_ATTR InterruptLock::InterruptLock() { state_ = irq_lock(); }
 IRAM_ATTR InterruptLock::~InterruptLock() { irq_unlock(state_); }
 
-// Zephyr doesn't support lwIP core locking, so this is a no-op
-LwIPLock::LwIPLock() {}
-LwIPLock::~LwIPLock() {}
+// Zephyr LwIPLock is defined inline as a no-op in helpers.h
 
 uint32_t random_uint32() { return rand(); }  // NOLINT(cert-msc30-c, cert-msc50-cpp)
 bool random_bytes(uint8_t *data, size_t len) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1930,19 +1930,26 @@ class InterruptLock {
 
 /** Helper class to lock the lwIP TCPIP core when making lwIP API calls from non-TCPIP threads.
  *
- * This is needed on multi-threaded platforms (ESP32) when CONFIG_LWIP_TCPIP_CORE_LOCKING is enabled.
- * It ensures thread-safe access to lwIP APIs.
+ * This is needed on multi-threaded platforms (ESP32) when CONFIG_LWIP_TCPIP_CORE_LOCKING is enabled,
+ * and on RP2040 when CYW43 WiFi is active (cyw43_arch_lwip_begin/end).
  *
- * @note This follows the same pattern as InterruptLock - platform-specific implementations in helpers.cpp
+ * On platforms without lwIP core locking (ESP8266, LibreTiny, Zephyr),
+ * this is a no-op defined inline so the compiler can eliminate all call overhead.
  */
 class LwIPLock {
  public:
-  LwIPLock();
-  ~LwIPLock();
-
-  // Delete copy constructor and copy assignment operator to prevent accidental copying
   LwIPLock(const LwIPLock &) = delete;
   LwIPLock &operator=(const LwIPLock &) = delete;
+
+#if defined(USE_ESP32) || defined(USE_RP2040)
+  // Platforms with potential lwIP core locking — out-of-line implementations in helpers.cpp
+  LwIPLock();
+  ~LwIPLock();
+#else
+  // No lwIP core locking — inline no-ops
+  LwIPLock() = default;
+  ~LwIPLock() = default;
+#endif
 };
 
 /** Helper class to request `loop()` to be called as fast as possible.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1946,9 +1946,10 @@ class LwIPLock {
   LwIPLock();
   ~LwIPLock();
 #else
-  // No lwIP core locking — inline no-ops
-  LwIPLock() = default;
-  ~LwIPLock() = default;
+  // No lwIP core locking — inline no-ops (empty bodies instead of = default
+  // to prevent clang-tidy unused-variable warnings at call sites)
+  LwIPLock() {}
+  ~LwIPLock() {}
 #endif
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a code size regression introduced in #14679 where `LwIPLock` was added for RP2040 WiFi race condition prevention, but the empty no-op stubs on other platforms (ESP8266, LibreTiny, Zephyr) were defined out-of-line in `.cpp` files. The compiler could not see through these, generating unnecessary function calls at every call site.

This moves the no-op `LwIPLock` implementation inline into `helpers.h` using a compile-time platform check. Platforms with real lwIP core locking (ESP32, RP2040) retain their out-of-line implementations.

This is a **bugfix** because it restores the pre-#14679 behavior where these platforms had zero `LwIPLock` overhead (the class didn't exist yet). The sibling PR #14756 is a separate **optimization** that inlines `Mutex` on single-threaded platforms — that overhead predates #14679 and is not a regression.

Recovers **304 bytes of flash** lost to the regression on ESP8266.

Identified using the inlining candidates analysis from #14779.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #14679

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).