### PR TITLE
[esp32_ble] Fix EventPool/LockFreeQueue sizing off-by-one

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -575,8 +575,9 @@ template<typename... Args> void enqueue_ble_event(Args... args) {
   load_ble_event(event, args...);
 
   // Push the event to the queue
+  // Push always succeeds: pool is sized to queue capacity (N-1), so if
+  // allocate() returned non-null, the queue is guaranteed to have room.
   global_ble->ble_events_.push(event);
-  // Push always succeeds because we're the only producer and the pool ensures we never exceed queue size
 }
 
 // Explicit template instantiations for the friend function

--- a/esphome/components/esp32_ble/ble.h
+++ b/esphome/components/esp32_ble/ble.h
@@ -221,7 +221,13 @@ class ESP32BLE : public Component {
 
   // Large objects (size depends on template parameters, but typically aligned to 4 bytes)
   esphome::LockFreeQueue<BLEEvent, MAX_BLE_QUEUE_SIZE> ble_events_;
-  esphome::EventPool<BLEEvent, MAX_BLE_QUEUE_SIZE> ble_event_pool_;
+  // Pool sized to queue capacity (SIZE-1) because LockFreeQueue<T,N> is a ring
+  // buffer that holds N-1 elements (one slot distinguishes full from empty).
+  // This guarantees allocate() returns nullptr before push() can fail, which:
+  //  1. Prevents leaking a pool slot (the Nth allocate succeeds but push fails)
+  //  2. Avoids needing release() on the producer path after a failed push(),
+  //     preserving the SPSC contract on the pool's internal free list
+  esphome::EventPool<BLEEvent, MAX_BLE_QUEUE_SIZE - 1> ble_event_pool_;
 
   // 4-byte aligned members
 #ifdef USE_ESP32_BLE_ADVERTISING


### PR DESCRIPTION
# What does this implement/fix?

`LockFreeQueue<T, N>` is a ring buffer that holds **N-1** elements (one slot is reserved to distinguish full from empty). With `EventPool` also sized to N, the Nth `allocate()` succeeds but `push()` fails — permanently leaking one pool slot since the element is never returned.

Size the pool to `N-1` to match queue capacity. This guarantees `allocate()` returns nullptr before `push()` can fail.

## Proof

The following self-contained test (using copies of `LockFreeQueue` and `EventPool`) demonstrates the leak with matching sizes:

<details>
<summary>ble_slot_race.cpp (click to expand)</summary>

```cpp
// Proof that EventPool<T,N> + LockFreeQueue<T,N> with matching sizes
// leaks one slot when the queue fills up (ring buffer capacity = N-1).
//
// Build: c++ -std=c++20 -o ble_slot_race ble_slot_race.cpp && ./ble_slot_race

#include <atomic>
#include <cassert>
#include <cstddef>
#include <cstdint>
#include <cstdio>
#include <cstdlib>

// -- Minimal LockFreeQueue (copied from esphome/core/lock_free_queue.h) --

template<class T, uint8_t SIZE> class LockFreeQueue {
 public:
  LockFreeQueue() : dropped_count_(0), head_(0), tail_(0) {}

  bool push(T *element) {
    if (element == nullptr)
      return false;
    uint8_t current_tail = tail_.load(std::memory_order_relaxed);
    uint8_t next_tail = next_index(current_tail);
    uint8_t head_before = head_.load(std::memory_order_acquire);
    if (next_tail == head_before) {
      dropped_count_.fetch_add(1, std::memory_order_relaxed);
      return false;
    }
    buffer_[current_tail] = element;
    tail_.store(next_tail, std::memory_order_release);
    return true;
  }

  T *pop() {
    uint8_t current_head = head_.load(std::memory_order_relaxed);
    if (current_head == tail_.load(std::memory_order_acquire))
      return nullptr;
    T *element = buffer_[current_head];
    head_.store(next_index(current_head), std::memory_order_release);
    return element;
  }

  size_t size() const {
    uint8_t tail = tail_.load(std::memory_order_acquire);
    uint8_t head = head_.load(std::memory_order_acquire);
    int diff = static_cast<int>(tail) - static_cast<int>(head);
    if (diff < 0)
      diff += SIZE;
    return static_cast<size_t>(diff);
  }

  uint16_t get_and_reset_dropped_count() {
    if (dropped_count_.load(std::memory_order_relaxed) == 0)
      return 0;
    return dropped_count_.exchange(0, std::memory_order_relaxed);
  }

  void increment_dropped_count() { dropped_count_.fetch_add(1, std::memory_order_relaxed); }

 private:
  static constexpr uint8_t next_index(uint8_t index) {
    uint8_t next = index + 1;
    if (next >= SIZE)
      next = 0;
    return next;
  }

  T *buffer_[SIZE]{};
  std::atomic<uint16_t> dropped_count_;
  std::atomic<uint8_t> head_;
  std::atomic<uint8_t> tail_;
};

// -- Minimal EventPool (copied from esphome/core/event_pool.h) --
// Simplified: uses new/delete instead of RAMAllocator

template<class T, uint8_t SIZE> class EventPool {
 public:
  EventPool() : total_created_(0) {}

  ~EventPool() {
    T *event;
    while ((event = free_list_.pop()) != nullptr)
      delete event;
  }

  T *allocate() {
    T *event = free_list_.pop();
    if (event != nullptr)
      return event;
    if (total_created_ >= SIZE)
      return nullptr;
    event = new T();
    total_created_++;
    return event;
  }

  void release(T *event) {
    if (event != nullptr) {
      event->release();
      free_list_.push(event);
    }
  }

  uint8_t total_created() const { return total_created_; }

 private:
  LockFreeQueue<T, SIZE> free_list_;
  uint8_t total_created_;
};

// -- Test event type --

struct TestEvent {
  int value{0};
  void release() { value = 0; }
};

// -- BLE pattern: pool and queue use the SAME size --

static constexpr uint8_t Q_SIZE = 8;  // ring buffer SIZE=8, capacity=7

int main() {
  EventPool<TestEvent, Q_SIZE> pool;      // can create up to 8 events
  LockFreeQueue<TestEvent, Q_SIZE> queue;  // can hold up to 7 events

  printf("Pool max: %u   Queue capacity: %u (ring buffer SIZE=%u, wastes 1 slot)\n\n",
         Q_SIZE, Q_SIZE - 1, Q_SIZE);

  // Phase 1: allocate and push until queue is full
  int pushed = 0;
  for (int i = 0; i < Q_SIZE; i++) {
    TestEvent *ev = pool.allocate();
    if (ev == nullptr) {
      printf("  allocate() returned nullptr at i=%d\n", i);
      break;
    }
    ev->value = i + 1;
    bool ok = queue.push(ev);
    if (!ok) {
      printf("  push() FAILED at i=%d (queue full) -- event #%d leaked!\n", i, ev->value);
      // BLE pattern: fire-and-forget, no release(), element is leaked
      break;
    }
    pushed++;
    printf("  pushed event #%d  (queue size=%zu, pool created=%u)\n",
           ev->value, queue.size(), pool.total_created());
  }

  printf("\nAfter filling: pushed=%d, queue size=%zu, pool total_created=%u\n\n",
         pushed, queue.size(), pool.total_created());

  // Phase 2: drain queue, release all back to pool
  int drained = 0;
  TestEvent *ev;
  while ((ev = queue.pop()) != nullptr) {
    pool.release(ev);
    drained++;
  }
  printf("Drained %d events back to pool\n\n", drained);

  // Phase 3: try to allocate all at once -- one slot is gone
  TestEvent *allocated[Q_SIZE]{};
  int reallocated = 0;
  for (int i = 0; i < Q_SIZE; i++) {
    allocated[i] = pool.allocate();
    if (allocated[i] == nullptr)
      break;
    reallocated++;
  }
  // Release them back
  for (int i = 0; i < reallocated; i++)
    pool.release(allocated[i]);

  printf("After drain, pool can allocate: %d out of %d\n", reallocated, Q_SIZE);

  uint16_t dropped = queue.get_and_reset_dropped_count();
  printf("Queue reported %u dropped event(s)\n\n", dropped);

  if (reallocated < Q_SIZE) {
    printf("PROVED: %d slot(s) leaked -- pool permanently lost capacity\n",
           Q_SIZE - reallocated);
    printf("The ring buffer holds SIZE-1=%d elements but the pool has SIZE=%d,\n",
           Q_SIZE - 1, Q_SIZE);
    printf("so the %dth allocate succeeds but push fails, leaking the element.\n",
           Q_SIZE);
    return 1;
  } else {
    printf("No leak detected (unexpected)\n");
    return 0;
  }
}
```
</details>

Output:

```
Pool max: 8   Queue capacity: 7 (ring buffer SIZE=8, wastes 1 slot)

  pushed event #1  (queue size=1, pool created=1)
  pushed event #2  (queue size=2, pool created=2)
  pushed event #3  (queue size=3, pool created=3)
  pushed event #4  (queue size=4, pool created=4)
  pushed event #5  (queue size=5, pool created=5)
  pushed event #6  (queue size=6, pool created=6)
  pushed event #7  (queue size=7, pool created=7)
  push() FAILED at i=7 (queue full) — event #8 leaked!

After filling: pushed=7, queue size=7, pool total_created=8

Drained 7 events back to pool

After drain, pool can allocate: 7 out of 8
Queue reported 1 dropped event(s)

PROVED: 1 slot(s) leaked — pool permanently lost capacity
The ring buffer holds SIZE-1=7 elements but the pool has SIZE=8,
so the 8th allocate succeeds but push fails, leaking the element.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes — internal fix.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).