### PR TITLE
[openthread] PoC: Action to set pollperiod or linkmode

### DIFF
--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -1,3 +1,4 @@
+from esphome import automation
 import esphome.codegen as cg
 from esphome.components.esp32 import (
     VARIANT_ESP32C5,
@@ -247,3 +248,67 @@ async def to_code(config):
         cg.add(ot.set_output_power(output_power))
 
     set_sdkconfig_options(config)
+
+
+# Actions
+
+# Single field action to set poll period
+OpenThreadComponentPollPeriodAction = openthread_ns.class_(
+    "OpenThreadComponentPollPeriodAction",
+    automation.Action,
+    cg.Parented.template(OpenThreadComponent),
+)
+# Example of combined action
+OpenThreadComponentLinkModeAction = openthread_ns.class_(
+    "OpenThreadComponentLinkModeAction",
+    automation.Action,
+    cg.Parented.template(OpenThreadComponent),
+)
+
+# TODO: Validations (e.g. MTD only)
+
+POLL_PERIOD_ACTION_SCHEMA = automation.maybe_conf(
+    CONF_POLL_PERIOD,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(OpenThreadComponent),
+            cv.Required(CONF_POLL_PERIOD): cv.positive_time_period_milliseconds,
+        }
+    ),
+)
+
+LINK_MODE_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.use_id(OpenThreadComponent),
+        cv.Optional(CONF_POLL_PERIOD): cv.positive_time_period_milliseconds,
+        # Other possible future fields
+    }
+)
+
+
+@automation.register_action(
+    "openthread.pollperiod",
+    OpenThreadComponentPollPeriodAction,
+    POLL_PERIOD_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def openthread_poll_period_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    cg.add(var.set_poll_period(config[CONF_POLL_PERIOD]))
+    return var
+
+
+@automation.register_action(
+    "openthread.linkmode",
+    OpenThreadComponentLinkModeAction,
+    LINK_MODE_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def openthread_link_mode_action_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    if (poll_period := config.get(CONF_POLL_PERIOD)) is not None:
+        cg.add(var.set_poll_period(poll_period))
+    # ...other fields...
+    return var

--- a/esphome/components/openthread/automation.cpp
+++ b/esphome/components/openthread/automation.cpp
@@ -1,0 +1,33 @@
+#include "esphome/core/defines.h"
+
+#ifdef USE_OPENTHREAD
+
+#include "automation.h"
+#include "esphome/core/log.h"
+
+namespace esphome::openthread {
+
+static const char *const TAG = "openthread.automation";
+
+void OpenThreadComponentBaseAction::lock_and_apply_() {
+  if (this->parent_->is_ready()) {
+    if (auto lock = InstanceLock::try_acquire(LOCK_ACQUIRE_TIMEOUT_MS); lock.has_value()) {
+      if (auto *instance = lock->get_instance(); instance != nullptr) {
+        this->apply_locked_(instance);
+      }
+    } else {
+      ESP_LOGW(TAG, "Failed to acquire lock in action");
+    }
+  } else {
+    // Action may trigger early before setup, e.g. due to enabled "restore mode".
+    // Trying to acquire lock would fail!
+    //
+    // But default component values already have been overwritten.
+    // It is sufficient to let component apply those later during setup.
+    ESP_LOGD(TAG, "Not (yet) ready to apply");
+  }
+}
+
+}  // namespace esphome::openthread
+
+#endif

--- a/esphome/components/openthread/automation.h
+++ b/esphome/components/openthread/automation.h
@@ -1,0 +1,83 @@
+#pragma once
+#include "esphome/core/defines.h"
+#ifdef USE_OPENTHREAD
+#include "openthread.h"
+
+#include "esphome/core/automation.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome::openthread {
+
+/** Base class allowing to fetch OpenThread lock from parent component
+ * while applying action
+ *
+ * - Nontemplate aspects belong here to avoid template bloat.
+ * - Subclasses implement virtual action method that is called under lock.
+ * - Seal leaf subclasses via @a final to support devirtualization.
+ */
+class OpenThreadComponentBaseAction : public Parented<OpenThreadComponent> {
+ public:
+  // Enforce ctor with parent argument (not without args)
+  explicit OpenThreadComponentBaseAction(OpenThreadComponent *ot) : Parented<OpenThreadComponent>(ot) {}
+
+ protected:
+  /** Handler to implement in subclass for applying action parts that need lock */
+  virtual void apply_locked_(otInstance *instance) = 0;
+
+  /** Fetch OT lock and then call @a apply_locked_ */
+  void lock_and_apply_();
+
+  /** Timeout (ms) for acquiring OT lock */
+  static constexpr int LOCK_ACQUIRE_TIMEOUT_MS = 100;
+};
+
+/** Action to set single poll period parameter */
+template<typename... Ts>
+class OpenThreadComponentPollPeriodAction final : public Action<Ts...>, public OpenThreadComponentBaseAction {
+  TEMPLATABLE_VALUE(uint32_t, poll_period)
+
+ public:
+  /* Passthrough ctor */
+  using OpenThreadComponentBaseAction::OpenThreadComponentBaseAction;
+
+ protected:
+  void play(const Ts &...x) override {
+#ifdef CONFIG_OPENTHREAD_MTD
+    this->parent_->set_poll_period(this->poll_period_.value(x...));
+
+    this->lock_and_apply_();
+#endif
+  }
+
+  void apply_locked_(otInstance *instance) override { this->parent_->apply_linkmode_locked(instance); }
+};
+
+/** Action to set multiple link mode parameters in one shot */
+template<typename... Ts>
+class OpenThreadComponentLinkModeAction final : public Action<Ts...>, public OpenThreadComponentBaseAction {
+  TEMPLATABLE_VALUE(uint32_t, poll_period)
+  // ... TODO: Other link mode fields ...
+
+ public:
+  /* Passthrough ctor */
+  using OpenThreadComponentBaseAction::OpenThreadComponentBaseAction;
+
+ protected:
+  void play(const Ts &...x) override {
+    // Arbitrary optional fields can be set
+
+#ifdef CONFIG_OPENTHREAD_MTD
+    if (this->poll_period_.has_value()) {
+      this->parent_->set_poll_period(this->poll_period_.value(x...));
+    }
+#endif
+    // ... TODO: Other link mode fields ...
+
+    this->lock_and_apply_();
+  }
+
+  void apply_locked_(otInstance *instance) override { this->parent_->apply_linkmode_locked(instance); }
+};
+
+}  // namespace esphome::openthread
+#endif

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -41,6 +41,11 @@ class OpenThreadComponent : public Component {
 #endif
   void set_output_power(int8_t output_power) { this->output_power_ = output_power; }
 
+  /** Internal: Apply settings for Link Mode incl poll period
+   * @pre Call while holding lock
+   */
+  void apply_linkmode_locked(otInstance *instance);
+
  protected:
   std::optional<otIp6Address> get_omr_address_(InstanceLock &lock);
   static void on_state_changed_(otChangedFlags flags, void *context);

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -108,32 +108,7 @@ void OpenThreadComponent::ot_main() {
 
   ESP_LOGD(TAG, "Thread Version: %" PRIu16, otThreadGetVersion());
 
-  otLinkModeConfig link_mode_config{};
-#if CONFIG_OPENTHREAD_FTD
-  link_mode_config.mRxOnWhenIdle = true;
-  link_mode_config.mDeviceType = true;
-  link_mode_config.mNetworkData = true;
-#elif CONFIG_OPENTHREAD_MTD
-  if (this->poll_period_ > 0) {
-    if (otLinkSetPollPeriod(instance, this->poll_period_) != OT_ERROR_NONE) {
-      ESP_LOGE(TAG, "Failed to set pollperiod");
-    }
-    ESP_LOGD(TAG, "Link Polling Period: %" PRIu32, otLinkGetPollPeriod(instance));
-  }
-  link_mode_config.mRxOnWhenIdle = this->poll_period_ == 0;
-  link_mode_config.mDeviceType = false;
-  link_mode_config.mNetworkData = false;
-#endif
-
-  if (otThreadSetLinkMode(instance, link_mode_config) != OT_ERROR_NONE) {
-    ESP_LOGE(TAG, "Failed to set linkmode");
-  }
-#ifdef ESPHOME_LOG_HAS_DEBUG  // Fetch link mode from OT only when DEBUG
-  link_mode_config = otThreadGetLinkMode(instance);
-  ESP_LOGD(TAG, "Link Mode Device Type: %s, Network Data: %s, RX On When Idle: %s",
-           TRUEFALSE(link_mode_config.mDeviceType), TRUEFALSE(link_mode_config.mNetworkData),
-           TRUEFALSE(link_mode_config.mRxOnWhenIdle));
-#endif
+  this->apply_linkmode_locked(instance);
 
   if (this->output_power_.has_value()) {
     if (const auto err = otPlatRadioSetTransmitPower(instance, *this->output_power_); err != OT_ERROR_NONE) {
@@ -191,6 +166,35 @@ void OpenThreadComponent::ot_main() {
 }
 
 int OpenThreadComponent::openthread_stop_() { return esp_openthread_mainloop_exit(); }
+
+void OpenThreadComponent::apply_linkmode_locked(otInstance *instance) {
+  otLinkModeConfig link_mode_config{};
+#if CONFIG_OPENTHREAD_FTD
+  link_mode_config.mRxOnWhenIdle = true;
+  link_mode_config.mDeviceType = true;
+  link_mode_config.mNetworkData = true;
+#elif CONFIG_OPENTHREAD_MTD
+  if (this->poll_period_ > 0) {
+    if (otLinkSetPollPeriod(instance, this->poll_period_) != OT_ERROR_NONE) {
+      ESP_LOGE(TAG, "Failed to set pollperiod");
+    }
+    ESP_LOGD(TAG, "Link Polling Period: %" PRIu32, otLinkGetPollPeriod(instance));
+  }
+  link_mode_config.mRxOnWhenIdle = this->poll_period_ == 0;
+  link_mode_config.mDeviceType = false;
+  link_mode_config.mNetworkData = false;
+#endif
+
+  if (otThreadSetLinkMode(instance, link_mode_config) != OT_ERROR_NONE) {
+    ESP_LOGE(TAG, "Failed to set linkmode");
+  }
+#ifdef ESPHOME_LOG_HAS_DEBUG  // Fetch link mode from OT only when DEBUG
+  link_mode_config = otThreadGetLinkMode(instance);
+  ESP_LOGD(TAG, "Link Mode Device Type: %s, Network Data: %s, RX On When Idle: %s",
+           TRUEFALSE(link_mode_config.mDeviceType), TRUEFALSE(link_mode_config.mNetworkData),
+           TRUEFALSE(link_mode_config.mRxOnWhenIdle));
+#endif
+}
 
 network::IPAddresses OpenThreadComponent::get_ip_addresses() {
   network::IPAddresses addresses;


### PR DESCRIPTION
# What does this implement/fix?

_Disclaimer/WiP/PoC -- for adding first OT action for setting poll period or link mode_

(based on concept discussion of how to wrap OT action for runtime OT reconfiguration e.g. during OTA)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

  - platform: template
    name: "Radio Short or Long Poll"
    turn_on_action:
      then:
        - openthread.pollperiod: 100ms # SED
    turn_off_action:
      then:
        - openthread.pollperiod: 5s # SED

  - platform: template
    name: "Radio Off or On"
    turn_on_action:
      then:
        - openthread.pollperiod: 0s # MED, always on
    turn_off_action:
      then:
        - openthread.pollperiod: 5s # SED

  - platform: template
    name: "Combi Radio Short or Long Poll"
    turn_on_action:
      then:
        - openthread.linkmode:
            poll_period: 150ms # SED
            # ...
    turn_off_action:
      then:
        - openthread.linkmode:
            poll_period: 8s # SED
            # ...
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
