### PR TITLE
[mipi_dsi] Fix ESP-IDF 6.0 compatibility for use_dma2d flag

### DIFF
--- a/esphome/components/mipi_dsi/mipi_dsi.cpp
+++ b/esphome/components/mipi_dsi/mipi_dsi.cpp
@@ -87,7 +87,9 @@ void MIPI_DSI::setup() {
                                                    .vsync_front_porch = this->vsync_front_porch_,
                                                },
                                            .flags = {
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)
                                                .use_dma2d = true,
+#endif
                                            }};
   // clang-format on
   err = esp_lcd_new_panel_dpi(this->bus_handle_, &dpi_config, &this->handle_);
@@ -95,6 +97,13 @@ void MIPI_DSI::setup() {
     this->smark_failed(LOG_STR("esp_lcd_new_panel_dpi failed"), err);
     return;
   }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  err = esp_lcd_dpi_panel_enable_dma2d(this->handle_);
+  if (err != ESP_OK) {
+    this->smark_failed(LOG_STR("esp_lcd_dpi_panel_enable_dma2d failed"), err);
+    return;
+  }
+#endif
   if (this->reset_pin_ != nullptr) {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(true);


### PR DESCRIPTION
# What does this implement/fix?

The `use_dma2d` flag was removed from `esp_lcd_dpi_panel_config_t` in ESP-IDF 6.0. In IDF 6.0, DMA2D is now controlled via runtime APIs (`esp_lcd_dpi_panel_enable_dma2d()` / `esp_lcd_dpi_panel_disable_dma2d()`) instead of a config struct flag.

This PR:
- Guards `.use_dma2d = true` with `#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0)`
- Calls `esp_lcd_dpi_panel_enable_dma2d()` after panel creation on IDF 6.0+ to maintain the same DMA2D-accelerated frame buffer copy behavior

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed - existing mipi_dsi configs work as before
display:
  - platform: mipi_dsi
    # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).