### PR TITLE
[usb_host] Fix ESP-IDF 6.0 compatibility for external USB host component

### DIFF
--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -4,7 +4,9 @@ from esphome.components.esp32 import (
     VARIANT_ESP32P4,
     VARIANT_ESP32S2,
     VARIANT_ESP32S3,
+    add_idf_component,
     add_idf_sdkconfig_option,
+    idf_version,
     only_on_variant,
 )
 import esphome.config_validation as cv
@@ -64,6 +66,9 @@ async def register_usb_client(config):
 
 
 async def to_code(config: ConfigType) -> None:
+    # IDF 6.0 moved USB host to an external component
+    if idf_version() >= cv.Version(6, 0, 0):
+        add_idf_component(name="espressif/usb", ref="1.3.0")
     add_idf_sdkconfig_option("CONFIG_USB_HOST_CONTROL_TRANSFER_MAX_SIZE", 1024)
     if config.get(CONF_ENABLE_HUBS):
         add_idf_sdkconfig_option("CONFIG_USB_HOST_HUBS_SUPPORTED", True)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -41,5 +41,9 @@ dependencies:
     version: "1.0.0"
     rules:
       - if: "idf_version >=6.0.0"
+  espressif/usb:
+    version: "1.3.0"
+    rules:
+      - if: "idf_version >=6.0.0 && target in [esp32s2, esp32s3, esp32p4]"
   esp32async/asynctcp:
     version: 3.4.91


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 moved the USB host stack from a builtin component to an external component in the IDF component registry. This causes a build failure:

```
fatal error: usb/usb_host.h: No such file or directory
```

On IDF 6.0+, add `espressif/usb` 1.3.0 as an IDF component dependency for USB-capable targets (ESP32-S2, S3, P4).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
usb_host:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).