### PR TITLE
[api] Avoid heap allocation in PSK update timeout lambda

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -46,10 +46,8 @@ void APIServer::setup() {
 
 #ifndef USE_API_NOISE_PSK_FROM_YAML
   // Only load saved PSK if not set from YAML
-  SavedNoisePsk noise_pref_saved{};
-  if (this->noise_pref_.load(&noise_pref_saved)) {
+  if (this->load_and_apply_noise_psk_()) {
     ESP_LOGD(TAG, "Loaded saved Noise PSK");
-    this->set_noise_psk(noise_pref_saved.psk);
   }
 #endif
 #endif
@@ -526,15 +524,28 @@ bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString 
   }
   ESP_LOGD(TAG, "%s", LOG_STR_ARG(save_log_msg));
   if (make_active) {
-    this->set_timeout(100, [this, active_psk]() {
+    this->set_timeout(100, [this]() {
+      // Re-read the PSK from preferences rather than capturing the 32-byte array
+      // in the lambda (which would exceed std::function SBO and heap-allocate).
+      if (!this->load_and_apply_noise_psk_()) {
+        ESP_LOGW(TAG, "Failed to load saved PSK for activation");
+        return;
+      }
       ESP_LOGW(TAG, "Disconnecting all clients to reset PSK");
-      this->set_noise_psk(active_psk);
       for (auto &c : this->clients_) {
         DisconnectRequest req;
         c->send_message(req);
       }
     });
   }
+  return true;
+}
+
+bool APIServer::load_and_apply_noise_psk_() {
+  SavedNoisePsk saved{};
+  if (!this->noise_pref_.load(&saved))
+    return false;
+  this->set_noise_psk(saved.psk);
   return true;
 }
 

--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -512,7 +512,7 @@ void APIServer::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeo
 
 #ifdef USE_API_NOISE
 bool APIServer::update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg,
-                                  const LogString *fail_log_msg, const psk_t &active_psk, bool make_active) {
+                                  const LogString *fail_log_msg, bool make_active) {
   if (!this->noise_pref_.save(&new_psk)) {
     ESP_LOGW(TAG, "%s", LOG_STR_ARG(fail_log_msg));
     return false;
@@ -563,7 +563,7 @@ bool APIServer::save_noise_psk(psk_t psk, bool make_active) {
   }
 
   SavedNoisePsk new_saved_psk{psk};
-  return this->update_noise_psk_(new_saved_psk, LOG_STR("Noise PSK saved"), LOG_STR("Failed to save Noise PSK"), psk,
+  return this->update_noise_psk_(new_saved_psk, LOG_STR("Noise PSK saved"), LOG_STR("Failed to save Noise PSK"),
                                  make_active);
 #endif
 }
@@ -575,8 +575,7 @@ bool APIServer::clear_noise_psk(bool make_active) {
   return false;
 #else
   SavedNoisePsk empty_psk{};
-  psk_t empty{};
-  return this->update_noise_psk_(empty_psk, LOG_STR("Noise PSK cleared"), LOG_STR("Failed to clear Noise PSK"), empty,
+  return this->update_noise_psk_(empty_psk, LOG_STR("Noise PSK cleared"), LOG_STR("Failed to clear Noise PSK"),
                                  make_active);
 #endif
 }

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -239,7 +239,7 @@ class APIServer final : public Component,
 
 #ifdef USE_API_NOISE
   bool update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg, const LogString *fail_log_msg,
-                         const psk_t &active_psk, bool make_active);
+                         bool make_active);
   // Load saved PSK from preferences and apply it. Returns true on success.
   bool load_and_apply_noise_psk_();
 #endif  // USE_API_NOISE

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -240,7 +240,7 @@ class APIServer final : public Component,
 #ifdef USE_API_NOISE
   bool update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg, const LogString *fail_log_msg,
                          const psk_t &active_psk, bool make_active);
-  /// Load saved PSK from preferences and apply it. Returns true on success.
+  // Load saved PSK from preferences and apply it. Returns true on success.
   bool load_and_apply_noise_psk_();
 #endif  // USE_API_NOISE
 #ifdef USE_API_HOMEASSISTANT_STATES

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -240,6 +240,8 @@ class APIServer final : public Component,
 #ifdef USE_API_NOISE
   bool update_noise_psk_(const SavedNoisePsk &new_psk, const LogString *save_log_msg, const LogString *fail_log_msg,
                          const psk_t &active_psk, bool make_active);
+  /// Load saved PSK from preferences and apply it. Returns true on success.
+  bool load_and_apply_noise_psk_();
 #endif  // USE_API_NOISE
 #ifdef USE_API_HOMEASSISTANT_STATES
   // Helper methods to reduce code duplication


### PR DESCRIPTION
# What does this implement/fix?

The `set_timeout` lambda in `update_noise_psk_` captured a `psk_t` (`std::array<uint8_t, 32>`) by value, making the lambda 36 bytes — well beyond the `std::function` small buffer optimization (SBO) threshold on 32-bit platforms, forcing a heap allocation on every PSK update.

This re-reads the PSK from preferences inside the timeout callback instead. The PSK was just saved to flash moments before the timeout was scheduled, so re-reading it is reliable and avoids the large capture. The lambda now captures only `[this]` (4 bytes), fitting comfortably in SBO.

Also extracts `load_and_apply_noise_psk_()` helper to deduplicate the load-from-preferences-and-apply pattern used in both `setup()` and the timeout callback, and removes the now-unused `active_psk` parameter from `update_noise_psk_()`.

### Safety of re-reading from preferences

The `load()` after `save()` is guaranteed to see the new value on all platforms because every preference backend checks its in-memory buffer before querying persistent storage:

- **ESP32 / LibreTiny**: `save()` pushes into the `s_pending_save` vector. `load()` scans `s_pending_save` first, before querying NVS/FlashDB — so even if `sync()` hasn't flushed to flash yet, the saved value is returned.
- **ESP8266 / RP2040**: `save()` writes directly to the `s_flash_storage[]` RAM buffer. `load()` reads from the same buffer — immediate visibility.

If the device were to reboot between save and load (power loss during the 100 ms window before `sync()` runs), the timeout never fires, and `setup()` loads whatever was last synced to flash — so no inconsistency is possible.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).