### PR TITLE
[openthread] Guard InstanceLock against uninitialized semaphore

### DIFF
--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -58,8 +58,11 @@ void OpenThreadComponent::on_state_changed_(otChangedFlags flags, void *context)
 
 // Gets the off-mesh routable address
 std::optional<otIp6Address> OpenThreadComponent::get_omr_address() {
-  InstanceLock lock = InstanceLock::acquire();
-  return this->get_omr_address_(lock);
+  auto lock = InstanceLock::acquire();
+  if (!lock) {
+    return std::nullopt;
+  }
+  return this->get_omr_address_(*lock);
 }
 
 std::optional<otIp6Address> OpenThreadComponent::get_omr_address_(InstanceLock &lock) {
@@ -123,8 +126,12 @@ void OpenThreadSrpComponent::srp_factory_reset_callback(otError err, const otSrp
 
 void OpenThreadSrpComponent::setup() {
   otError error;
-  InstanceLock lock = InstanceLock::acquire();
-  otInstance *instance = lock.get_instance();
+  auto lock = InstanceLock::acquire();
+  if (!lock) {
+    this->mark_failed();
+    return;
+  }
+  otInstance *instance = lock->get_instance();
 
   otSrpClientSetCallback(instance, OpenThreadSrpComponent::srp_callback, nullptr);
 
@@ -246,8 +253,12 @@ void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
   factory_reset_external_callback_ = callback;
   ESP_LOGD(TAG, "Start Removal SRP Host and Services");
   otError error;
-  InstanceLock lock = InstanceLock::acquire();
-  otInstance *instance = lock.get_instance();
+  auto lock = InstanceLock::acquire();
+  if (!lock) {
+    ESP_LOGW(TAG, "Failed to acquire lock for factory reset");
+    return;
+  }
+  otInstance *instance = lock->get_instance();
   otSrpClientSetCallback(instance, OpenThreadSrpComponent::srp_factory_reset_callback, this);
   error = otSrpClientRemoveHostAndServices(instance, true, true);
   if (error != OT_ERROR_NONE) {

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -58,11 +58,8 @@ void OpenThreadComponent::on_state_changed_(otChangedFlags flags, void *context)
 
 // Gets the off-mesh routable address
 std::optional<otIp6Address> OpenThreadComponent::get_omr_address() {
-  auto lock = InstanceLock::acquire();
-  if (!lock) {
-    return std::nullopt;
-  }
-  return this->get_omr_address_(*lock);
+  InstanceLock lock = InstanceLock::acquire();
+  return this->get_omr_address_(lock);
 }
 
 std::optional<otIp6Address> OpenThreadComponent::get_omr_address_(InstanceLock &lock) {
@@ -126,12 +123,8 @@ void OpenThreadSrpComponent::srp_factory_reset_callback(otError err, const otSrp
 
 void OpenThreadSrpComponent::setup() {
   otError error;
-  auto lock = InstanceLock::acquire();
-  if (!lock) {
-    this->mark_failed();
-    return;
-  }
-  otInstance *instance = lock->get_instance();
+  InstanceLock lock = InstanceLock::acquire();
+  otInstance *instance = lock.get_instance();
 
   otSrpClientSetCallback(instance, OpenThreadSrpComponent::srp_callback, nullptr);
 
@@ -253,12 +246,8 @@ void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
   factory_reset_external_callback_ = callback;
   ESP_LOGD(TAG, "Start Removal SRP Host and Services");
   otError error;
-  auto lock = InstanceLock::acquire();
-  if (!lock) {
-    ESP_LOGW(TAG, "Failed to acquire lock for factory reset");
-    return;
-  }
-  otInstance *instance = lock->get_instance();
+  InstanceLock lock = InstanceLock::acquire();
+  otInstance *instance = lock.get_instance();
   otSrpClientSetCallback(instance, OpenThreadSrpComponent::srp_factory_reset_callback, this);
   error = otSrpClientRemoveHostAndServices(instance, true, true);
   if (error != OT_ERROR_NONE) {

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -11,6 +11,7 @@
 #include <openthread/instance.h>
 #include <openthread/thread.h>
 
+#include <atomic>
 #include <optional>
 #include <vector>
 
@@ -28,6 +29,8 @@ class OpenThreadComponent : public Component {
   float get_setup_priority() const override { return setup_priority::WIFI; }
 
   bool is_connected() const { return this->connected_; }
+  /// Returns true once esp_openthread_init() has completed and the OT lock is usable.
+  bool is_lock_initialized() const { return this->lock_initialized_; }
   network::IPAddresses get_ip_addresses();
   std::optional<otIp6Address> get_omr_address();
   void ot_main();
@@ -51,6 +54,7 @@ class OpenThreadComponent : public Component {
   uint32_t poll_period_{0};
 #endif
   std::optional<int8_t> output_power_{};
+  std::atomic<bool> lock_initialized_{false};
   bool teardown_started_{false};
   bool teardown_complete_{false};
   bool connected_{false};

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -89,7 +89,7 @@ class OpenThreadSrpComponent : public Component {
 class InstanceLock {
  public:
   static std::optional<InstanceLock> try_acquire(int delay);
-  static std::optional<InstanceLock> acquire(uint32_t timeout_ms = 10000);
+  static InstanceLock acquire();
   ~InstanceLock();
 
   // Returns the global openthread instance guarded by this lock

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -89,7 +89,7 @@ class OpenThreadSrpComponent : public Component {
 class InstanceLock {
  public:
   static std::optional<InstanceLock> try_acquire(int delay);
-  static InstanceLock acquire();
+  static std::optional<InstanceLock> acquire(uint32_t timeout_ms = 10000);
   ~InstanceLock();
 
   // Returns the global openthread instance guarded by this lock

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -224,14 +224,23 @@ std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
   return {};
 }
 
-InstanceLock InstanceLock::acquire() {
+std::optional<InstanceLock> InstanceLock::acquire(uint32_t timeout_ms) {
   // Wait for the lock to be created by ot_main() before attempting to acquire it.
   // esp_openthread_lock_acquire() will assert-crash if called before esp_openthread_init().
+  uint32_t start = millis();
   while (global_openthread_component == nullptr || !global_openthread_component->is_lock_initialized()) {
+    if (millis() - start > timeout_ms) {
+      ESP_LOGE(TAG, "Timeout waiting for OpenThread lock initialization");
+      return {};
+    }
     delay(10);
     esp_task_wdt_reset();
   }
   while (!esp_openthread_lock_acquire(100)) {
+    if (millis() - start > timeout_ms) {
+      ESP_LOGE(TAG, "Timeout acquiring OpenThread lock");
+      return {};
+    }
     esp_task_wdt_reset();
   }
   return InstanceLock();

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -215,7 +215,7 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
 otInstance *OpenThreadComponent::get_openthread_instance_() { return esp_openthread_get_instance(); }
 
 std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
-  if (global_openthread_component == nullptr || !global_openthread_component->is_lock_initialized()) {
+  if (!global_openthread_component->is_lock_initialized()) {
     return {};
   }
   if (esp_openthread_lock_acquire(delay)) {
@@ -224,23 +224,20 @@ std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
   return {};
 }
 
-std::optional<InstanceLock> InstanceLock::acquire(uint32_t timeout_ms) {
+InstanceLock InstanceLock::acquire() {
   // Wait for the lock to be created by ot_main() before attempting to acquire it.
   // esp_openthread_lock_acquire() will assert-crash if called before esp_openthread_init().
+  constexpr uint32_t lock_init_timeout_ms = 10000;
   uint32_t start = millis();
-  while (global_openthread_component == nullptr || !global_openthread_component->is_lock_initialized()) {
-    if (millis() - start > timeout_ms) {
-      ESP_LOGE(TAG, "Timeout waiting for OpenThread lock initialization");
-      return {};
+  while (!global_openthread_component->is_lock_initialized()) {
+    if (millis() - start > lock_init_timeout_ms) {
+      ESP_LOGE(TAG, "OpenThread lock not initialized after %" PRIu32 "ms, aborting", lock_init_timeout_ms);
+      abort();
     }
     delay(10);
     esp_task_wdt_reset();
   }
   while (!esp_openthread_lock_acquire(100)) {
-    if (millis() - start > timeout_ms) {
-      ESP_LOGE(TAG, "Timeout acquiring OpenThread lock");
-      return {};
-    }
     esp_task_wdt_reset();
   }
   return InstanceLock();

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -8,6 +8,7 @@
 #include "esp_openthread_lock.h"
 
 #include "esp_task_wdt.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -81,6 +82,9 @@ void OpenThreadComponent::ot_main() {
   // Initialize the OpenThread stack
   // otLoggingSetLevel(OT_LOG_LEVEL_DEBG);
   ESP_ERROR_CHECK(esp_openthread_init(&config));
+  // Mark lock as initialized so InstanceLock callers know it's safe to acquire.
+  // Must be set after esp_openthread_init() which creates the internal semaphore.
+  this->lock_initialized_ = true;
   // Fetch OT instance once to avoid repeated call into OT stack
   otInstance *instance = esp_openthread_get_instance();
 
@@ -180,7 +184,8 @@ void OpenThreadComponent::ot_main() {
 
   esp_openthread_launch_mainloop();
 
-  // Clean up
+  // Clean up - reset lock flag before deinit destroys the semaphore
+  this->lock_initialized_ = false;
   esp_openthread_deinit();
   esp_openthread_netif_glue_deinit();
   esp_netif_destroy(openthread_netif);
@@ -210,6 +215,9 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
 otInstance *OpenThreadComponent::get_openthread_instance_() { return esp_openthread_get_instance(); }
 
 std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
+  if (global_openthread_component == nullptr || !global_openthread_component->is_lock_initialized()) {
+    return {};
+  }
   if (esp_openthread_lock_acquire(delay)) {
     return InstanceLock();
   }
@@ -217,6 +225,12 @@ std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
 }
 
 InstanceLock InstanceLock::acquire() {
+  // Wait for the lock to be created by ot_main() before attempting to acquire it.
+  // esp_openthread_lock_acquire() will assert-crash if called before esp_openthread_init().
+  while (global_openthread_component == nullptr || !global_openthread_component->is_lock_initialized()) {
+    delay(10);
+    esp_task_wdt_reset();
+  }
   while (!esp_openthread_lock_acquire(100)) {
     esp_task_wdt_reset();
   }


### PR DESCRIPTION
# What does this implement/fix?

`esp_openthread_lock_acquire()` calls `xQueueSemaphoreTake()` on an internal semaphore that is only created when `esp_openthread_init()` runs inside the async `ot_main` task. If any component calls `InstanceLock::acquire()` or `try_acquire()` before that initialization completes (e.g. during safe mode `App.setup()`, or if `esp_openthread_init()` fails due to NVS corruption), the NULL semaphore handle triggers a FreeRTOS assertion crash:

```
assert failed: xQueueSemaphoreTake queue.c:1709 (( pxQueue ))
```

This adds an `std::atomic<bool> lock_initialized_` flag that is set after `esp_openthread_init()` succeeds:
- `InstanceLock::try_acquire()` returns `nullopt` if the lock isn't ready
- `InstanceLock::acquire()` waits up to 10s for initialization, then aborts with a clear error message — allowing safe mode to eventually activate after enough failed boot attempts

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14924

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal bugfix
esp32:
  board: seeed_xiao_esp32c6
  framework:
    type: esp-idf

network:
  enable_ipv6: true

openthread:
  device_type: FTD
  tlv: !secret thread_tlv
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).