### PR TITLE
[esp32] Validate eFuse MAC reads and reject garbage MACs

### DIFF
--- a/esphome/components/esp32/helpers.cpp
+++ b/esphome/components/esp32/helpers.cpp
@@ -9,10 +9,13 @@
 
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
+#include "esphome/core/log.h"
 #include "esp_random.h"
 #include "esp_system.h"
 
 namespace esphome {
+
+static const char *const TAG = "esp32";
 
 bool random_bytes(uint8_t *data, size_t len) {
   esp_fill_random(data, len);
@@ -63,22 +66,43 @@ LwIPLock::~LwIPLock() {
 #endif
 }
 
+/// Read MAC and validate both the return code and content.
+static bool read_valid_mac(uint8_t *mac, esp_err_t err) { return err == ESP_OK && mac_address_is_valid(mac); }
+
+static constexpr size_t MAC_ADDRESS_SIZE_BITS = MAC_ADDRESS_SIZE * 8;  // 48 bits
+
 void get_mac_address_raw(uint8_t *mac) {  // NOLINT(readability-non-const-parameter)
 #if defined(CONFIG_SOC_IEEE802154_SUPPORTED)
   // When CONFIG_SOC_IEEE802154_SUPPORTED is defined, esp_efuse_mac_get_default
   // returns the 802.15.4 EUI-64 address, so we read directly from eFuse instead.
-  if (has_custom_mac_address()) {
-    esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48);
-  } else {
-    esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, 48);
+  // Both paths already read raw eFuse bytes, so there is no CRC-bypass fallback
+  // (unlike the non-IEEE802154 path where esp_efuse_mac_get_default does CRC checks).
+  if (has_custom_mac_address() &&
+      read_valid_mac(mac, esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, MAC_ADDRESS_SIZE_BITS))) {
+    return;
+  }
+  if (read_valid_mac(mac, esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, MAC_ADDRESS_SIZE_BITS))) {
+    return;
   }
 #else
-  if (has_custom_mac_address()) {
-    esp_efuse_mac_get_custom(mac);
-  } else {
-    esp_efuse_mac_get_default(mac);
+  if (has_custom_mac_address() && read_valid_mac(mac, esp_efuse_mac_get_custom(mac))) {
+    return;
+  }
+  if (read_valid_mac(mac, esp_efuse_mac_get_default(mac))) {
+    return;
+  }
+  // Default MAC read failed (e.g., eFuse CRC error) - try reading raw eFuse bytes
+  // directly, bypassing CRC validation. A MAC that passes mac_address_is_valid()
+  // (non-zero, non-broadcast, unicast) is almost certainly the real factory MAC
+  // with a corrupted CRC byte, which is far better than returning garbage or zeros.
+  if (read_valid_mac(mac, esp_efuse_read_field_blob(ESP_EFUSE_MAC_FACTORY, mac, MAC_ADDRESS_SIZE_BITS))) {
+    ESP_LOGW(TAG, "eFuse MAC CRC failed but raw bytes appear valid - using raw eFuse MAC");
+    return;
   }
 #endif
+  // All methods failed - zero the MAC rather than returning garbage
+  ESP_LOGE(TAG, "Failed to read a valid MAC address from eFuse");
+  memset(mac, 0, MAC_ADDRESS_SIZE);
 }
 
 void set_mac_address(uint8_t *mac) { esp_base_mac_addr_set(mac); }
@@ -88,9 +112,11 @@ bool has_custom_mac_address() {
   uint8_t mac[6];
   // do not use 'esp_efuse_mac_get_custom(mac)' because it drops an error in the logs whenever it fails
 #ifndef USE_ESP32_VARIANT_ESP32
-  return (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
+  return (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA_MAC_CUSTOM, mac, MAC_ADDRESS_SIZE_BITS) == ESP_OK) &&
+         mac_address_is_valid(mac);
 #else
-  return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, 48) == ESP_OK) && mac_address_is_valid(mac);
+  return (esp_efuse_read_field_blob(ESP_EFUSE_MAC_CUSTOM, mac, MAC_ADDRESS_SIZE_BITS) == ESP_OK) &&
+         mac_address_is_valid(mac);
 #endif
 #else
   return false;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -863,7 +863,16 @@ bool mac_address_is_valid(const uint8_t *mac) {
       is_all_ones = false;
     }
   }
