### PR TITLE
[i2s_audio] Fix ESP-IDF 6.0 compatibility for I2S port types

### DIFF
--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass, field
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components.esp32 import (
@@ -254,7 +256,68 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
+@dataclass
+class I2SPortData:
+    """I2S port assignments, computed during final validation."""
+
+    port_map: dict[str, int] = field(default_factory=dict)
+
+
+I2S_PORT_DATA_KEY = "i2s_port_data"
+
+
+def _get_port_data() -> I2SPortData:
+    if I2S_PORT_DATA_KEY not in CORE.data:
+        CORE.data[I2S_PORT_DATA_KEY] = I2SPortData()
+    return CORE.data[I2S_PORT_DATA_KEY]
+
+
+def _assign_ports():
+    """Assign I2S port numbers, prioritizing instances with microphone children.
+
+    Microphones (especially PDM) require port 0 on most ESP32 variants.
+    This runs once and stores the mapping in CORE.data.
+    """
+    port_data = _get_port_data()
+    if port_data.port_map:
+        return
+
+    full_config = fv.full_config.get()
+    i2s_configs = full_config[CONF_I2S_AUDIO]
+
+    # Find i2s_audio instances with microphones that require port 0
+    # (PDM and internal ADC only work on I2S port 0)
+    port0_parent_id = None
+    for mic_config in full_config.get("microphone", []):
+        if CONF_I2S_AUDIO_ID not in mic_config:
+            continue
+        if mic_config.get("pdm") or mic_config.get("adc_type") == "internal":
+            if port0_parent_id is not None:
+                raise cv.Invalid(
+                    "Only one PDM/ADC microphone is supported (requires I2S port 0)"
+                )
+            port0_parent_id = str(mic_config[CONF_I2S_AUDIO_ID])
+
+    # Assign ports: port 0 parent first (if any), rest get sequential
+    next_port = 0
+    if port0_parent_id is not None:
+        port_data.port_map[port0_parent_id] = next_port
+        next_port += 1
+    for config in i2s_configs:
+        config_id = str(config[CONF_ID])
+        if config_id != port0_parent_id:
+            port_data.port_map[config_id] = next_port
+            next_port += 1
+
+
 def _final_validate(_):
+    from esphome.components.esp32 import idf_version
+
+    if use_legacy() and idf_version() >= cv.Version(6, 0, 0):
+        raise cv.Invalid(
+            "The legacy I2S driver is not available in ESP-IDF 6.0+. "
+            "Set 'use_legacy: false' in i2s_audio configuration."
+        )
     i2s_audio_configs = fv.full_config.get()[CONF_I2S_AUDIO]
     variant = get_esp32_variant()
     if variant not in I2S_PORTS:
@@ -263,6 +326,7 @@ def _final_validate(_):
         raise cv.Invalid(
             f"Only {I2S_PORTS[variant]} I2S audio ports are supported on {variant}"
         )
+    _assign_ports()
 
 
 def use_legacy():
@@ -275,6 +339,14 @@ FINAL_VALIDATE_SCHEMA = _final_validate
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    # Assign I2S port from _final_validate computed mapping
+    port_data = _get_port_data()
+    if not port_data.port_map:
+        raise cv.Invalid("I2S port assignments not computed")
+    if (port := port_data.port_map.get(str(config[CONF_ID]))) is None:
+        raise cv.Invalid(f"No I2S port assigned for {config[CONF_ID]}")
+    cg.add(var.set_port(port))
 
     # Re-enable ESP-IDF's I2S driver (excluded by default to save compile time)
     include_builtin_idf_component("esp_driver_i2s")

--- a/esphome/components/i2s_audio/__init__.py
+++ b/esphome/components/i2s_audio/__init__.py
@@ -28,6 +28,9 @@ CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["esp32"]
 MULTI_CONF = True
 
+CONF_PDM = "pdm"
+CONF_ADC_TYPE = "adc_type"
+
 CONF_I2S_DOUT_PIN = "i2s_dout_pin"
 CONF_I2S_DIN_PIN = "i2s_din_pin"
 CONF_I2S_MCLK_PIN = "i2s_mclk_pin"
@@ -257,29 +260,26 @@ CONFIG_SCHEMA = cv.All(
 
 
 @dataclass
-class I2SPortData:
-    """I2S port assignments, computed during final validation."""
+class I2SAudioData:
+    """I2S audio component state stored in CORE.data."""
 
     port_map: dict[str, int] = field(default_factory=dict)
 
 
-I2S_PORT_DATA_KEY = "i2s_port_data"
+def _get_data() -> I2SAudioData:
+    if CONF_I2S_AUDIO not in CORE.data:
+        CORE.data[CONF_I2S_AUDIO] = I2SAudioData()
+    return CORE.data[CONF_I2S_AUDIO]
 
 
-def _get_port_data() -> I2SPortData:
-    if I2S_PORT_DATA_KEY not in CORE.data:
-        CORE.data[I2S_PORT_DATA_KEY] = I2SPortData()
-    return CORE.data[I2S_PORT_DATA_KEY]
-
-
-def _assign_ports():
+def _assign_ports() -> None:
     """Assign I2S port numbers, prioritizing instances with microphone children.
 
     Microphones (especially PDM) require port 0 on most ESP32 variants.
     This runs once and stores the mapping in CORE.data.
     """
-    port_data = _get_port_data()
-    if port_data.port_map:
+    data = _get_data()
+    if data.port_map:
         return
 
     full_config = fv.full_config.get()
@@ -291,7 +291,7 @@ def _assign_ports():
     for mic_config in full_config.get("microphone", []):
         if CONF_I2S_AUDIO_ID not in mic_config:
             continue
-        if mic_config.get("pdm") or mic_config.get("adc_type") == "internal":
+        if mic_config.get(CONF_PDM) or mic_config.get(CONF_ADC_TYPE) == "internal":
             if port0_parent_id is not None:
                 raise cv.Invalid(
                     "Only one PDM/ADC microphone is supported (requires I2S port 0)"
@@ -301,12 +301,12 @@ def _assign_ports():
     # Assign ports: port 0 parent first (if any), rest get sequential
     next_port = 0
     if port0_parent_id is not None:
-        port_data.port_map[port0_parent_id] = next_port
+        data.port_map[port0_parent_id] = next_port
         next_port += 1
     for config in i2s_configs:
         config_id = str(config[CONF_ID])
         if config_id != port0_parent_id:
-            port_data.port_map[config_id] = next_port
+            data.port_map[config_id] = next_port
             next_port += 1
 
 
@@ -341,11 +341,9 @@ async def to_code(config):
     await cg.register_component(var, config)
 
     # Assign I2S port from _final_validate computed mapping
-    port_data = _get_port_data()
-    if not port_data.port_map:
-        raise cv.Invalid("I2S port assignments not computed")
-    if (port := port_data.port_map.get(str(config[CONF_ID]))) is None:
-        raise cv.Invalid(f"No I2S port assigned for {config[CONF_ID]}")
+    data = _get_data()
+    if (port := data.port_map.get(str(config[CONF_ID]))) is None:
+        raise ValueError(f"No I2S port assigned for {config[CONF_ID]}")
     cg.add(var.set_port(port))
 
     # Re-enable ESP-IDF's I2S driver (excluded by default to save compile time)

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -2,26 +2,8 @@
 
 #ifdef USE_ESP32
 
-#include "esphome/core/log.h"
-
 namespace esphome {
-namespace i2s_audio {
-
-static const char *const TAG = "i2s_audio";
-
-void I2SAudioComponent::setup() {
-  static i2s_port_t next_port_num = I2S_NUM_0;
-  if (next_port_num >= SOC_I2S_NUM) {
-    ESP_LOGE(TAG, "Too many components");
-    this->mark_failed();
-    return;
-  }
-
-  this->port_ = next_port_num;
-  next_port_num = (i2s_port_t) (next_port_num + 1);
-}
-
-}  // namespace i2s_audio
+namespace i2s_audio {}  // namespace i2s_audio
 }  // namespace esphome
 
 #endif  // USE_ESP32

--- a/esphome/components/i2s_audio/i2s_audio.cpp
+++ b/esphome/components/i2s_audio/i2s_audio.cpp
@@ -1,9 +1,0 @@
-#include "i2s_audio.h"
-
-#ifdef USE_ESP32
-
-namespace esphome {
-namespace i2s_audio {}  // namespace i2s_audio
-}  // namespace esphome
-
-#endif  // USE_ESP32

--- a/esphome/components/i2s_audio/i2s_audio.h
+++ b/esphome/components/i2s_audio/i2s_audio.h
@@ -5,6 +5,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
+#include <esp_idf_version.h>
 #ifdef USE_I2S_LEGACY
 #include <driver/i2s.h>
 #else
@@ -56,8 +57,6 @@ class I2SAudioOut : public I2SAudioBase {};
 
 class I2SAudioComponent : public Component {
  public:
-  void setup() override;
-
 #ifdef USE_I2S_LEGACY
   i2s_pin_config_t get_pin_config() const {
     return {
@@ -86,12 +85,16 @@ class I2SAudioComponent : public Component {
   void set_mclk_pin(int pin) { this->mclk_pin_ = pin; }
   void set_bclk_pin(int pin) { this->bclk_pin_ = pin; }
   void set_lrclk_pin(int pin) { this->lrclk_pin_ = pin; }
+  void set_port(int port) { this->port_ = port; }
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+  int get_port() const { return this->port_; }
+#else
+  i2s_port_t get_port() const { return static_cast<i2s_port_t>(this->port_); }
+#endif
 
   void lock() { this->lock_.lock(); }
   bool try_lock() { return this->lock_.try_lock(); }
   void unlock() { this->lock_.unlock(); }
-
-  i2s_port_t get_port() const { return this->port_; }
 
  protected:
   Mutex lock_;
@@ -106,7 +109,7 @@ class I2SAudioComponent : public Component {
   int bclk_pin_{I2S_GPIO_UNUSED};
 #endif
   int lrclk_pin_;
-  i2s_port_t port_{};
+  int port_{};
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/microphone/__init__.py
+++ b/esphome/components/i2s_audio/microphone/__init__.py
@@ -13,9 +13,11 @@ from esphome.const import (
 )
 
 from .. import (
+    CONF_ADC_TYPE,
     CONF_I2S_DIN_PIN,
     CONF_LEFT,
     CONF_MONO,
+    CONF_PDM,
     CONF_RIGHT,
     I2SAudioIn,
     i2s_audio_component_schema,
@@ -29,9 +31,7 @@ CODEOWNERS = ["@jesserockz"]
 DEPENDENCIES = ["i2s_audio"]
 
 CONF_ADC_PIN = "adc_pin"
-CONF_ADC_TYPE = "adc_type"
 CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
-CONF_PDM = "pdm"
 
 I2SAudioMicrophone = i2s_audio_ns.class_(
     "I2SAudioMicrophone", I2SAudioIn, microphone.Microphone, cg.Component

--- a/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
+++ b/esphome/components/i2s_audio/microphone/i2s_audio_microphone.cpp
@@ -37,27 +37,6 @@ enum MicrophoneEventGroupBits : uint32_t {
 };
 
 void I2SAudioMicrophone::setup() {
-#ifdef USE_I2S_LEGACY
-#if SOC_I2S_SUPPORTS_ADC
-  if (this->adc_) {
-    if (this->parent_->get_port() != I2S_NUM_0) {
-      ESP_LOGE(TAG, "Internal ADC only works on I2S0");
-      this->mark_failed();
-      return;
-    }
-  } else
-#endif
-#endif
-  {
-    if (this->pdm_) {
-      if (this->parent_->get_port() != I2S_NUM_0) {
-        ESP_LOGE(TAG, "PDM only works on I2S0");
-        this->mark_failed();
-        return;
-      }
-    }
-  }
-
   this->active_listeners_semaphore_ = xSemaphoreCreateCounting(MAX_LISTENERS, MAX_LISTENERS);
   if (this->active_listeners_semaphore_ == nullptr) {
     ESP_LOGE(TAG, "Creating semaphore failed");


### PR DESCRIPTION
# What does this implement/fix?

The legacy I2S driver (`driver/i2s.h`) was removed in ESP-IDF 6.0. The `i2s_audio` component used `i2s_port_t`, `SOC_I2S_NUM`, and runtime port allocation that only worked with the legacy driver.

### Changes

**Port assignment moved to Python:**
- Ports are now assigned at config time in `_final_validate` using a `@dataclass` stored in `CORE.data`
- PDM and internal ADC microphones are prioritized for port 0 (hardware requirement confirmed in IDF source — `i2s_pdm.c` checks `controller->id == I2S_NUM_0`)
- Config error if more than one PDM/ADC microphone is configured
- Removes C++ `setup()` entirely — no more runtime port allocation

**IDF 6.0 compatibility:**
- `get_port()` returns `i2s_port_t` on IDF < 6.0 (cast from int), `int` on IDF 6.0
- `port_` stored as `int` (set from Python, works on all IDF versions)
- Non-legacy speaker/microphone use `get_port()` for `i2s_chan_config_t.id` instead of `I2S_NUM_AUTO`
- Add validation error when `use_legacy: true` with IDF >= 6.0

**Cleanup:**
- Removed redundant ADC/PDM port 0 runtime checks from microphone C++ code (Python guarantees correct assignment)

### Tested configs

- Single instance: gets port 0
- Two instances with PDM mic listed second in YAML: PDM parent gets port 0, speaker gets port 1
- Two PDM mics: config validation error

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
i2s_audio:
  i2s_lrclk_pin: GPIO33
  i2s_bclk_pin: GPIO19
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).