### PR TITLE
[logger] Fix race condition in task log buffer initialization

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -331,11 +331,27 @@ async def to_code(config: ConfigType) -> None:
     CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
     tx_buffer_size = config[CONF_TX_BUFFER_SIZE]
     cg.add_define("ESPHOME_LOGGER_TX_BUFFER_SIZE", tx_buffer_size)
-    log = cg.new_Pvariable(
-        config[CONF_ID],
-        baud_rate,
-    )
-    if CORE.is_esp32:
+    # Determine task log buffer size and define USE_ESPHOME_TASK_LOG_BUFFER early
+    # so the constructor can allocate the buffer immediately, preventing a race
+    # where another task logs before the buffer is initialized.
+    task_log_buffer_size = 0
+    if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
+        task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
+    elif CORE.is_host:
+        task_log_buffer_size = 64  # Fixed 64 slots for host
+    if task_log_buffer_size > 0:
+        cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
+        log = cg.new_Pvariable(
+            config[CONF_ID],
+            baud_rate,
+            task_log_buffer_size,
+        )
+    else:
+        log = cg.new_Pvariable(
+            config[CONF_ID],
+            baud_rate,
+        )
+    if CORE.is_esp32 or CORE.is_host:
         cg.add(log.create_pthread_key())
     # set_uart_selection() must be called before pre_setup() because
     # pre_setup() switches on uart_ to decide which hardware to initialize
@@ -364,17 +380,10 @@ async def _late_logger_init(config: ConfigType) -> None:
     log = await cg.get_variable(config[CONF_ID])
     level = config[CONF_LEVEL]
     baud_rate: int = config[CONF_BAUD_RATE]
-    if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
-        task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
+    if CORE.using_zephyr:
+        task_log_buffer_size = config.get(CONF_TASK_LOG_BUFFER_SIZE, 0)
         if task_log_buffer_size > 0:
-            cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
-            cg.add(log.init_log_buffer(task_log_buffer_size))
-            if CORE.using_zephyr:
-                zephyr_add_prj_conf("MPSC_PBUF", True)
-    elif CORE.is_host:
-        cg.add(log.create_pthread_key())
-        cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
-        cg.add(log.init_log_buffer(64))  # Fixed 64 slots for host
+            zephyr_add_prj_conf("MPSC_PBUF", True)
 
     # Enable runtime tag levels if logs are configured or explicitly enabled
     logs_config = config[CONF_LOGS]

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -162,7 +162,7 @@ Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
 #elif defined(USE_ZEPHYR)
   this->main_task_ = k_current_get();
 #elif defined(USE_HOST)
-  this->main_thread_ = pthread_self();
+this->main_thread_ = pthread_self();
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   this->init_log_buffer_(task_log_buffer_size);

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -165,11 +165,11 @@ Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
 this->main_thread_ = pthread_self();
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  this->init_log_buffer(task_log_buffer_size);
+  this->init_log_buffer_(task_log_buffer_size);
 #endif
 }
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-void Logger::init_log_buffer(size_t total_buffer_size) {
+void Logger::init_log_buffer_(size_t total_buffer_size) {
   // Host uses slot count instead of byte size
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
   this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -170,16 +170,11 @@ this->main_thread_ = pthread_self();
 }
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
 void Logger::init_log_buffer_(size_t total_buffer_size) {
-  // Host uses slot count instead of byte size
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
   this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);
-
-#if !(defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
-  // Start with loop disabled when using task buffer
-  // The loop will be enabled automatically when messages arrive
-  // Zephyr with USB CDC needs loop active to poll port readiness via cdc_loop_()
-  this->disable_loop_when_buffer_empty_();
-#endif
+  // Note: we don't call disable_loop_when_buffer_empty_() here because this is called
+  // from the constructor before the component is registered with App. The loop will
+  // self-disable on its first iteration when it finds no messages to process.
 }
 #endif
 

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -165,18 +165,12 @@ Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
 this->main_thread_ = pthread_self();
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  this->init_log_buffer_(task_log_buffer_size);
-#endif
-}
-#ifdef USE_ESPHOME_TASK_LOG_BUFFER
-void Logger::init_log_buffer_(size_t total_buffer_size) {
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
-  this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);
-  // Note: we don't call disable_loop_when_buffer_empty_() here because this is called
-  // from the constructor before the component is registered with App. The loop will
-  // self-disable on its first iteration when it finds no messages to process.
-}
+  this->log_buffer_ = new logger::TaskLogBuffer(task_log_buffer_size);
+  // Note: we don't disable loop here because the component isn't registered with App yet.
+  // The loop self-disables on its first iteration when it finds no messages to process.
 #endif
