### PR TITLE
[lilygo_t5_47] Fix Y coordinate mapping and clamp touch point count

### DIFF
--- a/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
+++ b/esphome/components/lilygo_t5_47/touchscreen/lilygo_t5_47_touchscreen.cpp
@@ -42,7 +42,7 @@ void LilygoT547Touchscreen::setup() {
       this->x_raw_max_ = this->display_->get_native_width();
     }
     if (this->y_raw_max_ == this->y_raw_min_) {
-      this->x_raw_max_ = this->display_->get_native_height();
+      this->y_raw_max_ = this->display_->get_native_height();
     }
   }
 }
@@ -64,6 +64,10 @@ void LilygoT547Touchscreen::update_touches() {
   }
 
   point = buffer[5] & 0xF;
+  if (point > 2) {
+    ESP_LOGW(TAG, "Invalid touch point count: %d", point);
+    point = 2;
+  }
 
   if (point == 1) {
     err = this->write_register(TOUCH_REGISTER, READ_TOUCH, 1);


### PR DESCRIPTION
## What does this implement/fix?

Two bugs in the Lilygo T5 4.7" touchscreen driver:

### 1. Y coordinate mapping (copy-paste bug since original PR #3084)

In `setup()`, line 45 sets `x_raw_max_` instead of `y_raw_max_`:
```cpp
// Before (wrong):
this->x_raw_max_ = this->display_->get_native_height();
// After (correct):
this->y_raw_max_ = this->display_->get_native_height();
```

This means X gets overwritten with the display height, and Y keeps its default value. Both X and Y touch coordinate mapping are wrong when the display auto-configures the raw ranges.

### 2. Touch point count not bounds-checked

`buffer[5] & 0xF` extracts a 4-bit value (0-15) from I2C, but the L58 touch controller only supports 2 touch points. For `point >= 8`, the read `this->read(&buffer[5], 5 * (point - 1) + 3)` would write past the 40-byte stack buffer (e.g. point=15 reads 73 bytes at offset 5). Added a clamp to 2 with a warning log.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed.
touchscreen:
  - platform: lilygo_t5_47
    interrupt_pin: GPIO36
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).