### PR TITLE
[i2c] Handle ESP_ERR_INVALID_RESPONSE as NACK for IDF 6.0

### DIFF
--- a/esphome/components/i2c/i2c_bus_esp_idf.cpp
+++ b/esphome/components/i2c/i2c_bus_esp_idf.cpp
@@ -185,7 +185,7 @@ ErrorCode IDFI2CBus::write_readv(uint8_t address, const uint8_t *write_buffer, s
   jobs[num_jobs++].command = I2C_MASTER_CMD_STOP;
   ESP_LOGV(TAG, "Sending %zu jobs", num_jobs);
   esp_err_t err = i2c_master_execute_defined_operations(this->dev_, jobs, num_jobs, 100);
-  if (err == ESP_ERR_INVALID_STATE) {
+  if (err == ESP_ERR_INVALID_STATE || err == ESP_ERR_INVALID_RESPONSE) {
     ESP_LOGV(TAG, "TX to %02X failed: not acked", address);
     return ERROR_NOT_ACKNOWLEDGED;
   } else if (err == ESP_ERR_TIMEOUT) {


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 changed the error code returned by `i2c_master_execute_defined_operations` for NACK from `ESP_ERR_INVALID_STATE` to `ESP_ERR_INVALID_RESPONSE`. Without this fix, every non-existent address during I2C bus scan returns `ERROR_UNKNOWN` instead of `ERROR_NOT_ACKNOWLEDGED`, flooding the log with "Unknown error at address" for every scanned address.

One-line fix: treat `ESP_ERR_INVALID_RESPONSE` the same as `ESP_ERR_INVALID_STATE` (both mean NACK).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed
i2c:
  sda: GPIO26
  scl: GPIO27
  scan: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).