### PR TITLE
2026.3.0b5

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.3.0b4
+PROJECT_NUMBER         = 2026.3.0b5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/apds9960/apds9960.cpp
+++ b/esphome/components/apds9960/apds9960.cpp
@@ -251,11 +251,11 @@ void APDS9960::read_gesture_data_() {
 
   uint8_t buf[128];
   for (uint8_t pos = 0; pos < fifo_level * 4; pos += 32) {
-    // The ESP's i2c driver has a limited buffer size.
-    // This way of retrieving the data should be wrong according to the datasheet
-    // but it seems to work.
+    // Read in 32-byte chunks due to ESP8266 I2C buffer limit.
+    // Always read from 0xFC — the FIFO auto-increments through 0xFC-0xFF
+    // and advances its internal pointer after every 4th byte.
     uint8_t read = std::min(32, fifo_level * 4 - pos);
-    APDS9960_WARNING_CHECK(this->read_bytes(0xFC + pos, buf + pos, read), "Reading FIFO buffer failed.");
+    APDS9960_WARNING_CHECK(this->read_bytes(0xFC, buf + pos, read), "Reading FIFO buffer failed.");
   }
 
   if (millis() - this->gesture_start_ > 500) {

--- a/esphome/components/ee895/ee895.cpp
+++ b/esphome/components/ee895/ee895.cpp
@@ -24,7 +24,7 @@ void EE895Component::setup() {
   this->read(serial_number, 20);
 
   crc16_check = (serial_number[19] << 8) + serial_number[18];
-  if (crc16_check != calc_crc16_(serial_number, 19)) {
+  if (crc16_check != calc_crc16_(serial_number, 18)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->mark_failed();
     return;
@@ -84,7 +84,7 @@ void EE895Component::write_command_(uint16_t addr, uint16_t reg_cnt) {
   address[2] = addr & 0xFF;
   address[3] = (reg_cnt >> 8) & 0xFF;
   address[4] = reg_cnt & 0xFF;
-  crc16 = calc_crc16_(address, 6);
+  crc16 = calc_crc16_(address, 5);
   address[5] = crc16 & 0xFF;
   address[6] = (crc16 >> 8) & 0xFF;
   this->write(address, 7);
@@ -95,7 +95,7 @@ float EE895Component::read_float_() {
   uint8_t i2c_response[8];
   this->read(i2c_response, 8);
   crc16_check = (i2c_response[7] << 8) + i2c_response[6];
-  if (crc16_check != calc_crc16_(i2c_response, 7)) {
+  if (crc16_check != calc_crc16_(i2c_response, 6)) {
     this->error_code_ = CRC_CHECK_FAILED;
     this->status_set_warning();
     return 0;
@@ -107,12 +107,9 @@ float EE895Component::read_float_() {
 }
 
 uint16_t EE895Component::calc_crc16_(const uint8_t buf[], uint8_t len) {
-  uint8_t crc_check_buf[22];
-  for (int i = 0; i < len; i++) {
-    crc_check_buf[i + 1] = buf[i];
-  }
-  crc_check_buf[0] = this->address_;
-  return crc16(crc_check_buf, len);
+  uint8_t addr = this->address_;
+  uint16_t crc = crc16(&addr, 1);
+  return crc16(buf, len, crc);
 }
 }  // namespace ee895
 }  // namespace esphome

--- a/esphome/components/gree/gree.cpp
+++ b/esphome/components/gree/gree.cpp
@@ -87,19 +87,12 @@ void GreeClimate::transmit_state() {
   // Calculate the checksum
   if (this->model_ == GREE_YAN || this->model_ == GREE_YX1FF) {
     remote_state[7] = ((remote_state[0] << 4) + (remote_state[1] << 4) + 0xC0);
-  } else if (this->model_ == GREE_YAG) {
+  } else {
     remote_state[7] =
         ((((remote_state[0] & 0x0F) + (remote_state[1] & 0x0F) + (remote_state[2] & 0x0F) + (remote_state[3] & 0x0F) +
            ((remote_state[4] & 0xF0) >> 4) + ((remote_state[5] & 0xF0) >> 4) + ((remote_state[6] & 0xF0) >> 4) + 0x0A) &
           0x0F)
          << 4);
-  } else {
-    remote_state[7] =
-        ((((remote_state[0] & 0x0F) + (remote_state[1] & 0x0F) + (remote_state[2] & 0x0F) + (remote_state[3] & 0x0F) +
-           ((remote_state[5] & 0xF0) >> 4) + ((remote_state[6] & 0xF0) >> 4) + ((remote_state[7] & 0xF0) >> 4) + 0x0A) &
-          0x0F)
-         << 4) |
-        (remote_state[7] & 0x0F);
   }
 
   auto transmit = this->transmitter_->transmit();

--- a/esphome/components/hdc2010/hdc2010.cpp
+++ b/esphome/components/hdc2010/hdc2010.cpp
@@ -7,50 +7,36 @@ namespace hdc2010 {
 
 static const char *const TAG = "hdc2010";
 
-static const uint8_t HDC2010_ADDRESS = 0x40;  // 0b1000000 or 0b1000001 from datasheet
-static const uint8_t HDC2010_CMD_CONFIGURATION_MEASUREMENT = 0x8F;
-static const uint8_t HDC2010_CMD_START_MEASUREMENT = 0xF9;
-static const uint8_t HDC2010_CMD_TEMPERATURE_LOW = 0x00;
-static const uint8_t HDC2010_CMD_TEMPERATURE_HIGH = 0x01;
-static const uint8_t HDC2010_CMD_HUMIDITY_LOW = 0x02;
-static const uint8_t HDC2010_CMD_HUMIDITY_HIGH = 0x03;
-static const uint8_t CONFIG = 0x0E;
-static const uint8_t MEASUREMENT_CONFIG = 0x0F;
+// Register addresses
+static constexpr uint8_t REG_TEMPERATURE_LOW = 0x00;
+static constexpr uint8_t REG_TEMPERATURE_HIGH = 0x01;
+static constexpr uint8_t REG_HUMIDITY_LOW = 0x02;
+static constexpr uint8_t REG_HUMIDITY_HIGH = 0x03;
+static constexpr uint8_t REG_RESET_DRDY_INT_CONF = 0x0E;
+static constexpr uint8_t REG_MEASUREMENT_CONF = 0x0F;
+
+// REG_MEASUREMENT_CONF (0x0F) bit masks
+static constexpr uint8_t MEAS_TRIG = 0x01;       // Bit 0: measurement trigger
+static constexpr uint8_t MEAS_CONF_MASK = 0x06;  // Bits 2:1: measurement mode
+static constexpr uint8_t HRES_MASK = 0x30;       // Bits 5:4: humidity resolution
+static constexpr uint8_t TRES_MASK = 0xC0;       // Bits 7:6: temperature resolution
+
+// REG_RESET_DRDY_INT_CONF (0x0E) bit masks
+static constexpr uint8_t AMM_MASK = 0x70;  // Bits 6:4: auto measurement mode
 
 void HDC2010Component::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
 
-  const uint8_t data[2] = {
-      0b00000000,  // resolution 14bit for both humidity and temperature
-      0b00000000   // reserved
-  };
-
-  if (!this->write_bytes(HDC2010_CMD_CONFIGURATION_MEASUREMENT, data, 2)) {
-    ESP_LOGW(TAG, "Initial config instruction error");
-    this->status_set_warning();
-    return;
-  }
-
-  // Set measurement mode to temperature and humidity
+  // Set 14-bit resolution for both sensors and measurement mode to temp + humidity
   uint8_t config_contents;
-  this->read_register(MEASUREMENT_CONFIG, &config_contents, 1);
-  config_contents = (config_contents & 0xF9);  // Always set to TEMP_AND_HUMID mode
-  this->write_bytes(MEASUREMENT_CONFIG, &config_contents, 1);
+  this->read_register(REG_MEASUREMENT_CONF, &config_contents, 1);
+  config_contents &= ~(TRES_MASK | HRES_MASK | MEAS_CONF_MASK);  // 14-bit temp, 14-bit humidity, temp+humidity mode
+  this->write_bytes(REG_MEASUREMENT_CONF, &config_contents, 1);
 
-  // Set rate to manual
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0x8F;
-  this->write_bytes(CONFIG, &config_contents, 1);
-
-  // Set temperature resolution to 14bit
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0x3F;
-  this->write_bytes(CONFIG, &config_contents, 1);
-
-  // Set humidity resolution to 14bit
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents &= 0xCF;
-  this->write_bytes(CONFIG, &config_contents, 1);
+  // Set auto measurement rate to manual (on-demand via MEAS_TRIG)
+  this->read_register(REG_RESET_DRDY_INT_CONF, &config_contents, 1);
+  config_contents &= ~AMM_MASK;
+  this->write_bytes(REG_RESET_DRDY_INT_CONF, &config_contents, 1);
 }
 
 void HDC2010Component::dump_config() {
@@ -67,9 +53,9 @@ void HDC2010Component::dump_config() {
 void HDC2010Component::update() {
   // Trigger measurement
   uint8_t config_contents;
-  this->read_register(CONFIG, &config_contents, 1);
-  config_contents |= 0x01;
-  this->write_bytes(MEASUREMENT_CONFIG, &config_contents, 1);
+  this->read_register(REG_MEASUREMENT_CONF, &config_contents, 1);
+  config_contents |= MEAS_TRIG;
+  this->write_bytes(REG_MEASUREMENT_CONF, &config_contents, 1);
 
   // 1ms delay after triggering the sample
   set_timeout(1, [this]() {
@@ -90,8 +76,8 @@ void HDC2010Component::update() {
 float HDC2010Component::read_temp() {
   uint8_t byte[2];
 
-  this->read_register(HDC2010_CMD_TEMPERATURE_LOW, &byte[0], 1);
-  this->read_register(HDC2010_CMD_TEMPERATURE_HIGH, &byte[1], 1);
+  this->read_register(REG_TEMPERATURE_LOW, &byte[0], 1);
+  this->read_register(REG_TEMPERATURE_HIGH, &byte[1], 1);
 
   uint16_t temp = encode_uint16(byte[1], byte[0]);
   return (float) temp * 0.0025177f - 40.0f;
@@ -100,8 +86,8 @@ float HDC2010Component::read_temp() {
 float HDC2010Component::read_humidity() {
   uint8_t byte[2];
 
-  this->read_register(HDC2010_CMD_HUMIDITY_LOW, &byte[0], 1);
-  this->read_register(HDC2010_CMD_HUMIDITY_HIGH, &byte[1], 1);
+  this->read_register(REG_HUMIDITY_LOW, &byte[0], 1);
+  this->read_register(REG_HUMIDITY_HIGH, &byte[1], 1);
 
   uint16_t humidity = encode_uint16(byte[1], byte[0]);
   return (float) humidity * 0.001525879f;

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -23,6 +23,12 @@ namespace http_request {
 
 static const char *const TAG = "http_request.update";
 
+// Wraps UpdateInfo + error for the task→main-loop handoff.
+struct TaskResult {
+  update::UpdateInfo info;
+  const LogString *error_str{nullptr};
+};
+
 static const size_t MAX_READ_SIZE = 256;
 static constexpr uint32_t INITIAL_CHECK_INTERVAL_ID = 0;
 static constexpr uint32_t INITIAL_CHECK_INTERVAL_MS = 10000;
@@ -77,134 +83,148 @@ void HttpRequestUpdate::update() {
 void HttpRequestUpdate::update_task(void *params) {
   HttpRequestUpdate *this_update = (HttpRequestUpdate *) params;
 
+  // Allocate once — every path below returns via the single defer at the end.
+  // On failure, error_str is set; on success it is nullptr.
+  auto *result = new TaskResult();
+  auto *info = &result->info;
+
   auto container = this_update->request_parent_->get(this_update->source_url_);
 
   if (container == nullptr || container->status_code != HTTP_STATUS_OK) {
     ESP_LOGE(TAG, "Failed to fetch manifest from %s", this_update->source_url_.c_str());
-    // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to fetch manifest")); });
-    UPDATE_RETURN;
+    if (container != nullptr)
+      container->end();
+    result->error_str = LOG_STR("Failed to fetch manifest");
+    goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
   }
 
-  RAMAllocator<uint8_t> allocator;
-  uint8_t *data = allocator.allocate(container->content_length);
-  if (data == nullptr) {
-    ESP_LOGE(TAG, "Failed to allocate %zu bytes for manifest", container->content_length);
-    // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer(
-        [this_update]() { this_update->status_set_error(LOG_STR("Failed to allocate memory for manifest")); });
-    container->end();
-    UPDATE_RETURN;
-  }
-
-  auto read_result = http_read_fully(container.get(), data, container->content_length, MAX_READ_SIZE,
-                                     this_update->request_parent_->get_timeout());
-  if (read_result.status != HttpReadStatus::OK) {
-    if (read_result.status == HttpReadStatus::TIMEOUT) {
-      ESP_LOGE(TAG, "Timeout reading manifest");
-    } else {
-      ESP_LOGE(TAG, "Error reading manifest: %d", read_result.error_code);
+  {
+    RAMAllocator<uint8_t> allocator;
+    uint8_t *data = allocator.allocate(container->content_length);
+    if (data == nullptr) {
+      ESP_LOGE(TAG, "Failed to allocate %zu bytes for manifest", container->content_length);
+      container->end();
+      result->error_str = LOG_STR("Failed to allocate memory for manifest");
+      goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
-    // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to read manifest")); });
-    allocator.deallocate(data, container->content_length);
-    container->end();
-    UPDATE_RETURN;
-  }
-  size_t read_index = container->get_bytes_read();
-  size_t content_length = container->content_length;
 
-  container->end();
-  container.reset();  // Release ownership of the container's shared_ptr
-
-  bool valid = false;
-  {  // Scope to ensure JsonDocument is destroyed before deallocating buffer
-    valid = json::parse_json(data, read_index, [this_update](JsonObject root) -> bool {
-      if (!root[ESPHOME_F("name")].is<const char *>() || !root[ESPHOME_F("version")].is<const char *>() ||
-          !root[ESPHOME_F("builds")].is<JsonArray>()) {
-        ESP_LOGE(TAG, "Manifest does not contain required fields");
-        return false;
+    auto read_result = http_read_fully(container.get(), data, container->content_length, MAX_READ_SIZE,
+                                       this_update->request_parent_->get_timeout());
+    if (read_result.status != HttpReadStatus::OK) {
+      if (read_result.status == HttpReadStatus::TIMEOUT) {
+        ESP_LOGE(TAG, "Timeout reading manifest");
+      } else {
+        ESP_LOGE(TAG, "Error reading manifest: %d", read_result.error_code);
       }
-      this_update->update_info_.title = root[ESPHOME_F("name")].as<std::string>();
-      this_update->update_info_.latest_version = root[ESPHOME_F("version")].as<std::string>();
+      allocator.deallocate(data, container->content_length);
+      container->end();
+      result->error_str = LOG_STR("Failed to read manifest");
+      goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+    size_t read_index = container->get_bytes_read();
+    size_t content_length = container->content_length;
 
-      auto builds_array = root[ESPHOME_F("builds")].as<JsonArray>();
-      for (auto build : builds_array) {
-        if (!build[ESPHOME_F("chipFamily")].is<const char *>()) {
+    container->end();
+    container.reset();  // Release ownership of the container's shared_ptr
+
+    bool valid = false;
+    {  // Scope to ensure JsonDocument is destroyed before deallocating buffer
+      valid = json::parse_json(data, read_index, [info](JsonObject root) -> bool {
+        if (!root[ESPHOME_F("name")].is<const char *>() || !root[ESPHOME_F("version")].is<const char *>() ||
+            !root[ESPHOME_F("builds")].is<JsonArray>()) {
           ESP_LOGE(TAG, "Manifest does not contain required fields");
           return false;
         }
-        if (build[ESPHOME_F("chipFamily")] == ESPHOME_VARIANT) {
-          if (!build[ESPHOME_F("ota")].is<JsonObject>()) {
+        info->title = root[ESPHOME_F("name")].as<std::string>();
+        info->latest_version = root[ESPHOME_F("version")].as<std::string>();
+
+        auto builds_array = root[ESPHOME_F("builds")].as<JsonArray>();
+        for (auto build : builds_array) {
+          if (!build[ESPHOME_F("chipFamily")].is<const char *>()) {
             ESP_LOGE(TAG, "Manifest does not contain required fields");
             return false;
           }
-          JsonObject ota = build[ESPHOME_F("ota")].as<JsonObject>();
-          if (!ota[ESPHOME_F("path")].is<const char *>() || !ota[ESPHOME_F("md5")].is<const char *>()) {
-            ESP_LOGE(TAG, "Manifest does not contain required fields");
-            return false;
+          if (build[ESPHOME_F("chipFamily")] == ESPHOME_VARIANT) {
+            if (!build[ESPHOME_F("ota")].is<JsonObject>()) {
+              ESP_LOGE(TAG, "Manifest does not contain required fields");
+              return false;
+            }
+            JsonObject ota = build[ESPHOME_F("ota")].as<JsonObject>();
+            if (!ota[ESPHOME_F("path")].is<const char *>() || !ota[ESPHOME_F("md5")].is<const char *>()) {
+              ESP_LOGE(TAG, "Manifest does not contain required fields");
+              return false;
+            }
+            info->firmware_url = ota[ESPHOME_F("path")].as<std::string>();
+            info->md5 = ota[ESPHOME_F("md5")].as<std::string>();
+
+            if (ota[ESPHOME_F("summary")].is<const char *>())
+              info->summary = ota[ESPHOME_F("summary")].as<std::string>();
+            if (ota[ESPHOME_F("release_url")].is<const char *>())
+              info->release_url = ota[ESPHOME_F("release_url")].as<std::string>();
+
+            return true;
           }
-          this_update->update_info_.firmware_url = ota[ESPHOME_F("path")].as<std::string>();
-          this_update->update_info_.md5 = ota[ESPHOME_F("md5")].as<std::string>();
-
-          if (ota[ESPHOME_F("summary")].is<const char *>())
-            this_update->update_info_.summary = ota[ESPHOME_F("summary")].as<std::string>();
-          if (ota[ESPHOME_F("release_url")].is<const char *>())
-            this_update->update_info_.release_url = ota[ESPHOME_F("release_url")].as<std::string>();
-
-          return true;
         }
-      }
-      return false;
-    });
-  }
-  allocator.deallocate(data, content_length);
-
-  if (!valid) {
-    ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
-    // Defer to main loop to avoid race condition on component_state_ read-modify-write
-    this_update->defer([this_update]() { this_update->status_set_error(LOG_STR("Failed to parse manifest JSON")); });
-    UPDATE_RETURN;
-  }
-
-  // Merge source_url_ and this_update->update_info_.firmware_url
-  if (this_update->update_info_.firmware_url.find("http") == std::string::npos) {
-    std::string path = this_update->update_info_.firmware_url;
-    if (path[0] == '/') {
-      std::string domain = this_update->source_url_.substr(0, this_update->source_url_.find('/', 8));
-      this_update->update_info_.firmware_url = domain + path;
-    } else {
-      std::string domain = this_update->source_url_.substr(0, this_update->source_url_.rfind('/') + 1);
-      this_update->update_info_.firmware_url = domain + path;
+        return false;
+      });
     }
-  }
+    allocator.deallocate(data, content_length);
+
+    if (!valid) {
+      ESP_LOGE(TAG, "Failed to parse JSON from %s", this_update->source_url_.c_str());
+      result->error_str = LOG_STR("Failed to parse manifest JSON");
+      goto defer;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
+
+    // Merge source_url_ and firmware_url
+    if (!info->firmware_url.empty() && info->firmware_url.find("http") == std::string::npos) {
+      std::string path = info->firmware_url;
+      if (path[0] == '/') {
+        std::string domain = this_update->source_url_.substr(0, this_update->source_url_.find('/', 8));
+        info->firmware_url = domain + path;
+      } else {
+        std::string domain = this_update->source_url_.substr(0, this_update->source_url_.rfind('/') + 1);
+        info->firmware_url = domain + path;
+      }
+    }
 
 #ifdef ESPHOME_PROJECT_VERSION
-  this_update->update_info_.current_version = ESPHOME_PROJECT_VERSION;
+    info->current_version = ESPHOME_PROJECT_VERSION;
 #else
-  this_update->update_info_.current_version = ESPHOME_VERSION;
+    info->current_version = ESPHOME_VERSION;
 #endif
-
-  bool trigger_update_available = false;
-
-  if (this_update->update_info_.latest_version.empty() ||
-      this_update->update_info_.latest_version == this_update->update_info_.current_version) {
-    this_update->state_ = update::UPDATE_STATE_NO_UPDATE;
-  } else {
-    if (this_update->state_ != update::UPDATE_STATE_AVAILABLE) {
-      trigger_update_available = true;
-    }
-    this_update->state_ = update::UPDATE_STATE_AVAILABLE;
   }
 
-  // Defer to main loop to ensure thread-safe execution of:
-  // - status_clear_error() performs non-atomic read-modify-write on component_state_
-  // - publish_state() triggers API callbacks that write to the shared protobuf buffer
-  //   which can be corrupted if accessed concurrently from task and main loop threads
-  // - update_available trigger to ensure consistent state when the trigger fires
-  this_update->defer([this_update, trigger_update_available]() {
-    this_update->update_info_.has_progress = false;
-    this_update->update_info_.progress = 0.0f;
+defer:
+  // Release container before vTaskDelete (which doesn't call destructors)
+  container.reset();
+
+  // Defer to the main loop so all update_info_ and state_ writes happen on the
+  // same thread as readers (API, MQTT, web server). This is a single defer for
+  // both success and error paths to avoid multiple std::function instantiations.
+  // Lambda captures only 2 pointers (8 bytes) — fits in std::function SBO on supported toolchains.
+  this_update->defer([this_update, result]() {
+    if (result->error_str != nullptr) {
+      this_update->status_set_error(result->error_str);
+      delete result;
+      return;
+    }
+
+    // Determine new state on main loop (avoids extra lambda captures from task)
+    bool trigger_update_available = false;
+    update::UpdateState new_state;
+    if (result->info.latest_version.empty() || result->info.latest_version == result->info.current_version) {
+      new_state = update::UPDATE_STATE_NO_UPDATE;
+    } else {
+      new_state = update::UPDATE_STATE_AVAILABLE;
+      if (this_update->state_ != update::UPDATE_STATE_AVAILABLE) {
+        trigger_update_available = true;
+      }
+    }
+
+    this_update->update_info_ = std::move(result->info);
+    this_update->state_ = new_state;
+    delete result;  // Safe: moved-from state is valid for destruction
 
     this_update->status_clear_error();
     this_update->publish_state();

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -80,6 +80,7 @@ bool StreamingModel::load_model_() {
     TfLiteTensor *output = this->interpreter_->output(0);
     if ((output->dims->size != 2) || (output->dims->data[0] != 1) || (output->dims->data[1] != 1)) {
       ESP_LOGE(TAG, "Streaming model tensor output dimension is not 1x1.");
+      return false;
     }
 
     if (output->type != kTfLiteUInt8) {

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -297,19 +297,17 @@ void MR24HPC1Component::r24_split_data_frame_(uint8_t value) {
       this->sg_recv_data_state_ = FRAME_DATA_LEN_H;
       break;
     case FRAME_DATA_LEN_H:
-      if (value <= 4) {
-        this->sg_data_len_ = value * 256;
+      if (value == 0) {
         this->sg_frame_buf_[4] = value;
         this->sg_recv_data_state_ = FRAME_DATA_LEN_L;
       } else {
-        this->sg_data_len_ = 0;
         this->sg_recv_data_state_ = FRAME_IDLE;
         ESP_LOGD(TAG, "FRAME_DATA_LEN_H ERROR value:%x", value);
       }
       break;
     case FRAME_DATA_LEN_L:
-      this->sg_data_len_ += value;
-      if (this->sg_data_len_ > 32) {
+      this->sg_data_len_ = value;
+      if (this->sg_data_len_ == 0 || this->sg_data_len_ > 32) {
         ESP_LOGD(TAG, "len=%d, FRAME_DATA_LEN_L ERROR value:%x", this->sg_data_len_, value);
         this->sg_data_len_ = 0;
         this->sg_recv_data_state_ = FRAME_IDLE;
@@ -320,9 +318,8 @@ void MR24HPC1Component::r24_split_data_frame_(uint8_t value) {
       }
       break;
     case FRAME_DATA_BYTES:
-      this->sg_data_len_ -= 1;
       this->sg_frame_buf_[this->sg_frame_len_++] = value;
-      if (this->sg_data_len_ <= 0) {
+      if (--this->sg_data_len_ == 0) {
         this->sg_recv_data_state_ = FRAME_DATA_CRC;
       }
       break;

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -403,10 +403,12 @@ async def filter_out_filter_to_code(config, filter_id):
 QUANTILE_SCHEMA = cv.All(
     cv.Schema(
         {
-            cv.Optional(CONF_WINDOW_SIZE, default=5): cv.positive_not_null_int,
-            cv.Optional(CONF_SEND_EVERY, default=5): cv.positive_not_null_int,
-            cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.positive_not_null_int,
-            cv.Optional(CONF_QUANTILE, default=0.9): cv.zero_to_one_float,
+            cv.Optional(CONF_WINDOW_SIZE, default=5): cv.int_range(min=1, max=65535),
+            cv.Optional(CONF_SEND_EVERY, default=5): cv.int_range(min=1, max=65535),
+            cv.Optional(CONF_SEND_FIRST_AT, default=1): cv.int_range(min=1, max=65535),
+            cv.Optional(CONF_QUANTILE, default=0.9): cv.float_range(
+                min=0, min_included=False, max=1
+            ),
         }
     ),
     validate_send_first_at,

--- a/esphome/components/tc74/tc74.cpp
+++ b/esphome/components/tc74/tc74.cpp
@@ -50,8 +50,9 @@ void TC74Component::read_temperature_() {
     }
   }
 
-  uint8_t temperature_reg;
-  if (this->read_register(TC74_REGISTER_TEMPERATURE, &temperature_reg, 1) != i2c::ERROR_OK) {
+  int8_t temperature_reg;
+  if (this->read_register(TC74_REGISTER_TEMPERATURE, reinterpret_cast<uint8_t *>(&temperature_reg), 1) !=
+      i2c::ERROR_OK) {
     this->status_set_warning();
     return;
   }

--- a/esphome/components/voice_assistant/voice_assistant.cpp
+++ b/esphome/components/voice_assistant/voice_assistant.cpp
@@ -619,6 +619,8 @@ void VoiceAssistant::start_playback_timeout_() {
     this->cancel_timeout("speaker-timeout");
     this->set_state_(State::RESPONSE_FINISHED, State::RESPONSE_FINISHED);
 
+    if (this->api_client_ == nullptr)
+      return;
     api::VoiceAssistantAnnounceFinished msg;
     msg.success = true;
     this->api_client_->send_message(msg);

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.3.0b4"
+__version__ = "2026.3.0b5"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [seeed_mr24hpc1] Fix frame parser length handling bugs [esphome#14863](https://github.com/esphome/esphome/pull/14863)
- [gree] Fix IR checksum for YAA/YAC/YAC1FB9/GENERIC models [esphome#14888](https://github.com/esphome/esphome/pull/14888)
- [sensor][ee895][hdc2010] Fix misc bugs found during component scan [esphome#14890](https://github.com/esphome/esphome/pull/14890)
- [voice_assistant][micro_wake_word] Fix null deref and missing error return [esphome#14906](https://github.com/esphome/esphome/pull/14906)
- [tc74][apds9960] Fix signed temperature and FIFO register address [esphome#14907](https://github.com/esphome/esphome/pull/14907)
- [http_request] Fix data race on update_info_ strings in update task [esphome#14909](https://github.com/esphome/esphome/pull/14909)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
