### PR TITLE
[sensor][ee895][hdc2010] Fix misc bugs found during component scan

### DIFF
--- a/esphome/components/ee895/ee895.cpp
+++ b/esphome/components/ee895/ee895.cpp
@@ -24,7 +24,7 @@ void EE895Component::setup() {
   this->read(serial_number, 20);
 
   crc16_check = (serial_number[19] << 8) + serial_number[18];
-  if (crc16_check != calc_crc16_(serial_number, 19)) {
+  if (crc16_check != calc_crc16_(serial_number, 18)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->mark_failed();
     return;
@@ -84,7 +84,7 @@ void EE895Component::write_command_(uint16_t addr, uint16_t reg_cnt) {
   address[2] = addr & 0xFF;
   address[3] = (reg_cnt >> 8) & 0xFF;
   address[4] = reg_cnt & 0xFF;
-  crc16 = calc_crc16_(address, 6);
+  crc16 = calc_crc16_(address, 5);
   address[5] = crc16 & 0xFF;
   address[6] = (crc16 >> 8) & 0xFF;
   this->write(address, 7);
@@ -95,7 +95,7 @@ float EE895Component::read_float_() {
   uint8_t i2c_response[8];
   this->read(i2c_response, 8);
   crc16_check = (i2c_response[7] << 8) + i2c_response[6];
-  if (crc16_check != calc_crc16_(i2c_response, 7)) {
+  if (crc16_check != calc_crc16_(i2c_response, 6)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->status_set_warning();
     return 0;
@@ -107,12 +107,9 @@ float EE895Component::read_float_() {
 }
 
 uint16_t EE895Component::calc_crc16_(const uint8_t buf[], uint8_t len) {
-  uint8_t crc_check_buf[22];
-  for (int i = 0; i < len; i++) {
-    crc_check_buf[i + 1] = buf[i];
-  }
-  crc_check_buf[0] = this->address_;
-  return crc16(crc_check_buf, len);
+  uint8_t addr = this->address_;
+  uint16_t crc = crc16(&addr, 1);
+  return crc16(buf, len, crc);
 }
 }  // namespace ee895
 }  // namespace esphome

--- a/esphome/components/hdc2010/hdc2010.cpp
+++ b/esphome/components/hdc2010/hdc2010.cpp
@@ -7,50 +7,36 @@ namespace hdc2010 {
 
 static const char *const TAG = "hdc2010";
 
-static const uint8_t HDC2010_ADDRESS = 0x40;  // 0b1000000 or 0b1000001 from datasheet
-static const uint8_t HDC2010_CMD_CONFIGURATION_MEASUREMENT = 0x8F;
-static const uint8_t HDC2010_CMD_START_MEASUREMENT = 0xF9;
-static const uint8_t HDC2010_CMD_TEMPERATURE_LOW = 0x00;
-static const uint8_t HDC2010_CMD_TEMPERATURE_HIGH = 0x01;
-static const uint8_t HDC2010_CMD_HUMIDITY_LOW = 0x02;
-static const uint8_t HDC2010_CMD_HUMIDITY_HIGH = 0x03;
-static const uint8_t CONFIG = 0x0E;
-static const uint8_t MEASUREMENT_CONFIG = 0x0F;
+// Register addresses
+static constexpr uint8_t REG_TEMPERATURE_LOW = 0x00;
+static constexpr uint8_t REG_TEMPERATURE_HIGH = 0x01;
+static constexpr uint8_t REG_HUMIDITY_LOW = 0x02;
+static constexpr uint8_t REG_HUMIDITY_HIGH = 0x03;
+static constexpr uint8_t REG_RESET_DRDY_INT_CONF = 0x0E;
+static constexpr uint8_t REG_MEASUREMENT_CONF = 0x0F;
+
+// REG_MEASUREMENT_CONF (0x0F) bit masks
+static constexpr uint8_t MEAS_TRIG = 0x01;       // Bit 0: measurement trigger
+static constexpr uint8_t MEAS_CONF_MASK = 0x06;  // Bits 2:1: measurement mode
+static constexpr uint8_t HRES_MASK = 0x30;       // Bits 5:4: humidity resolution
+static constexpr uint8_t TRES_MASK = 0xC0;       // Bits 7:6: temperature resolution
+
+// REG_RESET_DRDY_INT_CONF (0x0E) bit masks
+static constexpr uint8_t AMM_MASK = 0x70;  // Bits 6:4: auto measurement mode
 
 void HDC2010Component::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
 
-  const uint8_t data[2] = {
-      0b00000000,  // resolution 14bit for both humidity and temperature
-      0b00000000   // reserved
-  };
-
-  if (!this->write_bytes(HDC2010_CMD_CONFIGURATION_MEASUREMENT, data, 2)) {
-    ESP_LOGW(TAG, "Initial config instruction error");
-    this->status_set_warning();
-    return;
-  }
-
-  // Set measurement mode to temperature and humidity
+  // Set 14-bit resolution for both sensors and measurement mode to temp + humidity
   uint8_t config_contents;
-  this->read_register(MEASUREMENT_CONFIG, &config_contents, 1);
-  config_contents = (config_contents & 0xF9);  // Always set to TEMP_AND_HUMID mode
-  this->write_bytes(MEASUREMENT_CONFIG, &config_contents, 1);
+  this->read_register(REG_MEASUREMENT_CONF, &config_contents, 1);
+  config_contents &= ~(TRES_MASK | HRES_MASK | MEAS_CONF_MASK);  // 14-bit temp, 14-bit humidity, temp+humidity mode
+  this->write_bytes(REG_MEASUREMENT_CONF, &config_contents, 1);
 
-  // Set rate to manual
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0x8F;
-  this->write_bytes(CONFIG, &config_contents, 1);
-
-  // Set temperature resolution to 14bit
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0x3F;
-  this->write_bytes(CONFIG, &config_contents, 1);
-
-  // Set humidity resolution to 14bit
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0xCF;
-  this->write_bytes(CONFIG, &config_contents, 1);
+  // Set auto measurement rate to manual (on-demand via MEAS_TRIG)
+  this->read_register(REG_RESET_DRDY_INT_CONF, &config_contents, 1);
+  config_contents &= ~AMM_MASK;
+  this->write_bytes(REG_RESET_DRDY_INT_CONF, &config_contents, 1);
 }
 
 void HDC2010Component::dump_config() {
@@ -67,9 +53,9 @@ void HDC2010Component::dump_config() {
 void HDC2010Component::update() {
   // Trigger measurement
   uint8_t config_contents;
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents |= 0x01;
-  this->write_bytes(MEASUREMENT_CONFIG, &config_contents, 1);
+  this->read_register(REG_MEASUREMENT_CONF, &config_contents, 1);
+  config_contents |= MEAS_TRIG;
+  this->write_bytes(REG_MEASUREMENT_CONF, &config_contents, 1);
 
   // 1ms delay after triggering the sample
   set_timeout(1, [this]() {
@@ -90,8 +76,8 @@ void HDC2010Component::update() {
 float HDC2010Component::read_temp() {
   uint8_t byte[2];
 
-  this->read_register(HDC2010_CMD_TEMPERATURE_LOW, &byte[0], 1);
-  this->read_register(HDC2010_CMD_TEMPERATURE_HIGH, &byte[1], 1);
+  this->read_register(REG_TEMPERATURE_LOW, &byte[0], 1);
+  this->read_register(REG_TEMPERATURE_HIGH, &byte[1], 1);
 
   uint16_t temp = encode_uint16(byte[1], byte[0]);
   return (float) temp * 0.0025177f - 40.0f;
@@ -100,8 +86,8 @@ float HDC2010Component::read_temp() {
 float HDC2010Component::read_humidity() {
   uint8_t byte[2];
 
-  this->read_register(HDC2010_CMD_HUMIDITY_LOW, &byte[0], 1);
-  this->read_register(HDC2010_CMD_HUMIDITY_HIGH, &byte[1], 1);
+  this->read_register(REG_HUMIDITY_LOW, &byte[0], 1);
+  this->read_register(REG_HUMIDITY_HIGH, &byte[1], 1);
 
   uint16_t humidity = encode_uint16(byte[1], byte[0]);
   return (float) humidity * 0.001525879f;

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -406,7 +406,9 @@ QUANTILE_SCHEMA = cv.All(
             cv.Optional(CONF_WINDOW_SIZE, default=5): cv.int_range(min=1, max=65535),
             cv.Optional(CONF_SEND_EVERY, default=5): cv.int_range(min=1, max=65535),
             cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.int_range(min=1, max=65535),
-            cv.Optional(CONF_QUANTILE, default=0.9): cv.zero_to_one_float,
+            cv.Optional(CONF_QUANTILE, default=0.9): cv.float_range(
+                min=0, min_included=False, max=1
+            ),
         }
     ),
     validate_send_first_at,


### PR DESCRIPTION
## What does this implement/fix?

Three small bugfixes found during a systematic component review:

### 1. [sensor] Disallow quantile: 0.0

`QuantileFilter` computes `ceilf(size * quantile) - 1` as a `size_t`. With `quantile=0.0`, `ceilf` returns 0 and `0 - 1` wraps to `SIZE_MAX`, causing an out-of-bounds access in `std::nth_element`. Changed validation from `cv.zero_to_one_float` (allows 0.0) to `cv.float_range(min=0, min_included=False, max=1)`.

### 2. [ee895] Remove unnecessary buffer copy in CRC calculation

`calc_crc16_` was copying the entire data buffer into a 22-byte stack array just to prepend the I2C address byte. The callers passed a length that included one extra byte beyond the data they intended to CRC, and the function used that length both for the copy (reading one byte past the intended data) and for the CRC calculation (which happened to produce the correct result because the address byte offset consumed the extra count). 

Replaced with a two-step CRC: compute over the address byte first, then chain as the seed for the data bytes. Fixed callers to pass the actual data length so the interface is clear and nothing reads past intended bounds.

### 3. [hdc2010] Fix wrong register for resolution and measurement trigger

Per the [HDC2010 datasheet](https://www.ti.com/lit/ds/symlink/hdc2010.pdf) (Tables 7-35 through 7-38):
- Temperature resolution (TRES), humidity resolution (HRES), measurement mode (MEAS_CONF), and trigger (MEAS_TRIG) are all in register **0x0F** (Measurement Configuration)
- Auto measurement rate (AMM) is in register **0x0E** (Reset and DRDY/INT Configuration)

The code was writing temperature and humidity resolution to 0x0E instead of 0x0F, and `update()` was reading 0x0E before triggering a measurement in 0x0F. Both worked by accident since the default values happen to be 0. Also renamed constants to match the datasheet, switched to `constexpr`, added named bit masks, and removed unused constants.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# sensor quantile filter - quantile: 0.0 now rejected
sensor:
  - platform: ...
    filters:
      - quantile:
          quantile: 0.5  # must be > 0.0

# ee895 / hdc2010 - no config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).