### PR TITLE
[hmac_sha256] Migrate to PSA Crypto MAC API for ESP-IDF 6.0

### DIFF
--- a/esphome/components/hmac_sha256/hmac_sha256.cpp
+++ b/esphome/components/hmac_sha256/hmac_sha256.cpp
@@ -7,7 +7,55 @@ namespace esphome::hmac_sha256 {
 
 constexpr size_t SHA256_DIGEST_SIZE = 32;
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_HMAC_SHA256_PSA)
+
+// ESP-IDF 6.0 ships mbedtls 4.0 which removed the legacy mbedtls_md HMAC API.
+// Use the PSA Crypto MAC API instead.
+
+HmacSHA256::~HmacSHA256() {
+  psa_mac_abort(&this->op_);
+  psa_destroy_key(this->key_id_);
+}
+
+void HmacSHA256::init(const uint8_t *key, size_t len) {
+  psa_mac_abort(&this->op_);
+  psa_destroy_key(this->key_id_);
+
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attributes, PSA_KEY_TYPE_HMAC);
+  psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_SIGN_MESSAGE);
+  psa_set_key_algorithm(&attributes, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+  psa_import_key(&attributes, key, len, &this->key_id_);
+
+  this->op_ = PSA_MAC_OPERATION_INIT;
+  psa_mac_sign_setup(&this->op_, this->key_id_, PSA_ALG_HMAC(PSA_ALG_SHA_256));
+}
+
+void HmacSHA256::add(const uint8_t *data, size_t len) { psa_mac_update(&this->op_, data, len); }
+
+void HmacSHA256::calculate() {
+  size_t mac_length;
+  psa_mac_sign_finish(&this->op_, this->digest_, sizeof(this->digest_), &mac_length);
+}
+
+void HmacSHA256::get_bytes(uint8_t *output) { memcpy(output, this->digest_, SHA256_DIGEST_SIZE); }
+
+void HmacSHA256::get_hex(char *output) {
+  format_hex_to(output, SHA256_DIGEST_SIZE * 2 + 1, this->digest_, SHA256_DIGEST_SIZE);
+}
+
+bool HmacSHA256::equals_bytes(const uint8_t *expected) {
+  return memcmp(this->digest_, expected, SHA256_DIGEST_SIZE) == 0;
+}
+
+bool HmacSHA256::equals_hex(const char *expected) {
+  char hex_output[SHA256_DIGEST_SIZE * 2 + 1];
+  this->get_hex(hex_output);
+  hex_output[SHA256_DIGEST_SIZE * 2] = '\0';
+  return strncmp(hex_output, expected, SHA256_DIGEST_SIZE * 2) == 0;
+}
+
+#elif defined(USE_HMAC_SHA256_MBEDTLS)
 
 HmacSHA256::~HmacSHA256() { mbedtls_md_free(&this->ctx_); }
 
@@ -93,7 +141,7 @@ bool HmacSHA256::equals_bytes(const uint8_t *expected) { return this->ohash_.equ
 
 bool HmacSHA256::equals_hex(const char *expected) { return this->ohash_.equals_hex(expected); }
 
-#endif  // USE_ESP32 || USE_LIBRETINY
+#endif  // USE_HMAC_SHA256_PSA / USE_HMAC_SHA256_MBEDTLS
 
 }  // namespace esphome::hmac_sha256
 #endif

--- a/esphome/components/hmac_sha256/hmac_sha256.h
+++ b/esphome/components/hmac_sha256/hmac_sha256.h
@@ -5,7 +5,19 @@
 
 #include <string>
 
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_ESP32)
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+// mbedtls 4.0 (IDF 6.0) removed the legacy mbedtls_md HMAC API.
+// Use the PSA Crypto MAC API instead.
+#define USE_HMAC_SHA256_PSA
+#include <psa/crypto.h>
+#else
+#define USE_HMAC_SHA256_MBEDTLS
+#include "mbedtls/md.h"
+#endif
+#elif defined(USE_LIBRETINY)
+#define USE_HMAC_SHA256_MBEDTLS
 #include "mbedtls/md.h"
 #else
 #include "esphome/components/sha256/sha256.h"
