### PR TITLE
[hub75] Bump esp-hub75 to 0.3.4

### DIFF
--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -587,7 +587,7 @@ def _build_config_struct(
 async def to_code(config: ConfigType) -> None:
     add_idf_component(
         name="esphome/esp-hub75",
-        ref="0.3.2",
+        ref="0.3.4",
     )
 
     # Set compile-time configuration via build flags (so external library sees them)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -64,7 +64,7 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.3.2
+    version: 0.3.4
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32c6, esp32p4]"
   espressif/mqtt:


### PR DESCRIPTION
# What does this implement/fix?

Bumps `esphome/esp-hub75` from 0.3.2 to 0.3.4. Version 0.3.3 fixed ESP-IDF 6.0 compilation errors:
- `esp_private/gdma.h: No such file or directory` (GDMA platform, ESP32-S3)
- `soc/i2s_periph.h: No such file or directory` (I2S DMA platform, ESP32)

Version 0.3.4 adds support for additional panel wiring types.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).