### PR TITLE
[core] Support both dot and dash separators in Version.parse

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -314,7 +314,7 @@ class Version:
 
     @classmethod
     def parse(cls, value: str) -> Version:
-        match = re.match(r"^(\d+).(\d+).(\d+)-?(\w*)$", value)
+        match = re.match(r"^(\d+).(\d+).(\d+)[-.]?(\w*)$", value)
         if match is None:
             raise ValueError(f"Not a valid version number {value}")
         major = int(match[1])


### PR DESCRIPTION
# What does this implement/fix?

`Version.parse` only accepted `-` as separator for the extra field (e.g. `5.5.3-1`). This broke when parsing versions with dot-separated extras like `5.5.3.1` which is used by pioarduino IDF releases.

The regex now accepts both `.` and `-`: `[-.]?` instead of `-?`.

Examples:
- `5.5.3` → `Version(5, 5, 3, "")`
- `5.5.3.1` → `Version(5, 5, 3, "1")`
- `5.5.3-1` → `Version(5, 5, 3, "1")`
- `6.0.0-rc1` → `Version(6, 0, 0, "rc1")`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
esp32:
  framework:
    type: esp-idf
    version: 5.5.3.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).