### PR TITLE
[api] Enable HAVE_WEAK_SYMBOLS and HAVE_INLINE_ASM for libsodium

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -455,6 +455,9 @@ async def to_code(config: ConfigType) -> None:
             cg.add_define("USE_API_PLAINTEXT")
         cg.add_define("USE_API_NOISE")
         cg.add_library("esphome/noise-c", "0.1.11")
+        # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
+        cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
+        cg.add_build_flag("-DHAVE_INLINE_ASM=1")
     else:
         cg.add_define("USE_API_PLAINTEXT")
 


### PR DESCRIPTION
# What does this implement/fix?

Enable `HAVE_WEAK_SYMBOLS` and `HAVE_INLINE_ASM` build flags when building with Noise encryption. Without these flags, libsodium's `sodium_memzero()` falls through every `#elif` in `sodium/utils.c` to the **slowest fallback**: a volatile byte-by-byte zeroing loop:

```c
volatile unsigned char *volatile pnt_ =
    (volatile unsigned char *volatile) pnt;
size_t i = (size_t) 0U;
while (i < len) {
    pnt_[i++] = 0U;
}
```

With the flags defined, it instead uses `memset()` (word-sized stores, often a compiler builtin) guarded by a weak-symbol call + inline asm memory clobber to prevent the compiler from optimizing it away:

```c
memset(pnt, 0, len);
_sodium_dummy_symbol_to_prevent_memzero_lto(pnt, len);
__asm__ __volatile__ ("" : : "r"(pnt) : "memory");
```

This also improves `sodium_memcmp()` and `sodium_compare()` codegen by allowing non-volatile pointer access with weak barriers, and enables a timing-safe comparison optimization in `crypto_verify/verify.c`.

Both flags are safe for all ESPHome targets:
- **`HAVE_WEAK_SYMBOLS`**: `__attribute__((weak))` is a core GCC feature supported by all toolchains (Xtensa, RISC-V, ARM, x86_64).
- **`HAVE_INLINE_ASM`**: `__asm__` is likewise supported across all toolchains. The actual asm used is just a compiler barrier (`""` with memory clobber), not architecture-specific instructions.

### Benchmark results (ESP32, Noise encrypt)

| Message Size | Before (μs/op) | After (μs/op) | Speedup |
|---|---|---|---|
| 50B | 80.9 | 61.3 | **24% faster** |
| 100B | 97.4 | 76.5 | **21% faster** |
| 1000B | 372.5 | 356.2 | **4.4% faster** |

### Benchmark results (ESP8266, Noise encrypt)

| Message Size | Before (μs/op) | After (μs/op) | Speedup |
|---|---|---|---|
| 50B | 216.6 | 192.6 | **11% faster** |
| 100B | 293.8 | 269.7 | **8.2% faster** |
| 1000B | 1699.8 | 1676.0 | **1.4% faster** |

### Benchmark results (RP2040, Noise encrypt)

| Message Size | Before (μs/op) | After (μs/op) | Speedup |
|---|---|---|---|
| 50B | 159.2 | 142.6 | **10% faster** |
| 100B | 229.2 | 209.9 | **8.4% faster** |
| 1000B | 1148.8 | 1121.8 | **2.4% faster** |

The improvement is largest for small messages, which is the most impactful case — nearly all API messages (state updates, sensor readings, service calls) are under 50 bytes. Only Bluetooth proxy traffic typically produces large messages.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - flags are automatically added when encryption is enabled.
# Benchmark config used for testing:
esphome:
  name: noise-bench
  platformio_options:
    build_src_flags:
      - "-include noise/protocol.h"

api:
  encryption:
    key: !secret api_encryption_key

button:
  - platform: template
    name: "Benchmark Noise Encrypt 50B"
    on_press:
      - lambda: |-
          static const char *const BENCH_TAG = "noise_bench";
          size_t msg_size = 50;
          int iterations = 10000;

          NoiseCipherState *cipher = nullptr;
          int err = noise_cipherstate_new_by_id(&cipher, NOISE_CIPHER_CHACHAPOLY);
          if (err != NOISE_ERROR_NONE || cipher == nullptr) {
            ESP_LOGE(BENCH_TAG, "Failed to create cipher state: %d", err);
            return;
          }

          uint8_t key[32];
          memset(key, 0xAB, sizeof(key));
          err = noise_cipherstate_init_key(cipher, key, sizeof(key));
          if (err != NOISE_ERROR_NONE) {
            ESP_LOGE(BENCH_TAG, "Failed to init key: %d", err);
            noise_cipherstate_free(cipher);
            return;
          }

          size_t mac_len = noise_cipherstate_get_mac_length(cipher);
          size_t buf_capacity = msg_size + mac_len;
          auto buffer = std::make_unique<uint8_t[]>(buf_capacity);
          memset(buffer.get(), 0x42, msg_size);

          ESP_LOGI(BENCH_TAG, "Benchmarking: %d x encrypt %zu bytes (+ %zu MAC)...",
                   iterations, msg_size, mac_len);

          uint32_t start = micros();
          for (int i = 0; i < iterations; i++) {
            noise_cipherstate_set_nonce(cipher, i);
            NoiseBuffer mbuf;
            noise_buffer_set_inout(mbuf, buffer.get(), msg_size, buf_capacity);
            err = noise_cipherstate_encrypt(cipher, &mbuf);
            if (err != NOISE_ERROR_NONE) {
              ESP_LOGE(BENCH_TAG, "Encrypt failed at iteration %d: %d", i, err);
              break;
            }
          }

          uint32_t elapsed = micros() - start;
          float us_per_op = static_cast<float>(elapsed) / iterations;
          float mb_per_sec = (static_cast<float>(msg_size) * iterations) / elapsed;

          ESP_LOGI(BENCH_TAG, "Results: %u us total, %.1f us/op, %.2f MB/s",
                   elapsed, us_per_op, mb_per_sec);
          ESP_LOGI(BENCH_TAG, "  msg_size=%zu, iterations=%d, mac_len=%zu",
                   msg_size, iterations, mac_len);

          noise_cipherstate_free(cipher);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).