### PR TITLE
[preferences] Shorten TAG strings across all platforms

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -10,7 +10,7 @@
 
 namespace esphome::esp32 {
 
-static const char *const TAG = "esp32.preferences";
+static const char *const TAG = "preferences";
 
 // Buffer size for converting uint32_t to string: max "4294967295" (10 chars) + null terminator + 1 padding
 static constexpr size_t KEY_BUFFER_SIZE = 12;

--- a/esphome/components/esp8266/preferences.cpp
+++ b/esphome/components/esp8266/preferences.cpp
@@ -13,7 +13,7 @@ extern "C" {
 
 namespace esphome::esp8266 {
 
-static const char *const TAG = "esp8266.preferences";
+static const char *const TAG = "preferences";
 
 static constexpr uint32_t ESP_RTC_USER_MEM_START = 0x60001200;
 static constexpr uint32_t ESP_RTC_USER_MEM_SIZE_WORDS = 128;

--- a/esphome/components/host/preferences.cpp
+++ b/esphome/components/host/preferences.cpp
@@ -9,7 +9,7 @@
 namespace esphome::host {
 namespace fs = std::filesystem;
 
-static const char *const TAG = "host.preferences";
+static const char *const TAG = "preferences";
 
 void HostPreferences::setup_() {
   if (this->setup_complete_)

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -9,7 +9,7 @@
 
 namespace esphome::libretiny {
 
-static const char *const TAG = "lt.preferences";
+static const char *const TAG = "preferences";
 
 // Buffer size for converting uint32_t to string: max "4294967295" (10 chars) + null terminator + 1 padding
 static constexpr size_t KEY_BUFFER_SIZE = 12;

--- a/esphome/components/rp2040/preferences.cpp
+++ b/esphome/components/rp2040/preferences.cpp
@@ -14,7 +14,7 @@
 
 namespace esphome::rp2040 {
 
-static const char *const TAG = "rp2040.preferences";
+static const char *const TAG = "preferences";
 
 static constexpr uint32_t RP2040_FLASH_STORAGE_SIZE = 512;
 

--- a/esphome/components/zephyr/preferences.cpp
+++ b/esphome/components/zephyr/preferences.cpp
@@ -10,7 +10,7 @@
 
 namespace esphome::zephyr {
 
-static const char *const TAG = "zephyr.preferences";
+static const char *const TAG = "preferences";
 
 bool ZephyrPreferenceBackend::save(const uint8_t *data, size_t len) {
   this->data.resize(len);


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #14825. Shorten all preferences TAG strings from `"<platform>.preferences"` to just `"preferences"`. Only one preferences backend is ever compiled per binary, so the platform prefix is redundant. On ESP8266, TAG strings live in `.rodata` (RAM), so this saves 8 bytes of RAM.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14825

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).