### PR TITLE
[esp32_touch] Fix initial state never published when sensor untouched

### DIFF
--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -360,11 +360,16 @@ void ESP32TouchComponent::loop() {
   }
 
   // Publish initial OFF state for sensors that haven't received events yet
+  bool all_initial_published = true;
   for (auto *child : this->children_) {
     this->publish_initial_state_if_needed_(child, now);
+    if (!child->initial_state_published_) {
+      all_initial_published = false;
+    }
   }
 
-  if (!this->setup_mode_) {
+  // Only disable loop once all initial states are published
+  if (!this->setup_mode_ && all_initial_published) {
     this->disable_loop();
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes touch binary sensors showing "Unknown" in Home Assistant when the sensor is not being touched.

The `loop()` was calling `disable_loop()` before the initial OFF state had been published. The initial state publication is delayed by 1500ms (`INITIAL_STATE_DELAY_MS`) to allow the touch driver to stabilize, but `disable_loop()` runs on the first loop iteration (well before 1500ms). Once loop is disabled, it only re-enables when a touch callback fires — which never happens if the sensor isnt touched. So the sensor stays "Unknown" forever.

The fix keeps loop running until all children have published their initial state.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from esp32_touch rewrite in 2026.3.0

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for config.yaml:

No config changes required.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under tests/ folder).