### PR TITLE
[runtime_image] Add esp-dsp dependency for JPEGDEC SIMD on ESP32

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -532,10 +532,6 @@ def add_idf_component(
         KEY_REF: ref,
         KEY_PATH: path,
     }
-    # Also un-stub this component if it was excluded (e.g. in ARDUINO_EXCLUDED_IDF_COMPONENTS)
-    # The stub key uses "__" separator while add_idf_component uses "/"
-    stub_key = name.replace("/", "__")
-    CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].discard(stub_key)
 
 
 def exclude_builtin_idf_component(name: str) -> None:
@@ -1982,13 +1978,10 @@ def _write_idf_component_yml():
             for comp in ARDUINO_LIBRARY_IDF_COMPONENTS.get(lib, ())
         }
 
-        # Only stub components that are still in the exclusion set
-        # (components may have been re-enabled via include_builtin_idf_component())
-        # and not required by any enabled Arduino library
-        excluded_components = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
+        # Only stub components that are not required by any enabled Arduino library
         components_to_stub = (
-            set(ARDUINO_EXCLUDED_IDF_COMPONENTS) & excluded_components
-        ) - required_idf_components
+            set(ARDUINO_EXCLUDED_IDF_COMPONENTS) - required_idf_components
+        )
 
         stubs_dir = CORE.relative_build_path("component_stubs")
         stubs_dir.mkdir(exist_ok=True)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1991,8 +1991,8 @@ def _write_idf_component_yml():
         # and not required by any enabled Arduino library
         excluded_components = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
         components_to_stub = (
-            set(ARDUINO_EXCLUDED_IDF_COMPONENTS)
-            & excluded_components - required_idf_components
+            (set(ARDUINO_EXCLUDED_IDF_COMPONENTS) & excluded_components)
+            - required_idf_components
         )
 
         stubs_dir = CORE.relative_build_path("component_stubs")

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1991,9 +1991,8 @@ def _write_idf_component_yml():
         # and not required by any enabled Arduino library
         excluded_components = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
         components_to_stub = (
-            (set(ARDUINO_EXCLUDED_IDF_COMPONENTS) & excluded_components)
-            - required_idf_components
-        )
+            set(ARDUINO_EXCLUDED_IDF_COMPONENTS) & excluded_components
+        ) - required_idf_components
 
         stubs_dir = CORE.relative_build_path("component_stubs")
         stubs_dir.mkdir(exist_ok=True)

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -532,6 +532,10 @@ def add_idf_component(
         KEY_REF: ref,
         KEY_PATH: path,
     }
+    # Also un-stub this component if it was excluded (e.g. in ARDUINO_EXCLUDED_IDF_COMPONENTS)
+    # The stub key uses "__" separator while add_idf_component uses "/"
+    stub_key = name.replace("/", "__")
+    CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].discard(stub_key)
 
 
 def exclude_builtin_idf_component(name: str) -> None:
@@ -546,21 +550,13 @@ def exclude_builtin_idf_component(name: str) -> None:
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].add(name)
 
 
-def include_builtin_idf_component(name: str, component: str | None = None) -> None:
+def include_builtin_idf_component(name: str) -> None:
     """Remove an ESP-IDF component from the exclusion list.
 
     Call this from components that need an ESP-IDF component that is
-    excluded by default. This ensures the component will be built when needed.
-
-    For builtin IDF components:
-        include_builtin_idf_component("esp_lcd")
-
-    For managed components (namespace/component):
-        include_builtin_idf_component("espressif", "esp-dsp")
+    excluded by default in DEFAULT_EXCLUDED_IDF_COMPONENTS. This ensures the
+    component will be built when needed.
     """
-    if component is not None:
-        # Managed component: format as "namespace__component"
-        name = f"{name}__{component}"
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].discard(name)
 
 

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -546,13 +546,21 @@ def exclude_builtin_idf_component(name: str) -> None:
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].add(name)
 
 
-def include_builtin_idf_component(name: str) -> None:
+def include_builtin_idf_component(name: str, component: str | None = None) -> None:
     """Remove an ESP-IDF component from the exclusion list.
 
     Call this from components that need an ESP-IDF component that is
-    excluded by default in DEFAULT_EXCLUDED_IDF_COMPONENTS. This ensures the
-    component will be built when needed.
+    excluded by default. This ensures the component will be built when needed.
+
+    For builtin IDF components:
+        include_builtin_idf_component("esp_lcd")
+
+    For managed components (namespace/component):
+        include_builtin_idf_component("espressif", "esp-dsp")
     """
+    if component is not None:
+        # Managed component: format as "namespace__component"
+        name = f"{name}__{component}"
     CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS].discard(name)
 
 
@@ -1978,9 +1986,13 @@ def _write_idf_component_yml():
             for comp in ARDUINO_LIBRARY_IDF_COMPONENTS.get(lib, ())
         }
 
-        # Only stub components that are not required by any enabled Arduino library
+        # Only stub components that are still in the exclusion set
+        # (components may have been re-enabled via include_builtin_idf_component())
+        # and not required by any enabled Arduino library
+        excluded_components = CORE.data[KEY_ESP32][KEY_EXCLUDE_COMPONENTS]
         components_to_stub = (
-            set(ARDUINO_EXCLUDED_IDF_COMPONENTS) - required_idf_components
+            set(ARDUINO_EXCLUDED_IDF_COMPONENTS)
+            & excluded_components - required_idf_components
         )
 
         stubs_dir = CORE.relative_build_path("component_stubs")

