### PR TITLE
[lis2dh12_base][lis2dh12_i2c] (PR 2/3) Add event detection, orientation, and automation triggers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -284,6 +284,8 @@ esphome/components/libretiny_pwm/* @kuba2k2
 esphome/components/light/* @esphome/core
 esphome/components/lightwaverf/* @max246
 esphome/components/lilygo_t5_47/touchscreen/* @jesserockz
+esphome/components/lis2dh12_base/* @latonita
+esphome/components/lis2dh12_i2c/* @latonita
 esphome/components/lm75b/* @beormund
 esphome/components/ln882x/* @lamauny
 esphome/components/lock/* @esphome/core

--- a/esphome/components/lis2dh12_base/__init__.py
+++ b/esphome/components/lis2dh12_base/__init__.py
@@ -1,0 +1,123 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_CALIBRATION,
+    CONF_HIGH,
+    CONF_ID,
+    CONF_LOW,
+    CONF_MEDIUM,
+    CONF_MIRROR_X,
+    CONF_MIRROR_Y,
+    CONF_OFFSET_X,
+    CONF_OFFSET_Y,
+    CONF_OFFSET_Z,
+    CONF_RANGE,
+    CONF_RESOLUTION,
+    CONF_SWAP_XY,
+    CONF_TRANSFORM,
+)
+
+CODEOWNERS = ["@latonita"]
+
+CONF_LIS2DH12_ID = "lis2dh12_id"
+
+CONF_OUTPUT_DATA_RATE = "output_data_rate"
+CONF_MIRROR_Z = "mirror_z"
+
+lis2dh12_base_ns = cg.esphome_ns.namespace("lis2dh12_base")
+LIS2DH12Component = lis2dh12_base_ns.class_("LIS2DH12Component", cg.PollingComponent)
+
+LIS2DH12Range = lis2dh12_base_ns.enum("Range", True)
+RANGES = {
+    "2G": LIS2DH12Range.RANGE_2G,
+    "4G": LIS2DH12Range.RANGE_4G,
+    "8G": LIS2DH12Range.RANGE_8G,
+    "16G": LIS2DH12Range.RANGE_16G,
+}
+
+LIS2DH12Resolution = lis2dh12_base_ns.enum("Resolution", True)
+RESOLUTIONS = {
+    CONF_HIGH: LIS2DH12Resolution.HIGH_RESOLUTION,
+    CONF_MEDIUM: LIS2DH12Resolution.NORMAL,
+    CONF_LOW: LIS2DH12Resolution.LOW_POWER,
+}
+
+LIS2DH12DataRate = lis2dh12_base_ns.enum("DataRate", True)
+DATA_RATES = {
+    "1Hz": LIS2DH12DataRate.RATE_1HZ,
+    "10Hz": LIS2DH12DataRate.RATE_10HZ,
+    "25Hz": LIS2DH12DataRate.RATE_25HZ,
+    "50Hz": LIS2DH12DataRate.RATE_50HZ,
+    "100Hz": LIS2DH12DataRate.RATE_100HZ,
+    "200Hz": LIS2DH12DataRate.RATE_200HZ,
+    "400Hz": LIS2DH12DataRate.RATE_400HZ,
+    "1620Hz": LIS2DH12DataRate.RATE_1620HZ_LP,
+    "5376Hz": LIS2DH12DataRate.RATE_5376HZ_LP,
+}
+
+CONFIG_SCHEMA_BASE = cv.Schema(
+    {
+        cv.Optional(CONF_RANGE, default="2G"): cv.enum(RANGES, upper=True),
+        cv.Optional(CONF_RESOLUTION, default=CONF_HIGH): cv.enum(
+            RESOLUTIONS, lower=True
+        ),
+        cv.Optional(CONF_OUTPUT_DATA_RATE, default="100Hz"): cv.enum(DATA_RATES),
+        cv.Optional(CONF_CALIBRATION): cv.Schema(
+            {
+                cv.Optional(CONF_OFFSET_X, default=0): cv.float_range(
+                    min=-4.5, max=4.5
+                ),
+                cv.Optional(CONF_OFFSET_Y, default=0): cv.float_range(
+                    min=-4.5, max=4.5
+                ),
+                cv.Optional(CONF_OFFSET_Z, default=0): cv.float_range(
+                    min=-4.5, max=4.5
+                ),
+            }
+        ),
+        cv.Optional(CONF_TRANSFORM): cv.Schema(
+            {
+                cv.Optional(CONF_MIRROR_X, default=False): cv.boolean,
+                cv.Optional(CONF_MIRROR_Y, default=False): cv.boolean,
+                cv.Optional(CONF_MIRROR_Z, default=False): cv.boolean,
+                cv.Optional(CONF_SWAP_XY, default=False): cv.boolean,
+            }
+        ),
+    }
+).extend(cv.polling_component_schema("10s"))
+
+LIS2DH12_SENSOR_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_LIS2DH12_ID): cv.use_id(LIS2DH12Component),
+    }
+)
+
+
+async def to_code_base(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+
+    cg.add(var.set_range(RANGES[config[CONF_RANGE]]))
+    cg.add(var.set_resolution(RESOLUTIONS[config[CONF_RESOLUTION]]))
+    cg.add(var.set_output_data_rate(DATA_RATES[config[CONF_OUTPUT_DATA_RATE]]))
+
+    if transform := config.get(CONF_TRANSFORM):
+        cg.add(
+            var.set_transform(
+                transform[CONF_MIRROR_X],
+                transform[CONF_MIRROR_Y],
+                transform[CONF_MIRROR_Z],
+                transform[CONF_SWAP_XY],
+            )
+        )
+
+    if calibration_config := config.get(CONF_CALIBRATION):
+        cg.add(
+            var.set_offset(
+                calibration_config[CONF_OFFSET_X],
+                calibration_config[CONF_OFFSET_Y],
+                calibration_config[CONF_OFFSET_Z],
+            )
+        )
+
+    return var

--- a/esphome/components/lis2dh12_base/__init__.py
+++ b/esphome/components/lis2dh12_base/__init__.py
@@ -1,3 +1,4 @@
+from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
@@ -23,6 +24,11 @@ CONF_LIS2DH12_ID = "lis2dh12_id"
 
 CONF_OUTPUT_DATA_RATE = "output_data_rate"
 CONF_MIRROR_Z = "mirror_z"
+CONF_ON_ACTIVE = "on_active"
+CONF_ON_DOUBLE_TAP = "on_double_tap"
+CONF_ON_FREEFALL = "on_freefall"
+CONF_ON_ORIENTATION = "on_orientation"
+CONF_ON_TAP = "on_tap"
 
 lis2dh12_base_ns = cg.esphome_ns.namespace("lis2dh12_base")
 LIS2DH12Component = lis2dh12_base_ns.class_("LIS2DH12Component", cg.PollingComponent)
@@ -83,6 +89,11 @@ CONFIG_SCHEMA_BASE = cv.Schema(
                 cv.Optional(CONF_SWAP_XY, default=False): cv.boolean,
             }
         ),
+        cv.Optional(CONF_ON_ACTIVE): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_TAP): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_DOUBLE_TAP): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_FREEFALL): automation.validate_automation(single=True),
+        cv.Optional(CONF_ON_ORIENTATION): automation.validate_automation(single=True),
     }
 ).extend(cv.polling_component_schema("10s"))
 
@@ -119,5 +130,19 @@ async def to_code_base(config):
                 calibration_config[CONF_OFFSET_Z],
             )
         )
+
+    for trigger_key, getter in [
+        (CONF_ON_TAP, "get_tap_trigger"),
+        (CONF_ON_DOUBLE_TAP, "get_double_tap_trigger"),
+        (CONF_ON_FREEFALL, "get_freefall_trigger"),
+        (CONF_ON_ACTIVE, "get_active_trigger"),
+        (CONF_ON_ORIENTATION, "get_orientation_trigger"),
+    ]:
+        if trigger_key in config:
+            await automation.build_automation(
+                getattr(var, getter)(),
+                [],
+                config[trigger_key],
+            )
 
     return var

--- a/esphome/components/lis2dh12_base/binary_sensor.py
+++ b/esphome/components/lis2dh12_base/binary_sensor.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ACTIVE, CONF_NAME, DEVICE_CLASS_VIBRATION, ICON_VIBRATE
+
+from . import CONF_LIS2DH12_ID, LIS2DH12_SENSOR_SCHEMA
+
+CODEOWNERS = ["@latonita"]
+DEPENDENCIES = ["lis2dh12_base"]
+
+CONF_TAP = "tap"
+CONF_DOUBLE_TAP = "double_tap"
+CONF_FREEFALL = "freefall"
+
+ICON_TAP = "mdi:gesture-tap"
+ICON_DOUBLE_TAP = "mdi:gesture-double-tap"
+ICON_FREEFALL = "mdi:parachute"
+
+EVENT_SENSORS = (CONF_TAP, CONF_DOUBLE_TAP, CONF_FREEFALL, CONF_ACTIVE)
+ICONS = (ICON_TAP, ICON_DOUBLE_TAP, ICON_FREEFALL, ICON_VIBRATE)
+
+CONFIG_SCHEMA = LIS2DH12_SENSOR_SCHEMA.extend(
+    {
+        cv.Optional(event): cv.maybe_simple_value(
+            binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_VIBRATION,
+                icon=icon,
+            ),
+            key=CONF_NAME,
+        )
+        for event, icon in zip(EVENT_SENSORS, ICONS)
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS2DH12_ID])
+
+    for sensor_key in EVENT_SENSORS:
+        if sensor_key in config:
+            sens = await binary_sensor.new_binary_sensor(config[sensor_key])
+            cg.add(getattr(hub, f"set_{sensor_key}_binary_sensor")(sens))

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -1,0 +1,424 @@
+#include "lis2dh12_base.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+
+namespace esphome::lis2dh12_base {
+
+static const char *const TAG = "lis2dh12";
+
+static const uint8_t LIS2DH12_WHO_AM_I_VALUE = 0x33;
+static const float GRAVITY_EARTH = 9.80665f;
+
+static const uint32_t TAP_COOLDOWN_MS = 500;
+static const uint32_t DOUBLE_TAP_COOLDOWN_MS = 500;
+static const uint32_t FREEFALL_COOLDOWN_MS = 500;
+static const uint32_t ACTIVITY_COOLDOWN_MS = 500;
+
+// Sensitivity in mg/LSB indexed by Range enum value: 2G=0, 4G=1, 8G=2, 16G=3
+// High-resolution mode (12-bit)
+static const float SENSITIVITY_HR[] = {1.0f, 2.0f, 4.0f, 12.0f};
+// Normal mode (10-bit)
+static const float SENSITIVITY_NM[] = {4.0f, 8.0f, 16.0f, 48.0f};
+// Low-power mode (8-bit)
+static const float SENSITIVITY_LP[] = {16.0f, 32.0f, 64.0f, 192.0f};
+
+static const LogString *resolution_to_string(Resolution res) {
+  switch (res) {
+    case Resolution::HIGH_RESOLUTION:
+      return LOG_STR("High Resolution (12-bit)");
+    case Resolution::NORMAL:
+      return LOG_STR("Normal (10-bit)");
+    case Resolution::LOW_POWER:
+      return LOG_STR("Low Power (8-bit)");
+    default:
+      return LOG_STR("Unknown");
+  }
+}
+
+static const LogString *range_to_string(Range range) {
+  switch (range) {
+    case Range::RANGE_2G:
+      return LOG_STR("±2g");
+    case Range::RANGE_4G:
+      return LOG_STR("±4g");
+    case Range::RANGE_8G:
+      return LOG_STR("±8g");
+    case Range::RANGE_16G:
+      return LOG_STR("±16g");
+    default:
+      return LOG_STR("Unknown");
+  }
+}
+
+static const LogString *data_rate_to_string(DataRate rate) {
+  switch (rate) {
+    case DataRate::RATE_POWER_DOWN:
+      return LOG_STR("Power Down");
+    case DataRate::RATE_1HZ:
+      return LOG_STR("1 Hz");
+    case DataRate::RATE_10HZ:
+      return LOG_STR("10 Hz");
+    case DataRate::RATE_25HZ:
+      return LOG_STR("25 Hz");
+    case DataRate::RATE_50HZ:
+      return LOG_STR("50 Hz");
+    case DataRate::RATE_100HZ:
+      return LOG_STR("100 Hz");
+    case DataRate::RATE_200HZ:
+      return LOG_STR("200 Hz");
+    case DataRate::RATE_400HZ:
+      return LOG_STR("400 Hz");
+    case DataRate::RATE_1620HZ_LP:
+      return LOG_STR("1620 Hz (LP)");
+    case DataRate::RATE_5376HZ_LP:
+      return LOG_STR("5376 Hz (LP) / 1344 Hz (NM/HR)");
+    default:
+      return LOG_STR("Unknown");
+  }
+}
+
+void LIS2DH12Component::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up LIS2DH12...");
+
+  // Verify WHO_AM_I
+  uint8_t who_am_i{0};
+  if (!this->read_byte(static_cast<uint8_t>(RegisterMap::WHO_AM_I), &who_am_i) || who_am_i != LIS2DH12_WHO_AM_I_VALUE) {
+    ESP_LOGE(TAG, "WHO_AM_I check failed. Got 0x%02X, expected 0x%02X", who_am_i, LIS2DH12_WHO_AM_I_VALUE);
+    this->mark_failed();
+    return;
+  }
+
+  // Reboot memory content (CTRL_REG5 bit 7)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG5), 0x80)) {
+    ESP_LOGE(TAG, "Reboot failed");
+    this->mark_failed();
+    return;
+  }
+  delay(5);  // NOLINT - wait for reboot to complete
+
+  if (!this->configure_registers_()) {
+    ESP_LOGE(TAG, "Register configuration failed");
+    this->mark_failed();
+    return;
+  }
+
+  // Set sensitivity based on range and resolution
+  uint8_t range_idx = static_cast<uint8_t>(this->range_);
+  switch (this->resolution_) {
+    case Resolution::HIGH_RESOLUTION:
+      this->sensitivity_ = SENSITIVITY_HR[range_idx];
+      break;
+    case Resolution::NORMAL:
+      this->sensitivity_ = SENSITIVITY_NM[range_idx];
+      break;
+    case Resolution::LOW_POWER:
+      this->sensitivity_ = SENSITIVITY_LP[range_idx];
+      break;
+  }
+}
+
+bool LIS2DH12Component::configure_registers_() {
+  // CTRL_REG1: ODR[7:4] + LPen[3] + Zen[2] + Yen[1] + Xen[0]
+  uint8_t ctrl1 = (static_cast<uint8_t>(this->data_rate_) << 4) | 0x07;  // all axes enabled
+  if (this->resolution_ == Resolution::LOW_POWER) {
+    ctrl1 |= 0x08;  // LPen=1
+  }
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG1), ctrl1)) {
+    return false;
+  }
+
+  // CTRL_REG3: I1_CLICK=1 (bit 7), I1_IA1=1 (bit 6)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG3), 0xC0)) {
+    return false;
+  }
+
+  // CTRL_REG4: BDU[7]=1 + FS[5:4] + HR[3]
+  uint8_t ctrl4 = 0x80;  // BDU=1
+  ctrl4 |= (static_cast<uint8_t>(this->range_) << 4);
+  if (this->resolution_ == Resolution::HIGH_RESOLUTION) {
+    ctrl4 |= 0x08;  // HR=1
+  }
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG4), ctrl4)) {
+    return false;
+  }
+
+  // CTRL_REG5: LIR_INT1=1 (bit 3) - latch interrupt on INT1
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG5), 0x08)) {
+    return false;
+  }
+
+  // CLICK_CFG: XS=1, XD=1, YS=1, YD=1, ZS=1, ZD=1 (all axes, single+double)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CLICK_CFG), 0x3F)) {
+    return false;
+  }
+
+  // CLICK_THS: LIR_CLICK[7]=1, THS[6:0]=0x30
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CLICK_THS), 0xB0)) {
+    return false;
+  }
+
+  // TIME_LIMIT
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::TIME_LIMIT), 0x10)) {
+    return false;
+  }
+
+  // TIME_LATENCY
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::TIME_LATENCY), 0x20)) {
+    return false;
+  }
+
+  // TIME_WINDOW
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::TIME_WINDOW), 0x40)) {
+    return false;
+  }
+
+  // INT1_CFG: 6D=1, ZHIE=1, ZLIE=1, YHIE=1, YLIE=1, XHIE=1, XLIE=1
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_CFG), 0x7F)) {
+    return false;
+  }
+
+  // INT1_THS
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_THS), 0x10)) {
+    return false;
+  }
+
+  // INT1_DURATION
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_DURATION), 0x00)) {
+    return false;
+  }
+
+  // ACT_THS
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::ACT_THS), 0x04)) {
+    return false;
+  }
+
+  // ACT_DUR
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::ACT_DUR), 0x02)) {
+    return false;
+  }
+
+  return true;
+}
+
+void LIS2DH12Component::dump_config() {
+  ESP_LOGCONFIG(TAG, "LIS2DH12:");
+  if (this->is_failed()) {
+    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
+  }
+  ESP_LOGCONFIG(TAG,
+                "  Resolution: %s\n"
+                "  Data Rate: %s\n"
+                "  Range: %s\n"
+                "  Offsets: {%.3f m/s\xC2\xB2, %.3f m/s\xC2\xB2, %.3f m/s\xC2\xB2}\n"
+                "  Transform: {mirror_x=%s, mirror_y=%s, mirror_z=%s, swap_xy=%s}",
+                LOG_STR_ARG(resolution_to_string(this->resolution_)),
+                LOG_STR_ARG(data_rate_to_string(this->data_rate_)), LOG_STR_ARG(range_to_string(this->range_)),
+                this->offset_x_, this->offset_y_, this->offset_z_, YESNO(this->mirror_x_), YESNO(this->mirror_y_),
+                YESNO(this->mirror_z_), YESNO(this->swap_xy_));
+  LOG_UPDATE_INTERVAL(this);
+
+#ifdef USE_BINARY_SENSOR
+  LOG_BINARY_SENSOR("  ", "Tap", this->tap_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Double Tap", this->double_tap_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Freefall", this->freefall_binary_sensor_);
+  LOG_BINARY_SENSOR("  ", "Active", this->active_binary_sensor_);
+#endif
+
+#ifdef USE_SENSOR
+  LOG_SENSOR("  ", "Acceleration X", this->acceleration_x_sensor_);
+  LOG_SENSOR("  ", "Acceleration Y", this->acceleration_y_sensor_);
+  LOG_SENSOR("  ", "Acceleration Z", this->acceleration_z_sensor_);
+#endif
+
+#ifdef USE_TEXT_SENSOR
+  LOG_TEXT_SENSOR("  ", "Orientation", this->orientation_text_sensor_);
+#endif
+}
+
+bool LIS2DH12Component::read_acceleration_data_() {
+  uint8_t accel_data[6];
+  if (!this->read_bytes(static_cast<uint8_t>(RegisterMap::OUT_X_L), accel_data, 6)) {
+    return false;
+  }
+
+  int16_t raw_x = static_cast<int16_t>((accel_data[1] << 8) | accel_data[0]);
+  int16_t raw_y = static_cast<int16_t>((accel_data[3] << 8) | accel_data[2]);
+  int16_t raw_z = static_cast<int16_t>((accel_data[5] << 8) | accel_data[4]);
+
+  switch (this->resolution_) {
+    case Resolution::HIGH_RESOLUTION:
+      raw_x >>= 4;
+      raw_y >>= 4;
+      raw_z >>= 4;
+      break;
+    case Resolution::NORMAL:
+      raw_x >>= 6;
+      raw_y >>= 6;
+      raw_z >>= 6;
+      break;
+    case Resolution::LOW_POWER:
+      raw_x >>= 8;
+      raw_y >>= 8;
+      raw_z >>= 8;
+      break;
+  }
+
+  if (this->swap_xy_) {
+    std::swap(raw_x, raw_y);
+  }
+  if (this->mirror_x_) {
+    raw_x = -raw_x;
+  }
+  if (this->mirror_y_) {
+    raw_y = -raw_y;
+  }
+  if (this->mirror_z_) {
+    raw_z = -raw_z;
+  }
+
+  float factor = this->sensitivity_ * 0.001f * GRAVITY_EARTH;
+  this->data_.x = raw_x * factor + this->offset_x_;
+  this->data_.y = raw_y * factor + this->offset_y_;
+  this->data_.z = raw_z * factor + this->offset_z_;
+
+  return true;
+}
+
+bool LIS2DH12Component::read_interrupt_status_() {
+  uint8_t click_src = 0;
+  uint8_t int1_src = 0;
+  bool ok = this->read_byte(static_cast<uint8_t>(RegisterMap::CLICK_SRC), &click_src);
+  ok = this->read_byte(static_cast<uint8_t>(RegisterMap::INT1_SRC), &int1_src) && ok;
+  if (!ok) {
+    this->status_.click.raw = 0;
+    this->status_.int1.raw = 0;
+    return false;
+  }
+  this->status_.click.raw = click_src;
+  this->status_.int1.raw = int1_src;
+  return true;
+}
+
+const char *LIS2DH12Component::get_orientation_string_() {
+  if (this->status_.int1.xh)
+    return "X Up";
+  if (this->status_.int1.xl)
+    return "X Down";
+  if (this->status_.int1.yh)
+    return "Y Up";
+  if (this->status_.int1.yl)
+    return "Y Down";
+  if (this->status_.int1.zh)
+    return "Z Up";
+  if (this->status_.int1.zl)
+    return "Z Down";
+  return "Unknown";
+}
+
+static void binary_event_debounce(bool state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger, uint32_t cooldown_ms,
+                                  void *bs, const char *desc) {
+  if (state && now - last_ms > cooldown_ms) {
+    ESP_LOGV(TAG, "%s detected", desc);
+    trigger.trigger();
+    last_ms = now;
+#ifdef USE_BINARY_SENSOR
+    if (bs != nullptr) {
+      static_cast<binary_sensor::BinarySensor *>(bs)->publish_state(true);
+    }
+#endif
+  } else if (!state && now - last_ms > cooldown_ms && bs != nullptr) {
+#ifdef USE_BINARY_SENSOR
+    static_cast<binary_sensor::BinarySensor *>(bs)->publish_state(false);
+#endif
+  }
+}
+
+#ifdef USE_BINARY_SENSOR
+#define BS_OPTIONAL_PTR(x) ((void *) (x))
+#else
+#define BS_OPTIONAL_PTR(x) (nullptr)
+#endif
+
+void LIS2DH12Component::process_events_() {
+  uint32_t now = millis();
+
+  binary_event_debounce(this->status_.click.sclick, now, this->status_.last_tap_ms, this->tap_trigger_, TAP_COOLDOWN_MS,
+                        BS_OPTIONAL_PTR(this->tap_binary_sensor_), "Tap");
+  binary_event_debounce(this->status_.click.dclick, now, this->status_.last_double_tap_ms, this->double_tap_trigger_,
+                        DOUBLE_TAP_COOLDOWN_MS, BS_OPTIONAL_PTR(this->double_tap_binary_sensor_), "Double Tap");
+
+  binary_event_debounce(
+      this->status_.int1.ia && !this->status_.int1.xh && !this->status_.int1.yh && !this->status_.int1.zh, now,
+      this->status_.last_freefall_ms, this->freefall_trigger_, FREEFALL_COOLDOWN_MS,
+      BS_OPTIONAL_PTR(this->freefall_binary_sensor_), "Freefall");
+  binary_event_debounce(
+      this->status_.int1.ia && (this->status_.int1.xh || this->status_.int1.yh || this->status_.int1.zh), now,
+      this->status_.last_active_ms, this->active_trigger_, ACTIVITY_COOLDOWN_MS,
+      BS_OPTIONAL_PTR(this->active_binary_sensor_), "Activity");
+
+  if (this->status_.int1.ia && this->status_.int1.raw != this->status_.int1_old.raw) {
+    ESP_LOGVV(TAG, "Orientation changed");
+    this->orientation_trigger_.trigger();
+  }
+}
+
+void LIS2DH12Component::loop() {
+  if (!this->is_ready()) {
+    return;
+  }
+
+  if (!this->read_interrupt_status_()) {
+    this->status_set_warning();
+    return;
+  }
+  this->process_events_();
+}
+
+void LIS2DH12Component::update() {
+  if (!this->is_ready()) {
+    return;
+  }
+
+  if (!this->read_acceleration_data_()) {
+    this->status_set_warning();
+    return;
+  }
+
+  ESP_LOGV(TAG, "Acceleration: {x = %+1.3f m/s\xC2\xB2, y = %+1.3f m/s\xC2\xB2, z = %+1.3f m/s\xC2\xB2}", this->data_.x,
+           this->data_.y, this->data_.z);
+
+#ifdef USE_SENSOR
+  if (this->acceleration_x_sensor_ != nullptr)
+    this->acceleration_x_sensor_->publish_state(this->data_.x);
+  if (this->acceleration_y_sensor_ != nullptr)
+    this->acceleration_y_sensor_->publish_state(this->data_.y);
+  if (this->acceleration_z_sensor_ != nullptr)
+    this->acceleration_z_sensor_->publish_state(this->data_.z);
+#endif
+
+#ifdef USE_TEXT_SENSOR
+  if (this->orientation_text_sensor_ != nullptr &&
+      (this->status_.int1.raw != this->status_.int1_old.raw || this->status_.never_published)) {
+    this->orientation_text_sensor_->publish_state(this->get_orientation_string_());
+    this->status_.int1_old = this->status_.int1;
+  }
+#endif
+
+  this->status_.never_published = false;
+  this->status_clear_warning();
+}
+
+void LIS2DH12Component::set_offset(float offset_x, float offset_y, float offset_z) {
+  this->offset_x_ = offset_x;
+  this->offset_y_ = offset_y;
+  this->offset_z_ = offset_z;
+}
+
+void LIS2DH12Component::set_transform(bool mirror_x, bool mirror_y, bool mirror_z, bool swap_xy) {
+  this->mirror_x_ = mirror_x;
+  this->mirror_y_ = mirror_y;
+  this->mirror_z_ = mirror_z;
+  this->swap_xy_ = swap_xy;
+}
+
+}  // namespace esphome::lis2dh12_base

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -129,8 +129,9 @@ bool LIS2DH12Component::configure_registers_() {
     return false;
   }
 
-  // INT1_CFG: 6D=1, ZHIE=1, ZLIE=1, YHIE=1, YLIE=1, XHIE=1, XLIE=1
-  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_CFG), 0x7F)) {
+  // INT1_CFG: AOI=1, 6D=1 → 6D position recognition (active while in known position)
+  // ZHIE=1, ZLIE=1, YHIE=1, YLIE=1, XHIE=1, XLIE=1
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_CFG), 0xFF)) {
     return false;
   }
 

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -295,45 +295,41 @@ const char *LIS2DH12Component::get_orientation_string_() {
   return "Unknown";
 }
 
-static void binary_event_debounce(bool state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger, uint16_t cooldown_ms,
-                                  void *bs, const char *desc) {
+static void trigger_with_cooldown(bool state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger, uint16_t cooldown_ms,
+                                  const char *desc) {
   if (state && now - last_ms > cooldown_ms) {
     ESP_LOGV(TAG, "%s detected", desc);
     trigger.trigger();
     last_ms = now;
-#ifdef USE_BINARY_SENSOR
-    if (bs != nullptr) {
-      static_cast<binary_sensor::BinarySensor *>(bs)->publish_state(true);
-    }
-#endif
-  } else if (!state && now - last_ms > cooldown_ms && bs != nullptr) {
-#ifdef USE_BINARY_SENSOR
-    static_cast<binary_sensor::BinarySensor *>(bs)->publish_state(false);
-#endif
   }
 }
-
-#ifdef USE_BINARY_SENSOR
-#define BS_OPTIONAL_PTR(x) ((void *) (x))
-#else
-#define BS_OPTIONAL_PTR(x) (nullptr)
-#endif
 
 void LIS2DH12Component::process_events_() {
   uint32_t now = millis();
 
-  binary_event_debounce(this->status_.click.sclick, now, this->status_.last_tap_ms, this->tap_trigger_,
-                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->tap_binary_sensor_), "Tap");
-  binary_event_debounce(this->status_.click.dclick, now, this->status_.last_double_tap_ms, this->double_tap_trigger_,
-                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->double_tap_binary_sensor_), "Double Tap");
+  bool tap = this->status_.click.sclick;
+  bool double_tap = this->status_.click.dclick;
+  bool freefall = this->status_.int2.ia;
+  bool active = this->status_.click.ia || this->status_.int1.raw != this->status_.int1_old.raw;
 
-  // Freefall: INT2 configured as AOI=1 with low bits only → all axes below threshold
-  binary_event_debounce(this->status_.int2.ia, now, this->status_.last_freefall_ms, this->freefall_trigger_,
-                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->freefall_binary_sensor_), "Freefall");
-  // Activity: click or orientation change detected (device is being moved)
-  binary_event_debounce(this->status_.click.ia || this->status_.int1.raw != this->status_.int1_old.raw, now,
-                        this->status_.last_active_ms, this->active_trigger_, EVENT_COOLDOWN_MS,
-                        BS_OPTIONAL_PTR(this->active_binary_sensor_), "Activity");
+  trigger_with_cooldown(tap, now, this->status_.last_tap_ms, this->tap_trigger_, EVENT_COOLDOWN_MS, "Tap");
+  trigger_with_cooldown(double_tap, now, this->status_.last_double_tap_ms, this->double_tap_trigger_, EVENT_COOLDOWN_MS,
+                        "Double Tap");
+  trigger_with_cooldown(freefall, now, this->status_.last_freefall_ms, this->freefall_trigger_, EVENT_COOLDOWN_MS,
+                        "Freefall");
+  trigger_with_cooldown(active, now, this->status_.last_active_ms, this->active_trigger_, EVENT_COOLDOWN_MS,
+                        "Activity");
+
+#ifdef USE_BINARY_SENSOR
+  if (this->tap_binary_sensor_)
+    this->tap_binary_sensor_->publish_state(tap);
+  if (this->double_tap_binary_sensor_)
+    this->double_tap_binary_sensor_->publish_state(double_tap);
+  if (this->freefall_binary_sensor_)
+    this->freefall_binary_sensor_->publish_state(freefall);
+  if (this->active_binary_sensor_)
+    this->active_binary_sensor_->publish_state(active);
+#endif
 
   if (this->status_.int1.ia && this->status_.int1.raw != this->status_.int1_old.raw) {
     ESP_LOGVV(TAG, "Orientation changed");

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "esphome/core/progmem.h"
 
 namespace esphome::lis2dh12_base {
 

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -1,5 +1,6 @@
 #include "lis2dh12_base.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
 namespace esphome::lis2dh12_base {
@@ -9,96 +10,52 @@ static const char *const TAG = "lis2dh12";
 static const uint8_t LIS2DH12_WHO_AM_I_VALUE = 0x33;
 static const float GRAVITY_EARTH = 9.80665f;
 
-static const uint32_t TAP_COOLDOWN_MS = 500;
-static const uint32_t DOUBLE_TAP_COOLDOWN_MS = 500;
-static const uint32_t FREEFALL_COOLDOWN_MS = 500;
-static const uint32_t ACTIVITY_COOLDOWN_MS = 500;
+static const uint16_t EVENT_COOLDOWN_MS = 500;
 
 // Sensitivity in mg/LSB indexed by Range enum value: 2G=0, 4G=1, 8G=2, 16G=3
-// High-resolution mode (12-bit)
-static const float SENSITIVITY_HR[] = {1.0f, 2.0f, 4.0f, 12.0f};
-// Normal mode (10-bit)
-static const float SENSITIVITY_NM[] = {4.0f, 8.0f, 16.0f, 48.0f};
-// Low-power mode (8-bit)
-static const float SENSITIVITY_LP[] = {16.0f, 32.0f, 64.0f, 192.0f};
+constexpr float SENSITIVITY_HR[] PROGMEM = {1.0f, 2.0f, 4.0f, 12.0f};      // High-resolution (12-bit)
+constexpr float SENSITIVITY_NM[] PROGMEM = {4.0f, 8.0f, 16.0f, 48.0f};     // Normal (10-bit)
+constexpr float SENSITIVITY_LP[] PROGMEM = {16.0f, 32.0f, 64.0f, 192.0f};  // Low-power (8-bit)
+
+PROGMEM_STRING_TABLE(ResolutionStrings, "High Resolution (12-bit)", "Normal (10-bit)", "Low Power (8-bit)", "Unknown");
 
 static const LogString *resolution_to_string(Resolution res) {
-  switch (res) {
-    case Resolution::HIGH_RESOLUTION:
-      return LOG_STR("High Resolution (12-bit)");
-    case Resolution::NORMAL:
-      return LOG_STR("Normal (10-bit)");
-    case Resolution::LOW_POWER:
-      return LOG_STR("Low Power (8-bit)");
-    default:
-      return LOG_STR("Unknown");
-  }
+  return ResolutionStrings::get_log_str(static_cast<uint8_t>(res), ResolutionStrings::LAST_INDEX);
 }
+
+PROGMEM_STRING_TABLE(RangeStrings, "±2g", "±4g", "±8g", "±16g", "±??g");
 
 static const LogString *range_to_string(Range range) {
-  switch (range) {
-    case Range::RANGE_2G:
-      return LOG_STR("±2g");
-    case Range::RANGE_4G:
-      return LOG_STR("±4g");
-    case Range::RANGE_8G:
-      return LOG_STR("±8g");
-    case Range::RANGE_16G:
-      return LOG_STR("±16g");
-    default:
-      return LOG_STR("Unknown");
-  }
+  return RangeStrings::get_log_str(static_cast<uint8_t>(range), RangeStrings::LAST_INDEX);
 }
 
+PROGMEM_STRING_TABLE(DataRateStrings, "Power Down", "1 Hz", "10 Hz", "25 Hz", "50 Hz", "100 Hz", "200 Hz", "400 Hz",
+                     "1620 Hz (LP)", "5376 Hz (LP) / 1344 Hz (NM/HR)", "Unknown");
+
 static const LogString *data_rate_to_string(DataRate rate) {
-  switch (rate) {
-    case DataRate::RATE_POWER_DOWN:
-      return LOG_STR("Power Down");
-    case DataRate::RATE_1HZ:
-      return LOG_STR("1 Hz");
-    case DataRate::RATE_10HZ:
-      return LOG_STR("10 Hz");
-    case DataRate::RATE_25HZ:
-      return LOG_STR("25 Hz");
-    case DataRate::RATE_50HZ:
-      return LOG_STR("50 Hz");
-    case DataRate::RATE_100HZ:
-      return LOG_STR("100 Hz");
-    case DataRate::RATE_200HZ:
-      return LOG_STR("200 Hz");
-    case DataRate::RATE_400HZ:
-      return LOG_STR("400 Hz");
-    case DataRate::RATE_1620HZ_LP:
-      return LOG_STR("1620 Hz (LP)");
-    case DataRate::RATE_5376HZ_LP:
-      return LOG_STR("5376 Hz (LP) / 1344 Hz (NM/HR)");
-    default:
-      return LOG_STR("Unknown");
-  }
+  return DataRateStrings::get_log_str(static_cast<uint8_t>(rate), DataRateStrings::LAST_INDEX);
 }
 
 void LIS2DH12Component::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up LIS2DH12...");
+  ESP_LOGV(TAG, "Setting up LIS2DH12");
 
   // Verify WHO_AM_I
   uint8_t who_am_i{0};
   if (!this->read_byte(static_cast<uint8_t>(RegisterMap::WHO_AM_I), &who_am_i) || who_am_i != LIS2DH12_WHO_AM_I_VALUE) {
-    ESP_LOGE(TAG, "WHO_AM_I check failed. Got 0x%02X, expected 0x%02X", who_am_i, LIS2DH12_WHO_AM_I_VALUE);
-    this->mark_failed();
+    ESP_LOGD(TAG, "Expected Chip ID 0x%02X, got 0x%02X", LIS2DH12_WHO_AM_I_VALUE, who_am_i);
+    this->mark_failed(LOG_STR("Unknown Chip ID"));
     return;
   }
 
   // Reboot memory content (CTRL_REG5 bit 7)
   if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG5), 0x80)) {
-    ESP_LOGE(TAG, "Reboot failed");
-    this->mark_failed();
+    this->mark_failed(LOG_STR("Reboot failed"));
     return;
   }
   delay(5);  // NOLINT - wait for reboot to complete
 
   if (!this->configure_registers_()) {
-    ESP_LOGE(TAG, "Register configuration failed");
-    this->mark_failed();
+    this->mark_failed(LOG_STR("Register config failed"));
     return;
   }
 
@@ -177,13 +134,13 @@ bool LIS2DH12Component::configure_registers_() {
     return false;
   }
 
-  // INT1_THS
-  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_THS), 0x10)) {
+  // INT1_THS: ~60° threshold (0x36 = 54×16mg = 864mg ≈ sin(60°)×1g)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_THS), 0x36)) {
     return false;
   }
 
-  // INT1_DURATION
-  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_DURATION), 0x00)) {
+  // INT1_DURATION: 240ms debounce at 25Hz (6×1/25Hz) per ST DT0097
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_DURATION), 0x06)) {
     return false;
   }
 
@@ -202,9 +159,6 @@ bool LIS2DH12Component::configure_registers_() {
 
 void LIS2DH12Component::dump_config() {
   ESP_LOGCONFIG(TAG, "LIS2DH12:");
-  if (this->is_failed()) {
-    ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-  }
   ESP_LOGCONFIG(TAG,
                 "  Resolution: %s\n"
                 "  Data Rate: %s\n"
@@ -241,9 +195,9 @@ bool LIS2DH12Component::read_acceleration_data_() {
     return false;
   }
 
-  int16_t raw_x = static_cast<int16_t>((accel_data[1] << 8) | accel_data[0]);
-  int16_t raw_y = static_cast<int16_t>((accel_data[3] << 8) | accel_data[2]);
-  int16_t raw_z = static_cast<int16_t>((accel_data[5] << 8) | accel_data[4]);
+  int16_t raw_x = static_cast<int16_t>(encode_uint16(accel_data[1], accel_data[0]));
+  int16_t raw_y = static_cast<int16_t>(encode_uint16(accel_data[3], accel_data[2]));
+  int16_t raw_z = static_cast<int16_t>(encode_uint16(accel_data[5], accel_data[4]));
 
   switch (this->resolution_) {
     case Resolution::HIGH_RESOLUTION:
@@ -300,22 +254,22 @@ bool LIS2DH12Component::read_interrupt_status_() {
 }
 
 const char *LIS2DH12Component::get_orientation_string_() {
-  if (this->status_.int1.xh)
-    return "X Up";
-  if (this->status_.int1.xl)
-    return "X Down";
-  if (this->status_.int1.yh)
-    return "Y Up";
-  if (this->status_.int1.yl)
-    return "Y Down";
   if (this->status_.int1.zh)
-    return "Z Up";
+    return "Face Up";
   if (this->status_.int1.zl)
-    return "Z Down";
+    return "Face Down";
+  if (this->status_.int1.xh)
+    return "Portrait Up";
+  if (this->status_.int1.xl)
+    return "Portrait Down";
+  if (this->status_.int1.yh)
+    return "Landscape Right";
+  if (this->status_.int1.yl)
+    return "Landscape Left";
   return "Unknown";
 }
 
-static void binary_event_debounce(bool state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger, uint32_t cooldown_ms,
+static void binary_event_debounce(bool state, uint32_t now, uint32_t &last_ms, Trigger<> &trigger, uint16_t cooldown_ms,
                                   void *bs, const char *desc) {
   if (state && now - last_ms > cooldown_ms) {
     ESP_LOGV(TAG, "%s detected", desc);
@@ -342,18 +296,18 @@ static void binary_event_debounce(bool state, uint32_t now, uint32_t &last_ms, T
 void LIS2DH12Component::process_events_() {
   uint32_t now = millis();
 
-  binary_event_debounce(this->status_.click.sclick, now, this->status_.last_tap_ms, this->tap_trigger_, TAP_COOLDOWN_MS,
-                        BS_OPTIONAL_PTR(this->tap_binary_sensor_), "Tap");
+  binary_event_debounce(this->status_.click.sclick, now, this->status_.last_tap_ms, this->tap_trigger_,
+                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->tap_binary_sensor_), "Tap");
   binary_event_debounce(this->status_.click.dclick, now, this->status_.last_double_tap_ms, this->double_tap_trigger_,
-                        DOUBLE_TAP_COOLDOWN_MS, BS_OPTIONAL_PTR(this->double_tap_binary_sensor_), "Double Tap");
+                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->double_tap_binary_sensor_), "Double Tap");
 
   binary_event_debounce(
       this->status_.int1.ia && !this->status_.int1.xh && !this->status_.int1.yh && !this->status_.int1.zh, now,
-      this->status_.last_freefall_ms, this->freefall_trigger_, FREEFALL_COOLDOWN_MS,
+      this->status_.last_freefall_ms, this->freefall_trigger_, EVENT_COOLDOWN_MS,
       BS_OPTIONAL_PTR(this->freefall_binary_sensor_), "Freefall");
   binary_event_debounce(
       this->status_.int1.ia && (this->status_.int1.xh || this->status_.int1.yh || this->status_.int1.zh), now,
-      this->status_.last_active_ms, this->active_trigger_, ACTIVITY_COOLDOWN_MS,
+      this->status_.last_active_ms, this->active_trigger_, EVENT_COOLDOWN_MS,
       BS_OPTIONAL_PTR(this->active_binary_sensor_), "Activity");
 
   if (this->status_.int1.ia && this->status_.int1.raw != this->status_.int1_old.raw) {

--- a/esphome/components/lis2dh12_base/lis2dh12_base.cpp
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.cpp
@@ -100,8 +100,13 @@ bool LIS2DH12Component::configure_registers_() {
     return false;
   }
 
-  // CTRL_REG5: LIR_INT1=1 (bit 3) - latch interrupt on INT1
-  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG5), 0x08)) {
+  // CTRL_REG5: LIR_INT1=1 (bit 3), LIR_INT2=1 (bit 1) - latch both interrupts
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG5), 0x0A)) {
+    return false;
+  }
+
+  // CTRL_REG6: I2_IA2=1 (bit 5) - route INT2 generator to INT2 pin
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::CTRL_REG6), 0x20)) {
     return false;
   }
 
@@ -143,6 +148,21 @@ bool LIS2DH12Component::configure_registers_() {
 
   // INT1_DURATION: 240ms debounce at 25Hz (6×1/25Hz) per ST DT0097
   if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT1_DURATION), 0x06)) {
+    return false;
+  }
+
+  // INT2_CFG: AOI=1, 6D=0, XL=1, YL=1, ZL=1 → freefall (all axes below threshold)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT2_CFG), 0x95)) {
+    return false;
+  }
+
+  // INT2_THS: freefall threshold = 350mg (0x16 = 22×16mg = 352mg)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT2_THS), 0x16)) {
+    return false;
+  }
+
+  // INT2_DURATION: 30ms minimum event duration (3/ODR at 100Hz)
+  if (!this->write_byte(static_cast<uint8_t>(RegisterMap::INT2_DURATION), 0x03)) {
     return false;
   }
 
@@ -243,15 +263,19 @@ bool LIS2DH12Component::read_acceleration_data_() {
 bool LIS2DH12Component::read_interrupt_status_() {
   uint8_t click_src = 0;
   uint8_t int1_src = 0;
+  uint8_t int2_src = 0;
   bool ok = this->read_byte(static_cast<uint8_t>(RegisterMap::CLICK_SRC), &click_src);
   ok = this->read_byte(static_cast<uint8_t>(RegisterMap::INT1_SRC), &int1_src) && ok;
+  ok = this->read_byte(static_cast<uint8_t>(RegisterMap::INT2_SRC), &int2_src) && ok;
   if (!ok) {
     this->status_.click.raw = 0;
     this->status_.int1.raw = 0;
+    this->status_.int2.raw = 0;
     return false;
   }
   this->status_.click.raw = click_src;
   this->status_.int1.raw = int1_src;
+  this->status_.int2.raw = int2_src;
   return true;
 }
 
@@ -303,18 +327,23 @@ void LIS2DH12Component::process_events_() {
   binary_event_debounce(this->status_.click.dclick, now, this->status_.last_double_tap_ms, this->double_tap_trigger_,
                         EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->double_tap_binary_sensor_), "Double Tap");
 
-  binary_event_debounce(
-      this->status_.int1.ia && !this->status_.int1.xh && !this->status_.int1.yh && !this->status_.int1.zh, now,
-      this->status_.last_freefall_ms, this->freefall_trigger_, EVENT_COOLDOWN_MS,
-      BS_OPTIONAL_PTR(this->freefall_binary_sensor_), "Freefall");
-  binary_event_debounce(
-      this->status_.int1.ia && (this->status_.int1.xh || this->status_.int1.yh || this->status_.int1.zh), now,
-      this->status_.last_active_ms, this->active_trigger_, EVENT_COOLDOWN_MS,
-      BS_OPTIONAL_PTR(this->active_binary_sensor_), "Activity");
+  // Freefall: INT2 configured as AOI=1 with low bits only → all axes below threshold
+  binary_event_debounce(this->status_.int2.ia, now, this->status_.last_freefall_ms, this->freefall_trigger_,
+                        EVENT_COOLDOWN_MS, BS_OPTIONAL_PTR(this->freefall_binary_sensor_), "Freefall");
+  // Activity: click or orientation change detected (device is being moved)
+  binary_event_debounce(this->status_.click.ia || this->status_.int1.raw != this->status_.int1_old.raw, now,
+                        this->status_.last_active_ms, this->active_trigger_, EVENT_COOLDOWN_MS,
+                        BS_OPTIONAL_PTR(this->active_binary_sensor_), "Activity");
 
   if (this->status_.int1.ia && this->status_.int1.raw != this->status_.int1_old.raw) {
     ESP_LOGVV(TAG, "Orientation changed");
     this->orientation_trigger_.trigger();
+#ifdef USE_TEXT_SENSOR
+    if (this->orientation_text_sensor_ != nullptr) {
+      this->orientation_text_sensor_->publish_state(this->get_orientation_string_());
+    }
+#endif
+    this->status_.int1_old = this->status_.int1;
   }
 }
 
@@ -353,8 +382,7 @@ void LIS2DH12Component::update() {
 #endif
 
 #ifdef USE_TEXT_SENSOR
-  if (this->orientation_text_sensor_ != nullptr &&
-      (this->status_.int1.raw != this->status_.int1_old.raw || this->status_.never_published)) {
+  if (this->orientation_text_sensor_ != nullptr && this->status_.never_published) {
     this->orientation_text_sensor_->publish_state(this->get_orientation_string_());
     this->status_.int1_old = this->status_.int1;
   }

--- a/esphome/components/lis2dh12_base/lis2dh12_base.h
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+#ifdef USE_TEXT_SENSOR
+#include "esphome/components/text_sensor/text_sensor.h"
+#endif
+
+namespace esphome::lis2dh12_base {
+
+// LIS2DH12 Register Map
+enum class RegisterMap : uint8_t {
+  TEMP_CFG_REG = 0x1F,
+  CTRL_REG1 = 0x20,
+  CTRL_REG2 = 0x21,
+  CTRL_REG3 = 0x22,
+  CTRL_REG4 = 0x23,
+  CTRL_REG5 = 0x24,
+  CTRL_REG6 = 0x25,
+  REFERENCE = 0x26,
+  STATUS_REG = 0x27,
+  OUT_X_L = 0x28,
+  OUT_X_H = 0x29,
+  OUT_Y_L = 0x2A,
+  OUT_Y_H = 0x2B,
+  OUT_Z_L = 0x2C,
+  OUT_Z_H = 0x2D,
+  FIFO_CTRL_REG = 0x2E,
+  FIFO_SRC_REG = 0x2F,
+  INT1_CFG = 0x30,
+  INT1_SRC = 0x31,
+  INT1_THS = 0x32,
+  INT1_DURATION = 0x33,
+  INT2_CFG = 0x34,
+  INT2_SRC = 0x35,
+  INT2_THS = 0x36,
+  INT2_DURATION = 0x37,
+  CLICK_CFG = 0x38,
+  CLICK_SRC = 0x39,
+  CLICK_THS = 0x3A,
+  TIME_LIMIT = 0x3B,
+  TIME_LATENCY = 0x3C,
+  TIME_WINDOW = 0x3D,
+  ACT_THS = 0x3E,
+  ACT_DUR = 0x3F,
+  WHO_AM_I = 0x0F,
+};
+
+enum class Range : uint8_t {
+  RANGE_2G = 0b00,
+  RANGE_4G = 0b01,
+  RANGE_8G = 0b10,
+  RANGE_16G = 0b11,
+};
+
+enum class Resolution : uint8_t {
+  HIGH_RESOLUTION = 0,  // 12-bit
+  NORMAL = 1,           // 10-bit
+  LOW_POWER = 2,        // 8-bit
+};
+
+enum class DataRate : uint8_t {
+  RATE_POWER_DOWN = 0b0000,
+  RATE_1HZ = 0b0001,
+  RATE_10HZ = 0b0010,
+  RATE_25HZ = 0b0011,
+  RATE_50HZ = 0b0100,
+  RATE_100HZ = 0b0101,
+  RATE_200HZ = 0b0110,
+  RATE_400HZ = 0b0111,
+  RATE_1620HZ_LP = 0b1000,
+  RATE_5376HZ_LP = 0b1001,
+};
+
+// CLICK_SRC register (0x39)
+union RegClickSrc {
+  struct {
+    bool x : 1;
+    bool y : 1;
+    bool z : 1;
+    bool sign : 1;
+    bool sclick : 1;
+    bool dclick : 1;
+    bool ia : 1;
+    uint8_t reserved : 1;
+  } __attribute__((packed));
+  uint8_t raw{0};
+};
+
+// INT1_SRC register (0x31)
+union RegInt1Src {
+  struct {
+    bool xl : 1;
+    bool xh : 1;
+    bool yl : 1;
+    bool yh : 1;
+    bool zl : 1;
+    bool zh : 1;
+    bool ia : 1;
+    uint8_t reserved : 1;
+  } __attribute__((packed));
+  uint8_t raw{0};
+};
+
+class LIS2DH12Component : public PollingComponent {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+  void update() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void set_resolution(Resolution res) { this->resolution_ = res; }
+  void set_output_data_rate(DataRate rate) { this->data_rate_ = rate; }
+  void set_range(Range range) { this->range_ = range; }
+  void set_offset(float offset_x, float offset_y, float offset_z);
+  void set_transform(bool mirror_x, bool mirror_y, bool mirror_z, bool swap_xy);
+
+#ifdef USE_BINARY_SENSOR
+  SUB_BINARY_SENSOR(tap)
+  SUB_BINARY_SENSOR(double_tap)
+  SUB_BINARY_SENSOR(freefall)
+  SUB_BINARY_SENSOR(active)
+#endif
+
+#ifdef USE_SENSOR
+  SUB_SENSOR(acceleration_x)
+  SUB_SENSOR(acceleration_y)
+  SUB_SENSOR(acceleration_z)
+#endif
+
+#ifdef USE_TEXT_SENSOR
+  SUB_TEXT_SENSOR(orientation)
+#endif
+
+  Trigger<> *get_tap_trigger() { return &this->tap_trigger_; }
+  Trigger<> *get_double_tap_trigger() { return &this->double_tap_trigger_; }
+  Trigger<> *get_freefall_trigger() { return &this->freefall_trigger_; }
+  Trigger<> *get_active_trigger() { return &this->active_trigger_; }
+  Trigger<> *get_orientation_trigger() { return &this->orientation_trigger_; }
+
+  // Bus abstraction - implemented by I2C/SPI variants
+  virtual bool read_byte(uint8_t a_register, uint8_t *data) = 0;
+  virtual bool write_byte(uint8_t a_register, uint8_t data) = 0;
+  virtual bool read_bytes(uint8_t a_register, uint8_t *data, size_t len) = 0;
+
+ protected:
+  Resolution resolution_{Resolution::HIGH_RESOLUTION};
+  DataRate data_rate_{DataRate::RATE_100HZ};
+  Range range_{Range::RANGE_2G};
+  float offset_x_{0}, offset_y_{0}, offset_z_{0};
+  bool mirror_x_{false}, mirror_y_{false}, mirror_z_{false}, swap_xy_{false};
+
+  float sensitivity_{1.0f};  // mg per LSB (HR, 2G default)
+
+  struct {
+    float x, y, z;
+  } data_{};
+
+  struct {
+    RegClickSrc click;
+    RegInt1Src int1;
+    RegInt1Src int1_old;
+
+    uint32_t last_tap_ms{0};
+    uint32_t last_double_tap_ms{0};
+    uint32_t last_freefall_ms{0};
+    uint32_t last_active_ms{0};
+
+    bool never_published{true};
+  } status_{};
+
+  bool configure_registers_();
+  bool read_acceleration_data_();
+  bool read_interrupt_status_();
+  void process_events_();
+  const char *get_orientation_string_();
+
+  Trigger<> tap_trigger_;
+  Trigger<> double_tap_trigger_;
+  Trigger<> freefall_trigger_;
+  Trigger<> active_trigger_;
+  Trigger<> orientation_trigger_;
+};
+
+}  // namespace esphome::lis2dh12_base

--- a/esphome/components/lis2dh12_base/lis2dh12_base.h
+++ b/esphome/components/lis2dh12_base/lis2dh12_base.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "esphome/core/component.h"
 #include "esphome/core/automation.h"
 
@@ -94,8 +96,8 @@ union RegClickSrc {
   uint8_t raw{0};
 };
 
-// INT1_SRC register (0x31)
-union RegInt1Src {
+// INT1_SRC register (0x31) / INT2_SRC register (0x35) — same bit layout
+union RegIntSrc {
   struct {
     bool xl : 1;
     bool xh : 1;
@@ -166,8 +168,9 @@ class LIS2DH12Component : public PollingComponent {
 
   struct {
     RegClickSrc click;
-    RegInt1Src int1;
-    RegInt1Src int1_old;
+    RegIntSrc int1;  // 6D orientation (INT1_SRC)
+    RegIntSrc int1_old;
+    RegIntSrc int2;  // Freefall/activity (INT2_SRC)
 
     uint32_t last_tap_ms{0};
     uint32_t last_double_tap_ms{0};

--- a/esphome/components/lis2dh12_base/sensor.py
+++ b/esphome/components/lis2dh12_base/sensor.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ACCELERATION_X,
+    CONF_ACCELERATION_Y,
+    CONF_ACCELERATION_Z,
+    CONF_NAME,
+    ICON_BRIEFCASE_DOWNLOAD,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_METER_PER_SECOND_SQUARED,
+)
+
+from . import CONF_LIS2DH12_ID, LIS2DH12_SENSOR_SCHEMA
+
+CODEOWNERS = ["@latonita"]
+DEPENDENCIES = ["lis2dh12_base"]
+
+ACCELERATION_SENSORS = (CONF_ACCELERATION_X, CONF_ACCELERATION_Y, CONF_ACCELERATION_Z)
+
+accel_schema = cv.maybe_simple_value(
+    sensor.sensor_schema(
+        unit_of_measurement=UNIT_METER_PER_SECOND_SQUARED,
+        icon=ICON_BRIEFCASE_DOWNLOAD,
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    key=CONF_NAME,
+)
+
+
+CONFIG_SCHEMA = LIS2DH12_SENSOR_SCHEMA.extend(
+    {cv.Optional(sensor): accel_schema for sensor in ACCELERATION_SENSORS}
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS2DH12_ID])
+    for accel_key in ACCELERATION_SENSORS:
+        if accel_key in config:
+            sens = await sensor.new_sensor(config[accel_key])
+            cg.add(getattr(hub, f"set_{accel_key}_sensor")(sens))

--- a/esphome/components/lis2dh12_base/text_sensor.py
+++ b/esphome/components/lis2dh12_base/text_sensor.py
@@ -1,0 +1,29 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_NAME
+
+from . import CONF_LIS2DH12_ID, LIS2DH12_SENSOR_SCHEMA
+
+CODEOWNERS = ["@latonita"]
+DEPENDENCIES = ["lis2dh12_base"]
+
+CONF_ORIENTATION = "orientation"
+ICON_SCREEN_ROTATION = "mdi:screen-rotation"
+
+CONFIG_SCHEMA = LIS2DH12_SENSOR_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ORIENTATION): cv.maybe_simple_value(
+            text_sensor.text_sensor_schema(icon=ICON_SCREEN_ROTATION),
+            key=CONF_NAME,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_LIS2DH12_ID])
+
+    if sensor_config := config.get(CONF_ORIENTATION):
+        var = await text_sensor.new_text_sensor(sensor_config)
+        cg.add(hub.set_orientation_text_sensor(var))

--- a/esphome/components/lis2dh12_i2c/__init__.py
+++ b/esphome/components/lis2dh12_i2c/__init__.py
@@ -1,0 +1,30 @@
+import esphome.codegen as cg
+from esphome.components import i2c
+from esphome.components.lis2dh12_base import (
+    CONFIG_SCHEMA_BASE,
+    LIS2DH12Component,
+    to_code_base,
+)
+import esphome.config_validation as cv
+
+CODEOWNERS = ["@latonita"]
+AUTO_LOAD = ["lis2dh12_base"]
+DEPENDENCIES = ["i2c"]
+
+MULTI_CONF = True
+
+lis2dh12_i2c_ns = cg.esphome_ns.namespace("lis2dh12_i2c")
+LIS2DH12I2CComponent = lis2dh12_i2c_ns.class_(
+    "LIS2DH12I2CComponent", LIS2DH12Component, i2c.I2CDevice
+)
+
+CONFIG_SCHEMA = CONFIG_SCHEMA_BASE.extend(
+    {
+        cv.GenerateID(): cv.declare_id(LIS2DH12I2CComponent),
+    }
+).extend(i2c.i2c_device_schema(0x19))
+
+
+async def to_code(config):
+    var = await to_code_base(config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/lis2dh12_i2c/lis2dh12_i2c.cpp
+++ b/esphome/components/lis2dh12_i2c/lis2dh12_i2c.cpp
@@ -1,0 +1,13 @@
+#include "lis2dh12_i2c.h"
+#include "esphome/core/log.h"
+
+namespace esphome::lis2dh12_i2c {
+
+static const char *const TAG = "lis2dh12_i2c";
+
+void LIS2DH12I2CComponent::dump_config() {
+  LOG_I2C_DEVICE(this);
+  lis2dh12_base::LIS2DH12Component::dump_config();
+}
+
+}  // namespace esphome::lis2dh12_i2c

--- a/esphome/components/lis2dh12_i2c/lis2dh12_i2c.h
+++ b/esphome/components/lis2dh12_i2c/lis2dh12_i2c.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/lis2dh12_base/lis2dh12_base.h"
+
+namespace esphome::lis2dh12_i2c {
+
+class LIS2DH12I2CComponent : public lis2dh12_base::LIS2DH12Component, public i2c::I2CDevice {
+ public:
+  bool read_byte(uint8_t a_register, uint8_t *data) override { return i2c::I2CDevice::read_byte(a_register, data); }
+  bool write_byte(uint8_t a_register, uint8_t data) override { return i2c::I2CDevice::write_byte(a_register, data); }
+  // LIS2DH12 I2C multi-byte reads require MSB set for auto-increment
+  bool read_bytes(uint8_t a_register, uint8_t *data, size_t len) override {
+    return i2c::I2CDevice::read_bytes(a_register | 0x80, data, len);
+  }
+
+  void dump_config() override;
+};
+
+}  // namespace esphome::lis2dh12_i2c

--- a/tests/components/lis2dh12_i2c/common.yaml
+++ b/tests/components/lis2dh12_i2c/common.yaml
@@ -14,6 +14,21 @@ lis2dh12_i2c:
     mirror_y: true
     mirror_z: true
     swap_xy: false
+  on_tap:
+    - then:
+        - logger.log: "Tapped"
+  on_double_tap:
+    - then:
+        - logger.log: "Double tapped"
+  on_freefall:
+    - then:
+        - logger.log: "Freefall detected"
+  on_active:
+    - then:
+        - logger.log: "Activity detected"
+  on_orientation:
+    - then:
+        - logger.log: "Orientation changed"
 
 sensor:
   - platform: lis2dh12_base
@@ -21,3 +36,21 @@ sensor:
     acceleration_x: Accel X
     acceleration_y: Accel Y
     acceleration_z: Accel Z
+
+text_sensor:
+  - platform: lis2dh12_base
+    lis2dh12_id: lis2dh12_i2c_accel
+    orientation: Orientation
+
+binary_sensor:
+  - platform: lis2dh12_base
+    lis2dh12_id: lis2dh12_i2c_accel
+    tap: Single tap
+    double_tap:
+      name: Double tap
+    freefall:
+      name: Freefall
+    active:
+      name: Active
+      filters:
+        - delayed_off: 5000ms

--- a/tests/components/lis2dh12_i2c/common.yaml
+++ b/tests/components/lis2dh12_i2c/common.yaml
@@ -1,0 +1,23 @@
+lis2dh12_i2c:
+  id: lis2dh12_i2c_accel
+  i2c_id: i2c_bus
+  range: 4G
+  resolution: high
+  output_data_rate: 100Hz
+  update_interval: 10s
+  calibration:
+    offset_x: -0.250
+    offset_y: -0.400
+    offset_z: -0.800
+  transform:
+    mirror_x: false
+    mirror_y: true
+    mirror_z: true
+    swap_xy: false
+
+sensor:
+  - platform: lis2dh12_base
+    lis2dh12_id: lis2dh12_i2c_accel
+    acceleration_x: Accel X
+    acceleration_y: Accel Y
+    acceleration_z: Accel Z

--- a/tests/components/lis2dh12_i2c/test.esp32-ard.yaml
+++ b/tests/components/lis2dh12_i2c/test.esp32-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis2dh12_i2c/test.esp32-idf.yaml
+++ b/tests/components/lis2dh12_i2c/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis2dh12_i2c/test.esp8266-ard.yaml
+++ b/tests/components/lis2dh12_i2c/test.esp8266-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
+
+<<: !include common.yaml

--- a/tests/components/lis2dh12_i2c/test.rp2040-ard.yaml
+++ b/tests/components/lis2dh12_i2c/test.rp2040-ard.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
PR1: Base I2C https://github.com/esphome/esphome/pull/14788
**PR2: Triggers https://github.com/esphome/esphome/pull/14804**
PR3: SPI https://github.com/esphome/esphome/pull/14805

# What does this implement/fix?

Add event detection and orientation features to the LIS2DH12 accelerometer component (introduced in #14788):

- **Binary sensors**: tap, double-tap, freefall, activity detection with 500ms debounce
- **Text sensor**: 6D orientation (X/Y/Z Up/Down)
- **Automation triggers**: `on_tap`, `on_double_tap`, `on_freefall`, `on_active`, `on_orientation`

> **Note:** This PR depends on #14788 and should be merged after it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #14788

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6286

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO21
  scl: GPIO22

lis2dh12_i2c:
  id: lis2dh12_accel
  range: 4G
  resolution: high
  output_data_rate: 100Hz
  update_interval: 10s
  on_tap:
    - logger.log: "Tapped"
  on_double_tap:
    - logger.log: "Double tapped"
  on_freefall:
    - logger.log: "Freefall detected"
  on_active:
    - logger.log: "Activity detected"
  on_orientation:
    - logger.log: "Orientation changed"

sensor:
  - platform: lis2dh12_base
    lis2dh12_id: lis2dh12_accel
    acceleration_x: "Accel X"
    acceleration_y: "Accel Y"
    acceleration_z: "Accel Z"

text_sensor:
  - platform: lis2dh12_base
    lis2dh12_id: lis2dh12_accel
    orientation: "Orientation"

binary_sensor:
  - platform: lis2dh12_base
    lis2dh12_id: lis2dh12_accel
    tap: "Single tap"
    double_tap: "Double tap"
    freefall: "Freefall"
    active:
      name: "Active"
      filters:
        - delayed_off: 5000ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
