### PR TITLE
[esp32] Disable SHA-512 in mbedTLS on IDF 6.0+ and add idf_version() helper

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1802,6 +1802,13 @@ async def to_code(config):
     elif advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
 
+    # Disable SHA-512 support in mbedTLS
+    # ESPHome only uses SHA-256 (OTA, noise protocol, etc.)
+    # On IDF < 6.0, MBEDTLS_SHA512_C also controls SHA-384 which TLS needs,
+    # so only disable on IDF 6.0+ where SHA-384 has its own config.
+    if framework_ver >= cv.Version(6, 0, 0):
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)
+
     # Disable regi2c control functions in IRAM
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
     if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -427,9 +427,13 @@ def set_core_data(config):
     # Store the underlying IDF version for framework-agnostic checks
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         CORE.data[KEY_ESP32][KEY_IDF_VERSION] = framework_ver
+    elif (idf_ver := ARDUINO_IDF_VERSION_LOOKUP.get(framework_ver)) is not None:
+        CORE.data[KEY_ESP32][KEY_IDF_VERSION] = idf_ver
     else:
-        CORE.data[KEY_ESP32][KEY_IDF_VERSION] = ARDUINO_IDF_VERSION_LOOKUP.get(
-            framework_ver, framework_ver
+        raise cv.Invalid(
+            f"Arduino version {framework_ver} has no known ESP-IDF version mapping. "
+            "Please update ARDUINO_IDF_VERSION_LOOKUP.",
+            path=[CONF_FRAMEWORK, CONF_VERSION],
         )
 
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -974,6 +974,7 @@ KEY_USB_SERIAL_JTAG_SECONDARY_REQUIRED = "usb_serial_jtag_secondary_required"
 KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
 KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
+KEY_MBEDTLS_SHA512_REQUIRED = "mbedtls_sha512_required"
 
 
 def require_vfs_select() -> None:
@@ -1041,6 +1042,16 @@ def require_mbedtls_pkcs7() -> None:
     This prevents CONFIG_MBEDTLS_PKCS7_C from being disabled.
     """
     CORE.data[KEY_ESP32][KEY_MBEDTLS_PKCS7_REQUIRED] = True
+
+
+def require_mbedtls_sha512() -> None:
+    """Mark that mbedTLS SHA-384/SHA-512 support is required by a component.
+
+    Call this from components that need to verify TLS certificates or signatures
+    using SHA-384 or SHA-512 algorithms. This prevents CONFIG_MBEDTLS_SHA384_C
+    and CONFIG_MBEDTLS_SHA512_C from being disabled.
+    """
+    CORE.data[KEY_ESP32][KEY_MBEDTLS_SHA512_REQUIRED] = True
 
 
 def require_fatfs() -> None:
@@ -1810,7 +1821,10 @@ async def to_code(config):
     # On IDF < 6.0 these are a single config and hardware-only (no
     # software fallback), so there was no code size cost to leaving
     # them enabled.
-    if framework_ver >= cv.Version(6, 0, 0):
+    # Components that need SHA-384/SHA-512 can call require_mbedtls_sha512()
+    if framework_ver >= cv.Version(6, 0, 0) and not CORE.data[KEY_ESP32].get(
+        KEY_MBEDTLS_SHA512_REQUIRED, False
+    ):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1802,11 +1802,17 @@ async def to_code(config):
     elif advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
 
-    # Disable SHA-512 support in mbedTLS
+    # Disable SHA-384 and SHA-512 support in mbedTLS
     # ESPHome only uses SHA-256 (OTA, noise protocol, etc.)
-    # On IDF < 6.0, MBEDTLS_SHA512_C also controls SHA-384 which TLS needs,
-    # so only disable on IDF 6.0+ where SHA-384 has its own config.
+    # SHA-384 uses the same compression function as SHA-512
+    # (mbedtls_internal_sha512_process), so both must be disabled to
+    # eliminate the ~3KB software SHA-512 implementation.
+    # TLS still works with SHA-256 cipher suites (TLS_AES_128_GCM_SHA256,
+    # TLS_CHACHA20_POLY1305_SHA256) which are universally supported.
+    # On IDF < 6.0, SHA-384 and SHA-512 share a single config
+    # (MBEDTLS_SHA512_C), so only disable on IDF 6.0+ where they're separate.
     if framework_ver >= cv.Version(6, 0, 0):
+        add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)
 
     # Disable regi2c control functions in IRAM

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -59,6 +59,7 @@ from .const import (  # noqa
     KEY_EXTRA_BUILD_FILES,
     KEY_FLASH_SIZE,
     KEY_FULL_CERT_BUNDLE,
+    KEY_IDF_VERSION,
     KEY_PATH,
     KEY_REF,
     KEY_REPO,
@@ -420,9 +421,16 @@ def set_core_data(config):
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS] = excluded
     # Initialize Arduino library tracking - cg.add_library() auto-enables libraries
     CORE.data[KEY_ESP32][KEY_ARDUINO_LIBRARIES] = set()
-    CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version.parse(
-        config[CONF_FRAMEWORK][CONF_VERSION]
-    )
+    framework_ver = cv.Version.parse(config[CONF_FRAMEWORK][CONF_VERSION])
+    CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = framework_ver
+
+    # Store the underlying IDF version for framework-agnostic checks
+    if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
+        CORE.data[KEY_ESP32][KEY_IDF_VERSION] = framework_ver
+    else:
+        CORE.data[KEY_ESP32][KEY_IDF_VERSION] = ARDUINO_IDF_VERSION_LOOKUP.get(
+            framework_ver, framework_ver
+        )
 
     CORE.data[KEY_ESP32][KEY_BOARD] = config[CONF_BOARD]
     CORE.data[KEY_ESP32][KEY_FLASH_SIZE] = config[CONF_FLASH_SIZE]
@@ -1052,6 +1060,15 @@ def require_mbedtls_sha512() -> None:
     and CONFIG_MBEDTLS_SHA512_C from being disabled.
     """
     CORE.data[KEY_ESP32][KEY_MBEDTLS_SHA512_REQUIRED] = True
+
+
+def idf_version() -> cv.Version:
+    """Return the underlying ESP-IDF version regardless of framework choice.
+
+    For ESP-IDF builds this is the framework version directly.
+    For Arduino builds this is the mapped IDF version from ARDUINO_IDF_VERSION_LOOKUP.
+    """
+    return CORE.data[KEY_ESP32][KEY_IDF_VERSION]
 
 
 def require_fatfs() -> None:
@@ -1822,7 +1839,7 @@ async def to_code(config):
     # software fallback), so there was no code size cost to leaving
     # them enabled.
     # Components that need SHA-384/SHA-512 can call require_mbedtls_sha512()
-    if framework_ver >= cv.Version(6, 0, 0) and not CORE.data[KEY_ESP32].get(
+    if idf_version() >= cv.Version(6, 0, 0) and not CORE.data[KEY_ESP32].get(
         KEY_MBEDTLS_SHA512_REQUIRED, False
     ):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1802,15 +1802,14 @@ async def to_code(config):
     elif advanced[CONF_DISABLE_MBEDTLS_PKCS7]:
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_PKCS7_C", False)
 
-    # Disable SHA-384 and SHA-512 support in mbedTLS
-    # ESPHome only uses SHA-256 (OTA, noise protocol, etc.)
-    # SHA-384 uses the same compression function as SHA-512
-    # (mbedtls_internal_sha512_process), so both must be disabled to
-    # eliminate the ~3KB software SHA-512 implementation.
-    # TLS still works with SHA-256 cipher suites (TLS_AES_128_GCM_SHA256,
-    # TLS_CHACHA20_POLY1305_SHA256) which are universally supported.
-    # On IDF < 6.0, SHA-384 and SHA-512 share a single config
-    # (MBEDTLS_SHA512_C), so only disable on IDF 6.0+ where they're separate.
+    # Disable SHA-384 and SHA-512 in mbedTLS
+    # ESPHome doesn't use either algorithm. SHA-384 shares the same
+    # compression function as SHA-512 (mbedtls_internal_sha512_process),
+    # so both must be disabled to eliminate the ~3KB software fallback
+    # that IDF 6.0's PSA parallel engine always links in.
+    # On IDF < 6.0 these are a single config and hardware-only (no
+    # software fallback), so there was no code size cost to leaving
+    # them enabled.
     if framework_ver >= cv.Version(6, 0, 0):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)

--- a/esphome/components/esp32/const.py
+++ b/esphome/components/esp32/const.py
@@ -15,6 +15,7 @@ KEY_PATH = "path"
 KEY_SUBMODULES = "submodules"
 KEY_EXTRA_BUILD_FILES = "extra_build_files"
 KEY_FULL_CERT_BUNDLE = "full_cert_bundle"
+KEY_IDF_VERSION = "idf_version"
 
 VARIANT_ESP32 = "ESP32"
 VARIANT_ESP32C2 = "ESP32C2"

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -4,14 +4,7 @@ from pathlib import Path
 from esphome import pins
 from esphome.components import esp32
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_CLK_PIN,
-    CONF_RESET_PIN,
-    CONF_VARIANT,
-    KEY_CORE,
-    KEY_FRAMEWORK_VERSION,
-)
-from esphome.core import CORE
+from esphome.const import CONF_CLK_PIN, CONF_RESET_PIN, CONF_VARIANT
 from esphome.cpp_generator import add_define
 
 CODEOWNERS = ["@swoboda1337"]
