### PR TITLE
[multiple] Fix implicit int-to-gpio_num_t conversions for GCC 15

### DIFF
--- a/esphome/components/ledc/ledc_output.cpp
+++ b/esphome/components/ledc/ledc_output.cpp
@@ -3,6 +3,7 @@
 
 #ifdef USE_ESP32
 
+#include <driver/gpio.h>
 #include <driver/ledc.h>
 #include <cinttypes>
 #include <esp_idf_version.h>
@@ -189,7 +190,7 @@ void LEDCOutput::setup() {
            this->phase_angle_, hpoint);
 
   ledc_channel_config_t chan_conf{};
-  chan_conf.gpio_num = this->pin_->get_pin();
+  chan_conf.gpio_num = static_cast<gpio_num_t>(this->pin_->get_pin());
   chan_conf.speed_mode = speed_mode;
   chan_conf.channel = chan_num;
   chan_conf.intr_type = LEDC_INTR_DISABLE;

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -4,7 +4,8 @@
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include "esp_lcd_panel_rgb.h"
+#include <driver/gpio.h>
+#include <esp_lcd_panel_rgb.h>
 #include <span>
 
 namespace esphome {
@@ -153,18 +154,18 @@ void MipiRgb::common_setup_() {
   config.clk_src = LCD_CLK_SRC_PLL160M;
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
   for (size_t i = 0; i != data_pin_count; i++) {
-    config.data_gpio_nums[i] = this->data_pins_[i]->get_pin();
+    config.data_gpio_nums[i] = static_cast<gpio_num_t>(this->data_pins_[i]->get_pin());
   }
   config.data_width = data_pin_count;
-  config.disp_gpio_num = -1;
-  config.hsync_gpio_num = this->hsync_pin_->get_pin();
-  config.vsync_gpio_num = this->vsync_pin_->get_pin();
+  config.disp_gpio_num = GPIO_NUM_NC;
+  config.hsync_gpio_num = static_cast<gpio_num_t>(this->hsync_pin_->get_pin());
+  config.vsync_gpio_num = static_cast<gpio_num_t>(this->vsync_pin_->get_pin());
   if (this->de_pin_) {
-    config.de_gpio_num = this->de_pin_->get_pin();
+    config.de_gpio_num = static_cast<gpio_num_t>(this->de_pin_->get_pin());
   } else {
-    config.de_gpio_num = -1;
+    config.de_gpio_num = GPIO_NUM_NC;
   }
-  config.pclk_gpio_num = this->pclk_pin_->get_pin();
+  config.pclk_gpio_num = static_cast<gpio_num_t>(this->pclk_pin_->get_pin());
   esp_err_t err = esp_lcd_new_rgb_panel(&config, &this->handle_);
   if (err == ESP_OK)
     err = esp_lcd_panel_reset(this->handle_);

--- a/esphome/components/pulse_counter/pulse_counter_sensor.cpp
+++ b/esphome/components/pulse_counter/pulse_counter_sensor.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/log.h"
 
 #ifdef HAS_PCNT
+#include <driver/gpio.h>
 #include <esp_private/esp_clk.h>
 #include <hal/pcnt_ll.h>
 #endif
@@ -76,8 +77,8 @@ bool HwPulseCounterStorage::pulse_counter_setup(InternalGPIOPin *pin) {
   }
 
   pcnt_chan_config_t chan_config = {
-      .edge_gpio_num = this->pin->get_pin(),
-      .level_gpio_num = -1,
+      .edge_gpio_num = static_cast<gpio_num_t>(this->pin->get_pin()),
+      .level_gpio_num = GPIO_NUM_NC,
   };
   error = pcnt_new_channel(this->pcnt_unit, &chan_config, &this->pcnt_channel);
   if (error != ESP_OK) {

--- a/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
+++ b/esphome/components/rpi_dpi_rgb/rpi_dpi_rgb.cpp
@@ -2,6 +2,7 @@
 #include "rpi_dpi_rgb.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
+#include <driver/gpio.h>
 
 namespace esphome {
 namespace rpi_dpi_rgb {
@@ -25,14 +26,14 @@ void RpiDpiRgb::setup() {
   config.clk_src = LCD_CLK_SRC_PLL160M;
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
   for (size_t i = 0; i != data_pin_count; i++) {
-    config.data_gpio_nums[i] = this->data_pins_[i]->get_pin();
+    config.data_gpio_nums[i] = static_cast<gpio_num_t>(this->data_pins_[i]->get_pin());
   }
   config.data_width = data_pin_count;
-  config.disp_gpio_num = -1;
-  config.hsync_gpio_num = this->hsync_pin_->get_pin();
-  config.vsync_gpio_num = this->vsync_pin_->get_pin();
-  config.de_gpio_num = this->de_pin_->get_pin();
-  config.pclk_gpio_num = this->pclk_pin_->get_pin();
+  config.disp_gpio_num = GPIO_NUM_NC;
+  config.hsync_gpio_num = static_cast<gpio_num_t>(this->hsync_pin_->get_pin());
+  config.vsync_gpio_num = static_cast<gpio_num_t>(this->vsync_pin_->get_pin());
+  config.de_gpio_num = static_cast<gpio_num_t>(this->de_pin_->get_pin());
+  config.pclk_gpio_num = static_cast<gpio_num_t>(this->pclk_pin_->get_pin());
   esp_err_t err = esp_lcd_new_rgb_panel(&config, &this->handle_);
   if (err != ESP_OK) {
     ESP_LOGE(TAG, "lcd_new_rgb_panel failed: %s", esp_err_to_name(err));

--- a/esphome/components/st7701s/st7701s.cpp
+++ b/esphome/components/st7701s/st7701s.cpp
@@ -2,6 +2,7 @@
 #include "st7701s.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
+#include <driver/gpio.h>
 
 namespace esphome {
 namespace st7701s {
@@ -27,14 +28,14 @@ void ST7701S::setup() {
   config.clk_src = LCD_CLK_SRC_PLL160M;
   size_t data_pin_count = sizeof(this->data_pins_) / sizeof(this->data_pins_[0]);
   for (size_t i = 0; i != data_pin_count; i++) {
-    config.data_gpio_nums[i] = this->data_pins_[i]->get_pin();
+    config.data_gpio_nums[i] = static_cast<gpio_num_t>(this->data_pins_[i]->get_pin());
   }
   config.data_width = data_pin_count;
-  config.disp_gpio_num = -1;
-  config.hsync_gpio_num = this->hsync_pin_->get_pin();
-  config.vsync_gpio_num = this->vsync_pin_->get_pin();
-  config.de_gpio_num = this->de_pin_->get_pin();
-  config.pclk_gpio_num = this->pclk_pin_->get_pin();
+  config.disp_gpio_num = GPIO_NUM_NC;
+  config.hsync_gpio_num = static_cast<gpio_num_t>(this->hsync_pin_->get_pin());
+  config.vsync_gpio_num = static_cast<gpio_num_t>(this->vsync_pin_->get_pin());
+  config.de_gpio_num = static_cast<gpio_num_t>(this->de_pin_->get_pin());
+  config.pclk_gpio_num = static_cast<gpio_num_t>(this->pclk_pin_->get_pin());
   esp_err_t err = esp_lcd_new_rgb_panel(&config, &this->handle_);
   if (err != ESP_OK) {
     esph_log_e(TAG, "lcd_new_rgb_panel failed: %s", esp_err_to_name(err));


### PR DESCRIPTION
# What does this implement/fix?

GCC 15 (shipped with the ESP-IDF 6.0 toolchain) treats implicit `int`/`uint8_t` to enum conversions as errors. Several components assign `get_pin()` results (which return `uint8_t`) or `-1` directly to `gpio_num_t` struct fields without a cast.

Changes:
- Add explicit `static_cast<gpio_num_t>()` for pin assignments
- Use `GPIO_NUM_NC` instead of `-1` for unconnected pins
- Add `<driver/gpio.h>` include where needed (transitive includes changed in IDF 6.0)
- Fix `"esp_lcd_panel_rgb.h"` to `<esp_lcd_panel_rgb.h>` (system header)

Affected components: st7701s, mipi_rgb, rpi_dpi_rgb, pulse_counter, ledc

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).