### PR TITLE
[debug] Fix shared buffer between reset reason and wakeup cause

### DIFF
--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -18,6 +18,7 @@ namespace debug {
 
 static constexpr size_t DEVICE_INFO_BUFFER_SIZE = 256;
 static constexpr size_t RESET_REASON_BUFFER_SIZE = 128;
+static constexpr size_t WAKEUP_CAUSE_BUFFER_SIZE = 128;
 
 // buf_append_printf is now provided by esphome/core/helpers.h
 
@@ -94,7 +95,7 @@ class DebugComponent : public PollingComponent {
 #endif  // USE_TEXT_SENSOR
 
   const char *get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer);
-  const char *get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer);
+  const char *get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer);
   uint32_t get_free_heap_();
   size_t get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE> buffer, size_t pos);
   void update_platform_();

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -196,9 +196,10 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   uint32_t cpu_freq_mhz = arch_get_cpu_freq_hz() / 1000000;
   pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32 " MHz", cpu_freq_mhz);
 
-  char reason_buffer[RESET_REASON_BUFFER_SIZE];
-  const char *reset_reason = get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE>(reason_buffer));
-  const char *wakeup_cause = get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE>(reason_buffer));
+  char reset_buffer[RESET_REASON_BUFFER_SIZE];
+  char wakeup_buffer[RESET_REASON_BUFFER_SIZE];
+  const char *reset_reason = get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE>(reset_buffer));
+  const char *wakeup_cause = get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE>(wakeup_buffer));
 
   uint8_t mac[6];
   get_mac_address_raw(mac);

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -98,7 +98,7 @@ static const char *const WAKEUP_CAUSES[] = {
     "BT",
 };
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) {
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) {
   const char *wake_reason;
   unsigned reason = esp_sleep_get_wakeup_cause();
   if (reason < sizeof(WAKEUP_CAUSES) / sizeof(WAKEUP_CAUSES[0])) {
@@ -197,9 +197,9 @@ size_t DebugComponent::get_device_info_(std::span<char, DEVICE_INFO_BUFFER_SIZE>
   pos = buf_append_printf(buf, size, pos, "|CPU Frequency: %" PRIu32 " MHz", cpu_freq_mhz);
 
   char reset_buffer[RESET_REASON_BUFFER_SIZE];
-  char wakeup_buffer[RESET_REASON_BUFFER_SIZE];
+  char wakeup_buffer[WAKEUP_CAUSE_BUFFER_SIZE];
   const char *reset_reason = get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE>(reset_buffer));
-  const char *wakeup_cause = get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE>(wakeup_buffer));
+  const char *wakeup_cause = get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE>(wakeup_buffer));
 
   uint8_t mac[6];
   get_mac_address_raw(mac);

--- a/esphome/components/debug/debug_esp8266.cpp
+++ b/esphome/components/debug/debug_esp8266.cpp
@@ -91,7 +91,7 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
   return buffer.data();
 }
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) {
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) {
   // ESP8266 doesn't have detailed wakeup cause like ESP32
   return "";
 }

--- a/esphome/components/debug/debug_host.cpp
+++ b/esphome/components/debug/debug_host.cpp
@@ -7,7 +7,7 @@ namespace debug {
 
 const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) { return ""; }
 
 uint32_t DebugComponent::get_free_heap_() { return INT_MAX; }
 

--- a/esphome/components/debug/debug_libretiny.cpp
+++ b/esphome/components/debug/debug_libretiny.cpp
@@ -12,7 +12,7 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
   return lt_get_reboot_reason_name(lt_get_reboot_reason());
 }
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) { return ""; }
 
 uint32_t DebugComponent::get_free_heap_() { return lt_heap_get_free(); }
 

--- a/esphome/components/debug/debug_rp2040.cpp
+++ b/esphome/components/debug/debug_rp2040.cpp
@@ -67,7 +67,7 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
   return buf;
 }
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) { return ""; }
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) { return ""; }
 
 uint32_t DebugComponent::get_free_heap_() { return ::rp2040.getFreeHeap(); }
 

--- a/esphome/components/debug/debug_zephyr.cpp
+++ b/esphome/components/debug/debug_zephyr.cpp
@@ -53,7 +53,7 @@ const char *DebugComponent::get_reset_reason_(std::span<char, RESET_REASON_BUFFE
   return buf;
 }
 
-const char *DebugComponent::get_wakeup_cause_(std::span<char, RESET_REASON_BUFFER_SIZE> buffer) {
+const char *DebugComponent::get_wakeup_cause_(std::span<char, WAKEUP_CAUSE_BUFFER_SIZE> buffer) {
   // Zephyr doesn't have detailed wakeup cause like ESP32
   return "";
 }


### PR DESCRIPTION
# What does this implement/fix?

`get_reset_reason_()` and `get_wakeup_cause_()` were sharing the same `reason_buffer`. Since `get_wakeup_cause_()` is called second, it overwrites the reset reason string, causing the Device Info text sensor to show the wakeup cause for both fields.

This was masked on IDF < 6.0 because `get_wakeup_cause_()` usually returned a static string pointer from the `WAKEUP_CAUSES` array rather than writing to the buffer. But on `ESP_RST_SW` resets (where `get_reset_reason_()` writes to the buffer), the bug was always present.

Fix: use separate buffers for each function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
debug:
  update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).