### PR TITLE
[benchmark] Add noise encryption benchmarks

### DIFF
--- a/script/setup_codspeed_lib.py
+++ b/script/setup_codspeed_lib.py
@@ -205,7 +205,13 @@ def setup_codspeed_lib(output_dir: Path) -> None:
     if hooks_dist_c.exists():
         _copy_if_missing(hooks_dist_c, lib_src / "instrument_hooks.c")
 
-    # 4. Write library.json
+    # 4. Copy instrument-hooks headers (core.h, callgrind.h, valgrind.h) next to
+    #    measurement.hpp so they are found before any same-named headers from
+    #    other libraries (e.g. libsodium's core.h).
+    for header in hooks_include.glob("*.h"):
+        _copy_if_missing(header, core_include / header.name)
+
+    # 5. Write library.json
     version = _read_codspeed_version(output_dir / CORE_CMAKE)
     _write_library_json(
         benchmark_dir, core_include, hooks_include, version, project_root

--- a/tests/benchmarks/components/api/__init__.py
+++ b/tests/benchmarks/components/api/__init__.py
@@ -1,8 +1,17 @@
+import esphome.codegen as cg
 from tests.testing_helpers import ComponentManifestOverride
+
+# Keep in sync with esphome/components/api/__init__.py
+NOISE_C_LIB = ("esphome/noise-c", "0.1.11")
 
 
 def override_manifest(manifest: ComponentManifestOverride) -> None:
-    # api must run its to_code during benchmark builds because it
-    # defines USE_API, USE_API_PLAINTEXT, and USE_API_NOISE which
-    # are needed by the frame helper headers.
-    manifest.enable_codegen()
+    # Add defines for frame helper headers without running the full api
+    # to_code (which brings in socket/network setup that fails in
+    # benchmark builds).
+    async def to_code(config):
+        cg.add_define("USE_API_PLAINTEXT")
+        cg.add_define("USE_API_NOISE")
+        cg.add_library(*NOISE_C_LIB)
+
+    manifest.to_code = to_code

--- a/tests/benchmarks/components/api/__init__.py
+++ b/tests/benchmarks/components/api/__init__.py
@@ -1,0 +1,8 @@
+from tests.testing_helpers import ComponentManifestOverride
+
+
+def override_manifest(manifest: ComponentManifestOverride) -> None:
+    # api must run its to_code during benchmark builds because it
+    # defines USE_API, USE_API_PLAINTEXT, and USE_API_NOISE which
+    # are needed by the frame helper headers.
+    manifest.enable_codegen()

--- a/tests/benchmarks/components/api/bench_noise_encrypt.cpp
+++ b/tests/benchmarks/components/api/bench_noise_encrypt.cpp
@@ -1,0 +1,129 @@
+#include "esphome/core/defines.h"
+#ifdef USE_API_NOISE
+
+#include <benchmark/benchmark.h>
+#include <cstring>
+
+#include "noise/protocol.h"
+
+namespace esphome::api::benchmarks {
+
+static constexpr int kInnerIterations = 2000;
+
+// Helper to create and initialize a NoiseCipherState with ChaChaPoly.
+// Returns nullptr on failure.
+static NoiseCipherState *create_cipher() {
+  NoiseCipherState *cipher = nullptr;
+  int err = noise_cipherstate_new_by_id(&cipher, NOISE_CIPHER_CHACHAPOLY);
+  if (err != NOISE_ERROR_NONE || cipher == nullptr)
+    return nullptr;
+
+  // Initialize with a dummy 32-byte key (same pattern as handshake split produces)
+  uint8_t key[32];
+  memset(key, 0xAB, sizeof(key));
+  err = noise_cipherstate_init_key(cipher, key, sizeof(key));
+  if (err != NOISE_ERROR_NONE) {
+    noise_cipherstate_free(cipher);
+    return nullptr;
+  }
+  return cipher;
+}
+
+// --- Encrypt a typical sensor state message (small payload ~14 bytes) ---
+// This is the most common message encrypted on every sensor update.
+
+static void NoiseEncrypt_SmallMessage(benchmark::State &state) {
+  NoiseCipherState *cipher = create_cipher();
+  if (cipher == nullptr) {
+    state.SkipWithError("Failed to create cipher state");
+    return;
+  }
+
+  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
+  // Typical SensorStateResponse: 4 bytes type+len header + ~10 bytes payload
+  constexpr size_t plaintext_size = 14;
+  size_t buf_capacity = plaintext_size + mac_len;
+  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
+  memset(buffer.get(), 0x42, plaintext_size);
+
+  uint64_t nonce = 0;
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      noise_cipherstate_set_nonce(cipher, nonce++);
+      NoiseBuffer mbuf;
+      noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
+      noise_cipherstate_encrypt(cipher, &mbuf);
+    }
+    benchmark::DoNotOptimize(buffer[0]);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+
+  noise_cipherstate_free(cipher);
+}
+BENCHMARK(NoiseEncrypt_SmallMessage);
+
+// --- Encrypt a medium message (~128 bytes, typical for LightStateResponse) ---
+
+static void NoiseEncrypt_MediumMessage(benchmark::State &state) {
+  NoiseCipherState *cipher = create_cipher();
+  if (cipher == nullptr) {
+    state.SkipWithError("Failed to create cipher state");
+    return;
+  }
+
+  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
+  constexpr size_t plaintext_size = 128;
+  size_t buf_capacity = plaintext_size + mac_len;
+  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
+  memset(buffer.get(), 0x42, plaintext_size);
+
+  uint64_t nonce = 0;
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      noise_cipherstate_set_nonce(cipher, nonce++);
+      NoiseBuffer mbuf;
+      noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
+      noise_cipherstate_encrypt(cipher, &mbuf);
+    }
+    benchmark::DoNotOptimize(buffer[0]);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+
+  noise_cipherstate_free(cipher);
+}
+BENCHMARK(NoiseEncrypt_MediumMessage);
+
+// --- Encrypt a large message (~1024 bytes, typical for DeviceInfoResponse) ---
+
+static void NoiseEncrypt_LargeMessage(benchmark::State &state) {
+  NoiseCipherState *cipher = create_cipher();
+  if (cipher == nullptr) {
+    state.SkipWithError("Failed to create cipher state");
+    return;
+  }
+
+  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
+  constexpr size_t plaintext_size = 1024;
+  size_t buf_capacity = plaintext_size + mac_len;
+  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
+  memset(buffer.get(), 0x42, plaintext_size);
+
+  uint64_t nonce = 0;
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      noise_cipherstate_set_nonce(cipher, nonce++);
+      NoiseBuffer mbuf;
+      noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
+      noise_cipherstate_encrypt(cipher, &mbuf);
+    }
+    benchmark::DoNotOptimize(buffer[0]);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+
+  noise_cipherstate_free(cipher);
+}
+BENCHMARK(NoiseEncrypt_LargeMessage);
+
+}  // namespace esphome::api::benchmarks
+
+#endif  // USE_API_NOISE

