### PR TITLE
[core] Add copy() method to StringRef for std::string compatibility

### DIFF
--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -76,6 +76,15 @@ class StringRef {
   constexpr bool empty() const { return len_ == 0; }
   constexpr const_reference operator[](size_type pos) const { return *(base_ + pos); }
 
+  /// Copy characters to destination buffer (compatible with std::string::copy)
+  size_type copy(char *dest, size_type count, size_type pos = 0) const {
+    if (pos >= len_)
+      return 0;
+    size_type actual = (count > len_ - pos) ? len_ - pos : count;
+    std::memcpy(dest, base_ + pos, actual);
+    return actual;
+  }
+
   std::string str() const { return std::string(base_, len_); }
   const uint8_t *byte() const { return reinterpret_cast<const uint8_t *>(base_); }
 

--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -76,7 +76,7 @@ class StringRef {
   constexpr bool empty() const { return len_ == 0; }
   constexpr const_reference operator[](size_type pos) const { return *(base_ + pos); }
 
-  /// Copy characters to destination buffer (compatible with std::string::copy)
+  /// Copy characters to destination buffer (std::string::copy-like, but returns 0 instead of throwing on out-of-range)
   size_type copy(char *dest, size_type count, size_type pos = 0) const {
     if (pos >= len_)
       return 0;


### PR DESCRIPTION
# What does this implement/fix?

Add a `copy()` method to `StringRef` that is compatible with `std::string::copy()`. When API service string arguments changed from `std::string` to `StringRef`, user lambdas that called `.copy()` on string variables started failing to compile.

The affected pattern (common in DSMR configurations):
```cpp
private_key.copy(id(stored_decryption_key), 32);
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15013
- fixes https://github.com/esphome/esphome/issues/15016

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Affected pattern - API service with string variable using .copy()
api:
  services:
    service: set_dsmr_key
    variables:
      private_key: string
    then:
      - lambda: |-
          if (private_key.length() == 32)
            private_key.copy(id(stored_decryption_key), 32);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).