--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -11,6 +11,7 @@ from esphome.components.image import (
 )
 import esphome.config_validation as cv
 from esphome.const import CONF_FORMAT, CONF_ID, CONF_RESIZE, CONF_TYPE
+from esphome.core import CORE
 
 AUTO_LOAD = ["image"]
 CODEOWNERS = ["@guillempages", "@clydebarrow", "@kahrendt"]
@@ -75,6 +76,11 @@ class JPEGFormat(Format):
     def actions(self) -> None:
         cg.add_define("USE_RUNTIME_IMAGE_JPEG")
         cg.add_library("JPEGDEC", "1.8.4", "https://github.com/bitbank2/JPEGDEC#1.8.4")
+        if CORE.is_esp32:
+            from esphome.components.esp32 import include_builtin_idf_component
+
+            # JPEGDEC uses ESP32-S3 SIMD optimizations that require esp-dsp headers
+            include_builtin_idf_component("espressif", "esp-dsp")
 
 
 class PNGFormat(Format):

--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -81,7 +81,7 @@ class JPEGFormat(Format):
 
             # JPEGDEC uses ESP32-S3 SIMD optimizations (guarded by board-level
             # ARDUINO_ESP32S3_DEV define) that require esp-dsp headers.
-            # add_idf_component also un-stubs for Arduino builds.
+            # On Arduino this overwrites the stub; on IDF it adds the component.
             add_idf_component(name="espressif/esp-dsp", ref="1.7.1")
 
 

--- a/esphome/components/runtime_image/__init__.py
+++ b/esphome/components/runtime_image/__init__.py
@@ -77,10 +77,12 @@ class JPEGFormat(Format):
         cg.add_define("USE_RUNTIME_IMAGE_JPEG")
         cg.add_library("JPEGDEC", "1.8.4", "https://github.com/bitbank2/JPEGDEC#1.8.4")
         if CORE.is_esp32:
-            from esphome.components.esp32 import include_builtin_idf_component
+            from esphome.components.esp32 import add_idf_component
 
-            # JPEGDEC uses ESP32-S3 SIMD optimizations that require esp-dsp headers
-            include_builtin_idf_component("espressif", "esp-dsp")
+            # JPEGDEC uses ESP32-S3 SIMD optimizations (guarded by board-level
+            # ARDUINO_ESP32S3_DEV define) that require esp-dsp headers.
+            # add_idf_component also un-stubs for Arduino builds.
+            add_idf_component(name="espressif/esp-dsp", ref="1.7.1")
 
 
 class PNGFormat(Format):

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -5,6 +5,8 @@ dependencies:
     version: 2.0.3
   esphome/micro-opus:
     version: 0.3.5
+  espressif/esp-dsp:
+    version: "1.7.1"
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:

--- a/tests/components/online_image/test.esp32-s3-ard.yaml
+++ b/tests/components/online_image/test.esp32-s3-ard.yaml
@@ -1,0 +1,19 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-s3-ard.yaml
+
+<<: !include common.yaml
+
+http_request:
+
+display:
+  - platform: ili9xxx
+    spi_id: spi_bus
+    id: main_lcd
+    model: ili9342
+    cs_pin: 20
+    dc_pin: 13
+    reset_pin: 21
+    invert_colors: true
+    lambda: |-
+      it.fill(Color(0, 0, 0));
+      it.image(0, 0, id(online_rgba_image));

--- a/tests/components/online_image/test.esp32-s3-idf.yaml
+++ b/tests/components/online_image/test.esp32-s3-idf.yaml
@@ -1,0 +1,19 @@
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-s3-idf.yaml
+
+<<: !include common.yaml
+
+http_request:
+
+display:
+  - platform: ili9xxx
+    spi_id: spi_bus
+    id: main_lcd
+    model: ili9342
+    cs_pin: 20
+    dc_pin: 13
+    reset_pin: 21
+    invert_colors: true
+    lambda: |-
+      it.fill(Color(0, 0, 0));
+      it.image(0, 0, id(online_rgba_image));


### PR DESCRIPTION
# What does this implement/fix?

JPEGDEC 1.8.4 includes ESP32-S3 SIMD optimizations (`s3_simd_dequant.S`) that require `dsps_fft2r_platform.h` from the `esp-dsp` managed component. This code is [guarded by `#ifdef ARDUINO_ESP32S3_DEV`](https://github.com/bitbank2/JPEGDEC/blob/1.8.4/src/s3_simd_dequant.S#L7), which is defined in the **board JSON** (e.g. [`esp32-s3-devkitc-1.json`](https://github.com/pioarduino/platform-espressif32/blob/v55.03.37/boards/esp32-s3-devkitc-1.json#L8)), not the framework — so it affects both Arduino and IDF builds for boards that define it.

For Arduino builds, ESPHome stubs out `esp-dsp` by default. For IDF builds, `esp-dsp` is not included at all. In both cases, the missing headers cause a compilation failure.

### Fix

Calls `add_idf_component(name="espressif/esp-dsp", ref="1.7.1")` when JPEG decoding is used on ESP32. Since `add_idf_component` entries are written after Arduino stubs in `idf_component.yml`, the explicit component entry naturally overwrites the stub. This ensures the same pinned version (1.7.1) is used on both Arduino and IDF builds.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14831

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  framework:
    type: esp-idf

http_request:

online_image:
  - id: jpeg
    format: jpeg
    type: RGB
    url: http://example.com/image.jpg

display:
  # display needed to use online_image
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).