### PR TITLE
[mhz19] Fix unused function warning for detection_range_to_log_string

### DIFF
--- a/esphome/components/mhz19/mhz19.cpp
+++ b/esphome/components/mhz19/mhz19.cpp
@@ -16,6 +16,7 @@ static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_2000PPM[] = {0xFF, 0x01, 0x
 static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_5000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x13, 0x88};
 static const uint8_t MHZ19_COMMAND_DETECTION_RANGE_0_10000PPM[] = {0xFF, 0x01, 0x99, 0x00, 0x00, 0x00, 0x27, 0x10};
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
 static const LogString *detection_range_to_log_string(MHZ19DetectionRange range) {
   switch (range) {
     case MHZ19_DETECTION_RANGE_0_2000PPM:
@@ -28,6 +29,7 @@ static const LogString *detection_range_to_log_string(MHZ19DetectionRange range)
       return LOG_STR("default");
   }
 }
+#endif
 
 uint8_t mhz19_checksum(const uint8_t *command) {
   uint8_t sum = 0;


### PR DESCRIPTION
# What does this implement/fix?

Fixes compiler warning `-Wunused-function` for `detection_range_to_log_string()` when the log level is set below DEBUG (e.g., INFO, WARN, ERROR, NONE).

The function is only called from `ESP_LOGD` and `ESP_LOGCONFIG` macros, which are compiled out at lower log levels. Without a matching preprocessor guard on the function definition, the compiler warns it is defined but never used.

Adds `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG` guard around the function.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14975

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml - set log level below DEBUG to reproduce the warning
logger:
  level: WARN

uart:
  rx_pin: GPIO3
  tx_pin: GPIO1
  baud_rate: 9600

sensor:
  - platform: mhz19
    co2:
      name: "MH-Z19 CO2"
    temperature:
      name: "MH-Z19 Temperature"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).