### PR TITLE
[api] Emit raw tag+value writes for forced fixed32 key fields

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -316,7 +316,7 @@ message ListEntitiesBinarySensorResponse {
   option (ifdef) = "USE_BINARY_SENSOR";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -334,7 +334,7 @@ message BinarySensorStateResponse {
   option (ifdef) = "USE_BINARY_SENSOR";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   // If the binary sensor does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -350,7 +350,7 @@ message ListEntitiesCoverResponse {
   option (ifdef) = "USE_COVER";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -383,7 +383,7 @@ message CoverStateResponse {
   option (ifdef) = "USE_COVER";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   // legacy: state has been removed in 1.13
   // clients/servers must still send/accept it until the next protocol change
   // Deprecated in API version 1.1
@@ -409,7 +409,7 @@ message CoverCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
 
   // legacy: command has been removed in 1.13
   // clients/servers must still send/accept it until the next protocol change
@@ -434,7 +434,7 @@ message ListEntitiesFanResponse {
   option (ifdef) = "USE_FAN";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -466,7 +466,7 @@ message FanStateResponse {
   option (ifdef) = "USE_FAN";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   bool oscillating = 3;
   // Deprecated in API version 1.6
@@ -483,7 +483,7 @@ message FanCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool has_state = 2;
   bool state = 3;
   // Deprecated in API version 1.6
@@ -522,7 +522,7 @@ message ListEntitiesLightResponse {
   option (ifdef) = "USE_LIGHT";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -551,7 +551,7 @@ message LightStateResponse {
   option (ifdef) = "USE_LIGHT";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   float brightness = 3;
   ColorMode color_mode = 11;
@@ -573,7 +573,7 @@ message LightCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool has_state = 2;
   bool state = 3;
   bool has_brightness = 4;
@@ -627,7 +627,7 @@ message ListEntitiesSensorResponse {
   option (ifdef) = "USE_SENSOR";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -651,7 +651,7 @@ message SensorStateResponse {
   option (ifdef) = "USE_SENSOR";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   float state = 2;
   // If the sensor does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -667,7 +667,7 @@ message ListEntitiesSwitchResponse {
   option (ifdef) = "USE_SWITCH";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -685,7 +685,7 @@ message SwitchStateResponse {
   option (ifdef) = "USE_SWITCH";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -696,7 +696,7 @@ message SwitchCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -709,7 +709,7 @@ message ListEntitiesTextSensorResponse {
   option (ifdef) = "USE_TEXT_SENSOR";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -726,7 +726,7 @@ message TextSensorStateResponse {
   option (ifdef) = "USE_TEXT_SENSOR";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string state = 2;
   // If the text sensor does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -922,7 +922,7 @@ message ListEntitiesServicesResponse {
   option (ifdef) = "USE_API_USER_DEFINED_ACTIONS";
 
   string name = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   repeated ListEntitiesServicesArgument args = 3 [(fixed_vector) = true];
   SupportsResponseType supports_response = 4;
 }
@@ -945,7 +945,7 @@ message ExecuteServiceRequest {
   option (no_delay) = true;
   option (ifdef) = "USE_API_USER_DEFINED_ACTIONS";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   repeated ExecuteServiceArgument args = 2 [(fixed_vector) = true];
   uint32 call_id = 3 [(field_ifdef) = "USE_API_USER_DEFINED_ACTION_RESPONSES"];
   bool return_response = 4 [(field_ifdef) = "USE_API_USER_DEFINED_ACTION_RESPONSES"];
@@ -972,7 +972,7 @@ message ListEntitiesCameraResponse {
   option (ifdef) = "USE_CAMERA";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
   bool disabled_by_default = 5;
@@ -987,7 +987,7 @@ message CameraImageResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_CAMERA";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bytes data = 2;
   bool done = 3;
   uint32 device_id = 4 [(field_ifdef) = "USE_DEVICES"];
@@ -1057,7 +1057,7 @@ message ListEntitiesClimateResponse {
   option (ifdef) = "USE_CLIMATE";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1095,7 +1095,7 @@ message ClimateStateResponse {
   option (ifdef) = "USE_CLIMATE";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   ClimateMode mode = 2;
   float current_temperature = 3;
   float target_temperature = 4;
@@ -1121,7 +1121,7 @@ message ClimateCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool has_mode = 2;
   ClimateMode mode = 3;
   bool has_target_temperature = 4;
@@ -1168,7 +1168,7 @@ message ListEntitiesWaterHeaterResponse {
   option (ifdef) = "USE_WATER_HEATER";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   string icon = 4 [(field_ifdef) = "USE_ENTITY_ICON"];
   bool disabled_by_default = 5;
@@ -1189,7 +1189,7 @@ message WaterHeaterStateResponse {
   option (ifdef) = "USE_WATER_HEATER";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   float current_temperature = 2;
   float target_temperature = 3;
   WaterHeaterMode mode = 4;
@@ -1219,7 +1219,7 @@ message WaterHeaterCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   // Bitmask of which fields are set (see WaterHeaterCommandHasField)
   uint32 has_fields = 2;
   WaterHeaterMode mode = 3;
@@ -1244,7 +1244,7 @@ message ListEntitiesNumberResponse {
   option (ifdef) = "USE_NUMBER";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1266,7 +1266,7 @@ message NumberStateResponse {
   option (ifdef) = "USE_NUMBER";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   float state = 2;
   // If the number does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -1280,7 +1280,7 @@ message NumberCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   float state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -1293,7 +1293,7 @@ message ListEntitiesSelectResponse {
   option (ifdef) = "USE_SELECT";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1310,7 +1310,7 @@ message SelectStateResponse {
   option (ifdef) = "USE_SELECT";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string state = 2;
   // If the select does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -1324,7 +1324,7 @@ message SelectCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -1337,7 +1337,7 @@ message ListEntitiesSirenResponse {
   option (ifdef) = "USE_SIREN";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1356,7 +1356,7 @@ message SirenStateResponse {
   option (ifdef) = "USE_SIREN";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -1367,7 +1367,7 @@ message SirenCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool has_state = 2;
   bool state = 3;
   bool has_tone = 4;
@@ -1400,7 +1400,7 @@ message ListEntitiesLockResponse {
   option (ifdef) = "USE_LOCK";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1422,7 +1422,7 @@ message LockStateResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_LOCK";
   option (no_delay) = true;
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   LockState state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -1432,7 +1432,7 @@ message LockCommandRequest {
   option (ifdef) = "USE_LOCK";
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   LockCommand command = 2;
 
   // Not yet implemented:
@@ -1449,7 +1449,7 @@ message ListEntitiesButtonResponse {
   option (ifdef) = "USE_BUTTON";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1466,7 +1466,7 @@ message ButtonCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   uint32 device_id = 2 [(field_ifdef) = "USE_DEVICES"];
 }
 
@@ -1516,7 +1516,7 @@ message ListEntitiesMediaPlayerResponse {
   option (ifdef) = "USE_MEDIA_PLAYER";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -1538,7 +1538,7 @@ message MediaPlayerStateResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_MEDIA_PLAYER";
   option (no_delay) = true;
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   MediaPlayerState state = 2;
   float volume = 3;
   bool muted = 4;
@@ -1551,7 +1551,7 @@ message MediaPlayerCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
 
   bool has_command = 2;
   MediaPlayerCommand command = 3;
@@ -2104,7 +2104,7 @@ message ListEntitiesAlarmControlPanelResponse {
   option (ifdef) = "USE_ALARM_CONTROL_PANEL";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
   string icon = 5 [(field_ifdef) = "USE_ENTITY_ICON"];
@@ -2122,7 +2122,7 @@ message AlarmControlPanelStateResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_ALARM_CONTROL_PANEL";
   option (no_delay) = true;
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   AlarmControlPanelState state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -2133,7 +2133,7 @@ message AlarmControlPanelCommandRequest {
   option (ifdef) = "USE_ALARM_CONTROL_PANEL";
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   AlarmControlPanelStateCommand command = 2;
   string code = 3;
   uint32 device_id = 4 [(field_ifdef) = "USE_DEVICES"];
@@ -2151,7 +2151,7 @@ message ListEntitiesTextResponse {
   option (ifdef) = "USE_TEXT";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
   string icon = 5 [(field_ifdef) = "USE_ENTITY_ICON"];
@@ -2171,7 +2171,7 @@ message TextStateResponse {
   option (ifdef) = "USE_TEXT";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string state = 2;
   // If the Text does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
@@ -2185,7 +2185,7 @@ message TextCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string state = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -2199,7 +2199,7 @@ message ListEntitiesDateResponse {
   option (ifdef) = "USE_DATETIME_DATE";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2215,7 +2215,7 @@ message DateStateResponse {
   option (ifdef) = "USE_DATETIME_DATE";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   // If the date does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
   bool missing_state = 2;
@@ -2231,7 +2231,7 @@ message DateCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   uint32 year = 2;
   uint32 month = 3;
   uint32 day = 4;
@@ -2246,7 +2246,7 @@ message ListEntitiesTimeResponse {
   option (ifdef) = "USE_DATETIME_TIME";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2262,7 +2262,7 @@ message TimeStateResponse {
   option (ifdef) = "USE_DATETIME_TIME";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   // If the time does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
   bool missing_state = 2;
@@ -2278,7 +2278,7 @@ message TimeCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   uint32 hour = 2;
   uint32 minute = 3;
   uint32 second = 4;
@@ -2293,7 +2293,7 @@ message ListEntitiesEventResponse {
   option (ifdef) = "USE_EVENT";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2311,7 +2311,7 @@ message EventResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_EVENT";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   string event_type = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -2324,7 +2324,7 @@ message ListEntitiesValveResponse {
   option (ifdef) = "USE_VALVE";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2351,7 +2351,7 @@ message ValveStateResponse {
   option (ifdef) = "USE_VALVE";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   float position = 2;
   ValveOperation current_operation = 3;
   uint32 device_id = 4 [(field_ifdef) = "USE_DEVICES"];
@@ -2364,7 +2364,7 @@ message ValveCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool has_position = 2;
   float position = 3;
   bool stop = 4;
@@ -2379,7 +2379,7 @@ message ListEntitiesDateTimeResponse {
   option (ifdef) = "USE_DATETIME_DATETIME";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2395,7 +2395,7 @@ message DateTimeStateResponse {
   option (ifdef) = "USE_DATETIME_DATETIME";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   // If the datetime does not have a valid state yet.
   // Equivalent to `!obj->has_state()` - inverse logic to make state packets smaller
   bool missing_state = 2;
@@ -2409,7 +2409,7 @@ message DateTimeCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   fixed32 epoch_seconds = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -2422,7 +2422,7 @@ message ListEntitiesUpdateResponse {
   option (ifdef) = "USE_UPDATE";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   reserved 4; // Deprecated: was string unique_id
 
@@ -2439,7 +2439,7 @@ message UpdateStateResponse {
   option (ifdef) = "USE_UPDATE";
   option (no_delay) = true;
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   bool missing_state = 2;
   bool in_progress = 3;
   bool has_progress = 4;
@@ -2463,7 +2463,7 @@ message UpdateCommandRequest {
   option (no_delay) = true;
   option (base_class) = "CommandProtoMessage";
 
-  fixed32 key = 1;
+  fixed32 key = 1 [(force) = true];
   UpdateCommand command = 2;
   uint32 device_id = 3 [(field_ifdef) = "USE_DEVICES"];
 }
@@ -2505,7 +2505,7 @@ message ListEntitiesInfraredResponse {
   option (ifdef) = "USE_INFRARED";
 
   string object_id = 1;
-  fixed32 key = 2;
+  fixed32 key = 2 [(force) = true];
   string name = 3;
   string icon = 4 [(field_ifdef) = "USE_ENTITY_ICON"];
   bool disabled_by_default = 5;
@@ -2521,7 +2521,7 @@ message InfraredRFTransmitRawTimingsRequest {
   option (ifdef) = "USE_IR_RF";
 
   uint32 device_id = 1 [(field_ifdef) = "USE_DEVICES"];
-  fixed32 key = 2;                                       // Key identifying the transmitter instance
+  fixed32 key = 2 [(force) = true];                                       // Key identifying the transmitter instance
   uint32 carrier_frequency = 3;                          // Carrier frequency in Hz
   uint32 repeat_count = 4;                               // Number of times to transmit (1 = once, 2 = twice, etc.)
   repeated sint32 timings = 5 [packed = true, (packed_buffer) = true];  // Raw timings in microseconds (zigzag-encoded): positive = mark (LED/TX on), negative = space (LED/TX off)
@@ -2535,7 +2535,7 @@ message InfraredRFReceiveEvent {
   option (no_delay) = true;
 
   uint32 device_id = 1 [(field_ifdef) = "USE_DEVICES"];
-  fixed32 key = 2;                                    // Key identifying the receiver instance
+  fixed32 key = 2 [(force) = true];                                    // Key identifying the receiver instance
   repeated sint32 timings = 3 [packed = true, (container_pointer_no_template) = "std::vector<int32_t>"];  // Raw timings in microseconds (zigzag-encoded): alternating mark/space periods
 }
 

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -208,7 +208,7 @@ uint32_t DeviceInfoResponse::calculate_size() const {
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   buffer.encode_string(5, this->device_class);
   buffer.encode_bool(6, this->is_status_binary_sensor);
@@ -224,7 +224,7 @@ void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesBinarySensorResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   size += ProtoSize::calc_length(1, this->device_class.size());
   size += ProtoSize::calc_bool(1, this->is_status_binary_sensor);
@@ -239,7 +239,7 @@ uint32_t ListEntitiesBinarySensorResponse::calculate_size() const {
   return size;
 }
 void BinarySensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -248,7 +248,7 @@ void BinarySensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t BinarySensorStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->state);
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -260,7 +260,7 @@ uint32_t BinarySensorStateResponse::calculate_size() const {
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->assumed_state);
   buffer.encode_bool(6, this->supports_position);
@@ -279,7 +279,7 @@ void ListEntitiesCoverResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesCoverResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   size += ProtoSize::calc_bool(1, this->assumed_state);
   size += ProtoSize::calc_bool(1, this->supports_position);
@@ -297,7 +297,7 @@ uint32_t ListEntitiesCoverResponse::calculate_size() const {
   return size;
 }
 void CoverStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_float(3, this->position);
   buffer.encode_float(4, this->tilt);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->current_operation));
@@ -307,7 +307,7 @@ void CoverStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t CoverStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_float(1, this->position);
   size += ProtoSize::calc_float(1, this->tilt);
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->current_operation));
@@ -357,7 +357,7 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_oscillation);
   buffer.encode_bool(6, this->supports_speed);
@@ -378,7 +378,7 @@ void ListEntitiesFanResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesFanResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   size += ProtoSize::calc_bool(1, this->supports_oscillation);
   size += ProtoSize::calc_bool(1, this->supports_speed);
@@ -400,7 +400,7 @@ uint32_t ListEntitiesFanResponse::calculate_size() const {
   return size;
 }
 void FanStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->oscillating);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
@@ -412,7 +412,7 @@ void FanStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t FanStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->state);
   size += ProtoSize::calc_bool(1, this->oscillating);
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->direction));
@@ -487,7 +487,7 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   for (const auto &it : *this->supported_color_modes) {
     buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
@@ -509,7 +509,7 @@ void ListEntitiesLightResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesLightResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   if (!this->supported_color_modes->empty()) {
     for (const auto &it : *this->supported_color_modes) {
@@ -534,7 +534,7 @@ uint32_t ListEntitiesLightResponse::calculate_size() const {
   return size;
 }
 void LightStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->state);
   buffer.encode_float(3, this->brightness);
   buffer.encode_uint32(11, static_cast<uint32_t>(this->color_mode));
@@ -553,7 +553,7 @@ void LightStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t LightStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->state);
   size += ProtoSize::calc_float(1, this->brightness);
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->color_mode));
@@ -683,7 +683,7 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -702,7 +702,7 @@ void ListEntitiesSensorResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesSensorResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -720,7 +720,7 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
   return size;
 }
 void SensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -729,7 +729,7 @@ void SensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t SensorStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_float(1, this->state);
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -741,7 +741,7 @@ uint32_t SensorStateResponse::calculate_size() const {
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -757,7 +757,7 @@ void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesSwitchResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -772,7 +772,7 @@ uint32_t ListEntitiesSwitchResponse::calculate_size() const {
   return size;
 }
 void SwitchStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -780,7 +780,7 @@ void SwitchStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t SwitchStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->state);
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -816,7 +816,7 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -831,7 +831,7 @@ void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesTextSensorResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -845,7 +845,7 @@ uint32_t ListEntitiesTextSensorResponse::calculate_size() const {
   return size;
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -854,7 +854,7 @@ void TextSensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t TextSensorStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->state.size());
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -1124,7 +1124,7 @@ uint32_t ListEntitiesServicesArgument::calculate_size() const {
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->name);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   for (auto &it : this->args) {
     buffer.encode_sub_message(3, it);
   }
@@ -1133,7 +1133,7 @@ void ListEntitiesServicesResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesServicesResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->name.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   if (!this->args.empty()) {
     for (const auto &it : this->args) {
       size += ProtoSize::calc_message_force(1, it.calculate_size());
@@ -1269,7 +1269,7 @@ uint32_t ExecuteServiceResponse::calculate_size() const {
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
@@ -1283,7 +1283,7 @@ void ListEntitiesCameraResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesCameraResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
@@ -1296,7 +1296,7 @@ uint32_t ListEntitiesCameraResponse::calculate_size() const {
   return size;
 }
 void CameraImageResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bytes(2, this->data_ptr_, this->data_len_);
   buffer.encode_bool(3, this->done);
 #ifdef USE_DEVICES
@@ -1305,7 +1305,7 @@ void CameraImageResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t CameraImageResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->data_len_);
   size += ProtoSize::calc_bool(1, this->done);
 #ifdef USE_DEVICES
@@ -1330,7 +1330,7 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t v
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
@@ -1374,7 +1374,7 @@ void ListEntitiesClimateResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesClimateResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   size += ProtoSize::calc_bool(1, this->supports_current_temperature);
   size += ProtoSize::calc_bool(1, this->supports_two_point_target_temperature);
@@ -1429,7 +1429,7 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
   return size;
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
   buffer.encode_float(3, this->current_temperature);
   buffer.encode_float(4, this->target_temperature);
@@ -1449,7 +1449,7 @@ void ClimateStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t ClimateStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
   size += ProtoSize::calc_float(1, this->current_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature);
@@ -1563,7 +1563,7 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_WATER_HEATER
 void ListEntitiesWaterHeaterResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -1584,7 +1584,7 @@ void ListEntitiesWaterHeaterResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -1606,7 +1606,7 @@ uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   return size;
 }
 void WaterHeaterStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_float(2, this->current_temperature);
   buffer.encode_float(3, this->target_temperature);
   buffer.encode_uint32(4, static_cast<uint32_t>(this->mode));
@@ -1619,7 +1619,7 @@ void WaterHeaterStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t WaterHeaterStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_float(1, this->current_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature);
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
@@ -1675,7 +1675,7 @@ bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1695,7 +1695,7 @@ void ListEntitiesNumberResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesNumberResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -1714,7 +1714,7 @@ uint32_t ListEntitiesNumberResponse::calculate_size() const {
   return size;
 }
 void NumberStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1723,7 +1723,7 @@ void NumberStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t NumberStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_float(1, this->state);
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -1760,7 +1760,7 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1777,7 +1777,7 @@ void ListEntitiesSelectResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesSelectResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -1795,7 +1795,7 @@ uint32_t ListEntitiesSelectResponse::calculate_size() const {
   return size;
 }
 void SelectStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1804,7 +1804,7 @@ void SelectStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t SelectStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->state.size());
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -1849,7 +1849,7 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1868,7 +1868,7 @@ void ListEntitiesSirenResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesSirenResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -1888,7 +1888,7 @@ uint32_t ListEntitiesSirenResponse::calculate_size() const {
   return size;
 }
 void SirenStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -1896,7 +1896,7 @@ void SirenStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t SirenStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->state);
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -1961,7 +1961,7 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1979,7 +1979,7 @@ void ListEntitiesLockResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesLockResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -1996,7 +1996,7 @@ uint32_t ListEntitiesLockResponse::calculate_size() const {
   return size;
 }
 void LockStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -2004,7 +2004,7 @@ void LockStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t LockStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -2054,7 +2054,7 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2069,7 +2069,7 @@ void ListEntitiesButtonResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesButtonResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -2124,7 +2124,7 @@ uint32_t MediaPlayerSupportedFormat::calculate_size() const {
 }
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2143,7 +2143,7 @@ void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesMediaPlayerResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -2163,7 +2163,7 @@ uint32_t ListEntitiesMediaPlayerResponse::calculate_size() const {
   return size;
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_float(3, this->volume);
   buffer.encode_bool(4, this->muted);
@@ -2173,7 +2173,7 @@ void MediaPlayerStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t MediaPlayerStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
   size += ProtoSize::calc_float(1, this->volume);
   size += ProtoSize::calc_bool(1, this->muted);
@@ -2942,7 +2942,7 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2959,7 +2959,7 @@ void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer &buffer) con
 uint32_t ListEntitiesAlarmControlPanelResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -2975,7 +2975,7 @@ uint32_t ListEntitiesAlarmControlPanelResponse::calculate_size() const {
   return size;
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -2983,7 +2983,7 @@ void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t AlarmControlPanelStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -3030,7 +3030,7 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3048,7 +3048,7 @@ void ListEntitiesTextResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesTextResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3065,7 +3065,7 @@ uint32_t ListEntitiesTextResponse::calculate_size() const {
   return size;
 }
 void TextStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -3074,7 +3074,7 @@ void TextStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t TextStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->state.size());
   size += ProtoSize::calc_bool(1, this->missing_state);
 #ifdef USE_DEVICES
@@ -3119,7 +3119,7 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3133,7 +3133,7 @@ void ListEntitiesDateResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesDateResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3146,7 +3146,7 @@ uint32_t ListEntitiesDateResponse::calculate_size() const {
   return size;
 }
 void DateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->year);
   buffer.encode_uint32(4, this->month);
@@ -3157,7 +3157,7 @@ void DateStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t DateStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->missing_state);
   size += ProtoSize::calc_uint32(1, this->year);
   size += ProtoSize::calc_uint32(1, this->month);
@@ -3202,7 +3202,7 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3216,7 +3216,7 @@ void ListEntitiesTimeResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesTimeResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3229,7 +3229,7 @@ uint32_t ListEntitiesTimeResponse::calculate_size() const {
   return size;
 }
 void TimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->hour);
   buffer.encode_uint32(4, this->minute);
@@ -3240,7 +3240,7 @@ void TimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t TimeStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->missing_state);
   size += ProtoSize::calc_uint32(1, this->hour);
   size += ProtoSize::calc_uint32(1, this->minute);
@@ -3285,7 +3285,7 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3303,7 +3303,7 @@ void ListEntitiesEventResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesEventResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3322,7 +3322,7 @@ uint32_t ListEntitiesEventResponse::calculate_size() const {
   return size;
 }
 void EventResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_string(2, this->event_type);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -3330,7 +3330,7 @@ void EventResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t EventResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->event_type.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -3341,7 +3341,7 @@ uint32_t EventResponse::calculate_size() const {
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3359,7 +3359,7 @@ void ListEntitiesValveResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesValveResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3376,7 +3376,7 @@ uint32_t ListEntitiesValveResponse::calculate_size() const {
   return size;
 }
 void ValveStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_float(2, this->position);
   buffer.encode_uint32(3, static_cast<uint32_t>(this->current_operation));
 #ifdef USE_DEVICES
@@ -3385,7 +3385,7 @@ void ValveStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t ValveStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_float(1, this->position);
   size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->current_operation));
 #ifdef USE_DEVICES
@@ -3428,7 +3428,7 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3442,7 +3442,7 @@ void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesDateTimeResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3455,7 +3455,7 @@ uint32_t ListEntitiesDateTimeResponse::calculate_size() const {
   return size;
 }
 void DateTimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_fixed32(3, this->epoch_seconds);
 #ifdef USE_DEVICES
@@ -3464,7 +3464,7 @@ void DateTimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t DateTimeStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->missing_state);
   size += ProtoSize::calc_fixed32(1, this->epoch_seconds);
 #ifdef USE_DEVICES
@@ -3501,7 +3501,7 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3516,7 +3516,7 @@ void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesUpdateResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3530,7 +3530,7 @@ uint32_t ListEntitiesUpdateResponse::calculate_size() const {
   return size;
 }
 void UpdateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key);
+  buffer.encode_fixed32(1, this->key, true);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_bool(3, this->in_progress);
   buffer.encode_bool(4, this->has_progress);
@@ -3546,7 +3546,7 @@ void UpdateStateResponse::encode(ProtoWriteBuffer &buffer) const {
 }
 uint32_t UpdateStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_bool(1, this->missing_state);
   size += ProtoSize::calc_bool(1, this->in_progress);
   size += ProtoSize::calc_bool(1, this->has_progress);
@@ -3642,7 +3642,7 @@ uint32_t ZWaveProxyRequest::calculate_size() const {
 #ifdef USE_INFRARED
 void ListEntitiesInfraredResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -3657,7 +3657,7 @@ void ListEntitiesInfraredResponse::encode(ProtoWriteBuffer &buffer) const {
 uint32_t ListEntitiesInfraredResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->object_id.size());
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
@@ -3717,7 +3717,7 @@ void InfraredRFReceiveEvent::encode(ProtoWriteBuffer &buffer) const {
 #ifdef USE_DEVICES
   buffer.encode_uint32(1, this->device_id);
 #endif
-  buffer.encode_fixed32(2, this->key);
+  buffer.encode_fixed32(2, this->key, true);
   for (const auto &it : *this->timings) {
     buffer.encode_sint32(3, it, true);
   }
@@ -3727,7 +3727,7 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
-  size += ProtoSize::calc_fixed32(1, this->key);
+  size += 5;
   if (!this->timings->empty()) {
     for (const auto &it : *this->timings) {
       size += ProtoSize::calc_sint32_force(1, it);

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -208,7 +208,8 @@ uint32_t DeviceInfoResponse::calculate_size() const {
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_string(5, this->device_class);
   buffer.encode_bool(6, this->is_status_binary_sensor);
@@ -239,7 +240,8 @@ uint32_t ListEntitiesBinarySensorResponse::calculate_size() const {
   return size;
 }
 void BinarySensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -260,7 +262,8 @@ uint32_t BinarySensorStateResponse::calculate_size() const {
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->assumed_state);
   buffer.encode_bool(6, this->supports_position);
@@ -297,7 +300,8 @@ uint32_t ListEntitiesCoverResponse::calculate_size() const {
   return size;
 }
 void CoverStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_float(3, this->position);
   buffer.encode_float(4, this->tilt);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->current_operation));
@@ -357,7 +361,8 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_oscillation);
   buffer.encode_bool(6, this->supports_speed);
@@ -400,7 +405,8 @@ uint32_t ListEntitiesFanResponse::calculate_size() const {
   return size;
 }
 void FanStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->oscillating);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
@@ -487,7 +493,8 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   for (const auto &it : *this->supported_color_modes) {
     buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
@@ -534,7 +541,8 @@ uint32_t ListEntitiesLightResponse::calculate_size() const {
   return size;
 }
 void LightStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_float(3, this->brightness);
   buffer.encode_uint32(11, static_cast<uint32_t>(this->color_mode));
@@ -683,7 +691,8 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -720,7 +729,8 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
   return size;
 }
 void SensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -741,7 +751,8 @@ uint32_t SensorStateResponse::calculate_size() const {
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -772,7 +783,8 @@ uint32_t ListEntitiesSwitchResponse::calculate_size() const {
   return size;
 }
 void SwitchStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -816,7 +828,8 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -845,7 +858,8 @@ uint32_t ListEntitiesTextSensorResponse::calculate_size() const {
   return size;
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1124,7 +1138,8 @@ uint32_t ListEntitiesServicesArgument::calculate_size() const {
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->name);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   for (auto &it : this->args) {
     buffer.encode_sub_message(3, it);
   }
@@ -1269,7 +1284,8 @@ uint32_t ExecuteServiceResponse::calculate_size() const {
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
@@ -1296,7 +1312,8 @@ uint32_t ListEntitiesCameraResponse::calculate_size() const {
   return size;
 }
 void CameraImageResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bytes(2, this->data_ptr_, this->data_len_);
   buffer.encode_bool(3, this->done);
 #ifdef USE_DEVICES
@@ -1330,7 +1347,8 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t v
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
@@ -1429,7 +1447,8 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
   return size;
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
   buffer.encode_float(3, this->current_temperature);
   buffer.encode_float(4, this->target_temperature);
@@ -1563,7 +1582,8 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_WATER_HEATER
 void ListEntitiesWaterHeaterResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -1606,7 +1626,8 @@ uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   return size;
 }
 void WaterHeaterStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_float(2, this->current_temperature);
   buffer.encode_float(3, this->target_temperature);
   buffer.encode_uint32(4, static_cast<uint32_t>(this->mode));
@@ -1675,7 +1696,8 @@ bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1714,7 +1736,8 @@ uint32_t ListEntitiesNumberResponse::calculate_size() const {
   return size;
 }
 void NumberStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1760,7 +1783,8 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1795,7 +1819,8 @@ uint32_t ListEntitiesSelectResponse::calculate_size() const {
   return size;
 }
 void SelectStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1849,7 +1874,8 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1888,7 +1914,8 @@ uint32_t ListEntitiesSirenResponse::calculate_size() const {
   return size;
 }
 void SirenStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -1961,7 +1988,8 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1996,7 +2024,8 @@ uint32_t ListEntitiesLockResponse::calculate_size() const {
   return size;
 }
 void LockStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -2054,7 +2083,8 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2124,7 +2154,8 @@ uint32_t MediaPlayerSupportedFormat::calculate_size() const {
 }
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2163,7 +2194,8 @@ uint32_t ListEntitiesMediaPlayerResponse::calculate_size() const {
   return size;
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_float(3, this->volume);
   buffer.encode_bool(4, this->muted);
@@ -2942,7 +2974,8 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2975,7 +3008,8 @@ uint32_t ListEntitiesAlarmControlPanelResponse::calculate_size() const {
   return size;
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -3030,7 +3064,8 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3065,7 +3100,8 @@ uint32_t ListEntitiesTextResponse::calculate_size() const {
   return size;
 }
 void TextStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -3119,7 +3155,8 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3146,7 +3183,8 @@ uint32_t ListEntitiesDateResponse::calculate_size() const {
   return size;
 }
 void DateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->year);
   buffer.encode_uint32(4, this->month);
@@ -3202,7 +3240,8 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3229,7 +3268,8 @@ uint32_t ListEntitiesTimeResponse::calculate_size() const {
   return size;
 }
 void TimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->hour);
   buffer.encode_uint32(4, this->minute);
@@ -3285,7 +3325,8 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3322,7 +3363,8 @@ uint32_t ListEntitiesEventResponse::calculate_size() const {
   return size;
 }
 void EventResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(2, this->event_type);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -3341,7 +3383,8 @@ uint32_t EventResponse::calculate_size() const {
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3376,7 +3419,8 @@ uint32_t ListEntitiesValveResponse::calculate_size() const {
   return size;
 }
 void ValveStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_float(2, this->position);
   buffer.encode_uint32(3, static_cast<uint32_t>(this->current_operation));
 #ifdef USE_DEVICES
@@ -3428,7 +3472,8 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3455,7 +3500,8 @@ uint32_t ListEntitiesDateTimeResponse::calculate_size() const {
   return size;
 }
 void DateTimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_fixed32(3, this->epoch_seconds);
 #ifdef USE_DEVICES
@@ -3501,7 +3547,8 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3530,7 +3577,8 @@ uint32_t ListEntitiesUpdateResponse::calculate_size() const {
   return size;
 }
 void UpdateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.encode_fixed32(1, this->key, true);
+  buffer.write_raw_byte(13);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_bool(3, this->in_progress);
   buffer.encode_bool(4, this->has_progress);
@@ -3642,7 +3690,8 @@ uint32_t ZWaveProxyRequest::calculate_size() const {
 #ifdef USE_INFRARED
 void ListEntitiesInfraredResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -3717,7 +3766,8 @@ void InfraredRFReceiveEvent::encode(ProtoWriteBuffer &buffer) const {
 #ifdef USE_DEVICES
   buffer.encode_uint32(1, this->device_id);
 #endif
-  buffer.encode_fixed32(2, this->key, true);
+  buffer.write_raw_byte(21);
+  buffer.write_fixed32_raw(this->key);
   for (const auto &it : *this->timings) {
     buffer.encode_sint32(3, it, true);
   }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -208,8 +208,7 @@ uint32_t DeviceInfoResponse::calculate_size() const {
 #ifdef USE_BINARY_SENSOR
 void ListEntitiesBinarySensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_string(5, this->device_class);
   buffer.encode_bool(6, this->is_status_binary_sensor);
@@ -240,8 +239,7 @@ uint32_t ListEntitiesBinarySensorResponse::calculate_size() const {
   return size;
 }
 void BinarySensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -262,8 +260,7 @@ uint32_t BinarySensorStateResponse::calculate_size() const {
 #ifdef USE_COVER
 void ListEntitiesCoverResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->assumed_state);
   buffer.encode_bool(6, this->supports_position);
@@ -300,8 +297,7 @@ uint32_t ListEntitiesCoverResponse::calculate_size() const {
   return size;
 }
 void CoverStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_float(3, this->position);
   buffer.encode_float(4, this->tilt);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->current_operation));
@@ -361,8 +357,7 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_oscillation);
   buffer.encode_bool(6, this->supports_speed);
@@ -405,8 +400,7 @@ uint32_t ListEntitiesFanResponse::calculate_size() const {
   return size;
 }
 void FanStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_bool(3, this->oscillating);
   buffer.encode_uint32(5, static_cast<uint32_t>(this->direction));
@@ -493,8 +487,7 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   for (const auto &it : *this->supported_color_modes) {
     buffer.encode_uint32(12, static_cast<uint32_t>(it), true);
@@ -541,8 +534,7 @@ uint32_t ListEntitiesLightResponse::calculate_size() const {
   return size;
 }
 void LightStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->state);
   buffer.encode_float(3, this->brightness);
   buffer.encode_uint32(11, static_cast<uint32_t>(this->color_mode));
@@ -691,8 +683,7 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -729,8 +720,7 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
   return size;
 }
 void SensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -751,8 +741,7 @@ uint32_t SensorStateResponse::calculate_size() const {
 #ifdef USE_SWITCH
 void ListEntitiesSwitchResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -783,8 +772,7 @@ uint32_t ListEntitiesSwitchResponse::calculate_size() const {
   return size;
 }
 void SwitchStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -828,8 +816,7 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -858,8 +845,7 @@ uint32_t ListEntitiesTextSensorResponse::calculate_size() const {
   return size;
 }
 void TextSensorStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1138,8 +1124,7 @@ uint32_t ListEntitiesServicesArgument::calculate_size() const {
 }
 void ListEntitiesServicesResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->name);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   for (auto &it : this->args) {
     buffer.encode_sub_message(3, it);
   }
@@ -1284,8 +1269,7 @@ uint32_t ExecuteServiceResponse::calculate_size() const {
 #ifdef USE_CAMERA
 void ListEntitiesCameraResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->disabled_by_default);
 #ifdef USE_ENTITY_ICON
@@ -1312,8 +1296,7 @@ uint32_t ListEntitiesCameraResponse::calculate_size() const {
   return size;
 }
 void CameraImageResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bytes(2, this->data_ptr_, this->data_len_);
   buffer.encode_bool(3, this->done);
 #ifdef USE_DEVICES
@@ -1347,8 +1330,7 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t v
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
   buffer.encode_bool(5, this->supports_current_temperature);
   buffer.encode_bool(6, this->supports_two_point_target_temperature);
@@ -1447,8 +1429,7 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
   return size;
 }
 void ClimateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->mode));
   buffer.encode_float(3, this->current_temperature);
   buffer.encode_float(4, this->target_temperature);
@@ -1582,8 +1563,7 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_WATER_HEATER
 void ListEntitiesWaterHeaterResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -1626,8 +1606,7 @@ uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   return size;
 }
 void WaterHeaterStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_float(2, this->current_temperature);
   buffer.encode_float(3, this->target_temperature);
   buffer.encode_uint32(4, static_cast<uint32_t>(this->mode));
@@ -1696,8 +1675,7 @@ bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1736,8 +1714,7 @@ uint32_t ListEntitiesNumberResponse::calculate_size() const {
   return size;
 }
 void NumberStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_float(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1783,8 +1760,7 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1819,8 +1795,7 @@ uint32_t ListEntitiesSelectResponse::calculate_size() const {
   return size;
 }
 void SelectStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -1874,8 +1849,7 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -1914,8 +1888,7 @@ uint32_t ListEntitiesSirenResponse::calculate_size() const {
   return size;
 }
 void SirenStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->state);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -1988,8 +1961,7 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2024,8 +1996,7 @@ uint32_t ListEntitiesLockResponse::calculate_size() const {
   return size;
 }
 void LockStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -2083,8 +2054,7 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2154,8 +2124,7 @@ uint32_t MediaPlayerSupportedFormat::calculate_size() const {
 }
 void ListEntitiesMediaPlayerResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -2194,8 +2163,7 @@ uint32_t ListEntitiesMediaPlayerResponse::calculate_size() const {
   return size;
 }
 void MediaPlayerStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
   buffer.encode_float(3, this->volume);
   buffer.encode_bool(4, this->muted);
@@ -2974,8 +2942,7 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3008,8 +2975,7 @@ uint32_t ListEntitiesAlarmControlPanelResponse::calculate_size() const {
   return size;
 }
 void AlarmControlPanelStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->state));
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -3064,8 +3030,7 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3100,8 +3065,7 @@ uint32_t ListEntitiesTextResponse::calculate_size() const {
   return size;
 }
 void TextStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_string(2, this->state);
   buffer.encode_bool(3, this->missing_state);
 #ifdef USE_DEVICES
@@ -3155,8 +3119,7 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3183,8 +3146,7 @@ uint32_t ListEntitiesDateResponse::calculate_size() const {
   return size;
 }
 void DateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->year);
   buffer.encode_uint32(4, this->month);
@@ -3240,8 +3202,7 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3268,8 +3229,7 @@ uint32_t ListEntitiesTimeResponse::calculate_size() const {
   return size;
 }
 void TimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_uint32(3, this->hour);
   buffer.encode_uint32(4, this->minute);
@@ -3325,8 +3285,7 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3363,8 +3322,7 @@ uint32_t ListEntitiesEventResponse::calculate_size() const {
   return size;
 }
 void EventResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_string(2, this->event_type);
 #ifdef USE_DEVICES
   buffer.encode_uint32(3, this->device_id);
@@ -3383,8 +3341,7 @@ uint32_t EventResponse::calculate_size() const {
 #ifdef USE_VALVE
 void ListEntitiesValveResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3419,8 +3376,7 @@ uint32_t ListEntitiesValveResponse::calculate_size() const {
   return size;
 }
 void ValveStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_float(2, this->position);
   buffer.encode_uint32(3, static_cast<uint32_t>(this->current_operation));
 #ifdef USE_DEVICES
@@ -3472,8 +3428,7 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3500,8 +3455,7 @@ uint32_t ListEntitiesDateTimeResponse::calculate_size() const {
   return size;
 }
 void DateTimeStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_fixed32(3, this->epoch_seconds);
 #ifdef USE_DEVICES
@@ -3547,8 +3501,7 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(5, this->icon);
@@ -3577,8 +3530,7 @@ uint32_t ListEntitiesUpdateResponse::calculate_size() const {
   return size;
 }
 void UpdateStateResponse::encode(ProtoWriteBuffer &buffer) const {
-  buffer.write_raw_byte(13);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(13, this->key);
   buffer.encode_bool(2, this->missing_state);
   buffer.encode_bool(3, this->in_progress);
   buffer.encode_bool(4, this->has_progress);
@@ -3690,8 +3642,7 @@ uint32_t ZWaveProxyRequest::calculate_size() const {
 #ifdef USE_INFRARED
 void ListEntitiesInfraredResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->object_id);
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   buffer.encode_string(3, this->name);
 #ifdef USE_ENTITY_ICON
   buffer.encode_string(4, this->icon);
@@ -3766,8 +3717,7 @@ void InfraredRFReceiveEvent::encode(ProtoWriteBuffer &buffer) const {
 #ifdef USE_DEVICES
   buffer.encode_uint32(1, this->device_id);
 #endif
-  buffer.write_raw_byte(21);
-  buffer.write_fixed32_raw(this->key);
+  buffer.write_tag_and_fixed32(21, this->key);
   for (const auto &it : *this->timings) {
     buffer.encode_sint32(3, it, true);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -236,12 +236,20 @@ class ProtoWriteBuffer {
    * Following https://protobuf.dev/programming-guides/encoding/#structure
    */
   void encode_field_raw(uint32_t field_id, uint32_t type) { this->encode_varint_raw((field_id << 3) | type); }
-  /// Write a single raw byte to the buffer (no tag, no encoding).
-  inline void write_raw_byte(uint8_t b) ESPHOME_ALWAYS_INLINE { *this->pos_++ = b; }
-  /// Write a raw 32-bit value in little-endian format (no tag, no zero check).
-  inline void write_fixed32_raw(uint32_t value) ESPHOME_ALWAYS_INLINE {
-    std::memcpy(this->pos_, &value, 4);
-    this->pos_ += 4;
+  /// Write a precomputed tag byte + 32-bit value in one operation.
+  /// Tag must be a single-byte varint (< 128). No zero check.
+  inline void write_tag_and_fixed32(uint8_t tag, uint32_t value) ESPHOME_ALWAYS_INLINE {
+    this->debug_check_bounds_(5);
+    this->pos_[0] = tag;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    std::memcpy(this->pos_ + 1, &value, 4);
+#else
+    this->pos_[1] = static_cast<uint8_t>(value & 0xFF);
+    this->pos_[2] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    this->pos_[3] = static_cast<uint8_t>((value >> 16) & 0xFF);
+    this->pos_[4] = static_cast<uint8_t>((value >> 24) & 0xFF);
+#endif
+    this->pos_ += 5;
   }
   void encode_string(uint32_t field_id, const char *string, size_t len, bool force = false) {
     if (len == 0 && !force)

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -236,6 +236,13 @@ class ProtoWriteBuffer {
    * Following https://protobuf.dev/programming-guides/encoding/#structure
    */
   void encode_field_raw(uint32_t field_id, uint32_t type) { this->encode_varint_raw((field_id << 3) | type); }
+  /// Write a single raw byte to the buffer (no tag, no encoding).
+  inline void write_raw_byte(uint8_t b) ESPHOME_ALWAYS_INLINE { *this->pos_++ = b; }
+  /// Write a raw 32-bit value in little-endian format (no tag, no zero check).
+  inline void write_fixed32_raw(uint32_t value) ESPHOME_ALWAYS_INLINE {
+    std::memcpy(this->pos_, &value, 4);
+    this->pos_ += 4;
+  }
   void encode_string(uint32_t field_id, const char *string, size_t len, bool force = false) {
     if (len == 0 && !force)
       return;
@@ -276,7 +283,7 @@ class ProtoWriteBuffer {
     this->debug_check_bounds_(1);
     *this->pos_++ = value ? 0x01 : 0x00;
   }
-  inline void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) ESPHOME_ALWAYS_INLINE {
+  void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
     if (value == 0 && !force)
       return;
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -276,8 +276,7 @@ class ProtoWriteBuffer {
     this->debug_check_bounds_(1);
     *this->pos_++ = value ? 0x01 : 0x00;
   }
-  // noinline: 51 call sites; inlining causes net code growth vs a single out-of-line copy
-  __attribute__((noinline)) void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
+  void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
     if (value == 0 && !force)
       return;
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -276,7 +276,7 @@ class ProtoWriteBuffer {
     this->debug_check_bounds_(1);
     *this->pos_++ = value ? 0x01 : 0x00;
   }
-  void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) {
+  inline void encode_fixed32(uint32_t field_id, uint32_t value, bool force = false) ESPHOME_ALWAYS_INLINE {
     if (value == 0 && !force)
       return;
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -254,14 +254,17 @@ class TypeInfo(ABC):
     def dump(self, name: str) -> str:
         """Dump the value to the output."""
 
+    def calculate_tag(self) -> int:
+        """Calculate the protobuf tag (field_id << 3 | wire_type)."""
+        return (self.number << 3) | (self.wire_type & 0b111)
+
     def calculate_field_id_size(self) -> int:
         """Calculates the size of a field ID in bytes.
 
         Returns:
             The number of bytes needed to encode the field ID
         """
-        # Calculate the tag by combining field_id and wire_type
-        tag = (self.number << 3) | (self.wire_type & 0b111)
+        tag = self.calculate_tag()
 
         # Calculate the varint size
         if tag < 128:
@@ -558,13 +561,10 @@ class Fixed32Type(TypeInfo):
 
     @property
     def encode_content(self) -> str:
-        tag = (self.number << 3) | (self.wire_type & 0b111)
+        tag = self.calculate_tag()
         if self.force and tag < 128:
-            # Emit raw byte writes: precomputed tag + direct memcpy
-            return (
-                f"buffer.write_raw_byte({tag});\n"
-                f"buffer.write_fixed32_raw(this->{self.field_name});"
-            )
+            # Emit combined tag+value write: precomputed tag + direct memcpy
+            return f"buffer.write_tag_and_fixed32({tag}, this->{self.field_name});"
         if self.force:
             return f"buffer.{self.encode_func}({self.number}, this->{self.field_name}, true);"
         return f"buffer.{self.encode_func}({self.number}, this->{self.field_name});"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -556,6 +556,19 @@ class Fixed32Type(TypeInfo):
         o += "out.append(buffer);"
         return o
 
+    @property
+    def encode_content(self) -> str:
+        tag = (self.number << 3) | (self.wire_type & 0b111)
+        if self.force and tag < 128:
+            # Emit raw byte writes: precomputed tag + direct memcpy
+            return (
+                f"buffer.write_raw_byte({tag});\n"
+                f"buffer.write_fixed32_raw(this->{self.field_name});"
+            )
+        if self.force:
+            return f"buffer.{self.encode_func}({self.number}, this->{self.field_name}, true);"
+        return f"buffer.{self.encode_func}({self.number}, this->{self.field_name});"
+
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         field_id_size = self.calculate_field_id_size()
         if force:


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the protobuf encode hot path based on CodSpeed CPU profiling of `CalcAndEncode_SensorStateResponse`.

**Problem:** `encode_fixed32` was `__attribute__((noinline))` and even without it, `-Os` heuristics kept it out-of-line at 51 call sites. The function body is trivial (1-byte tag + 4-byte memcpy) but call overhead dominated the hot encode path — called twice per `SensorStateResponse` (key + float state).

**Solution (3 commits):**

1. **Remove `noinline`** from `encode_fixed32` — the attribute was redundant since `-Os` already chose not to inline it.

2. **Mark all `fixed32 key` fields with `[(force) = true]`** in `api.proto` — entity keys are FNV hashes and never zero. This eliminates the zero-check branch in `encode()` and lets `calculate_size()` use compile-time constants (`size += 5`).

3. **Emit `write_tag_and_fixed32(tag, value)`** from the code generator — `api_protobuf.py` precomputes the tag byte at generation time via `calculate_tag()` and emits a combined write: `pos[0] = tag; memcpy(pos + 1, &value, 4); pos += 5`. No function call to `encode_fixed32`, no `encode_field_raw`, no zero check, no varint branching.

**Disassembly before:**
```asm
call8   encode_fixed32    # function call with zero-check branch + encode_field_raw call
```

**Disassembly after:**
```asm
movi    a9, 13            # precomputed tag byte (field 1, wire type 5)
s8i     a9, a8, 0         # pos[0] = tag
addi.n  a10, a10, 1       # pos + 1
callx8  memcpy            # memcpy(pos + 1, &key, 4)
addi.n  a8, a8, 5         # pos += 5
```

Flash impact: +92 bytes (555167 → 555259) on ESP32.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).