### PR TITLE
[dlms_meter] Migrate GCM to PSA AEAD API for ESP-IDF 6.0

### DIFF
--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -260,7 +260,8 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
     if (psa_aead_decrypt_setup(&op, key_id, PSA_ALG_GCM) == PSA_SUCCESS &&
         psa_aead_set_nonce(&op, iv, sizeof(iv)) == PSA_SUCCESS) {
       size_t outlen = 0;
-      if (psa_aead_update(&op, payload_ptr, message_length, payload_ptr, message_length, &outlen) == PSA_SUCCESS) {
+      if (psa_aead_update(&op, payload_ptr, message_length, payload_ptr, message_length, &outlen) == PSA_SUCCESS &&
+          outlen == message_length) {
         decrypt_failed = false;
       }
     }

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -3,8 +3,13 @@
 #if defined(USE_ESP8266_FRAMEWORK_ARDUINO)
 #include <bearssl/bearssl.h>
 #elif defined(USE_ESP32)
+#include <esp_idf_version.h>
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+#include <psa/crypto.h>
+#else
 #include "mbedtls/esp_config.h"
 #include "mbedtls/gcm.h"
+#endif
 #endif
 
 namespace esphome::dlms_meter {
@@ -240,6 +245,34 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
   br_gcm_flip(&gcm_ctx);
   br_gcm_run(&gcm_ctx, 0, payload_ptr, message_length);
 #elif defined(USE_ESP32)
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  // PSA Crypto multipart AEAD (no tag verification, matching legacy behavior)
+  psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+  psa_set_key_type(&attributes, PSA_KEY_TYPE_AES);
+  psa_set_key_bits(&attributes, this->decryption_key_.size() * 8);
+  psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DECRYPT);
+  psa_set_key_algorithm(&attributes, PSA_ALG_GCM);
+
+  mbedtls_svc_key_id_t key_id;
+  bool decrypt_failed = true;
+  if (psa_import_key(&attributes, this->decryption_key_.data(), this->decryption_key_.size(), &key_id) == PSA_SUCCESS) {
+    psa_aead_operation_t op = PSA_AEAD_OPERATION_INIT;
+    if (psa_aead_decrypt_setup(&op, key_id, PSA_ALG_GCM) == PSA_SUCCESS &&
+        psa_aead_set_nonce(&op, iv, sizeof(iv)) == PSA_SUCCESS) {
+      size_t outlen = 0;
+      if (psa_aead_update(&op, payload_ptr, message_length, payload_ptr, message_length, &outlen) == PSA_SUCCESS) {
+        decrypt_failed = false;
+      }
+    }
+    psa_aead_abort(&op);
+    psa_destroy_key(key_id);
+  }
+  if (decrypt_failed) {
+    ESP_LOGE(TAG, "Decryption failed");
+    this->receive_buffer_.clear();
+    return false;
+  }
+#else
   size_t outlen = 0;
   mbedtls_gcm_context gcm_ctx;
   mbedtls_gcm_init(&gcm_ctx);
@@ -252,6 +285,7 @@ bool DlmsMeterComponent::decrypt_(std::vector<uint8_t> &mbus_payload, uint16_t m
     this->receive_buffer_.clear();
     return false;
   }
+#endif
 #else
 #error "Invalid Platform"
 #endif


### PR DESCRIPTION
# What does this implement/fix?

mbedtls 4.0 (shipped with ESP-IDF 6.0) removed the public `mbedtls/gcm.h` header. This breaks the `dlms_meter` component which uses AES-GCM for decrypting DLMS/COSEM smart meter data.

On IDF 6.0+:
- Uses PSA Crypto multipart AEAD API (`psa_aead_decrypt_setup()` / `psa_aead_set_nonce()` / `psa_aead_update()` / `psa_aead_abort()` with `PSA_ALG_GCM`)
- Uses `psa_aead_abort()` instead of `psa_aead_verify()` to match the legacy behavior of not checking the authentication tag
- Validates `outlen` matches `message_length` after `psa_aead_update` to ensure full decryption
- PSA crypto is auto-initialized by ESP-IDF at startup

On IDF < 6.0:
- Keeps existing `mbedtls_gcm_*` API (unchanged)

On ESP8266:
- Keeps existing BearSSL GCM implementation (unchanged)

Verified on ESP32-S3 with IDF 6.0 using AES-GCM encrypt then multipart decrypt round-trip test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- ESP-IDF 6.0 support

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

To test the PSA AES-GCM multipart decrypt path on an IDF 6.0 device, create `aes_test.h` alongside your YAML:

```cpp
// aes_test.h
#pragma once
#include <psa/crypto.h>
```

Then use this config — press the "Test AES-GCM Decrypt" button and check the log:

```yaml
esphome:
  name: test-gcm
  includes:
    - aes_test.h

esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

logger:

button:
  - platform: template
    name: "Test AES-GCM Decrypt"
    on_press:
      - lambda: |-
          // Test AES-GCM multipart decrypt without tag verification
          // (same pattern as dlms_meter uses)
          static constexpr uint8_t key[16] = {
            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
            0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
          };
          static constexpr uint8_t iv[12] = {
            0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
            0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C
          };
          static constexpr uint8_t original[] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE};
          static constexpr size_t PT_SIZE = sizeof(original);

          // Step 1: Encrypt with single-shot API
          psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
          psa_set_key_type(&attr, PSA_KEY_TYPE_AES);
          psa_set_key_bits(&attr, 128);
          psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT);
          psa_set_key_algorithm(&attr, PSA_ALG_GCM);
          mbedtls_svc_key_id_t key_id;
          if (psa_import_key(&attr, key, 16, &key_id) != PSA_SUCCESS) {
            ESP_LOGE("test_gcm", "import failed");
            return;
          }
          uint8_t ct_buf[PT_SIZE + 16];
          size_t ct_len;
          if (psa_aead_encrypt(key_id, PSA_ALG_GCM, iv, sizeof(iv),
                               nullptr, 0, original, PT_SIZE,
                               ct_buf, sizeof(ct_buf), &ct_len) != PSA_SUCCESS) {
            ESP_LOGE("test_gcm", "encrypt failed");
            psa_destroy_key(key_id);
            return;
          }

          // Step 2: Decrypt with multipart API + abort (no tag verify)
          uint8_t decrypted[PT_SIZE];
          bool ok = false;
          psa_aead_operation_t op = PSA_AEAD_OPERATION_INIT;
          if (psa_aead_decrypt_setup(&op, key_id, PSA_ALG_GCM) == PSA_SUCCESS &&
              psa_aead_set_nonce(&op, iv, sizeof(iv)) == PSA_SUCCESS) {
            size_t outlen = 0;
            if (psa_aead_update(&op, ct_buf, PT_SIZE, decrypted, PT_SIZE, &outlen) == PSA_SUCCESS) {
              ok = (outlen == PT_SIZE && memcmp(decrypted, original, PT_SIZE) == 0);
            }
          }
          psa_aead_abort(&op);
          psa_destroy_key(key_id);

          if (ok) {
            ESP_LOGI("test_gcm", "AES-GCM PSA multipart decrypt PASSED");
          } else {
            ESP_LOGE("test_gcm", "AES-GCM PSA multipart decrypt FAILED");
          }
```

Expected log output:
```
[I][test_gcm:234]: AES-GCM PSA multipart decrypt PASSED
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).