@@ -45,7 +57,12 @@ class HmacSHA256 {
   bool equals_hex(const char *expected);
 
  protected:
-#if defined(USE_ESP32) || defined(USE_LIBRETINY)
+#if defined(USE_HMAC_SHA256_PSA)
+  static constexpr size_t SHA256_DIGEST_SIZE = 32;
+  psa_mac_operation_t op_ = PSA_MAC_OPERATION_INIT;
+  mbedtls_svc_key_id_t key_id_{};
+  uint8_t digest_[SHA256_DIGEST_SIZE]{};
+#elif defined(USE_HMAC_SHA256_MBEDTLS)
   static constexpr size_t SHA256_DIGEST_SIZE = 32;
   mbedtls_md_context_t ctx_{};
   uint8_t digest_[SHA256_DIGEST_SIZE]{};

--- a/esphome/components/hmac_sha256/hmac_sha256.h
+++ b/esphome/components/hmac_sha256/hmac_sha256.h
@@ -60,7 +60,7 @@ class HmacSHA256 {
 #if defined(USE_HMAC_SHA256_PSA)
   static constexpr size_t SHA256_DIGEST_SIZE = 32;
   psa_mac_operation_t op_ = PSA_MAC_OPERATION_INIT;
-  mbedtls_svc_key_id_t key_id_{};
+  mbedtls_svc_key_id_t key_id_ = MBEDTLS_SVC_KEY_ID_INIT;
   uint8_t digest_[SHA256_DIGEST_SIZE]{};
 #elif defined(USE_HMAC_SHA256_MBEDTLS)
   static constexpr size_t SHA256_DIGEST_SIZE = 32;


### PR DESCRIPTION
# What does this implement/fix?

mbedtls 4.0 (shipped with ESP-IDF 6.0) removed the legacy `mbedtls_md` HMAC API (`mbedtls_md_hmac_starts`, `mbedtls_md_hmac_update`, `mbedtls_md_hmac_finish`). This breaks the `hmac_sha256` component on IDF 6.0.

On IDF 6.0+:
- Uses PSA Crypto MAC API (`psa_mac_sign_setup()` / `psa_mac_update()` / `psa_mac_sign_finish()` with `PSA_ALG_HMAC(PSA_ALG_SHA_256)`)
- PSA crypto is auto-initialized by ESP-IDF at startup

On IDF < 6.0 and LibreTiny:
- Keeps existing `mbedtls_md_*` HMAC API (unchanged)

On ESP8266, RP2040, and Host:
- Keeps existing software HMAC implementation using SHA256 (unchanged)

Verified on ESP32-S3 with IDF 6.0 using RFC 4231 HMAC-SHA256 test vectors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

To test the PSA HMAC-SHA256 path on an IDF 6.0 device, press the "Test HMAC-SHA256" button and check the log for PASSED/FAILED:

```yaml
hmac_sha256:

button:
  - platform: template
    name: "Test HMAC-SHA256"
    on_press:
      - lambda: |-
          // RFC 4231 Test Case 2: HMAC-SHA256
          esphome::hmac_sha256::HmacSHA256 hmac;
          hmac.init("Jefe", 4);
          hmac.add("what do ya want for nothing?", 28);
          hmac.calculate();
          if (hmac.equals_hex("5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843")) {
            ESP_LOGI("test_hmac", "HMAC-SHA256 PSA test PASSED");
          } else {
            ESP_LOGE("test_hmac", "HMAC-SHA256 PSA test FAILED");
          }
```

Expected log output:
```
[I][test_hmac:120]: HMAC-SHA256 PSA test PASSED
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).