### PR TITLE
[gpio] Use constexpr uint32_t timer ID for interlock timeout

### DIFF
--- a/esphome/components/gpio/switch/gpio_switch.cpp
+++ b/esphome/components/gpio/switch/gpio_switch.cpp
@@ -5,6 +5,7 @@ namespace esphome {
 namespace gpio {
 
 static const char *const TAG = "switch.gpio";
+static constexpr uint32_t INTERLOCK_TIMEOUT_ID = 0;
 
 float GPIOSwitch::get_setup_priority() const { return setup_priority::HARDWARE; }
 void GPIOSwitch::setup() {
@@ -51,7 +52,7 @@ void GPIOSwitch::write_state(bool state) {
       }
     }
     if (found && this->interlock_wait_time_ != 0) {
-      this->set_timeout("interlock", this->interlock_wait_time_, [this, state] {
+      this->set_timeout(INTERLOCK_TIMEOUT_ID, this->interlock_wait_time_, [this, state] {
         // Don't write directly, call the function again
         // (some other switch may have changed state while we were waiting)
         this->write_state(state);
@@ -61,7 +62,7 @@ void GPIOSwitch::write_state(bool state) {
   } else if (this->interlock_wait_time_ != 0) {
     // If we are switched off during the interlock wait time, cancel any pending
     // re-activations
-    this->cancel_timeout("interlock");
+    this->cancel_timeout(INTERLOCK_TIMEOUT_ID);
   }
 
   this->pin_->digital_write(state);


### PR DESCRIPTION
# What does this implement/fix?

Replace the string-based timeout ID `"interlock"` with a `constexpr uint32_t` in the GPIO switch component. This saves 12 bytes of RAM on ESP8266 (the string literal) and replaces the string pointer comparison in the scheduler with a direct integer compare.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
switch:
  - platform: gpio
    pin: GPIO5
    name: "My Switch"
    interlock: [other_switch]
    interlock_wait_time: 500ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).