### PR TITLE
[core] Document EventPool sizing requirement with LockFreeQueue

### DIFF
--- a/esphome/core/event_pool.h
+++ b/esphome/core/event_pool.h
@@ -13,6 +13,14 @@ namespace esphome {
 // Events are allocated on first use and reused thereafter, growing to peak usage
 // @tparam T The type of objects managed by the pool (must have a release() method)
 // @tparam SIZE The maximum number of objects in the pool (1-255, limited by uint8_t)
+//
+// SIZING: When paired with a LockFreeQueue<T, Q_SIZE>, the pool SIZE should be
+// Q_SIZE - 1 (the queue's actual capacity, since the ring buffer reserves one slot).
+// This ensures allocate() returns nullptr before push() can fail, which:
+//  - Prevents the allocate-succeeds-but-push-fails mismatch that permanently
+//    leaks a pool slot (the element is never returned to the pool)
+//  - Avoids needing release() on the producer path after a failed push(),
+//    preserving the SPSC contract on the internal free list
 template<class T, uint8_t SIZE> class EventPool {
  public:
   EventPool() : total_created_(0) {}


### PR DESCRIPTION
# What does this implement/fix?

Adds a comment to `EventPool` in `event_pool.h` documenting the sizing relationship with `LockFreeQueue`:

> When paired with a `LockFreeQueue<T, Q_SIZE>`, the pool SIZE should be `Q_SIZE - 1` (the queue's actual capacity, since the ring buffer reserves one slot).

This makes the invariant discoverable for anyone adding new EventPool+LockFreeQueue pairs.

Context: PRs #14891–#14896 fixed all existing usages where pool and queue were incorrectly using the same SIZE, causing a one-slot leak when the queue fills. See #14892 for a self-contained proof-of-concept demonstrating the issue.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #14891, #14892, #14893, #14894, #14895, #14896

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a — comment-only change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).