### PR TITLE
[vbus][shelly_dimmer][st7789v][modbus_controller] Fix integer overflows, off-by-one, and coordinate swap

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -178,7 +178,7 @@ template<typename N> N mask_and_shift_by_rightbit(N data, uint32_t mask) {
     return result;
   }
   for (size_t pos = 0; pos < sizeof(N) << 3; pos++) {
-    if ((mask & (1 << pos)) != 0)
+    if ((mask & (1UL << pos)) != 0)
       return result >> pos;
   }
   return 0;

--- a/esphome/components/shelly_dimmer/shelly_dimmer.cpp
+++ b/esphome/components/shelly_dimmer/shelly_dimmer.cpp
@@ -402,7 +402,7 @@ bool ShellyDimmer::handle_frame_() {
   // Handle response.
   switch (cmd) {
     case SHELLY_DIMMER_PROTO_CMD_POLL: {
-      if (payload_len < 16) {
+      if (payload_len < 17) {
         return false;
       }
 

--- a/esphome/components/st7789v/st7789v.cpp
+++ b/esphome/components/st7789v/st7789v.cpp
@@ -156,9 +156,9 @@ void ST7789V::update() {
 void ST7789V::set_model_str(const char *model_str) { this->model_str_ = model_str; }
 
 void ST7789V::write_display_data() {
-  uint16_t x1 = this->offset_height_;
+  uint16_t x1 = this->offset_width_;
   uint16_t x2 = x1 + get_width_internal() - 1;
-  uint16_t y1 = this->offset_width_;
+  uint16_t y1 = this->offset_height_;
   uint16_t y2 = y1 + get_height_internal() - 1;
 
   this->enable();

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -48,8 +48,8 @@ void DeltaSolBSPlusSensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 18));
   if (this->heat_quantity_sensor_ != nullptr) {
-    this->heat_quantity_sensor_->publish_state(get_u16(message, 20) + get_u16(message, 22) * 1000 +
-                                               get_u16(message, 24) * 1000000);
+    this->heat_quantity_sensor_->publish_state(get_u16(message, 20) + get_u16(message, 22) * 1000.0f +
+                                               get_u16(message, 24) * 1000000.0f);
   }
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 12));
@@ -130,8 +130,8 @@ void DeltaSolCSensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
   if (this->heat_quantity_sensor_ != nullptr) {
-    this->heat_quantity_sensor_->publish_state(get_u16(message, 16) + get_u16(message, 18) * 1000 +
-                                               get_u16(message, 20) * 1000000);
+    this->heat_quantity_sensor_->publish_state(get_u16(message, 16) + get_u16(message, 18) * 1000.0f +
+                                               get_u16(message, 20) * 1000000.0f);
   }
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));
@@ -163,7 +163,8 @@ void DeltaSolCS2Sensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours_sensor_ != nullptr)
     this->operating_hours_sensor_->publish_state(get_u16(message, 14));
   if (this->heat_quantity_sensor_ != nullptr)
-    this->heat_quantity_sensor_->publish_state((get_u16(message, 26) << 16) + get_u16(message, 24));
+    this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 26)) << 16) |
+                                               get_u16(message, 24));
   if (this->version_sensor_ != nullptr)
     this->version_sensor_->publish_state(get_u16(message, 28) * 0.01f);
 }
@@ -205,7 +206,8 @@ void DeltaSolCS4Sensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
   if (this->heat_quantity_sensor_ != nullptr)
-    this->heat_quantity_sensor_->publish_state((get_u16(message, 30) << 16) + get_u16(message, 28));
+    this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 30)) << 16) |
+                                               get_u16(message, 28));
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));
   if (this->version_sensor_ != nullptr)
@@ -251,7 +253,8 @@ void DeltaSolCSPlusSensor::handle_message(std::vector<uint8_t> &message) {
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
   if (this->heat_quantity_sensor_ != nullptr)
-    this->heat_quantity_sensor_->publish_state((get_u16(message, 30) << 16) + get_u16(message, 28));
+    this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 30)) << 16) |
+                                               get_u16(message, 28));
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));
   if (this->version_sensor_ != nullptr)

--- a/esphome/components/vbus/sensor/vbus_sensor.cpp
+++ b/esphome/components/vbus/sensor/vbus_sensor.cpp
@@ -162,9 +162,10 @@ void DeltaSolCS2Sensor::handle_message(std::vector<uint8_t> &message) {
     this->pump_speed_sensor_->publish_state(message[12]);
   if (this->operating_hours_sensor_ != nullptr)
     this->operating_hours_sensor_->publish_state(get_u16(message, 14));
-  if (this->heat_quantity_sensor_ != nullptr)
+  if (this->heat_quantity_sensor_ != nullptr) {
     this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 26)) << 16) |
                                                get_u16(message, 24));
