### PR TITLE
[esp32_ble][esp32_ble_server] Inline is_active/is_running and remove STL bloat

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -81,8 +81,6 @@ void ESP32BLE::disable() {
   this->state_ = BLE_COMPONENT_STATE_DISABLE;
 }
 
-bool ESP32BLE::is_active() { return this->state_ == BLE_COMPONENT_STATE_ACTIVE; }
-
 #ifdef USE_ESP32_BLE_ADVERTISING
 void ESP32BLE::advertising_start() {
   this->advertising_init_();

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -135,7 +135,7 @@ class ESP32BLE : public Component {
 
   void enable();
   void disable();
-  bool is_active();
+  ESPHOME_ALWAYS_INLINE bool is_active() { return this->state_ == BLE_COMPONENT_STATE_ACTIVE; }
   void setup() override;
   void loop() override;
   void dump_config() override;

--- a/esphome/components/esp32_ble_server/ble_server.cpp
+++ b/esphome/components/esp32_ble_server/ble_server.cpp
@@ -7,7 +7,6 @@
 
 #ifdef USE_ESP32
 
-#include <algorithm>
 #include <nvs_flash.h>
 #include <freertos/FreeRTOSConfig.h>
 #include <esp_bt_main.h>
@@ -39,16 +38,17 @@ void BLEServer::loop() {
     case RUNNING: {
       // Start all services that are pending to start
       if (!this->services_to_start_.empty()) {
-        for (auto &service : this->services_to_start_) {
+        size_t write_idx = 0;
+        for (auto *service : this->services_to_start_) {
           if (service->is_created()) {
             service->start();  // Needs to be called once per characteristic in the service
           }
+          // Remove services that have started or are starting
+          if (!service->is_starting() && !service->is_running()) {
+            this->services_to_start_[write_idx++] = service;
+          }
         }
-        // Remove services that have been started
-        this->services_to_start_.erase(
-            std::remove_if(this->services_to_start_.begin(), this->services_to_start_.end(),
-                           [](BLEService *service) { return service->is_starting() || service->is_running(); }),
-            this->services_to_start_.end());
+        this->services_to_start_.erase(this->services_to_start_.begin() + write_idx, this->services_to_start_.end());
       }
       break;
     }
@@ -90,8 +90,6 @@ void BLEServer::loop() {
     }
   }
 }
-
-bool BLEServer::is_running() { return this->parent_->is_active() && this->state_ == RUNNING; }
 
 bool BLEServer::can_proceed() { return this->is_running() || !this->parent_->is_active(); }
 

--- a/esphome/components/esp32_ble_server/ble_server.h
+++ b/esphome/components/esp32_ble_server/ble_server.h
@@ -32,7 +32,7 @@ class BLEServer : public Component, public GATTsEventHandler, public BLEStatusEv
   float get_setup_priority() const override;
   bool can_proceed() override;
 
-  bool is_running();
+  ESPHOME_ALWAYS_INLINE bool is_running() { return this->parent_->is_active() && this->state_ == RUNNING; }
 
   void set_manufacturer_data(const std::vector<uint8_t> &data) {
     this->manufacturer_data_ = data;


### PR DESCRIPTION
# What does this implement/fix?

Inline `ESP32BLE::is_active()` and `BLEServer::is_running()` with `ESPHOME_ALWAYS_INLINE` to eliminate cross-translation-unit call overhead on every loop iteration. Replace `std::remove_if` + `erase` in `BLEServer::loop()` with a simple index-based compacting loop, removing ~250 bytes of unrolled STL template machinery (`__find_if` Duff's device unrolling).

**Before:** `BLEServer::loop()` → `BLEServer::is_running()` (34B, stack frame) → `ESP32BLE::is_active()` (12B, call/ret) on every iteration. The `std::remove_if` generated ~250B of unrolled `__find_if` with 4x loop + Duff's device switch.

**After:** Both checks inline to a byte load + compare at each call site. No function calls in the steady-state fast path (RUNNING, no pending services). `BLEServer::loop()` drops from 450B → 398B. The `std::remove_if` lambda predicate symbol is eliminated entirely.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
esp32_improv:
  authorizer: none
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).