### PR TITLE
[core] Devirtualize PollingComponent::set_update_interval

### DIFF
--- a/esphome/components/sds011/sds011.h
+++ b/esphome/components/sds011/sds011.h
@@ -21,8 +21,6 @@ class SDS011Component : public Component, public uart::UARTDevice {
   void dump_config() override;
   void loop() override;
 
-  void set_update_interval(uint32_t val) { /* ignore */
-  }
   void set_update_interval_min(uint8_t update_interval_min);
   void set_working_state(bool working_state);
 

--- a/esphome/components/sds011/sensor.py
+++ b/esphome/components/sds011/sensor.py
@@ -64,12 +64,15 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    # Pop update_interval before register_component so it doesn't generate
+    # a set_update_interval call — sds011 handles this via set_update_interval_min
+    update_interval = config.pop(CONF_UPDATE_INTERVAL, None)
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
 
-    if CONF_UPDATE_INTERVAL in config:
-        cg.add(var.set_update_interval_min(config[CONF_UPDATE_INTERVAL]))
+    if update_interval is not None:
+        cg.add(var.set_update_interval_min(update_interval))
     cg.add(var.set_rx_mode_only(config[CONF_RX_ONLY]))
 
     if CONF_PM_2_5 in config:

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -508,7 +508,6 @@ void PollingComponent::stop_poller() {
 }
 
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }
-void PollingComponent::set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
 
 void __attribute__((noinline, cold))
 WarnIfComponentBlockingGuard::warn_blocking(Component *component, uint32_t blocking_time) {

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -549,11 +549,9 @@ class PollingComponent : public Component {
 
   /** Manually set the update interval in ms for this polling object.
    *
-   * Override this if you want to do some validation for the update interval.
-   *
    * @param update_interval The update interval in ms.
    */
-  virtual void set_update_interval(uint32_t update_interval);
+  void set_update_interval(uint32_t update_interval) { this->update_interval_ = update_interval; }
 
   // ========== OVERRIDE METHODS ==========
   // (You'll only need this when creating your own custom sensor)


### PR DESCRIPTION
# What does this implement/fix?

Remove the `virtual` keyword from `PollingComponent::set_update_interval` and inline the trivial setter in the header. Saves ~88 bytes of flash.

No component in the tree actually overrides this method on `PollingComponent`. The only apparent override was in `sds011`, which extends `Component` (not `PollingComponent`), so it was just a name-hiding no-op — that is also removed here. The sds011 codegen is updated to pop `update_interval` from config before `register_component`, since it handles this via its own `set_update_interval_min` method.

This allows the compiler to inline the setter at all call sites generated by `register_component`, eliminating function call overhead and removing a vtable entry.

**Note:** This is technically a developer breaking change for any external component that overrides `set_update_interval` on a `PollingComponent` subclass. However, no known component does this — the override mechanism was dead code in practice.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).