### PR TITLE
[logger] Move log level lookup tables to PROGMEM

### DIFF
--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -8,8 +9,8 @@ namespace esphome::logger {
 // Maximum header size: 35 bytes fixed + 32 bytes tag + 16 bytes thread name = 83 bytes (45 byte safety margin)
 static constexpr uint16_t MAX_HEADER_SIZE = 128;
 
-// ANSI color code last digit (30-38 range, store only last digit to save RAM)
-static constexpr char LOG_LEVEL_COLOR_DIGIT[] = {
+// ANSI color code last digit (30-38 range, store only last digit to save RAM on ESP8266)
+static const char LOG_LEVEL_COLOR_DIGIT[] PROGMEM = {
     '\0',  // NONE
     '1',   // ERROR (31 = red)
     '3',   // WARNING (33 = yellow)
@@ -20,7 +21,7 @@ static constexpr char LOG_LEVEL_COLOR_DIGIT[] = {
     '8',   // VERY_VERBOSE (38 = white)
 };
 
-static constexpr char LOG_LEVEL_LETTER_CHARS[] = {
+static const char LOG_LEVEL_LETTER_CHARS[] PROGMEM = {
     '\0',  // NONE
     'E',   // ERROR
     'W',   // WARNING
@@ -64,7 +65,7 @@ struct LogBuffer {
         *p++ = 'V';  // VERY_VERBOSE = "VV"
         *p++ = 'V';
       } else {
-        *p++ = LOG_LEVEL_LETTER_CHARS[level];
+        *p++ = static_cast<char>(progmem_read_byte(reinterpret_cast<const uint8_t *>(&LOG_LEVEL_LETTER_CHARS[level])));
       }
     }
     *p++ = ']';
@@ -184,7 +185,7 @@ struct LogBuffer {
     *p++ = (level == 1) ? '1' : '0';  // Only ERROR is bold
     *p++ = ';';
     *p++ = '3';
-    *p++ = LOG_LEVEL_COLOR_DIGIT[level];
+    *p++ = static_cast<char>(progmem_read_byte(reinterpret_cast<const uint8_t *>(&LOG_LEVEL_COLOR_DIGIT[level])));
     *p++ = 'm';
   }
   // Copy string without null terminator, updates pointer in place


### PR DESCRIPTION
# What does this implement/fix?

Move `LOG_LEVEL_COLOR_DIGIT` and `LOG_LEVEL_LETTER_CHARS` arrays from `.rodata` (RAM) to PROGMEM (flash) on ESP8266. These small lookup tables were placed in RAM by GCC as `static constexpr` arrays, consuming 16 bytes of precious RAM unnecessarily.

Results on a minimal ESP8266 config (`logger` only):
- **RAM: -16 bytes** (`.rodata` 948 → 932 bytes)
- Flash: +32 bytes (PROGMEM access code)

On non-ESP8266 platforms, `PROGMEM` is a no-op and `progmem_read_byte` is a direct dereference, so there is zero overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).