--- a/tests/benchmarks/components/api/bench_noise_encrypt.cpp
+++ b/tests/benchmarks/components/api/bench_noise_encrypt.cpp
@@ -88,11 +88,12 @@ BENCHMARK(NoiseEncrypt_LargeMessage);
 // Benchmark helper matching the exact pattern from
 // APINoiseFrameHelper::read_packet:
 //   - noise_buffer_init + noise_buffer_set_inout with capacity == size (decrypt shrinks)
-//   - No explicit set_nonce (production relies on internal nonce increment)
 //   - Error checking on decrypt return
 //
-// Uses a separate encrypt cipher to produce valid ciphertext each iteration,
-// then benchmarks only the decryption.
+// Pre-encrypts kInnerIterations messages with sequential nonces before the
+// timed loop. Each outer iteration re-inits the decrypt key to reset the
+// nonce back to 0, then decrypts all pre-encrypted messages in sequence.
+// The init_key cost is amortized over kInnerIterations decrypts.
 static void noise_decrypt_bench(benchmark::State &state, size_t plaintext_size) {
   NoiseCipherState *encrypt_cipher = create_cipher();
   NoiseCipherState *decrypt_cipher = create_cipher();
@@ -106,55 +107,45 @@ static void noise_decrypt_bench(benchmark::State &state, size_t plaintext_size) 
   }
 
   size_t mac_len = noise_cipherstate_get_mac_length(encrypt_cipher);
-  size_t buf_capacity = plaintext_size + mac_len;
-  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
+  size_t encrypted_size = plaintext_size + mac_len;
 
