### PR TITLE
[bthome_mithermometer][xiaomi_ble] Migrate CCM to PSA AEAD API for ESP-IDF 6.0

### DIFF
--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -203,7 +203,10 @@ bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &da
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   // PSA AEAD expects ciphertext + tag concatenated
-  uint8_t ct_with_tag[ciphertext_size + BTHOME_MIC_SIZE];
+  // BLE advertisement max payload is 31 bytes, so this is always sufficient
+  static constexpr size_t MAX_CT_WITH_TAG = 32;
+  uint8_t ct_with_tag[MAX_CT_WITH_TAG];
+  size_t ct_with_tag_size = ciphertext_size + BTHOME_MIC_SIZE;
   memcpy(ct_with_tag, ciphertext, ciphertext_size);
   memcpy(ct_with_tag + ciphertext_size, mic, BTHOME_MIC_SIZE);
 
@@ -221,7 +224,7 @@ bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &da
 
   size_t plaintext_length;
   psa_status_t status = psa_aead_decrypt(key_id, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, BTHOME_MIC_SIZE),
-                                         nonce.data(), nonce.size(), nullptr, 0, ct_with_tag, sizeof(ct_with_tag),
+                                         nonce.data(), nonce.size(), nullptr, 0, ct_with_tag, ct_with_tag_size,
                                          payload.data(), ciphertext_size, &plaintext_length);
   psa_destroy_key(key_id);
   if (status != PSA_SUCCESS) {

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -227,7 +227,7 @@ bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &da
                                          nonce.data(), nonce.size(), nullptr, 0, ct_with_tag, ct_with_tag_size,
                                          payload.data(), ciphertext_size, &plaintext_length);
   psa_destroy_key(key_id);
-  if (status != PSA_SUCCESS) {
+  if (status != PSA_SUCCESS || plaintext_length != ciphertext_size) {
     ESP_LOGVV(TAG, "BTHome decryption failed.");
     return false;
   }

--- a/esphome/components/bthome_mithermometer/bthome_ble.cpp
+++ b/esphome/components/bthome_mithermometer/bthome_ble.cpp
@@ -10,7 +10,12 @@
 
 #ifdef USE_ESP32
 
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <psa/crypto.h>
+#else
 #include "mbedtls/ccm.h"
+#endif
 
 namespace esphome {
 namespace bthome_mithermometer {
@@ -196,6 +201,34 @@ bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &da
   const uint8_t *ciphertext = data.data() + 1;
   const uint8_t *mic = data.data() + data.size() - BTHOME_MIC_SIZE;
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  // PSA AEAD expects ciphertext + tag concatenated
+  uint8_t ct_with_tag[ciphertext_size + BTHOME_MIC_SIZE];
+  memcpy(ct_with_tag, ciphertext, ciphertext_size);
+  memcpy(ct_with_tag + ciphertext_size, mic, BTHOME_MIC_SIZE);
+
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
+  psa_set_key_bits(&attributes, BTHOME_BINDKEY_SIZE * 8);
+  psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DECRYPT);
+  psa_set_key_algorithm(&attributes, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, BTHOME_MIC_SIZE));
+
+  mbedtls_svc_key_id_t key_id;
+  if (psa_import_key(&attributes, this->bindkey_, BTHOME_BINDKEY_SIZE, &key_id) != PSA_SUCCESS) {
+    ESP_LOGVV(TAG, "psa_import_key() failed.");
+    return false;
+  }
+
+  size_t plaintext_length;
+  psa_status_t status = psa_aead_decrypt(key_id, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, BTHOME_MIC_SIZE),
+                                         nonce.data(), nonce.size(), nullptr, 0, ct_with_tag, sizeof(ct_with_tag),
+                                         payload.data(), ciphertext_size, &plaintext_length);
+  psa_destroy_key(key_id);
+  if (status != PSA_SUCCESS) {
+    ESP_LOGVV(TAG, "BTHome decryption failed.");
+    return false;
+  }
+#else
   mbedtls_ccm_context ctx;
   mbedtls_ccm_init(&ctx);
 
@@ -213,6 +246,7 @@ bool BTHomeMiThermometer::decrypt_bthome_payload_(const std::vector<uint8_t> &da
     ESP_LOGVV(TAG, "BTHome decryption failed (ret=%d).", ret);
     return false;
   }
+#endif
   return true;
 }
 

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -321,9 +321,10 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
   // PSA AEAD expects ciphertext + tag concatenated
-  uint8_t ct_with_tag[vector.datasize + vector.tagsize];
+  uint8_t ct_with_tag[sizeof(vector.ciphertext) + sizeof(vector.tag)];
   memcpy(ct_with_tag, vector.ciphertext, vector.datasize);
   memcpy(ct_with_tag + vector.datasize, vector.tag, vector.tagsize);
