### PR TITLE
[core] Reduce automation call chain stack depth

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -322,7 +322,9 @@ template<typename... Ts> class Automation;
 template<typename... Ts> class Trigger {
  public:
   /// Inform the parent automation that the event has triggered.
-  void trigger(const Ts &...x) {
+  // Force-inline: collapses the Trigger→Automation→ActionList forwarding
+  // chain into a single frame, reducing automation call stack depth.
+  __attribute__((always_inline)) void trigger(const Ts &...x) {
     if (this->automation_parent_ == nullptr)
       return;
     this->automation_parent_->trigger(x...);
@@ -429,7 +431,9 @@ template<typename... Ts> class ActionList {
       this->add_action(action);
     }
   }
-  void play(const Ts &...x) {
+  // Force-inline: part of the Trigger→Automation→ActionList forwarding
+  // chain collapsed to reduce automation call stack depth.
+  __attribute__((always_inline)) void play(const Ts &...x) {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->play_complex(x...);
   }
@@ -473,7 +477,9 @@ template<typename... Ts> class Automation {
 
   void stop() { this->actions_.stop(); }
 
-  void trigger(const Ts &...x) { this->actions_.play(x...); }
+  // Force-inline: part of the Trigger→Automation→ActionList forwarding
+  // chain collapsed to reduce automation call stack depth.
+  __attribute__((always_inline)) void trigger(const Ts &...x) { this->actions_.play(x...); }
 
   bool is_running() { return this->actions_.is_running(); }
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -324,7 +324,7 @@ template<typename... Ts> class Trigger {
   /// Inform the parent automation that the event has triggered.
   // Force-inline: collapses the Trigger→Automation→ActionList forwarding
   // chain into a single frame, reducing automation call stack depth.
-  __attribute__((always_inline)) void trigger(const Ts &...x) {
+  inline void trigger(const Ts &...x) ESPHOME_ALWAYS_INLINE {
     if (this->automation_parent_ == nullptr)
       return;
     this->automation_parent_->trigger(x...);
@@ -433,7 +433,7 @@ template<typename... Ts> class ActionList {
   }
   // Force-inline: part of the Trigger→Automation→ActionList forwarding
   // chain collapsed to reduce automation call stack depth.
-  __attribute__((always_inline)) void play(const Ts &...x) {
+  inline void play(const Ts &...x) ESPHOME_ALWAYS_INLINE {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->play_complex(x...);
   }
@@ -479,7 +479,7 @@ template<typename... Ts> class Automation {
 
   // Force-inline: part of the Trigger→Automation→ActionList forwarding
   // chain collapsed to reduce automation call stack depth.
-  __attribute__((always_inline)) void trigger(const Ts &...x) { this->actions_.play(x...); }
+  inline void trigger(const Ts &...x) ESPHOME_ALWAYS_INLINE { this->actions_.play(x...); }
 
   bool is_running() { return this->actions_.is_running(); }
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -322,7 +322,7 @@ template<typename... Ts> class Automation;
 template<typename... Ts> class Trigger {
  public:
   /// Inform the parent automation that the event has triggered.
-  __attribute__((always_inline)) void trigger(const Ts &...x) {
+  void trigger(const Ts &...x) {
     if (this->automation_parent_ == nullptr)
       return;
     this->automation_parent_->trigger(x...);
@@ -429,7 +429,7 @@ template<typename... Ts> class ActionList {
       this->add_action(action);
     }
   }
-  __attribute__((always_inline)) void play(const Ts &...x) {
+  void play(const Ts &...x) {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->play_complex(x...);
   }
@@ -473,7 +473,7 @@ template<typename... Ts> class Automation {
 
   void stop() { this->actions_.stop(); }
 
-  __attribute__((always_inline)) void trigger(const Ts &...x) { this->actions_.play(x...); }
+  void trigger(const Ts &...x) { this->actions_.play(x...); }
 
   bool is_running() { return this->actions_.is_running(); }
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -322,7 +322,7 @@ template<typename... Ts> class Automation;
 template<typename... Ts> class Trigger {
  public:
   /// Inform the parent automation that the event has triggered.
-  void trigger(const Ts &...x) {
+  __attribute__((always_inline)) void trigger(const Ts &...x) {
     if (this->automation_parent_ == nullptr)
       return;
     this->automation_parent_->trigger(x...);
@@ -429,7 +429,7 @@ template<typename... Ts> class ActionList {
       this->add_action(action);
     }
   }
-  void play(const Ts &...x) {
+  __attribute__((always_inline)) void play(const Ts &...x) {
     if (this->actions_begin_ != nullptr)
       this->actions_begin_->play_complex(x...);
   }
@@ -473,7 +473,7 @@ template<typename... Ts> class Automation {
 
   void stop() { this->actions_.stop(); }
 
-  void trigger(const Ts &...x) { this->actions_.play(x...); }
+  __attribute__((always_inline)) void trigger(const Ts &...x) { this->actions_.play(x...); }
 
   bool is_running() { return this->actions_.is_running(); }
 

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -217,6 +217,13 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
  public:
   explicit LambdaAction(std::function<void(Ts...)> &&f) : f_(std::move(f)) {}
 
+  // Override play_complex to call play() non-virtually (qualified call),
+  // eliminating one virtual dispatch frame from the call stack.
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    LambdaAction::play(x...);
+    this->play_next_(x...);
+  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -250,6 +257,13 @@ template<typename... Ts> class ContinuationAction : public Action<Ts...> {
  public:
   explicit ContinuationAction(Action<Ts...> *parent) : parent_(parent) {}
 
+  // Override play_complex to call play() non-virtually (qualified call),
+  // eliminating one virtual dispatch frame from the call stack.
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    ContinuationAction::play(x...);
+    this->play_next_(x...);
+  }
   void play(const Ts &...x) override { this->parent_->play_next_(x...); }
 
  protected:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -217,13 +217,6 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
  public:
   explicit LambdaAction(std::function<void(Ts...)> &&f) : f_(std::move(f)) {}
 
-  // Override play_complex to call play() non-virtually (qualified call),
-  // eliminating one virtual dispatch frame from the call stack.
-  void play_complex(const Ts &...x) override {
-    this->num_running_++;
-    LambdaAction::play(x...);
-    this->play_next_(x...);
-  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -237,13 +230,6 @@ template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
  public:
   explicit StatelessLambdaAction(void (*f)(Ts...)) : f_(f) {}
 
-  // Override play_complex to call play() non-virtually (qualified call),
-  // eliminating one virtual dispatch frame from the call stack.
-  void play_complex(const Ts &...x) override {
-    this->num_running_++;
-    StatelessLambdaAction::play(x...);
-    this->play_next_(x...);
-  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -257,13 +243,6 @@ template<typename... Ts> class ContinuationAction : public Action<Ts...> {
  public:
   explicit ContinuationAction(Action<Ts...> *parent) : parent_(parent) {}
 
-  // Override play_complex to call play() non-virtually (qualified call),
-  // eliminating one virtual dispatch frame from the call stack.
-  void play_complex(const Ts &...x) override {
-    this->num_running_++;
-    ContinuationAction::play(x...);
-    this->play_next_(x...);
-  }
   void play(const Ts &...x) override { this->parent_->play_next_(x...); }
 
  protected:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -217,13 +217,6 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
  public:
   explicit LambdaAction(std::function<void(Ts...)> &&f) : f_(std::move(f)) {}
 
-  // Override play_complex to call play() non-virtually (qualified call),
-  // eliminating one virtual dispatch frame from the call stack.
-  void play_complex(const Ts &...x) override {
-    this->num_running_++;
-    LambdaAction::play(x...);
-    this->play_next_(x...);
-  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -257,13 +250,6 @@ template<typename... Ts> class ContinuationAction : public Action<Ts...> {
  public:
   explicit ContinuationAction(Action<Ts...> *parent) : parent_(parent) {}
 
-  // Override play_complex to call play() non-virtually (qualified call),
-  // eliminating one virtual dispatch frame from the call stack.
-  void play_complex(const Ts &...x) override {
-    this->num_running_++;
-    ContinuationAction::play(x...);
-    this->play_next_(x...);
-  }
   void play(const Ts &...x) override { this->parent_->play_next_(x...); }
 
  protected:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -217,6 +217,11 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
  public:
   explicit LambdaAction(std::function<void(Ts...)> &&f) : f_(std::move(f)) {}
 
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    this->f_(x...);
+    this->play_next_(x...);
+  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -230,6 +235,11 @@ template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
  public:
   explicit StatelessLambdaAction(void (*f)(Ts...)) : f_(f) {}
 
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    this->f_(x...);
+    this->play_next_(x...);
+  }
   void play(const Ts &...x) override { this->f_(x...); }
 
  protected:
@@ -243,6 +253,11 @@ template<typename... Ts> class ContinuationAction : public Action<Ts...> {
  public:
   explicit ContinuationAction(Action<Ts...> *parent) : parent_(parent) {}
 
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    this->parent_->play_next_(x...);
+    this->play_next_(x...);
+  }
   void play(const Ts &...x) override { this->parent_->play_next_(x...); }
 
  protected:

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -217,9 +217,11 @@ template<typename... Ts> class LambdaAction : public Action<Ts...> {
  public:
   explicit LambdaAction(std::function<void(Ts...)> &&f) : f_(std::move(f)) {}
 
+  // Override play_complex to call play() non-virtually (qualified call),
+  // eliminating one virtual dispatch frame from the call stack.
   void play_complex(const Ts &...x) override {
     this->num_running_++;
-    this->f_(x...);
+    LambdaAction::play(x...);
     this->play_next_(x...);
   }
   void play(const Ts &...x) override { this->f_(x...); }
@@ -235,9 +237,11 @@ template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
  public:
   explicit StatelessLambdaAction(void (*f)(Ts...)) : f_(f) {}
 
+  // Override play_complex to call play() non-virtually (qualified call),
+  // eliminating one virtual dispatch frame from the call stack.
   void play_complex(const Ts &...x) override {
     this->num_running_++;
-    this->f_(x...);
+    StatelessLambdaAction::play(x...);
     this->play_next_(x...);
   }
   void play(const Ts &...x) override { this->f_(x...); }
@@ -253,9 +257,11 @@ template<typename... Ts> class ContinuationAction : public Action<Ts...> {
  public:
   explicit ContinuationAction(Action<Ts...> *parent) : parent_(parent) {}
 
+  // Override play_complex to call play() non-virtually (qualified call),
+  // eliminating one virtual dispatch frame from the call stack.
   void play_complex(const Ts &...x) override {
     this->num_running_++;
-    this->parent_->play_next_(x...);
+    ContinuationAction::play(x...);
     this->play_next_(x...);
   }
   void play(const Ts &...x) override { this->parent_->play_next_(x...); }


### PR DESCRIPTION
# What does this implement/fix?

Force-inlines the `Trigger::trigger()` → `Automation::trigger()` → `ActionList::play()` forwarding chain using `__attribute__((always_inline))`, collapsing 3 stack frames into 1.

These are non-virtual header-only methods that just forward calls. The compiler doesn't always inline them despite being trivial, adding unnecessary stack depth to every automation invocation.

**Verified on real device (ESP32, ol.yaml) with #15041:**

Before (16 frames for button→lambda):
```
BT0:  user lambda
BT1:  StatelessLambdaAction::play
BT2:  Action::play_complex          [virtual]
BT3:  ActionList::play
BT4:  Automation::trigger
BT5:  Trigger::trigger
BT6:  ButtonPressTrigger::{lambda}
BT7:  Callback::_FUN
BT8:  Callback::call
BT9:  Button::press
BT10: APIConnection::on_button_command_request
BT11: APIServerConnectionBase::read_message
BT12: APIConnection::loop
BT13: APIServer::loop
BT14: Application::loop
BT15: loop_task
```

After this PR (10 frames — 6 fewer):
```
BT0:  user lambda
BT1:  StatelessLambdaAction::play
BT2:  Action::play_complex          [virtual]
BT3:  ActionList::play              ← Automation::trigger, Trigger::trigger,
                                      ButtonPressTrigger::{lambda}, Callback::_FUN
                                      all inlined here
BT4:  Callback::call                ← CallbackManager::call, LazyCallbackManager::call,
                                      Button::press all inlined here
BT5:  APIConnection::on_button_command_request
BT6:  APIServerConnectionBase::read_message
BT7:  APIConnection::loop
BT8:  APIServer::loop
BT9:  Application::loop             ← loop_task inlined here (#15041)
```

Flash impact: **-72 bytes** on the CI test config, **+20 bytes** on a real device config, **0 bytes** on ESP8266. Essentially free.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).