### PR TITLE
[fastled] Include esp_lcd IDF component for ESP32-S3 compatibility

### DIFF
--- a/esphome/components/fastled_base/__init__.py
+++ b/esphome/components/fastled_base/__init__.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_OUTPUT_ID,
     CONF_RGB_ORDER,
 )
+from esphome.core import CORE
 
 CODEOWNERS = ["@OttoWinter"]
 fastled_base_ns = cg.esphome_ns.namespace("fastled_base")
@@ -41,5 +42,9 @@ async def new_fastled_light(config):
         cg.add(var.set_max_refresh_rate(config[CONF_MAX_REFRESH_RATE]))
 
     cg.add_library("fastled/FastLED", "3.9.16")
+    if CORE.is_esp32:
+        from esphome.components.esp32 import include_builtin_idf_component
+
+        include_builtin_idf_component("esp_lcd")
     await light.register_light(var, config)
     return var

--- a/tests/components/fastled_clockless/test.esp32-s3-ard.yaml
+++ b/tests/components/fastled_clockless/test.esp32-s3-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

FastLED 3.9.16 includes an I2S-based LED driver for ESP32-S3 (`I2SClockLessLedDriveresp32s3`) that requires `esp_lcd_panel_interface.h`. ESPHome excludes the `esp_lcd` ESP-IDF component by default to save compile time, which causes compilation to fail on ESP32-S3 with Arduino framework.

This adds `include_builtin_idf_component("esp_lcd")` to `fastled_base` when targeting ESP32, following the same pattern used by the `display` component.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14827

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32

## Example entry for `config.yaml`:

```yaml
light:
  - platform: fastled_clockless
    chipset: WS2812
    pin: GPIO38
    num_leds: 1
    rgb_order: RGB
    name: "RGB LED"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).