### PR TITLE
[mipi_rgb] Make h- and v-sync pins optional

### DIFF
--- a/esphome/components/mipi_rgb/display.py
+++ b/esphome/components/mipi_rgb/display.py
@@ -194,8 +194,12 @@ def model_schema(config):
                 CONF_DE_PIN, cv.UNDEFINED
             ): pins.internal_gpio_output_pin_schema,
             model.option(CONF_PCLK_PIN): pins.internal_gpio_output_pin_schema,
-            model.option(CONF_HSYNC_PIN): pins.internal_gpio_output_pin_schema,
-            model.option(CONF_VSYNC_PIN): pins.internal_gpio_output_pin_schema,
+            model.option(
+                CONF_HSYNC_PIN, cv.UNDEFINED
+            ): pins.internal_gpio_output_pin_schema,
+            model.option(
+                CONF_VSYNC_PIN, cv.UNDEFINED
+            ): pins.internal_gpio_output_pin_schema,
             model.option(CONF_RESET_PIN, cv.UNDEFINED): pins.gpio_output_pin_schema,
         }
     )
@@ -307,10 +311,12 @@ async def to_code(config):
         cg.add(var.set_de_pin(pin))
     pin = await cg.gpio_pin_expression(config[CONF_PCLK_PIN])
     cg.add(var.set_pclk_pin(pin))
-    pin = await cg.gpio_pin_expression(config[CONF_HSYNC_PIN])
-    cg.add(var.set_hsync_pin(pin))
-    pin = await cg.gpio_pin_expression(config[CONF_VSYNC_PIN])
-    cg.add(var.set_vsync_pin(pin))
+    if hsync_pin := config.get(CONF_HSYNC_PIN):
+        pin = await cg.gpio_pin_expression(hsync_pin)
+        cg.add(var.set_hsync_pin(pin))
+    if vsync_pin := config.get(CONF_VSYNC_PIN):
+        pin = await cg.gpio_pin_expression(vsync_pin)
+        cg.add(var.set_vsync_pin(pin))
 
     await display.register_display(var, config)
     if lamb := config.get(CONF_LAMBDA):

--- a/esphome/components/mipi_rgb/mipi_rgb.cpp
+++ b/esphome/components/mipi_rgb/mipi_rgb.cpp
@@ -158,8 +158,16 @@ void MipiRgb::common_setup_() {
   }
   config.data_width = data_pin_count;
   config.disp_gpio_num = GPIO_NUM_NC;
-  config.hsync_gpio_num = static_cast<gpio_num_t>(this->hsync_pin_->get_pin());
-  config.vsync_gpio_num = static_cast<gpio_num_t>(this->vsync_pin_->get_pin());
+  if (this->hsync_pin_) {
+    config.hsync_gpio_num = static_cast<gpio_num_t>(this->hsync_pin_->get_pin());
+  } else {
+    config.hsync_gpio_num = GPIO_NUM_NC;
+  }
+  if (this->vsync_pin_) {
+    config.vsync_gpio_num = static_cast<gpio_num_t>(this->vsync_pin_->get_pin());
+  } else {
+    config.vsync_gpio_num = GPIO_NUM_NC;
+  }
   if (this->de_pin_) {
     config.de_gpio_num = static_cast<gpio_num_t>(this->de_pin_->get_pin());
   } else {


### PR DESCRIPTION
# What does this implement/fix?

This PR is making the `hsync_pin`/`vsync_pin` for the [mipi_rgb](https://esphome.io/components/display/mipi_rgb/) component optional to support the [BigTreeTech PandaTouch](https://github.com/bigtreetech/PandaTouch_IDF/blob/396eabad1ab7c342b2d1ca1fee1818b7e361aef6/docs/pinout.md#23-lcd-fpc-u1--50-pin-tft-rgb) devices with esphome. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discussion (with no response) https://github.com/orgs/esphome/discussions/3478

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation:**

- esphome/esphome-docs#6290

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Config for PandaTouch
display:
  - platform: mipi_rgb
    model: rpi
    auto_clear_enabled: false
    update_interval: 5s
    show_test_card: true
    color_order: RGB
    dimensions:
      width: 800
      height: 480
    pclk_pin: GPIO5
    pclk_frequency: 14800000
    reset_pin: GPIO46
    de_pin: GPIO38
    hsync_pulse_width: 4
    hsync_front_porch: 16
    hsync_back_porch: 16
    vsync_pulse_width: 4
    vsync_back_porch: 32
    vsync_front_porch: 32
    data_pins:
      red:
        - 6
        - 7
        - 8
        - 9
        - 10
      green:
        - 11
        - 12
        - 13
        - 14
        - 15
        - 16
      blue:
        - 17
        - 18
        - 48
        - 47
        - 39

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
  - - I don't know how this should be tested, is it enough to validate that the schema allows a configuration without a v/hsync? 

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


