### PR TITLE
[logger] Fix ESP8266 crash with VERY_VERBOSE log level

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -329,7 +329,6 @@ async def to_code(config: ConfigType) -> None:
     baud_rate: int = config[CONF_BAUD_RATE]
     level = config[CONF_LEVEL]
     CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
-    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
     tx_buffer_size = config[CONF_TX_BUFFER_SIZE]
     cg.add_define("ESPHOME_LOGGER_TX_BUFFER_SIZE", tx_buffer_size)
     log = cg.new_Pvariable(
@@ -348,10 +347,22 @@ async def to_code(config: ConfigType) -> None:
                 HARDWARE_UART_TO_UART_SELECTION[config[CONF_HARDWARE_UART]]
             )
         )
-    # pre_setup() must be called before init_log_buffer() because
-    # init_log_buffer() calls disable_loop() which may log at VV level,
-    # and global_logger must be set before any logging occurs.
+    # pre_setup() sets global_logger and must run before any other code
+    # that may call ESP_LOG* (e.g. setup_preferences contains ESP_LOGVV).
     cg.add(log.pre_setup())
+
+    # Schedule the rest of logger setup at DIAGNOSTICS priority, after
+    # Application is constructed (CORE priority) but before most components.
+    CORE.add_job(_late_logger_init, config)
+
+
+@coroutine_with_priority(CoroPriority.DIAGNOSTICS)
+async def _late_logger_init(config: ConfigType) -> None:
+    """Finish logger setup after Application is constructed."""
+    log = await cg.get_variable(config[CONF_ID])
+    level = config[CONF_LEVEL]
+    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
+    baud_rate: int = config[CONF_BAUD_RATE]
     if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
         task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
         if task_log_buffer_size > 0:

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -350,6 +350,8 @@ async def to_code(config: ConfigType) -> None:
     # pre_setup() sets global_logger and must run before any other code
     # that may call ESP_LOG* (e.g. setup_preferences contains ESP_LOGVV).
     cg.add(log.pre_setup())
+    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
+    cg.add(log.set_log_level(initial_level))
 
     # Schedule the rest of logger setup at DIAGNOSTICS priority, after
     # Application is constructed (CORE priority) but before most components.
@@ -361,7 +363,6 @@ async def _late_logger_init(config: ConfigType) -> None:
     """Finish logger setup after Application is constructed."""
     log = await cg.get_variable(config[CONF_ID])
     level = config[CONF_LEVEL]
-    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
     baud_rate: int = config[CONF_BAUD_RATE]
     if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
         task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
@@ -374,8 +375,6 @@ async def _late_logger_init(config: ConfigType) -> None:
         cg.add(log.create_pthread_key())
         cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
         cg.add(log.init_log_buffer(64))  # Fixed 64 slots for host
-
-    cg.add(log.set_log_level(initial_level))
 
     # Enable runtime tag levels if logs are configured or explicitly enabled
     logs_config = config[CONF_LOGS]

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -56,6 +56,7 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE, CoroPriority, Lambda, coroutine_with_priority
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
 logger_ns = cg.esphome_ns.namespace("logger")
@@ -323,9 +324,9 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-@coroutine_with_priority(CoroPriority.DIAGNOSTICS)
-async def to_code(config):
-    baud_rate = config[CONF_BAUD_RATE]
+@coroutine_with_priority(CoroPriority.LOGGER_INIT)
+async def to_code(config: ConfigType) -> None:
+    baud_rate: int = config[CONF_BAUD_RATE]
     level = config[CONF_LEVEL]
     CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
     initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -324,7 +324,7 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-@coroutine_with_priority(CoroPriority.LOGGER_INIT)
+@coroutine_with_priority(CoroPriority.EARLY_INIT)
 async def to_code(config: ConfigType) -> None:
     baud_rate: int = config[CONF_BAUD_RATE]
     level = config[CONF_LEVEL]

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -587,7 +587,9 @@ async def _add_looping_components() -> None:
 
 @coroutine_with_priority(CoroPriority.CORE)
 async def to_code(config: ConfigType) -> None:
-    cg.add_global(cg.global_ns.namespace("esphome").using)
+    # using namespace esphome is hardcoded in writer.py to guarantee it
+    # precedes all variable declarations regardless of coroutine priority.
+
     # These can be used by user lambdas, put them to default scope
     # picolibc (IDF 6.0+) declares isnan in global scope, conflicting with using std::isnan
     cg.add_global(cg.RawStatement("#ifndef __PICOLIBC__"))

