### PR TITLE
[uart] Fix RTL87xx compilation failure due to SUCCESS macro collision

### DIFF
--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -30,12 +30,17 @@ enum UARTDirection {
 const LogString *parity_to_str(UARTParityOptions parity);
 
 /// Result of a flush() call.
+// Some vendor SDKs (e.g., Realtek) define SUCCESS as a macro.
+// Save and restore around the enum to avoid collisions with our scoped enum value.
+#pragma push_macro("SUCCESS")
+#undef SUCCESS
 enum class FlushResult {
   SUCCESS,          ///< Confirmed: all bytes left the TX FIFO.
   TIMEOUT,          ///< Confirmed: timed out before TX completed.
   FAILED,           ///< Confirmed: driver or hardware error.
   ASSUMED_SUCCESS,  ///< Platform cannot report result; success is assumed.
 };
+#pragma pop_macro("SUCCESS")
 
 class UARTComponent {
  public:

--- a/tests/components/uart/test.rtl87xx-ard.yaml
+++ b/tests/components/uart/test.rtl87xx-ard.yaml
@@ -1,0 +1,14 @@
+uart:
+  - id: uart_id
+    tx_pin: PA23
+    rx_pin: PA18
+    baud_rate: 9600
+    data_bits: 8
+    parity: NONE
+    stop_bits: 1
+
+switch:
+  - platform: uart
+    name: "UART Switch"
+    uart_id: uart_id
+    data: [0x01, 0x02, 0x03]


### PR DESCRIPTION
# What does this implement/fix?

The Realtek SDK (`basic_types.h`) defines `#define SUCCESS 0` as a preprocessor macro. When the `api` or `wifi` components are included, the socket/lwIP include chain pulls in this SDK header before `uart_component.h` is processed. This causes the `FlushResult::SUCCESS` enum value (added in #14608) to be replaced by the preprocessor with `0`, breaking the enum definition and cascading into errors for `FlushResult`, `InternalGPIOPin`, `UARTParityOptions`, etc.

The fix adds `#undef SUCCESS` before the `FlushResult` enum definition, following the same pattern used elsewhere in the codebase for vendor SDK macro collisions (e.g., `socket/headers.h` for `INADDR_ANY`, `mdns_rp2040.cpp` for `IRAM_ATTR`, `http_request/httplib.h` for `X509_NAME`).

Also adds an RTL87xx UART compilation test.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15053

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any RTL87xx config using uart + api/wifi triggers this:
esphome:
  name: test

rtl87xx:
  board: generic-rtl8710bx-4mb-980k

api:

wifi:
  ssid: "test"
  password: "testtest"

uart:
  tx_pin: PA23
  rx_pin: PA18
  baud_rate: 9600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).