### PR TITLE
[esp32_ble_server] Remove vestigial semaphore from BLECharacteristic

### DIFF
--- a/esphome/components/esp32_ble_server/ble_characteristic.cpp
+++ b/esphome/components/esp32_ble_server/ble_characteristic.cpp
@@ -16,13 +16,9 @@ BLECharacteristic::~BLECharacteristic() {
   for (auto *descriptor : this->descriptors_) {
     delete descriptor;  // NOLINT(cppcoreguidelines-owning-memory)
   }
-  vSemaphoreDelete(this->set_value_lock_);
 }
 
 BLECharacteristic::BLECharacteristic(const ESPBTUUID uuid, uint32_t properties) : uuid_(uuid) {
-  this->set_value_lock_ = xSemaphoreCreateBinary();
-  xSemaphoreGive(this->set_value_lock_);
-
   this->properties_ = (esp_gatt_char_prop_t) 0;
 
   this->set_broadcast_property((properties & PROPERTY_BROADCAST) != 0);
@@ -35,11 +31,7 @@ BLECharacteristic::BLECharacteristic(const ESPBTUUID uuid, uint32_t properties) 
 
 void BLECharacteristic::set_value(ByteBuffer buffer) { this->set_value(buffer.get_data()); }
 
-void BLECharacteristic::set_value(std::vector<uint8_t> &&buffer) {
-  xSemaphoreTake(this->set_value_lock_, 0L);
-  this->value_ = std::move(buffer);
-  xSemaphoreGive(this->set_value_lock_);
-}
+void BLECharacteristic::set_value(std::vector<uint8_t> &&buffer) { this->value_ = std::move(buffer); }
 
 void BLECharacteristic::set_value(std::initializer_list<uint8_t> data) {
   this->set_value(std::vector<uint8_t>(data));  // Delegate to move overload

--- a/esphome/components/esp32_ble_server/ble_characteristic.h
+++ b/esphome/components/esp32_ble_server/ble_characteristic.h
@@ -16,8 +16,6 @@
 #include <esp_gattc_api.h>
 #include <esp_gatts_api.h>
 #include <esp_bt_defs.h>
-#include <freertos/FreeRTOS.h>
-#include <freertos/semphr.h>
 
 namespace esphome {
 namespace esp32_ble_server {
@@ -84,8 +82,6 @@ class BLECharacteristic {
 
   uint16_t value_read_offset_{0};
   std::vector<uint8_t> value_;
-  SemaphoreHandle_t set_value_lock_;
-
   std::vector<BLEDescriptor *> descriptors_;
 
   struct ClientNotificationEntry {


### PR DESCRIPTION
# What does this implement/fix?

Remove the vestigial `set_value_lock_` binary semaphore from `BLECharacteristic`. All `value_` access (reads in `notify()`, `gatts_event_handler` READ/WRITE events, and writes in `set_value()`) runs on the main ESPHome loop task, so there is no cross-thread race to protect against.

The GATTS callbacks from the BT task are already safely transferred to the main loop via the lock-free event queue in `esp32_ble` (`ESP32BLE::gatts_event_handler()` enqueues, `ESP32BLE::loop()` dequeues and dispatches). This is the same pattern identified in #10057 which eliminated the redundant ring buffer from `esp32_ble_tracker`.

The semaphore was also broken as a lock — `xSemaphoreTake` with timeout `0L` is non-blocking, and the return value was never checked — but this was harmless since all access is single-threaded on the main loop anyway. Reads of `value_` in `notify()` and the GATTS read handler were unprotected by the semaphore, which further confirms it was never providing real synchronization.

Saves ~80 bytes of RAM per characteristic (FreeRTOS binary semaphore overhead).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required
esp32_ble_server:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).