### PR TITLE
[substitutions] refactor substitute() as a pure function (package refactor part 3)

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -300,9 +300,14 @@ def do_packages_pass(config: dict, skip_update: bool = False) -> dict:
             context_vars = package_config.vars
             if CONF_PACKAGES in package_config or CONF_URL in package_config:
                 # Remote package definition: eagerly resolve before PACKAGE_SCHEMA validation.
-                from esphome.components.substitutions import substitute_context_vars
+                from esphome.components.substitutions import ContextVars, substitute
 
-                substitute_context_vars(package_config, context_vars)
+                package_config = substitute(
+                    package_config,
+                    [],
+                    ContextVars(context_vars),
+                    strict_undefined=False,
+                )
         package_config = PACKAGE_SCHEMA(package_config)
         if isinstance(package_config, str):
             return package_config  # Jinja string, skip processing

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -335,7 +335,8 @@ def substitute(
         value = _expand_substitutions(
             item.value, path, context_vars, strict_undefined, errors
         )
-        result = type(item)(value)
+        if item.value is not value:
+            result = type(item)(value)
 
     if isinstance(item, ESPHomeDataBase):
         result = make_data_base(result, item)

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -298,7 +298,7 @@ def substitute(
     strict_undefined: bool,
     errors: ErrList | None = None,
 ) -> Any:
-    """Returns a substituted version of `item`."""
+    """Returns a recursively substituted version of `item`."""
 
     if isinstance(item, ESPLiteralValue):
         return item  # do not substitute inside literal blocks
@@ -308,15 +308,12 @@ def substitute(
 
     result = item
 
-    # If the item is a list, iterate over its elements and substitute recursively
     if isinstance(item, list):
-        result = []
-        for i, it in enumerate(item):
-            result.append(
-                substitute(it, path + [i], context_vars, strict_undefined, errors)
-            )
+        result = [
+            substitute(it, path + [i], context_vars, strict_undefined, errors)
+            for i, it in enumerate(item)
+        ]
 
-    # If the item is a dictionary, substitute keys and values recursively
     elif isinstance(item, dict):
         result = OrderedDict()
         for k, v in item.items():
@@ -324,18 +321,16 @@ def substitute(
             k = substitute(k, path + [k], context_vars, strict_undefined, errors)
             result[k] = merge_config(result.get(k), v)
 
-    # If the item is a string, attempt to expand substitutions
     elif isinstance(item, str):
         result = _expand_substitutions(
             item, path, context_vars, strict_undefined, errors
         )
 
-    # If the item is a special type (Lambda, Extend, Remove) with a value, substitute its value
     elif isinstance(item, (core.Lambda, Extend, Remove)) and item.value:
         value = _expand_substitutions(
             item.value, path, context_vars, strict_undefined, errors
         )
-        if item.value is not value:
+        if item.value != value:
             result = type(item)(value)
 
     if isinstance(item, ESPHomeDataBase):
@@ -369,7 +364,7 @@ def do_substitution_pass(
     Extracts the ``substitutions:`` block, merges in any command-line
     overrides, resolves inter-variable dependencies, then walks the
     config tree replacing all ``$var`` / ``${expr}`` references.
-    Returns the (mutated) config dict with resolved substitutions
+    Returns a new config dict with resolved substitutions
     restored at the front.
     """
     # Extract substitutions from config, overriding with substitutions coming from command line:

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -304,7 +304,7 @@ def substitute(
         return item  # do not substitute inside literal blocks
 
     # Push the current item's context onto the context stack
-    context_vars = push_context(item, parent_context)
+    context_vars = push_context(item, parent_context, errors)
 
     result = item
 

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -81,12 +81,6 @@ def _restore_data_base(value: Any, orig_value: ESPHomeDataBase) -> ESPHomeDataBa
     return value
 
 
-def _try_substitute(value: Any, context: ContextVars) -> Any:
-    """Substitute variables in value, returning the result or the original if unchanged."""
-    result = _substitute_item(value, [], context, strict_undefined=True)
-    return result if result is not None else value
-
-
 def _resolve_var(name: str, context_vars: ContextVars) -> Any:
     """Look up a substitution variable, falling back to the resolver callback."""
     sub = context_vars.get(name, Missing)
@@ -253,7 +247,7 @@ def _push_context(
         if value is Missing:
             return Missing
         try:
-            value = _try_substitute(value, resolver_context)
+            value = substitute(value, [], resolver_context, True)
         except UndefinedError as err:
             unresolvables[key] = (value, err)
             return Missing
@@ -297,68 +291,55 @@ def push_context(
     return parent_context
 
 
-def _substitute_item(
+def substitute(
     item: Any,
     path: SubstitutionPath,
     parent_context: ContextVars,
     strict_undefined: bool,
     errors: ErrList | None = None,
-) -> Any | None:
-    """Recursively substitute variables in a config item.
+) -> Any:
+    """Returns a substituted version of `item`."""
 
-    Walks dicts, lists, strings, Lambdas, Extend, and Remove nodes,
-    replacing variable references with values from context_vars.
-    Mutates containers in-place; returns a replacement value for
-    strings/scalars, or None if the item was unchanged.
-    """
+    if isinstance(item, ESPLiteralValue):
+        return item  # do not substitute inside literal blocks
 
-    def _walk(item: Any, path: SubstitutionPath, parent_ctx: ContextVars) -> Any | None:
-        if isinstance(item, ESPLiteralValue):
-            return None  # do not substitute inside literal blocks
+    # Push the current item's context onto the context stack
+    context_vars = push_context(item, parent_context)
 
-        ctx = push_context(item, parent_ctx, errors)
+    result = item
 
-        if isinstance(item, list):
-            for idx, it in enumerate(item):
-                sub = _walk(it, path + [idx], ctx)
-                if sub is not None:
-                    item[idx] = sub
-        elif isinstance(item, dict):
-            replace_keys: list[tuple[str, Any]] = []
-            for k, v in item.items():
-                if path or k != CONF_SUBSTITUTIONS:
-                    sub = _walk(k, path + [k], ctx)
-                    if sub is not None:
-                        replace_keys.append((k, sub))
-                sub = _walk(v, path + [k], ctx)
-                if sub is not None:
-                    item[k] = sub
-            for old, new in replace_keys:
-                if str(new) == str(old):
-                    item[new] = item[old]
-                else:
-                    item[new] = merge_config(item.get(new), item.get(old))
-                    del item[old]
-        elif isinstance(item, str):
-            sub = _expand_substitutions(item, path, ctx, strict_undefined, errors)
-            if not isinstance(sub, str) or sub != item:
-                return sub
-        elif isinstance(item, (core.Lambda, Extend, Remove)) and item.value:
-            sub = _expand_substitutions(item.value, path, ctx, strict_undefined, errors)
-            if sub != item.value:
-                item.value = sub
-        return None
+    # If the item is a list, iterate over its elements and substitute recursively
+    if isinstance(item, list):
+        result = []
+        for i, it in enumerate(item):
+            result.append(
+                substitute(it, path + [i], context_vars, strict_undefined, errors)
+            )
 
-    return _walk(item, path, parent_context)
+    # If the item is a dictionary, substitute keys and values recursively
+    elif isinstance(item, dict):
+        result = OrderedDict()
+        for k, v in item.items():
+            v = substitute(v, path + [k], context_vars, strict_undefined, errors)
+            k = substitute(k, path + [k], context_vars, strict_undefined, errors)
+            result[k] = merge_config(result.get(k), v)
 
+    # If the item is a string, attempt to expand substitutions
+    elif isinstance(item, str):
+        result = _expand_substitutions(
+            item, path, context_vars, strict_undefined, errors
+        )
 
-def substitute_context_vars(node: Any, context_vars: dict[str, Any]) -> None:
-    """Eagerly substitute context vars into a config node in-place.
+    # If the item is a special type (Lambda, Extend, Remove) with a value, substitute its value
+    elif isinstance(item, (core.Lambda, Extend, Remove)) and item.value:
+        value = _expand_substitutions(
+            item.value, path, context_vars, strict_undefined, errors
+        )
+        result = type(item)(value)
 
-    Undefined variables are silently ignored — this is used before
-    the main substitution pass when not all variables are visible yet.
-    """
-    _substitute_item(node, [], ContextVars(context_vars), strict_undefined=False)
+    if isinstance(item, ESPHomeDataBase):
+        result = make_data_base(result, item)
+    return result
 
 
 def _warn_unresolved_variables(errors: ErrList) -> None:
@@ -415,7 +396,7 @@ def do_substitution_pass(
     errors: ErrList = []  # Collect undefined errors during substitution
     parent_context, substitutions = _push_context(substitutions, ContextVars(), errors)
 
-    _substitute_item(config, [], parent_context, False, errors)
+    config = substitute(config, [], parent_context, False, errors)
 
     if errors:
         _warn_unresolved_variables(errors)

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -581,6 +581,40 @@ def test_extend_substitution() -> None:
     assert config["sensor"].value == "my_sensor"
 
 
+def test_substitute_does_not_mutate_input() -> None:
+    """substitute() must return a new tree without modifying the original."""
+    inner_list = ["${var}", "static"]
+    inner_dict = OrderedDict({"key": "${var}"})
+    lam = Lambda("return ${var};")
+    config = OrderedDict(
+        {
+            "a_list": inner_list,
+            "a_dict": inner_dict,
+            "a_lambda": lam,
+            "plain": "${var}",
+        }
+    )
+    context = substitutions.ContextVars({"var": "replaced"})
+    result = substitutions.substitute(config, [], context, strict_undefined=True)
+
+    # Result has substitutions applied
+    assert result["plain"] == "replaced"
+    assert result["a_list"] == ["replaced", "static"]
+    assert result["a_dict"]["key"] == "replaced"
+    assert result["a_lambda"].value == "return replaced;"
+
+    # Original input is untouched
+    assert config["plain"] == "${var}"
+    assert inner_list == ["${var}", "static"]
+    assert inner_dict["key"] == "${var}"
+    assert lam.value == "return ${var};"
+
+    # Containers are new objects, not the originals
+    assert result["a_list"] is not inner_list
+    assert result["a_dict"] is not inner_dict
+    assert result["a_lambda"] is not lam
+
+
 def test_do_substitution_pass_substitutions_must_be_mapping_from_config() -> None:
     """Non-mapping substitutions raises cv.Invalid."""
     config = OrderedDict(

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -564,8 +564,8 @@ def test_lambda_no_substitution_unchanged() -> None:
             "lambda": lam,
         }
     )
-    config = substitutions.do_substitution_pass(config)
-    assert config["lambda"].value == original_value
+    substitutions.do_substitution_pass(config)
+    assert lam.value is original_value
 
 
 def test_extend_substitution() -> None:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -522,6 +522,7 @@ def test_config_context_unresolvable_warns(
     with caplog.at_level(logging.WARNING):
         substitutions.do_substitution_pass(config)
 
+    assert "Could not resolve substitution variable 'a'" in caplog.text
     assert "'undefined' is undefined" in caplog.text
 
 

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -564,8 +564,8 @@ def test_lambda_no_substitution_unchanged() -> None:
             "lambda": lam,
         }
     )
-    substitutions.do_substitution_pass(config)
-    assert lam.value is original_value
+    config = substitutions.do_substitution_pass(config)
+    assert config["lambda"].value is original_value
 
 
 def test_extend_substitution() -> None:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -522,7 +522,6 @@ def test_config_context_unresolvable_warns(
     with caplog.at_level(logging.WARNING):
         substitutions.do_substitution_pass(config)
 
-    assert "Could not resolve substitution variable 'a'" in caplog.text
     assert "'undefined' is undefined" in caplog.text
 
 
@@ -550,8 +549,8 @@ def test_lambda_substitution() -> None:
             "lambda": lam,
         }
     )
-    substitutions.do_substitution_pass(config)
-    assert lam.value == "return 42;"
+    config = substitutions.do_substitution_pass(config)
+    assert config["lambda"].value == "return 42;"
 
 
 def test_lambda_no_substitution_unchanged() -> None:
@@ -564,8 +563,8 @@ def test_lambda_no_substitution_unchanged() -> None:
             "lambda": lam,
         }
     )
-    substitutions.do_substitution_pass(config)
-    assert lam.value is original_value
+    config = substitutions.do_substitution_pass(config)
+    assert config["lambda"].value == original_value
 
 
 def test_extend_substitution() -> None:
@@ -577,8 +576,8 @@ def test_extend_substitution() -> None:
             "sensor": ext,
         }
     )
-    substitutions.do_substitution_pass(config)
-    assert ext.value == "my_sensor"
+    config = substitutions.do_substitution_pass(config)
+    assert config["sensor"].value == "my_sensor"
 
 
 def test_do_substitution_pass_substitutions_must_be_mapping_from_config() -> None:


### PR DESCRIPTION
# What does this implement/fix?

This PR is **part 3 of 4** in a series splitting [#12126](https://github.com/esphome/esphome/pull/12126), which refactors ESPHome's substitution system to perform **all variable substitutions in a single, linear pass**. Each sub-PR is independently reviewable, testable, and mergeable in order.

> **Stacked PR:** This builds on [#14918](https://github.com/esphome/esphome/pull/14918) — please review/merge that first.

- **Part 1:** [#14917](https://github.com/esphome/esphome/pull/14917) — Infrastructure: `ConfigContext` mixin and `add_context()` helper
- **Part 2:** [#14918](https://github.com/esphome/esphome/pull/14918) — Remove `JinjaStr`; adapt substitution engine to `ContextVars`
- **Part 3 (this PR):** Refactor `_substitute_item` into a pure function `substitute()`
- **Part 4:** [#12126](https://github.com/esphome/esphome/pull/12126) — Package pass integration

---

## What this part does

Renames the internal `_substitute_item` to the public `substitute()` and converts it from a mutation-based traversal to a **pure function** that returns a new value rather than modifying the input in place.

### Why this matters

Part 2 rewrote the substitution engine to propagate `ContextVars` through the tree, but `_substitute_item` still mutated lists and dicts in place and returned `None` on no-change or the replacement value otherwise.

`substitute()` always returns the (possibly new) value, building fresh `list` / `OrderedDict` structures rather than modifying the originals. This is important for several reasons:

1. **`ESPHomeDataBase` metadata preservation** — the function wraps results with `make_data_base()` to preserve source-location metadata (`esp_range`) used for error reporting. Building new structures makes this wrapping natural; in-place mutation would either lose this metadata or require complex re-wrapping of existing objects.

2. **Packages reuse (prerequisite for Part 4)** — in the packages system, the same included YAML fragment can be instantiated multiple times with different substitution variables (via `ConfigContext.vars`). If `substitute()` mutated the original tree, the first instantiation would destroy the template for subsequent ones. Returning a copy preserves the source config as a reusable template. This is the key reason Part 4 requires this refactor.

3. **Correct `ConfigContext` scoping** — `push_context()` layers local variables via `ChainMap`, so a child node can shadow a parent's variable. If the function mutated in-place, a node processed under one scope could corrupt results for siblings processed under a different scope. Fresh copies keep scoping clean.

4. **Easier to understand** — a pure function with no side effects is simpler to reason about than one that sometimes returns `None` (no change) and sometimes returns a value (changed), while also mutating the input.

### Key changes

**`esphome/components/substitutions/__init__.py`**

- `_substitute_item` → renamed to `substitute` and made public.
- Return type changed from `Any | None` to `Any` — callers no longer need to check for `None`.
- **Lists**: built by appending substituted elements, not by index-assigning into the original.
- **Dicts**: built as a new `OrderedDict` with `merge_config` for key collisions (handles key substitution producing the same key), not by mutating the original.
- **`ESPLiteralValue`**: returns the item itself rather than `None`.
- **`Lambda`/`Extend`/`Remove`**: creates a new instance via `type(item)(value)` rather than assigning to `.value` in place.
- **`ESPHomeDataBase` preservation**: any result is re-wrapped with `make_data_base` to preserve source-location metadata.
- `_push_context` and `do_substitution_pass` updated to call `substitute` instead of `_substitute_item`.

**`esphome/components/packages/__init__.py`**

- Eager resolve for nested remote-package definitions updated to call `substitute` (now public) instead of `_substitute_item`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Part of [#12126](https://github.com/esphome/esphome/pull/12126)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing changes.

## Test Environment

- [x] all (config)

## Example entry for `config.yaml`:

N/A — internal refactor only; no change in observable behavior.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).