### PR TITLE
[api] Replace std::bind with lambdas in CustomAPIDevice

### DIFF
--- a/esphome/components/api/custom_api_device.h
+++ b/esphome/components/api/custom_api_device.h
@@ -136,8 +136,9 @@ class CustomAPIDevice {
   template<typename T>
   void subscribe_homeassistant_state(void (T::*callback)(StringRef), const std::string &entity_id,
                                      const std::string &attribute = "") {
-    auto f = std::bind(callback, (T *) this, std::placeholders::_1);
-    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute), std::move(f));
+    auto *obj = static_cast<T *>(this);
+    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute),
+                                                      [obj, callback](StringRef state) { (obj->*callback)(state); });
   }
 
   /** Subscribe to the state (or attribute state) of an entity from Home Assistant (legacy std::string version).
@@ -148,10 +149,12 @@ class CustomAPIDevice {
   ESPDEPRECATED("Use void callback(StringRef) instead. Will be removed in 2027.1.0.", "2026.1.0")
   void subscribe_homeassistant_state(void (T::*callback)(std::string), const std::string &entity_id,
                                      const std::string &attribute = "") {
-    auto f = std::bind(callback, (T *) this, std::placeholders::_1);
+    auto *obj = static_cast<T *>(this);
     // Explicit type to disambiguate overload resolution
-    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute),
-                                                      std::function<void(const std::string &)>(f));
+    global_api_server->subscribe_home_assistant_state(
+        entity_id, optional<std::string>(attribute),
+        std::function<void(const std::string &)>(
+            [obj, callback](const std::string &state) { (obj->*callback)(state); }));
   }
 
   /** Subscribe to the state (or attribute state) of an entity from Home Assistant.
@@ -176,8 +179,10 @@ class CustomAPIDevice {
   template<typename T>
   void subscribe_homeassistant_state(void (T::*callback)(const std::string &, StringRef), const std::string &entity_id,
                                      const std::string &attribute = "") {
-    auto f = std::bind(callback, (T *) this, entity_id, std::placeholders::_1);
-    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute), std::move(f));
+    auto *obj = static_cast<T *>(this);
+    global_api_server->subscribe_home_assistant_state(
+        entity_id, optional<std::string>(attribute),
+        [obj, callback, entity_id](StringRef state) { (obj->*callback)(entity_id, state); });
   }
 
   /** Subscribe to the state (or attribute state) of an entity from Home Assistant (legacy std::string version).
@@ -188,10 +193,12 @@ class CustomAPIDevice {
   ESPDEPRECATED("Use void callback(const std::string &, StringRef) instead. Will be removed in 2027.1.0.", "2026.1.0")
   void subscribe_homeassistant_state(void (T::*callback)(std::string, std::string), const std::string &entity_id,
                                      const std::string &attribute = "") {
-    auto f = std::bind(callback, (T *) this, entity_id, std::placeholders::_1);
+    auto *obj = static_cast<T *>(this);
     // Explicit type to disambiguate overload resolution
-    global_api_server->subscribe_home_assistant_state(entity_id, optional<std::string>(attribute),
-                                                      std::function<void(const std::string &)>(f));
+    global_api_server->subscribe_home_assistant_state(
+        entity_id, optional<std::string>(attribute),
+        std::function<void(const std::string &)>(
+            [obj, callback, entity_id](const std::string &state) { (obj->*callback)(entity_id, state); }));
   }
 #else
   template<typename T>


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::bind` calls in `CustomAPIDevice::subscribe_homeassistant_state` template methods with equivalent lambdas. Also replaces C-style `(T *) this` casts with `static_cast<T *>(this)` for type safety.

**4 call sites converted** across 4 overloads of `subscribe_homeassistant_state`:
- `void(T::*)(StringRef)` — captures `[obj, callback]`
- `void(T::*)(std::string)` (deprecated) — captures `[obj, callback]`
- `void(T::*)(const std::string &, StringRef)` — captures `[obj, callback, entity_id]`
- `void(T::*)(std::string, std::string)` (deprecated) — captures `[obj, callback, entity_id]`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Chained off https://github.com/esphome/esphome/pull/14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).