### PR TITLE
[psram] Fix ESP-IDF 6.0 compatibility for PSRAM sdkconfig options

### DIFF
--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -178,9 +178,6 @@ async def to_code(config):
         if config[CONF_MODE] == TYPE_OCTAL:
             cg.add_platformio_option("board_build.arduino.memory_type", "qio_opi")
 
-    add_idf_sdkconfig_option(
-        f"CONFIG_{get_esp32_variant().upper()}_SPIRAM_SUPPORT", True
-    )
     add_idf_sdkconfig_option("CONFIG_SOC_SPIRAM_SUPPORTED", True)
     add_idf_sdkconfig_option("CONFIG_SPIRAM", True)
     add_idf_sdkconfig_option("CONFIG_SPIRAM_USE", True)
@@ -195,11 +192,19 @@ async def to_code(config):
     speed = int(config[CONF_SPEED][:-3])
     add_idf_sdkconfig_option(f"CONFIG_SPIRAM_SPEED_{speed}M", True)
     add_idf_sdkconfig_option("CONFIG_SPIRAM_SPEED", speed)
-    if config[CONF_MODE] == TYPE_OCTAL and speed == 120:
-        add_idf_sdkconfig_option("CONFIG_ESPTOOLPY_FLASHFREQ_120M", True)
-        if CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] >= cv.Version(5, 4, 0):
+    if speed == 120:
+        variant = get_esp32_variant()
+        # On chips with MSPI timing tuning, FLASH and PSRAM share the core
+        # clock so flash frequency must match PSRAM frequency.
+        # ESP32 and ESP32-S2 don't have this constraint.
+        if variant not in (VARIANT_ESP32, VARIANT_ESP32S2):
+            add_idf_sdkconfig_option("CONFIG_ESPTOOLPY_FLASHFREQ_120M", True)
+        if config[CONF_MODE] == TYPE_OCTAL and CORE.data[KEY_CORE][
+            KEY_FRAMEWORK_VERSION
+        ] >= cv.Version(5, 4, 0):
             add_idf_sdkconfig_option(
-                "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR", True
+                "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR",
+                True,
             )
     if config[CONF_ENABLE_ECC]:
         add_idf_sdkconfig_option("CONFIG_SPIRAM_ECC_ENABLE", True)


### PR DESCRIPTION
# What does this implement/fix?

Two PSRAM sdkconfig fixes:

1. **Remove legacy `CONFIG_{VARIANT}_SPIRAM_SUPPORT` option** — This per-variant option (e.g. `CONFIG_ESP32C5_SPIRAM_SUPPORT`) doesn't exist for newer chips like ESP32-C5 and ESP32-P4. IDF 6.0's stricter kconfig parser crashes on unknown options. The canonical `CONFIG_SPIRAM` (already set) works for all chips, and older chips have sdkconfig rename files that map the legacy names to it.

2. **Set flash frequency to 120MHz when PSRAM is 120MHz** — On chips with MSPI timing tuning (ESP32-S3, ESP32-C5, ESP32-P4, ESP32-C61), FLASH and PSRAM share the core clock register. When both need timing tuning, the expected core clocks must match. Previously `CONFIG_ESPTOOLPY_FLASHFREQ_120M` was only set for octal PSRAM at 120MHz (ESP32-S3 only). ESP32-C5 uses quad PSRAM at 120MHz, causing a static assertion failure. ESP32 and ESP32-S2 are excluded as they don't have this constraint.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
psram:
  speed: 120MHz
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).