### PR TITLE
[web_server] Fix wrong printf format specifier

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -415,7 +415,7 @@ void WebServer::setup() {
   this->set_interval(10000, [this]() {
     char buf[32];
     auto uptime = static_cast<uint32_t>(millis_64() / 1000);
-    buf_append_printf(buf, sizeof(buf), 0, "{\"uptime\":%u}", uptime);
+    buf_append_printf(buf, sizeof(buf), 0, "{\"uptime\":%" PRIu32 "}", uptime);
     this->events_.try_send_nodefer(buf, "ping", millis(), 30000);
   });
 }


### PR DESCRIPTION
# What does this implement/fix?

Commit 33f9ad9cee4e712d14721966318f99d8d0f63238 current dev branch results in:

```
src/esphome/components/web_server/web_server.cpp: In lambda function:                                                                      
src/esphome/components/web_server/web_server.cpp:418:58: error: format '%u' expects argument of type 'unsigned int', but argument 5 has typ
e 'long unsigned int' [-Werror=format=]                              
  418 |     buf_append_printf(buf, sizeof(buf), 0, "{\"uptime\":%u}", uptime);                                                             
      |                                                         ~^    ~~~~~~
      |                                                          |    |                                                                    
      |                                                          |    long unsigned int
      |                                                          unsigned int                                                              
      |                                                         %lu  
```

I just used %lu and cast explicitly to `unsigned long` to be extra sure.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
