### PR TITLE
[light] Fix gamma LUT quantizing small brightness to zero

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -88,7 +88,15 @@ def _get_or_create_gamma_table(gamma_correct):
 
     if gamma_correct > 0:
         forward = [
-            HexInt(min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
+            # Clamp non-zero indices to minimum of 1 to preserve the invariant
+            # that non-zero input always produces non-zero output. Without this,
+            # small brightness values (e.g. 1%) get quantized to exactly 0.0,
+            # which breaks zero_means_zero logic in FloatOutput.
+            HexInt(
+                max(1, min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
+                if i > 0
+                else HexInt(0)
+            )
             for i in range(256)
         ]
     else:

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -81,17 +81,16 @@ def _get_data() -> LightData:
     return CORE.data[DOMAIN]
 
 
-def _get_or_create_gamma_table(gamma_correct):
-    data = _get_data()
-    if gamma_correct in data.gamma_tables:
-        return data.gamma_tables[gamma_correct]
+def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
+    """Generate a 256-entry uint16 gamma lookup table.
 
+    For gamma > 0, non-zero indices are clamped to a minimum of 1 to preserve
+    the invariant that non-zero input always produces non-zero output. Without
+    this, small brightness values (e.g. 1%) get quantized to exactly 0.0,
+    which breaks zero_means_zero logic in FloatOutput.
+    """
     if gamma_correct > 0:
-        forward = [
-            # Clamp non-zero indices to minimum of 1 to preserve the invariant
-            # that non-zero input always produces non-zero output. Without this,
-            # small brightness values (e.g. 1%) get quantized to exactly 0.0,
-            # which breaks zero_means_zero logic in FloatOutput.
+        return [
             HexInt(
                 max(1, min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
                 if i > 0
@@ -99,8 +98,15 @@ def _get_or_create_gamma_table(gamma_correct):
             )
             for i in range(256)
         ]
-    else:
-        forward = [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+    return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+
+
+def _get_or_create_gamma_table(gamma_correct):
+    data = _get_data()
+    if gamma_correct in data.gamma_tables:
+        return data.gamma_tables[gamma_correct]
+
+    forward = generate_gamma_table(gamma_correct)
 
     gamma_str = f"{gamma_correct}".replace(".", "_")
     fwd_id = ID(f"gamma_{gamma_str}_fwd", is_declaration=True, type=cg.uint16)

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -1,0 +1,117 @@
+"""Tests for the gamma LUT table generation."""
+
+import pytest
+
+from esphome.components.light import generate_gamma_table
+
+
+def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
+    """Simulate the C++ gamma_correct_lut interpolation from light_state.cpp."""
+    if value <= 0.0:
+        return 0.0
+    if value >= 1.0:
+        return 1.0
+    scaled = value * 255.0
+    idx = int(scaled)
+    if idx >= 255:
+        return table[255] / 65535.0
+    frac = scaled - idx
+    a = float(table[idx])
+    b = float(table[idx + 1])
+    return (a + frac * (b - a)) / 65535.0
+
+
+def test_table_length() -> None:
+    """Table must always have exactly 256 entries."""
+    table = generate_gamma_table(2.8)
+    assert len(table) == 256
+
+
+def test_index_zero_is_zero() -> None:
+    """Index 0 must be 0 so true off remains off."""
+    for gamma in (1.0, 2.0, 2.2, 2.8, 3.0):
+        table = generate_gamma_table(gamma)
+        assert table[0] == 0, f"gamma={gamma}"
+
+
+def test_index_255_is_max() -> None:
+    """Index 255 must be 65535 (full on)."""
+    for gamma in (1.0, 2.0, 2.2, 2.8, 3.0):
+        table = generate_gamma_table(gamma)
+        assert table[255] == 65535, f"gamma={gamma}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_nonzero_indices_are_nonzero(gamma: float) -> None:
+    """All indices > 0 must produce non-zero values.
+
+    This prevents zero_means_zero breakage: non-zero input must always
+    produce non-zero output so FloatOutput applies min_power scaling.
+    """
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert table[i] >= 1, f"gamma={gamma}, index {i}: got {table[i]}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_table_monotonically_nondecreasing(gamma: float) -> None:
+    """The gamma table must be monotonically non-decreasing."""
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert table[i] >= table[i - 1], (
+            f"gamma={gamma}: table[{i}]={table[i]} < table[{i - 1}]={table[i - 1]}"
+        )
+
+
+def test_linear_gamma() -> None:
+    """With gamma=0 (linear), table should be evenly spaced."""
+    table = generate_gamma_table(0)
+    assert table[0] == 0
+    assert table[128] == round(128 / 255.0 * 65535)
+    assert table[255] == 65535
+
+
+@pytest.mark.parametrize("brightness", [0.01, 0.005, 0.001, 1 / 255])
+def test_small_brightness_nonzero_after_lut(brightness: float) -> None:
+    """Small but non-zero brightness must produce non-zero output through the LUT.
+
+    Regression test for #15055: with zero_means_zero=true, a gamma-corrected
+    value of exactly 0.0 causes FloatOutput to skip min_power scaling, turning
+    the LED off instead of to minimum brightness.
+    """
+    table = generate_gamma_table(2.8)
+    result = _simulate_gamma_correct_lut(table, brightness)
+    assert result > 0.0, (
+        f"brightness={brightness}: gamma LUT returned 0.0, would break zero_means_zero"
+    )
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_small_brightness_nonzero_all_gammas(gamma: float) -> None:
+    """1% brightness must be non-zero for all common gamma values."""
+    table = generate_gamma_table(gamma)
+    result = _simulate_gamma_correct_lut(table, 0.01)
+    assert result > 0.0, f"gamma={gamma}: 1% brightness returned 0.0"
+
+
+def test_lut_zero_returns_zero() -> None:
+    """LUT with input 0.0 must return 0.0."""
+    table = generate_gamma_table(2.8)
+    assert _simulate_gamma_correct_lut(table, 0.0) == 0.0
+
+
+def test_lut_one_returns_one() -> None:
+    """LUT with input 1.0 must return 1.0."""
+    table = generate_gamma_table(2.8)
+    assert _simulate_gamma_correct_lut(table, 1.0) == 1.0
+
+
+def test_lut_output_monotonically_nondecreasing() -> None:
+    """LUT output must be monotonically non-decreasing across the full range."""
+    table = generate_gamma_table(2.8)
+    prev = 0.0
+    for i in range(1001):
+        value = i / 1000.0
+        result = _simulate_gamma_correct_lut(table, value)
+        assert result >= prev, f"value={value}: result {result} < previous {prev}"
+        prev = result


### PR DESCRIPTION
# What does this implement/fix?

The gamma LUT refactor (#14123) introduced a regression where small brightness values (e.g. 1%) get quantized to exactly 0.0 because the uint16 LUT entries round down to 0 for indices 1-3 with the default gamma of 2.8.

This breaks `zero_means_zero: true` in `FloatOutput` because the `min_power` scaling is skipped when `state == 0.0`, causing LEDs to turn off completely instead of respecting the configured `min_power`.

**Root cause:** With gamma=2.8, `(1/255)^2.8 * 65535 = 0.012`, `(2/255)^2.8 * 65535 = 0.083`, `(3/255)^2.8 * 65535 = 0.259` — all round to 0 in uint16. The old `powf()` implementation returned tiny but non-zero values (e.g. `powf(0.01, 2.8) ≈ 2.5e-6`), which correctly triggered the `min_power` scaling path.

**Fix:** Clamp non-zero LUT entries to a minimum of 1 (i.e. 1/65535), preserving the invariant that non-zero input always produces non-zero output. Index 0 remains 0 so true off still works.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15055

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
output:
  - platform: libretiny_pwm
    id: output_cw
    pin: P8
    frequency: 1kHz
    min_power: 0.01
    max_power: 0.3
    zero_means_zero: true

  - platform: libretiny_pwm
    id: output_ww
    pin: P7
    frequency: 1kHz
    min_power: 0.01
    max_power: 0.3
    zero_means_zero: true

light:
  - platform: cwww
    name: "Light"
    cold_white: output_cw
    warm_white: output_ww
    cold_white_color_temperature: 6500 K
    warm_white_color_temperature: 2700 K
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).