### PR TITLE
[core] Add no-arg status_set_warning() to allow linker GC of const char* overload

### DIFF
--- a/esphome/components/rx8130/rx8130.cpp
+++ b/esphome/components/rx8130/rx8130.cpp
@@ -68,7 +68,7 @@ void RX8130Component::dump_config() {
 void RX8130Component::read_time() {
   uint8_t date[7];
   if (this->read_register(RX8130_REG_SEC, date, 7) != i2c::ERROR_OK) {
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
     return;
   }
   ESPTime rtc_time{
@@ -109,7 +109,7 @@ void RX8130Component::write_time() {
   buff[6] = dec2bcd(now.year % 100);
   this->stop_(true);
   if (this->write_register(RX8130_REG_SEC, buff, 7) != i2c::ERROR_OK) {
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
   } else {
     ESP_LOGD(TAG, "Wrote UTC time: %04d-%02d-%02d %02d:%02d:%02d", now.year, now.month, now.day_of_month, now.hour,
              now.minute, now.second);
@@ -120,7 +120,7 @@ void RX8130Component::write_time() {
 void RX8130Component::stop_(bool stop) {
   const uint8_t data = stop ? RX8130_BIT_CTRL_STOP : RX8130_CLEAR_FLAGS;
   if (this->write_register(RX8130_REG_CTRL0, &data, 1) != i2c::ERROR_OK) {
-    this->status_set_warning(ESP_LOG_MSG_COMM_FAIL);
+    this->status_set_warning(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
   }
 }
 

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -416,7 +416,7 @@ void USBUartTypeCdcAcm::on_connected() {
   for (auto *channel : this->channels_) {
     if (i == cdc_devs.size()) {
       ESP_LOGE(TAG, "No configuration found for channel %d", channel->index_);
-      this->status_set_warning("No configuration found for channel");
+      this->status_set_warning(LOG_STR("No configuration found for channel"));
       break;
     }
     channel->cdc_dev_ = cdc_devs[i++];

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -90,7 +90,7 @@ void ZWaveProxy::process_uart_() {
   while (this->available()) {
     uint8_t byte;
     if (!this->read_byte(&byte)) {
-      this->status_set_warning("UART read failed");
+      this->status_set_warning(LOG_STR("UART read failed"));
       return;
     }
     if (this->parse_byte_(byte)) {

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -392,6 +392,7 @@ bool Component::set_status_flag_(uint8_t flag) {
   return true;
 }
 
+void Component::status_set_warning() { this->status_set_warning((const LogString *) nullptr); }
 void Component::status_set_warning(const char *message) {
   if (!this->set_status_flag_(STATUS_LED_WARNING))
     return;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -240,7 +240,8 @@ class Component {
 
   bool status_has_error() const { return this->component_state_ & STATUS_LED_ERROR; }
 
-  void status_set_warning(const char *message = nullptr);
+  void status_set_warning();  // Set warning flag without message
+  void status_set_warning(const char *message);
   void status_set_warning(const LogString *message);
 
   void status_set_error();  // Set error flag without message


### PR DESCRIPTION
# What does this implement/fix?

Add a separate no-argument `status_set_warning()` overload that delegates to the `LogString*` overload, matching the existing `status_set_error()` pattern. Previously, `status_set_warning()` used a default parameter (`const char *message = nullptr`), which meant every no-argument call pulled in the `const char*` overload and prevented the linker from garbage-collecting it.

Also migrates static string literal callers in `rx8130`, `usb_uart`, and `zwave_proxy` to use `LOG_STR()` so the `const char*` overload can be eliminated in firmware that doesn't use dynamic warning messages.

Components that legitimately need dynamic messages (e.g., `ch423`, `qmc5883l` with `snprintf` buffers) continue to use the `const char*` overload.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal API only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).