### PR TITLE
[hub75] Bump esp-hub75 to 0.3.5

### DIFF
--- a/esphome/components/hub75/display.py
+++ b/esphome/components/hub75/display.py
@@ -587,7 +587,7 @@ def _build_config_struct(
 async def to_code(config: ConfigType) -> None:
     add_idf_component(
         name="esphome/esp-hub75",
-        ref="0.3.4",
+        ref="0.3.5",
     )
 
     # Set compile-time configuration via build flags (so external library sees them)

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -64,7 +64,7 @@ dependencies:
     rules:
       - if: "target in [esp32s2, esp32s3, esp32p4]"
   esphome/esp-hub75:
-    version: 0.3.4
+    version: 0.3.5
     rules:
       - if: "target in [esp32, esp32s2, esp32s3, esp32c6, esp32p4]"
   espressif/mqtt:


### PR DESCRIPTION
# What does this implement/fix?

Bump esp-hub75 library from 0.3.4 to 0.3.5. The new version adds ESP-IDF 6.0 support (esphome-libs/esp-hub75#104).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).