### PR TITLE
[ble_nus] fix uart debug

### DIFF
--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -67,14 +67,14 @@ bool BLENUS::read_array(uint8_t *data, size_t len) {
 
   // First, use the peek buffer if available
   if (this->has_peek_) {
+#ifdef USE_UART_DEBUGGER
+    this->debug_callback_.call(uart::UART_DIRECTION_RX, this->peek_buffer_);
+#endif
     data[0] = this->peek_buffer_;
     this->has_peek_ = false;
     data++;
     if (--len == 0) {  // Decrement len first, then check it...
-#ifdef USE_UART_DEBUGGER
-      this->debug_callback_.call(uart::UART_DIRECTION_RX, this->peek_buffer_);
-#endif
-      return true;  // No more to read
+      return true;     // No more to read
     }
   }
 


### PR DESCRIPTION
# What does this implement/fix?

peek_buffer_ is not printed if there is more data available. The assumption was to print only data but it is shifted by 1. This is second fix for it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
