### PR TITLE
[core] Inline Component::get_component_log_str()

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -272,9 +272,6 @@ void Component::call() {
       break;
   }
 }
-const LogString *Component::get_component_log_str() const {
-  return this->component_source_ == nullptr ? LOG_STR("<unknown>") : this->component_source_;
-}
 bool Component::should_warn_of_blocking(uint32_t blocking_time) {
   if (blocking_time > this->warn_if_blocking_over_) {
     // Prevent overflow when adding increment - if we're about to overflow, just max out

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -294,7 +294,9 @@ class Component {
    *
    * Returns LOG_STR("<unknown>") if source not set
    */
-  const LogString *get_component_log_str() const;
+  const LogString *get_component_log_str() const {
+    return this->component_source_ == nullptr ? LOG_STR("<unknown>") : this->component_source_;
+  }
 
   bool should_warn_of_blocking(uint32_t blocking_time);
 


### PR DESCRIPTION
# What does this implement/fix?

Move `Component::get_component_log_str()` from `component.cpp` into `component.h` as an inline method. This is a trivial null-check that returns a pointer, and inlining it eliminates function call overhead at the many call sites in hot logging paths (scheduler, application loop, component setup/teardown).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).