### PR TITLE
[packet_transport] Use FixedVector and parent pointer to enable inline Callback storage

### DIFF
--- a/esphome/components/packet_transport/__init__.py
+++ b/esphome/components/packet_transport/__init__.py
@@ -177,13 +177,19 @@ async def register_packet_transport(var, config):
             cg.add(var.set_provider_encryption(name, hash_encryption_key(encryption)))
 
     is_provider = False
-    for sens_conf in config.get(CONF_SENSORS, ()):
+    sensors = config.get(CONF_SENSORS, ())
+    binary_sensors = config.get(CONF_BINARY_SENSORS, ())
+    if sensors:
+        cg.add(var.set_sensor_count(len(sensors)))
+    if binary_sensors:
+        cg.add(var.set_binary_sensor_count(len(binary_sensors)))
+    for sens_conf in sensors:
         is_provider = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)
         bcst_id = sens_conf.get(CONF_BROADCAST_ID, sens_id.id)
         cg.add(var.add_sensor(bcst_id, sensor))
-    for sens_conf in config.get(CONF_BINARY_SENSORS, ()):
+    for sens_conf in binary_sensors:
         is_provider = True
         sens_id = sens_conf[CONF_ID]
         sensor = await cg.get_variable(sens_id)

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -221,6 +221,8 @@ void PacketTransport::setup() {
   }
 #ifdef USE_SENSOR
   for (auto &sensor : this->sensors_) {
+    // [&sensor] is safe: sensor refers to a vector element that is never modified after setup(),
+    // so the reference remains valid for the component's lifetime.
     sensor.sensor->add_on_state_callback([&sensor](float x) {
       sensor.parent->updated_ = true;
       sensor.updated = true;
@@ -229,6 +231,8 @@ void PacketTransport::setup() {
 #endif
 #ifdef USE_BINARY_SENSOR
   for (auto &sensor : this->binary_sensors_) {
+    // [&sensor] is safe: sensor refers to a vector element that is never modified after setup(),
+    // so the reference remains valid for the component's lifetime.
     sensor.sensor->add_on_state_callback([&sensor](bool value) {
       sensor.parent->updated_ = true;
       sensor.updated = true;

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -221,7 +221,7 @@ void PacketTransport::setup() {
   }
 #ifdef USE_SENSOR
   for (auto &sensor : this->sensors_) {
-    // [&sensor] is safe: sensor refers to a vector element that is never modified after setup(),
+    // [&sensor] is safe: sensor refers to a FixedVector element that never reallocates,
     // so the reference remains valid for the component's lifetime.
     sensor.sensor->add_on_state_callback([&sensor](float x) {
       sensor.parent->updated_ = true;
@@ -231,7 +231,7 @@ void PacketTransport::setup() {
 #endif
 #ifdef USE_BINARY_SENSOR
   for (auto &sensor : this->binary_sensors_) {
-    // [&sensor] is safe: sensor refers to a vector element that is never modified after setup(),
+    // [&sensor] is safe: sensor refers to a FixedVector element that never reallocates,
     // so the reference remains valid for the component's lifetime.
     sensor.sensor->add_on_state_callback([&sensor](bool value) {
       sensor.parent->updated_ = true;

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -221,16 +221,16 @@ void PacketTransport::setup() {
   }
 #ifdef USE_SENSOR
   for (auto &sensor : this->sensors_) {
-    sensor.sensor->add_on_state_callback([this, &sensor](float x) {
-      this->updated_ = true;
+    sensor.sensor->add_on_state_callback([&sensor](float x) {
+      sensor.parent->updated_ = true;
       sensor.updated = true;
     });
   }
 #endif
 #ifdef USE_BINARY_SENSOR
   for (auto &sensor : this->binary_sensors_) {
-    sensor.sensor->add_on_state_callback([this, &sensor](bool value) {
-      this->updated_ = true;
+    sensor.sensor->add_on_state_callback([&sensor](bool value) {
+      sensor.parent->updated_ = true;
       sensor.updated = true;
     });
   }

--- a/esphome/components/packet_transport/packet_transport.cpp
+++ b/esphome/components/packet_transport/packet_transport.cpp
@@ -552,11 +552,11 @@ void PacketTransport::dump_config() {
                 "  Ping-pong: %s",
                 this->platform_name_, YESNO(this->is_encrypted_()), YESNO(this->ping_pong_enable_));
 #ifdef USE_SENSOR
-  for (auto sensor : this->sensors_)
+  for (const auto &sensor : this->sensors_)
     ESP_LOGCONFIG(TAG, "  Sensor: %s", sensor.id);
 #endif
 #ifdef USE_BINARY_SENSOR
-  for (auto sensor : this->binary_sensors_)
+  for (const auto &sensor : this->binary_sensors_)
     ESP_LOGCONFIG(TAG, "  Binary Sensor: %s", sensor.id);
 #endif
   for (const auto &host : this->providers_) {

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -58,13 +58,6 @@ struct BinarySensor {
 #endif
 
 class PacketTransport : public PollingComponent {
-#ifdef USE_SENSOR
-  friend struct Sensor;
-#endif
-#ifdef USE_BINARY_SENSOR
-  friend struct BinarySensor;
-#endif
-
  public:
   void setup() override;
   void loop() override;

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -37,11 +37,14 @@ struct Provider {
 #endif
 };
 
+class PacketTransport;
+
 #ifdef USE_SENSOR
 struct Sensor {
   sensor::Sensor *sensor;
   const char *id;
   bool updated;
+  PacketTransport *parent;
 };
 #endif
 #ifdef USE_BINARY_SENSOR
@@ -49,10 +52,18 @@ struct BinarySensor {
   binary_sensor::BinarySensor *sensor;
   const char *id;
   bool updated;
+  PacketTransport *parent;
 };
 #endif
 
 class PacketTransport : public PollingComponent {
+#ifdef USE_SENSOR
+  friend struct Sensor;
+#endif
+#ifdef USE_BINARY_SENSOR
+  friend struct BinarySensor;
+#endif
+
  public:
   void setup() override;
   void loop() override;
@@ -61,7 +72,7 @@ class PacketTransport : public PollingComponent {
 
 #ifdef USE_SENSOR
   void add_sensor(const char *id, sensor::Sensor *sensor) {
-    Sensor st{sensor, id, true};
+    Sensor st{sensor, id, true, this};
     this->sensors_.push_back(st);
   }
   void add_remote_sensor(const char *hostname, const char *remote_id, sensor::Sensor *sensor) {
@@ -71,7 +82,7 @@ class PacketTransport : public PollingComponent {
 #endif
 #ifdef USE_BINARY_SENSOR
   void add_binary_sensor(const char *id, binary_sensor::BinarySensor *sensor) {
-    BinarySensor st{sensor, id, true};
+    BinarySensor st{sensor, id, true, this};
     this->binary_sensors_.push_back(st);
   }
 

--- a/esphome/components/packet_transport/packet_transport.h
+++ b/esphome/components/packet_transport/packet_transport.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
@@ -71,6 +72,7 @@ class PacketTransport : public PollingComponent {
   void dump_config() override;
 
 #ifdef USE_SENSOR
+  void set_sensor_count(size_t count) { this->sensors_.init(count); }
   void add_sensor(const char *id, sensor::Sensor *sensor) {
     Sensor st{sensor, id, true, this};
     this->sensors_.push_back(st);
@@ -81,6 +83,7 @@ class PacketTransport : public PollingComponent {
   }
 #endif
 #ifdef USE_BINARY_SENSOR
+  void set_binary_sensor_count(size_t count) { this->binary_sensors_.init(count); }
   void add_binary_sensor(const char *id, binary_sensor::BinarySensor *sensor) {
     BinarySensor st{sensor, id, true, this};
     this->binary_sensors_.push_back(st);
@@ -152,11 +155,11 @@ class PacketTransport : public PollingComponent {
   std::vector<uint8_t> encryption_key_{};
 
 #ifdef USE_SENSOR
-  std::vector<Sensor> sensors_{};
+  FixedVector<Sensor> sensors_{};
   string_map_t<string_map_t<sensor::Sensor *>> remote_sensors_{};
 #endif
 #ifdef USE_BINARY_SENSOR
-  std::vector<BinarySensor> binary_sensors_{};
+  FixedVector<BinarySensor> binary_sensors_{};
   string_map_t<string_map_t<binary_sensor::BinarySensor *>> remote_binary_sensors_{};
 #endif
 

--- a/tests/components/packet_transport/binary_sensor/binary_sensor_test.cpp
+++ b/tests/components/packet_transport/binary_sensor/binary_sensor_test.cpp
@@ -5,6 +5,7 @@ namespace esphome::packet_transport::testing {
 TEST(PacketTransportBinarySensorTest, AddBinarySensor) {
   TestablePacketTransport transport;
   binary_sensor::BinarySensor bs;
+  transport.set_binary_sensor_count(1);
   transport.add_binary_sensor("motion", &bs);
   ASSERT_EQ(transport.binary_sensors_.size(), 1u);
   EXPECT_STREQ(transport.binary_sensors_[0].id, "motion");
@@ -24,6 +25,7 @@ TEST(PacketTransportBinarySensorTest, UnencryptedBinarySensorRoundTrip) {
   encoder.init_for_test("sender");
   binary_sensor::BinarySensor local_bs;
   local_bs.state = true;
+  encoder.set_binary_sensor_count(1);
   encoder.add_binary_sensor("motion", &local_bs);
 
   encoder.send_data_(true);
@@ -46,11 +48,13 @@ TEST(PacketTransportBinarySensorTest, MultipleSensorsRoundTrip) {
   sensor::Sensor s1, s2;
   s1.state = 10.0f;
   s2.state = 20.0f;
+  encoder.set_sensor_count(2);
   encoder.add_sensor("s1", &s1);
   encoder.add_sensor("s2", &s2);
 
   binary_sensor::BinarySensor bs1;
   bs1.state = true;
+  encoder.set_binary_sensor_count(1);
   encoder.add_binary_sensor("bs1", &bs1);
 
   encoder.send_data_(true);

--- a/tests/components/packet_transport/sensor/sensor_test.cpp
+++ b/tests/components/packet_transport/sensor/sensor_test.cpp
@@ -5,6 +5,7 @@ namespace esphome::packet_transport::testing {
 TEST(PacketTransportSensorTest, AddSensor) {
   TestablePacketTransport transport;
   sensor::Sensor s;
+  transport.set_sensor_count(1);
   transport.add_sensor("temp", &s);
   ASSERT_EQ(transport.sensors_.size(), 1u);
   EXPECT_STREQ(transport.sensors_[0].id, "temp");
@@ -26,6 +27,7 @@ TEST(PacketTransportSensorTest, UnencryptedSensorRoundTrip) {
   encoder.init_for_test("sender");
   sensor::Sensor local_sensor;
   local_sensor.state = 42.5f;
+  encoder.set_sensor_count(1);
   encoder.add_sensor("temp", &local_sensor);
 
   encoder.send_data_(true);
@@ -53,6 +55,7 @@ TEST(PacketTransportSensorTest, EncryptedSensorRoundTrip) {
   encoder.set_encryption_key(key);
   sensor::Sensor local_sensor;
   local_sensor.state = 99.9f;
+  encoder.set_sensor_count(1);
   encoder.add_sensor("temp", &local_sensor);
 
   encoder.send_data_(true);
@@ -77,6 +80,7 @@ TEST(PacketTransportSensorTest, SendDataOnlyUpdated) {
   sensor::Sensor s1, s2;
   s1.state = 1.0f;
   s2.state = 2.0f;
+  encoder.set_sensor_count(2);
   encoder.add_sensor("s1", &s1);
   encoder.add_sensor("s2", &s2);
 
@@ -111,6 +115,7 @@ TEST(PacketTransportSensorTest, PingKeyIncludedInTransmittedPacket) {
   responder.set_encryption_key(key);
   sensor::Sensor local_sensor;
   local_sensor.state = 77.7f;
+  responder.set_sensor_count(1);
   responder.add_sensor("temp", &local_sensor);
 
   // Requester sends a MAGIC_PING that the responder processes
@@ -148,6 +153,7 @@ TEST(PacketTransportSensorTest, MissingPingKeyBlocksSensorData) {
   responder.set_encryption_key(key);
   sensor::Sensor local_sensor;
   local_sensor.state = 77.7f;
+  responder.set_sensor_count(1);
   responder.add_sensor("temp", &local_sensor);
   responder.send_data_(true);
   ASSERT_EQ(responder.sent_packets.size(), 1u);


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #14923. The `packet_transport` callback lambdas were noted as "not converted" in that PR because they aren't the same mechanical refactoring — they capture `[this, &sensor]` where `&sensor` is a reference to a loop variable (each iteration references a different vector element), so there's no existing pointer to simply hoist to a class member.

### Change 1: Back-pointer for inline Callback storage

Adds a `parent` back-pointer in the `Sensor` and `BinarySensor` structs and a forward declaration + `friend` declarations so the structs can access `PacketTransport::updated_`. The lambdas then capture only `[&sensor]` (one pointer = `sizeof(void*)`) instead of `[this, &sensor]` (two pointers), bringing them within the `Callback` inline storage threshold and avoiding a heap allocation per callback registration.

### Change 2: FixedVector to eliminate realloc machinery

The sensor and binary sensor counts are known at config time, so `FixedVector` with `init(count)` replaces `std::vector`, eliminating the `_M_realloc_insert` template instantiation code that `std::vector<Sensor>` / `std::vector<BinarySensor>` would pull in.

### Trade-off

Each `Sensor`/`BinarySensor` struct grows by 4 bytes (the back-pointer), but this eliminates a permanent heap allocation per sensor callback. The heap cost of each non-inline `Callback` is the lambda storage (8 bytes for two-pointer capture) plus allocator metadata/alignment overhead — typically 16-24 bytes total. More importantly, eliminating these small scattered allocations reduces long-term heap fragmentation on devices that run for months.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).