### PR TITLE
[ci] Support URL and version extras in generate-esp32-boards.py

### DIFF
--- a/script/generate-esp32-boards.py
+++ b/script/generate-esp32-boards.py
@@ -11,13 +11,21 @@ from esphome.components.esp32 import PLATFORM_VERSION_LOOKUP
 from esphome.helpers import write_file_if_changed
 
 ver = PLATFORM_VERSION_LOOKUP["recommended"]
-version_str = f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}"
 root = Path(__file__).parent.parent
 boards_file_path = root / "esphome" / "components" / "esp32" / "boards.py"
 
 
 def get_boards():
     with tempfile.TemporaryDirectory() as tempdir:
+        if hasattr(ver, "major"):
+            branch = f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}"
+            if ver.extra:
+                branch += f"-{ver.extra}"
+            repo = "https://github.com/pioarduino/platform-espressif32"
+        else:
+            # URL format: "https://github.com/user/repo.git#branch"
+            url = str(ver)
+            repo, branch = url.rsplit("#", 1) if "#" in url else (url, "main")
         subprocess.run(
             [
                 "git",
@@ -28,8 +36,8 @@ def get_boards():
                 "--depth",
                 "1",
                 "--branch",
-                f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}",
-                "https://github.com/pioarduino/platform-espressif32",
+                branch,
+                repo,
                 tempdir,
             ],
             check=True,

--- a/script/generate-esp32-boards.py
+++ b/script/generate-esp32-boards.py
@@ -9,6 +9,7 @@ import tempfile
 
 from esphome.components.esp32 import PLATFORM_VERSION_LOOKUP
 from esphome.helpers import write_file_if_changed
+from esphome import config_validation as cv
 
 ver = PLATFORM_VERSION_LOOKUP["recommended"]
 root = Path(__file__).parent.parent
@@ -17,7 +18,7 @@ boards_file_path = root / "esphome" / "components" / "esp32" / "boards.py"
 
 def get_boards():
     with tempfile.TemporaryDirectory() as tempdir:
-        if hasattr(ver, "major"):
+        if isinstance(ver, cv.Version):
             branch = f"{ver.major}.{ver.minor:02d}.{ver.patch:02d}"
             if ver.extra:
                 branch += f"-{ver.extra}"

--- a/script/generate-esp32-boards.py
+++ b/script/generate-esp32-boards.py
@@ -7,9 +7,9 @@ import subprocess
 import sys
 import tempfile
 
+from esphome import config_validation as cv
 from esphome.components.esp32 import PLATFORM_VERSION_LOOKUP
 from esphome.helpers import write_file_if_changed
-from esphome import config_validation as cv
 
 ver = PLATFORM_VERSION_LOOKUP["recommended"]
 root = Path(__file__).parent.parent


### PR DESCRIPTION
# What does this implement/fix?

`generate-esp32-boards.py` assumed `PLATFORM_VERSION_LOOKUP["recommended"]` is always a `cv.Version`. This fails when using a custom platform fork URL (e.g. for IDF 6.0 testing) or when the version has an extra field.

Changes:
- Support URL strings by parsing `repo#branch` format
- Support version extras (e.g. `55.03.37-1`) with dash separator

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# N/A - CI script change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).