### PR TITLE
[sha256] Migrate to PSA Crypto API for ESP-IDF 6.0

### DIFF
--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -31,6 +31,40 @@ void SHA256::calculate() {
 
 #elif defined(USE_SHA256_MBEDTLS)
 
+// CRITICAL ESP32 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
+//
+// ESP32 variants (except original ESP32) use DMA-based hardware SHA acceleration that requires
+// 32-byte aligned digest buffers. This is handled automatically via HashBase::digest_ which has
+// alignas(32) on these platforms. Two additional constraints apply:
+//
+// 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
+//    write to incorrect memory locations. This results in null pointer dereferences and crashes.
+//    ALWAYS use fixed-size arrays (e.g., char buf[65], not char buf[size+1]).
+//
+// 2. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
+//    function. NEVER pass the SHA256 object or HashBase pointer to another function. When the stack
+//    frame changes (function call/return), the DMA references become invalid and will produce
+//    truncated hash output (20 bytes instead of 32) or corrupt memory.
+//
+// CORRECT USAGE:
+//   void my_function() {
+//     sha256::SHA256 hasher;
+//     hasher.init();
+//     hasher.add(data, len);  // Any size, no chunking needed
+//     hasher.calculate();
+//     bool ok = hasher.equals_hex(expected);
+//     // hasher destroyed when function returns
+//   }
+//
+// INCORRECT USAGE (WILL FAIL):
+//   void my_function() {
+//     sha256::SHA256 hasher;
+//     helper(&hasher);  // WRONG: Passed to different stack frame
+//   }
+//   void helper(HashBase *h) {
+//     h->init();  // WRONG: Will produce truncated/corrupted output
+//   }
+
 SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
 
 void SHA256::init() {

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -8,7 +8,28 @@
 
 namespace esphome::sha256 {
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+
+// ESP-IDF 6.0 ships mbedtls 4.0 which removed the legacy mbedtls_sha256_* API.
+// Use the PSA Crypto API instead. PSA crypto is auto-initialized by ESP-IDF
+// at startup, so no psa_crypto_init() call is needed.
+
+SHA256::~SHA256() { psa_hash_abort(&this->op_); }
+
+void SHA256::init() {
+  psa_hash_abort(&this->op_);
+  this->op_ = PSA_HASH_OPERATION_INIT;
+  psa_hash_setup(&this->op_, PSA_ALG_SHA_256);
+}
+
+void SHA256::add(const uint8_t *data, size_t len) { psa_hash_update(&this->op_, data, len); }
+
+void SHA256::calculate() {
+  size_t hash_length;
+  psa_hash_finish(&this->op_, this->digest_, sizeof(this->digest_), &hash_length);
+}
+
+#elif defined(USE_ESP32) || defined(USE_LIBRETINY)
 
 // CRITICAL ESP32 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
 //

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -8,8 +8,7 @@
 
 namespace esphome::sha256 {
 
-#if defined(USE_ESP32)
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if defined(USE_SHA256_PSA)
 
 // ESP-IDF 6.0 ships mbedtls 4.0 which removed the legacy mbedtls_sha256_* API.
 // Use the PSA Crypto API instead. PSA crypto is auto-initialized by ESP-IDF
@@ -30,62 +29,13 @@ void SHA256::calculate() {
   psa_hash_finish(&this->op_, this->digest_, sizeof(this->digest_), &hash_length);
 }
 
-#else  // ESP_IDF_VERSION < 6.0.0
-
-// CRITICAL ESP32 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
-//
-// ESP32 variants (except original ESP32) use DMA-based hardware SHA acceleration that requires
-// 32-byte aligned digest buffers. This is handled automatically via HashBase::digest_ which has
-// alignas(32) on these platforms. Two additional constraints apply:
-//
-// 1. NO VARIABLE LENGTH ARRAYS (VLAs): VLAs corrupt the stack layout, causing the DMA engine to
-//    write to incorrect memory locations. This results in null pointer dereferences and crashes.
-//    ALWAYS use fixed-size arrays (e.g., char buf[65], not char buf[size+1]).
-//
-// 2. SAME STACK FRAME ONLY: The SHA256 object must be created and used entirely within the same
-//    function. NEVER pass the SHA256 object or HashBase pointer to another function. When the stack
-//    frame changes (function call/return), the DMA references become invalid and will produce
-//    truncated hash output (20 bytes instead of 32) or corrupt memory.
-//
-// CORRECT USAGE:
-//   void my_function() {
-//     sha256::SHA256 hasher;
-//     hasher.init();
-//     hasher.add(data, len);  // Any size, no chunking needed
-//     hasher.calculate();
-//     bool ok = hasher.equals_hex(expected);
-//     // hasher destroyed when function returns
-//   }
-//
-// INCORRECT USAGE (WILL FAIL):
-//   void my_function() {
-//     sha256::SHA256 hasher;
-//     helper(&hasher);  // WRONG: Passed to different stack frame
-//   }
-//   void helper(HashBase *h) {
-//     h->init();  // WRONG: Will produce truncated/corrupted output
-//   }
+#elif defined(USE_SHA256_MBEDTLS)
 
 SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
 
 void SHA256::init() {
   mbedtls_sha256_init(&this->ctx_);
   mbedtls_sha256_starts(&this->ctx_, 0);  // 0 = SHA256, not SHA224
-}
-
-void SHA256::add(const uint8_t *data, size_t len) { mbedtls_sha256_update(&this->ctx_, data, len); }
-
-void SHA256::calculate() { mbedtls_sha256_finish(&this->ctx_, this->digest_); }
-
-#endif  // ESP_IDF_VERSION check
-
-#elif defined(USE_LIBRETINY)
-
-SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
-
-void SHA256::init() {
-  mbedtls_sha256_init(&this->ctx_);
-  mbedtls_sha256_starts(&this->ctx_, 0);
 }
 
 void SHA256::add(const uint8_t *data, size_t len) { mbedtls_sha256_update(&this->ctx_, data, len); }

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -8,7 +8,8 @@
 
 namespace esphome::sha256 {
 
-#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if defined(USE_ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
 
 // ESP-IDF 6.0 ships mbedtls 4.0 which removed the legacy mbedtls_sha256_* API.
 // Use the PSA Crypto API instead. PSA crypto is auto-initialized by ESP-IDF
@@ -29,7 +30,7 @@ void SHA256::calculate() {
   psa_hash_finish(&this->op_, this->digest_, sizeof(this->digest_), &hash_length);
 }
 
-#elif defined(USE_ESP32) || defined(USE_LIBRETINY)
+#else  // ESP_IDF_VERSION < 6.0.0
 
 // CRITICAL ESP32 HARDWARE SHA ACCELERATION REQUIREMENTS (IDF 5.5.x):
 //

--- a/esphome/components/sha256/sha256.cpp
+++ b/esphome/components/sha256/sha256.cpp
@@ -77,6 +77,21 @@ void SHA256::add(const uint8_t *data, size_t len) { mbedtls_sha256_update(&this-
 
 void SHA256::calculate() { mbedtls_sha256_finish(&this->ctx_, this->digest_); }
 
+#endif  // ESP_IDF_VERSION check
+
+#elif defined(USE_LIBRETINY)
+
+SHA256::~SHA256() { mbedtls_sha256_free(&this->ctx_); }
+
+void SHA256::init() {
+  mbedtls_sha256_init(&this->ctx_);
+  mbedtls_sha256_starts(&this->ctx_, 0);
+}
+
+void SHA256::add(const uint8_t *data, size_t len) { mbedtls_sha256_update(&this->ctx_, data, len); }
+
+void SHA256::calculate() { mbedtls_sha256_finish(&this->ctx_, this->digest_); }
+
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
 
 SHA256::~SHA256() = default;

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -16,11 +16,14 @@
 // mbedtls 4.0 (IDF 6.0) removed the legacy mbedtls_sha256_* API.
 // Use the PSA Crypto API instead. PSA crypto is auto-initialized by
 // ESP-IDF at startup (esp_psa_crypto_init.c, priority 104).
+#define USE_SHA256_PSA
 #include <psa/crypto.h>
 #else
+#define USE_SHA256_MBEDTLS
 #include "mbedtls/sha256.h"
 #endif
 #elif defined(USE_LIBRETINY)
+#define USE_SHA256_MBEDTLS
 #include "mbedtls/sha256.h"
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
 #include <bearssl/bearssl_hash.h>
@@ -61,13 +64,9 @@ class SHA256 : public esphome::HashBase {
   size_t get_size() const override { return 32; }
 
  protected:
-#if defined(USE_ESP32)
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if defined(USE_SHA256_PSA)
   psa_hash_operation_t op_ = PSA_HASH_OPERATION_INIT;
-#else
-  mbedtls_sha256_context ctx_{};
-#endif
-#elif defined(USE_LIBRETINY)
+#elif defined(USE_SHA256_MBEDTLS)
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -68,8 +68,6 @@ class SHA256 : public esphome::HashBase {
   mbedtls_sha256_context ctx_{};
 #endif
 #elif defined(USE_LIBRETINY)
-  // The mbedtls context for ESP32-S3 hardware SHA requires proper alignment and stack frame constraints.
-  // See class documentation above for critical requirements.
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -67,6 +67,8 @@ class SHA256 : public esphome::HashBase {
 #if defined(USE_SHA256_PSA)
   psa_hash_operation_t op_ = PSA_HASH_OPERATION_INIT;
 #elif defined(USE_SHA256_MBEDTLS)
+  // The mbedtls context for ESP32-S3 hardware SHA requires proper alignment and stack frame constraints.
+  // See class documentation above for critical requirements.
   mbedtls_sha256_context ctx_{};
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
   br_sha256_context ctx_{};

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -61,9 +61,13 @@ class SHA256 : public esphome::HashBase {
   size_t get_size() const override { return 32; }
 
  protected:
-#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#if defined(USE_ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   psa_hash_operation_t op_ = PSA_HASH_OPERATION_INIT;
-#elif defined(USE_ESP32) || defined(USE_LIBRETINY)
+#else
+  mbedtls_sha256_context ctx_{};
+#endif
+#elif defined(USE_LIBRETINY)
   // The mbedtls context for ESP32-S3 hardware SHA requires proper alignment and stack frame constraints.
   // See class documentation above for critical requirements.
   mbedtls_sha256_context ctx_{};

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -10,7 +10,17 @@
 #include <memory>
 #include "esphome/core/hash_base.h"
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// mbedtls 4.0 (IDF 6.0) removed the legacy mbedtls_sha256_* API.
+// Use the PSA Crypto API instead. PSA crypto is auto-initialized by
+// ESP-IDF at startup (esp_psa_crypto_init.c, priority 104).
+#include <psa/crypto.h>
+#else
+#include "mbedtls/sha256.h"
+#endif
+#elif defined(USE_LIBRETINY)
 #include "mbedtls/sha256.h"
 #elif defined(USE_ESP8266) || defined(USE_RP2040)
 #include <bearssl/bearssl_hash.h>
@@ -51,7 +61,9 @@ class SHA256 : public esphome::HashBase {
   size_t get_size() const override { return 32; }
 
  protected:
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32) && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  psa_hash_operation_t op_ = PSA_HASH_OPERATION_INIT;
+#elif defined(USE_ESP32) || defined(USE_LIBRETINY)
   // The mbedtls context for ESP32-S3 hardware SHA requires proper alignment and stack frame constraints.
   // See class documentation above for critical requirements.
   mbedtls_sha256_context ctx_{};


### PR DESCRIPTION
# What does this implement/fix?

mbedtls 4.0 (shipped with ESP-IDF 6.0) removed the legacy `mbedtls_sha256_*` API entirely. Instead of using private headers with `MBEDTLS_ALLOW_PRIVATE_ACCESS` (as attempted in #14770), this migrates to the official replacement: the PSA Crypto API.

On IDF 6.0+:
- Uses `psa_hash_setup()`/`psa_hash_update()`/`psa_hash_finish()`/`psa_hash_abort()` with `PSA_ALG_SHA_256`
- PSA crypto is auto-initialized by ESP-IDF at startup (`esp_psa_crypto_init.c`, priority 104), so no `psa_crypto_init()` call is needed

On IDF < 6.0 and LibreTiny:
- Keeps existing `mbedtls_sha256_*` API (unchanged)

Reference: [mbedtls 4.0 migration guide](https://github.com/Mbed-TLS/mbedtls/blob/mbedtls-4.0.0/docs/4.0-migration-guide.md), [TF-PSA-Crypto 1.0 migration guide](https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/v1.0.0/docs/1.0-migration-guide.md)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support (related to #14770)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - sha256 is used internally by OTA and other components
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).