### PR TITLE
[esp32] Fix intermittent boot hang by switching to ESP-IDF Log V2

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1614,6 +1614,11 @@ async def to_code(config):
     # This saves ~250 bytes of RAM (tag cache) and associated code
     add_idf_sdkconfig_option("CONFIG_LOG_TAG_LEVEL_IMPL_NONE", True)
 
+    # Use ESP-IDF Log V2 to eliminate per-site esp_log_timestamp() macro expansions
+    # V2 centralizes formatting inside esp_log(), reducing flash usage
+    add_idf_sdkconfig_option("CONFIG_LOG_VERSION_1", False)
+    add_idf_sdkconfig_option("CONFIG_LOG_VERSION_2", True)
+
     # Reduce PHY TX power in the event of a brownout
     add_idf_sdkconfig_option("CONFIG_ESP_PHY_REDUCE_TX_POWER", True)
 

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -113,7 +113,7 @@ static void __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *messa
   static const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
   // Format into stack buffer and output atomically via esp_rom_printf
   // to prevent interleaving. Can't use fwrite (newlib locks not initialized).
-  char buf[256];
+  char buf[512];
   int pos = 0;
   uint8_t level = message->config.opts.log_level;
   if (level > 0 && level < sizeof(lvl)) {

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -116,10 +116,10 @@ static void IRAM_ATTR __attribute__((noinline)) esp_log_format_early_(esp_log_ms
   // our override is in a different compilation unit so we must use DRAM_ATTR explicitly.
   static DRAM_ATTR const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
   static DRAM_ATTR const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
-  static DRAM_ATTR const char fmt_header[] = "\033[0;3%cm[%c][%s:000]: ";
+  static DRAM_ATTR const char fmt_header[] = "\033[0;3%cm[%c][%s]: ";
   static DRAM_ATTR const char fmt_reset_nl[] = "\033[0m\n";
   static DRAM_ATTR const char fmt_nl[] = "\n";
-  static DRAM_ATTR const char tag_fallback[] = "esp-idf";
+  static DRAM_ATTR const char tag_fallback[] = "idf";
   uint8_t level = message->config.opts.log_level;
 #if CONFIG_LIBC_NEWLIB
   if (!message->config.opts.constrained_env) {

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -136,8 +136,10 @@ static void __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *messa
 
 extern "C" {
 // Override esp_log_format from liblog.a to prevent V2's 3-call vprintf
-// fragmentation. IRAM_ATTR to match ESP-IDF's linker fragment placement.
-void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
+// fragmentation. No IRAM_ATTR needed — the only case where flash is
+// inaccessible (ISR with cache disabled) would crash anyway because the
+// caller's format string and tag are also in flash.
+void esp_log_format(esp_log_msg_t *message) {
   extern vprintf_like_t esp_log_vprint_func;
   extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
   if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -102,6 +102,8 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 // locks crash on USB JTAG devices).
 // Formats in ESPHome style with ANSI colors into a 512-byte stack buffer,
 // then outputs atomically via esp_rom_printf.
+// This path is cold on 99.9% of builds — it only runs during early boot
+// and at DEBUG framework log level (default is ERROR).
 static void __attribute__((noinline)) esp_log_format_direct_(esp_log_msg_t *message) {
   // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
   // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
@@ -133,10 +135,10 @@ static void __attribute__((noinline)) esp_log_format_direct_(esp_log_msg_t *mess
 
 extern "C" {
 // Override esp_log_format from liblog.a to prevent V2's 3-call vprintf
-// fragmentation. No IRAM_ATTR needed — the only case where flash is
-// inaccessible (ISR with cache disabled) would crash anyway because the
-// caller's format string and tag are also in flash.
-void esp_log_format(esp_log_msg_t *message) {
+// fragmentation. IRAM_ATTR to match esp_log_va's IRAM placement and avoid
+// an IRAM→flash cache miss on every ESP-IDF log call. This function is
+// tiny (~43 bytes) so the IRAM cost is negligible.
+void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
   extern vprintf_like_t esp_log_vprint_func;
   extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
   if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -140,25 +140,17 @@ extern "C" {
 void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
   extern vprintf_like_t esp_log_vprint_func;
   extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
-  if (message->config.opts.constrained_env) [[unlikely]] {
-    // Constrained env: constrained_env combines three conditions —
-    // scheduler not running, in ISR, or cache disabled. Only the first
-    // is safe for flash access. Check ISR context explicitly to decide.
-    if (xPortInIsrContext()) {
-      // In ISR: flash may be inaccessible. Output tag only via ROM printf.
-      // This matches V1 behavior where ISR logging was best-effort.
-      static DRAM_ATTR const char isr_fmt[] = "[%s] (ISR log)\n";
-      esp_rom_printf(isr_fmt, message->tag ? message->tag : "idf");
-    } else {
-      // Scheduler not running or PHY init: flash is accessible.
-      // Use stack buffer formatting (can't use ESPHome hook — fwrite
-      // locks crash during PHY init on USB JTAG devices).
-      esp_log_format_early_(message);
-    }
-    return;
-  }
-  if (esp_log_vprint_func == &vprintf) [[unlikely]] {
-    // Early boot: hook not installed yet. Format with ESPHome style.
+  if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {
+    // Early boot or constrained env (PHY init, efuse reads, scheduler not
+    // running). Can't use the ESPHome hook — fwrite locks crash during PHY
+    // init on USB JTAG devices and newlib isn't initialized during early boot.
+    // Format to stack buffer with vsnprintf + esp_rom_printf instead.
+    //
+    // Note: if called from an ISR with flash cache disabled, this will crash
+    // because the format string and tag are in flash. This is the same as V1
+    // where ESP_EARLY_LOGx from ISR also used flash-resident format strings
+    // via esp_rom_printf. No ESP-IDF code is known to log from ISR with
+    // cache disabled.
     esp_log_format_early_(message);
     return;
   }

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -102,64 +102,58 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 #include <esp_private/log_format.h>
 #include <esp_log_write.h>
 
-// Outlined cold path for early boot / constrained environment logging.
-// Uses esp_log_printf/esp_log_vprintf which dispatch to esp_rom_vprintf
-// for constrained environments (same as ESP-IDF's original esp_log_format).
-// Must be in IRAM since it's called from the IRAM esp_log_format during
-// early boot when the scheduler isn't running (constrained_env=1).
-static void IRAM_ATTR __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
+// Outlined cold path for early boot logging (before ESPHome hook is installed).
+// Formats messages in ESPHome style with ANSI colors.
+// Not IRAM_ATTR — flash is always accessible during early boot (cache is enabled,
+// constrained_env is set only because the scheduler isn't running yet).
+static void __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
   // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
   // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
-  // DRAM_ATTR required: this function is IRAM_ATTR and may be called from constrained
-  // environments where flash cache is disabled. All string constants must be in DRAM.
-  // ESP-IDF's own log_format_text.c achieves this via linker fragment (noflash), but
-  // our override is in a different compilation unit so we must use DRAM_ATTR explicitly.
-  static DRAM_ATTR const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
-  static DRAM_ATTR const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
-  static DRAM_ATTR const char fmt_header[] = "\033[0;3%cm[%c][%s]: ";
-  static DRAM_ATTR const char fmt_reset_nl[] = "\033[0m\n";
-  static DRAM_ATTR const char fmt_nl[] = "\n";
-  static DRAM_ATTR const char tag_fallback[] = "idf";
+  static const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
+  static const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
+  // Format into stack buffer and output atomically via esp_rom_printf
+  // to prevent interleaving. Can't use fwrite (newlib locks not initialized).
+  char buf[256];
+  int pos = 0;
   uint8_t level = message->config.opts.log_level;
-#if CONFIG_LIBC_NEWLIB
-  if (!message->config.opts.constrained_env) {
-    flockfile(stdout);
-  }
-#endif
   if (level > 0 && level < sizeof(lvl)) {
-    esp_log_printf(message->config, fmt_header, color_digit[level], lvl[level],
-                   message->tag ? message->tag : tag_fallback);
+    pos = snprintf(buf, sizeof(buf), "\033[0;3%cm[%c][%s]: ", color_digit[level], lvl[level],
+                   message->tag ? message->tag : "idf");
   }
-  esp_log_vprintf(message->config, message->format, message->args);
-  if (level > 0 && level < sizeof(lvl)) {
-    esp_log_printf(message->config, fmt_reset_nl);
-  } else {
-    esp_log_printf(message->config, fmt_nl);
+  if (pos >= 0 && pos < (int) sizeof(buf) - 2) {
+    int body = vsnprintf(buf + pos, sizeof(buf) - pos, message->format, message->args);
+    if (body > 0)
+      pos += (body < (int) sizeof(buf) - pos) ? body : (int) sizeof(buf) - pos - 1;
   }
-#if CONFIG_LIBC_NEWLIB
-  if (!message->config.opts.constrained_env) {
-    funlockfile(stdout);
+  if (level > 0 && level < sizeof(lvl) && pos < (int) sizeof(buf) - 6) {
+    pos += snprintf(buf + pos, sizeof(buf) - pos, "\033[0m");
   }
-#endif
+  if (pos < (int) sizeof(buf) - 1) {
+    buf[pos++] = '\n';
+  }
+  buf[pos] = '\0';
+  esp_rom_printf("%s", buf);
 }
 
 extern "C" {
-// IRAM_ATTR required because ESP-IDF places esp_log_format in IRAM when
-// CONFIG_LOG_IN_IRAM is enabled, and it may be called from constrained
-// environments (ISR, cache disabled) where flash is inaccessible.
+// Override esp_log_format from liblog.a to prevent V2's 3-call vprintf
+// fragmentation. IRAM_ATTR to match ESP-IDF's linker fragment placement.
 void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
-  // Check if ESPHome's vprintf hook is installed by comparing against default.
-  // Before logger init, esp_log_vprint_func == &vprintf (the default).
   extern vprintf_like_t esp_log_vprint_func;
   extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
   if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {
-    // Early boot or constrained env (ISR, cache disabled):
-    // use ROM functions only — flash may be inaccessible.
+    // Early boot or constrained env (PHY init, ISR): can't use the ESPHome
+    // hook (fwrite locks crash during PHY init on USB JTAG devices).
+    // Format to stack buffer with vsnprintf + esp_rom_printf (both safe
+    // without stdio locks). vsnprintf writes to a buffer (no stdio init
+    // needed), esp_rom_printf is ROM-resident.
     esp_log_format_early_(message);
     return;
   }
-  // After hook installed, normal environment: skip formatting, forward body only
-  esp_log_vprintf(message->config, message->format, message->args);
+  // After hook installed, normal environment: skip formatting, forward body only.
+  // Call esp_log_vprint_func directly to avoid pulling in esp_rom_vprintf
+  // (1.2KB IRAM) through the esp_log_vprintf inline.
+  esp_log_vprint_func(message->format, message->args);
 }
 }  // extern "C"
 #endif

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -140,12 +140,25 @@ extern "C" {
 void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
   extern vprintf_like_t esp_log_vprint_func;
   extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
-  if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {
-    // Early boot or constrained env (PHY init, ISR): can't use the ESPHome
-    // hook (fwrite locks crash during PHY init on USB JTAG devices).
-    // Format to stack buffer with vsnprintf + esp_rom_printf (both safe
-    // without stdio locks). vsnprintf writes to a buffer (no stdio init
-    // needed), esp_rom_printf is ROM-resident.
+  if (message->config.opts.constrained_env) [[unlikely]] {
+    // Constrained env: constrained_env combines three conditions —
+    // scheduler not running, in ISR, or cache disabled. Only the first
+    // is safe for flash access. Check ISR context explicitly to decide.
+    if (xPortInIsrContext()) {
+      // In ISR: flash may be inaccessible. Output tag only via ROM printf.
+      // This matches V1 behavior where ISR logging was best-effort.
+      static DRAM_ATTR const char isr_fmt[] = "[%s] (ISR log)\n";
+      esp_rom_printf(isr_fmt, message->tag ? message->tag : "idf");
+    } else {
+      // Scheduler not running or PHY init: flash is accessible.
+      // Use stack buffer formatting (can't use ESPHome hook — fwrite
+      // locks crash during PHY init on USB JTAG devices).
+      esp_log_format_early_(message);
+    }
+    return;
+  }
+  if (esp_log_vprint_func == &vprintf) [[unlikely]] {
+    // Early boot: hook not installed yet. Format with ESPHome style.
     esp_log_format_early_(message);
     return;
   }

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -86,3 +86,73 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 #endif
 
 }  // namespace esphome
+
+#if defined(USE_ESP32) && !defined(BOOTLOADER_BUILD)
+// Override esp_log_format to disable ESP-IDF's own log formatting so that
+// the vprintf hook receives a single call per message (just the user's format
+// string + args). Without this, Log V2 makes 3 vprintf calls per message
+// (header, body, newline) which fragments the output in ESPHome's logger.
+// This strong definition overrides the archive symbol from ESP-IDF's liblog.
+// It affects all callers including precompiled blobs (e.g. wifi).
+//
+// Before the ESPHome logger hook is installed (early boot), we fall through
+// to the original ESP-IDF formatting so boot messages have proper formatting.
+#include <esp_private/log_message.h>
+#include <esp_private/log_print.h>
+#include <esp_private/log_format.h>
+#include <esp_log_write.h>
+
+// Outlined cold path for early boot / constrained environment logging.
+// Uses esp_log_printf/esp_log_vprintf which dispatch to esp_rom_vprintf
+// for constrained environments (same as ESP-IDF's original esp_log_format).
+// Must be in IRAM since it's called from the IRAM esp_log_format during
+// early boot when the scheduler isn't running (constrained_env=1).
+static void IRAM_ATTR __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
+  // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
+  // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
+  // DRAM_ATTR required since this function is in IRAM and can't access flash constants
+  static DRAM_ATTR const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
+  static DRAM_ATTR const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
+  uint8_t level = message->config.opts.log_level;
+#if CONFIG_LIBC_NEWLIB
+  if (!message->config.opts.constrained_env) {
+    flockfile(stdout);
+  }
+#endif
+  if (level > 0 && level < sizeof(lvl)) {
+    esp_log_printf(message->config, "\033[0;3%cm[%c][%s:000]: ", color_digit[level], lvl[level],
+                   message->tag ? message->tag : "esp-idf");
+  }
+  esp_log_vprintf(message->config, message->format, message->args);
+  if (level > 0 && level < sizeof(lvl)) {
+    esp_log_printf(message->config, "\033[0m\n");
+  } else {
+    esp_log_printf(message->config, "\n");
+  }
+#if CONFIG_LIBC_NEWLIB
+  if (!message->config.opts.constrained_env) {
+    funlockfile(stdout);
+  }
+#endif
+}
+
+extern "C" {
+// IRAM_ATTR required because ESP-IDF places esp_log_format in IRAM when
+// CONFIG_LOG_IN_IRAM is enabled, and it may be called from constrained
+// environments (ISR, cache disabled) where flash is inaccessible.
+void IRAM_ATTR esp_log_format(esp_log_msg_t *message) {
+  // Check if ESPHome's vprintf hook is installed by comparing against default.
+  // Before logger init, esp_log_vprint_func == &vprintf (the default).
+  extern vprintf_like_t esp_log_vprint_func;
+  extern int vprintf(const char *, __gnuc_va_list);  // NOLINT
+  if (esp_log_vprint_func == &vprintf || message->config.opts.constrained_env) [[unlikely]] {
+    // Early boot or constrained env (ISR, cache disabled):
+    // use ROM functions only — flash may be inaccessible.
+    esp_log_format_early_(message);
+    return;
+  }
+  // After hook installed, normal environment: skip formatting, forward body only
+  esp_log_vprintf(message->config, message->format, message->args);
+}
+}  // extern "C"
+#endif

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -110,9 +110,16 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 static void IRAM_ATTR __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
   // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
   // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
-  // DRAM_ATTR required since this function is in IRAM and can't access flash constants
+  // DRAM_ATTR required: this function is IRAM_ATTR and may be called from constrained
+  // environments where flash cache is disabled. All string constants must be in DRAM.
+  // ESP-IDF's own log_format_text.c achieves this via linker fragment (noflash), but
+  // our override is in a different compilation unit so we must use DRAM_ATTR explicitly.
   static DRAM_ATTR const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
   static DRAM_ATTR const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
+  static DRAM_ATTR const char fmt_header[] = "\033[0;3%cm[%c][%s:000]: ";
+  static DRAM_ATTR const char fmt_reset_nl[] = "\033[0m\n";
+  static DRAM_ATTR const char fmt_nl[] = "\n";
+  static DRAM_ATTR const char tag_fallback[] = "esp-idf";
   uint8_t level = message->config.opts.log_level;
 #if CONFIG_LIBC_NEWLIB
   if (!message->config.opts.constrained_env) {
@@ -120,14 +127,14 @@ static void IRAM_ATTR __attribute__((noinline)) esp_log_format_early_(esp_log_ms
   }
 #endif
   if (level > 0 && level < sizeof(lvl)) {
-    esp_log_printf(message->config, "\033[0;3%cm[%c][%s:000]: ", color_digit[level], lvl[level],
-                   message->tag ? message->tag : "esp-idf");
+    esp_log_printf(message->config, fmt_header, color_digit[level], lvl[level],
+                   message->tag ? message->tag : tag_fallback);
   }
   esp_log_vprintf(message->config, message->format, message->args);
   if (level > 0 && level < sizeof(lvl)) {
-    esp_log_printf(message->config, "\033[0m\n");
+    esp_log_printf(message->config, fmt_reset_nl);
   } else {
-    esp_log_printf(message->config, "\n");
+    esp_log_printf(message->config, fmt_nl);
   }
 #if CONFIG_LIBC_NEWLIB
   if (!message->config.opts.constrained_env) {

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -96,16 +96,13 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 #include <esp_private/log_message.h>
 #include <esp_log_write.h>
 
-// Outlined cold path for early boot and constrained environment logging.
-// Used before ESPHome's hook is installed (early boot) and for constrained
-// env calls (PHY init, efuse reads) where the ESPHome hook would crash
-// due to fwrite lock issues on USB JTAG devices.
-// Formats messages in ESPHome style with ANSI colors into a 512-byte stack
-// buffer, then outputs atomically via esp_rom_printf.
-// Not IRAM_ATTR — flash is accessible in all cases this is called (cache
-// is enabled; constrained_env is set because the scheduler isn't running
-// or PHY init context, not because flash cache is disabled).
-static void __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
+// Format an ESP-IDF log message directly to the console, bypassing the
+// ESPHome logger hook. Used when the hook isn't installed (early boot) or
+// can't be used safely (constrained env: PHY init, efuse reads — fwrite
+// locks crash on USB JTAG devices).
+// Formats in ESPHome style with ANSI colors into a 512-byte stack buffer,
+// then outputs atomically via esp_rom_printf.
+static void __attribute__((noinline)) esp_log_format_direct_(esp_log_msg_t *message) {
   // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
   // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
   static const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
@@ -153,7 +150,7 @@ void esp_log_format(esp_log_msg_t *message) {
     // where ESP_EARLY_LOGx from ISR also used flash-resident format strings
     // via esp_rom_printf. No ESP-IDF code is known to log from ISR with
     // cache disabled.
-    esp_log_format_early_(message);
+    esp_log_format_direct_(message);
     return;
   }
   // After hook installed, normal environment: skip formatting, forward body only.

--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -88,31 +88,30 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
 }  // namespace esphome
 
 #if defined(USE_ESP32) && !defined(BOOTLOADER_BUILD)
-// Override esp_log_format to disable ESP-IDF's own log formatting so that
-// the vprintf hook receives a single call per message (just the user's format
-// string + args). Without this, Log V2 makes 3 vprintf calls per message
-// (header, body, newline) which fragments the output in ESPHome's logger.
-// This strong definition overrides the archive symbol from ESP-IDF's liblog.
-// It affects all callers including precompiled blobs (e.g. wifi).
-//
-// Before the ESPHome logger hook is installed (early boot), we fall through
-// to the original ESP-IDF formatting so boot messages have proper formatting.
+// Override esp_log_format to prevent V2's 3-call vprintf fragmentation.
+// Without this, Log V2 calls the vprintf hook 3 times per message (header,
+// body, newline) which creates 3 separate log entries in ESPHome's logger.
+// This strong definition overrides the archive symbol from ESP-IDF's liblog,
+// affecting all callers including precompiled blobs (e.g. wifi).
 #include <esp_private/log_message.h>
-#include <esp_private/log_print.h>
-#include <esp_private/log_format.h>
 #include <esp_log_write.h>
 
-// Outlined cold path for early boot logging (before ESPHome hook is installed).
-// Formats messages in ESPHome style with ANSI colors.
-// Not IRAM_ATTR — flash is always accessible during early boot (cache is enabled,
-// constrained_env is set only because the scheduler isn't running yet).
+// Outlined cold path for early boot and constrained environment logging.
+// Used before ESPHome's hook is installed (early boot) and for constrained
+// env calls (PHY init, efuse reads) where the ESPHome hook would crash
+// due to fwrite lock issues on USB JTAG devices.
+// Formats messages in ESPHome style with ANSI colors into a 512-byte stack
+// buffer, then outputs atomically via esp_rom_printf.
+// Not IRAM_ATTR — flash is accessible in all cases this is called (cache
+// is enabled; constrained_env is set because the scheduler isn't running
+// or PHY init context, not because flash cache is disabled).
 static void __attribute__((noinline)) esp_log_format_early_(esp_log_msg_t *message) {
   // ESP-IDF levels: NONE=0 ERROR=1 WARN=2 INFO=3 DEBUG=4 VERBOSE=5
   // Color digits: E=1(red) W=3(yellow) I=2(green) D=6(cyan) V=7(gray)
   static const char color_digit[] = {'\0', '1', '3', '2', '6', '7'};
   static const char lvl[] = {'\0', 'E', 'W', 'I', 'D', 'V'};
-  // Format into stack buffer and output atomically via esp_rom_printf
-  // to prevent interleaving. Can't use fwrite (newlib locks not initialized).
+  // Format into stack buffer and output atomically via esp_rom_printf.
+  // Can't use fwrite (locks crash during early boot and PHY init).
   char buf[512];
   int pos = 0;
   uint8_t level = message->config.opts.log_level;


### PR DESCRIPTION
# What does this implement/fix?

Fixes an intermittent boot hang where approximately 1 in 45 flashes would get stuck after `Disabling RNG early entropy source...` during early boot. This was observed when uploading via USB Serial JTAG, more commonly on ESP32-C6 but also occasionally on ESP32-S3. The root cause is unknown, but the issue has not reproduced since switching to ESP-IDF Log V2.

The original investigation was aimed at reducing flash size by switching to Log V2, but during testing it became clear that V2 also resolved this boot hang — which is far more important than the flash savings.

This PR switches from ESP-IDF Log V1 to V2 (`CONFIG_LOG_VERSION_2`), which centralizes log formatting inside a single `esp_log()` function instead of expanding it at every `ESP_LOGx` macro call site.

ESP-IDF Log V2 documentation: https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html

### Additional benefits

- **~4KB flash savings** from eliminating ~500 per-site macro expansions in ESP-IDF library code (gpio, ethernet, mdns, uart, wifi, etc.)
- **~180 bytes RAM savings**

### How it works

V1 expanded every `ESP_LOGx` call site to:
```c
esp_log_write(level, tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag, ...);
```

V2 replaces this with a single function call:
```c
esp_log(config, tag, format, ...);
```

### Compatibility with ESPHome's vprintf hook

ESP-IDF V2's `esp_log_format()` calls the vprintf hook 3 times per message (header, body, newline), which would fragment output in ESPHome's logger. We override `esp_log_format()` with a strong symbol (replacing the archive symbol from `liblog.a`) to handle three cases:

1. **After ESPHome hook installed (normal operation):** Skip ESP-IDF formatting entirely, forward only the body by calling `esp_log_vprint_func` directly. This also avoids pulling in `esp_rom_vprintf` (1.2KB IRAM on some variants) which would otherwise be referenced through the `esp_log_vprintf` inline.
2. **Early boot (before hook installed):** Format messages in ESPHome style with ANSI colors into a 512-byte stack buffer using `vsnprintf` + `esp_rom_printf`. Can't use `fwrite` (newlib locks not initialized during early boot).
3. **Constrained environment (PHY init, efuse reads):** Also routed through the stack buffer path. V2 routes `ESP_EARLY_LOGx` through `esp_log()` unlike V1 which used `esp_rom_printf` directly at the call site. The ESPHome hook can't be used here because `fwrite` lock acquisition crashes during PHY init on USB JTAG devices.

The `esp_log_format` override is `IRAM_ATTR` to match ESP-IDF's linker fragment placement (`CONFIG_LOG_IN_IRAM`). The early/constrained formatting function is NOT `IRAM_ATTR` — flash is accessible in all cases it's called (cache is enabled; `constrained_env` is set because the scheduler isn't running or PHY init context, not because flash cache is disabled).

ESPHome's own logging (`esph_log_*` macros) is completely unaffected — it uses a separate path through `esp_log_printf_()` and never touches ESP-IDF's logging machinery.

### Note: constrained environment log interleaving

Per ESP-IDF's [Thread Safety](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/log.html#thread-safety) documentation:

> Logging from constrained environments (or for ESP_EARLY_LOGx and ESP_DRAM_LOGx) does not use locking mechanisms, which can lead to rare cases of log corruption if other tasks are logging in parallel.

This is a pre-existing ESP-IDF limitation that applies to both V1 and V2, and is not a regression from this change. It is only visible when the framework `log_level` is set to `DEBUG` — at the default `ERROR` level, these constrained environment messages are compiled out entirely.

### IRAM safety analysis

| Function | Location | IRAM-safe? | Notes |
|---|---|---|---|
| `esp_log_vprint_func` | DRAM | Yes | Global variable, placed by `log_write (noflash)` linker fragment |
| `esp_log_format_early_` | `.flash.text` | No | Only called when flash is accessible (early boot, PHY init) |
| `esp_rom_printf` | ROM | Yes | Actual ROM function, always accessible |
| `vsnprintf` | `.flash.text` | No | Only called from `esp_log_format_early_` (flash accessible) |

### Tested on

- ESP32 (original, dual-core)
- ESP32-S3 (dual-core, USB Serial JTAG)
- ESP32-C3 (single-core)

All with `log_level: DEBUG` to exercise the early boot and constrained environment paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing configuration changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed. V2 is automatically enabled for all ESP-IDF builds.
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).