### PR TITLE
[core] Inline calculate_looping_components_ into header

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -394,22 +394,6 @@ void Application::teardown_components(uint32_t timeout_ms) {
   }
 }
 
-void Application::calculate_looping_components_() {
-  // FixedVector capacity was pre-initialized by codegen with the exact count
-  // of components that override loop(), computed at C++ compile time.
-
-  // Add all components with loop override that aren't already LOOP_DONE
-  // Some components (like logger) may call disable_loop() during initialization
-  // before setup runs, so we need to respect their LOOP_DONE state
-  this->add_looping_components_by_state_(false);
-
-  this->looping_components_active_end_ = this->looping_components_.size();
-
-  // Then add any components that are already LOOP_DONE to the inactive section
-  // This handles components that called disable_loop() during initialization
-  this->add_looping_components_by_state_(true);
-}
-
 void Application::add_looping_components_by_state_(bool match_loop_done) {
   for (auto *obj : this->components_) {
     if (obj->has_overridden_loop() &&

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -595,7 +595,19 @@ class Application {
 
   void register_component_impl_(Component *comp, bool has_loop);
 
-  void calculate_looping_components_();
+  void calculate_looping_components_() {
+    // FixedVector capacity was pre-initialized by codegen with the exact count
+    // of components that override loop(), computed at C++ compile time.
+
+    // Add all components with loop override that aren't already LOOP_DONE
+    // Some components (like logger) may call disable_loop() during initialization
+    // before setup runs, so we need to respect their LOOP_DONE state
+    this->add_looping_components_by_state_(false);
+    this->looping_components_active_end_ = this->looping_components_.size();
+    // Then add any components that are already LOOP_DONE to the inactive section
+    // This handles components that called disable_loop() during initialization
+    this->add_looping_components_by_state_(true);
+  }
   void add_looping_components_by_state_(bool match_loop_done);
 
   // These methods are called by Component::disable_loop() and Component::enable_loop()


### PR DESCRIPTION
# What does this implement/fix?

Move `calculate_looping_components_()` from `application.cpp` to `application.h` as an inline method. This function has only had a single caller (`setup()`) since it was introduced in 2019 (#860) and is small enough for the compiler to inline, saving ~20 bytes of flash by eliminating the function call overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal refactor, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).