### PR TITLE
[am43] Fix battery update throttle using wrong type

### DIFF
--- a/esphome/components/am43/sensor/am43_sensor.h
+++ b/esphome/components/am43/sensor/am43_sensor.h
@@ -35,7 +35,7 @@ class Am43 : public esphome::ble_client::BLEClientNode, public PollingComponent 
   uint8_t current_sensor_;
   // The AM43 often gets into a state where it spams loads of battery update
   // notifications. Here we will limit to no more than every 10s.
-  uint8_t last_battery_update_;
+  uint32_t last_battery_update_;
 };
 
 }  // namespace am43


### PR DESCRIPTION
## What does this implement/fix?

`last_battery_update_` was declared as `uint8_t` but stores the return value of `millis()` (which is `uint32_t`). The value truncates to 0-255, so the 10-second throttle check `millis() - this->last_battery_update_ > 10000` is always true after just 255ms, completely defeating the throttle.

The comment in the code explains why the throttle exists:
> The AM43 often gets into a state where it spams loads of battery update notifications. Here we will limit to no more than every 10s.

With `uint8_t`, this throttle never worked — battery state was published on every BLE notification.

Fix: change `uint8_t` to `uint32_t`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed.
sensor:
  - platform: am43
    ble_client_id: am43_blind
    battery_level:
      name: "AM43 Battery"
    illuminance:
      name: "AM43 Light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).