### PR TITLE
[api] Extract overflow buffer from frame helper into APIOverflowBuffer

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -306,7 +306,7 @@ CONFIG_SCHEMA = cv.All(
                 CONF_MAX_SEND_QUEUE,
                 esp8266=4,  # Limited RAM, need to fail fast
                 esp32=8,  # More RAM, can buffer more
-                rp2040=5,  # Limited RAM
+                rp2040=8,  # Moderate RAM
                 bk72xx=8,  # Moderate RAM
                 nrf52=8,  # Moderate RAM
                 rtl87xx=8,  # Moderate RAM

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -301,7 +301,7 @@ CONFIG_SCHEMA = cv.All(
             # Maximum queued send buffers per connection before dropping connection
             # Each buffer uses ~8-12 bytes overhead plus actual message size
             # Platform defaults based on available RAM and typical message rates:
-            # CONF_MAX_SEND_QUEUE should be a power 2 for best performance
+            # CONF_MAX_SEND_QUEUE defaults are power of 2 for efficient modulo
             cv.SplitDefault(
                 CONF_MAX_SEND_QUEUE,
                 esp8266=4,  # Limited RAM, need to fail fast

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -301,6 +301,7 @@ CONFIG_SCHEMA = cv.All(
             # Maximum queued send buffers per connection before dropping connection
             # Each buffer uses ~8-12 bytes overhead plus actual message size
             # Platform defaults based on available RAM and typical message rates:
+            # CONF_MAX_SEND_QUEUE should be a power 2 for best performance
             cv.SplitDefault(
                 CONF_MAX_SEND_QUEUE,
                 esp8266=4,  # Limited RAM, need to fail fast

--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -303,7 +303,7 @@ CONFIG_SCHEMA = cv.All(
             # Platform defaults based on available RAM and typical message rates:
             cv.SplitDefault(
                 CONF_MAX_SEND_QUEUE,
-                esp8266=5,  # Limited RAM, need to fail fast
+                esp8266=4,  # Limited RAM, need to fail fast
                 esp32=8,  # More RAM, can buffer more
                 rp2040=5,  # Limited RAM
                 bk72xx=8,  # Moderate RAM

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -100,17 +100,6 @@ const LogString *api_error_to_logstr(APIError err) {
   return LOG_STR("UNKNOWN");
 }
 
-// Default implementation for loop - handles draining overflow buffer
-APIError APIFrameHelper::loop() {
-  if (!this->overflow_buf_.empty() && this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-    HELPER_LOG("Socket write failed with errno %d", errno);
-    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-      return APIError::SOCKET_WRITE_FAILED;
-  }
-  // Convert WOULD_BLOCK to OK to avoid connection termination
-  return APIError::OK;
-}
-
 // This method writes data to socket or buffers it
 APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len) {
   // Returns APIError::OK if all data was sent or successfully queued.

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -103,9 +103,8 @@ const LogString *api_error_to_logstr(APIError err) {
 // Default implementation for loop - handles draining overflow buffer
 APIError APIFrameHelper::loop() {
   if (!this->overflow_buf_.empty() && this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-    const int sav_errno = errno;
-    HELPER_LOG("Socket write failed with errno %d", sav_errno);
-    if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+    HELPER_LOG("Socket write failed with errno %d", errno);
+    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
       return APIError::SOCKET_WRITE_FAILED;
   }
   // Convert WOULD_BLOCK to OK to avoid connection termination
@@ -144,9 +143,8 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
       (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
   if (sent == -1) {
-    const int sav_errno = errno;
-    HELPER_LOG("Socket write failed with errno %d", sav_errno);
-    if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+    HELPER_LOG("Socket write failed with errno %d", errno);
+    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
       return APIError::SOCKET_WRITE_FAILED;
     // Socket would block — queue everything
     return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -100,72 +100,22 @@ const LogString *api_error_to_logstr(APIError err) {
   return LOG_STR("UNKNOWN");
 }
 
-// Default implementation for loop - handles sending buffered data
+// Default implementation for loop - handles draining overflow buffer
 APIError APIFrameHelper::loop() {
-  if (this->tx_buf_count_ > 0) {
-    APIError err = try_send_tx_buf_();
-    if (err != APIError::OK && err != APIError::WOULD_BLOCK) {
-      return err;
-    }
+  if (!this->overflow_buf_.empty() && this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
+    const int sav_errno = errno;
+    HELPER_LOG("Socket write failed with errno %d", sav_errno);
+    if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+      return APIError::SOCKET_WRITE_FAILED;
   }
-  return APIError::OK;  // Convert WOULD_BLOCK to OK to avoid connection termination
-}
-
-// Common socket write error handling
-APIError APIFrameHelper::handle_socket_write_error_() {
-  const int err = errno;
-  if (err == EWOULDBLOCK || err == EAGAIN) {
-    return APIError::WOULD_BLOCK;
-  }
-  HELPER_LOG("Socket write failed with errno %d", err);
-  this->state_ = State::FAILED;
-  return APIError::SOCKET_WRITE_FAILED;
-}
-
-// Helper method to buffer data from IOVs
-void APIFrameHelper::buffer_data_from_iov_(const struct iovec *iov, int iovcnt, uint16_t total_write_len,
-                                           uint16_t offset) {
-  // Check if queue is full
-  if (this->tx_buf_count_ >= API_MAX_SEND_QUEUE) {
-    HELPER_LOG("Send queue full (%u buffers), dropping connection", this->tx_buf_count_);
-    this->state_ = State::FAILED;
-    return;
-  }
-
-  uint16_t buffer_size = total_write_len - offset;
-  auto &buffer = this->tx_buf_[this->tx_buf_tail_];
-  buffer = std::make_unique<SendBuffer>(SendBuffer{
-      .data = std::make_unique<uint8_t[]>(buffer_size),
-      .size = buffer_size,
-      .offset = 0,
-  });
-
-  uint16_t to_skip = offset;
-  uint16_t write_pos = 0;
-
-  for (int i = 0; i < iovcnt; i++) {
-    if (to_skip >= iov[i].iov_len) {
-      // Skip this entire segment
-      to_skip -= static_cast<uint16_t>(iov[i].iov_len);
-    } else {
-      // Include this segment (partially or fully)
-      const uint8_t *src = reinterpret_cast<uint8_t *>(iov[i].iov_base) + to_skip;
-      uint16_t len = static_cast<uint16_t>(iov[i].iov_len) - to_skip;
-      std::memcpy(buffer->data.get() + write_pos, src, len);
-      write_pos += len;
-      to_skip = 0;
-    }
-  }
-
-  // Update circular buffer tracking
-  this->tx_buf_tail_ = (this->tx_buf_tail_ + 1) % API_MAX_SEND_QUEUE;
-  this->tx_buf_count_++;
+  // Convert WOULD_BLOCK to OK to avoid connection termination
+  return APIError::OK;
 }
 
 // This method writes data to socket or buffers it
 APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len) {
-  // Returns APIError::OK if successful (or would block, but data has been buffered)
-  // Returns APIError::SOCKET_WRITE_FAILED if socket write failed, and sets state to FAILED
+  // Returns APIError::OK if all data was sent or successfully queued.
+  // Returns APIError::SOCKET_WRITE_FAILED if socket write failed, and sets state to FAILED.
 
   if (iovcnt == 0)
     return APIError::OK;  // Nothing to do, success
@@ -176,74 +126,34 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   }
 #endif
 
-  // Try to send any existing buffered data first if there is any
-  if (this->tx_buf_count_ > 0) {
-    APIError send_result = try_send_tx_buf_();
-    // If real error occurred (not just WOULD_BLOCK), return it
-    if (send_result != APIError::OK && send_result != APIError::WOULD_BLOCK) {
-      return send_result;
-    }
-
-    // If there is still data in the buffer, we can't send, buffer
-    // the new data and return
-    if (this->tx_buf_count_ > 0) {
-      this->buffer_data_from_iov_(iov, iovcnt, total_write_len, 0);
-      return APIError::OK;  // Success, data buffered
-    }
+  // If there is already backlogged data, try to drain then queue behind it
+  if (!this->overflow_buf_.empty()) {
+    this->overflow_buf_.try_drain(this->socket_.get());
+    // If still backlogged, queue new data behind it; otherwise fall through to direct send
+    if (!this->overflow_buf_.empty())
+      return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);
   }
 
-  // Try to send directly if no buffered data
+  // No backlog — try to send directly
   // Optimize for single iovec case (common for plaintext API)
   ssize_t sent =
       (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
   if (sent == -1) {
-    APIError err = this->handle_socket_write_error_();
-    if (err == APIError::WOULD_BLOCK) {
-      // Socket would block, buffer the data
-      this->buffer_data_from_iov_(iov, iovcnt, total_write_len, 0);
-      return APIError::OK;  // Success, data buffered
-    }
-    return err;  // Socket write failed
-  } else if (static_cast<uint16_t>(sent) < total_write_len) {
-    // Partially sent, buffer the remaining data
-    this->buffer_data_from_iov_(iov, iovcnt, total_write_len, static_cast<uint16_t>(sent));
+    const int sav_errno = errno;
+    HELPER_LOG("Socket write failed with errno %d", sav_errno);
+    if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+      return APIError::SOCKET_WRITE_FAILED;
+    // Socket would block — queue everything
+    return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);
   }
 
-  return APIError::OK;  // Success, all data sent or buffered
-}
-
-// Common implementation for trying to send buffered data
-// IMPORTANT: Caller MUST ensure tx_buf_count_ > 0 before calling this method
-APIError APIFrameHelper::try_send_tx_buf_() {
-  // Try to send from tx_buf - we assume it's not empty as it's the caller's responsibility to check
-  while (this->tx_buf_count_ > 0) {
-    // Get the first buffer in the queue
-    SendBuffer *front_buffer = this->tx_buf_[this->tx_buf_head_].get();
-
-    // Try to send the remaining data in this buffer
-    ssize_t sent = this->socket_->write(front_buffer->current_data(), front_buffer->remaining());
-
-    if (sent == -1) {
-      return this->handle_socket_write_error_();
-    } else if (sent == 0) {
-      // Nothing sent but not an error
-      return APIError::WOULD_BLOCK;
-    } else if (static_cast<uint16_t>(sent) < front_buffer->remaining()) {
-      // Partially sent, update offset
-      // Cast to ensure no overflow issues with uint16_t
-      front_buffer->offset += static_cast<uint16_t>(sent);
-      return APIError::WOULD_BLOCK;  // Stop processing more buffers if we couldn't send a complete buffer
-    } else {
-      // Buffer completely sent, remove it from the queue
-      this->tx_buf_[this->tx_buf_head_].reset();
-      this->tx_buf_head_ = (this->tx_buf_head_ + 1) % API_MAX_SEND_QUEUE;
-      this->tx_buf_count_--;
-      // Continue loop to try sending the next buffer
-    }
+  if (static_cast<uint16_t>(sent) < total_write_len) {
+    // Partially sent — queue the remainder
+    return this->enqueue_or_fail_(iov, iovcnt, total_write_len, static_cast<uint16_t>(sent));
   }
 
-  return APIError::OK;  // All buffers sent successfully
+  return APIError::OK;
 }
 
 const char *APIFrameHelper::get_peername_to(std::span<char, socket::SOCKADDR_STR_LEN> buf) const {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -105,9 +105,6 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   // Returns APIError::OK if all data was sent or successfully queued.
   // Returns APIError::SOCKET_WRITE_FAILED if socket write failed, and sets state to FAILED.
 
-  if (iovcnt == 0)
-    return APIError::OK;  // Nothing to do, success
-
 #ifdef HELPER_LOG_PACKETS
   for (int i = 0; i < iovcnt; i++) {
     LOG_PACKET_SENDING(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -128,7 +128,13 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   // If there is already backlogged data, try to drain then queue behind it
   if (!this->overflow_buf_.empty()) {
-    this->overflow_buf_.try_drain(this->socket_.get());
+    ssize_t ret = this->overflow_buf_.try_drain(this->socket_.get());
+    if (ret == -1) {
+      const int sav_errno = errno;
+      HELPER_LOG("Socket write failed with errno %d", sav_errno);
+      if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+        return APIError::SOCKET_WRITE_FAILED;
+    }
     // If still backlogged, queue new data behind it; otherwise fall through to direct send
     if (!this->overflow_buf_.empty())
       return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -150,6 +150,7 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   // Queue unsent data into overflow buffer
   if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_write_len, skip)) {
+    HELPER_LOG("Overflow buffer full, dropping connection");
     this->state_ = State::FAILED;
     return APIError::SOCKET_WRITE_FAILED;
   }

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -114,9 +114,11 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   // Drain any existing backlog first
   if (!this->overflow_buf_.empty()) [[unlikely]] {
-    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1 &&
-        this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-      return APIError::SOCKET_WRITE_FAILED;
+    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
+      HELPER_LOG("Socket write failed with errno %d", errno);
+      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+        return APIError::SOCKET_WRITE_FAILED;
+    }
   }
 
   // If backlog is clear, try direct send
@@ -125,6 +127,7 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
     if (sent == -1) [[unlikely]] {
+      HELPER_LOG("Socket write failed with errno %d", errno);
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
     } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -111,6 +111,8 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   }
 #endif
 
+  uint16_t skip = 0;
+
   // If there is already backlogged data, try to drain then queue behind it
   if (!this->overflow_buf_.empty()) {
     if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
@@ -118,9 +120,9 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
     }
-    // If still backlogged, queue new data behind it; otherwise fall through to direct send
+    // If still backlogged, queue new data behind it
     if (!this->overflow_buf_.empty())
-      return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);
+      return this->enqueue_or_fail_(iov, iovcnt, total_write_len, skip);
   }
 
   // No backlog — try to send directly
@@ -132,16 +134,15 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
     HELPER_LOG("Socket write failed with errno %d", errno);
     if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
       return APIError::SOCKET_WRITE_FAILED;
-    // Socket would block — queue everything
-    return this->enqueue_or_fail_(iov, iovcnt, total_write_len, 0);
-  }
-
-  if (static_cast<uint16_t>(sent) < total_write_len) {
+  } else if (static_cast<uint16_t>(sent) >= total_write_len) {
+    // All data sent successfully
+    return APIError::OK;
+  } else {
     // Partially sent — queue the remainder
-    return this->enqueue_or_fail_(iov, iovcnt, total_write_len, static_cast<uint16_t>(sent));
+    skip = static_cast<uint16_t>(sent);
   }
 
-  return APIError::OK;
+  return this->enqueue_or_fail_(iov, iovcnt, total_write_len, skip);
 }
 
 const char *APIFrameHelper::get_peername_to(std::span<char, socket::SOCKADDR_STR_LEN> buf) const {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -128,11 +128,9 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   // If there is already backlogged data, try to drain then queue behind it
   if (!this->overflow_buf_.empty()) {
-    ssize_t ret = this->overflow_buf_.try_drain(this->socket_.get());
-    if (ret == -1) {
-      const int sav_errno = errno;
-      HELPER_LOG("Socket write failed with errno %d", sav_errno);
-      if (this->check_socket_write_err_(sav_errno) != APIError::WOULD_BLOCK)
+    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
+      HELPER_LOG("Socket write failed with errno %d", errno);
+      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
     }
     // If still backlogged, queue new data behind it; otherwise fall through to direct send

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -102,9 +102,10 @@ const LogString *api_error_to_logstr(APIError err) {
 
 APIError APIFrameHelper::drain_overflow_and_handle_errors_() {
   if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-    HELPER_LOG("Socket write failed with errno %d", errno);
-    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK) {
+      HELPER_LOG("Socket write failed with errno %d", errno);
       return APIError::SOCKET_WRITE_FAILED;
+    }
   }
   return APIError::OK;
 }
@@ -134,9 +135,10 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
     if (sent == -1) [[unlikely]] {
-      HELPER_LOG("Socket write failed with errno %d", errno);
-      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK) {
+        HELPER_LOG("Socket write failed with errno %d", errno);
         return APIError::SOCKET_WRITE_FAILED;
+      }
     } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {
       return APIError::OK;
     } else {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -102,8 +102,9 @@ const LogString *api_error_to_logstr(APIError err) {
 
 APIError APIFrameHelper::drain_overflow_and_handle_errors_() {
   if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK) {
-      HELPER_LOG("Socket write failed with errno %d", errno);
+    int err = errno;
+    if (this->check_socket_write_err_(err) != APIError::WOULD_BLOCK) {
+      HELPER_LOG("Socket write failed with errno %d", err);
       return APIError::SOCKET_WRITE_FAILED;
     }
   }
@@ -135,8 +136,9 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
     if (sent == -1) [[unlikely]] {
-      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK) {
-        HELPER_LOG("Socket write failed with errno %d", errno);
+      int err = errno;
+      if (this->check_socket_write_err_(err) != APIError::WOULD_BLOCK) {
+        HELPER_LOG("Socket write failed with errno %d", err);
         return APIError::SOCKET_WRITE_FAILED;
       }
     } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -114,7 +114,7 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   uint16_t skip = 0;
 
   // If there is already backlogged data, try to drain it first
-  if (!this->overflow_buf_.empty()) {
+  if (!this->overflow_buf_.empty()) [[unlikely]] {
     if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
       HELPER_LOG("Socket write failed with errno %d", errno);
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
@@ -129,18 +129,23 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
     ssize_t sent =
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
-    if (sent == -1) {
+    if (sent == -1) [[unlikely]] {  // Socket write failed
       HELPER_LOG("Socket write failed with errno %d", errno);
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
-    } else if (static_cast<uint16_t>(sent) >= total_write_len) {
-      return APIError::OK;  // All data sent successfully
+    } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {  // All data sent successfully
+      return APIError::OK;                                                   // All data sent successfully
     } else {
       skip = static_cast<uint16_t>(sent);  // Partially sent — queue the remainder
     }
   }
 
-  return this->enqueue_or_fail_(iov, iovcnt, total_write_len, skip);
+  // Queue data into overflow buffer, or fail the connection if full
+  if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_write_len, skip)) {
+    this->state_ = State::FAILED;
+    return APIError::SOCKET_WRITE_FAILED;
+  }
+  return APIError::OK;
 }
 
 const char *APIFrameHelper::get_peername_to(std::span<char, socket::SOCKADDR_STR_LEN> buf) const {

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -120,10 +120,11 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
     }
+    // If drain didn't fully clear, skip direct send and queue behind backlog
   }
 
-  // If no backlog (either drained or was empty), try to send directly
   if (this->overflow_buf_.empty()) {
+    // No backlog — try to send directly
     // Optimize for single iovec case (common for plaintext API)
     ssize_t sent =
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -113,33 +113,30 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   uint16_t skip = 0;
 
-  // If there is already backlogged data, try to drain then queue behind it
+  // If there is already backlogged data, try to drain it first
   if (!this->overflow_buf_.empty()) {
     if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
       HELPER_LOG("Socket write failed with errno %d", errno);
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
     }
-    // If still backlogged, queue new data behind it
-    if (!this->overflow_buf_.empty())
-      return this->enqueue_or_fail_(iov, iovcnt, total_write_len, skip);
   }
 
-  // No backlog — try to send directly
-  // Optimize for single iovec case (common for plaintext API)
-  ssize_t sent =
-      (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
+  // If no backlog (either drained or was empty), try to send directly
+  if (this->overflow_buf_.empty()) {
+    // Optimize for single iovec case (common for plaintext API)
+    ssize_t sent =
+        (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
-  if (sent == -1) {
-    HELPER_LOG("Socket write failed with errno %d", errno);
-    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-      return APIError::SOCKET_WRITE_FAILED;
-  } else if (static_cast<uint16_t>(sent) >= total_write_len) {
-    // All data sent successfully
-    return APIError::OK;
-  } else {
-    // Partially sent — queue the remainder
-    skip = static_cast<uint16_t>(sent);
+    if (sent == -1) {
+      HELPER_LOG("Socket write failed with errno %d", errno);
+      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+        return APIError::SOCKET_WRITE_FAILED;
+    } else if (static_cast<uint16_t>(sent) >= total_write_len) {
+      return APIError::OK;  // All data sent successfully
+    } else {
+      skip = static_cast<uint16_t>(sent);  // Partially sent — queue the remainder
+    }
   }
 
   return this->enqueue_or_fail_(iov, iovcnt, total_write_len, skip);

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -122,7 +122,7 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
   }
 
   // If backlog is clear, try direct send
-  if (this->overflow_buf_.empty()) {
+  if (this->overflow_buf_.empty()) [[likely]] {
     ssize_t sent =
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -100,11 +100,10 @@ const LogString *api_error_to_logstr(APIError err) {
   return LOG_STR("UNKNOWN");
 }
 
-// This method writes data to socket or buffers it
+// Write data to socket, overflow to backlog buffer if LWIP TCP send buffer is full.
+// Returns OK if all data was sent or successfully queued.
+// Returns SOCKET_WRITE_FAILED on hard error (sets state to FAILED).
 APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len) {
-  // Returns APIError::OK if all data was sent or successfully queued.
-  // Returns APIError::SOCKET_WRITE_FAILED if socket write failed, and sets state to FAILED.
-
 #ifdef HELPER_LOG_PACKETS
   for (int i = 0; i < iovcnt; i++) {
     LOG_PACKET_SENDING(reinterpret_cast<uint8_t *>(iov[i].iov_base), iov[i].iov_len);
@@ -113,34 +112,29 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   uint16_t skip = 0;
 
-  // If there is already backlogged data, try to drain it first
+  // Drain any existing backlog first
   if (!this->overflow_buf_.empty()) [[unlikely]] {
-    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-      HELPER_LOG("Socket write failed with errno %d", errno);
-      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-        return APIError::SOCKET_WRITE_FAILED;
-    }
-    // If drain didn't fully clear, skip direct send and queue behind backlog
+    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1 &&
+        this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+      return APIError::SOCKET_WRITE_FAILED;
   }
 
+  // If backlog is clear, try direct send
   if (this->overflow_buf_.empty()) {
-    // No backlog — try to send directly
-    // Optimize for single iovec case (common for plaintext API)
     ssize_t sent =
         (iovcnt == 1) ? this->socket_->write(iov[0].iov_base, iov[0].iov_len) : this->socket_->writev(iov, iovcnt);
 
-    if (sent == -1) [[unlikely]] {  // Socket write failed
-      HELPER_LOG("Socket write failed with errno %d", errno);
+    if (sent == -1) [[unlikely]] {
       if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
         return APIError::SOCKET_WRITE_FAILED;
-    } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {  // All data sent successfully
-      return APIError::OK;                                                   // All data sent successfully
+    } else if (static_cast<uint16_t>(sent) >= total_write_len) [[likely]] {
+      return APIError::OK;
     } else {
-      skip = static_cast<uint16_t>(sent);  // Partially sent — queue the remainder
+      skip = static_cast<uint16_t>(sent);
     }
   }
 
-  // Queue data into overflow buffer, or fail the connection if full
+  // Queue unsent data into overflow buffer
   if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_write_len, skip)) {
     this->state_ = State::FAILED;
     return APIError::SOCKET_WRITE_FAILED;

--- a/esphome/components/api/api_frame_helper.cpp
+++ b/esphome/components/api/api_frame_helper.cpp
@@ -100,6 +100,15 @@ const LogString *api_error_to_logstr(APIError err) {
   return LOG_STR("UNKNOWN");
 }
 
+APIError APIFrameHelper::drain_overflow_and_handle_errors_() {
+  if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
+    HELPER_LOG("Socket write failed with errno %d", errno);
+    if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+      return APIError::SOCKET_WRITE_FAILED;
+  }
+  return APIError::OK;
+}
+
 // Write data to socket, overflow to backlog buffer if LWIP TCP send buffer is full.
 // Returns OK if all data was sent or successfully queued.
 // Returns SOCKET_WRITE_FAILED on hard error (sets state to FAILED).
@@ -114,11 +123,9 @@ APIError APIFrameHelper::write_raw_(const struct iovec *iov, int iovcnt, uint16_
 
   // Drain any existing backlog first
   if (!this->overflow_buf_.empty()) [[unlikely]] {
-    if (this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-      HELPER_LOG("Socket write failed with errno %d", errno);
-      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-        return APIError::SOCKET_WRITE_FAILED;
-    }
+    APIError err = this->drain_overflow_and_handle_errors_();
+    if (err != APIError::OK)
+      return err;
   }
 
   // If backlog is clear, try direct send

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -9,6 +9,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 #include "esphome/components/api/api_buffer.h"
+#include "esphome/components/api/api_overflow_buffer.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"
@@ -106,7 +107,7 @@ class APIFrameHelper {
   virtual APIError init() = 0;
   virtual APIError loop();
   virtual APIError read_packet(ReadPacketBuffer *buffer) = 0;
-  bool can_write_without_blocking() { return this->state_ == State::DATA && this->tx_buf_count_ == 0; }
+  bool can_write_without_blocking() { return this->state_ == State::DATA && this->overflow_buf_.empty(); }
   int getpeername(struct sockaddr *addr, socklen_t *addrlen) { return socket_->getpeername(addr, addrlen); }
   APIError close() {
     if (state_ == State::CLOSED)
@@ -189,28 +190,26 @@ class APIFrameHelper {
   }
 
  protected:
-  // Buffer containing data to be sent
-  struct SendBuffer {
-    std::unique_ptr<uint8_t[]> data;
-    uint16_t size{0};    // Total size of the buffer
-    uint16_t offset{0};  // Current offset within the buffer
-
-    // Using uint16_t reduces memory usage since ESPHome API messages are limited to UINT16_MAX (65535) bytes
-    uint16_t remaining() const { return size - offset; }
-    const uint8_t *current_data() const { return data.get() + offset; }
-  };
-
   // Common implementation for writing raw data to socket
   APIError write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len);
 
-  // Try to send data from the tx buffer
-  APIError try_send_tx_buf_();
+  // Check if a socket write errno is a hard error (not WOULD_BLOCK/EAGAIN).
+  // Returns WOULD_BLOCK for transient errors, SOCKET_WRITE_FAILED for hard errors.
+  APIError check_socket_write_err_(int err) {
+    if (err == EWOULDBLOCK || err == EAGAIN)
+      return APIError::WOULD_BLOCK;
+    this->state_ = State::FAILED;
+    return APIError::SOCKET_WRITE_FAILED;
+  }
 
-  // Helper method to buffer data from IOVs
-  void buffer_data_from_iov_(const struct iovec *iov, int iovcnt, uint16_t total_write_len, uint16_t offset);
-
-  // Common socket write error handling
-  APIError handle_socket_write_error_();
+  // Enqueue IOV data into the overflow buffer, or fail the connection if full
+  APIError enqueue_or_fail_(const struct iovec *iov, int iovcnt, uint16_t total_len, uint16_t skip) {
+    if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_len, skip)) {
+      this->state_ = State::FAILED;
+      return APIError::SOCKET_WRITE_FAILED;
+    }
+    return APIError::OK;
+  }
 
   // Socket ownership (4 bytes on 32-bit, 8 bytes on 64-bit)
   std::unique_ptr<socket::Socket> socket_;
@@ -245,8 +244,8 @@ class APIFrameHelper {
     return APIError::WOULD_BLOCK;
   }
 
-  // Containers (size varies, but typically 12+ bytes on 32-bit)
-  std::array<std::unique_ptr<SendBuffer>, API_MAX_SEND_QUEUE> tx_buf_;
+  // Backlog for unsent data when TCP send buffer is full (rarely used in production)
+  APIOverflowBuffer overflow_buf_;
   APIBuffer rx_buf_;
 
   // Client name buffer - stores name from Hello message or initial peername
@@ -257,9 +256,6 @@ class APIFrameHelper {
   State state_{State::INITIALIZE};
   uint8_t frame_header_padding_{0};
   uint8_t frame_footer_size_{0};
-  uint8_t tx_buf_head_{0};
-  uint8_t tx_buf_tail_{0};
-  uint8_t tx_buf_count_{0};
   // Nagle batching counter for log messages. 0 means NODELAY is enabled (immediate send).
   // Values 1..LOG_NAGLE_COUNT count log messages in the current Nagle batch.
   // After LOG_NAGLE_COUNT logs, we flush by re-enabling NODELAY and resetting to 0.

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -212,15 +212,6 @@ class APIFrameHelper {
     return APIError::SOCKET_WRITE_FAILED;
   }
 
-  // Enqueue IOV data into the overflow buffer, or fail the connection if full
-  APIError enqueue_or_fail_(const struct iovec *iov, int iovcnt, uint16_t total_len, uint16_t skip) {
-    if (!this->overflow_buf_.enqueue_iov(iov, iovcnt, total_len, skip)) {
-      this->state_ = State::FAILED;
-      return APIError::SOCKET_WRITE_FAILED;
-    }
-    return APIError::OK;
-  }
-
   // Socket ownership (4 bytes on 32-bit, 8 bytes on 64-bit)
   std::unique_ptr<socket::Socket> socket_;
 

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -105,7 +105,7 @@ class APIFrameHelper {
   }
   virtual ~APIFrameHelper() = default;
   virtual APIError init() = 0;
-  virtual APIError loop();
+  virtual APIError loop() = 0;
   virtual APIError read_packet(ReadPacketBuffer *buffer) = 0;
   bool can_write_without_blocking() { return this->state_ == State::DATA && this->overflow_buf_.empty(); }
   int getpeername(struct sockaddr *addr, socklen_t *addrlen) { return socket_->getpeername(addr, addrlen); }
@@ -190,6 +190,16 @@ class APIFrameHelper {
   }
 
  protected:
+  // Drain any backlogged overflow data to the socket.
+  // Returns OK even for WOULD_BLOCK to avoid connection termination.
+  APIError try_drain_overflow_buffer_() {
+    if (!this->overflow_buf_.empty() && this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
+      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
+        return APIError::SOCKET_WRITE_FAILED;
+    }
+    return APIError::OK;
+  }
+
   // Common implementation for writing raw data to socket
   APIError write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len);
 

--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -190,15 +190,11 @@ class APIFrameHelper {
   }
 
  protected:
-  // Drain any backlogged overflow data to the socket.
-  // Returns OK even for WOULD_BLOCK to avoid connection termination.
-  APIError try_drain_overflow_buffer_() {
-    if (!this->overflow_buf_.empty() && this->overflow_buf_.try_drain(this->socket_.get()) == -1) {
-      if (this->check_socket_write_err_(errno) != APIError::WOULD_BLOCK)
-        return APIError::SOCKET_WRITE_FAILED;
-    }
-    return APIError::OK;
-  }
+  // Drain backlogged overflow data to the socket and handle errors.
+  // Called when overflow_buf_.empty() is false. Out-of-line to keep the
+  // fast path (empty check) inline at call sites.
+  // Returns OK for transient errors (WOULD_BLOCK), SOCKET_WRITE_FAILED for hard errors.
+  APIError drain_overflow_and_handle_errors_();
 
   // Common implementation for writing raw data to socket
   APIError write_raw_(const struct iovec *iov, int iovcnt, uint16_t total_write_len);

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -153,8 +153,7 @@ APIError APINoiseFrameHelper::loop() {
     }
   }
 
-  // Use base class implementation for buffer sending
-  return APIFrameHelper::loop();
+  return this->try_drain_overflow_buffer_();
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -154,9 +154,7 @@ APIError APINoiseFrameHelper::loop() {
   }
 
   if (!this->overflow_buf_.empty()) [[unlikely]] {
-    APIError err = this->drain_overflow_and_handle_errors_();
-    if (err != APIError::OK)
-      return err;
+    return this->drain_overflow_and_handle_errors_();
   }
   return APIError::OK;
 }

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -153,7 +153,11 @@ APIError APINoiseFrameHelper::loop() {
     }
   }
 
-  return this->try_drain_overflow_buffer_();
+  APIError err = this->try_drain_overflow_buffer_();
+  if (err != APIError::OK) {
+    HELPER_LOG("Overflow drain failed with errno %d", errno);
+  }
+  return err;
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -153,11 +153,12 @@ APIError APINoiseFrameHelper::loop() {
     }
   }
 
-  APIError err = this->try_drain_overflow_buffer_();
-  if (err != APIError::OK) {
-    HELPER_LOG("Overflow drain failed with errno %d", errno);
+  if (!this->overflow_buf_.empty()) [[unlikely]] {
+    APIError err = this->drain_overflow_and_handle_errors_();
+    if (err != APIError::OK)
+      return err;
   }
-  return err;
+  return APIError::OK;
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -64,7 +64,11 @@ APIError APIPlaintextFrameHelper::loop() {
   if (state_ != State::DATA) {
     return APIError::BAD_STATE;
   }
-  return this->try_drain_overflow_buffer_();
+  APIError err = this->try_drain_overflow_buffer_();
+  if (err != APIError::OK) {
+    HELPER_LOG("Overflow drain failed with errno %d", errno);
+  }
+  return err;
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -64,8 +64,7 @@ APIError APIPlaintextFrameHelper::loop() {
   if (state_ != State::DATA) {
     return APIError::BAD_STATE;
   }
-  // Use base class implementation for buffer sending
-  return APIFrameHelper::loop();
+  return this->try_drain_overflow_buffer_();
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -64,11 +64,12 @@ APIError APIPlaintextFrameHelper::loop() {
   if (state_ != State::DATA) {
     return APIError::BAD_STATE;
   }
-  APIError err = this->try_drain_overflow_buffer_();
-  if (err != APIError::OK) {
-    HELPER_LOG("Overflow drain failed with errno %d", errno);
+  if (!this->overflow_buf_.empty()) [[unlikely]] {
+    APIError err = this->drain_overflow_and_handle_errors_();
+    if (err != APIError::OK)
+      return err;
   }
-  return err;
+  return APIError::OK;
 }
 
 /** Read a packet into the rx_buf_.

--- a/esphome/components/api/api_frame_helper_plaintext.cpp
+++ b/esphome/components/api/api_frame_helper_plaintext.cpp
@@ -65,9 +65,7 @@ APIError APIPlaintextFrameHelper::loop() {
     return APIError::BAD_STATE;
   }
   if (!this->overflow_buf_.empty()) [[unlikely]] {
-    APIError err = this->drain_overflow_and_handle_errors_();
-    if (err != APIError::OK)
-      return err;
+    return this->drain_overflow_and_handle_errors_();
   }
   return APIError::OK;
 }

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -1,0 +1,72 @@
+#include "api_overflow_buffer.h"
+#ifdef USE_API
+#include <cstring>
+
+namespace esphome::api {
+
+APIOverflowBuffer::~APIOverflowBuffer() {
+  for (auto *entry : this->queue_) {
+    if (entry != nullptr)
+      Entry::destroy(entry);
+  }
+}
+
+ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
+  while (this->count_ > 0) {
+    Entry *front = this->queue_[this->head_];
+
+    ssize_t sent = socket->write(front->current_data(), front->remaining());
+
+    if (sent <= 0) {
+      // -1 = error (caller checks errno), 0 = would block
+      return sent;
+    }
+
+    if (static_cast<uint16_t>(sent) < front->remaining()) {
+      // Partially sent, update offset and stop
+      front->offset += static_cast<uint16_t>(sent);
+      return sent;
+    }
+
+    // Entry fully sent — free it and advance
+    Entry::destroy(front);
+    this->queue_[this->head_] = nullptr;
+    this->head_ = (this->head_ + 1) % API_MAX_SEND_QUEUE;
+    this->count_--;
+  }
+
+  return 0;  // All drained
+}
+
+bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_t total_len, uint16_t skip) {
+  if (this->count_ >= API_MAX_SEND_QUEUE)
+    return false;
+
+  uint16_t buffer_size = total_len - skip;
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  auto *entry = new Entry{new uint8_t[buffer_size], buffer_size, 0};
+  this->queue_[this->tail_] = entry;
+
+  uint16_t to_skip = skip;
+  uint16_t write_pos = 0;
+
+  for (int i = 0; i < iovcnt; i++) {
+    if (to_skip >= iov[i].iov_len) {
+      to_skip -= static_cast<uint16_t>(iov[i].iov_len);
+    } else {
+      const uint8_t *src = reinterpret_cast<uint8_t *>(iov[i].iov_base) + to_skip;
+      uint16_t len = static_cast<uint16_t>(iov[i].iov_len) - to_skip;
+      std::memcpy(entry->data + write_pos, src, len);
+      write_pos += len;
+      to_skip = 0;
+    }
+  }
+
+  this->tail_ = (this->tail_ + 1) % API_MAX_SEND_QUEUE;
+  this->count_++;
+  return true;
+}
+
+}  // namespace esphome::api
+
+#endif  // USE_API

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -31,7 +31,8 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     // Entry fully sent — free it and advance
     Entry::destroy(front);
     this->queue_[this->head_] = nullptr;
-    this->head_ = (this->head_ + 1) % API_MAX_SEND_QUEUE;
+    if (++this->head_ >= API_MAX_SEND_QUEUE)
+      this->head_ = 0;
     this->count_--;
   }
 
@@ -62,7 +63,8 @@ bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_
     }
   }
 
-  this->tail_ = (this->tail_ + 1) % API_MAX_SEND_QUEUE;
+  if (++this->tail_ >= API_MAX_SEND_QUEUE)
+    this->tail_ = 0;
   this->count_++;
   return true;
 }

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -31,8 +31,7 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     // Entry fully sent — free it and advance
     Entry::destroy(front);
     this->queue_[this->head_] = nullptr;
-    if (++this->head_ >= API_MAX_SEND_QUEUE)
-      this->head_ = 0;
+    this->head_ = (this->head_ + 1) % API_MAX_SEND_QUEUE;
     this->count_--;
   }
 
@@ -63,8 +62,7 @@ bool APIOverflowBuffer::enqueue_iov(const struct iovec *iov, int iovcnt, uint16_
     }
   }
 
-  if (++this->tail_ >= API_MAX_SEND_QUEUE)
-    this->tail_ = 0;
+  this->tail_ = (this->tail_ + 1) % API_MAX_SEND_QUEUE;
   this->count_++;
   return true;
 }

--- a/esphome/components/api/api_overflow_buffer.cpp
+++ b/esphome/components/api/api_overflow_buffer.cpp
@@ -18,7 +18,8 @@ ssize_t APIOverflowBuffer::try_drain(socket::Socket *socket) {
     ssize_t sent = socket->write(front->current_data(), front->remaining());
 
     if (sent <= 0) {
-      // -1 = error (caller checks errno), 0 = would block
+      // -1 = error (caller checks errno for EWOULDBLOCK vs hard error)
+      // 0 = nothing sent (treat as no progress)
       return sent;
     }
 

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -52,7 +52,8 @@ class APIOverflowBuffer {
   uint8_t count() const { return this->count_; }
 
   /// Try to drain queued data to the socket.
-  /// Returns bytes-written >= 0 on success/partial, -1 on hard error (errno set).
+  /// Returns bytes-written > 0 on success/partial, 0 if all drained,
+  /// -1 on error (caller must check errno to distinguish EWOULDBLOCK from hard errors).
   /// Frees entries as they are fully sent.
   ssize_t try_drain(socket::Socket *socket);
 

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -6,6 +6,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_API
 
+#include "esphome/components/socket/headers.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/core/helpers.h"
 
@@ -52,8 +53,9 @@ class APIOverflowBuffer {
   uint8_t count() const { return this->count_; }
 
   /// Try to drain queued data to the socket.
-  /// Returns bytes-written > 0 on success/partial, 0 if all drained,
+  /// Returns bytes-written > 0 on success/partial, 0 if all drained or no progress,
   /// -1 on error (caller must check errno to distinguish EWOULDBLOCK from hard errors).
+  /// Callers only need to act on -1; 0 and positive values both mean "no error".
   /// Frees entries as they are fully sent.
   ssize_t try_drain(socket::Socket *socket);
 

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -13,7 +13,7 @@ namespace esphome::api {
 /// Circular queue of heap-allocated byte buffers used as a TCP send backlog.
 ///
 /// Under normal operation this buffer is **never used** — data goes straight
-/// from the frame helper to the socket.  It only fills when the kernel TCP
+/// from the frame helper to the socket.  It only fills when the LWIP TCP
 /// send buffer is full (slow client, congested network, heavy logging).
 /// The queue drains automatically on subsequent write/loop calls once the
 /// socket becomes writable again.

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -1,0 +1,72 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <sys/types.h>
+
+#include "esphome/core/defines.h"
+#ifdef USE_API
+
+#include "esphome/components/socket/socket.h"
+
+namespace esphome::api {
+
+/// Circular queue of heap-allocated byte buffers used as a TCP send backlog.
+///
+/// Under normal operation this buffer is **never used** — data goes straight
+/// from the frame helper to the socket.  It only fills when the kernel TCP
+/// send buffer is full (slow client, congested network, heavy logging).
+/// The queue drains automatically on subsequent write/loop calls once the
+/// socket becomes writable again.
+///
+/// Capacity is compile-time-fixed via API_MAX_SEND_QUEUE (set from Python
+/// config).  If the queue fills completely the connection is marked failed.
+class APIOverflowBuffer {
+ public:
+  /// A single heap-allocated send-backlog entry.
+  /// Lifetime is manually managed — see destroy().
+  struct Entry {
+    uint8_t *data;
+    uint16_t size;    // Total size of the buffer
+    uint16_t offset;  // Current send offset within the buffer
+
+    uint16_t remaining() const { return this->size - this->offset; }
+    const uint8_t *current_data() const { return this->data + this->offset; }
+
+    /// Free this entry and its data buffer.
+    static void destroy(Entry *entry) {
+      delete[] entry->data;
+      delete entry;  // NOLINT(cppcoreguidelines-owning-memory)
+    }
+  };
+
+  ~APIOverflowBuffer();
+
+  /// True when no backlogged data is waiting.
+  bool empty() const { return this->count_ == 0; }
+
+  /// True when the queue has no room for another entry.
+  bool full() const { return this->count_ >= API_MAX_SEND_QUEUE; }
+
+  /// Number of entries currently queued.
+  uint8_t count() const { return this->count_; }
+
+  /// Try to drain queued data to the socket.
+  /// Returns bytes-written >= 0 on success/partial, -1 on hard error (errno set).
+  /// Frees entries as they are fully sent.
+  ssize_t try_drain(socket::Socket *socket);
+
+  /// Enqueue unsent IOV data into the backlog.
+  /// Copies iov data starting at byte offset `skip` into a new entry.
+  /// Returns false if the queue is full (caller should fail the connection).
+  bool enqueue_iov(const struct iovec *iov, int iovcnt, uint16_t total_len, uint16_t skip);
+
+ protected:
+  std::array<Entry *, API_MAX_SEND_QUEUE> queue_{};
+  uint8_t head_{0};
+  uint8_t tail_{0};
+  uint8_t count_{0};
+};
+
+}  // namespace esphome::api
+
+#endif  // USE_API

--- a/esphome/components/api/api_overflow_buffer.h
+++ b/esphome/components/api/api_overflow_buffer.h
@@ -7,6 +7,7 @@
 #ifdef USE_API
 
 #include "esphome/components/socket/socket.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome::api {
 
@@ -33,7 +34,7 @@ class APIOverflowBuffer {
     const uint8_t *current_data() const { return this->data + this->offset; }
 
     /// Free this entry and its data buffer.
-    static void destroy(Entry *entry) {
+    static ESPHOME_ALWAYS_INLINE void destroy(Entry *entry) {
       delete[] entry->data;
       delete entry;  // NOLINT(cppcoreguidelines-owning-memory)
     }


### PR DESCRIPTION
# What does this implement/fix?

The TCP send overflow buffer code was embedded directly inside `APIFrameHelper`, making it look like part of the primary send path. In reality, this buffer is **rarely used in production** — it only fills when the LWIP TCP send buffer is full (slow client, congested network, or heavy logging). Every review of the frame helper code has to navigate past this buffer management code, and new contributors often assume it's a frequently-used hot path.

This PR extracts the overflow buffer into a dedicated `APIOverflowBuffer` class in its own files (`api_overflow_buffer.h` / `.cpp`), with clear documentation about when and why it's used.

## Changes

- **New `APIOverflowBuffer` class** — self-contained circular queue with `try_drain()` and `enqueue_iov()` methods, clear doc comments explaining it's a rarely-used backlog
- **Replaced `std::unique_ptr<SendBuffer>` with raw pointer management** — lifetime was already explicitly managed by head/tail/count, `unique_ptr` just added template overhead
- **Made `loop()` pure virtual** — base class only had overflow drain logic, extracted to `drain_overflow_and_handle_errors_()`. Subclasses call it behind an inline `empty()` fast-path check with `[[unlikely]]` hint so the common case (no backlog) is a single byte compare
- **Restructured `write_raw_()`** — clear three-phase flow: drain backlog → try direct send → queue remainder. Single tail-call to `enqueue_iov` instead of three separate `buffer_data_from_iov_` calls. Added `[[likely]]`/`[[unlikely]]` branch hints
- **Only log hard errors** — `HELPER_LOG` now fires after the errno check, so transient `EWOULDBLOCK` during normal backpressure doesn't spam very-verbose logs
- **Removed dead `iovcnt == 0` check** — no caller ever passes 0 iovecs
- **Force-inlined `Entry::destroy()`** via `ESPHOME_ALWAYS_INLINE`
- **ESP8266 `max_send_queue` 5→4** — power of 2 lets `%` compile to `& 3` (bitmask) instead of software division
- **Minor behavior change:** when the overflow buffer is full, `write_raw_` now immediately returns `SOCKET_WRITE_FAILED` instead of returning OK with state silently set to FAILED (old `buffer_data_from_iov_` was void, state was set but caller returned OK — connection would fail on next iteration anyway)
- **Net ~172 bytes flash savings** on CI test build (ESP8266), ~96 bytes on ESP32

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — internal refactor, no user-facing changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — no configuration changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).