### PR TITLE
[gpio][dallas_temp] Fix one_wire read64() and DS18S20 division by zero

### DIFF
--- a/esphome/components/dallas_temp/dallas_temp.cpp
+++ b/esphome/components/dallas_temp/dallas_temp.cpp
@@ -136,6 +136,9 @@ bool DallasTemperatureSensor::check_scratch_pad_() {
 float DallasTemperatureSensor::get_temp_c_() {
   int16_t temp = (this->scratch_pad_[1] << 8) | this->scratch_pad_[0];
   if ((this->address_ & 0xff) == DALLAS_MODEL_DS18S20) {
+    if (this->scratch_pad_[7] == 0) {
+      return NAN;
+    }
     return (temp >> 1) + (this->scratch_pad_[7] - this->scratch_pad_[6]) / float(this->scratch_pad_[7]) - 0.25;
   }
   switch (this->resolution_) {

--- a/esphome/components/gpio/one_wire/gpio_one_wire.cpp
+++ b/esphome/components/gpio/one_wire/gpio_one_wire.cpp
@@ -131,7 +131,7 @@ uint8_t IRAM_ATTR GPIOOneWireBus::read8() {
 uint64_t IRAM_ATTR GPIOOneWireBus::read64() {
   InterruptLock lock;
   uint64_t ret = 0;
-  for (uint8_t i = 0; i < 8; i++) {
+  for (uint8_t i = 0; i < 64; i++) {
     ret |= (uint64_t(this->read_bit_()) << i);
   }
   return ret;


### PR DESCRIPTION
## What does this implement/fix?

Two one-wire related bugfixes:

### 1. `GPIOOneWireBus::read64()` only reads 8 bits

Copy-paste from `read8()` — the loop condition is `i < 8` instead of `i < 64`, so only the lowest byte is read. Nothing currently calls `read64()`, but it's part of the public `OneWireBus` interface and would silently return truncated values if used.

### 2. DS18S20 division by zero in temperature calculation

`get_temp_c_()` divides by `scratch_pad_[7]` (COUNT_PER_C) in the DS18S20 extended resolution formula. If a malfunctioning sensor returns 0 for this byte (while still passing the CRC check), the division produces Inf which gets published as the temperature. Added a guard to return NAN instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed.
one_wire:
  - platform: gpio
    pin: GPIO25

sensor:
  - platform: dallas_temp
    address: 0x1234567890ABCD28
    name: "Temperature"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).