### PR TITLE
[ld2412] Inline trivial gate threshold number setters

### DIFF
--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -825,13 +825,6 @@ void LD2412Component::get_gate_threshold() {
   this->send_command_(CMD_QUERY_STATIC_GATE_SENS, nullptr, 0);
 }
 
-void LD2412Component::set_gate_still_threshold_number(uint8_t gate, number::Number *n) {
-  this->gate_still_threshold_numbers_[gate] = n;
-}
-
-void LD2412Component::set_gate_move_threshold_number(uint8_t gate, number::Number *n) {
-  this->gate_move_threshold_numbers_[gate] = n;
-}
 #endif
 
 void LD2412Component::set_light_out_control() {

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -85,8 +85,10 @@ class LD2412Component : public Component, public uart::UARTDevice {
   void set_light_out_control();
   void set_basic_config();
 #ifdef USE_NUMBER
-  void set_gate_move_threshold_number(uint8_t gate, number::Number *n);
-  void set_gate_still_threshold_number(uint8_t gate, number::Number *n);
+  void set_gate_move_threshold_number(uint8_t gate, number::Number *n) { this->gate_move_threshold_numbers_[gate] = n; }
+  void set_gate_still_threshold_number(uint8_t gate, number::Number *n) {
+    this->gate_still_threshold_numbers_[gate] = n;
+  }
   void set_gate_threshold();
   void get_gate_threshold();
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Move `set_gate_move_threshold_number` and `set_gate_still_threshold_number` definitions into the header. These are single-line array assignments called 14 times each (once per gate), and inlining them eliminates function call overhead, saving ~52 bytes of flash.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).