+}
 
 #if defined(USE_ESPHOME_TASK_LOG_BUFFER) || (defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
 void Logger::loop() {

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -152,13 +152,20 @@ inline uint8_t Logger::level_for(const char *tag) {
   return this->current_level_;
 }
 
+#ifdef USE_ESPHOME_TASK_LOG_BUFFER
+Logger::Logger(uint32_t baud_rate, size_t task_log_buffer_size) : baud_rate_(baud_rate) {
+#else
 Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
+#endif
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
   this->main_task_ = xTaskGetCurrentTaskHandle();
 #elif defined(USE_ZEPHYR)
   this->main_task_ = k_current_get();
 #elif defined(USE_HOST)
-  this->main_thread_ = pthread_self();
+this->main_thread_ = pthread_self();
+#endif
+#ifdef USE_ESPHOME_TASK_LOG_BUFFER
+  this->init_log_buffer(task_log_buffer_size);
 #endif
 }
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -162,7 +162,7 @@ Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
 #elif defined(USE_ZEPHYR)
   this->main_task_ = k_current_get();
 #elif defined(USE_HOST)
-this->main_thread_ = pthread_self();
+  this->main_thread_ = pthread_self();
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
   this->init_log_buffer_(task_log_buffer_size);

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -143,9 +143,10 @@ enum UARTSelection : uint8_t {
  */
 class Logger final : public Component {
  public:
-  explicit Logger(uint32_t baud_rate);
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  void init_log_buffer(size_t total_buffer_size);
+  explicit Logger(uint32_t baud_rate, size_t task_log_buffer_size);
+#else
+  explicit Logger(uint32_t baud_rate);
 #endif
 #if defined(USE_ESPHOME_TASK_LOG_BUFFER) || (defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
   void loop() override;
@@ -353,6 +354,7 @@ class Logger final : public Component {
   std::vector<LoggerLevelListener *> level_listeners_;  // Log level change listeners
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
+  void init_log_buffer(size_t total_buffer_size);
   logger::TaskLogBuffer *log_buffer_{nullptr};  // Allocated once, never freed
 #endif
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -354,7 +354,7 @@ class Logger final : public Component {
   std::vector<LoggerLevelListener *> level_listeners_;  // Log level change listeners
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  void init_log_buffer(size_t total_buffer_size);
+  void init_log_buffer_(size_t total_buffer_size);
   logger::TaskLogBuffer *log_buffer_{nullptr};  // Allocated once, never freed
 #endif
 

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -354,7 +354,6 @@ class Logger final : public Component {
   std::vector<LoggerLevelListener *> level_listeners_;  // Log level change listeners
 #endif
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  void init_log_buffer_(size_t total_buffer_size);
   logger::TaskLogBuffer *log_buffer_{nullptr};  // Allocated once, never freed
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Fix a crash (Guru Meditation Error: Load access fault) caused by a race condition where a FreeRTOS task logs a message before the `TaskLogBuffer` is initialized.

Previously, the `Logger` was constructed at `EARLY_INIT` priority but `init_log_buffer()` was called later at `DIAGNOSTICS` priority. Between those two points, `global_logger` was already set, so any FreeRTOS task that logged would dereference the null `log_buffer_` pointer.

The fix moves the buffer allocation into the `Logger` constructor so it's ready before `global_logger` is set, eliminating the race entirely.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://ptb.discord.com/channels/429907082951524364/1485105412033482942

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).