### PR TITLE
[rp2040] Fix get_mac_address_raw to use ethernet MAC when WiFi unavailable

### DIFF
--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -10,6 +10,7 @@
 #include <pico/cyw43_arch.h>  // For cyw43_arch_lwip_begin/end (LwIPLock)
 #elif defined(USE_ETHERNET)
 #include <LwipEthernet.h>  // For ethernet_arch_lwip_begin/end (LwIPLock)
+#include "esphome/components/ethernet/ethernet_component.h"
 #endif
 #include <hardware/structs/rosc.h>
 #include <hardware/sync.h>
@@ -71,6 +72,8 @@ LwIPLock::~LwIPLock() {}
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #ifdef USE_WIFI
   WiFi.macAddress(mac);
+#elif defined(USE_ETHERNET)
+  ethernet::global_eth_component->get_eth_mac_address_raw(mac);
 #endif
 }
 


### PR DESCRIPTION
# What does this implement/fix?

On RP2040, `get_mac_address_raw()` only queried `WiFi.macAddress()`. When ethernet is configured without WiFi, the MAC address was never written, leaving the stack-allocated buffer uninitialized. This causes `get_mac_address()` and `get_mac_address_pretty()` to return random garbage bytes (e.g. `08:1F:04:20:C1:6C`). This affects device identification (API, mDNS, unique ID) — the device gets a different identity on every boot.

Unlike ESP32 which reads from eFuse (always available regardless of network interface), RP2040 must query the actual network driver. This adds a fallback to `ethernet::global_eth_component->get_eth_mac_address_raw()` when `USE_ETHERNET` is defined and `USE_WIFI` is not.

Follow-up from https://github.com/esphome/esphome/pull/14945#issuecomment-4101544773

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up from #14945

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any RP2040 ethernet config without WiFi
ethernet:
  type: W5500
  clk_pin: 18
  mosi_pin: 19
  miso_pin: 16
  cs_pin: 17
  interrupt_pin: 21
  reset_pin: 20
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).