### PR TITLE
[core] Replace std::bind with lambdas across 13 components

### DIFF
--- a/esphome/components/dps310/dps310.cpp
+++ b/esphome/components/dps310/dps310.cpp
@@ -127,8 +127,7 @@ void DPS310Component::read_() {
     this->update_in_progress_ = false;
     this->status_clear_warning();
   } else {
-    auto f = std::bind(&DPS310Component::read_, this);
-    this->set_timeout("dps310", 10, f);
+    this->set_timeout("dps310", 10, [this]() { this->read_(); });
   }
 }
 

--- a/esphome/components/esp32_improv/esp32_improv_component.cpp
+++ b/esphome/components/esp32_improv/esp32_improv_component.cpp
@@ -350,8 +350,7 @@ void ESP32ImprovComponent::process_incoming_data_() {
         ESP_LOGD(TAG, "Received Improv Wi-Fi settings ssid=%s, password=" LOG_SECRET("%s"), command.ssid.c_str(),
                  command.password.c_str());
 
-        auto f = std::bind(&ESP32ImprovComponent::on_wifi_connect_timeout_, this);
-        this->set_timeout("wifi-connect-timeout", 30000, f);
+        this->set_timeout("wifi-connect-timeout", 30000, [this]() { this->on_wifi_connect_timeout_(); });
         this->incoming_data_.clear();
         break;
       }

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -245,8 +245,7 @@ bool ImprovSerialComponent::parse_improv_payload_(improv::ImprovCommand &command
       ESP_LOGD(TAG, "Received settings: SSID=%s, password=" LOG_SECRET("%s"), command.ssid.c_str(),
                command.password.c_str());
 
-      auto f = std::bind(&ImprovSerialComponent::on_wifi_connect_timeout_, this);
-      this->set_timeout("wifi-connect-timeout", 30000, f);
+      this->set_timeout("wifi-connect-timeout", 30000, [this]() { this->on_wifi_connect_timeout_(); });
       return true;
     }
     case improv::GET_CURRENT_STATE:

--- a/esphome/components/max31855/max31855.cpp
+++ b/esphome/components/max31855/max31855.cpp
@@ -15,8 +15,7 @@ void MAX31855Sensor::update() {
   this->disable();
 
   // Conversion time typ: 170ms, max: 220ms
-  auto f = std::bind(&MAX31855Sensor::read_data_, this);
-  this->set_timeout("value", 220, f);
+  this->set_timeout("value", 220, [this]() { this->read_data_(); });
 }
 
 void MAX31855Sensor::setup() { this->spi_setup(); }

