### PR TITLE
[ci] Add libretiny and zephyr to memory impact platform filter

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -111,11 +111,13 @@ PLATFORM_SPECIFIC_COMPONENTS = frozenset(
         "esp32",  # ESP32 platform implementation
         "esp8266",  # ESP8266 platform implementation
         "rp2040",  # Raspberry Pi Pico / RP2040 platform implementation
+        "libretiny",  # LibreTiny base platform implementation
         "bk72xx",  # Beken BK72xx platform implementation (uses LibreTiny)
         "rtl87xx",  # Realtek RTL87xx platform implementation (uses LibreTiny)
         "ln882x",  # Winner Micro LN882x platform implementation (uses LibreTiny)
         "host",  # Host platform (for testing on development machine)
         "nrf52",  # Nordic nRF52 platform implementation (uses Zephyr)
+        "zephyr",  # Zephyr RTOS platform implementation
     }
 )
 


### PR DESCRIPTION
# What does this implement/fix?

`PLATFORM_SPECIFIC_COMPONENTS` in `determine-jobs.py` was missing `libretiny` and `zephyr`. This meant that when an incompatible platform (e.g., `esp32-idf`) was selected for memory impact analysis, the `libretiny` component was not filtered out — causing the memory impact comment to incorrectly show both `esp32` and `libretiny` as analyzed components.

For example, [PR #14984](https://github.com/esphome/esphome/pull/14984) changed files in both `esp32/` and `libretiny/`, and the memory impact comment listed **Components: `esp32`, `libretiny`** with platform `esp32-idf`, which is nonsensical since libretiny cannot build on esp32-idf.

This adds both `libretiny` and `zephyr` to the platform-specific set so they are correctly excluded when an incompatible platform is selected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is a CI-only fix.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).