### PR TITLE
[api] Reduce API code size with buffer and nodelay optimizations

### DIFF
--- a/esphome/components/api/api_buffer.h
+++ b/esphome/components/api/api_buffer.h
@@ -44,6 +44,12 @@ class APIBuffer {
     this->reserve(n);
     this->size_ = n;  // no zero-fill
   }
+  /// Reserve capacity for max(reserve_size, new_size) bytes, then set size to new_size.
+  /// Single grow_ check regardless of argument order.
+  inline void reserve_and_resize(size_t reserve_size, size_t new_size) ESPHOME_ALWAYS_INLINE {
+    this->reserve(std::max(reserve_size, new_size));
+    this->size_ = new_size;
+  }
   uint8_t *data() { return this->data_.get(); }
   const uint8_t *data() const { return this->data_.get(); }
   size_t size() const { return this->size_; }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2025,8 +2025,7 @@ uint16_t APIConnection::encode_to_buffer(uint32_t calculated_size, MessageEncode
     // Batch message second or later
     // Add padding for previous message footer + this message header
     size_t current_size = shared_buf.size();
-    shared_buf.reserve(current_size + total_calculated_size);
-    shared_buf.resize(current_size + footer_size + header_padding);
+    shared_buf.reserve_and_resize(current_size + total_calculated_size, current_size + footer_size + header_padding);
   }
 
   // Pre-resize buffer to include payload, then encode through raw pointer

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -305,9 +305,9 @@ class APIConnection final : public APIServerConnectionBase {
     // Reserve space for header padding + message + footer
     // - Header padding: space for protocol headers (7 bytes for Noise, 6 for Plaintext)
     // - Footer: space for MAC (16 bytes for Noise, 0 for Plaintext)
-    shared_buf.reserve(total_size);
-    // Resize to add header padding so message encoding starts at the correct position
-    shared_buf.resize(header_padding);
+    // Reserve full size but only set initial size to header padding
+    // so message encoding starts at the correct position
+    shared_buf.reserve_and_resize(total_size, header_padding);
   }
 
   // Convenience overload - computes frame overhead internally

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -147,22 +147,18 @@ class APIFrameHelper {
   //
   void set_nodelay_for_message(bool is_log_message) {
     if (!is_log_message) {
-      if (this->nodelay_state_ != NODELAY_ON) {
+      if (this->nodelay_counter_) {
         this->set_nodelay_raw_(true);
-        this->nodelay_state_ = NODELAY_ON;
+        this->nodelay_counter_ = 0;
       }
       return;
     }
-
-    // Log messages: state transitions -1 -> 1 -> ... -> LOG_NAGLE_COUNT -> -1 (flush)
-    if (this->nodelay_state_ == NODELAY_ON) {
+    // Log message: enable Nagle on first, flush after LOG_NAGLE_COUNT
+    if (!this->nodelay_counter_)
       this->set_nodelay_raw_(false);
-      this->nodelay_state_ = 1;
-    } else if (this->nodelay_state_ >= LOG_NAGLE_COUNT) {
+    if (++this->nodelay_counter_ > LOG_NAGLE_COUNT) {
       this->set_nodelay_raw_(true);
-      this->nodelay_state_ = NODELAY_ON;
-    } else {
-      this->nodelay_state_++;
+      this->nodelay_counter_ = 0;
     }
   }
   virtual APIError write_protobuf_packet(uint8_t type, ProtoWriteBuffer buffer) = 0;
@@ -258,18 +254,17 @@ class APIFrameHelper {
   uint8_t tx_buf_head_{0};
   uint8_t tx_buf_tail_{0};
   uint8_t tx_buf_count_{0};
-  // Nagle batching state for log messages. NODELAY_ON (-1) means NODELAY is enabled
-  // (immediate send). Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
-  // After LOG_NAGLE_COUNT logs, we switch to NODELAY to flush and reset.
+  // Nagle batching counter for log messages. 0 means NODELAY is enabled (immediate send).
+  // Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
+  // After LOG_NAGLE_COUNT logs, we flush by re-enabling NODELAY and resetting to 0.
   // ESP8266 has the tightest TCP send buffer (2×MSS) and needs conservative batching.
   // ESP32 (4×MSS+), RP2040 (8×MSS), and LibreTiny (4×MSS) can coalesce more.
-  static constexpr int8_t NODELAY_ON = -1;
 #ifdef USE_ESP8266
-  static constexpr int8_t LOG_NAGLE_COUNT = 2;
+  static constexpr uint8_t LOG_NAGLE_COUNT = 2;
 #else
-  static constexpr int8_t LOG_NAGLE_COUNT = 3;
+  static constexpr uint8_t LOG_NAGLE_COUNT = 3;
 #endif
-  int8_t nodelay_state_{NODELAY_ON};
+  uint8_t nodelay_counter_{0};
 
   // Internal helper to set TCP_NODELAY socket option
   void set_nodelay_raw_(bool enable) {


### PR DESCRIPTION
# What does this implement/fix?

Two small code size optimizations for the API component:

1. **`APIBuffer::reserve_and_resize()`** - New method that performs a single `grow_()` capacity check when `reserve()` is immediately followed by `resize()`. Previously the compiler emitted redundant capacity checks at each call site (~12 bytes each). Applied to `encode_to_buffer()` and `prepare_first_message_buffer()`.

2. **Simplified `set_nodelay_for_message()`** - Replaced the `NODELAY_ON = -1` sentinel-based state machine with a simple counter starting at 0. Reduces branches from 5 to 3 with identical behavior verified by exhaustive testing of all 2^N message sequences up to length 12 for both `LOG_NAGLE_COUNT=2` (ESP8266) and `LOG_NAGLE_COUNT=3` (ESP32/RP2040/LT).

**Measured savings:** 32 bytes flash on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).