### PR TITLE
[audio] Bump microOpus to avoid creating an extra opus-staged directory

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -214,4 +214,4 @@ async def to_code(config):
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
     if data.opus_support:
         cg.add_define("USE_AUDIO_OPUS_SUPPORT")
-        add_idf_component(name="esphome/micro-opus", ref="0.3.5")
+        add_idf_component(name="esphome/micro-opus", ref="0.3.6")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -4,7 +4,7 @@ dependencies:
   esphome/esp-audio-libs:
     version: 2.0.3
   esphome/micro-opus:
-    version: 0.3.5
+    version: 0.3.6
   espressif/esp-dsp:
     version: "1.7.1"
   espressif/esp-tflite-micro:

--- a/script/analyze_component_buses.py
+++ b/script/analyze_component_buses.py
@@ -83,6 +83,7 @@ ISOLATED_COMPONENTS = {
     "openthread": "Conflicts with wifi: used by most components",
     "openthread_info": "Conflicts with wifi: used by most components",
     "matrix_keypad": "Needs isolation due to keypad",
+    "microphone": "Defines PDM microphone requiring I2S port 0 - conflicts with micro_wake_word PDM mic when merged",
     "modbus_controller": "Defines multiple modbus buses for testing client/server functionality - conflicts with package modbus bus",
     "neopixelbus": "RMT type conflict with ESP32 Arduino/ESP-IDF headers (enum vs struct rmt_channel_t)",
     "packages": "cannot merge packages",


### PR DESCRIPTION
# What does this implement/fix?

The microOpus library copies the upstream opus library and patches it in an opus-staged directory. Previously, it would do this twice. The first time would create an opus-staged directory in the current folder, even though it was unused. This bumps microOpus to v0.3.6 ([GitHub release](https://github.com/esphome-libs/micro-opus/releases/tag/v0.3.6), [Espressif Component Registry](https://components.espressif.com/components/esphome/micro-opus/versions/0.3.6/readme)) where it only does the staging in the internal build directory.

Isolates the microphone test from others. With the recent changes to the i2s_audio component on dev (removing legacy), it failed when the tests were merged. I can do this in a separate PR if desired!

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
