### PR TITLE
[sht4x] Fix heater causing measurement jitter

### DIFF
--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -79,7 +79,9 @@ void SHT4XComponent::dump_config() {
 }
 
 void SHT4XComponent::update() {
+  // Send command
   if (!this->write_command(MEASURECOMMANDS[this->precision_])) {
+    // Warning will be printed only if warning status is not set yet
     this->status_set_warning(LOG_STR("Failed to send measurement command"));
     return;
   }
@@ -87,7 +89,9 @@ void SHT4XComponent::update() {
   this->set_timeout(10, [this]() {
     uint16_t buffer[2];
 
+    // Read measurement
     if (!this->read_data(buffer, 2)) {
+      // Using ESP_LOGW to force the warning to be printed
       ESP_LOGW(TAG, "Sensor read failed");
       this->status_set_warning();
       return;
@@ -95,12 +99,15 @@ void SHT4XComponent::update() {
 
     this->status_clear_warning();
 
+    // Evaluate and publish measurements
     if (this->temp_sensor_ != nullptr) {
+      // Temp is contained in the first result word
       float temp = TEMPERATURE_OFFSET + TEMPERATURE_SPAN * static_cast<float>(buffer[0]) / RAW_MAX;
       this->temp_sensor_->publish_state(temp);
     }
 
     if (this->humidity_sensor_ != nullptr) {
+      // Relative humidity is in the second result word
       float rh = HUMIDITY_OFFSET + HUMIDITY_SPAN * static_cast<float>(buffer[1]) / RAW_MAX;
       this->humidity_sensor_->publish_state(rh);
     }

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -79,63 +79,44 @@ void SHT4XComponent::dump_config() {
 }
 
 void SHT4XComponent::update() {
-  bool use_heater = false;
-
-  // Check if heater is due during this measurement cycle
-  if (this->heater_interval_ > 0) {
-    uint32_t now = millis();
-    if (now - this->last_heater_millis_ >= this->heater_interval_) {
-      use_heater = true;
-    }
-  }
-
-  if (use_heater) {
-    // Heater command heats the sensor to remove condensation (datasheet 4.9).
-    // The measurement it produces is taken while hot and does not reflect
-    // ambient conditions, so we skip this cycle. The next update() will
-    // take a regular reading after the sensor has cooled.
-    ESP_LOGD(TAG, "Heater turning on");
-    if (!this->write_command(this->heater_command_)) {
-      this->status_set_warning(LOG_STR("Failed to send heater command"));
-      return;
-    }
-    // Only update timestamp after successful command. Ensure at least one
-    // normal measurement between heater cycles by pushing the next eligible
-    // heater time forward by at least one update interval.
-    uint32_t now = millis();
-    uint32_t interval = std::max(this->heater_interval_, this->get_update_interval());
-    this->last_heater_millis_ = now - this->heater_interval_ + interval;
-    return;
-  }
-
   if (!this->write_command(MEASURECOMMANDS[this->precision_])) {
     this->status_set_warning(LOG_STR("Failed to send measurement command"));
     return;
   }
 
-  this->set_timeout(10, [this]() { this->read_and_publish_(); });
-}
+  this->set_timeout(10, [this]() {
+    uint16_t buffer[2];
 
-void SHT4XComponent::read_and_publish_() {
-  uint16_t buffer[2];
+    if (!this->read_data(buffer, 2)) {
+      ESP_LOGW(TAG, "Sensor read failed");
+      this->status_set_warning();
+      return;
+    }
 
-  if (!this->read_data(buffer, 2)) {
-    ESP_LOGW(TAG, "Sensor read failed");
-    this->status_set_warning();
-    return;
-  }
+    this->status_clear_warning();
 
-  this->status_clear_warning();
+    if (this->temp_sensor_ != nullptr) {
+      float temp = TEMPERATURE_OFFSET + TEMPERATURE_SPAN * static_cast<float>(buffer[0]) / RAW_MAX;
+      this->temp_sensor_->publish_state(temp);
+    }
 
-  if (this->temp_sensor_ != nullptr) {
-    float temp = TEMPERATURE_OFFSET + TEMPERATURE_SPAN * static_cast<float>(buffer[0]) / RAW_MAX;
-    this->temp_sensor_->publish_state(temp);
-  }
+    if (this->humidity_sensor_ != nullptr) {
+      float rh = HUMIDITY_OFFSET + HUMIDITY_SPAN * static_cast<float>(buffer[1]) / RAW_MAX;
+      this->humidity_sensor_->publish_state(rh);
+    }
 
-  if (this->humidity_sensor_ != nullptr) {
-    float rh = HUMIDITY_OFFSET + HUMIDITY_SPAN * static_cast<float>(buffer[1]) / RAW_MAX;
-    this->humidity_sensor_->publish_state(rh);
-  }
+    // Fire heater after measurement to maximize cooldown time before the next reading.
+    // The heater command produces a measurement that we don't need (datasheet 4.9).
+    if (this->heater_interval_ > 0) {
+      uint32_t now = millis();
+      if (now - this->last_heater_millis_ >= this->heater_interval_) {
+        ESP_LOGD(TAG, "Heater turning on");
+        if (this->write_command(this->heater_command_)) {
+          this->last_heater_millis_ = now;
+        }
+      }
+    }
+  });
 }
 
 }  // namespace sht4x

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -9,14 +9,12 @@ static const char *const TAG = "sht4x";
 static const uint8_t MEASURECOMMANDS[] = {0xFD, 0xF6, 0xE0};
 static const uint8_t SERIAL_NUMBER_COMMAND = 0x89;
 
-void SHT4XComponent::start_heater_() {
-  uint8_t cmd[] = {this->heater_command_};
-
-  ESP_LOGD(TAG, "Heater turning on");
-  if (this->write(cmd, 1) != i2c::ERROR_OK) {
-    this->status_set_error(LOG_STR("Failed to turn on heater"));
-  }
-}
+// Conversion constants from SHT4x datasheet
+static constexpr float TEMPERATURE_OFFSET = -45.0f;
+static constexpr float TEMPERATURE_SPAN = 175.0f;
+static constexpr float HUMIDITY_OFFSET = -6.0f;
+static constexpr float HUMIDITY_SPAN = 125.0f;
+static constexpr float RAW_MAX = 65535.0f;
 
 void SHT4XComponent::read_serial_number_() {
   uint16_t buffer[2];
@@ -39,8 +37,8 @@ void SHT4XComponent::setup() {
   this->read_serial_number_();
 
   if (std::isfinite(this->duty_cycle_) && this->duty_cycle_ > 0.0f) {
-    uint32_t heater_interval = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
-    ESP_LOGD(TAG, "Heater interval: %" PRIu32, heater_interval);
+    this->heater_interval_ = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
+    ESP_LOGD(TAG, "Heater interval: %" PRIu32, this->heater_interval_);
 
     if (this->heater_power_ == SHT4X_HEATERPOWER_HIGH) {
       if (this->heater_time_ == SHT4X_HEATERTIME_LONG) {
@@ -62,8 +60,6 @@ void SHT4XComponent::setup() {
       }
     }
     ESP_LOGD(TAG, "Heater command: %x", this->heater_command_);
-
-    this->set_interval(heater_interval, [this]() { this->start_heater_(); });
   }
 }
 
@@ -83,43 +79,59 @@ void SHT4XComponent::dump_config() {
 }
 
 void SHT4XComponent::update() {
-  // Send command
+  bool use_heater = false;
+
+  // Check if heater is due during this measurement cycle
+  if (this->heater_interval_ > 0) {
+    uint32_t now = millis();
+    if (now - this->last_heater_millis_ >= this->heater_interval_) {
+      use_heater = true;
+      this->last_heater_millis_ = now;
+    }
+  }
+
+  if (use_heater) {
+    // Heater command heats the sensor to remove condensation, then takes a
+    // measurement (per datasheet section 4.9). The measurement is taken while
+    // the sensor is still hot, so we must discard it — it does not reflect
+    // ambient conditions. The next regular update() cycle will provide a
+    // valid reading after the sensor has cooled.
+    ESP_LOGD(TAG, "Heater turning on");
+    if (!this->write_command(this->heater_command_)) {
+      this->status_set_warning(LOG_STR("Failed to send heater command"));
+      return;
+    }
+    return;
+  }
+
   if (!this->write_command(MEASURECOMMANDS[this->precision_])) {
-    // Warning will be printed only if warning status is not set yet
     this->status_set_warning(LOG_STR("Failed to send measurement command"));
     return;
   }
 
-  this->set_timeout(10, [this]() {
-    uint16_t buffer[2];
+  this->set_timeout(10, [this]() { this->read_and_publish_(); });
+}
 
-    // Read measurement
-    if (!this->read_data(buffer, 2)) {
-      // Using ESP_LOGW to force the warning to be printed
-      ESP_LOGW(TAG, "Sensor read failed");
-      this->status_set_warning();
-      return;
-    }
+void SHT4XComponent::read_and_publish_() {
+  uint16_t buffer[2];
 
-    this->status_clear_warning();
+  if (!this->read_data(buffer, 2)) {
+    ESP_LOGW(TAG, "Sensor read failed");
+    this->status_set_warning();
+    return;
+  }
 
-    // Evaluate and publish measurements
-    if (this->temp_sensor_ != nullptr) {
-      // Temp is contained in the first result word
-      float sensor_value_temp = buffer[0];
-      float temp = -45 + 175 * sensor_value_temp / 65535;
+  this->status_clear_warning();
 
-      this->temp_sensor_->publish_state(temp);
-    }
+  if (this->temp_sensor_ != nullptr) {
+    float temp = TEMPERATURE_OFFSET + TEMPERATURE_SPAN * static_cast<float>(buffer[0]) / RAW_MAX;
+    this->temp_sensor_->publish_state(temp);
+  }
 
-    if (this->humidity_sensor_ != nullptr) {
-      // Relative humidity is in the second result word
-      float sensor_value_rh = buffer[1];
-      float rh = -6 + 125 * sensor_value_rh / 65535;
-
-      this->humidity_sensor_->publish_state(rh);
-    }
-  });
+  if (this->humidity_sensor_ != nullptr) {
+    float rh = HUMIDITY_OFFSET + HUMIDITY_SPAN * static_cast<float>(buffer[1]) / RAW_MAX;
+    this->humidity_sensor_->publish_state(rh);
+  }
 }
 
 }  // namespace sht4x

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -86,11 +86,6 @@ void SHT4XComponent::update() {
     uint32_t now = millis();
     if (now - this->last_heater_millis_ >= this->heater_interval_) {
       use_heater = true;
-      // Ensure at least one normal measurement between heater cycles by
-      // pushing the next eligible heater time forward by one update interval.
-      // The configured duty cycle is a maximum, not an exact target.
-      uint32_t interval = std::max(this->heater_interval_, this->get_update_interval());
-      this->last_heater_millis_ = now - this->heater_interval_ + interval;
     }
   }
 
@@ -104,6 +99,12 @@ void SHT4XComponent::update() {
       this->status_set_warning(LOG_STR("Failed to send heater command"));
       return;
     }
+    // Only update timestamp after successful command. Ensure at least one
+    // normal measurement between heater cycles by pushing the next eligible
+    // heater time forward by at least one update interval.
+    uint32_t now = millis();
+    uint32_t interval = std::max(this->heater_interval_, this->get_update_interval());
+    this->last_heater_millis_ = now - this->heater_interval_ + interval;
     return;
   }
 

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -86,16 +86,19 @@ void SHT4XComponent::update() {
     uint32_t now = millis();
     if (now - this->last_heater_millis_ >= this->heater_interval_) {
       use_heater = true;
-      this->last_heater_millis_ = now;
+      // Ensure at least one normal measurement between heater cycles by
+      // pushing the next eligible heater time forward by one update interval.
+      // The configured duty cycle is a maximum, not an exact target.
+      uint32_t interval = std::max(this->heater_interval_, this->get_update_interval());
+      this->last_heater_millis_ = now - this->heater_interval_ + interval;
     }
   }
 
   if (use_heater) {
-    // Heater command heats the sensor to remove condensation, then takes a
-    // measurement (per datasheet section 4.9). The measurement is taken while
-    // the sensor is still hot, so we must discard it — it does not reflect
-    // ambient conditions. The next regular update() cycle will provide a
-    // valid reading after the sensor has cooled.
+    // Heater command heats the sensor to remove condensation (datasheet 4.9).
+    // The measurement it produces is taken while hot and does not reflect
+    // ambient conditions, so we skip this cycle. The next update() will
+    // take a regular reading after the sensor has cooled.
     ESP_LOGD(TAG, "Heater turning on");
     if (!this->write_command(this->heater_command_)) {
       this->status_set_warning(LOG_STR("Failed to send heater command"));

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -36,7 +36,6 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   float duty_cycle_;
 
   void read_serial_number_();
-  void read_and_publish_();
   uint8_t heater_command_;
   uint32_t heater_interval_{0};
   uint32_t last_heater_millis_{0};

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -35,9 +35,11 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   SHT4XHEATERTIME heater_time_;
   float duty_cycle_;
 
-  void start_heater_();
   void read_serial_number_();
+  void read_and_publish_();
   uint8_t heater_command_;
+  uint32_t heater_interval_{0};
+  uint32_t last_heater_millis_{0};
   uint32_t serial_number_;
 
   sensor::Sensor *temp_sensor_{nullptr};

--- a/tests/components/sht4x/common.yaml
+++ b/tests/components/sht4x/common.yaml
@@ -6,4 +6,8 @@ sensor:
     humidity:
       name: SHT4X Humidity
     address: 0x44
+    precision: High
+    heater_max_duty: 0.02
+    heater_power: High
+    heater_time: Long
     update_interval: 15s


### PR DESCRIPTION
# What does this implement/fix?

PR #14497 correctly fixed the SHT4x heater which had been broken for a long time. However, this exposed a latent bug: the heater ran on an independent `set_interval()` timer with no synchronization with the measurement polling in `update()`. When the two timers overlapped, measurements were taken while the sensor was still hot from the heater cycle, causing large jitter in temperature and humidity readings.

This PR integrates the heater into the `update()` cycle by firing it **after** the measurement read, instead of on a separate timer. This maximizes cooldown time before the next reading and avoids skipping any measurement cycles. Per datasheet section 4.9, the heater command produces its own measurement (taken while hot), which we don't need — it goes unread.

Also replaces magic numbers in the temperature/humidity conversion formulas with named `constexpr` constants from the datasheet.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15011

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: sht4x
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    precision: "High"
    heater_max_duty: 0.02
    heater_power: "High"
    heater_time: "Long"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).