### PR TITLE
[core] Optimize Component::is_ready() with bitmask check

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -378,9 +378,10 @@ void Component::set_retry(uint32_t initial_wait_time, uint8_t max_attempts, std:
 #pragma GCC diagnostic pop
 }
 bool Component::is_ready() const {
-  return (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP ||
-         (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE ||
-         (this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_SETUP;
+  // Bitmask check: valid states are SETUP(1), LOOP(2), LOOP_DONE(4)
+  // (1 << state) & 0b10110 checks membership in one instruction
+  return ((1u << (this->component_state_ & COMPONENT_STATE_MASK)) &
+          ((1u << COMPONENT_STATE_SETUP) | (1u << COMPONENT_STATE_LOOP) | (1u << COMPONENT_STATE_LOOP_DONE))) != 0;
 }
 bool Component::can_proceed() { return true; }
 bool Component::set_status_flag_(uint8_t flag) {


### PR DESCRIPTION
# What does this implement/fix?

Replace three separate equality comparisons in `Component::is_ready()` with a single bitmask shift-and-test. The valid "ready" states are SETUP(1), LOOP(2), and LOOP_DONE(4), so `(1u << masked_state) & 0b10110` checks membership in a single operation.

This compiles to fully branchless code and halves the function size on Xtensa:
- **38 → 19 bytes** (50% smaller)
- **14 → 7 instructions**
- Zero branches

Before (three comparisons, one branch):
```asm
   l8ui    a3, a2, 10
   movi.n  a5, 1
   extui   a3, a3, 0, 3
   addi    a4, a3, -1
   extui   a4, a4, 0, 8
   bltui   a4, 2, 14
   movi    a5, 0
   addi    a3, a3, -4
   movi.n  a4, 0
   movi.n  a2, 1
   movnez  a2, a4, a3
   or      a2, a2, a5
   extui   a2, a2, 0, 1
   ret.n
```

After (bitmask, fully branchless):
```asm
   l8ui    a2, a2, 10
   extui   a3, a2, 0, 3
   movi.n  a2, 22
   ssr     a3
   srl     a2, a2
   extui   a2, a2, 0, 1
   ret.n
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).