### PR TITLE
[uart] Fix UART0 default pin IOMUX loopback on ESP32

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -7,7 +7,9 @@
 #include "esphome/core/log.h"
 #include "esphome/core/gpio.h"
 #include "driver/gpio.h"
+#include "esp_private/gpio.h"
 #include "soc/gpio_num.h"
+#include "soc/uart_pins.h"
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
 #include "esphome/core/application.h"
@@ -20,6 +22,20 @@
 namespace esphome::uart {
 
 static const char *const TAG = "uart.idf";
+
+/// Check if a pin number matches one of the default UART0 GPIO pins.
+/// These pins may have residual IOMUX state from the ROM bootloader that
+/// must be cleared before UART reconfiguration.
+///
+/// ESP-IDF's uart_set_pin() has an asymmetry: when routing TX via GPIO matrix,
+/// it calls gpio_func_sel(PIN_FUNC_GPIO) to clear IOMUX, but for RX it only
+/// calls gpio_input_enable() which does NOT clear the IOMUX function select.
+/// If a default UART0 TX pin (configured as TX via IOMUX during boot) is later
+/// reassigned as RX via GPIO matrix, the old IOMUX TX function remains active,
+/// causing TX data to loop back into RX on the same pin.
+static constexpr bool is_default_uart0_pin(int8_t pin_num) {
+  return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM;
+}
 
 uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;
@@ -131,6 +147,19 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
+  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
+  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
+  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
+
+  // Clear residual IOMUX function on UART0 default pins left by the ROM bootloader.
+  // See is_default_uart0_pin() comment for details on the ESP-IDF uart_set_pin() bug.
+  if (is_default_uart0_pin(tx)) {
+    gpio_func_sel(static_cast<gpio_num_t>(tx), PIN_FUNC_GPIO);
+  }
+  if (is_default_uart0_pin(rx)) {
+    gpio_func_sel(static_cast<gpio_num_t>(rx), PIN_FUNC_GPIO);
+  }
+
   auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
@@ -145,10 +174,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
-
-  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
-  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
-  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {


### PR DESCRIPTION
# What does this implement/fix?

Fix UART communication broken on ESP32 chips when using UART0 default pins with swapped TX/RX assignment (e.g. ESP32-C3 with `tx_pin: GPIO20, rx_pin: GPIO21`).

## History

This is the latest chapter in a long-running pin initialization saga:

1. **#9248** — Added `pin->setup()` for all UART pins to support pullup/pulldown settings.
2. **#11823** — Reported that unconditional `pin->setup()` broke external components relying on default pin state.
3. **#11914** — Fix: only call `pin->setup()` when pullup/pulldown/open-drain flags are set. This fixed #11823 but meant UART0 default pins no longer got their residual boot state cleared.
4. **#10132** — Reported that UART0 default pins (especially on ESP32-C3) stopped working because the ROM bootloader's IOMUX state was no longer being cleared.
5. **#14130** — Fix: call `gpio_reset_pin()` + always call `pin->setup()` for UART0 default pins. This fixed #10132 but `gpio_reset_pin()` is a big hammer (disables input/output, enables pull-up, changes function select).
6. **#14363** — Reverted #14130, trusting that ESP-IDF 5.5.2 fixed `uart_set_pin()` internally.
7. **#14612, #14973** — The revert broke UART0 default pins again. The ESP-IDF fix is incomplete.

Each previous fix solved one group of users while breaking another. This PR attempts a more targeted approach that should work for everyone.

## Root cause

The ROM bootloader configures UART0 default pins via IOMUX for console output. ESP-IDF's `uart_set_pin()` has an incomplete fix: when routing TX via GPIO matrix it clears the IOMUX function select (via `gpio_func_sel(PIN_FUNC_GPIO)` inside `gpio_matrix_output()`), but for RX it only calls `gpio_input_enable()` which does **not** clear the IOMUX function select.

TX path in [`uart_set_pin()`](https://github.com/espressif/esp-idf/blob/v5.5.3/components/esp_driver_uart/src/uart.c#L1159) — clears IOMUX via `gpio_matrix_output()` → `gpio_hal_matrix_out()` → `gpio_ll_func_sel(PIN_FUNC_GPIO)` ✓

RX path in [`uart_set_pin()`](https://github.com/espressif/esp-idf/blob/v5.5.3/components/esp_driver_uart/src/uart.c#L1174) — does NOT clear IOMUX ✗:
```c
gpio_input_enable(rx_io_num);           // only enables input buffer
esp_rom_gpio_connect_in_signal(rx_io_num, ...);
```

[`gpio_input_enable()`](https://github.com/espressif/esp-idf/blob/v5.5.3/components/esp_driver_gpio/src/gpio.c#L189-L194) → `gpio_hal_input_enable()` → `gpio_ll_input_enable()` — sets `FUN_IE` (bit 9) in the IO MUX register to enable the input buffer. It does not touch the function select field (`MCU_SEL`, bits 12-14).

If a default UART0 TX pin is later reassigned as RX via GPIO matrix, the old IOMUX TX function remains active alongside the new GPIO matrix RX input. This causes transmitted data to loop back into the RX path internally. The device receives its own TX data as echo, and the connected peripheral never responds.

This is an upstream ESP-IDF bug — the RX GPIO matrix path in `uart_set_pin()` should clear the IOMUX function select the same way the TX path does.

## Fix

The fix calls `gpio_func_sel(pin, PIN_FUNC_GPIO)` on UART0 default pins before `uart_set_pin()` to clear the residual IOMUX routing. This only writes the IO MUX function select field (`MCU_SEL`, bits 12-14) — it does not change direction, pull resistors, input/output enable, or any other pin state.

Unlike the previous `gpio_reset_pin()` approach (#14130) which disables input/output and enables pull-up, this should not break external components that rely on default pin state (#11823).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14973
- fixes https://github.com/esphome/esphome/issues/14612

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ESP32-C3 with UART0 default pins swapped (triggers the bug without fix)
esp32:
  board: esp32-c3-devkitm-1
  framework:
    type: arduino

uart:
  tx_pin: GPIO20
  rx_pin: GPIO21
  baud_rate: 9600

climate:
  - platform: midea
    name: aire
    autoconf: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).