@@ -100,9 +93,9 @@ async def to_code(config):
         int(config[CONF_SDIO_FREQUENCY] // 1000),
     )
 
-    framework_ver: cv.Version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
-    os.environ["ESP_IDF_VERSION"] = f"{framework_ver.major}.{framework_ver.minor}"
-    if framework_ver >= cv.Version(5, 5, 0):
+    idf_ver = esp32.idf_version()
+    os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
+    if idf_ver >= cv.Version(5, 5, 0):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.4.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.4")
         esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.1")

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -14,6 +14,7 @@ from esphome.components.esp32 import (
     add_idf_component,
     add_idf_sdkconfig_option,
     get_esp32_variant,
+    idf_version,
     include_builtin_idf_component,
 )
 from esphome.components.network import ip_address_literal
@@ -176,13 +177,12 @@ ManualIP = ethernet_ns.struct("ManualIP")
 def _is_framework_spi_polling_mode_supported():
     # SPI Ethernet without IRQ feature is added in
     # esp-idf >= (5.3+ ,5.2.1+, 5.1.4)
-    # Note: Arduino now uses ESP-IDF as a component, so we only check IDF version
-    framework_version = CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]
-    if framework_version >= cv.Version(5, 3, 0):
+    ver = idf_version()
+    if ver >= cv.Version(5, 3, 0):
         return True
