### PR TITLE
[esp32] Disable PicolibC Newlib compatibility shim on IDF 6.0+

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1920,6 +1920,15 @@ async def to_code(config):
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA384_C", False)
         add_idf_sdkconfig_option("CONFIG_MBEDTLS_SHA512_C", False)
 
+    # Disable PicolibC Newlib compatibility shim on IDF 6.0+
+    # IDF 6.0 switched from Newlib to PicolibC. The shim provides thread-local
+    # stdin/stdout/stderr and getreent() for code compiled against Newlib.
+    # ESPHome doesn't link against Newlib-built libraries that use stdio.
+    # If a component needs it (e.g. precompiled Newlib binaries), re-enable via
+    # sdkconfig_options: CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
+    if idf_version() >= cv.Version(6, 0, 0):
+        add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", False)
+
     # Disable regi2c control functions in IRAM
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
     if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1924,8 +1924,11 @@ async def to_code(config):
     # IDF 6.0 switched from Newlib to PicolibC. The shim provides thread-local
     # stdin/stdout/stderr and getreent() for code compiled against Newlib.
     # ESPHome doesn't link against Newlib-built libraries that use stdio.
-    # If a component needs it (e.g. precompiled Newlib binaries), re-enable via
-    # sdkconfig_options: CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
+    # If a component needs it (e.g. precompiled Newlib binaries), re-enable via:
+    #   esp32:
+    #     framework:
+    #       sdkconfig_options:
+    #         CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
     if idf_version() >= cv.Version(6, 0, 0):
         add_idf_sdkconfig_option("CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY", False)
 


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6.0 switched from Newlib to PicolibC. The Newlib compatibility shim (`CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY`) is enabled by default and provides thread-local `stdin`/`stdout`/`stderr` and `getreent()` for code compiled against Newlib.

ESPHome doesn't link against Newlib-built libraries that use stdio, so the shim is unnecessary. The per-task cost is small (a few dozen bytes of TLS per FreeRTOS task, totaling low hundreds of bytes across all tasks), but there's no reason to carry it by default.

Users who link precompiled Newlib binaries can re-enable via:
```yaml
esp32:
  framework:
    sdkconfig_options:
      CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - automatically applied for IDF 6.0+ builds
# To re-enable if needed:
esp32:
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_LIBC_PICOLIBC_NEWLIB_COMPATIBILITY: "y"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).