+  size_t ct_with_tag_size = vector.datasize + vector.tagsize;
 
   psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
   psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
@@ -340,7 +341,7 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   size_t plaintext_length;
   psa_status_t status = psa_aead_decrypt(key_id, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, vector.tagsize),
                                          vector.iv, vector.ivsize, vector.authdata, vector.authsize, ct_with_tag,
-                                         sizeof(ct_with_tag), vector.plaintext, vector.datasize, &plaintext_length);
+                                         ct_with_tag_size, vector.plaintext, vector.datasize, &plaintext_length);
   psa_destroy_key(key_id);
   bool decrypt_ok = (status == PSA_SUCCESS);
 #else

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -343,7 +343,7 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
                                          vector.iv, vector.ivsize, vector.authdata, vector.authsize, ct_with_tag,
                                          ct_with_tag_size, vector.plaintext, vector.datasize, &plaintext_length);
   psa_destroy_key(key_id);
-  bool decrypt_ok = (status == PSA_SUCCESS);
+  bool decrypt_ok = (status == PSA_SUCCESS && plaintext_length == vector.datasize);
 #else
   mbedtls_ccm_context ctx;
   mbedtls_ccm_init(&ctx);

--- a/esphome/components/xiaomi_ble/xiaomi_ble.cpp
+++ b/esphome/components/xiaomi_ble/xiaomi_ble.cpp
@@ -5,7 +5,12 @@
 #ifdef USE_ESP32
 
 #include <vector>
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <psa/crypto.h>
+#else
 #include "mbedtls/ccm.h"
+#endif
 
 namespace esphome {
 namespace xiaomi_ble {
@@ -314,6 +319,31 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   memcpy(vector.iv + 6, v + 2, 3);               // sensor type (2) + packet id (1)
   memcpy(vector.iv + 9, v + raw.size() - 7, 3);  // payload counter
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  // PSA AEAD expects ciphertext + tag concatenated
+  uint8_t ct_with_tag[vector.datasize + vector.tagsize];
+  memcpy(ct_with_tag, vector.ciphertext, vector.datasize);
+  memcpy(ct_with_tag + vector.datasize, vector.tag, vector.tagsize);
+
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
+  psa_set_key_bits(&attributes, vector.keysize * 8);
+  psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DECRYPT);
+  psa_set_key_algorithm(&attributes, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, vector.tagsize));
+
+  mbedtls_svc_key_id_t key_id;
+  if (psa_import_key(&attributes, vector.key, vector.keysize, &key_id) != PSA_SUCCESS) {
+    ESP_LOGVV(TAG, "decrypt_xiaomi_payload(): psa_import_key() failed.");
+    return false;
+  }
+
+  size_t plaintext_length;
+  psa_status_t status = psa_aead_decrypt(key_id, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, vector.tagsize),
+                                         vector.iv, vector.ivsize, vector.authdata, vector.authsize, ct_with_tag,
+                                         sizeof(ct_with_tag), vector.plaintext, vector.datasize, &plaintext_length);
+  psa_destroy_key(key_id);
+  bool decrypt_ok = (status == PSA_SUCCESS);
+#else
   mbedtls_ccm_context ctx;
   mbedtls_ccm_init(&ctx);
 
@@ -326,7 +356,11 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
 
   ret = mbedtls_ccm_auth_decrypt(&ctx, vector.datasize, vector.iv, vector.ivsize, vector.authdata, vector.authsize,
                                  vector.ciphertext, vector.plaintext, vector.tag, vector.tagsize);
