### PR TITLE
[time] Fix timezone_offset() and recalc_timestamp_local() always returning UTC

### DIFF
--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -283,19 +283,15 @@ void ESPTime::recalc_timestamp_local() {
   bool dst_valid = time::is_in_dst(utc_if_dst, tz);
   bool std_valid = !time::is_in_dst(utc_if_std, tz);
 
-  if (dst_valid && std_valid) {
-    // Ambiguous time (repeated hour during fall-back) - prefer standard time
-    this->timestamp = utc_if_std;
-  } else if (dst_valid) {
+  if (dst_valid && !std_valid) {
     // Only DST interpretation is valid
     this->timestamp = utc_if_dst;
-  } else if (std_valid) {
-    // Only standard interpretation is valid
-    this->timestamp = utc_if_std;
   } else {
-    // Invalid time (skipped hour during spring-forward)
-    // libc normalizes forward: 02:30 CST -> 08:30 UTC -> 03:30 CDT
-    // Using std offset achieves this since the UTC result falls during DST
+    // All other cases use standard offset:
+    // - Both valid (ambiguous fall-back repeated hour): prefer standard time
+    // - Only standard valid: straightforward
+    // - Neither valid (spring-forward skipped hour): std offset normalizes
+    //   forward to match libc mktime(), e.g. 02:30 CST -> 03:30 CDT
     this->timestamp = utc_if_std;
   }
 #else

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
# What does this implement/fix?

`time.h` was missing `#include "esphome/core/defines.h"`, so `USE_TIME_TIMEZONE` was never defined when compiling `time.cpp`. This caused `timezone_offset()` to always return 0 and `recalc_timestamp_local()` to treat local time as UTC, since both functions always took the `#else` fallback path.

The user's lambda could still call `get_global_tz()` successfully because lambdas are compiled in a different translation unit that includes `esphome.h` (which transitively includes `defines.h`). So the timezone data was correctly set — it just wasn't being used by the core time functions.

Additionally, simplified the DST resolution logic in `recalc_timestamp_local()` from four branches to two. Three of the four branches (`dst_valid && std_valid`, `std_valid` only, and the fallback) all assigned `utc_if_std`, so they are collapsed into a single `else` branch. This fixes a `bugprone-branch-clone` clang-tidy warning while preserving identical behavior.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14994

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: sntp
    timezone: Asia/Taipei
    on_time_sync:
      then:
        - lambda: |-
            int32_t offset = ESPTime::timezone_offset();
            ESP_LOGW("tz", "timezone_offset() = %d", offset);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).