### PR TITLE
[lvgl] Don't animate page change when not requested

### DIFF
--- a/esphome/components/lvgl/defines.py
+++ b/esphome/components/lvgl/defines.py
@@ -280,7 +280,7 @@ SWIPE_TRIGGERS = tuple(
 
 
 LV_ANIM = LvConstant(
-    "LV_SCR_LOAD_ANIM_",
+    "LV_SCREEN_LOAD_ANIM_",
     "NONE",
     "OVER_LEFT",
     "OVER_RIGHT",

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -176,7 +176,11 @@ void LvglComponent::show_page(size_t index, lv_scr_load_anim_t anim, uint32_t ti
   if (index >= this->pages_.size())
     return;
   this->current_page_ = index;
-  lv_scr_load_anim(this->pages_[this->current_page_]->obj, anim, time, 0, false);
+  if (anim == LV_SCREEN_LOAD_ANIM_NONE) {
+    lv_scr_load(this->pages_[this->current_page_]->obj);
+  } else {
+    lv_scr_load_anim(this->pages_[this->current_page_]->obj, anim, time, 0, false);
+  }
 }
 
 void LvglComponent::show_next_page(lv_scr_load_anim_t anim, uint32_t time) {
@@ -262,8 +266,8 @@ void LvglComponent::flush_cb_(lv_display_t *disp_drv, const lv_area_t *area, uin
   if (!this->is_paused()) {
     auto now = millis();
     this->draw_buffer_(area, reinterpret_cast<lv_color_data *>(color_p));
-    ESP_LOGV(TAG, "flush_cb, area=%d/%d, %d/%d took %dms", area->x1, area->y1, lv_area_get_width(area),
-             lv_area_get_height(area), (int) (millis() - now));
+    ESP_LOGV(TAG, "flush_cb, area=%d/%d, %d/%d took %dms", (int) area->x1, (int) area->y1,
+             (int) lv_area_get_width(area), (int) lv_area_get_height(area), (int) (millis() - now));
   }
   lv_display_flush_ready(disp_drv);
 }

--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -623,7 +623,7 @@ void LvglComponent::setup() {
   // Rotation will be handled by our drawing function, so reset the display rotation.
   for (auto *disp : this->displays_)
     disp->set_rotation(display::DISPLAY_ROTATION_0_DEGREES);
-  this->show_page(0, LV_SCR_LOAD_ANIM_NONE, 0);
+  this->show_page(0, LV_SCREEN_LOAD_ANIM_NONE, 0);
   lv_display_trigger_activity(this->disp_);
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

In LVGL 9.x `lv_screen_load_anim()` with ANIM_NONE behaves differently to LVGL 8.x, and results in some odd artifacts on page change.

Use `lv_screen_load_anim()` only when animation is requested.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1270223320989831178/1484954420784398437

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
