### PR TITLE
[ledc] Fix ESP-IDF 6.0 compatibility for peripheral reset

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -5,10 +5,9 @@
 
 #include <driver/ledc.h>
 #include <cinttypes>
+#include <esp_idf_version.h>
 #include <esp_private/periph_ctrl.h>
-#if !defined(SOC_LEDC_SUPPORT_FADE_STOP)
 #include <hal/ledc_ll.h>
-#endif
 
 #define CLOCK_FREQUENCY 80e6f
 
@@ -161,7 +160,14 @@ void LEDCOutput::write_state(float state) {
 void LEDCOutput::setup() {
   if (!ledc_peripheral_reset_done) {
     ESP_LOGV(TAG, "Resetting LEDC peripheral to clear stale state after reboot");
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    PERIPH_RCC_ATOMIC() {
+      ledc_ll_enable_reset_reg(true);
+      ledc_ll_enable_reset_reg(false);
+    }
+#else
     periph_module_reset(PERIPH_LEDC_MODULE);
+#endif
     ledc_peripheral_reset_done = true;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

`PERIPH_LEDC_MODULE` was removed from the `periph_module_t` enum in ESP-IDF 6.0, causing a compilation failure in `ledc_output.cpp`.

This replaces `periph_module_reset(PERIPH_LEDC_MODULE)` with `ledc_ll_enable_reset_reg(true/false)` inside `PERIPH_RCC_ATOMIC()` for IDF 6.0+, which is the same approach IDF's own LEDC driver uses internally. The old code path is kept for IDF < 6.0.

Also includes `<hal/ledc_ll.h>` unconditionally since it's now needed for both the reset (IDF 6.0+) and the existing `ledc_duty_update_pending` helper (classic ESP32).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed - existing ledc configs work as before
output:
  - platform: ledc
    pin: GPIO2
    id: my_ledc
    frequency: 1000Hz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).