### PR TITLE
[wifi] Reject WiFi config on RP2040/RP2350 boards without CYW43 chip

### DIFF
--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -24,6 +24,7 @@ from esphome.const import (
 from esphome.core import CORE, CoroPriority, EsphomeError, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed, read_file, write_file_if_changed
 
+from . import boards
 from .const import KEY_BOARD, KEY_PIO_FILES, KEY_RP2040, rp2040_ns
 
 # force import gpio to register pin schema
@@ -33,6 +34,16 @@ _LOGGER = logging.getLogger(__name__)
 CODEOWNERS = ["@jesserockz"]
 AUTO_LOAD = ["preferences"]
 IS_TARGET_PLATFORM = True
+
+
+def get_board() -> str:
+    """Return the configured board name."""
+    return CORE.data[KEY_RP2040][KEY_BOARD]
+
+
+def board_has_wifi() -> bool:
+    """Return True if the configured board has WiFi (CYW43 wireless chip)."""
+    return boards.BOARDS.get(get_board(), {}).get("wifi", False)
 
 
 def set_core_data(config):

--- a/esphome/components/rp2040/__init__.py
+++ b/esphome/components/rp2040/__init__.py
@@ -42,8 +42,15 @@ def get_board() -> str:
 
 
 def board_has_wifi() -> bool:
-    """Return True if the configured board has WiFi (CYW43 wireless chip)."""
-    return boards.BOARDS.get(get_board(), {}).get("wifi", False)
+    """Return True if the configured board has WiFi (CYW43 wireless chip).
+
+    Returns True for unknown/custom boards to avoid rejecting valid
+    configurations for boards not in the generated list.
+    """
+    board_info = boards.BOARDS.get(get_board())
+    if board_info is None:
+        return True
+    return board_info.get("wifi", False)
 
 
 def set_core_data(config):

--- a/esphome/components/rp2040/boards.py
+++ b/esphome/components/rp2040/boards.py
@@ -1910,6 +1910,7 @@ BOARDS = {
         "name": "Pimoroni PicoPlus2W",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "pimoroni_plasma2040": {
@@ -1926,6 +1927,7 @@ BOARDS = {
         "name": "Pimoroni Plasma2350W",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
     },
     "pimoroni_servo2040": {
         "name": "Pimoroni Servo2040",
@@ -1976,12 +1978,14 @@ BOARDS = {
         "name": "Raspberry Pi Pico 2W",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "rpipicow": {
         "name": "Raspberry Pi Pico W",
         "mcu": "rp2040",
         "max_pin": 29,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "sea_picro": {
@@ -2013,6 +2017,7 @@ BOARDS = {
         "name": "Soldered Electronics NULA RP2350",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
     },
     "solderparty_rp2040_stamp": {
         "name": "Solder Party RP2040 Stamp",
@@ -2038,6 +2043,7 @@ BOARDS = {
         "name": "SparkFun IoT RedBoard RP2350",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
     },
     "sparkfun_micromodrp2040": {
         "name": "SparkFun MicroMod RP2040",
@@ -2063,18 +2069,21 @@ BOARDS = {
         "name": "SparkFun Thing Plus RP2350",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "sparkfun_xrp_controller": {
         "name": "SparkFun XRP Controller",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "sparkfun_xrp_controller_beta": {
         "name": "SparkFun XRP Controller (Beta)",
         "mcu": "rp2040",
         "max_pin": 29,
+        "wifi": True,
         "max_virtual_pin": 64,
     },
     "upesy_rp2040_devkit": {
@@ -2161,6 +2170,7 @@ BOARDS = {
         "name": "Waveshare RP2350B Plus W",
         "mcu": "rp2350",
         "max_pin": 47,
+        "wifi": True,
     },
     "wiznet_5100s_evb_pico": {
         "name": "WIZnet W5100S-EVB-Pico",

--- a/esphome/components/rp2040/generate_boards.py
+++ b/esphome/components/rp2040/generate_boards.py
@@ -78,11 +78,17 @@ def load_boards(arduino_pico_path: Path) -> tuple[dict, dict]:
 
         display_name = f"{vendor} {name}".strip() if vendor else name
 
-        boards[board_name] = {
+        extra_flags = build.get("extra_flags", "")
+        has_wifi = "PICO_CYW43_SUPPORTED=1" in extra_flags
+
+        board_entry: dict = {
             "name": display_name,
             "mcu": mcu,
             "max_pin": MCU_MAX_PIN.get(mcu, DEFAULT_MAX_PIN),
         }
+        if has_wifi:
+            board_entry["wifi"] = True
+        boards[board_name] = board_entry
 
         # Get pins for this variant
         if variant not in variant_pins_cache:

--- a/esphome/components/wifi/__init__.py
+++ b/esphome/components/wifi/__init__.py
@@ -235,6 +235,14 @@ def validate_variant(_):
         variant = get_esp32_variant()
         if variant in NO_WIFI_VARIANTS and "esp32_hosted" not in fv.full_config.get():
             raise cv.Invalid(f"WiFi requires component esp32_hosted on {variant}")
+    if CORE.is_rp2040:
+        from esphome.components.rp2040 import board_has_wifi, get_board
+
+        if not board_has_wifi():
+            raise cv.Invalid(
+                f"Board '{get_board()}' does not have WiFi support (no CYW43 wireless chip). "
+                f"Use a WiFi-capable board like 'rpipicow' or 'rpipico2w'."
+            )
 
 
 def _apply_min_auth_mode_default(config):

--- a/tests/unit_tests/components/test_rp2040_generate_boards.py
+++ b/tests/unit_tests/components/test_rp2040_generate_boards.py
@@ -59,6 +59,7 @@ def _add_board(
     vendor: str = "",
     name: str | None = None,
     pins_header: str | None = None,
+    extra_flags: str = "",
 ) -> None:
     """Add a board JSON and variant to the fake arduino-pico tree."""
     if variant is None:
@@ -69,11 +70,15 @@ def _add_board(
     json_dir = arduino_pico / "tools" / "json"
     variants_dir = arduino_pico / "variants"
 
+    build: dict = {
+        "mcu": mcu,
+        "variant": variant,
+    }
+    if extra_flags:
+        build["extra_flags"] = extra_flags
+
     board_json = {
-        "build": {
-            "mcu": mcu,
-            "variant": variant,
-        },
+        "build": build,
         "name": name,
         "vendor": vendor,
     }
@@ -271,3 +276,35 @@ def test_placeholder_pins_not_treated_as_virtual(arduino_pico: Path) -> None:
 
     assert "MISO" not in board_pins["badpin"]
     assert boards["badpin"]["max_virtual_pin"] == 64
+
+
+def test_cyw43_supported_flag_sets_wifi(arduino_pico: Path) -> None:
+    """Boards with PICO_CYW43_SUPPORTED=1 in extra_flags should have wifi=True."""
+    _add_board(
+        arduino_pico,
+        "rpipicow",
+        vendor="Raspberry Pi",
+        name="Pico W",
+        pins_header=PICOW_PINS_HEADER,
+        extra_flags="-DARDUINO_RASPBERRY_PI_PICO_W -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1",
+    )
+
+    _, boards = load_boards(arduino_pico)
+
+    assert boards["rpipicow"]["wifi"] is True
+
+
+def test_board_without_cyw43_has_no_wifi(arduino_pico: Path) -> None:
+    """Boards without PICO_CYW43_SUPPORTED should not have wifi field."""
+    _add_board(
+        arduino_pico,
+        "rpipico",
+        vendor="Raspberry Pi",
+        name="Pico",
+        pins_header=PICO_PINS_HEADER,
+        extra_flags="-DARDUINO_RASPBERRY_PI_PICO",
+    )
+
+    _, boards = load_boards(arduino_pico)
+
+    assert "wifi" not in boards["rpipico"]


### PR DESCRIPTION
# What does this implement/fix?

Boards like `rpipico2` (Raspberry Pi Pico 2) and `rpipico` (Raspberry Pi Pico) don't have WiFi hardware (no CYW43 wireless chip), but ESPHome allowed configuring `wifi:` on them. This led to a confusing linker error with undefined references to `__wrap_cyw43_*` symbols.

This PR adds config-time validation to reject WiFi configuration on RP2040/RP2350 boards that lack WiFi hardware, with a clear error message suggesting WiFi-capable alternatives like `rpipicow` or `rpipico2w`.

Changes:
- Board generator (`generate_boards.py`) now detects `PICO_CYW43_SUPPORTED=1` in the upstream arduino-pico `extra_flags` and adds `"wifi": True` to the board definition
- Regenerated `boards.py` with the new `wifi` field for all 10 CYW43-capable boards
- Added `get_board()` and `board_has_wifi()` helpers to the `rp2040` component
- Added RP2040 board check in `wifi` component's `validate_variant()` using the new helpers

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14989

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config now produces a clear validation error instead of a linker failure:
esphome:
  name: pico-2350

rp2040:
  board: rpipico2  # No WiFi hardware

wifi:
  ssid: "my_ssid"
  password: "my_password"
```

Error message:
```
Board 'rpipico2' does not have WiFi support (no CYW43 wireless chip). Use a WiFi-capable board like 'rpipicow' or 'rpipico2w'.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).