### PR TITLE
[nextion] Fix inline doc parameter types for page and touch callbacks

### DIFF
--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -1160,13 +1160,13 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
 
   /** Add a callback to be notified when the nextion changes pages.
    *
-   * @param callback The void(std::string) callback.
+   * @param callback The void(uint8_t) callback.
    */
   template<typename F> void add_new_page_callback(F &&callback) { this->page_callback_.add(std::forward<F>(callback)); }
 
   /** Add a callback to be notified when Nextion has a touch event.
    *
-   * @param callback The void() callback.
+   * @param callback The void(uint8_t, uint8_t, bool) callback.
    */
   template<typename F> void add_touch_event_callback(F &&callback) {
     this->touch_callback_.add(std::forward<F>(callback));


### PR DESCRIPTION
# What does this implement/fix?

Fix incorrect `@param` doc comments for the `add_new_page_callback()` and `add_touch_event_callback()` inline documentation in `nextion.h`.

### Changes

- `add_new_page_callback()`: corrected callback parameter type from `std::string` to `uint8_t`, matching the actual `CallbackManager<void(uint8_t)>` signature.
- `add_touch_event_callback()`: corrected callback signature from `void()` to `void(uint8_t, uint8_t, bool)`, matching the actual `CallbackManager<void(uint8_t, uint8_t, bool)>` signature.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
