### PR TITLE
[tinyusb][usb_cdc_acm] Bump esp_tinyusb to 2.1.1

### DIFF
--- a/esphome/components/tinyusb/__init__.py
+++ b/esphome/components/tinyusb/__init__.py
@@ -54,7 +54,7 @@ async def to_code(config):
     if config[CONF_USB_SERIAL_STR]:
         cg.add(var.set_usb_desc_serial(config[CONF_USB_SERIAL_STR]))
 
-    add_idf_component(name="espressif/esp_tinyusb", ref="1.7.6~1")
+    add_idf_component(name="espressif/esp_tinyusb", ref="2.1.1")
 
     add_idf_sdkconfig_option("CONFIG_TINYUSB_DESC_USE_ESPRESSIF_VID", False)
     add_idf_sdkconfig_option("CONFIG_TINYUSB_DESC_USE_DEFAULT_PID", False)

--- a/esphome/components/tinyusb/tinyusb_component.cpp
+++ b/esphome/components/tinyusb/tinyusb_component.cpp
@@ -16,10 +16,14 @@ void TinyUSB::setup() {
   }
 
   this->tusb_cfg_ = {
-      .descriptor = &this->usb_descriptor_,
-      .string_descriptor = this->string_descriptor_,
-      .string_descriptor_count = SIZE,
-      .external_phy = false,
+      .port = TINYUSB_PORT_FULL_SPEED_0,
+      .phy = {.skip_setup = false},
+      .descriptor =
+          {
+              .device = &this->usb_descriptor_,
+              .string = this->string_descriptor_,
+              .string_count = SIZE,
+          },
   };
 
   esp_err_t result = tinyusb_driver_install(&this->tusb_cfg_);

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.h
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.h
@@ -8,7 +8,7 @@
 
 #include <functional>
 #include "freertos/ringbuf.h"
-#include "tusb_cdc_acm.h"
+#include "tinyusb_cdc_acm.h"
 
 namespace esphome::usb_cdc_acm {
 

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -11,7 +11,7 @@
 #include "esp_log.h"
 
 #include "tusb.h"
-#include "tusb_cdc_acm.h"
+#include "tinyusb_cdc_acm.h"
 
 namespace esphome::usb_cdc_acm {
 
@@ -140,7 +140,6 @@ void USBCDCACMInstance::setup() {
 
   // Configure this CDC interface
   const tinyusb_config_cdcacm_t acm_cfg = {
-      .usb_dev = TINYUSB_USBDEV_0,
       .cdc_port = static_cast<tinyusb_cdcacm_itf_t>(this->itf_),
       .callback_rx = &tinyusb_cdc_rx_callback,
       .callback_rx_wanted_char = NULL,
@@ -148,9 +147,9 @@ void USBCDCACMInstance::setup() {
       .callback_line_coding_changed = &tinyusb_cdc_line_coding_changed_callback,
   };
 
-  esp_err_t result = tusb_cdc_acm_init(&acm_cfg);
+  esp_err_t result = tinyusb_cdcacm_init(&acm_cfg);
   if (result != ESP_OK) {
-    ESP_LOGE(TAG, "tusb_cdc_acm_init failed: %d", result);
+    ESP_LOGE(TAG, "tinyusb_cdcacm_init failed: %d", result);
     this->parent_->mark_failed();
     return;
   }

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -30,7 +30,7 @@ dependencies:
     rules:
       - if: "target in [esp32, esp32p4]"
   espressif/esp_tinyusb:
-    version: "1.7.6~1"
+    version: "2.1.1"
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:


### PR DESCRIPTION
# What does this implement/fix?

Updates `esp_tinyusb` from 1.7.6~1 to 2.1.1. The `usb` IDF component was removed in ESP-IDF 6.0 and `esp_tinyusb` 2.x no longer depends on it. Version 2.1.1 supports IDF >= 5.0.

API migration:
- `tinyusb_config_t`: `.descriptor`/`.string_descriptor`/`.external_phy` replaced with `.port`/`.phy`/`.descriptor` (new sub-struct with `.device`/`.string`/`.string_count`)
- `tinyusb_config_cdcacm_t`: `.usb_dev` field removed (port is now set globally)
- `tusb_cdc_acm_init` renamed to `tinyusb_cdcacm_init`
- `tusb_cdc_acm.h` deprecated, use `tinyusb_cdc_acm.h`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
tinyusb:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).