### PR TITLE
[microphone] Switch IDF test to new I2S driver

### DIFF
--- a/tests/components/microphone/common.yaml
+++ b/tests/components/microphone/common.yaml
@@ -6,7 +6,7 @@ i2s_audio:
 microphone:
   - platform: i2s_audio
     id: mic_id_external
-    i2s_din_pin: ${i2s_din_pin}
+    i2s_din_pin: ${i2s_din_pin1}
     adc_type: external
     pdm: false
     mclk_multiple: 384
@@ -15,7 +15,15 @@ microphone:
       - if:
           condition:
             - microphone.is_muted:
+                id: mic_id_external
           then:
             - microphone.unmute:
+                id: mic_id_external
           else:
             - microphone.mute:
+                id: mic_id_external
+  - platform: i2s_audio
+    id: mic_id_pdm
+    i2s_din_pin: ${i2s_din_pin2}
+    adc_type: external
+    pdm: true

--- a/tests/components/microphone/test.esp32-idf.yaml
+++ b/tests/components/microphone/test.esp32-idf.yaml
@@ -8,7 +8,6 @@ i2s_audio:
   i2s_bclk_pin: ${i2s_bclk_pin}
   i2s_lrclk_pin: ${i2s_lrclk_pin}
   i2s_mclk_pin: ${i2s_mclk_pin}
-  use_legacy: true
 
 microphone:
   - platform: i2s_audio
@@ -17,6 +16,7 @@ microphone:
     adc_type: external
     pdm: false
   - platform: i2s_audio
-    id: mic_id_adc
-    adc_pin: 32
-    adc_type: internal
+    id: mic_id_pdm
+    i2s_din_pin: GPIO34
+    adc_type: external
+    pdm: true

--- a/tests/components/microphone/test.esp32-idf.yaml
+++ b/tests/components/microphone/test.esp32-idf.yaml
@@ -17,6 +17,6 @@ microphone:
     pdm: false
   - platform: i2s_audio
     id: mic_id_pdm
-    i2s_din_pin: GPIO34
+    i2s_din_pin: ${i2s_din_pin}
     adc_type: external
     pdm: true

--- a/tests/components/microphone/test.esp32-idf.yaml
+++ b/tests/components/microphone/test.esp32-idf.yaml
@@ -2,21 +2,7 @@ substitutions:
   i2s_bclk_pin: GPIO15
   i2s_lrclk_pin: GPIO4
   i2s_mclk_pin: GPIO5
-  i2s_din_pin: GPIO33
+  i2s_din_pin1: GPIO33
+  i2s_din_pin2: GPIO34
 
-i2s_audio:
-  i2s_bclk_pin: ${i2s_bclk_pin}
-  i2s_lrclk_pin: ${i2s_lrclk_pin}
-  i2s_mclk_pin: ${i2s_mclk_pin}
-
-microphone:
-  - platform: i2s_audio
-    id: mic_id_external
-    i2s_din_pin: ${i2s_din_pin}
-    adc_type: external
-    pdm: false
-  - platform: i2s_audio
-    id: mic_id_pdm
-    i2s_din_pin: ${i2s_din_pin}
-    adc_type: external
-    pdm: true
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

The ESP-IDF microphone test was using `use_legacy: true` which only tested the legacy I2S driver code path. This switches the test to use the new I2S driver (the default) and replaces the internal ADC microphone (which requires legacy) with a PDM microphone.

This ensures the new `driver/i2s_std.h` / `driver/i2s_pdm.h` code paths are covered by CI.

Also updates `common.yaml` to be shared config with both external and PDM microphones, using substitutions for all pin assignments.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2s_audio:
  i2s_bclk_pin: GPIO15
  i2s_lrclk_pin: GPIO4
  i2s_mclk_pin: GPIO5

microphone:
  - platform: i2s_audio
    id: mic_id_external
    i2s_din_pin: GPIO33
    adc_type: external
    pdm: false
  - platform: i2s_audio
    id: mic_id_pdm
    i2s_din_pin: GPIO34
    adc_type: external
    pdm: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).