### PR TITLE
[media_source] Add request helpers for smart sources

### DIFF
--- a/esphome/components/media_source/media_source.h
+++ b/esphome/components/media_source/media_source.h
@@ -153,6 +153,31 @@ class MediaSource {
     }
   }
 
+  // === Listener request helpers for smart sources ===
+  // Smart sources (those with internal playlists or external control) use these to request
+  // the orchestrator to take actions. Simple sources never call these.
+
+  /// @brief Request the orchestrator to play a new URI
+  void request_play_uri_(const std::string &uri) {
+    if (this->listener_ != nullptr) {
+      this->listener_->request_play_uri(uri);
+    }
+  }
+
+  /// @brief Request the orchestrator to change volume
+  void request_volume_(float volume) {
+    if (this->listener_ != nullptr) {
+      this->listener_->request_volume(volume);
+    }
+  }
+
+  /// @brief Request the orchestrator to change mute state
+  void request_mute_(bool is_muted) {
+    if (this->listener_ != nullptr) {
+      this->listener_->request_mute(is_muted);
+    }
+  }
+
  private:
   // Private to enforce the invariant that listener notifications always fire on state changes.
   // All state transitions must go through set_state_() which couples the update with notification.


### PR DESCRIPTION
# What does this implement/fix?

Adds protected helper methods to the `media_source` platform component for smart sources to request actions from the orchestrator. These mirror the existing `set_state_()` pattern by wrapping null-checked calls to the listener.

Three helpers added:
- `request_play_uri_()` - request the orchestrator to play a new URI
- `request_volume_()` - request a volume change
- `request_mute_()` - request a mute state change 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable; no user facing changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
