### PR TITLE
[http_request] Replace std::bind with lambdas in HttpRequestSendAction

### DIFF
--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -487,12 +487,10 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       body = this->body_.value(x...);
     }
     if (!this->json_.empty()) {
-      auto f = std::bind(&HttpRequestSendAction<Ts...>::encode_json_, this, x..., std::placeholders::_1);
-      body = json::build_json(f);
+      body = json::build_json([this, x...](JsonObject root) { this->encode_json_(x..., root); });
     }
     if (this->json_func_ != nullptr) {
-      auto f = std::bind(&HttpRequestSendAction<Ts...>::encode_json_func_, this, x..., std::placeholders::_1);
-      body = json::build_json(f);
+      body = json::build_json([this, x...](JsonObject root) { this->json_func_(x..., root); });
     }
     std::vector<Header> request_headers;
     request_headers.reserve(this->request_headers_.size());
@@ -561,7 +559,6 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
       root[item.first] = val.value(x...);
     }
   }
-  void encode_json_func_(Ts... x, JsonObject root) { this->json_func_(x..., root); }
   HttpRequestComponent *parent_;
   FixedVector<std::pair<const char *, TemplatableValue<const char *, Ts...>>> request_headers_{};
   std::vector<std::string> lower_case_collect_headers_{"content-type", "content-length"};


### PR DESCRIPTION
# What does this implement/fix?

Replace `std::bind` calls with `[this, x...]` lambdas for JSON encoding in `HttpRequestSendAction::play()`. The lambda captures the parameter pack directly, eliminating the need for the intermediate `encode_json_func_` helper which is removed.

**2 call sites converted:**
- `encode_json_` via `std::bind` → inline lambda calling `this->encode_json_(x..., root)`
- `encode_json_func_` via `std::bind` → inline lambda calling `this->json_func_(x..., root)` directly (helper removed)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Chained off https://github.com/esphome/esphome/pull/14923

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal optimization, no config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).