### PR TITLE
[usb_cdc_acm] Fix EventPool/LockFreeQueue sizing off-by-one

### DIFF
--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.cpp
@@ -26,16 +26,13 @@ void USBCDCACMInstance::queue_line_state_event(bool dtr, bool rts) {
   event->data.line_state.dtr = dtr;
   event->data.line_state.rts = rts;
 
-  if (!this->event_queue_.push(event)) {
-    ESP_LOGW(TAG, "Event queue full, line state event dropped (itf=%d)", this->itf_);
-    // Return event to pool since we couldn't queue it
-    this->event_pool_.release(event);
-  } else {
-    // Wake main loop immediately to process event
+  // Push always succeeds: pool is sized to queue capacity (SIZE-1), so if
+  // allocate() returned non-null, the queue cannot be full.
+  this->event_queue_.push(event);
+
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
-    App.wake_loop_threadsafe();
+  App.wake_loop_threadsafe();
 #endif
-  }
 }
 
 void USBCDCACMInstance::queue_line_coding_event(uint32_t bit_rate, uint8_t stop_bits, uint8_t parity,
@@ -53,16 +50,13 @@ void USBCDCACMInstance::queue_line_coding_event(uint32_t bit_rate, uint8_t stop_
   event->data.line_coding.parity = parity;
   event->data.line_coding.data_bits = data_bits;
 
-  if (!this->event_queue_.push(event)) {
-    ESP_LOGW(TAG, "Event queue full, line coding event dropped (itf=%d)", this->itf_);
-    // Return event to pool since we couldn't queue it
-    this->event_pool_.release(event);
-  } else {
-    // Wake main loop immediately to process event
+  // Push always succeeds: pool is sized to queue capacity (SIZE-1), so if
+  // allocate() returned non-null, the queue cannot be full.
+  this->event_queue_.push(event);
+
 #if defined(USE_SOCKET_SELECT_SUPPORT) && defined(USE_WAKE_LOOP_THREADSAFE)
-    App.wake_loop_threadsafe();
+  App.wake_loop_threadsafe();
 #endif
-  }
 }
 
 void USBCDCACMInstance::process_events_() {

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.h
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.h
@@ -102,7 +102,11 @@ class USBCDCACMInstance : public uart::UARTComponent, public Parented<USBCDCACMC
   LineStateCallback line_state_callback_{nullptr};
 
   // Lock-free queue and event pool for cross-task event passing
-  EventPool<CDCEvent, EVENT_QUEUE_SIZE> event_pool_;
+  // Pool sized to queue capacity (SIZE-1) because LockFreeQueue<T,N> is a ring
+  // buffer that holds N-1 elements. This guarantees allocate() returns nullptr
+  // before push() can fail, preventing both a pool slot leak and an SPSC
+  // violation on the pool's internal free list.
+  EventPool<CDCEvent, EVENT_QUEUE_SIZE - 1> event_pool_;
   LockFreeQueue<CDCEvent, EVENT_QUEUE_SIZE> event_queue_;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Same off-by-one as #14892 — `LockFreeQueue<T, N>` holds **N-1** elements but `EventPool` was sized to N.

This component had a worse variant of the bug: on push failure, it called `release()` from the **producer thread** (USB task), while the main loop also calls `release()`. This is an SPSC violation on the pool's internal free list — two threads pushing concurrently to a single-producer queue.

Size the pool to `N-1` to match queue capacity. Since push can no longer fail after a successful `allocate()`, the push-failure code paths (and the SPSC violation) are eliminated entirely.

See #14892 for a self-contained proof-of-concept that demonstrates the leak with matching sizes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #14892

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes — internal fix.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).