### PR TITLE
[ci] Fix clang-tidy hash check 403 error on fork PRs

### DIFF
--- a/.github/workflows/ci-clang-tidy-hash.yml
+++ b/.github/workflows/ci-clang-tidy-hash.yml
@@ -40,7 +40,7 @@ jobs:
           echo "You have modified clang-tidy configuration but have not updated the hash." | tee -a $GITHUB_STEP_SUMMARY
           echo "Please run 'script/clang_tidy_hash.py --update' and commit the changes." | tee -a $GITHUB_STEP_SUMMARY
 
-      - if: failure()
+      - if: failure() && github.event.pull_request.head.repo.full_name == github.repository
         name: Request changes
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -53,7 +53,7 @@ jobs:
               body: 'You have modified clang-tidy configuration but have not updated the hash.\nPlease run `script/clang_tidy_hash.py --update` and commit the changes.'
             })
 
-      - if: success()
+      - if: success() && github.event.pull_request.head.repo.full_name == github.repository
         name: Dismiss review
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:


### PR DESCRIPTION
# What does this implement/fix?

The clang-tidy hash verification workflow tries to create/dismiss PR reviews when the hash check fails/passes. For fork PRs, the `GITHUB_TOKEN` doesn't have `pull_requests: write` permission, causing a 403 error:

```
RequestError [HttpError]: Resource not accessible by integration
status: 403
x-accepted-github-permissions: pull_requests=write
```

This adds a condition to skip the PR review steps for fork PRs. The hash verification itself still runs — it just won't post a review comment on fork PRs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# N/A - CI workflow change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).