### PR TITLE
[bme68x_bsec2] Store trigger time as member to avoid std::function SBO overflow

### DIFF
--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -279,7 +279,8 @@ void BME68xBSEC2Component::run_() {
     uint32_t meas_dur = 0;
     meas_dur = bme68x_get_meas_dur(this->op_mode_, &bme68x_conf, &this->bme68x_);
     ESP_LOGV(TAG, "Queueing read in %uus", meas_dur);
-    this->set_timeout("read", meas_dur / 1000, [this, curr_time_ns]() { this->read_(curr_time_ns); });
+    this->trigger_time_ns_ = curr_time_ns;
+    this->set_timeout("read", meas_dur / 1000, [this]() { this->read_(this->trigger_time_ns_); });
   } else {
     ESP_LOGV(TAG, "Measurement not required");
     this->read_(curr_time_ns);

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -116,7 +116,8 @@ class BME68xBSEC2Component : public Component {
   int8_t bme68x_status_{BME68X_OK};
 
   int64_t last_time_ms_{0};
-  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to help avoid heap allocation on supported 32-bit toolchains with small std::function SBO
+  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to help avoid heap allocation on supported 32-bit
+                                // toolchains with small std::function SBO
   uint32_t millis_overflow_counter_{0};
 
   std::queue<std::function<void()>> queue_;

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -116,6 +116,7 @@ class BME68xBSEC2Component : public Component {
   int8_t bme68x_status_{BME68X_OK};
 
   int64_t last_time_ms_{0};
+  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to avoid exceeding std::function SBO
   uint32_t millis_overflow_counter_{0};
 
   std::queue<std::function<void()>> queue_;

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -116,7 +116,7 @@ class BME68xBSEC2Component : public Component {
   int8_t bme68x_status_{BME68X_OK};
 
   int64_t last_time_ms_{0};
-  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to avoid exceeding std::function SBO
+  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to help avoid heap allocation on supported 32-bit toolchains with small std::function SBO
   uint32_t millis_overflow_counter_{0};
 
   std::queue<std::function<void()>> queue_;


### PR DESCRIPTION
# What does this implement/fix?

The `set_timeout` lambda in `run_()` captured `[this, curr_time_ns]` where `curr_time_ns` is `int64_t` (8 bytes). On 32-bit platforms, this totals 12 bytes (4 + 8), exceeding the `std::function` small buffer optimization threshold (8 bytes) and forcing a heap allocation every measurement cycle — every 3 seconds in LP mode or every 5 minutes in ULP mode.

Store `curr_time_ns` as a class member (`trigger_time_ns_`) and capture only `[this]` (4 bytes), which fits inline in the SBO. Trades 8 bytes of permanent member storage (negligible given the struct already contains a large BSEC instance) to eliminate a recurring heap alloc+free cycle.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).