### PR TITLE
[tc74][apds9960] Fix signed temperature and FIFO register address

### DIFF
--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -251,11 +251,11 @@ void APDS9960::read_gesture_data_() {
 
   uint8_t buf[128];
   for (uint8_t pos = 0; pos < fifo_level * 4; pos += 32) {
-    // The ESP's i2c driver has a limited buffer size.
-    // This way of retrieving the data should be wrong according to the datasheet
-    // but it seems to work.
+    // Read in 32-byte chunks due to ESP8266 I2C buffer limit.
+    // Always read from 0xFC — the FIFO auto-increments through 0xFC-0xFF
+    // and advances its internal pointer after every 4th byte.
     uint8_t read = std::min(32, fifo_level * 4 - pos);
-    APDS9960_WARNING_CHECK(this->read_bytes(0xFC + pos, buf + pos, read), "Reading FIFO buffer failed.");
+    APDS9960_WARNING_CHECK(this->read_bytes(0xFC, buf + pos, read), "Reading FIFO buffer failed.");
   }
 
   if (millis() - this->gesture_start_ > 500) {

--- a/esphome/components/tc74/tc74.cpp
+++ b/esphome/components/tc74/tc74.cpp
@@ -50,8 +50,9 @@ void TC74Component::read_temperature_() {
     }
   }
 
-  uint8_t temperature_reg;
-  if (this->read_register(TC74_REGISTER_TEMPERATURE, &temperature_reg, 1) != i2c::ERROR_OK) {
+  int8_t temperature_reg;
+  if (this->read_register(TC74_REGISTER_TEMPERATURE, reinterpret_cast<uint8_t *>(&temperature_reg), 1) !=
+      i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }


### PR DESCRIPTION
## What does this implement/fix?

Two sensor bugfixes found during a systematic component review:

### 1. [tc74] Fix negative temperature readings

The TC74 temperature register is signed 8-bit two's complement per the [datasheet](https://ww1.microchip.com/downloads/en/DeviceDoc/21462D.pdf), but was read into a `uint8_t`. Negative temperatures (e.g. -10C stored as 0xF6) were published as large positive values (246). Changed to `int8_t`.

### 2. [apds9960] Fix FIFO read using wrong register for fifo_level > 8

The gesture FIFO is read in 32-byte chunks (ESP8266 I2C buffer limit). The register address was `0xFC + pos`, which overflows `uint8_t` when `pos >= 4` (fifo_level > 8), causing reads from wrong registers instead of the FIFO.

Per the [APDS-9960 datasheet](https://cdn.sparkfun.com/datasheets/Sensors/Proximity/apds9960.pdf), gesture FIFO data is read by starting a page read at register 0xFC and clocking out `4 * GFLVL` bytes — the internal FIFO pointer advances automatically after every 4th byte. Fixed to always read from 0xFC.

The existing code had a comment acknowledging "This way of retrieving the data should be wrong according to the datasheet but it seems to work" — it worked because fifo_level rarely exceeds 8 in practice.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed for either fix.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).