### PR TITLE
[core] Add back deprecated set_internal() for external projects

### DIFF
--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -100,11 +100,11 @@ class EntityBase {
   // Get whether this Entity should be hidden outside ESPHome
   bool is_internal() const { return this->flags_.internal; }
 
-  // Deprecated: set_internal() is unsafe at runtime. The internal flag may have already been read
-  // by components during setup and there is no guarantee the change will be observed. Clients
-  // (e.g. Home Assistant) are not notified of the change. Use the 'internal:' YAML key instead.
-  ESPDEPRECATED("set_internal() is unsafe at runtime and will be removed in 2027.3.0. "
-                "Use the 'internal:' YAML configuration key instead.",
+  // Deprecated: Calling set_internal() at runtime is undefined behavior. Components and clients
+  // are NOT notified of the change, the flag may have already been read during setup, and there
+  // is NO guarantee any consumer will observe the new value. Use the 'internal:' YAML key instead.
+  ESPDEPRECATED("set_internal() is undefined behavior at runtime — components and Home Assistant are NOT "
+                "notified. Use the 'internal:' YAML key instead. Will be removed in 2027.3.0.",
                 "2026.3.0")
   void set_internal(bool internal) { this->flags_.internal = internal; }
 

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -100,6 +100,14 @@ class EntityBase {
   // Get whether this Entity should be hidden outside ESPHome
   bool is_internal() const { return this->flags_.internal; }
 
+  // Deprecated: set_internal() is unsafe at runtime. The internal flag may have already been read
+  // by components during setup and there is no guarantee the change will be observed. Clients
+  // (e.g. Home Assistant) are not notified of the change. Use the 'internal:' YAML key instead.
+  ESPDEPRECATED("set_internal() is unsafe at runtime and will be removed in 2027.3.0. "
+                "Use the 'internal:' YAML configuration key instead.",
+                "2026.3.0")
+  void set_internal(bool internal) { this->flags_.internal = internal; }
+
   // Check if this object is declared to be disabled by default.
   // That means that when the device gets added to Home Assistant (or other clients) it should
   // not be added to the default view by default, and a user action is necessary to manually add it.


### PR DESCRIPTION
# What does this implement/fix?

Re-add `set_internal()` as a deprecated public method on `EntityBase` to give external projects a migration window until 2027.3.0.

The method was removed in #14564 but was being used by external projects (TX Ultimate Easy, etc.) to dynamically hide/show entities based on hardware configuration.

Unlike some of the other removed setters (e.g. string setters that could create dangling pointers), calling `set_internal()` at runtime is not a safety issue — it's a simple bool flag write. The behavior is technically undefined because:
- The flag may have already been read by components during setup
- Clients (e.g. Home Assistant) are not notified of the change
- There is no guarantee the change will be observed by all consumers

However, downstream projects were using it successfully in practice. The deprecation warning communicates that it's unsupported and gives authors a year to migrate to compile-time `internal:` YAML configuration or substitutions.

**Discord thread:** https://ptb.discord.com/channels/429907082951524364/1483096919436693709

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (reported by external project authors on Discord)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - this restores a C++ API method for use in lambdas
# External projects were using it like:
#   bs_button_1->set_internal(gang_count < 1);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).