-  return !(is_all_zeros || is_all_ones);
+  if (is_all_zeros || is_all_ones) {
+    return false;
+  }
+  // Reject multicast MACs (bit 0 of first byte set) - device MACs must be unicast.
+  // This catches garbage data from corrupted eFuse custom MAC areas, which often
+  // has random values that would otherwise pass the all-zeros/all-ones check.
+  if (mac[0] & 0x01) {
+    return false;
+  }
+  return true;
 }
 
 void IRAM_ATTR HOT delay_microseconds_safe(uint32_t us) {


### PR DESCRIPTION
# What does this implement/fix?

On some ESP32 boards (especially cheap clones and CYD boards), the eFuse custom MAC area contains random garbage that passes the existing all-zeros/all-ones validation in `mac_address_is_valid()`. Additionally, `esp_efuse_mac_get_default()` can fail with CRC errors (e.g., `Base MAC address version error, version = 84`), but the return value was ignored. This caused garbage MAC addresses to be advertised via mDNS, triggering false "MAC address changed" device conflict errors in Home Assistant on every boot.

Changes:

1. **`esp32/helpers.cpp` — `get_mac_address_raw()`**: Check return values from eFuse MAC read functions and add a fallback chain: custom MAC → default MAC → raw eFuse bytes (bypasses CRC) → zeroed MAC. Previously a failed read silently returned garbage. Logs `ESP_LOGW` when the CRC-bypass fallback is used and `ESP_LOGE` when all methods fail. When the CRC-bypass fallback reads a MAC that passes `mac_address_is_valid()` (non-zero, non-broadcast, unicast), it is almost certainly the real factory MAC with just a corrupted CRC byte — far better than returning garbage or zeros that cause device conflicts.

2. **`core/helpers.cpp` — `mac_address_is_valid()`**: Also reject multicast MACs (bit 0 of first byte set per IEEE 802.3 I/G bit). Device MACs must always be unicast. This catches garbage like `F5:D4:0D:80:00:FE` from corrupted custom MAC eFuse areas. This also strengthens the existing `has_custom_mac_address()` check which already calls this function.

3. **`esp32/helpers.cpp`**: Replace magic number `48` with `MAC_ADDRESS_SIZE_BITS` constexpr throughout.

### Fallback chains

Every step validates with `read_valid_mac()` which checks: `esp_err_t == ESP_OK` AND `mac_address_is_valid()` (not all-zeros, not all-ones, unicast).

The IEEE802154 path has only 2 steps because both already read raw eFuse bytes (no CRC to bypass). The non-IEEE802154 path has 3 steps because `esp_efuse_mac_get_default()` does CRC validation, so a raw eFuse fallback is needed when CRC is corrupted but the MAC bytes are intact.

```mermaid
flowchart TD
    start["get_mac_address_raw(mac)"]
    check_ieee["CONFIG_SOC_IEEE802154_SUPPORTED?"]

    start --> check_ieee

    %% IEEE802154 path
    check_ieee -->|Yes| ieee_custom{"has_custom_mac()?\nread ESP_EFUSE_MAC_CUSTOM\n(raw)"}
    ieee_custom -->|valid| done_ok["✓ Return valid MAC"]
    ieee_custom -->|fail| ieee_factory{"read ESP_EFUSE_MAC_FACTORY\n(raw)"}
    ieee_factory -->|valid| done_ok
    ieee_factory -->|fail| all_failed

    %% Non-IEEE802154 path
    check_ieee -->|No| std_custom{"has_custom_mac()?\nesp_efuse_mac_get_custom()\n(with CRC)"}
    std_custom -->|valid| done_ok
    std_custom -->|fail| std_default{"esp_efuse_mac_get_default()\n(with CRC)"}
    std_default -->|valid| done_ok
    std_default -->|fail| std_raw{"read ESP_EFUSE_MAC_FACTORY\n(raw, bypass CRC)"}
    std_raw -->|valid| done_warn["⚠ LOGW: CRC failed\nbut raw bytes valid\nReturn raw MAC"]
    std_raw -->|fail| all_failed

    all_failed["✗ LOGE: Failed to read\nvalid MAC from eFuse\nmemset(mac, 0)"]

    style done_ok fill:#2d6,stroke:#333,color:#fff
    style done_warn fill:#f90,stroke:#333,color:#fff
    style all_failed fill:#d33,stroke:#333,color:#fff
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14501

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing configuration changes)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — this fixes the default behavior.
# Users who previously needed this workaround may be able to remove it:
#
# esp32:
#   framework:
#     type: esp-idf
#     advanced:
#       ignore_efuse_custom_mac: true
#       ignore_efuse_mac_crc: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).