### PR TITLE
[esp32_camera] Bump esp32-camera to 2.1.5

### DIFF
--- a/esphome/components/camera_encoder/__init__.py
+++ b/esphome/components/camera_encoder/__init__.py
@@ -50,7 +50,7 @@ async def to_code(config: ConfigType) -> None:
     buffer = cg.new_Pvariable(config[CONF_ENCODER_BUFFER_ID])
     cg.add(buffer.set_buffer_size(config[CONF_BUFFER_SIZE]))
     if config[CONF_TYPE] == ESP32_CAMERA_ENCODER:
-        add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
+        add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
         cg.add_define("USE_ESP32_CAMERA_JPEG_ENCODER")
         var = cg.new_Pvariable(
             config[CONF_ID],

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -400,7 +400,7 @@ async def to_code(config):
     if config[CONF_JPEG_QUALITY] != 0 and config[CONF_PIXEL_FORMAT] != "JPEG":
         cg.add_define("USE_ESP32_CAMERA_JPEG_CONVERSION")
 
-    add_idf_component(name="espressif/esp32-camera", ref="2.1.1")
+    add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -8,7 +8,7 @@ dependencies:
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:
-    version: 2.1.1
+    version: 2.1.5
   espressif/mdns:
     version: 1.10.0
   espressif/esp_wifi_remote:


### PR DESCRIPTION
# What does this implement/fix?

Bumps `espressif/esp32-camera` from 2.1.1 to 2.1.5. Version 2.1.5 adds `esp_driver_ledc` as an explicit CMake dependency, which is required for ESP-IDF 6.0 where the legacy `driver` component no longer transitively provides LEDC headers.

Without this bump, compilation fails with:
```
fatal error: driver/ledc.h: No such file or directory
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
esp32_camera:
  # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).