### PR TITLE
[mqtt] Rate-limit component resends to prevent task WDT on reconnect

### DIFF
--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -404,7 +404,7 @@ void MQTTClientComponent::loop() {
         {
           uint8_t resend_count = 0;
           for (MQTTComponent *component : this->children_) {
-            if (component->resend_pending()) {
+            if (component->is_resend_pending()) {
               component->process_resend();
               if (++resend_count >= MAX_RESENDS_PER_LOOP)
                 break;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -30,7 +30,7 @@ static const char *const TAG = "mqtt";
 
 // Maximum number of MQTT component resends per loop iteration.
 // Limits work to avoid triggering the task watchdog on reconnect.
-static constexpr uint8_t MAX_RESENDS_PER_LOOP = 4;
+static constexpr uint8_t MAX_RESENDS_PER_LOOP = 8;
 
 // Disconnect reason strings indexed by MQTTClientDisconnectReason enum (0-8)
 PROGMEM_STRING_TABLE(MQTTDisconnectReasonStrings, "TCP disconnected", "Unacceptable Protocol Version",

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -28,6 +28,10 @@ namespace esphome::mqtt {
 
 static const char *const TAG = "mqtt";
 
+// Maximum number of MQTT component resends per loop iteration.
+// Limits work to avoid triggering the task watchdog on reconnect.
+static constexpr uint8_t MAX_RESENDS_PER_LOOP = 4;
+
 // Disconnect reason strings indexed by MQTTClientDisconnectReason enum (0-8)
 PROGMEM_STRING_TABLE(MQTTDisconnectReasonStrings, "TCP disconnected", "Unacceptable Protocol Version",
                      "Identifier Rejected", "Server Unavailable", "Malformed Credentials", "Not Authorized",
@@ -396,9 +400,16 @@ void MQTTClientComponent::loop() {
         this->resubscribe_subscriptions_();
 
         // Process pending resends for all MQTT components centrally
-        // This is more efficient than each component polling in its own loop
-        for (MQTTComponent *component : this->children_) {
-          component->process_resend();
+        // Limit work per loop iteration to avoid triggering task WDT on reconnect
+        {
+          uint8_t resend_count = 0;
+          for (MQTTComponent *component : this->children_) {
+            if (component->resend_pending()) {
+              component->process_resend();
+              if (++resend_count >= MAX_RESENDS_PER_LOOP)
+                break;
+            }
+          }
         }
       }
       break;

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -148,7 +148,7 @@ class MQTTComponent : public Component {
   void schedule_resend_state();
 
   /// Check if a resend is pending (called by MQTTClientComponent to rate-limit work)
-  bool resend_pending() const { return this->resend_state_; }
+  bool is_resend_pending() const { return this->resend_state_; }
 
   /// Process pending resend if needed (called by MQTTClientComponent)
   void process_resend();

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -147,6 +147,9 @@ class MQTTComponent : public Component {
   /// Internal method for the MQTT client base to schedule a resend of the state on reconnect.
   void schedule_resend_state();
 
+  /// Check if a resend is pending (called by MQTTClientComponent to rate-limit work)
+  bool resend_pending() const { return this->resend_state_; }
+
   /// Process pending resend if needed (called by MQTTClientComponent)
   void process_resend();
 


### PR DESCRIPTION
# What does this implement/fix?

When MQTT reconnects, all registered MQTT components have their discovery info and state republished via `process_resend()`. With many components (50-100+), processing all of them in a single loop iteration blocks the main loop long enough to trigger the ESP32 task watchdog timer (default 5s timeout).

This limits the resend loop to process at most 4 components per loop iteration, spreading the work across multiple cycles. Components that haven't been processed yet retain their `resend_state_` flag and are picked up in subsequent iterations.

Zero additional RAM cost — uses only a stack-local counter and an inline accessor on an existing bitfield.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15057

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal behavior fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).