### PR TITLE
[as3935] Fix ENERGY_MASK dropping bit 4 of lightning energy MMSB

### DIFF
--- a/esphome/components/as3935/as3935.h
+++ b/esphome/components/as3935/as3935.h
@@ -41,7 +41,7 @@ enum AS3935RegisterMasks {
   INT_MASK = 0xF0,
   THRESH_MASK = 0x0F,
   R_SPIKE_MASK = 0xF0,
-  ENERGY_MASK = 0xF0,
+  ENERGY_MASK = 0xE0,
   CAP_MASK = 0xF0,
   LIGHT_MASK = 0xCF,
   DISTURB_MASK = 0xDF,


### PR DESCRIPTION
## What does this implement/fix?

Fix incorrect `ENERGY_MASK` constant in the AS3935 lightning sensor component.

Per the [AS3935 datasheet](https://www.sciosense.com/wp-content/uploads/2024/01/AS3935-Datasheet.pdf), register 0x06 (`ENERGY_LIGHT_MMSB`) stores the lightning energy most-most-significant byte in **bits [4:0]** (5 bits), making the full energy value **21 bits** wide (8 + 8 + 5).

`ENERGY_MASK` was `0xF0`. The `read_register_()` function inverts the mask (`value &= ~mask`), so `~0xF0 = 0x0F` kept only bits [3:0], **dropping bit 4**. This truncated the energy value to 20 bits, silently losing the most significant bit for large lightning energy readings.

Changed `ENERGY_MASK` from `0xF0` to `0xE0` so that `~0xE0 = 0x1F` correctly preserves all 5 bits [4:0].

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - existing AS3935 configs will automatically
# report correct 21-bit lightning energy values after this fix.
sensor:
  - platform: as3935
    lightning_energy:
      name: "Lightning Energy"
    distance:
      name: "Storm Distance"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).