### PR TITLE
[vl53l0x][ld2420][ble_client][inkplate] Fix state corruption, crash, OOB read, and shift UB

### DIFF
--- a/esphome/components/ble_client/sensor/ble_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_sensor.cpp
@@ -102,6 +102,10 @@ void BLESensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t ga
       break;
     }
     case ESP_GATTC_NOTIFY_EVT: {
+      if (param->notify.value_len == 0) {
+        ESP_LOGW(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: empty value", this->get_name().c_str());
+        break;
+      }
       ESP_LOGD(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: handle=0x%x, value=0x%x", this->get_name().c_str(),
                param->notify.handle, param->notify.value[0]);
       if (param->notify.handle != this->handle)
@@ -131,8 +135,10 @@ float BLESensor::parse_data_(uint8_t *value, uint16_t value_len) {
   if (this->has_data_to_value_) {
     std::vector<uint8_t> data(value, value + value_len);
     return this->data_to_value_func_(data);
-  } else {
+  } else if (value_len > 0) {
     return value[0];
+  } else {
+    return NAN;
   }
 }
 

--- a/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
+++ b/esphome/components/ble_client/text_sensor/ble_text_sensor.cpp
@@ -104,6 +104,10 @@ void BLETextSensor::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_
     case ESP_GATTC_NOTIFY_EVT: {
       if (param->notify.handle != this->handle)
         break;
+      if (param->notify.value_len == 0) {
+        ESP_LOGW(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: empty value", this->get_name().c_str());
+        break;
+      }
       ESP_LOGV(TAG, "[%s] ESP_GATTC_NOTIFY_EVT: handle=0x%x, value=0x%x", this->get_name().c_str(),
                param->notify.handle, param->notify.value[0]);
       this->publish_state(reinterpret_cast<const char *>(param->notify.value), param->notify.value_len);

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -229,7 +229,7 @@ void Inkplate::eink_off_() {
   this->oe_pin_->digital_write(false);
   this->gmod_pin_->digital_write(false);
 
-  GPIO.out &= ~(this->get_data_pin_mask_() | (1 << this->cl_pin_->get_pin()) | (1 << this->le_pin_->get_pin()));
+  GPIO.out &= ~(this->get_data_pin_mask_() | (1UL << this->cl_pin_->get_pin()) | (1UL << this->le_pin_->get_pin()));
   this->ckv_pin_->digital_write(false);
   this->sph_pin_->digital_write(false);
   this->spv_pin_->digital_write(false);

--- a/esphome/components/inkplate/inkplate.h
+++ b/esphome/components/inkplate/inkplate.h
@@ -152,16 +152,16 @@ class Inkplate : public display::DisplayBuffer, public i2c::I2CDevice {
 
   size_t get_buffer_length_();
 
-  int get_data_pin_mask_() {
-    int data = 0;
-    data |= (1 << this->display_data_0_pin_->get_pin());
-    data |= (1 << this->display_data_1_pin_->get_pin());
-    data |= (1 << this->display_data_2_pin_->get_pin());
-    data |= (1 << this->display_data_3_pin_->get_pin());
-    data |= (1 << this->display_data_4_pin_->get_pin());
-    data |= (1 << this->display_data_5_pin_->get_pin());
-    data |= (1 << this->display_data_6_pin_->get_pin());
-    data |= (1 << this->display_data_7_pin_->get_pin());
+  uint32_t get_data_pin_mask_() {
+    uint32_t data = 0;
+    data |= (1UL << this->display_data_0_pin_->get_pin());
+    data |= (1UL << this->display_data_1_pin_->get_pin());
+    data |= (1UL << this->display_data_2_pin_->get_pin());
+    data |= (1UL << this->display_data_3_pin_->get_pin());
+    data |= (1UL << this->display_data_4_pin_->get_pin());
+    data |= (1UL << this->display_data_5_pin_->get_pin());
+    data |= (1UL << this->display_data_6_pin_->get_pin());
+    data |= (1UL << this->display_data_7_pin_->get_pin());
     return data;
   }
 

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -683,7 +683,7 @@ int LD2420Component::send_cmd_from_array(CmdFrameT frame) {
       retry = 0;
     }
     if (this->cmd_reply_.error > 0) {
-      this->handle_cmd_error(error);
+      this->handle_cmd_error(this->cmd_reply_.error);
     }
   }
   return error;

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -170,14 +170,18 @@ static uint8_t calc_checksum(void *data, size_t size) {
   return checksum;
 }
 
-static int get_firmware_int(const char *version_string) {
-  std::string version_str = version_string;
-  if (version_str[0] == 'v') {
-    version_str.erase(0, 1);
+static int32_t get_firmware_int(const char *version_string) {
+  // Convert "v1.5.4" -> 154 by skipping 'v' and '.', accumulating digits
+  const char *p = (*version_string == 'v') ? version_string + 1 : version_string;
+  int32_t result = 0;
+  for (; *p != '\0'; p++) {
+    if (*p == '.')
+      continue;
+    if (*p < '0' || *p > '9')
+      return 0;
+    result = result * 10 + (*p - '0');
   }
-  version_str.erase(remove(version_str.begin(), version_str.end(), '.'), version_str.end());
-  int version_integer = stoi(version_str);
-  return version_integer;
+  return result;
 }
 
 float LD2420Component::get_setup_priority() const { return setup_priority::BUS; }

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -266,6 +266,7 @@ void VL53L0XSensor::update() {
     this->status_momentary_warning("update", 5000);
     ESP_LOGW(TAG, "%s - update called before prior reading complete - initiated:%d waiting_for_interrupt:%d",
              this->name_.c_str(), this->initiated_read_, this->waiting_for_interrupt_);
+    return;
   }
 
   // initiate single shot measurement


### PR DESCRIPTION
## What does this implement/fix?

Four bugfixes found during a systematic component review:

### 1. [vl53l0x] Return early when prior read still in progress

`update()` detected when a prior read was incomplete, logged a warning and published NAN, but then fell through to start a new measurement anyway. This overwrites the in-progress state and corrupts the sensor reading. Added `return` after the warning.

### 2. [ld2420] Fix wrong error variable and replace stoi with safe parse

Two bugs:
- `handle_cmd_error()` was passed the local `error` variable (always 0) instead of `cmd_reply_.error`. Device errors were silently logged as "None".
- `get_firmware_int()` used `std::stoi()` which throws on non-numeric or empty strings. On embedded builds without exceptions, this aborts the device. Also allocated a `std::string` on the heap unnecessarily. Replaced with a simple loop that walks the `const char *` directly — no heap, no exceptions, returns 0 on invalid input.

### 3. [ble_client] Guard against zero-length BLE notifications

BLE spec allows zero-length notifications as change signals. If received, `value[0]` was accessed in the log statement and in `parse_data_()` without checking `value_len`, causing an OOB read. Added `value_len == 0` checks in both `ble_sensor` and `ble_text_sensor` notify handlers.

### 4. [inkplate] Fix signed shift UB in get_data_pin_mask_

`1 << pin` uses signed `int`. For GPIO pin 31, this shifts into the sign bit — undefined behavior. Changed to `1UL` (unsigned long) and updated return type to `uint32_t` to match callers. Also fixed same issue for `cl_pin_` and `le_pin_` shifts in `eink_off_()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed for any of these fixes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).