### PR TITLE
[ota] Pack deferred state args into uint32 to avoid heap allocation

### DIFF
--- a/esphome/components/ota/ota_backend.cpp
+++ b/esphome/components/ota/ota_backend.cpp
@@ -13,6 +13,19 @@ OTAGlobalCallback *get_global_ota_callback() {
   return global_ota_callback;
 }
 
+void OTAComponent::notify_state_deferred_(OTAState state, float progress, uint8_t error) {
+  // Pack state, error, and progress into a single uint32_t so the lambda
+  // captures only [this, packed] (8 bytes) — fits in std::function SBO.
+  // Layout: [state:8][error:8][progress_fixed:16] where progress is 0–10000 (0.01% resolution)
+  static_assert(OTA_ERROR <= 0xFF, "OTAState must fit in 8 bits for packing");
+  uint32_t packed = (static_cast<uint32_t>(state) << 24) | (static_cast<uint32_t>(error) << 16) |
+                    static_cast<uint16_t>(progress * 100.0f);
+  this->defer([this, packed]() {
+    this->notify_state_(static_cast<OTAState>(packed >> 24), static_cast<float>(packed & 0xFFFF) / 100.0f,
+                        static_cast<uint8_t>(packed >> 16));
+  });
+}
+
 void OTAComponent::notify_state_(OTAState state, float progress, uint8_t error) {
   for (auto *listener : this->state_listeners_) {
     listener->on_ota_state(state, progress, error);

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -77,6 +77,7 @@ class OTAComponent : public Component {
     // Pack state, error, and progress into a single uint32_t so the lambda
     // captures only [this, packed] (8 bytes) — intended to fit in std::function SBO on supported toolchains.
     // Layout: [state:8][error:8][progress_fixed:16] where progress is 0–10000 (0.01% resolution)
+    static_assert(OTA_ERROR <= 0xFF, "OTAState must fit in 8 bits for packing");
     uint32_t packed = (static_cast<uint32_t>(state) << 24) | (static_cast<uint32_t>(error) << 16) |
                       static_cast<uint16_t>(progress * 100.0f);
     this->defer([this, packed]() {

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -75,7 +75,7 @@ class OTAComponent : public Component {
    */
   void notify_state_deferred_(OTAState state, float progress, uint8_t error) {
     // Pack state, error, and progress into a single uint32_t so the lambda
-    // captures only [this, packed] (8 bytes) — fits in std::function SBO.
+    // captures only [this, packed] (8 bytes) — intended to fit in std::function SBO on supported toolchains.
     // Layout: [state:8][error:8][progress_fixed:16] where progress is 0–10000 (0.01% resolution)
     uint32_t packed = (static_cast<uint32_t>(state) << 24) | (static_cast<uint32_t>(error) << 16) |
                       static_cast<uint16_t>(progress * 100.0f);

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -73,18 +73,7 @@ class OTAComponent : public Component {
    * This should be used by OTA implementations that run in separate tasks
    * (like web_server OTA) to ensure listeners execute in the main loop.
    */
-  void notify_state_deferred_(OTAState state, float progress, uint8_t error) {
-    // Pack state, error, and progress into a single uint32_t so the lambda
-    // captures only [this, packed] (8 bytes) — intended to fit in std::function SBO on supported toolchains.
-    // Layout: [state:8][error:8][progress_fixed:16] where progress is 0–10000 (0.01% resolution)
-    static_assert(OTA_ERROR <= 0xFF, "OTAState must fit in 8 bits for packing");
-    uint32_t packed = (static_cast<uint32_t>(state) << 24) | (static_cast<uint32_t>(error) << 16) |
-                      static_cast<uint16_t>(progress * 100.0f);
-    this->defer([this, packed]() {
-      this->notify_state_(static_cast<OTAState>(packed >> 24), static_cast<float>(packed & 0xFFFF) / 100.0f,
-                          static_cast<uint8_t>(packed >> 16));
-    });
-  }
+  void notify_state_deferred_(OTAState state, float progress, uint8_t error);
 
   std::vector<OTAStateListener *> state_listeners_;
 #endif

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -74,7 +74,15 @@ class OTAComponent : public Component {
    * (like web_server OTA) to ensure listeners execute in the main loop.
    */
   void notify_state_deferred_(OTAState state, float progress, uint8_t error) {
-    this->defer([this, state, progress, error]() { this->notify_state_(state, progress, error); });
+    // Pack state, error, and progress into a single uint32_t so the lambda
+    // captures only [this, packed] (8 bytes) — fits in std::function SBO.
+    // Layout: [state:8][error:8][progress_fixed:16] where progress is 0–10000 (0.01% resolution)
+    uint32_t packed = (static_cast<uint32_t>(state) << 24) | (static_cast<uint32_t>(error) << 16) |
+                      static_cast<uint16_t>(progress * 100.0f);
+    this->defer([this, packed]() {
+      this->notify_state_(static_cast<OTAState>(packed >> 24), static_cast<float>(packed & 0xFFFF) / 100.0f,
+                          static_cast<uint8_t>(packed >> 16));
+    });
   }
 
   std::vector<OTAStateListener *> state_listeners_;


### PR DESCRIPTION
# What does this implement/fix?

The `notify_state_deferred_` lambda captured `[this, state, progress, error]` (16 bytes on 32-bit), exceeding `std::function` small buffer optimization (SBO) and forcing a heap allocation on every OTA progress update during web_server OTA.

Packs the three values into a single `uint32_t` using bit packing:
- `state` (8 bits) + `error` (8 bits) + `progress` as fixed-point ×100 (16 bits)

The lambda now captures `[this, packed]` (8 bytes), fitting in SBO. Progress resolution of 0.01% is more than adequate for OTA reporting (callers pass integer percentages).

The function is defined out-of-line in the `.cpp` file to avoid duplicating the packing logic at all 8 call sites in `ota_web_server.cpp`.

## Disassembly proof

### Before (dev baseline) — `M_manager` (75 bytes) calls `operator new` and `operator delete`:

```asm
400d48fc: entry   a1, 32
...
400d4920: call8   401368d8 <_Znwj>          ; operator new(16) — heap alloc
...
400d4941: call8   401368a8 <_ZdlPvj>        ; operator delete — heap free
```

### After (PR) — `M_manager` (37 bytes) is trivial copy/destroy, no heap calls:

```asm
40144ec0: entry   a1, 32
40144ec3: bnei    a4, 1, 40144ecc
40144ec6: s32i.n  a3, a2, 0
40144ec8: movi.n  a2, 0
40144eca: retw.n
...
40144eda: l32i.n  a9, a3, 0               ; just copies 8 bytes inline
40144edc: l32i.n  a8, a3, 4
40144ede: s32i.n  a9, a2, 0
40144ee0: s32i.n  a8, a2, 4
```

### Size comparison (ESP32 IDF, web_server OTA with `on_begin` automation):

| | dev | PR | Delta |
|---|---|---|---|
| Flash | 717499 | 717495 | -4 |
| RAM | 34428 | 34428 | 0 |
| `M_manager` | 75 bytes (`new`/`delete`) | 37 bytes (trivial copy) | -38 |
| Heap allocs per OTA progress | 1 | 0 | eliminated |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).