### PR TITLE
[pmsx003] Keep active-mode reads aligned

### DIFF
--- a/esphome/components/pmsx003/pmsx003.cpp
+++ b/esphome/components/pmsx003/pmsx003.cpp
@@ -95,10 +95,6 @@ void PMSX003Component::loop() {
         // Just go ahead and read stuff
         break;
     }
-  } else if (now - this->last_update_ < this->update_interval_) {
-    // Otherwise just leave the sensor powered up and come back when we hit the update
-    // time
-    return;
   }
 
   if (now - this->last_transmission_ >= 500) {
@@ -114,10 +110,11 @@ void PMSX003Component::loop() {
     this->read_byte(&this->data_[this->data_index_]);
     auto check = this->check_byte_();
     if (!check.has_value()) {
-      // finished
-      this->parse_data_();
+      if (this->update_interval_ > STABILISING_MS || now - this->last_update_ >= this->update_interval_) {
+        this->parse_data_();
+        this->last_update_ = now;
+      }
       this->data_index_ = 0;
-      this->last_update_ = now;
     } else if (!*check) {
       // wrong data
       this->data_index_ = 0;
@@ -138,7 +135,7 @@ optional<bool> PMSX003Component::check_byte_() {
       return true;
     }
 
-    ESP_LOGW(TAG, "Start character %u mismatch: 0x%02X != 0x%02X", index + 1, byte, START_CHARACTER_1);
+    ESP_LOGW(TAG, "Start character %u mismatch: 0x%02X != 0x%02X", index + 1, byte, start_char);
     return false;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

With a 30s update interval the sensor stays in active mode and continues streaming frames, but the loop stopped consuming UART data until the publish interval elapsed. That lets bytes build up in the RX buffer and can surface as repeated start character mismatch warnings when the stream is read again.

Keep consuming frames in active mode while only publishing when the update interval is due, preserving the existing passive sleep/wake behavior. Also report the correct expected start byte in mismatch warnings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes: #13081

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
