### PR TITLE
[tests] Fix integration helper to match entities exactly

### DIFF
--- a/tests/integration/fixtures/sensor_filters_nan_handling.yaml
+++ b/tests/integration/fixtures/sensor_filters_nan_handling.yaml
@@ -3,7 +3,7 @@ esphome:
 
 host:
 api:
-  batch_delay: 0ms  # Disable batching to receive all state updates
+  batch_delay: 0ms # Disable batching to receive all state updates
 logger:
   level: DEBUG
 
@@ -15,8 +15,8 @@ sensor:
 
   - platform: copy
     source_id: source_nan_sensor
-    name: "Min NaN Sensor"
-    id: min_nan_sensor
+    name: "Min NaN"
+    id: min_nan
     filters:
       - min:
           window_size: 5
@@ -25,8 +25,8 @@ sensor:
 
   - platform: copy
     source_id: source_nan_sensor
-    name: "Max NaN Sensor"
-    id: max_nan_sensor
+    name: "Max NaN"
+    id: max_nan
     filters:
       - max:
           window_size: 5
@@ -42,7 +42,7 @@ script:
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
-          state: !lambda 'return NAN;'
+          state: !lambda "return NAN;"
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
@@ -50,7 +50,7 @@ script:
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
-          state: !lambda 'return NAN;'
+          state: !lambda "return NAN;"
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
@@ -62,7 +62,7 @@ script:
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
-          state: !lambda 'return NAN;'
+          state: !lambda "return NAN;"
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
@@ -74,7 +74,7 @@ script:
       - delay: 20ms
       - sensor.template.publish:
           id: source_nan_sensor
-          state: !lambda 'return NAN;'
+          state: !lambda "return NAN;"
 
 button:
   - platform: template

--- a/tests/integration/fixtures/sensor_filters_ring_buffer.yaml
+++ b/tests/integration/fixtures/sensor_filters_ring_buffer.yaml
@@ -3,7 +3,7 @@ esphome:
 
 host:
 api:
-  batch_delay: 0ms  # Disable batching to receive all state updates
+  batch_delay: 0ms # Disable batching to receive all state updates
 logger:
   level: DEBUG
 
@@ -18,8 +18,8 @@ sensor:
   # Window of 5, send every 2 values
   - platform: copy
     source_id: source_sensor
-    name: "Sliding Min Sensor"
-    id: sliding_min_sensor
+    name: "Sliding Min"
+    id: sliding_min
     filters:
       - min:
           window_size: 5
@@ -28,8 +28,8 @@ sensor:
 
   - platform: copy
     source_id: source_sensor
-    name: "Sliding Max Sensor"
-    id: sliding_max_sensor
+    name: "Sliding Max"
+    id: sliding_max
     filters:
       - max:
           window_size: 5
@@ -38,8 +38,8 @@ sensor:
 
   - platform: copy
     source_id: source_sensor
-    name: "Sliding Median Sensor"
-    id: sliding_median_sensor
+    name: "Sliding Median"
+    id: sliding_median
     filters:
       - median:
           window_size: 5
@@ -48,8 +48,8 @@ sensor:
 
   - platform: copy
     source_id: source_sensor
-    name: "Sliding Moving Avg Sensor"
-    id: sliding_moving_avg_sensor
+    name: "Sliding Moving Avg"
+    id: sliding_moving_avg
     filters:
       - sliding_window_moving_average:
           window_size: 5

--- a/tests/integration/fixtures/sensor_filters_ring_buffer_wraparound.yaml
+++ b/tests/integration/fixtures/sensor_filters_ring_buffer_wraparound.yaml
@@ -3,20 +3,20 @@ esphome:
 
 host:
 api:
-  batch_delay: 0ms  # Disable batching to receive all state updates
+  batch_delay: 0ms # Disable batching to receive all state updates
 logger:
   level: DEBUG
 
 sensor:
   - platform: template
-    name: "Source Wraparound Sensor"
+    name: "Source Wraparound"
     id: source_wraparound
     accuracy_decimals: 2
 
   - platform: copy
     source_id: source_wraparound
-    name: "Wraparound Min Sensor"
-    id: wraparound_min_sensor
+    name: "Wraparound Min"
+    id: wraparound_min
     filters:
       - min:
           window_size: 3

--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -97,7 +97,7 @@ def build_key_to_entity_mapping(
     for entity in entities:
         obj_id = entity.object_id.lower()
         for entity_name in entity_names:
-            if entity_name in obj_id:
+            if entity_name == obj_id:
                 key_to_entity[entity.key] = entity_name
                 break
     return key_to_entity

--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -88,7 +88,7 @@ def build_key_to_entity_mapping(
 
     Args:
         entities: List of entity info objects from the API
-        entity_names: List of entity names to search for in object_ids
+        entity_names: List of entity names to match exactly against object_ids
 
     Returns:
         Dictionary mapping entity keys to entity names


### PR DESCRIPTION
# What does this implement/fix?

Fix the `build_key_to_entity_mapping` helper in `tests/integration/state_utils.py` to match entities by exact name rather than substring. Previously it used `if entity_name in obj_id`, which caused incorrect matches when one entity name was a substring of another (e.g. "foo" matching both "foo" and "foo_bar").

Also updates the related integration test fixture YAML files to use entity names that were relying on the old substring matching behaviour.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).
