### PR TITLE
[helpers] Replace deprecated std::is_trivial in FixedRingBuffer

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -417,7 +417,7 @@ template<typename T, size_t MAX_CAPACITY = std::numeric_limits<uint16_t>::max()>
 
   FixedRingBuffer() = default;
   ~FixedRingBuffer() {
-    if constexpr (std::is_trivial<T>::value) {
+    if constexpr (std::is_trivially_copyable<T>::value && std::is_trivially_default_constructible<T>::value) {
       ::operator delete(this->data_);
     } else {
       delete[] this->data_;
@@ -430,7 +430,7 @@ template<typename T, size_t MAX_CAPACITY = std::numeric_limits<uint16_t>::max()>
 
   /// Allocate capacity - can only be called once
   void init(index_type capacity) {
-    if constexpr (std::is_trivial<T>::value) {
+    if constexpr (std::is_trivially_copyable<T>::value && std::is_trivially_default_constructible<T>::value) {
       // Raw allocation without initialization (elements are written before read)
       // NOLINTNEXTLINE(bugprone-sizeof-expression)
       this->data_ = static_cast<T *>(::operator new(capacity * sizeof(T)));


### PR DESCRIPTION
# What does this implement/fix?

Replace deprecated `std::is_trivial` with `std::is_trivially_copyable && std::is_trivially_default_constructible` in `FixedRingBuffer`.

`std::is_trivial` was deprecated in C++20 and removed in C++26. GCC 15 (shipped with the latest ESP-IDF 6 toolchain) emits deprecation warnings for every translation unit that includes `helpers.h`. The replacement is semantically equivalent and is the exact substitution recommended by the standard and the compiler diagnostic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).