+  }
   if (this->version_sensor_ != nullptr)
     this->version_sensor_->publish_state(get_u16(message, 28) * 0.01f);
 }
@@ -205,9 +206,10 @@ void DeltaSolCS4Sensor::handle_message(std::vector<uint8_t> &message) {
     this->operating_hours1_sensor_->publish_state(get_u16(message, 10));
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
-  if (this->heat_quantity_sensor_ != nullptr)
+  if (this->heat_quantity_sensor_ != nullptr) {
     this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 30)) << 16) |
                                                get_u16(message, 28));
+  }
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));
   if (this->version_sensor_ != nullptr)
@@ -252,9 +254,10 @@ void DeltaSolCSPlusSensor::handle_message(std::vector<uint8_t> &message) {
     this->operating_hours1_sensor_->publish_state(get_u16(message, 10));
   if (this->operating_hours2_sensor_ != nullptr)
     this->operating_hours2_sensor_->publish_state(get_u16(message, 14));
-  if (this->heat_quantity_sensor_ != nullptr)
+  if (this->heat_quantity_sensor_ != nullptr) {
     this->heat_quantity_sensor_->publish_state((static_cast<uint32_t>(get_u16(message, 30)) << 16) |
                                                get_u16(message, 28));
+  }
   if (this->time_sensor_ != nullptr)
     this->time_sensor_->publish_state(get_u16(message, 22));
   if (this->version_sensor_ != nullptr)

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -67,8 +67,7 @@ void VBus::loop() {
         }
         septet_spread(this->buffer_.data(), 7, 6, this->buffer_[13]);
         uint16_t id = (this->buffer_[8] << 8) + this->buffer_[7];
-        uint32_t value = (static_cast<uint32_t>(this->buffer_[12]) << 24) |
-                         (static_cast<uint32_t>(this->buffer_[11]) << 16) | (this->buffer_[10] << 8) | this->buffer_[9];
+        uint32_t value = encode_uint32(this->buffer_[12], this->buffer_[11], this->buffer_[10], this->buffer_[9]);
         ESP_LOGV(TAG, "P1 C%04x %04x->%04x: %04x %04" PRIx32 " (%" PRIu32 ")", this->command_, this->source_,
                  this->dest_, id, value, value);
       } else if ((this->protocol_ == 0x10) && (this->buffer_.size() == 9)) {

--- a/esphome/components/vbus/vbus.cpp
+++ b/esphome/components/vbus/vbus.cpp
@@ -67,8 +67,8 @@ void VBus::loop() {
         }
         septet_spread(this->buffer_.data(), 7, 6, this->buffer_[13]);
         uint16_t id = (this->buffer_[8] << 8) + this->buffer_[7];
-        uint32_t value =
-            (this->buffer_[12] << 24) + (this->buffer_[11] << 16) + (this->buffer_[10] << 8) + this->buffer_[9];
+        uint32_t value = (static_cast<uint32_t>(this->buffer_[12]) << 24) |
+                         (static_cast<uint32_t>(this->buffer_[11]) << 16) | (this->buffer_[10] << 8) | this->buffer_[9];
         ESP_LOGV(TAG, "P1 C%04x %04x->%04x: %04x %04" PRIx32 " (%" PRIu32 ")", this->command_, this->source_,
                  this->dest_, id, value, value);
       } else if ((this->protocol_ == 0x10) && (this->buffer_.size() == 9)) {


### PR DESCRIPTION
## What does this implement/fix?

Four bugfixes found during a systematic component review:

### 1. [vbus] Fix integer overflow in heat quantity and value calculations

- `get_u16() * 1000000` overflows `int` when the MWh register is >= 3 (realistic for solar thermal systems running for years). Changed to float literals (`1000.0f`, `1000000.0f`) matching how `DeltaSolBS2Sensor` already does it correctly.
- `get_u16() << 16` promotes `uint16_t` to `int`, causing signed overflow UB when bit 15 is set (value >= 32768). Cast to `uint32_t` before shifting. Affects DeltaSolCS2, CS4, and CSPlus sensors.
- Same `<< 24` overflow fix in `vbus.cpp` protocol parser.

### 2. [shelly_dimmer] Fix off-by-one in poll response length check

The check requires `payload_len >= 16` (valid indices 0-15), but `payload[16]` (fade_rate) is accessed on line 419. Changed to require `>= 17`.

### 3. [st7789v] Fix swapped width/height offsets in display data

`offset_height_` was applied to the x (column) axis and `offset_width_` to the y (row) axis. Swapped so the width offset applies to columns and height offset applies to rows.

### 4. [modbus_controller] Fix signed overflow in mask_and_shift_by_rightbit

`1 << pos` uses `int` (signed 32-bit). When `pos` is 31 and `N` is `uint32_t`, this shifts into the sign bit — undefined behavior. Cast the literal to the template type `N` before shifting.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed for any of these fixes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).