-    if cv.Version(5, 3, 0) > framework_version >= cv.Version(5, 2, 1):
+    if cv.Version(5, 3, 0) > ver >= cv.Version(5, 2, 1):
         return True
-    if cv.Version(5, 2, 0) > framework_version >= cv.Version(5, 1, 4):  # noqa: SIM103
+    if cv.Version(5, 2, 0) > ver >= cv.Version(5, 1, 4):  # noqa: SIM103
         return True
     return False
 

--- a/esphome/components/psram/__init__.py
+++ b/esphome/components/psram/__init__.py
@@ -14,6 +14,7 @@ from esphome.components.esp32 import (
     VARIANT_ESP32S3,
     add_idf_sdkconfig_option,
     get_esp32_variant,
+    idf_version,
 )
 import esphome.config_validation as cv
 from esphome.const import (
@@ -23,8 +24,6 @@ from esphome.const import (
     CONF_ID,
     CONF_MODE,
     CONF_SPEED,
-    KEY_CORE,
-    KEY_FRAMEWORK_VERSION,
     PLATFORM_ESP32,
 )
 from esphome.core import CORE
@@ -202,9 +201,7 @@ async def to_code(config):
         # ESP32 and ESP32-S2 don't have this constraint.
         if variant not in (VARIANT_ESP32, VARIANT_ESP32S2):
             add_idf_sdkconfig_option("CONFIG_ESPTOOLPY_FLASHFREQ_120M", True)
-        if config[CONF_MODE] == TYPE_OCTAL and CORE.data[KEY_CORE][
-            KEY_FRAMEWORK_VERSION
-        ] >= cv.Version(5, 4, 0):
+        if config[CONF_MODE] == TYPE_OCTAL and idf_version() >= cv.Version(5, 4, 0):
             add_idf_sdkconfig_option(
                 "CONFIG_SPIRAM_TIMING_TUNING_POINT_VIA_TEMPERATURE_SENSOR",
                 True,


### PR DESCRIPTION
# What does this implement/fix?

Disables `CONFIG_MBEDTLS_SHA384_C` and `CONFIG_MBEDTLS_SHA512_C` on ESP-IDF 6.0+ builds, and adds infrastructure for framework-agnostic IDF version checks.

## SHA-384/SHA-512 disable

ESPHome does not use SHA-384 or SHA-512. SHA-256 is used by OTA verification and the sha256 component; the noise protocol uses a custom libsodium build, not mbedtls. On IDF 5.x this didn't matter because the hardware SHA accelerator handled everything via `MBEDTLS_SHA512_ALT` — no software code was linked in.

IDF 6.0 changed to a PSA driver architecture with a "parallel engine" that tries the hardware SHA engine at runtime and falls back to a software implementation if hardware is busy. Since the fallback is a runtime branch, the linker can't eliminate it, adding ~3KB of software SHA-512 code (`mbedtls_internal_sha512_process`, `esp_sha512_software_process`) that was never present before.

Rather than trying to disable just the software fallback (which would break when hardware is busy), we disable the algorithms entirely since ESPHome doesn't use them. TLS still works with SHA-256 cipher suites (`TLS_AES_128_GCM_SHA256`, `TLS_CHACHA20_POLY1305_SHA256`) which are universally supported.

Components that need SHA-384/SHA-512 TLS verification can call `require_mbedtls_sha512()` to prevent the disable, following the same pattern as `require_fatfs()` and `require_mbedtls_pkcs7()`.

On IDF < 6.0, `MBEDTLS_SHA512_C` controls both SHA-384 and SHA-512 as a single config, so this change only applies to IDF 6.0+ where they are separate configs.

## `idf_version()` helper

Adds `esp32.idf_version()` which returns the underlying ESP-IDF version regardless of whether Arduino or ESP-IDF framework is selected. For Arduino builds, the IDF version is mapped via `ARDUINO_IDF_VERSION_LOOKUP` and stored during `set_core_data()`. This replaces direct `CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION]` comparisons against IDF version numbers, which would be semantically incorrect for Arduino builds (where the framework version is the Arduino version, e.g. 3.x, not the IDF version).

Migrated consumers:
- `esp32/__init__.py` — SHA-512 disable check
- `psram/__init__.py` — SPIRAM timing tuning check
- `ethernet/__init__.py` — SPI polling mode support check
- `esp32_hosted/__init__.py` — ESP_IDF_VERSION env var and component version selection

If an Arduino version has no known IDF mapping in `ARDUINO_IDF_VERSION_LOOKUP`, config validation now raises `cv.Invalid` instead of silently using the wrong version.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support (related to #14770)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal optimization
esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).