### PR TITLE
[core] Inline progmem_read functions on non-ESP8266 platforms

### DIFF
--- a/esphome/components/esp32/core.cpp
+++ b/esphome/components/esp32/core.cpp
@@ -53,9 +53,6 @@ void arch_init() {
 }
 void HOT arch_feed_wdt() { esp_task_wdt_reset(); }
 
-uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
-const char *progmem_read_ptr(const char *const *addr) { return *addr; }
-uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
 uint32_t arch_get_cpu_cycle_count() { return esp_cpu_get_cycle_count(); }
 uint32_t arch_get_cpu_freq_hz() {
   uint32_t freq = 0;

--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -58,9 +58,6 @@ void HOT arch_feed_wdt() {
   // pass
 }
 
-uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
-const char *progmem_read_ptr(const char *const *addr) { return *addr; }
-uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
 uint32_t arch_get_cpu_cycle_count() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -54,9 +54,6 @@ void arch_restart() {
 void HOT arch_feed_wdt() { lt_wdt_feed(); }
 uint32_t arch_get_cpu_cycle_count() { return lt_cpu_get_cycle_count(); }
 uint32_t arch_get_cpu_freq_hz() { return lt_cpu_get_freq(); }
-uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
-const char *progmem_read_ptr(const char *const *addr) { return *addr; }
-uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
 
 }  // namespace esphome
 

--- a/esphome/components/rp2040/core.cpp
+++ b/esphome/components/rp2040/core.cpp
@@ -37,13 +37,6 @@ void arch_init() {
 
 void HOT arch_feed_wdt() { watchdog_update(); }
 
-uint8_t progmem_read_byte(const uint8_t *addr) {
-  return pgm_read_byte(addr);  // NOLINT
-}
-const char *progmem_read_ptr(const char *const *addr) {
-  return reinterpret_cast<const char *>(pgm_read_ptr(addr));  // NOLINT
-}
-uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
 uint32_t HOT arch_get_cpu_cycle_count() { return ulMainGetRunTimeCounterValue(); }
 uint32_t arch_get_cpu_freq_hz() { return RP2040::f_cpu(); }
 

--- a/esphome/components/zephyr/core.cpp
+++ b/esphome/components/zephyr/core.cpp
@@ -59,9 +59,6 @@ void arch_feed_wdt() {
 void arch_restart() { sys_reboot(SYS_REBOOT_COLD); }
 uint32_t arch_get_cpu_cycle_count() { return k_cycle_get_32(); }
 uint32_t arch_get_cpu_freq_hz() { return sys_clock_hw_cycles_per_sec(); }
-uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
-const char *progmem_read_ptr(const char *const *addr) { return *addr; }
-uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
 
 Mutex::Mutex() {
   auto *mutex = new k_mutex();

--- a/esphome/core/hal.h
+++ b/esphome/core/hal.h
@@ -41,8 +41,17 @@ void arch_init();
 void arch_feed_wdt();
 uint32_t arch_get_cpu_cycle_count();
 uint32_t arch_get_cpu_freq_hz();
+
+#ifdef USE_ESP8266
+// ESP8266: pgm_read_* does real flash reads on Harvard architecture
 uint8_t progmem_read_byte(const uint8_t *addr);
 const char *progmem_read_ptr(const char *const *addr);
 uint16_t progmem_read_uint16(const uint16_t *addr);
+#else
+// All other platforms: PROGMEM is a no-op, so these are direct dereferences
+inline uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
+inline const char *progmem_read_ptr(const char *const *addr) { return *addr; }
+inline uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }
+#endif
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Inline the `progmem_read_byte`, `progmem_read_ptr`, and `progmem_read_uint16` functions on all non-ESP8266 platforms. On these platforms, the functions are trivial dereferences (`return *addr`), but being out-of-line prevented the compiler from optimizing through them — notably in `PROGMEM_STRING_TABLE` where the offset lookup could not be folded into a direct array access.

ESP8266 keeps out-of-line implementations since `pgm_read_*` does real flash reads on its Harvard architecture, and inlining was measured to increase binary size there.

Also removes double indirection on RP2040 where `progmem_read_byte` called `pgm_read_byte` which was itself just a dereference.

Ideally these functions would live in `progmem.h` rather than `hal.h`, but that would be a breaking change for external components that include `hal.h` and call them. That migration can be done in a future deprecation cycle.

Measured: -48 bytes flash on ESP32, no change on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).