### PR TITLE
[mqtt] Fix ESP-IDF 6.0 compatibility for external MQTT component

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -3,7 +3,9 @@ from esphome.automation import Condition
 import esphome.codegen as cg
 from esphome.components import logger, socket
 from esphome.components.esp32 import (
+    add_idf_component,
     add_idf_sdkconfig_option,
+    idf_version,
     include_builtin_idf_component,
 )
 from esphome.config_helpers import filter_source_files_from_platform
@@ -351,7 +353,11 @@ async def to_code(config):
     if CORE.is_esp32:
         socket.require_wake_loop_threadsafe()
         # Re-enable ESP-IDF's mqtt component (excluded by default to save compile time)
-        include_builtin_idf_component("mqtt")
+        # IDF 6.0 moved esp-mqtt to an external component
+        if idf_version() >= cv.Version(6, 0, 0):
+            add_idf_component(name="espressif/mqtt", ref="1.0.0")
+        else:
+            include_builtin_idf_component("mqtt")
 
     cg.add_define("USE_MQTT")
     cg.add_global(mqtt_ns.using)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -37,5 +37,9 @@ dependencies:
     version: 0.3.2
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32c6, esp32p4]"
+  espressif/mqtt:
+    version: "1.0.0"
+    rules:
+      - if: "idf_version >=6.0.0"
   esp32async/asynctcp:
     version: 3.4.91


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 moved `esp-mqtt` from a builtin component to an external component in the IDF component registry. This causes a build failure:

```
fatal error: mqtt_client.h: No such file or directory
```

On IDF 6.0+, add `espressif/mqtt` 1.0.0 as an IDF component dependency. On older IDF versions, keep using the builtin `mqtt` component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
mqtt:
  broker: mqtt.example.com
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).