--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -63,11 +63,11 @@ class CoroPriority(enum.IntEnum):
     resolution during code generation.
     """
 
-    # Logger early init - must run before all other code because:
-    # 1. All code assumes global_logger is ready for ESP_LOG* calls
-    # 2. Without this, any log call before logger init dereferences nullptr
+    # Early init - runs before platform init and before Application exists.
+    # Currently used only to connect logging so ESP_LOG* calls work
+    # immediately in all subsequent phases.
     # Examples: logger (1100)
-    LOGGER_INIT = 1100
+    EARLY_INIT = 1100
 
     # Platform initialization
     # Examples: esp32, esp8266, rp2040

--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -63,7 +63,13 @@ class CoroPriority(enum.IntEnum):
     resolution during code generation.
     """
 
-    # Platform initialization - must run first
+    # Logger early init - must run before all other code because:
+    # 1. All code assumes global_logger is ready for ESP_LOG* calls
+    # 2. Without this, any log call before logger init dereferences nullptr
+    # Examples: logger (1100)
+    LOGGER_INIT = 1100
+
+    # Platform initialization
     # Examples: esp32, esp8266, rp2040
     PLATFORM = 1000
 
@@ -83,7 +89,7 @@ class CoroPriority(enum.IntEnum):
     CORE = 100
 
     # Diagnostic and debugging systems
-    # Examples: logger (90)
+    # Examples: debug component (90)
     DIAGNOSTICS = 90
 
     # Status and monitoring systems

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -381,7 +381,10 @@ def write_cpp(code_s):
         code_format = CPP_BASE_FORMAT
 
     copy_src_tree()
+    # using namespace esphome must precede all variable declarations since
+    # codegen types assume this namespace is in scope (esphome_ns = global_ns).
     global_s = '#include "esphome.h"\n'
+    global_s += "using namespace esphome;\n"
     global_s += CORE.cpp_global_section
 
     full_file = f"{code_format[0] + CPP_INCLUDE_BEGIN}\n{global_s}{CPP_INCLUDE_END}"


### PR DESCRIPTION
# What does this implement/fix?

Fixes the ESP8266 boot crash (`LoadProhibitedCause` exception 28) when using `logger: level: VERY_VERBOSE`.

The root cause is a codegen ordering issue: `setup_preferences()` was emitted at `PLATFORM` priority (1000) which ran before `Logger::pre_setup()` (emitted at `DIAGNOSTICS` priority 90). With `VERY_VERBOSE`, the `ESP_LOGVV` call in `ESP8266Preferences::setup()` dereferences `global_logger` which is still `nullptr` at that point.

With `VERBOSE` (level 6), `ESP_LOGVV` compiles to a no-op, which is why only `VERY_VERBOSE` crashes.

### Changes

- Add `EARLY_INIT` codegen priority (1100) above `PLATFORM` (1000) — a pre-Application phase where only logging setup belongs currently
- Split logger `to_code` into two phases:
  - **EARLY_INIT (1100):** Object creation, UART selection, and `pre_setup()` (sets `global_logger` so ESP_LOG* works immediately)
  - **DIAGNOSTICS (90):** `register_component`, `set_log_level`, `init_log_buffer`, and remaining setup (needs Application to exist)
- Hardcode `using namespace esphome;` in `writer.py` before all codegen globals so variable declarations work regardless of priority ordering
- Remove the now-redundant `add_global(using namespace esphome)` from `config.py`

### Generated setup() order before fix
```
setup_preferences();        // PLATFORM (1000) — ESP_LOGVV crashes here
...
new (&App) Application();   // CORE (100)
logger->pre_setup();        // DIAGNOSTICS (90) — sets global_logger too late
App.register_component_(logger);
```

### Generated setup() order after fix
```
logger->pre_setup();        // EARLY_INIT (1100) — sets global_logger first
...
setup_preferences();        // PLATFORM (1000) — ESP_LOGVV works now
...
new (&App) Application();   // CORE (100)
App.register_component_(logger);  // DIAGNOSTICS (90) — App exists
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14970

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
logger:
  level: VERY_VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).