### PR TITLE
[http_request] Prevent double update task launch

### DIFF
--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -68,6 +68,10 @@ void HttpRequestUpdate::update() {
   }
   this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
 #ifdef USE_ESP32
+  if (this->update_task_handle_ != nullptr) {
+    ESP_LOGW(TAG, "Update check already in progress");
+    return;
+  }
   xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);
 #else
   this->update_task(this);
@@ -82,7 +86,10 @@ void HttpRequestUpdate::update_task(void *params) {
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
     ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to fetch manifest")); });
+    this_update->defer([this_update]() {
+      this_update->clear_update_task_handle_();
+      this_update->status_set_error(LOG_STR("Failed to fetch manifest"));
+    });
     UPDATE_RETURN;
   }
 
@@ -91,8 +98,10 @@ void HttpRequestUpdate::update_task(void *params) {
   if (data == nullptr) {
     ESP_LOGE(TAG, "Failed to allocate %zu bytes for manifest", container->content_length);
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer(
-        [this_update]() { this_update->status_set_error(LOG_STR("Failed to allocate memory for manifest")); });
+    this_update->defer([this_update]() {
+      this_update->clear_update_task_handle_();
+      this_update->status_set_error(LOG_STR("Failed to allocate memory for manifest"));
+    });
     container->end();
     UPDATE_RETURN;
   }
@@ -106,7 +115,10 @@ void HttpRequestUpdate::update_task(void *params) {
       ESP_LOGE(TAG, "Error reading manifest: %d", read_result.error_code);
     }
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to read manifest")); });
+    this_update->defer([this_update]() {
+      this_update->clear_update_task_handle_();
+      this_update->status_set_error(LOG_STR("Failed to read manifest"));
+    });
     allocator.deallocate(data, container->content_length);
     container->end();
     UPDATE_RETURN;
@@ -163,7 +175,10 @@ void HttpRequestUpdate::update_task(void *params) {
   if (!valid) {
     ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
     // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to parse manifest JSON")); });
+    this_update->defer([this_update]() {
+      this_update->clear_update_task_handle_();
+      this_update->status_set_error(LOG_STR("Failed to parse manifest JSON"));
+    });
     UPDATE_RETURN;
   }
 
@@ -203,6 +218,7 @@ void HttpRequestUpdate::update_task(void *params) {
   //   which can be corrupted if accessed concurrently from task and main loop threads
   // - update_available trigger to ensure consistent state when the trigger fires
   this_update->defer([this_update, trigger_update_available]() {
+    this_update->clear_update_task_handle_();
     this_update->update_info_.has_progress = false;
     this_update->update_info_.progress = 0.0f;
 

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -37,6 +37,11 @@ class HttpRequestUpdate final : public update::UpdateEntity, public PollingCompo
   std::string source_url_;
 
   static void update_task(void *params);
+  void clear_update_task_handle_() {
+#ifdef USE_ESP32
+    this->update_task_handle_ = nullptr;
+#endif
+  }
 #ifdef USE_ESP32
   TaskHandle_t update_task_handle_{nullptr};
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Prevents launching a second FreeRTOS update task while one is already running. Without this guard, calling `update()` twice (e.g., from both the polling interval and the initial check interval) could spawn two concurrent tasks both writing to the same `update_info_` fields, causing data corruption.

Changes:
- Check `update_task_handle_` before calling `xTaskCreate` — skip with a warning if a task is already running
- Clear the task handle in every deferred callback (all exit paths from the task) so subsequent update checks can proceed normally
- Add a `clear_update_task_handle_()` helper to handle the `#ifdef USE_ESP32` guard cleanly

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal fix
http_request:

update:
  - platform: http_request
    name: Firmware Update
    source: http://example.com/manifest.json
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).