### PR TITLE
[web_server] Increase httpd task stack size to prevent stack overflow

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -123,9 +123,9 @@ void AsyncWebServer::begin() {
   }
   // Default httpd stack is 4096. Increase to accommodate SerializationBuffer's
   // 640-byte stack buffer used by web_server JSON request handlers.
-  constexpr size_t HTTPD_STACK_SIZE = 4096 + 256;
+  constexpr size_t httpd_stack_size = 4096 + 256;
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-  config.stack_size = HTTPD_STACK_SIZE;
+  config.stack_size = httpd_stack_size;
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -121,7 +121,11 @@ void AsyncWebServer::begin() {
   if (this->server_) {
     this->end();
   }
+  // Default httpd stack is 4096. Increase to accommodate SerializationBuffer's
+  // 640-byte stack buffer used by web_server JSON request handlers.
+  constexpr size_t HTTPD_STACK_SIZE = 4096 + 256;
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  config.stack_size = HTTPD_STACK_SIZE;
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -121,11 +121,10 @@ void AsyncWebServer::begin() {
   if (this->server_) {
     this->end();
   }
-  // Default httpd stack is 4096. Increase to accommodate SerializationBuffer's
+  // Default httpd stack is defined by ESP-IDF. Increase to accommodate SerializationBuffer's
   // 640-byte stack buffer used by web_server JSON request handlers.
-  constexpr size_t httpd_stack_size = 4096 + 256;
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-  config.stack_size = httpd_stack_size;
+  config.stack_size = config.stack_size + 256;
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.


### PR DESCRIPTION
# What does this implement/fix?

The `SerializationBuffer` introduced in #13625 places a 640-byte buffer on the stack. When handling HTTP requests on the ESP-IDF httpd task (which has a default stack size of 4096 bytes), the deep call chain from `handleRequest` → `handle_sensor_request` → `sensor_json_` → `serialize()` → `httpd_resp_send` → `lwip_send` can overflow the stack.

This manifests as either:
- `vApplicationStackOverflowHook` abort (direct stack overflow detection)
- lwip `sys_mutex_lock` assertion failure (stack corruption corrupts adjacent lwip mutex data)

We were unable to reproduce the crash in our testing. The reporter's config is a [~55KB YAML](https://github.com/joshuaboniface/supersensor/blob/v3.x/supersensor.yaml) with ~45 sensors, 25+ numbers, 5 text sensors, lights, selects, buttons, and voice assistant — likely pushing the httpd stack right to the edge.

Increasing the httpd task stack by 256 bytes (to 4352) restores headroom. This is preferable to reverting back to heap-allocated `std::string` returns because `SerializationBuffer` avoids heap churn on every JSON response — and 2026.3.0 already saved multiple hundreds of bytes of heap elsewhere, so we can afford to spend a bit on stack here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14991

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal fix
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).