### PR TITLE
[number] Clean up NumberCall::perform() increment/decrement logic

### DIFF
--- a/esphome/components/number/number_call.cpp
+++ b/esphome/components/number/number_call.cpp
@@ -80,35 +80,25 @@ void NumberCall::perform() {
       target_value = max_value;
     }
   } else if (this->operation_ == NUMBER_OP_INCREMENT) {
-    ESP_LOGD(TAG, "'%s': Increment with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Increment with%s cycling", name, this->cycle_ ? LOG_STR_LITERAL("") : LOG_STR_LITERAL("out"));
     if (!parent->has_state()) {
       this->log_perform_warning_(LOG_STR("Can't increment, no state"));
       return;
     }
     auto step = traits.get_step();
     target_value = parent->state + (std::isnan(step) ? 1 : step);
-    if (target_value > max_value) {
-      if (this->cycle_ && !std::isnan(min_value)) {
-        target_value = min_value;
-      } else {
-        target_value = max_value;
-      }
-    }
+    if (target_value > max_value)
+      target_value = this->cycle_or_clamp_(max_value, min_value);
   } else if (this->operation_ == NUMBER_OP_DECREMENT) {
-    ESP_LOGD(TAG, "'%s': Decrement with%s cycling", name, this->cycle_ ? "" : "out");
+    ESP_LOGD(TAG, "'%s': Decrement with%s cycling", name, this->cycle_ ? LOG_STR_LITERAL("") : LOG_STR_LITERAL("out"));
     if (!parent->has_state()) {
       this->log_perform_warning_(LOG_STR("Can't decrement, no state"));
       return;
     }
     auto step = traits.get_step();
     target_value = parent->state - (std::isnan(step) ? 1 : step);
-    if (target_value < min_value) {
-      if (this->cycle_ && !std::isnan(max_value)) {
-        target_value = max_value;
-      } else {
-        target_value = min_value;
-      }
-    }
+    if (target_value < min_value)
+      target_value = this->cycle_or_clamp_(min_value, max_value);
   }
 
   if (target_value < min_value) {

--- a/esphome/components/number/number_call.h
+++ b/esphome/components/number/number_call.h
@@ -33,6 +33,9 @@ class NumberCall {
   NumberCall &with_cycle(bool cycle);
 
  protected:
+  float cycle_or_clamp_(float clamp, float opposite) const {
+    return (this->cycle_ && !std::isnan(opposite)) ? opposite : clamp;
+  }
   void log_perform_warning_(const LogString *message);
   void log_perform_warning_value_range_(const LogString *comparison, const LogString *limit_type, float val,
                                         float limit);


### PR DESCRIPTION
# What does this implement/fix?

Clean up the increment/decrement branches in `NumberCall::perform()`:
- Extract `cycle_or_clamp_()` inline helper to replace repeated nested if/else cycle logic
- Flatten the increment/decrement into two separate `else if` branches instead of a combined branch with inner conditional
- Use `LOG_STR_LITERAL` for cycling log strings to keep them in flash on ESP8266

No functional changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).