### PR TITLE
[component] add Waveshare 3.97in BWYR e-paper display support

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -24,6 +24,9 @@ WaveshareEPaper = waveshare_epaper_ns.class_("WaveshareEPaper", WaveshareEPaperB
 WaveshareEPaperBWR = waveshare_epaper_ns.class_(
     "WaveshareEPaperBWR", WaveshareEPaperBase
 )
+WaveshareEPaperBWYR = waveshare_epaper_ns.class_(
+    "WaveshareEPaperBWYR", WaveshareEPaperBase
+)
 WaveshareEPaper7C = waveshare_epaper_ns.class_("WaveshareEPaper7C", WaveshareEPaperBase)
 WaveshareEPaperTypeA = waveshare_epaper_ns.class_(
     "WaveshareEPaperTypeA", WaveshareEPaper
@@ -60,6 +63,9 @@ WaveshareEPaper2P9InDKE = waveshare_epaper_ns.class_(
 GDEY042T81 = waveshare_epaper_ns.class_("GDEY042T81", WaveshareEPaper)
 WaveshareEPaper2P9InD = waveshare_epaper_ns.class_(
     "WaveshareEPaper2P9InD", WaveshareEPaper
+)
+WaveshareEPaper3P97InBWYR = waveshare_epaper_ns.class_(
+    "WaveshareEPaper3P97InBWYR", WaveshareEPaperBWYR
 )
 WaveshareEPaper4P2In = waveshare_epaper_ns.class_(
     "WaveshareEPaper4P2In", WaveshareEPaper
@@ -151,6 +157,7 @@ MODELS = {
     "2.90in-d": ("b", WaveshareEPaper2P9InD),
     "2.90in-dke": ("c", WaveshareEPaper2P9InDKE),
     "gdey042t81": ("c", GDEY042T81),
+    "3.97in-bwyr": ("b", WaveshareEPaper3P97InBWYR),
     "4.20in": ("b", WaveshareEPaper4P2In),
     "4.20in-bv2": ("b", WaveshareEPaper4P2InBV2),
     "4.20in-bv2-bwr": ("b", WaveshareEPaper4P2InBV2BWR),

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -184,17 +184,17 @@ void WaveshareEPaper::fill(Color color) {
     this->buffer_[i] = fill;
 }
 uint8_t WaveshareEPaperBWYR::color_to_hex(Color color) {
-  if (color.red == 0 && color.green == 0 && color.blue == 0 ) {
-      return 0x0;  // Black
+  if (color.red == 0 && color.green == 0 && color.blue == 0) {
+    return 0x0;  // Black
   }
-  if (color.red > 127 && color.green > 127 && color.blue > 127 ) {
-      return 0x1;  // White
+  if (color.red > 127 && color.green > 127 && color.blue > 127) {
+    return 0x1;  // White
   }
-  if (color.red > 127 && color.green > 127 && color.blue < 128 ) {
-      return 0x2;  // Yellow
+  if (color.red > 127 && color.green > 127 && color.blue < 128) {
+    return 0x2;  // Yellow
   }
-  if (color.red > 127 && color.green < 128 && color.blue < 128 ) {
-      return 0x3;  // Red
+  if (color.red > 127 && color.green < 128 && color.blue < 128) {
+    return 0x3;  // Red
   }
   return 0x1;
 }
@@ -2639,9 +2639,9 @@ void WaveshareEPaper3P97InBWYR::init_display_() {
 
   // VCOM DC Setting
   this->command(0x06);
-  this->data(0x0F);	
-  this->data(0x8B);	
-  this->data(0x93);	
+  this->data(0x0F);
+  this->data(0x8B);
+  this->data(0x93);
   this->data(0xC1);
 
   // COMMAND VCOM AND DATA INTERVAL SETTING
@@ -2649,7 +2649,7 @@ void WaveshareEPaper3P97InBWYR::init_display_() {
   this->data(0x37);
 
   this->command(0x30);
-  this->data(0x08);	
+  this->data(0x08);
 
   // COMMAND RESOLUTION SETTING
   this->command(0x61);
@@ -2660,14 +2660,14 @@ void WaveshareEPaper3P97InBWYR::init_display_() {
 
   // COMMAND TCON SETTING
   this->command(0x62);
-  this->data(0x76); 
   this->data(0x76);
-  this->data(0x76); 
+  this->data(0x76);
+  this->data(0x76);
   this->data(0x5A);
-  this->data(0x9D); 
-  this->data(0x8A);	
-  this->data(0x76); 
-  this->data(0x62); 
+  this->data(0x9D);
+  this->data(0x8A);
+  this->data(0x76);
+  this->data(0x62);
 
   // Resolution setting
   this->command(0x65);
@@ -2676,30 +2676,30 @@ void WaveshareEPaper3P97InBWYR::init_display_() {
   this->data(0x00);
   this->data(0x00);
 
-  this->command(0xE0);	//0xE3
-  this->data(0x10);	
+  this->command(0xE0);  // 0xE3
+  this->data(0x10);
 
-  this->command(0xE7);	//0xE7
-  this->data(0xA4);	
+  this->command(0xE7);  // 0xE7
+  this->data(0xA4);
 
-  this->command(0xE9);	
+  this->command(0xE9);
   this->data(0x01);
 
-  this->command(0xEF);	
+  this->command(0xEF);
   this->data(0x01);
-  this->command(0xF6);	
+  this->command(0xF6);
   this->data(0x20);
 
-  this->command(0xEF);	
+  this->command(0xEF);
   this->data(0x00);
 
-  this->command(0xE0);	
+  this->command(0xE0);
   this->data(0x12);
 
-  this->command(0xE6);	
+  this->command(0xE6);
   this->data(92);
 
-  this->command(0xA5);	
+  this->command(0xA5);
   this->data(0x00);
   this->wait_until_idle_();
 

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -382,8 +382,8 @@ void WaveshareEPaperBWYR::fill(Color color) {
   uint8_t pixel_bits = this->color_to_hex(color) & 0x03;
 
   const uint32_t bytes_per_line = this->get_width_internal() / 4;
-  for (uint32_t y = 0; y < this->get_height_internal(); ++y) {
-    for (uint32_t x = 0; x < this->get_width_internal(); ++x) {
+  for (int y = 0; y < this->get_height_internal(); ++y) {
+    for (int x = 0; x < this->get_width_internal(); ++x) {
       uint32_t pos = y * bytes_per_line + (x / 4);
       uint8_t shift = (3 - (x % 4)) * 2;
       this->buffer_[pos] &= ~(0x03 << shift);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -183,6 +183,21 @@ void WaveshareEPaper::fill(Color color) {
   for (uint32_t i = 0; i < this->get_buffer_length_(); i++)
     this->buffer_[i] = fill;
 }
+uint8_t WaveshareEPaperBWYR::color_to_hex(Color color) {
+  if (color.red == 0 && color.green == 0 && color.blue == 0 ) {
+      return 0x0;  // Black
+  }
+  if (color.red > 127 && color.green > 127 && color.blue > 127 ) {
+      return 0x1;  // White
+  }
+  if (color.red > 127 && color.green > 127 && color.blue < 128 ) {
+      return 0x2;  // Yellow
+  }
+  if (color.red > 127 && color.green < 128 && color.blue < 128 ) {
+      return 0x3;  // Red
+  }
+  return 0x1;
+}
 void WaveshareEPaper7C::setup() {
   this->init_internal_7c_(this->get_buffer_length_());
   this->setup_pins_();
@@ -331,6 +346,9 @@ uint32_t WaveshareEPaper::get_buffer_length_() {
 uint32_t WaveshareEPaperBWR::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 4u;
 }  // black and red buffer
+uint32_t WaveshareEPaperBWYR::get_buffer_length_() {
+  return this->get_width_controller() * this->get_height_internal() / 4u;
+}  // buffer for b w y r 2bit per pixel
 uint32_t WaveshareEPaper7C::get_buffer_length_() {
   return this->get_width_controller() * this->get_height_internal() / 8u * 3u;
 }  // 7 colors buffer, 1 pixel = 3 bits, we will store 8 pixels in 24 bits = 3 bytes
@@ -359,6 +377,31 @@ void HOT WaveshareEPaperBWR::draw_absolute_pixel_internal(int x, int y, Color co
   } else {
     this->buffer_[pos + buf_half_len] &= ~(0x80 >> subpos);
   }
+}
+void WaveshareEPaperBWYR::fill(Color color) {
+  uint8_t pixel_bits = this->color_to_hex(color) & 0x03;
+
+  const uint32_t bytes_per_line = this->get_width_internal() / 4;
+  for (uint32_t y = 0; y < this->get_height_internal(); ++y) {
+    for (uint32_t x = 0; x < this->get_width_internal(); ++x) {
+      uint32_t pos = y * bytes_per_line + (x / 4);
+      uint8_t shift = (3 - (x % 4)) * 2;
+      this->buffer_[pos] &= ~(0x03 << shift);
+      this->buffer_[pos] |= (pixel_bits << shift);
+    }
+  }
+}
+void HOT WaveshareEPaperBWYR::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
+    return;
+
+  uint8_t pixel_bits = this->color_to_hex(color) & 0x03;
+
+  const uint32_t bytes_per_line = this->get_width_internal() / 4;
+  uint32_t pos = y * bytes_per_line + (x / 4);
+  uint8_t shift = (3 - (x % 4)) * 2;
+  this->buffer_[pos] &= ~(0x03 << shift);
+  this->buffer_[pos] |= (pixel_bits << shift);
 }
 void HOT WaveshareEPaper7C::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x >= this->get_width_internal() || y >= this->get_height_internal() || x < 0 || y < 0)
@@ -2567,6 +2610,127 @@ static const uint8_t LUT_WHITE_TO_BLACK_4_2[] = {
     0x01, 0x00, 0x00, 0x01, 0x50, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
+
+// https://files.waveshare.com/wiki/3.97inch_e-Paper_HAT%2B_G/3in97_e-Paper_G.zip
+void WaveshareEPaper3P97InBWYR::initialize() { this->init_display_(); }
+bool WaveshareEPaper3P97InBWYR::wait_until_idle_() {
+  if (this->busy_pin_ == nullptr) {
+    return true;
+  }
+  const uint32_t start = millis();
+  while (this->busy_pin_->digital_read()) {
+    if (millis() - start > this->idle_timeout_()) {
+      ESP_LOGD(TAG, "Timeout while displaying image!");
+      return false;
+    }
+    App.feed_wdt();
+    delay(10);
+  }
+  delay(200);  // NOLINT
+  return true;
+}
+void WaveshareEPaper3P97InBWYR::init_display_() {
+  this->reset_();
+
+  // COMMAND POWER SETTING
+  this->command(0x00);
+  this->data(0x2B);
+  this->data(0x29);
+
+  // VCOM DC Setting
+  this->command(0x06);
+  this->data(0x0F);	
+  this->data(0x8B);	
+  this->data(0x93);	
+  this->data(0xC1);
+
+  // COMMAND VCOM AND DATA INTERVAL SETTING
+  this->command(0x50);
+  this->data(0x37);
+
+  this->command(0x30);
+  this->data(0x08);	
+
+  // COMMAND RESOLUTION SETTING
+  this->command(0x61);
+  this->data(0x03);  // source 800
+  this->data(0x20);
+  this->data(0x02);  // gate init 680
+  this->data(0xA8);
+
+  // COMMAND TCON SETTING
+  this->command(0x62);
+  this->data(0x76); 
+  this->data(0x76);
+  this->data(0x76); 
+  this->data(0x5A);
+  this->data(0x9D); 
+  this->data(0x8A);	
+  this->data(0x76); 
+  this->data(0x62); 
+
+  // Resolution setting
+  this->command(0x65);
+  this->data(0x00);
+  this->data(0x00);  // 800*480
+  this->data(0x00);
+  this->data(0x00);
+
+  this->command(0xE0);	//0xE3
+  this->data(0x10);	
+
+  this->command(0xE7);	//0xE7
+  this->data(0xA4);	
+
+  this->command(0xE9);	
+  this->data(0x01);
+
+  this->command(0xEF);	
+  this->data(0x01);
+  this->command(0xF6);	
+  this->data(0x20);
+
+  this->command(0xEF);	
+  this->data(0x00);
+
+  this->command(0xE0);	
+  this->data(0x12);
+
+  this->command(0xE6);	
+  this->data(92);
+
+  this->command(0xA5);	
+  this->data(0x00);
+  this->wait_until_idle_();
+
+  // POWER ON
+  this->command(0x04);
+  delay(100);  // NOLINT
+  this->wait_until_idle_();
+};
+void HOT WaveshareEPaper3P97InBWYR::display() {
+  this->init_display_();
+
+  this->command(0x10);
+  this->start_data_();
+  this->write_array(this->buffer_, this->get_buffer_length_());
+  this->end_data_();
+
+  this->command(0x12);  // Display Refresh
+  this->data(0x00);
+  this->wait_until_idle_();
+  this->deep_sleep();
+}
+int WaveshareEPaper3P97InBWYR::get_width_internal() { return 800; }
+int WaveshareEPaper3P97InBWYR::get_height_internal() { return 480; }
+void WaveshareEPaper3P97InBWYR::dump_config() {
+  LOG_DISPLAY("", "Waveshare E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 3.97in BWYR-Mode");
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
 
 void WaveshareEPaper4P2In::initialize() {
   // https://www.waveshare.com/w/upload/7/7f/4.2inch-e-paper-b-specification.pdf - page 8

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -535,7 +535,6 @@ class GDEY042T81 : public WaveshareEPaper {
 
 class WaveshareEPaper3P97InBWYR : public WaveshareEPaperBWYR {
  public:
-
   void initialize() override;
 
   void display() override;

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -83,6 +83,18 @@ class WaveshareEPaperBWR : public WaveshareEPaperBase {
   uint32_t get_buffer_length_() override;
 };
 
+class WaveshareEPaperBWYR : public WaveshareEPaperBase {
+ public:
+  uint8_t color_to_hex(Color color);
+  void fill(Color color) override;
+
+  display::DisplayType get_display_type() override { return display::DisplayType::DISPLAY_TYPE_COLOR; }
+
+ protected:
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+  uint32_t get_buffer_length_() override;
+};
+
 class WaveshareEPaper7C : public WaveshareEPaperBase {
  public:
   uint8_t color_to_hex(Color color);
@@ -518,6 +530,45 @@ class GDEY042T81 : public WaveshareEPaper {
   void reset_();
   void update_full_();
   void update_part_();
+  void init_display_();
+};
+
+class WaveshareEPaper3P97InBWYR : public WaveshareEPaperBWYR {
+ public:
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x02);  // Power off
+    this->data(0x00);
+    this->command(0x07);  // Deep sleep
+    this->data(0xA5);
+  }
+
+  void clear_screen();
+
+ protected:
+  bool wait_until_idle_();
+
+  int get_width_internal() override;
+
+  int get_height_internal() override;
+
+  void reset_() {
+    if (this->reset_pin_ != nullptr) {
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+      this->reset_pin_->digital_write(false);
+      delay(5);
+      this->reset_pin_->digital_write(true);
+      delay(200);  // NOLINT
+    }
+  };
+
   void init_display_();
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Add Waveshare 3.97in BWYR e-paper display support

## Types of changes

- [x] New feature
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
spi:
  clk_pin: GPIO13
  mosi_pin: GPIO12
display:
  - platform: waveshare_epaper
    id: epeper
    cs_pin: GPIO27
    dc_pin: GPIO26
    busy_pin: GPIO25
    reset_pin: GPIO33
    model: 3.97in-bwyr
    rotation: 0°
    update_interval: never
    lambda: |-
      const auto WHITE   = Color(255, 255, 255, 0);
      it.fill(WHITE);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
