### PR TITLE
[wireguard] Replace std::bind with inline lambdas

### DIFF
--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -2,7 +2,6 @@
 #ifdef USE_WIREGUARD
 #include <cinttypes>
 #include <ctime>
-#include <functional>
 
 #include "esphome/core/application.h"
 #include "esphome/core/log.h"

--- a/esphome/components/wireguard/wireguard.cpp
+++ b/esphome/components/wireguard/wireguard.cpp
@@ -48,8 +48,8 @@ void Wireguard::setup() {
   if (this->wg_initialized_ == ESP_OK) {
     ESP_LOGI(TAG, "Initialized");
     this->wg_peer_offline_time_ = millis();
-    this->srctime_->add_on_time_sync_callback(std::bind(&Wireguard::start_connection_, this));
-    this->defer(std::bind(&Wireguard::start_connection_, this));  // defer to avoid blocking setup
+    this->srctime_->add_on_time_sync_callback([this]() { this->start_connection_(); });
+    this->defer([this]() { this->start_connection_(); });  // defer to avoid blocking setup
 
 #ifdef USE_TEXT_SENSOR
     if (this->address_sensor_ != nullptr) {
@@ -206,7 +206,7 @@ void Wireguard::enable() {
 
 void Wireguard::disable() {
   this->enabled_ = false;
-  this->defer(std::bind(&Wireguard::stop_connection_, this));  // defer to avoid blocking running loop
+  this->defer([this]() { this->stop_connection_(); });  // defer to avoid blocking running loop
   ESP_LOGI(TAG, "Disabled");
   this->publish_enabled_state();
 }


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::bind(&Wireguard::start_connection_, this)` and `std::bind(&Wireguard::stop_connection_, this)` with `[this]` lambdas across three call sites:

- `add_on_time_sync_callback` — the `std::bind` result exceeds the `Callback` inline storage threshold (`sizeof(void*)`), forcing a permanent heap allocation. The `[this]` lambda fits inline.
- Two `defer` calls — same replacement for consistency and to avoid pulling in `<functional>` for `std::bind`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Chained off https://github.com/esphome/esphome/pull/14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).