### PR TITLE
[core] Mark leaf Component subclasses as final

### DIFF
--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -36,11 +36,11 @@ struct SavedNoisePsk {
 } PACKED;  // NOLINT
 #endif
 
-class APIServer : public Component,
-                  public Controller
+class APIServer final : public Component,
+                        public Controller
 #ifdef USE_CAMERA
     ,
-                  public camera::CameraListener
+                        public camera::CameraListener
 #endif
 {
  public:

--- a/esphome/components/binary_sensor/filter.h
+++ b/esphome/components/binary_sensor/filter.h
@@ -37,7 +37,7 @@ class TimeoutFilter : public Filter, public Component {
   TemplatableValue<uint32_t> timeout_delay_{};
 };
 
-class DelayedOnOffFilter : public Filter, public Component {
+class DelayedOnOffFilter final : public Filter, public Component {
  public:
   optional<bool> new_value(bool value) override;
 

--- a/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
+++ b/esphome/components/gpio/binary_sensor/gpio_binary_sensor.h
@@ -39,7 +39,7 @@ class GPIOBinarySensorStore {
   Component *component_{nullptr};  // Pointer to the component for enable_loop_soon_any_context()
 };
 
-class GPIOBinarySensor : public binary_sensor::BinarySensor, public Component {
+class GPIOBinarySensor final : public binary_sensor::BinarySensor, public Component {
  public:
   // No destructor needed: ESPHome components are created at boot and live forever.
   // Interrupts are only detached on reboot when memory is cleared anyway.

--- a/esphome/components/gpio/switch/gpio_switch.h
+++ b/esphome/components/gpio/switch/gpio_switch.h
@@ -8,7 +8,7 @@
 namespace esphome {
 namespace gpio {
 
-class GPIOSwitch : public switch_::Switch, public Component {
+class GPIOSwitch final : public switch_::Switch, public Component {
  public:
   void set_pin(GPIOPin *pin) { pin_ = pin; }
 

--- a/esphome/components/homeassistant/time/homeassistant_time.h
+++ b/esphome/components/homeassistant/time/homeassistant_time.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace homeassistant {
 
-class HomeassistantTime : public time::RealTimeClock {
+class HomeassistantTime final : public time::RealTimeClock {
  public:
   void setup() override;
   void update() override;

--- a/esphome/components/md5/md5.h
+++ b/esphome/components/md5/md5.h
@@ -32,7 +32,7 @@
 namespace esphome {
 namespace md5 {
 
-class MD5Digest : public HashBase {
+class MD5Digest final : public HashBase {
  public:
   MD5Digest() = default;
   ~MD5Digest() override;

--- a/esphome/components/preferences/syncer.h
+++ b/esphome/components/preferences/syncer.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace preferences {
 
-class IntervalSyncer : public Component {
+class IntervalSyncer final : public Component {
  public:
   void set_write_interval(uint32_t write_interval) { this->write_interval_ = write_interval; }
   void setup() override {

--- a/esphome/components/restart/button/restart_button.h
+++ b/esphome/components/restart/button/restart_button.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace restart {
 
-class RestartButton : public button::Button, public Component {
+class RestartButton final : public button::Button, public Component {
  public:
   void dump_config() override;
 

--- a/esphome/components/safe_mode/button/safe_mode_button.h
+++ b/esphome/components/safe_mode/button/safe_mode_button.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace safe_mode {
 
-class SafeModeButton : public button::Button, public Component {
+class SafeModeButton final : public button::Button, public Component {
  public:
   void dump_config() override;
   void set_safe_mode(SafeModeComponent *safe_mode_component);

--- a/esphome/components/sha256/sha256.h
+++ b/esphome/components/sha256/sha256.h
@@ -48,7 +48,7 @@ namespace esphome::sha256 {
 ///   hasher.init();
 ///   hasher.add(data, len);
 ///   hasher.calculate();
-class SHA256 : public esphome::HashBase {
+class SHA256 final : public esphome::HashBase {
  public:
   SHA256() = default;
   ~SHA256() override;

--- a/esphome/components/version/version_text_sensor.h
+++ b/esphome/components/version/version_text_sensor.h
@@ -5,7 +5,7 @@
 
 namespace esphome::version {
 
-class VersionTextSensor : public text_sensor::TextSensor, public Component {
+class VersionTextSensor final : public text_sensor::TextSensor, public Component {
  public:
   void set_hide_hash(bool hide_hash);
   void set_hide_timestamp(bool hide_timestamp);

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -399,7 +399,7 @@ class WiFiPowerSaveListener {
 };
 
 /// This component is responsible for managing the ESP WiFi interface.
-class WiFiComponent : public Component {
+class WiFiComponent final : public Component {
  public:
   /// Construct a WiFiComponent.
   WiFiComponent();


### PR DESCRIPTION
# What does this implement/fix?

Mark 12 leaf classes (classes with no subclasses) as `final` to enable compiler devirtualization of virtual calls, reducing code size and improving performance on embedded targets.

Classes marked `final`:
- `APIServer`
- `WiFiComponent`
- `GPIOSwitch`
- `GPIOBinarySensor`
- `SafeModeButton`
- `RestartButton`
- `VersionTextSensor`
- `IntervalSyncer`
- `HomeassistantTime`
- `DelayedOnOffFilter`
- `MD5Digest`
- `SHA256`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - this is a C++ only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).