### PR TITLE
[esp32_ble_tracker] Migrate to PSA Crypto API for ESP-IDF 6.0

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -775,7 +775,7 @@ bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
   psa_status_t status = psa_cipher_encrypt(key_id, PSA_ALG_ECB_NO_PADDING, ecb_plaintext, AES_BLOCK_SIZE,
                                            ecb_ciphertext, AES_BLOCK_SIZE, &output_length);
   psa_destroy_key(key_id);
-  if (status != PSA_SUCCESS) {
+  if (status != PSA_SUCCESS || output_length != AES_BLOCK_SIZE) {
     return false;
   }
 #else

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -27,8 +27,12 @@
 #include <esp_coexist.h>
 #endif
 
+#ifdef USE_BLE_TRACKER_PSA_AES
+#include <psa/crypto.h>
+#else
 #define MBEDTLS_AES_ALT
 #include <aes_alt.h>
+#endif
 
 // bt_trace.h
 #undef TAG
@@ -738,23 +742,48 @@ void ESP32BLETracker::print_bt_device_info(const ESPBTDevice &device) {
 }
 
 bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
-  uint8_t ecb_key[16];
-  uint8_t ecb_plaintext[16];
-  uint8_t ecb_ciphertext[16];
+  static constexpr size_t AES_BLOCK_SIZE = 16;
+  static constexpr size_t AES_KEY_BITS = 128;
+
+  uint8_t ecb_key[AES_BLOCK_SIZE];
+  uint8_t ecb_plaintext[AES_BLOCK_SIZE];
+  uint8_t ecb_ciphertext[AES_BLOCK_SIZE];
 
   uint64_t addr64 = esp32_ble::ble_addr_to_uint64(this->address_);
 
-  memcpy(&ecb_key, irk, 16);
-  memset(&ecb_plaintext, 0, 16);
+  memcpy(&ecb_key, irk, AES_BLOCK_SIZE);
+  memset(&ecb_plaintext, 0, AES_BLOCK_SIZE);
 
   ecb_plaintext[13] = (addr64 >> 40) & 0xff;
   ecb_plaintext[14] = (addr64 >> 32) & 0xff;
   ecb_plaintext[15] = (addr64 >> 24) & 0xff;
 
+#ifdef USE_BLE_TRACKER_PSA_AES
+  // Use PSA Crypto API (mbedtls 4.0 / IDF 6.0+)
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
+  psa_set_key_bits(&attributes, AES_KEY_BITS);
+  psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT);
+  psa_set_key_algorithm(&attributes, PSA_ALG_ECB_NO_PADDING);
+
+  mbedtls_svc_key_id_t key_id;
+  if (psa_import_key(&attributes, ecb_key, AES_BLOCK_SIZE, &key_id) != PSA_SUCCESS) {
+    return false;
+  }
+
+  size_t output_length;
+  psa_status_t status = psa_cipher_encrypt(key_id, PSA_ALG_ECB_NO_PADDING, ecb_plaintext, AES_BLOCK_SIZE,
+                                           ecb_ciphertext, AES_BLOCK_SIZE, &output_length);
+  psa_destroy_key(key_id);
+  if (status != PSA_SUCCESS) {
+    return false;
+  }
+#else
+  // Use legacy mbedtls AES API (IDF < 6.0)
   mbedtls_aes_context ctx = {0, 0, {0}};
   mbedtls_aes_init(&ctx);
 
