### PR TITLE
[wifi] Fix ESP8266 power_save_mode mapping (LIGHT/HIGH were swapped)

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -95,10 +95,10 @@ bool WiFiComponent::wifi_apply_power_save_() {
   sleep_type_t power_save;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_LIGHT:
-      power_save = LIGHT_SLEEP_T;
+      power_save = MODEM_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_HIGH:
-      power_save = MODEM_SLEEP_T;
+      power_save = LIGHT_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_NONE:
     default:

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -95,9 +95,17 @@ bool WiFiComponent::wifi_apply_power_save_() {
   sleep_type_t power_save;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_LIGHT:
+      // MODEM_SLEEP_T: only the WiFi modem sleeps between DTIM beacons, CPU stays active.
+      // This matches ESP32's WIFI_PS_MIN_MODEM behavior for power_save_mode: LIGHT.
+      // Note: despite the confusing naming, ESP8266's LIGHT_SLEEP_T is MORE aggressive
+      // (suspends the CPU), while MODEM_SLEEP_T is the lighter option.
       power_save = MODEM_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_HIGH:
+      // LIGHT_SLEEP_T: both WiFi modem AND CPU suspend between DTIM beacons.
+      // Most aggressive power saving but prevents TCP processing during sleep,
+      // which can cause 28-30s delays in noise handshakes.
+      // See https://github.com/esphome/esphome/issues/14999
       power_save = LIGHT_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_NONE:

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -92,19 +92,21 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   return ret;
 }
 bool WiFiComponent::wifi_apply_power_save_() {
+  // ESP8266 sleep types have confusing names — LIGHT_SLEEP_T is the MORE aggressive mode.
+  // SDK enum: NONE_SLEEP_T=0, LIGHT_SLEEP_T=1, MODEM_SLEEP_T=2
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/tools/sdk/include/user_interface.h#L447-L451
+  // Arduino ESP32 compat confirms: WIFI_PS_MIN_MODEM=MODEM_SLEEP, WIFI_PS_MAX_MODEM=LIGHT_SLEEP
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/libraries/ESP8266WiFi/src/ESP8266WiFiType.h#L53-L55
   sleep_type_t power_save;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_LIGHT:
       // MODEM_SLEEP_T: only the WiFi modem sleeps between DTIM beacons, CPU stays active.
-      // This matches ESP32's WIFI_PS_MIN_MODEM behavior for power_save_mode: LIGHT.
-      // Note: despite the confusing naming, ESP8266's LIGHT_SLEEP_T is MORE aggressive
-      // (suspends the CPU), while MODEM_SLEEP_T is the lighter option.
+      // Matches ESP32's WIFI_PS_MIN_MODEM.
       power_save = MODEM_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_HIGH:
       // LIGHT_SLEEP_T: both WiFi modem AND CPU suspend between DTIM beacons.
-      // Most aggressive power saving but prevents TCP processing during sleep,
-      // which can cause 28-30s delays in noise handshakes.
+      // Most aggressive — prevents TCP processing during sleep. Matches ESP32's WIFI_PS_MAX_MODEM.
       // See https://github.com/esphome/esphome/issues/14999
       power_save = LIGHT_SLEEP_T;
       break;


### PR DESCRIPTION
# What does this implement/fix?

On ESP8266, `power_save_mode: LIGHT` was mapped to `LIGHT_SLEEP_T` (CPU suspends between DTIM beacons) and `HIGH` was mapped to `MODEM_SLEEP_T` (only modem sleeps). This has been wrong since the original commit in April 2019 (abf45b11ce). The mapping is inverted from both user expectations and ESP32 behavior, where LIGHT means light power saving and HIGH means aggressive power saving.

The result was that users setting `power_save_mode: LIGHT` got the **most aggressive** sleep mode, causing the CPU to suspend between DTIM beacons. This prevented TCP processing during sleep, leading to ~28-30s noise handshake times even with strong WiFi signal (-15 dBm) due to TCP segments sitting unsent while the CPU was suspended.

This was uncovered investigating #14999 — a user placed their ESP8266 right next to the AP (-15 dBm signal) and still saw 28s handshake times with `power_save_mode: LIGHT`. Signal strength was irrelevant because the issue is CPU light sleep suspending TCP processing, not WiFi packet loss.

**Fix confirmed by affected user** — handshake time dropped from **28.5s to 2.4s**:
- Before (LIGHT → LIGHT_SLEEP_T): `Successful handshake in 28.485s`
- After (LIGHT → MODEM_SLEEP_T): `Successful handshake in 2.373s`

The Arduino ESP8266 core's own ESP32 compatibility layer confirms the correct mapping:

SDK enum (`NONE_SLEEP_T=0, LIGHT_SLEEP_T=1, MODEM_SLEEP_T=2`):
https://github.com/esp8266/Arduino/blob/3.1.2/tools/sdk/include/user_interface.h#L447-L451

Arduino ESP32 compat (`WIFI_PS_MIN_MODEM=MODEM_SLEEP, WIFI_PS_MAX_MODEM=LIGHT_SLEEP`):
https://github.com/esp8266/Arduino/blob/3.1.2/libraries/ESP8266WiFi/src/ESP8266WiFiType.h#L53-L55

| `power_save_mode:` | ESP32 | ESP8266 (before) | ESP8266 (after) |
|---|---|---|---|
| `LIGHT` | `WIFI_PS_MIN_MODEM` (modem only) | `LIGHT_SLEEP_T` (CPU suspends!) | `MODEM_SLEEP_T` (modem only) |
| `HIGH` | `WIFI_PS_MAX_MODEM` (modem only) | `MODEM_SLEEP_T` (modem only) | `LIGHT_SLEEP_T` (CPU suspends) |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://github.com/esphome/esphome/issues/14999

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  power_save_mode: LIGHT  # Now correctly maps to modem sleep (not CPU light sleep)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).