### PR TITLE
[esp32] Support non-numeric version extras in IDF version string

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -612,10 +612,12 @@ def _format_framework_espidf_version(
         ext = "tar.xz"
     else:
         ext = "zip"
-    # Build version string with dot-separated extra (e.g., "5.5.3.1" not "5.5.3-1")
+    # Build version string with extra separator based on type:
+    # numeric extra uses dot (e.g., "5.5.3.1"), string extra uses dash (e.g., "6.0.0-rc1")
     ver_str = f"{ver.major}.{ver.minor}.{ver.patch}"
     if ver.extra:
-        ver_str += f".{ver.extra}"
+        sep = "." if str(ver.extra).isdigit() else "-"
+        ver_str += f"{sep}{ver.extra}"
     if release:
         return f"pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v{ver_str}.{release}/esp-idf-v{ver_str}.{ext}"
     return f"pioarduino/framework-espidf@https://github.com/pioarduino/esp-idf/releases/download/v{ver_str}/esp-idf-v{ver_str}.{ext}"


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF framework version URL formatter always used a dot separator for the version extra field (e.g., `5.5.3.1`). This doesn't work for non-numeric extras like release candidates (e.g., `6.0.0-rc1` was formatted as `6.0.0.rc1`).

Now uses a dash for string extras and a dot for numeric extras:
- `cv.Version(5, 5, 3, "1")` → `v5.5.3.1`
- `cv.Version(6, 0, 0, "rc1")` → `v6.0.0-rc1`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
esp32:
  framework:
    type: esp-idf
    version: 6.0.0-rc1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).