### PR TITLE
[deep_sleep] Fix ESP-IDF 6.0 GPIO wakeup API rename

### DIFF
--- a/esphome/components/deep_sleep/deep_sleep_esp32.cpp
+++ b/esphome/components/deep_sleep/deep_sleep_esp32.cpp
@@ -3,6 +3,7 @@
 #include "driver/gpio.h"
 #include "deep_sleep_component.h"
 #include "esphome/core/log.h"
+#include <esp_idf_version.h>
 
 namespace esphome {
 namespace deep_sleep {
@@ -26,7 +27,7 @@ namespace deep_sleep {
 // - ext0: Single pin wakeup using RTC GPIO (esp_sleep_enable_ext0_wakeup)
 // - ext1: Multiple pin wakeup (esp_sleep_enable_ext1_wakeup)
 // - Touch: Touch pad wakeup (esp_sleep_enable_touchpad_wakeup)
-// - GPIO wakeup: GPIO wakeup for RTC pins (esp_deep_sleep_enable_gpio_wakeup)
+// - GPIO wakeup: GPIO wakeup for RTC pins
 
 static const char *const TAG = "deep_sleep";
 
@@ -135,8 +136,13 @@ void DeepSleepComponent::deep_sleep_() {
     }
     // Internal pullup/pulldown resistors are enabled automatically, when
     // ESP_SLEEP_GPIO_ENABLE_INTERNAL_RESISTORS is set (by default it is)
-    esp_deep_sleep_enable_gpio_wakeup(1 << this->wakeup_pin_->get_pin(),
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
+    esp_sleep_enable_gpio_wakeup_on_hp_periph_powerdown(1ULL << this->wakeup_pin_->get_pin(),
+                                                        static_cast<esp_sleep_gpio_wake_up_mode_t>(level));
+#else
+    esp_deep_sleep_enable_gpio_wakeup(1ULL << this->wakeup_pin_->get_pin(),
                                       static_cast<esp_deepsleep_gpio_wake_up_mode_t>(level));
+#endif
   }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 renamed the deep sleep GPIO wakeup APIs:
- `esp_deep_sleep_enable_gpio_wakeup()` → `esp_sleep_enable_gpio_wakeup_on_hp_periph_powerdown()`
- `esp_deepsleep_gpio_wake_up_mode_t` → `esp_sleep_gpio_wake_up_mode_t`

The new APIs work for both deep sleep and light sleep when the peripheral power domain is powered down.

Also fixes the GPIO pin mask to use `1ULL` instead of `1` to avoid undefined behavior on pins >= 32.

See: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/migration-guides/release-6.x/6.0/system.html#gpio-wakeup-api-changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
deep_sleep:
  wakeup_pin: GPIO2
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).