### PR TITLE
[ble_client] Fix RSSI sensor reporting same value for all clients

### DIFF
--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
@@ -47,6 +47,8 @@ void BLEClientRSSISensor::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
   switch (event) {
     // server response on RSSI request:
     case ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT:
+      if (!this->parent()->check_addr(param->read_rssi_cmpl.remote_addr))
+        return;
       if (param->read_rssi_cmpl.status == ESP_BT_STATUS_SUCCESS) {
         int8_t rssi = param->read_rssi_cmpl.rssi;
         ESP_LOGI(TAG, "ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT RSSI: %d", rssi);


### PR DESCRIPTION
# What does this implement/fix?

When multiple `ble_client` RSSI sensors are configured for different devices, they all report the same RSSI value. This happens because the `gap_event_handler` in `BLEClientRSSISensor` does not check the remote device address on the `ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT` event, so every RSSI sensor publishes the value from whichever event arrives, regardless of which device it belongs to.

The fix adds an address check using the parent client's `check_addr()` method (the same pattern used for other GAP events like security events in `BLEClientBase`) so each sensor only processes RSSI events matching its own device.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14898

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ble_client:
  - mac_address: "B0:D2:78:34:F4:8E"
    id: client1
  - mac_address: "38:3B:26:B4:4A:7B"
    id: client2

sensor:
  - platform: ble_client
    type: rssi
    ble_client_id: client1
    name: 'Device 1 RSSI'
  - platform: ble_client
    type: rssi
    ble_client_id: client2
    name: 'Device 2 RSSI'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).