### PR TITLE
[core] Use SplitMix32 PRNG for random_uint32()

### DIFF
--- a/esphome/components/esp32/helpers.cpp
+++ b/esphome/components/esp32/helpers.cpp
@@ -14,7 +14,6 @@
 
 namespace esphome {
 
-uint32_t random_uint32() { return esp_random(); }
 bool random_bytes(uint8_t *data, size_t len) {
   esp_fill_random(data, len);
   return true;

--- a/esphome/components/host/helpers.cpp
+++ b/esphome/components/host/helpers.cpp
@@ -8,8 +8,6 @@
 #include <sys/ioctl.h>
 #endif
 #include <unistd.h>
-#include <limits>
-#include <random>
 
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
@@ -17,13 +15,6 @@
 namespace esphome {
 
 static const char *const TAG = "helpers.host";
-
-uint32_t random_uint32() {
-  std::random_device dev;
-  std::mt19937 rng(dev());
-  std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
-  return dist(rng);
-}
 
 bool random_bytes(uint8_t *data, size_t len) {
   FILE *fp = fopen("/dev/urandom", "r");

--- a/esphome/components/libretiny/helpers.cpp
+++ b/esphome/components/libretiny/helpers.cpp
@@ -8,8 +8,6 @@
 
 namespace esphome {
 
-uint32_t random_uint32() { return rand(); }
-
 bool random_bytes(uint8_t *data, size_t len) {
   lt_rand_bytes(data, len);
   return true;

--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -16,15 +16,6 @@
 
 namespace esphome {
 
-uint32_t random_uint32() {
-  uint32_t result = 0;
-  for (uint8_t i = 0; i < 32; i++) {
-    result <<= 1;
-    result |= rosc_hw->randombit;
-  }
-  return result;
-}
-
 bool random_bytes(uint8_t *data, size_t len) {
   while (len-- != 0) {
     uint8_t result = 0;

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -122,6 +122,8 @@ def zephyr_to_code(config: ConfigType) -> None:
     zephyr_add_prj_conf("FPU", True)
     zephyr_add_prj_conf("NEWLIB_LIBC_FLOAT_PRINTF", True)
     zephyr_add_prj_conf("STD_CPP20", True)
+    # random_bytes() uses sys_rand_get() which requires the entropy subsystem
+    zephyr_add_prj_conf("ENTROPY_GENERATOR", True)
 
     # <err> os: ***** USAGE FAULT *****
     # <err> os:   Illegal load of EXC_RETURN into PC

--- a/esphome/components/zephyr/core.cpp
+++ b/esphome/components/zephyr/core.cpp
@@ -75,7 +75,6 @@ IRAM_ATTR InterruptLock::~InterruptLock() { irq_unlock(state_); }
 
 // Zephyr LwIPLock is defined inline as a no-op in helpers.h
 
-uint32_t random_uint32() { return rand(); }  // NOLINT(cert-msc30-c, cert-msc50-cpp)
 bool random_bytes(uint8_t *data, size_t len) {
   sys_rand_get(data, len);
   return true;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -156,6 +156,25 @@ uint32_t fnv1_hash(const char *str) {
   return hash;
 }
 
+// SplitMix32 PRNG — MurmurHash3 finalizer with golden-ratio increment.
+// Provides fast, uniform, non-cryptographic random numbers.
+// Seeded lazily from the platform's hardware RNG via random_bytes().
+// ESP8266 uses os_random() instead (defined in esp8266/helpers.cpp).
+#ifndef USE_ESP8266
+static uint32_t splitmix32_state;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+uint32_t random_uint32() {
+  if (splitmix32_state == 0) {
+    random_bytes(reinterpret_cast<uint8_t *>(&splitmix32_state), sizeof(splitmix32_state));
+  }
+  splitmix32_state += 0x9e3779b9u;
+  uint32_t z = splitmix32_state;
+  z = (z ^ (z >> 16)) * 0x85ebca6bu;
+  z = (z ^ (z >> 13)) * 0xc2b2ae35u;
+  return z ^ (z >> 16);
+}
+#endif
+
 float random_float() { return static_cast<float>(random_uint32()) / static_cast<float>(UINT32_MAX); }
 
 // Strings

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -158,7 +158,7 @@ uint32_t fnv1_hash(const char *str) {
 
 // SplitMix32 PRNG — MurmurHash3 finalizer with golden-ratio increment.
 // Provides fast, uniform, non-cryptographic random numbers.
-// Seeded lazily from the platform's hardware RNG via random_bytes().
+// Seeded lazily from the platform's secure RNG via random_bytes().
 // ESP8266 uses os_random() instead (defined in esp8266/helpers.cpp).
 #ifndef USE_ESP8266
 static uint32_t splitmix32_state;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -156,8 +156,11 @@ uint32_t fnv1_hash(const char *str) {
   return hash;
 }
 
-// SplitMix32 PRNG — MurmurHash3 finalizer with golden-ratio increment.
-// Provides fast, uniform, non-cryptographic random numbers.
+// SplitMix32 — a fast, non-cryptographic PRNG from the SplitMix family
+// (Steele et al., 2014). Uses a Weyl sequence with golden-ratio increment
+// and the MurmurHash3 32-bit finalizer as output mixing function.
+// Reference: https://doi.org/10.1145/2714064.2660195
+// Test results: https://lemire.me/blog/2017/08/22/testing-non-cryptographic-random-number-generators-my-results/
 // Seeded lazily from the platform's secure RNG via random_bytes().
 // ESP8266 uses os_random() instead (defined in esp8266/helpers.cpp).
 #ifndef USE_ESP8266

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -164,6 +164,9 @@ uint32_t fnv1_hash(const char *str) {
 static uint32_t splitmix32_state;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 uint32_t random_uint32() {
+  // State of 0 means unseeded. The state will wrap back to 0 after 2^32 calls,
+  // triggering one extra random_bytes() call — an acceptable trade-off vs. adding
+  // a separate bool flag (4 bytes BSS + branch on every call).
   if (splitmix32_state == 0) {
     random_bytes(reinterpret_cast<uint8_t *>(&splitmix32_state), sizeof(splitmix32_state));
   }

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -172,6 +172,7 @@ uint32_t random_uint32() {
   // a separate bool flag (4 bytes BSS + branch on every call).
   if (splitmix32_state == 0) {
     random_bytes(reinterpret_cast<uint8_t *>(&splitmix32_state), sizeof(splitmix32_state));
+    splitmix32_state |= 1;  // ensure non-zero seed
   }
   splitmix32_state += 0x9e3779b9u;
   uint32_t z = splitmix32_state;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -842,10 +842,15 @@ template<typename ReturnT = uint32_t> inline constexpr ESPHOME_ALWAYS_INLINE Ret
 }
 
 /// Return a random 32-bit unsigned integer.
+/// Not thread-safe. Must only be called from the main loop.
+/// Not suitable for cryptographic use; use random_bytes() instead.
 uint32_t random_uint32();
 /// Return a random float between 0 and 1.
+/// Not thread-safe. Must only be called from the main loop.
+/// Not suitable for cryptographic use; use random_bytes() instead.
 float random_float();
-/// Generate \p len number of random bytes.
+/// Generate \p len number of random bytes from the platform's hardware RNG.
+/// Thread-safe. Suitable for cryptographic use.
 bool random_bytes(uint8_t *data, size_t len);
 
 ///@}

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -849,7 +849,7 @@ uint32_t random_uint32();
 /// Not thread-safe. Must only be called from the main loop.
 /// Not suitable for cryptographic use; use random_bytes() instead.
 float random_float();
-/// Generate \p len number of random bytes from the platform's hardware RNG.
+/// Generate \p len random bytes using the platform's secure RNG (hardware RNG or OS CSPRNG).
 /// Thread-safe. Suitable for cryptographic use.
 bool random_bytes(uint8_t *data, size_t len);
 


### PR DESCRIPTION
# What does this implement/fix?

`random_uint32()` is used exclusively for non-cryptographic purposes: scheduler jitter, light effects, random colors, ping keys, NFC URI generation, and shuffle. None of these callers need hardware entropy or cryptographic quality — they just need fast, well-distributed values.

Despite this, every platform implemented `random_uint32()` differently, with a mismatch between what callers actually need and what the implementations provide. Some platforms overpaid massively for crypto-grade entropy that no caller needed, while others got the opposite — bare `rand()` with poor distribution:

- **ESP32**: `esp_random()` — blocks on a hardware entropy pool meant for crypto. Massive overkill for picking a random pixel color.
- **RP2040**: Reads 32 individual bits from the ROSC hardware one at a time. Correct but absurdly slow (2.8μs per call).
- **LibreTiny/Zephyr**: `rand()` — the opposite problem. C stdlib PRNG with poor distribution and no seeding guarantee. Actively bad.
- **Host**: Creates a new `std::mt19937` engine and `std::random_device` on every single call. ~4KB of state churned per invocation.

The worst of both worlds — overpaying for entropy where it wasn't needed, and getting garbage where uniformity actually mattered.

This replaces all of them (except ESP8266) with a single [SplitMix32](https://doi.org/10.1145/2714064.2660195) PRNG in core. SplitMix32 is a well-studied non-cryptographic PRNG from the SplitMix family (Steele et al., 2014) that uses a Weyl sequence with golden-ratio increment and the MurmurHash3 32-bit finalizer as output mixing function. It passes [extensive statistical testing](https://lemire.me/blog/2017/08/22/testing-non-cryptographic-random-number-generators-my-results/) including PractRand and TestU01 SmallCrush. The implementation is just two multiplies and three xor-shifts, seeded once lazily from `random_bytes()`.

Now there's a clean split: `random_uint32()` = fast PRNG for the main loop, `random_bytes()` = platform hardware RNG for crypto. Each caller gets exactly what it needs.

ESP8266 keeps `os_random()` because it's already faster there (SDK-provided, likely a simple LFSR).

`random_bytes()` is completely unchanged — it remains platform-specific hardware RNG, used by the noise protocol and other crypto paths. However, on Zephyr/nRF52 this exposed a pre-existing bug: `random_bytes()` calls `sys_rand_get()` which requires `CONFIG_ENTROPY_GENERATOR`, but this was never enabled. It only worked before because nothing called `random_bytes()` in builds without OTA password or Noise API. This PR fixes that by enabling the entropy subsystem in the base Zephyr configuration.

**Benchmarked on real hardware (ns/call, before → after):**

| Platform | Before | After | Speedup |
|----------|--------|-------|---------|
| RP2040 | 2815 ns (ROSC bit-bang) | 333 ns | **8.5x** |
| ESP32 | 871 ns (`esp_random()`) | 354 ns | **2.5x** |
| BK72xx | 1073 ns (`rand()`) | 882 ns | **1.2x** + distribution fix |
| RTL87xx | 330 ns (`rand()`) | 283 ns | **1.2x** + distribution fix |
| ESP8266 | 763 ns (`os_random()`) | unchanged | kept as-is |

CodSpeed confirms the impact on the host platform — **550x on RandomUint32** (old code created a new MT19937 engine per call) and **+74% on Scheduler_SetInterval** (calls `random_uint32()` for jitter on every interval registration).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is an internal implementation change.
# random_uint32() and random_float() continue to work as before.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).