### PR TITLE
[tests] Fix flaky ld24xx integration tests by disabling API batching

### DIFF
--- a/tests/integration/fixtures/uart_mock_ld2410.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2410.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2410_engineering.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2410_engineering.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2412.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2412_engineering.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412_engineering.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2412_engineering_truncated.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2412_engineering_truncated.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2420.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2420.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2420_simple.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2420_simple.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 

--- a/tests/integration/fixtures/uart_mock_ld2450.yaml
+++ b/tests/integration/fixtures/uart_mock_ld2450.yaml
@@ -3,6 +3,7 @@ esphome:
 
 host:
 api:
+  batch_delay: 0ms  # Disable batching to receive all state updates
 logger:
   level: VERBOSE
 


### PR DESCRIPTION
# What does this implement/fix?

Add `batch_delay: 0ms` to all ld24xx UART mock integration test fixtures. Without this, the default API batching can coalesce rapid sensor state updates from consecutive UART mock injections, causing the test client to only see the final coalesced value instead of each intermediate state. This leads to flaky assertion failures like `assert 73.0 == 30.0` when the test expects the first injection's value but receives the second.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test fixture changes only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).