### PR TITLE
[tinyusb] Fix regression from bump to 2.x in #14796

### DIFF
--- a/esphome/components/tinyusb/tinyusb_component.cpp
+++ b/esphome/components/tinyusb/tinyusb_component.cpp
@@ -2,6 +2,7 @@
 #include "tinyusb_component.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include "tinyusb_default_config.h"
 
 namespace esphome::tinyusb {
 
@@ -15,19 +16,19 @@ void TinyUSB::setup() {
     this->string_descriptor_[SERIAL_NUMBER] = mac_addr_buf;
   }
 
-  this->tusb_cfg_ = {
-      .port = TINYUSB_PORT_FULL_SPEED_0,
-      .phy = {.skip_setup = false},
-      .descriptor =
-          {
-              .device = &this->usb_descriptor_,
-              .string = this->string_descriptor_,
-              .string_count = SIZE,
-          },
+  // Start from esp_tinyusb defaults to keep required task settings valid across esp_tinyusb updates.
+  this->tusb_cfg_ = TINYUSB_DEFAULT_CONFIG();
+  this->tusb_cfg_.port = TINYUSB_PORT_FULL_SPEED_0;
+  this->tusb_cfg_.phy.skip_setup = false;
+  this->tusb_cfg_.descriptor = {
+      .device = &this->usb_descriptor_,
+      .string = this->string_descriptor_,
+      .string_count = SIZE,
   };
 
   esp_err_t result = tinyusb_driver_install(&this->tusb_cfg_);
   if (result != ESP_OK) {
+    ESP_LOGE(TAG, "tinyusb_driver_install failed: %s", esp_err_to_name(result));
     this->mark_failed();
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

This patch fixes a TinyUSB startup regression introduced after upgrading `esp_tinyusb` to `2.1.1` in #14796.

On ESP32-S2/S3/P4, `tinyusb_driver_install()` now validates task configuration and rejects a zero task stack size (`tinyusb_task_check_config(): Task size can't be 0`). Our `tinyusb` component was manually initializing `tinyusb_config_t` without task settings, so TinyUSB initialization failed at boot and the component was marked failed.

## Root Cause

`esphome/components/tinyusb/tinyusb_component.cpp` built `tinyusb_config_t` directly with descriptor/PHY/port fields only.  
With the newer TinyUSB implementation, that no longer provides a valid default task configuration.

## Fix

- Initialize config with `TINYUSB_DEFAULT_CONFIG()` to inherit valid TinyUSB task defaults.
- Keep ESPHome behavior by overriding:
  - USB port (`TINYUSB_PORT_FULL_SPEED_0`)
  - PHY setup (`phy.skip_setup = false`)
  - Device/string descriptors (`tusb_cfg_.descriptor = { ... }`)
- Add explicit error logging on install failure:
  - `ESP_LOGE(TAG, "tinyusb_driver_install failed: %s", esp_err_to_name(result));`

## Validation

- Built & verified operation with test configuration used for #11689
- `tinyusb` is no longer marked failed during setup

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
