### PR TITLE
[xiaomi_rtcgq02lm] Drop unused capture from timeout lambdas

### DIFF
--- a/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
+++ b/esphome/components/xiaomi_rtcgq02lm/xiaomi_rtcgq02lm.cpp
@@ -58,15 +58,13 @@ bool XiaomiRTCGQ02LM::parse_device(const esp32_ble_tracker::ESPBTDevice &device)
 #ifdef USE_BINARY_SENSOR
     if (res->has_motion.has_value() && this->motion_ != nullptr) {
       this->motion_->publish_state(*res->has_motion);
-      this->set_timeout("motion_timeout", this->motion_timeout_,
-                        [this, res]() { this->motion_->publish_state(false); });
+      this->set_timeout("motion_timeout", this->motion_timeout_, [this]() { this->motion_->publish_state(false); });
     }
     if (res->is_light.has_value() && this->light_ != nullptr)
       this->light_->publish_state(*res->is_light);
     if (res->button_press.has_value() && this->button_ != nullptr) {
       this->button_->publish_state(*res->button_press);
-      this->set_timeout("button_timeout", this->button_timeout_,
-                        [this, res]() { this->button_->publish_state(false); });
+      this->set_timeout("button_timeout", this->button_timeout_, [this]() { this->button_->publish_state(false); });
     }
 #endif
 #ifdef USE_SENSOR


### PR DESCRIPTION
# What does this implement/fix?

The `motion_timeout` and `button_timeout` lambdas captured `res` (`optional<XiaomiParseResult>`) but never used it — the lambda body only calls `publish_state(false)`.

`XiaomiParseResult` is a large struct (~100+ bytes: enum, `std::string`, 10 `optional<float>`, 4 `optional<bool>`, 4 `bool`). Capturing it by value in each `set_timeout` lambda copies the entire struct into `std::function`, far exceeding the small buffer optimization threshold (8 bytes on 32-bit) and forcing a heap allocation.

Dropping the unused `res` capture reduces each lambda to `[this]` (4 bytes), which fits inline in `std::function` SBO.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).