--- a/esphome/components/max31856/max31856.cpp
+++ b/esphome/components/max31856/max31856.cpp
@@ -41,8 +41,8 @@ void MAX31856Sensor::update() {
   this->one_shot_temperature_();
 
   // Datasheet max conversion time for 1 shot is 155ms for 60Hz / 185ms for 50Hz
-  auto f = std::bind(&MAX31856Sensor::read_thermocouple_temperature_, this);
-  this->set_timeout("MAX31856Sensor::read_thermocouple_temperature_", filter_ == FILTER_60HZ ? 155 : 185, f);
+  this->set_timeout("MAX31856Sensor::read_thermocouple_temperature_", filter_ == FILTER_60HZ ? 155 : 185,
+                    [this]() { this->read_thermocouple_temperature_(); });
 }
 
 void MAX31856Sensor::read_thermocouple_temperature_() {

--- a/esphome/components/max31865/max31865.cpp
+++ b/esphome/components/max31865/max31865.cpp
@@ -60,8 +60,7 @@ void MAX31865Sensor::update() {
   this->write_config_(0b11100000, 0b10100000);
 
   // Datasheet max conversion time is 55ms for 60Hz / 66ms for 50Hz
-  auto f = std::bind(&MAX31865Sensor::read_data_, this);
-  this->set_timeout("value", filter_ == FILTER_60HZ ? 55 : 66, f);
+  this->set_timeout("value", filter_ == FILTER_60HZ ? 55 : 66, [this]() { this->read_data_(); });
 }
 
 void MAX31865Sensor::setup() {

--- a/esphome/components/max6675/max6675.cpp
+++ b/esphome/components/max6675/max6675.cpp
@@ -13,8 +13,7 @@ void MAX6675Sensor::update() {
   this->disable();
 
   // Conversion time typ: 170ms, max: 220ms
-  auto f = std::bind(&MAX6675Sensor::read_data_, this);
-  this->set_timeout("value", 250, f);
+  this->set_timeout("value", 250, [this]() { this->read_data_(); });
 }
 
 void MAX6675Sensor::setup() { this->spi_setup(); }

--- a/esphome/components/midea/appliance_base.h
+++ b/esphome/components/midea/appliance_base.h
@@ -59,7 +59,7 @@ template<typename T> class ApplianceBase : public Component {
  public:
   ApplianceBase() {
     this->base_.setStream(&this->stream_);
-    this->base_.addOnStateCallback(std::bind(&ApplianceBase::on_status_change, this));
+    this->base_.addOnStateCallback([this]() { this->on_status_change(); });
     dudanov::midea::ApplianceBase::setLogger(
         [](int level, const char *tag, int line, const String &format, va_list args) {
           esp_log_vprintf_(level, tag, line, format.c_str(), args);

--- a/esphome/components/ms5611/ms5611.cpp
+++ b/esphome/components/ms5611/ms5611.cpp
@@ -45,8 +45,7 @@ void MS5611Component::update() {
     return;
   }
 
-  auto f = std::bind(&MS5611Component::read_temperature_, this);
-  this->set_timeout("temperature", 10, f);
+  this->set_timeout("temperature", 10, [this]() { this->read_temperature_(); });
 }
 void MS5611Component::read_temperature_() {
   uint8_t bytes[3];
@@ -62,8 +61,7 @@ void MS5611Component::read_temperature_() {
     return;
   }
 
-  auto f = std::bind(&MS5611Component::read_pressure_, this, raw_temperature);
-  this->set_timeout("pressure", 10, f);
+  this->set_timeout("pressure", 10, [this, raw_temperature]() { this->read_pressure_(raw_temperature); });
 }
 void MS5611Component::read_pressure_(uint32_t raw_temperature) {
   uint8_t bytes[3];

--- a/esphome/components/ms8607/ms8607.cpp
+++ b/esphome/components/ms8607/ms8607.cpp
@@ -281,9 +281,8 @@ void MS8607Component::request_read_temperature_() {
     return;
   }
 
-  auto f = std::bind(&MS8607Component::read_temperature_, this);
   // datasheet says 17.2ms max conversion time at OSR 8192
-  this->set_timeout("temperature", 20, f);
+  this->set_timeout("temperature", 20, [this]() { this->read_temperature_(); });
 }
 
 void MS8607Component::read_temperature_() {
@@ -303,9 +302,8 @@ void MS8607Component::request_read_pressure_(uint32_t d2_raw_temperature) {
     return;
   }
 
-  auto f = std::bind(&MS8607Component::read_pressure_, this, d2_raw_temperature);
   // datasheet says 17.2ms max conversion time at OSR 8192
-  this->set_timeout("pressure", 20, f);
+  this->set_timeout("pressure", 20, [this, d2_raw_temperature]() { this->read_pressure_(d2_raw_temperature); });
 }
 
 void MS8607Component::read_pressure_(uint32_t d2_raw_temperature) {
@@ -325,9 +323,8 @@ void MS8607Component::request_read_humidity_(float temperature_float) {
     return;
   }
 
-  auto f = std::bind(&MS8607Component::read_humidity_, this, temperature_float);
   // datasheet says 15.89ms max conversion time at OSR 8192
-  this->set_timeout("humidity", 20, f);
+  this->set_timeout("humidity", 20, [this, temperature_float]() { this->read_humidity_(temperature_float); });
 }
 
 void MS8607Component::read_humidity_(float temperature_float) {

--- a/esphome/components/nau7802/nau7802.cpp
+++ b/esphome/components/nau7802/nau7802.cpp
@@ -83,8 +83,7 @@ void NAU7802Sensor::setup() {
 
   // turn on AFE
   pu_ctrl |= PU_CTRL_POWERUP_ANALOG;
-  auto f = std::bind(&NAU7802Sensor::complete_setup_, this);
-  this->set_timeout(600, f);
+  this->set_timeout(600, [this]() { this->complete_setup_(); });
 }
 
 void NAU7802Sensor::complete_setup_() {

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -63,7 +63,7 @@ void SHT4XComponent::setup() {
     }
     ESP_LOGD(TAG, "Heater command: %x", this->heater_command_);
 
-    this->set_interval(heater_interval, std::bind(&SHT4XComponent::start_heater_, this));
+    this->set_interval(heater_interval, [this]() { this->start_heater_(); });
   }
 }
 

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -335,8 +335,8 @@ Sprinkler::Sprinkler(const char *name) : name_(name) {
   // The `name` is stored for dump_config logging
   this->timer_.init(2);
   // Timer names only need to be unique within this component instance
-  this->timer_.push_back({"sm", false, 0, 0, std::bind(&Sprinkler::sm_timer_callback_, this)});
-  this->timer_.push_back({"vs", false, 0, 0, std::bind(&Sprinkler::valve_selection_callback_, this)});
+  this->timer_.push_back({"sm", false, 0, 0, [this]() { this->sm_timer_callback_(); }});
+  this->timer_.push_back({"vs", false, 0, 0, [this]() { this->valve_selection_callback_(); }});
 }
 
 void Sprinkler::setup() {


### PR DESCRIPTION
# What does this implement/fix?

Mechanical replacement of `std::bind` with equivalent lambdas across 13 components. `std::bind` produces larger callable objects than lambdas, is harder to read, and pulls in `<functional>` template machinery.

**Components converted (16 call sites):**

| Component | Call sites | Context |
|-----------|-----------|---------|
| `sht4x` | 1 | `set_interval` |
| `nau7802` | 1 | `set_timeout` |
| `max31855` | 1 | `set_timeout` |
| `max31865` | 1 | `set_timeout` |
| `max31856` | 1 | `set_timeout` |
| `max6675` | 1 | `set_timeout` |
| `dps310` | 1 | `set_timeout` |
| `ms5611` | 2 | `set_timeout` (one captures `raw_temperature`) |
| `ms8607` | 3 | `set_timeout` (two capture extra values) |
| `esp32_improv` | 1 | `set_timeout` |
| `improv_serial` | 1 | `set_timeout` |
| `sprinkler` | 2 | timer vector |
| `midea` | 1 | `addOnStateCallback` |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Chained off https://github.com/esphome/esphome/pull/14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).