-  // Pre-encrypt one message to get valid ciphertext + MAC
-  memset(buffer.get(), 0x42, plaintext_size);
-  NoiseBuffer setup_buf;
-  noise_buffer_init(setup_buf);
-  noise_buffer_set_inout(setup_buf, buffer.get(), plaintext_size, buf_capacity);
-  int err = noise_cipherstate_encrypt(encrypt_cipher, &setup_buf);
-  if (err != NOISE_ERROR_NONE) {
-    state.SkipWithError("Setup encrypt failed");
-    noise_cipherstate_free(encrypt_cipher);
-    noise_cipherstate_free(decrypt_cipher);
-    return;
+  // Pre-encrypt kInnerIterations messages with sequential nonces (0..N-1).
+  auto ciphertexts = std::make_unique<uint8_t[]>(encrypted_size * kInnerIterations);
+  for (int i = 0; i < kInnerIterations; i++) {
+    uint8_t *ct = ciphertexts.get() + i * encrypted_size;
+    memset(ct, 0x42, plaintext_size);
+    NoiseBuffer enc_buf;
+    noise_buffer_init(enc_buf);
+    noise_buffer_set_inout(enc_buf, ct, plaintext_size, encrypted_size);
+    int err = noise_cipherstate_encrypt(encrypt_cipher, &enc_buf);
+    if (err != NOISE_ERROR_NONE) {
+      state.SkipWithError("Pre-encrypt failed");
+      noise_cipherstate_free(encrypt_cipher);
+      noise_cipherstate_free(decrypt_cipher);
+      return;
+    }
   }
-  size_t encrypted_size = setup_buf.size;
 
-  // Save the encrypted data as a template for each iteration
-  auto encrypted_template = std::make_unique<uint8_t[]>(encrypted_size);
-  memcpy(encrypted_template.get(), buffer.get(), encrypted_size);
-
-  // Decrypt the setup message to advance decrypt cipher nonce to 1
-  // (matches the encrypt cipher which is now at nonce 1)
-  NoiseBuffer decrypt_setup;
-  noise_buffer_init(decrypt_setup);
-  noise_buffer_set_inout(decrypt_setup, buffer.get(), encrypted_size, encrypted_size);
-  err = noise_cipherstate_decrypt(decrypt_cipher, &decrypt_setup);
-  if (err != NOISE_ERROR_NONE) {
-    state.SkipWithError("Setup decrypt failed");
-    noise_cipherstate_free(encrypt_cipher);
-    noise_cipherstate_free(decrypt_cipher);
-    return;
-  }
+  // Working buffer — decrypt modifies in place
+  auto buffer = std::make_unique<uint8_t[]>(encrypted_size);
+  static constexpr uint8_t KEY[32] = {0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+                                      0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB,
+                                      0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB, 0xAB};
 
   for (auto _ : state) {
+    // Reset nonce to 0 by re-initing the key (amortized over kInnerIterations)
+    noise_cipherstate_init_key(decrypt_cipher, KEY, sizeof(KEY));
+
     for (int i = 0; i < kInnerIterations; i++) {
-      // Re-encrypt with encrypt cipher to get fresh ciphertext with correct nonce
-      memset(buffer.get(), 0x42, plaintext_size);
-      NoiseBuffer enc_buf;
-      noise_buffer_init(enc_buf);
-      noise_buffer_set_inout(enc_buf, buffer.get(), plaintext_size, buf_capacity);
-      noise_cipherstate_encrypt(encrypt_cipher, &enc_buf);
+      // Copy ciphertext into working buffer (decrypt modifies in place)
+      memcpy(buffer.get(), ciphertexts.get() + i * encrypted_size, encrypted_size);
 
       // Decrypt matching production pattern
       NoiseBuffer mbuf;
       noise_buffer_init(mbuf);
-      noise_buffer_set_inout(mbuf, buffer.get(), enc_buf.size, enc_buf.size);
+      noise_buffer_set_inout(mbuf, buffer.get(), encrypted_size, encrypted_size);
 
-      err = noise_cipherstate_decrypt(decrypt_cipher, &mbuf);
+      int err = noise_cipherstate_decrypt(decrypt_cipher, &mbuf);
       if (err != NOISE_ERROR_NONE) {
         state.SkipWithError("noise_cipherstate_decrypt failed");
         noise_cipherstate_free(encrypt_cipher);

--- a/tests/benchmarks/components/api/bench_noise_encrypt.cpp
+++ b/tests/benchmarks/components/api/bench_noise_encrypt.cpp
@@ -85,6 +85,102 @@ BENCHMARK(NoiseEncrypt_MediumMessage);
 static void NoiseEncrypt_LargeMessage(benchmark::State &state) { noise_encrypt_bench(state, 1024); }
 BENCHMARK(NoiseEncrypt_LargeMessage);
 
+// Benchmark helper matching the exact pattern from
+// APINoiseFrameHelper::read_packet:
+//   - noise_buffer_init + noise_buffer_set_inout with capacity == size (decrypt shrinks)
+//   - No explicit set_nonce (production relies on internal nonce increment)
+//   - Error checking on decrypt return
+//
+// Uses a separate encrypt cipher to produce valid ciphertext each iteration,
+// then benchmarks only the decryption.
+static void noise_decrypt_bench(benchmark::State &state, size_t plaintext_size) {
+  NoiseCipherState *encrypt_cipher = create_cipher();
+  NoiseCipherState *decrypt_cipher = create_cipher();
+  if (encrypt_cipher == nullptr || decrypt_cipher == nullptr) {
+    state.SkipWithError("Failed to create cipher state");
+    if (encrypt_cipher)
+      noise_cipherstate_free(encrypt_cipher);
+    if (decrypt_cipher)
+      noise_cipherstate_free(decrypt_cipher);
+    return;
+  }
+
+  size_t mac_len = noise_cipherstate_get_mac_length(encrypt_cipher);
+  size_t buf_capacity = plaintext_size + mac_len;
+  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
+
+  // Pre-encrypt one message to get valid ciphertext + MAC
+  memset(buffer.get(), 0x42, plaintext_size);
+  NoiseBuffer setup_buf;
+  noise_buffer_init(setup_buf);
+  noise_buffer_set_inout(setup_buf, buffer.get(), plaintext_size, buf_capacity);
+  int err = noise_cipherstate_encrypt(encrypt_cipher, &setup_buf);
+  if (err != NOISE_ERROR_NONE) {
+    state.SkipWithError("Setup encrypt failed");
+    noise_cipherstate_free(encrypt_cipher);
+    noise_cipherstate_free(decrypt_cipher);
+    return;
+  }
+  size_t encrypted_size = setup_buf.size;
+
+  // Save the encrypted data as a template for each iteration
+  auto encrypted_template = std::make_unique<uint8_t[]>(encrypted_size);
+  memcpy(encrypted_template.get(), buffer.get(), encrypted_size);
+
+  // Decrypt the setup message to advance decrypt cipher nonce to 1
+  // (matches the encrypt cipher which is now at nonce 1)
+  NoiseBuffer decrypt_setup;
+  noise_buffer_init(decrypt_setup);
+  noise_buffer_set_inout(decrypt_setup, buffer.get(), encrypted_size, encrypted_size);
+  err = noise_cipherstate_decrypt(decrypt_cipher, &decrypt_setup);
+  if (err != NOISE_ERROR_NONE) {
+    state.SkipWithError("Setup decrypt failed");
+    noise_cipherstate_free(encrypt_cipher);
+    noise_cipherstate_free(decrypt_cipher);
+    return;
+  }
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      // Re-encrypt with encrypt cipher to get fresh ciphertext with correct nonce
+      memset(buffer.get(), 0x42, plaintext_size);
+      NoiseBuffer enc_buf;
+      noise_buffer_init(enc_buf);
+      noise_buffer_set_inout(enc_buf, buffer.get(), plaintext_size, buf_capacity);
+      noise_cipherstate_encrypt(encrypt_cipher, &enc_buf);
+
+      // Decrypt matching production pattern
+      NoiseBuffer mbuf;
+      noise_buffer_init(mbuf);
+      noise_buffer_set_inout(mbuf, buffer.get(), enc_buf.size, enc_buf.size);
+
+      err = noise_cipherstate_decrypt(decrypt_cipher, &mbuf);
+      if (err != NOISE_ERROR_NONE) {
+        state.SkipWithError("noise_cipherstate_decrypt failed");
+        noise_cipherstate_free(encrypt_cipher);
+        noise_cipherstate_free(decrypt_cipher);
+        return;
+      }
+    }
+    benchmark::DoNotOptimize(buffer[0]);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+
+  noise_cipherstate_free(encrypt_cipher);
+  noise_cipherstate_free(decrypt_cipher);
+}
+
+// --- Decrypt benchmarks (matching read_packet path) ---
+
+static void NoiseDecrypt_SmallMessage(benchmark::State &state) { noise_decrypt_bench(state, 14); }
+BENCHMARK(NoiseDecrypt_SmallMessage);
+
+static void NoiseDecrypt_MediumMessage(benchmark::State &state) { noise_decrypt_bench(state, 128); }
+BENCHMARK(NoiseDecrypt_MediumMessage);
+
+static void NoiseDecrypt_LargeMessage(benchmark::State &state) { noise_decrypt_bench(state, 1024); }
+BENCHMARK(NoiseDecrypt_LargeMessage);
+
 }  // namespace esphome::api::benchmarks
 
 #endif  // USE_API_NOISE

--- a/tests/benchmarks/components/api/bench_noise_encrypt.cpp
+++ b/tests/benchmarks/components/api/bench_noise_encrypt.cpp
@@ -3,6 +3,7 @@
 
 #include <benchmark/benchmark.h>
 #include <cstring>
+#include <memory>
 
 #include "noise/protocol.h"
 
@@ -29,10 +30,12 @@ static NoiseCipherState *create_cipher() {
   return cipher;
 }
 
-// --- Encrypt a typical sensor state message (small payload ~14 bytes) ---
-// This is the most common message encrypted on every sensor update.
-
-static void NoiseEncrypt_SmallMessage(benchmark::State &state) {
+// Benchmark helper matching the exact pattern from
+// APINoiseFrameHelper::write_protobuf_messages:
+//   - noise_buffer_init + noise_buffer_set_inout (same as production)
+//   - No explicit set_nonce (production relies on internal nonce increment)
+//   - Error checking on encrypt return
+static void noise_encrypt_bench(benchmark::State &state, size_t plaintext_size) {
   NoiseCipherState *cipher = create_cipher();
   if (cipher == nullptr) {
     state.SkipWithError("Failed to create cipher state");
@@ -40,19 +43,23 @@ static void NoiseEncrypt_SmallMessage(benchmark::State &state) {
   }
 
   size_t mac_len = noise_cipherstate_get_mac_length(cipher);
-  // Typical SensorStateResponse: 4 bytes type+len header + ~10 bytes payload
-  constexpr size_t plaintext_size = 14;
   size_t buf_capacity = plaintext_size + mac_len;
   auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
   memset(buffer.get(), 0x42, plaintext_size);
 
-  uint64_t nonce = 0;
   for (auto _ : state) {
     for (int i = 0; i < kInnerIterations; i++) {
-      noise_cipherstate_set_nonce(cipher, nonce++);
+      // Match production: init buffer, set inout, encrypt
       NoiseBuffer mbuf;
+      noise_buffer_init(mbuf);
       noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
-      noise_cipherstate_encrypt(cipher, &mbuf);
+
+      int err = noise_cipherstate_encrypt(cipher, &mbuf);
+      if (err != NOISE_ERROR_NONE) {
+        state.SkipWithError("noise_cipherstate_encrypt failed");
+        noise_cipherstate_free(cipher);
+        return;
+      }
     }
     benchmark::DoNotOptimize(buffer[0]);
   }
@@ -60,68 +67,22 @@ static void NoiseEncrypt_SmallMessage(benchmark::State &state) {
 
   noise_cipherstate_free(cipher);
 }
+
+// --- Encrypt a typical sensor state message (small payload ~14 bytes) ---
+// This is the most common message encrypted on every sensor update.
+// 4 bytes type+len header + ~10 bytes payload.
+
+static void NoiseEncrypt_SmallMessage(benchmark::State &state) { noise_encrypt_bench(state, 14); }
 BENCHMARK(NoiseEncrypt_SmallMessage);
 
 // --- Encrypt a medium message (~128 bytes, typical for LightStateResponse) ---
 
-static void NoiseEncrypt_MediumMessage(benchmark::State &state) {
-  NoiseCipherState *cipher = create_cipher();
-  if (cipher == nullptr) {
-    state.SkipWithError("Failed to create cipher state");
-    return;
-  }
-
-  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
-  constexpr size_t plaintext_size = 128;
-  size_t buf_capacity = plaintext_size + mac_len;
-  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
-  memset(buffer.get(), 0x42, plaintext_size);
-
-  uint64_t nonce = 0;
-  for (auto _ : state) {
-    for (int i = 0; i < kInnerIterations; i++) {
-      noise_cipherstate_set_nonce(cipher, nonce++);
-      NoiseBuffer mbuf;
-      noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
-      noise_cipherstate_encrypt(cipher, &mbuf);
-    }
-    benchmark::DoNotOptimize(buffer[0]);
-  }
-  state.SetItemsProcessed(state.iterations() * kInnerIterations);
-
-  noise_cipherstate_free(cipher);
-}
+static void NoiseEncrypt_MediumMessage(benchmark::State &state) { noise_encrypt_bench(state, 128); }
 BENCHMARK(NoiseEncrypt_MediumMessage);
 
 // --- Encrypt a large message (~1024 bytes, typical for DeviceInfoResponse) ---
 
-static void NoiseEncrypt_LargeMessage(benchmark::State &state) {
-  NoiseCipherState *cipher = create_cipher();
-  if (cipher == nullptr) {
-    state.SkipWithError("Failed to create cipher state");
-    return;
-  }
-
-  size_t mac_len = noise_cipherstate_get_mac_length(cipher);
-  constexpr size_t plaintext_size = 1024;
-  size_t buf_capacity = plaintext_size + mac_len;
-  auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
-  memset(buffer.get(), 0x42, plaintext_size);
-
-  uint64_t nonce = 0;
-  for (auto _ : state) {
-    for (int i = 0; i < kInnerIterations; i++) {
-      noise_cipherstate_set_nonce(cipher, nonce++);
-      NoiseBuffer mbuf;
-      noise_buffer_set_inout(mbuf, buffer.get(), plaintext_size, buf_capacity);
-      noise_cipherstate_encrypt(cipher, &mbuf);
-    }
-    benchmark::DoNotOptimize(buffer[0]);
-  }
-  state.SetItemsProcessed(state.iterations() * kInnerIterations);
-
-  noise_cipherstate_free(cipher);
-}
+static void NoiseEncrypt_LargeMessage(benchmark::State &state) { noise_encrypt_bench(state, 1024); }
 BENCHMARK(NoiseEncrypt_LargeMessage);
 
 }  // namespace esphome::api::benchmarks

--- a/tests/benchmarks/components/api/benchmark.yaml
+++ b/tests/benchmarks/components/api/benchmark.yaml
@@ -108,6 +108,7 @@ esphome:
       area_id: area_20
 
 api:
+  encryption:
 sensor:
 binary_sensor:
 light:

--- a/tests/benchmarks/components/api/benchmark.yaml
+++ b/tests/benchmarks/components/api/benchmark.yaml
@@ -108,7 +108,6 @@ esphome:
       area_id: area_20
 
 api:
-  encryption:
 sensor:
 binary_sensor:
 light:

--- a/tests/benchmarks/components/mdns/__init__.py
+++ b/tests/benchmarks/components/mdns/__init__.py
@@ -2,6 +2,4 @@ from tests.testing_helpers import ComponentManifestOverride
 
 
 def override_manifest(manifest: ComponentManifestOverride) -> None:
-    # api must run its to_code to define USE_API, USE_API_PLAINTEXT,
-    # and add the noise-c library dependency.
     manifest.enable_codegen()

--- a/tests/benchmarks/components/network/__init__.py
+++ b/tests/benchmarks/components/network/__init__.py
@@ -2,6 +2,4 @@ from tests.testing_helpers import ComponentManifestOverride
 
 
 def override_manifest(manifest: ComponentManifestOverride) -> None:
-    # api must run its to_code to define USE_API, USE_API_PLAINTEXT,
-    # and add the noise-c library dependency.
     manifest.enable_codegen()

--- a/tests/benchmarks/components/socket/__init__.py
+++ b/tests/benchmarks/components/socket/__init__.py
@@ -2,6 +2,6 @@ from tests.testing_helpers import ComponentManifestOverride
 
 
 def override_manifest(manifest: ComponentManifestOverride) -> None:
-    # api must run its to_code to define USE_API, USE_API_PLAINTEXT,
-    # and add the noise-c library dependency.
+    # socket must run its to_code to define USE_SOCKET_IMPL_BSD_SOCKETS
+    # which is needed by the api frame helper benchmarks.
     manifest.enable_codegen()


### PR DESCRIPTION
## What does this implement/fix?

Add CodSpeed benchmarks for the Noise protocol encryption path (ChaChaPoly cipher), which is the primary bottleneck for API connections with encryption enabled, especially on ESP8266.

Benchmarks cover three message sizes matching real-world patterns:
- Small (14 bytes) — typical SensorStateResponse
- Medium (128 bytes) — typical LightStateResponse
- Large (1024 bytes) — typical DeviceInfoResponse

Uses the noise-c library's `NoiseCipherState` directly with `NOISE_CIPHER_CHACHAPOLY`, matching the exact cipher used by `APINoiseFrameHelper::write_protobuf_messages`.

Also enables api codegen in the benchmark build and adds `encryption:` to the benchmark config so both `USE_API_NOISE` and `USE_API_PLAINTEXT` are defined.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).