### PR TITLE
[online_image] Log download duration in milliseconds instead of seconds

### DIFF
--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -129,7 +129,7 @@ void OnlineImage::update() {
   }
 
   ESP_LOGI(TAG, "Downloading image (Size: %zu)", total_size);
-  this->start_time_ = ::time(nullptr);
+  this->start_time_ = millis();
   this->enable_loop();
 }
 
@@ -155,8 +155,8 @@ void OnlineImage::loop() {
     // Finalize decoding
     this->end_decode();
 
-    ESP_LOGD(TAG, "Image fully downloaded, %zu bytes in %" PRIu32 "s", this->downloader_->get_bytes_read(),
-             (uint32_t) (::time(nullptr) - this->start_time_));
+    ESP_LOGD(TAG, "Image fully downloaded, %zu bytes in %" PRIu32 " ms", this->downloader_->get_bytes_read(),
+             millis() - this->start_time_);
 
     // Save caching headers
     this->etag_ = this->downloader_->get_response_header(ETAG_HEADER_NAME);

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -97,7 +97,7 @@ class OnlineImage : public PollingComponent,
    */
   std::string last_modified_ = "";
 
-  time_t start_time_;
+  uint32_t start_time_{0};
 };
 
 template<typename... Ts> class OnlineImageSetUrlAction : public Action<Ts...> {


### PR DESCRIPTION
# What does this implement/fix?

The online_image component logs download times in seconds, but often logs "0s" which isn't that helpful. Millis is more relevant for understanding time spent.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other



## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840


## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
