### PR TITLE
[combination] Use FixedVector and parent pointer to enable inline Callback storage

### DIFF
--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -4,8 +4,6 @@
 #include "esphome/core/hal.h"
 
 #include <cmath>
-#include <functional>
-#include <vector>
 
 namespace esphome {
 namespace combination {
@@ -20,12 +18,12 @@ void CombinationComponent::log_config_(const LogString *combo_type) {
 
 void CombinationNoParameterComponent::add_source(Sensor *sensor) { this->sensors_.emplace_back(sensor); }
 
-void CombinationOneParameterComponent::add_source(Sensor *sensor, std::function<float(float)> const &stddev) {
-  this->sensor_pairs_.emplace_back(sensor, stddev);
+void CombinationOneParameterComponent::add_source(Sensor *sensor, std::function<float(float)> const &compute) {
+  this->sensor_sources_.push_back({sensor, compute, this});
 }
 
-void CombinationOneParameterComponent::add_source(Sensor *sensor, float stddev) {
-  this->add_source(sensor, std::function<float(float)>{[stddev](float x) -> float { return stddev; }});
+void CombinationOneParameterComponent::add_source(Sensor *sensor, float value) {
+  this->add_source(sensor, std::function<float(float)>{[value](float x) -> float { return value; }});
 }
 
 void CombinationNoParameterComponent::log_source_sensors() {
@@ -37,9 +35,8 @@ void CombinationNoParameterComponent::log_source_sensors() {
 
 void CombinationOneParameterComponent::log_source_sensors() {
   ESP_LOGCONFIG(TAG, "  Source Sensors:");
-  for (const auto &sensor : this->sensor_pairs_) {
-    auto &entity = *sensor.first;
-    ESP_LOGCONFIG(TAG, "    - %s", entity.get_name().c_str());
+  for (const auto &source : this->sensor_sources_) {
+    ESP_LOGCONFIG(TAG, "    - %s", source.sensor->get_name().c_str());
   }
 }
 
@@ -62,9 +59,10 @@ void KalmanCombinationComponent::dump_config() {
 }
 
 void KalmanCombinationComponent::setup() {
-  for (const auto &sensor : this->sensor_pairs_) {
-    const auto stddev = sensor.second;
-    sensor.first->add_on_state_callback([this, stddev](float x) -> void { this->correct_(x, stddev(x)); });
+  for (auto &source : this->sensor_sources_) {
+    source.sensor->add_on_state_callback([&source](float x) -> void {
+      static_cast<KalmanCombinationComponent *>(source.parent)->correct_(x, source.compute(x));
+    });
   }
 }
 
@@ -117,10 +115,10 @@ void KalmanCombinationComponent::correct_(float value, float stddev) {
 }
 
 void LinearCombinationComponent::setup() {
-  for (const auto &sensor : this->sensor_pairs_) {
+  for (auto &source : this->sensor_sources_) {
     // All sensor updates are deferred until the next loop. This avoids publishing the combined sensor's result
     // repeatedly in the same loop if multiple source senors update.
-    sensor.first->add_on_state_callback(
+    source.sensor->add_on_state_callback(
         [this](float value) -> void { this->defer("update", [this, value]() { this->handle_new_value(value); }); });
   }
 }
@@ -133,10 +131,10 @@ void LinearCombinationComponent::handle_new_value(float value) {
 
   float sum = 0.0;
 
-  for (const auto &sensor : this->sensor_pairs_) {
-    const float sensor_state = sensor.first->state;
+  for (const auto &source : this->sensor_sources_) {
+    const float sensor_state = source.sensor->state;
     if (std::isfinite(sensor_state)) {
-      sum += sensor_state * sensor.second(sensor_state);
+      sum += sensor_state * source.compute(sensor_state);
     }
   }
 

--- a/esphome/components/combination/combination.cpp
+++ b/esphome/components/combination/combination.cpp
@@ -60,6 +60,8 @@ void KalmanCombinationComponent::dump_config() {
 
 void KalmanCombinationComponent::setup() {
   for (auto &source : this->sensor_sources_) {
+    // [&source] is safe: source refers to a FixedVector element that never reallocates,
+    // so the reference remains valid for the component's lifetime.
     source.sensor->add_on_state_callback([&source](float x) -> void {
       static_cast<KalmanCombinationComponent *>(source.parent)->correct_(x, source.compute(x));
     });

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <functional>
 #include <vector>
 
 namespace esphome {
@@ -41,14 +42,20 @@ class CombinationNoParameterComponent : public CombinationComponent {
 // Base class for opertions that require one parameter to compute the combination
 class CombinationOneParameterComponent : public CombinationComponent {
  public:
-  void add_source(Sensor *sensor, std::function<float(float)> const &stddev);
-  void add_source(Sensor *sensor, float stddev);
+  void add_source(Sensor *sensor, std::function<float(float)> const &compute);
+  void add_source(Sensor *sensor, float value);
 
-  /// @brief Logs all source sensor's names in sensor_pairs_
+  /// @brief Logs all source sensor's names in sensor_sources_
   void log_source_sensors() override;
 
+  struct SensorSource {
+    sensor::Sensor *sensor;
+    std::function<float(float)> compute;
+    CombinationOneParameterComponent *parent;
+  };
+
  protected:
-  std::vector<std::pair<Sensor *, std::function<float(float)>>> sensor_pairs_;
+  std::vector<SensorSource> sensor_sources_;
 };
 
 class KalmanCombinationComponent : public CombinationOneParameterComponent {

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 #include "esphome/components/sensor/sensor.h"
 
 #include <functional>
-#include <vector>
 
 namespace esphome {
 namespace combination {
@@ -42,6 +42,7 @@ class CombinationNoParameterComponent : public CombinationComponent {
 // Base class for opertions that require one parameter to compute the combination
 class CombinationOneParameterComponent : public CombinationComponent {
  public:
+  void set_source_count(size_t count) { this->sensor_sources_.init(count); }
   void add_source(Sensor *sensor, std::function<float(float)> const &compute);
   void add_source(Sensor *sensor, float value);
 
@@ -55,7 +56,7 @@ class CombinationOneParameterComponent : public CombinationComponent {
   };
 
  protected:
-  std::vector<SensorSource> sensor_sources_;
+  FixedVector<SensorSource> sensor_sources_;
 };
 
 class KalmanCombinationComponent : public CombinationOneParameterComponent {

--- a/esphome/components/combination/combination.h
+++ b/esphome/components/combination/combination.h
@@ -46,16 +46,16 @@ class CombinationOneParameterComponent : public CombinationComponent {
   void add_source(Sensor *sensor, std::function<float(float)> const &compute);
   void add_source(Sensor *sensor, float value);
 
-  /// @brief Logs all source sensor's names in sensor_sources_
+  /// @brief Logs all source sensors' names in sensor_sources_
   void log_source_sensors() override;
 
+ protected:
   struct SensorSource {
     sensor::Sensor *sensor;
     std::function<float(float)> compute;
     CombinationOneParameterComponent *parent;
   };
 
- protected:
   FixedVector<SensorSource> sensor_sources_;
 };
 

--- a/esphome/components/combination/sensor.py
+++ b/esphome/components/combination/sensor.py
@@ -180,6 +180,9 @@ async def to_code(config):
     if proces_std_dev := config.get(CONF_PROCESS_STD_DEV):
         cg.add(var.set_process_std_dev(proces_std_dev))
 
+    if config[CONF_TYPE] in (CONF_KALMAN, CONF_LINEAR):
+        cg.add(var.set_source_count(len(config[CONF_SOURCES])))
+
     for source_conf in config[CONF_SOURCES]:
         source = await cg.get_variable(source_conf[CONF_SOURCE])
         if config[CONF_TYPE] == CONF_KALMAN:


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #14923. The `combination` component's Kalman filter callback was noted as "not converted" in that PR because it's not the same mechanical refactoring — it captures `[this, stddev]` where `stddev` is a full `std::function<float(float)>` copied by value into each callback lambda, which far exceeds the `Callback` inline threshold.

### Change 1: Struct with back-pointer for inline Callback storage

Replaces `std::pair<Sensor *, std::function<float(float)>>` with a `SensorSource` struct that includes a back-pointer to the parent component.

**Before:** Each callback lambda copied the entire `std::function` (~16+ bytes) into its capture:
```cpp
const auto stddev = sensor.second;  // copies std::function
sensor.first->add_on_state_callback([this, stddev](float x) -> void { this->correct_(x, stddev(x)); });
```

**After:** The lambda captures only `[&source]` (one pointer = `sizeof(void*)`), referencing the `std::function` already stored in the vector:
```cpp
source.sensor->add_on_state_callback([&source](float x) -> void {
  static_cast<KalmanCombinationComponent *>(source.parent)->correct_(x, source.compute(x));
});
```

### Change 2: FixedVector to eliminate realloc machinery

The source count is known at config time, so `FixedVector` with `init(count)` replaces `std::vector`, eliminating the `_M_realloc_insert` template instantiation and move constructor code that `std::vector<SensorSource>` would pull in.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).