### PR TITLE
[esp32] Mention ignore_pin_validation_error in flash pin error message

### DIFF
--- a/esphome/components/esp32/gpio_esp32.py
+++ b/esphome/components/esp32/gpio_esp32.py
@@ -28,7 +28,11 @@ def esp32_validate_gpio_pin(value: int) -> int:
         raise cv.Invalid(f"Invalid pin number: {value} (must be 0-39)")
     if value in _ESP_SDIO_PINS:
         raise cv.Invalid(
-            f"This pin cannot be used on ESP32s and is already used by the flash interface (function: {_ESP_SDIO_PINS[value]})"
+            f"This pin cannot be used on ESP32s and is already used by the flash interface"
+            f" (function: {_ESP_SDIO_PINS[value]})."
+            f" If you are using an ESP32 module that uses a different flash pin"
+            f" configuration (e.g. ESP32-PICO-V3-02), you can set"
+            f" 'ignore_pin_validation_error: true' to bypass this check."
         )
     if 9 <= value <= 10:
         _LOGGER.warning(


### PR DESCRIPTION
# What does this implement/fix?

The ESP32 pin validator blocks GPIO6, GPIO7, GPIO8, and GPIO11 because they are used by the flash interface on standard ESP32 modules (WROOM, WROVER, etc.). However, some ESP32 modules like the **ESP32-PICO-V3-02** use a different flash pin configuration where GPIO7 and GPIO8 are freely usable.

ESPHome already has an `ignore_pin_validation_error: true` option that allows bypassing this check, but the error message didn't mention it, making it very difficult to discover.

This PR updates the error message to tell users about `ignore_pin_validation_error` and gives the ESP32-PICO-V3-02 as a concrete example of when it's appropriate to use.

### Background: ESP32 package types and flash pins

The ESP32 comes in several package types, each with different flash pin assignments. ESP-IDF determines this at runtime via eFuses (`esp_efuse_get_pkg_ver()`), but ESPHome validates pins at compile time during YAML processing, so it cannot read eFuses from the chip.

| PKG_VERSION | Package | Flash Pins (GPIO) | GPIO 7/8 Free? |
|---|---|---|---|
| 0 | ESP32-D0WDQ6 (standard) | 6, 7, 8, 9, 10, 11 | No |
| 1 | ESP32-D0WDQ5 (standard) | 6, 7, 8, 9, 10, 11 | No |
| 2 | ESP32-D2WD (embedded flash) | varies | Varies |
| 4 | ESP32-U4WDH (embedded flash) | varies | Varies |
| 5 | ESP32-PICO-D4 | 6, 7, 8, 9, 10, 11 | No |
| 6 | **ESP32-PICO-V3-02** | **6, 9, 10, 11** | **Yes** |
| 7 | ESP32-D0WDR2-V3 | 6, 7, 8, 9, 10, 11 | No |

Since the package type is not available at YAML compile time (it lives in the chip's eFuses and PlatformIO board definitions don't carry this metadata), a proper automatic solution would require adding a `package` config option to the `esp32` component. That's a larger change — for now, making the existing workaround discoverable is the pragmatic fix.

### Before

```
This pin cannot be used on ESP32s and is already used by the flash interface (function: Flash Data 0)
```

### After

```
This pin cannot be used on ESP32s and is already used by the flash interface (function: Flash Data 0). If you are using an ESP32 module that uses a different flash pin configuration (e.g. ESP32-PICO-V3-02), you can set 'ignore_pin_validation_error: true' to bypass this check.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10400

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# For ESP32-PICO-V3-02 boards where GPIO7/8 are free:
ethernet:
  type: LAN8720
  mdc_pin:
    number: GPIO8
    ignore_pin_validation_error: true
  mdio_pin:
    number: GPIO7
    ignore_pin_validation_error: true
  clk:
    pin: GPIO0
    mode: CLK_EXT_IN
  phy_addr: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).