-  if (ret) {
+  mbedtls_ccm_free(&ctx);
+  bool decrypt_ok = (ret == 0);
+#endif
+
+  if (!decrypt_ok) {
     uint8_t mac_address[6] = {0};
     memcpy(mac_address, mac_reverse + 5, 1);
     memcpy(mac_address + 1, mac_reverse + 4, 1);
@@ -346,7 +380,6 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
     ESP_LOGVV(TAG, "           Iv : %s", format_hex_pretty_to(hex_buf, vector.iv, vector.ivsize));
     ESP_LOGVV(TAG, "       Cipher : %s", format_hex_pretty_to(hex_buf, vector.ciphertext, vector.datasize));
     ESP_LOGVV(TAG, "          Tag : %s", format_hex_pretty_to(hex_buf, vector.tag, vector.tagsize));
-    mbedtls_ccm_free(&ctx);
     return false;
   }
 
@@ -367,7 +400,6 @@ bool decrypt_xiaomi_payload(std::vector<uint8_t> &raw, const uint8_t *bindkey, c
   ESP_LOGVV(TAG, "  Plaintext : %s, Packet : %d",
             format_hex_pretty_to(hex_buf, raw.data() + cipher_pos, vector.datasize), static_cast<int>(raw[4]));
 
-  mbedtls_ccm_free(&ctx);
   return true;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

mbedtls 4.0 (shipped with ESP-IDF 6.0) removed the public `mbedtls/ccm.h` header (moved to `mbedtls/private/ccm.h`). This breaks the `bthome_mithermometer` and `xiaomi_ble` components which use AES-CCM for decrypting encrypted BLE advertisements.

On IDF 6.0+:
- Uses PSA Crypto AEAD API (`psa_aead_decrypt()` with `PSA_ALG_CCM`)
- Uses fixed-size buffers for ciphertext+tag concatenation (no VLAs)
- Validates `plaintext_length` matches expected size after decrypt
- PSA crypto is auto-initialized by ESP-IDF at startup

On IDF < 6.0:
- Keeps existing `mbedtls_ccm_*` API (unchanged)

Also refactored the xiaomi_ble error handling to share the decrypt result check between both code paths, reducing duplication.

Verified on ESP32-S3 with IDF 6.0 using real encrypted Xiaomi LYWSD03MMC BLE advertisement data from the [xiaomi-ble](https://github.com/Bluetooth-Devices/xiaomi-ble) test suite.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

To test the PSA AES-CCM decrypt path on an IDF 6.0 device, create `aes_test.h` alongside your YAML:

```cpp
// aes_test.h
#pragma once
#include <psa/crypto.h>
```

Then use this config — press the "Test AES-CCM Decrypt" button and check the log:

```yaml
esphome:
  name: test-ccm
  includes:
    - aes_test.h

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

logger:

esp32_ble_tracker:

button:
  - platform: template
    name: "Test AES-CCM Decrypt"
    on_press:
      - lambda: |-
          // Real Xiaomi LYWSD03MMC encrypted BLE advertisement
          // from xiaomi-ble test suite (test_Xiaomi_LYWSD03MMC_encrypted)
          // bindkey: e9ea895fac7cca6d30532432a516f3a8
          // MAC: A4:C1:38:02:83:F4, expected: humidity=46%
          static constexpr uint8_t key[16] = {
            0xE9, 0xEA, 0x89, 0x5F, 0xAC, 0x7C, 0xCA, 0x6D,
            0x30, 0x53, 0x24, 0x32, 0xA5, 0x16, 0xF3, 0xA8
          };
          static constexpr uint8_t nonce[12] = {
            0xF4, 0x83, 0x02, 0x38, 0xC1, 0xA4,
            0x5B, 0x05, 0x50, 0x26, 0x00, 0x00
          };
          static constexpr uint8_t aad[1] = {0x11};
          // ciphertext (5 bytes) + tag (4 bytes)
          static constexpr uint8_t ct_with_tag[9] = {
            0x95, 0xEF, 0x58, 0x76, 0x3C,
            0x97, 0xE2, 0xAB, 0xB5
          };
          static constexpr size_t TAG_SIZE = 4;
          static constexpr size_t PT_SIZE = 5;
          uint8_t plaintext[PT_SIZE];

          psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
          psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
          psa_set_key_bits(&attributes, 128);
          psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DECRYPT);
          psa_set_key_algorithm(&attributes, PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, TAG_SIZE));
          mbedtls_svc_key_id_t key_id;
          psa_status_t st = psa_import_key(&attributes, key, 16, &key_id);
          if (st != PSA_SUCCESS) {
            ESP_LOGE("test_ccm", "import failed: %d", (int)st);
            return;
          }
          size_t pt_len;
          st = psa_aead_decrypt(key_id,
                                PSA_ALG_AEAD_WITH_SHORTENED_TAG(PSA_ALG_CCM, TAG_SIZE),
                                nonce, sizeof(nonce), aad, sizeof(aad),
                                ct_with_tag, sizeof(ct_with_tag),
                                plaintext, sizeof(plaintext), &pt_len);
          psa_destroy_key(key_id);
          if (st != PSA_SUCCESS) {
            ESP_LOGE("test_ccm", "decrypt failed: %d", (int)st);
            return;
          }
          // Decrypted: 06 10 02 D3 01 = humidity type 0x1006, len 2, value 0x01D3 = 467 -> 46.7%
          ESP_LOGI("test_ccm", "AES-CCM PSA decrypt PASSED (pt_len=%d, pt=%02X%02X%02X%02X%02X)",
                   (int)pt_len, plaintext[0], plaintext[1], plaintext[2], plaintext[3], plaintext[4]);
```

Expected log output:
```
[I][test_ccm:175]: AES-CCM PSA decrypt PASSED (pt_len=5, pt=061002D301)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).