### PR TITLE
[core] Override play_complex in `StatelessLambdaAction<>`

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -236,6 +236,25 @@ template<typename... Ts> class StatelessLambdaAction : public Action<Ts...> {
   void (*f_)(Ts...);
 };
 
+/// Specialization for no-argument stateless lambdas (the most common case:
+/// button press, startup trigger, loop trigger, etc.).
+/// Overrides play_complex() to call play() non-virtually, eliminating one
+/// virtual dispatch frame from the call stack.
+template<> class StatelessLambdaAction<> : public Action<> {
+ public:
+  explicit StatelessLambdaAction(void (*f)()) : f_(f) {}
+
+  void play_complex() override {
+    this->num_running_++;
+    this->f_();
+    this->play_next_();
+  }
+  void play() override { this->f_(); }
+
+ protected:
+  void (*f_)();
+};
+
 /// Simple continuation action that calls play_next_ on a parent action.
 /// Used internally by IfAction, WhileAction, RepeatAction, etc. to chain actions.
 /// Memory: 4-8 bytes (parent pointer) vs 40 bytes (LambdaAction with std::function).


### PR DESCRIPTION
# What does this implement/fix?

Adds a template specialization of `StatelessLambdaAction<>` (no-argument case) that overrides `play_complex()` to call `play()` non-virtually, eliminating one virtual dispatch frame from the automation call stack.

The no-argument case is the most common automation action — button presses, startup triggers, loop triggers, etc. Only the `<>` specialization is added to avoid per-template-instantiation flash cost.

**Before (BT1-BT2 are two virtual calls):**
```
BT1: StatelessLambdaAction<>::play         [virtual]
BT2: Action<>::play_complex                [virtual]
```

**After (single frame):**
```
BT1: StatelessLambdaAction<>::play_complex [virtual, play() inlined]
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).