-  if (mbedtls_aes_setkey_enc(&ctx, ecb_key, 128) != 0) {
+  if (mbedtls_aes_setkey_enc(&ctx, ecb_key, AES_KEY_BITS) != 0) {
     mbedtls_aes_free(&ctx);
     return false;
   }
@@ -765,6 +794,7 @@ bool ESPBTDevice::resolve_irk(const uint8_t *irk) const {
   }
 
   mbedtls_aes_free(&ctx);
+#endif
 
   return ecb_ciphertext[15] == (addr64 & 0xff) && ecb_ciphertext[14] == ((addr64 >> 8) & 0xff) &&
          ecb_ciphertext[13] == ((addr64 >> 16) & 0xff);

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -27,12 +27,14 @@
 #include <esp_coexist.h>
 #endif
 
+#ifdef USE_ESP32_BLE_DEVICE
 #ifdef USE_BLE_TRACKER_PSA_AES
 #include <psa/crypto.h>
 #else
 #define MBEDTLS_AES_ALT
 #include <aes_alt.h>
 #endif
+#endif  // USE_ESP32_BLE_DEVICE
 
 // bt_trace.h
 #undef TAG

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -12,6 +12,15 @@
 
 #ifdef USE_ESP32
 
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// mbedtls 4.0 (IDF 6.0) removed the legacy mbedtls AES API.
+// Use the PSA Crypto API instead.
+#define USE_BLE_TRACKER_PSA_AES
+#else
+#define USE_BLE_TRACKER_MBEDTLS_AES
+#endif
+
 #include <esp_bt_defs.h>
 #include <esp_gap_ble_api.h>
 #include <esp_gattc_api.h>

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -17,8 +17,6 @@
 // mbedtls 4.0 (IDF 6.0) removed the legacy mbedtls AES API.
 // Use the PSA Crypto API instead.
 #define USE_BLE_TRACKER_PSA_AES
-#else
-#define USE_BLE_TRACKER_MBEDTLS_AES
 #endif
 
 #include <esp_bt_defs.h>


### PR DESCRIPTION
# What does this implement/fix?

mbedtls 4.0 (shipped with ESP-IDF 6.0) removed the legacy `aes_alt.h` header and ESP-IDF AES hardware acceleration port. This breaks `resolve_irk()` in `esp32_ble_tracker` which used the legacy API for AES-ECB encryption during BLE IRK resolution.

On IDF 6.0+:
- Uses PSA Crypto API (`psa_import_key()` / `psa_cipher_encrypt()` with `PSA_ALG_ECB_NO_PADDING`)
- PSA crypto is auto-initialized by ESP-IDF at startup
- Validates `output_length` matches expected block size

On IDF < 6.0:
- Keeps existing `mbedtls_aes_*` / `aes_alt.h` API (unchanged)

Also:
- Replaces magic numbers with named constants (`AES_BLOCK_SIZE`, `AES_KEY_BITS`)
- Guards AES includes with `USE_ESP32_BLE_DEVICE` to match `resolve_irk()` scope

Verified on ESP32-S3 with IDF 6.0 using NIST AES-128-ECB test vectors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

To test the PSA AES path on an IDF 6.0 device, create `aes_test.h` alongside your YAML:

```cpp
// aes_test.h
#pragma once
#include <psa/crypto.h>
```

Then use this config — press the "Test IRK AES" button and check the log for PASSED/FAILED:

```yaml
esphome:
  name: test-ble-aes
  includes:
    - aes_test.h

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

logger:

esp32_ble_tracker:

button:
  - platform: template
    name: "Test IRK AES"
    on_press:
      - lambda: |-
          // NIST AES-128-ECB test vector
          static constexpr uint8_t test_key[16] = {
            0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
            0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c
          };
          static constexpr uint8_t test_plaintext[16] = {
            0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96,
            0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a
          };
          static constexpr uint8_t expected[16] = {
            0x3a, 0xd7, 0x7b, 0xb4, 0x0d, 0x7a, 0x36, 0x60,
            0xa8, 0x9e, 0xca, 0xf3, 0x24, 0x66, 0xef, 0x97
          };
          uint8_t output[16];
          bool ok = false;

          psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
          psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
          psa_set_key_bits(&attributes, 128);
          psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_ENCRYPT);
          psa_set_key_algorithm(&attributes, PSA_ALG_ECB_NO_PADDING);
          mbedtls_svc_key_id_t key_id;
          if (psa_import_key(&attributes, test_key, 16, &key_id) == PSA_SUCCESS) {
            size_t output_length;
            if (psa_cipher_encrypt(key_id, PSA_ALG_ECB_NO_PADDING,
                                   test_plaintext, 16, output, 16, &output_length) == PSA_SUCCESS) {
              ok = (memcmp(output, expected, 16) == 0);
            }
            psa_destroy_key(key_id);
          }

          if (ok) {
            ESP_LOGI("test_irk", "AES-ECB PSA test PASSED");
          } else {
            ESP_LOGE("test_irk", "AES-ECB PSA test FAILED");
          }
```

Expected log output:
```
[I][test_irk:098]: AES-ECB PSA test PASSED
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).