### PR TITLE
[core] Widen loop index fields to uint32_t to eliminate truncation

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -157,7 +157,7 @@ void Application::setup() {
   // Components after the last blocking component only got one call() during setup
   // (CONSTRUCTION→SETUP) and never received the second call() (SETUP→LOOP).
   // The main loop calls loop() directly, bypassing call()'s state machine.
-  for (uint16_t i = 0; i < this->looping_components_active_end_; i++) {
+  for (uint32_t i = 0; i < this->looping_components_active_end_; i++) {
     this->looping_components_[i]->set_component_state_(COMPONENT_STATE_LOOP);
   }
 
@@ -424,7 +424,7 @@ void Application::disable_component_loop_(Component *component) {
   // Linear search to find component in active section
   // Most configs have 10-30 looping components (30 is on the high end)
   // O(n) is acceptable here as we optimize for memory, not complexity
-  for (uint16_t i = 0; i < this->looping_components_active_end_; i++) {
+  for (uint32_t i = 0; i < this->looping_components_active_end_; i++) {
     if (this->looping_components_[i] == component) {
       // Move last active component to this position
       this->looping_components_active_end_--;
@@ -448,7 +448,7 @@ void Application::disable_component_loop_(Component *component) {
   }
 }
 
-void Application::activate_looping_component_(uint16_t index) {
+void Application::activate_looping_component_(uint32_t index) {
   // Helper to move component from inactive to active section
   if (index != this->looping_components_active_end_) {
     std::swap(this->looping_components_[index], this->looping_components_[this->looping_components_active_end_]);
@@ -461,8 +461,8 @@ void Application::enable_component_loop_(Component *component) {
   // the component must be in the inactive section (if it exists in looping_components_)
   // Only search the inactive portion for better performance
   // With typical 0-5 inactive components, O(k) is much faster than O(n)
-  const uint16_t size = this->looping_components_.size();
-  for (uint16_t i = this->looping_components_active_end_; i < size; i++) {
+  const uint32_t size = this->looping_components_.size();
+  for (uint32_t i = this->looping_components_active_end_; i < size; i++) {
     if (this->looping_components_[i] == component) {
       // Found in inactive section - move to active
       this->activate_looping_component_(i);
@@ -486,10 +486,10 @@ void Application::enable_pending_loops_() {
   // 4. ISRs can safely set flags at any time - worst case is we process them next iteration
   // 5. The global flag (has_pending_enable_loop_requests_) is cleared before this method,
   //    so any ISR that fires during processing will be caught in the next loop
-  const uint16_t size = this->looping_components_.size();
+  const uint32_t size = this->looping_components_.size();
   bool has_pending = false;
 
-  for (uint16_t i = this->looping_components_active_end_; i < size; i++) {
+  for (uint32_t i = this->looping_components_active_end_; i < size; i++) {
     Component *component = this->looping_components_[i];
     if (!component->pending_enable_loop_) {
       continue;  // Skip components without pending requests

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -604,7 +604,7 @@ class Application {
   void disable_component_loop_(Component *component);
   void enable_component_loop_(Component *component);
   void enable_pending_loops_();
-  void activate_looping_component_(uint16_t index);
+  void activate_looping_component_(uint32_t index);
   void before_loop_tasks_(uint32_t loop_start_time);
   void after_loop_tasks_();
 
@@ -664,6 +664,11 @@ class Application {
   // 4-byte members
   uint32_t last_loop_{0};
   uint32_t loop_component_start_time_{0};
+  uint32_t looping_components_active_end_{0};  // Index marking end of active components in looping_components_
+  uint32_t current_loop_index_{0};             // For safe reentrant modifications during iteration
+#ifdef USE_SETUP_HEAP_STATS
+  uint32_t setup_heap_stats_baseline_{0};
+#endif
 
 #if defined(USE_SOCKET_SELECT_SUPPORT) && !defined(USE_LWIP_FAST_SELECT)
   int max_fd_{-1};  // Highest file descriptor number for select()
@@ -672,8 +677,6 @@ class Application {
   // 2-byte members (grouped together for alignment)
   uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress
   uint16_t loop_interval_{16};                                     // Loop interval in ms (max 65535ms = 65.5 seconds)
-  uint16_t looping_components_active_end_{0};  // Index marking end of active components in looping_components_
-  uint16_t current_loop_index_{0};             // For safe reentrant modifications during iteration
 
   // 1-byte members (grouped together to minimize padding)
   uint8_t app_state_{0};


### PR DESCRIPTION
# What does this implement/fix?

Widen `looping_components_active_end_` and `current_loop_index_` from `uint16_t` to `uint32_t` in `Application`. This eliminates per-component uint16_t truncation instructions that the compiler emits in the main loop body on multiple platforms:

- **ESP32-C3 (RISC-V):** -10 bytes (`slli`+`srli` pair removed)
- **RP2040 (ARM M0+):** -8 bytes (`uxth` removed)
- **ESP32 (Xtensa):** -5 bytes (`extui` removed)

On ESP32 the struct padding absorbs the 4 extra bytes, so there is no RAM or flash cost. Other platforms may see +4 bytes RAM which is negligible.

The truncation was emitted because the compiler had to enforce uint16_t wraparound semantics after each `i++` in the loop — even though no config will ever have 65535 looping components. Using native 32-bit fields matches the register width on all supported platforms and eliminates the unnecessary narrowing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).