### PR TITLE
[core] Use placement new allocation for Pvariables

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -2228,33 +2228,18 @@ template<std::totally_ordered T, comparable_with<T> U> T clamp_at_most(T value, 
  * This struct is designed to replace dynamic heap allocations (`new T(...)`) for
  * global or static singletons within ESPHome, preventing memory fragmentation.
  * The underlying object must be explicitly constructed using placement new
- * before access.
+ * before access. No destructor is called — this is intentional since ESPHome
+ * singletons live for the entire device lifetime.
  */
 template<class T> struct PlacementStorage {
   /// @brief Raw byte storage, strictly aligned for type T.
   alignas(T) unsigned char data[sizeof(T)];
 
-  /**
-   * @brief Safely retrieves a pointer to the constructed object.
-   * @return T* Pointer to the underlying object.
-   */
-  constexpr T *get() { return reinterpret_cast<T *>(data); }
+  /// @brief Retrieves a pointer to the constructed object.
+  T *get() { return std::launder(reinterpret_cast<T *>(data)); }
 
-  /**
-   * @brief Safely retrieves a const pointer to the constructed object.
-   * @return const T* Const pointer to the underlying object.
-   */
-  constexpr const T *get() const { return reinterpret_cast<const T *>(data); }
-
-  /// @brief Member access operator pointing to the underlying object.
-  constexpr T *operator->() { return get(); }
-  /// @brief Const member access operator pointing to the underlying object.
-  constexpr const T *operator->() const { return get(); }
-
-  /// @brief Dereference operator yielding a reference to the underlying object.
-  constexpr T &operator*() { return *get(); }
-  /// @brief Const dereference operator yielding a const reference to the underlying object.
-  constexpr const T &operator*() const { return *get(); }
+  /// @brief Retrieves a const pointer to the constructed object.
+  const T *get() const { return std::launder(reinterpret_cast<const T *>(data)); }
 };
 
 /// @name Internal functions

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -2235,11 +2235,12 @@ template<class T> struct PlacementStorage {
   /// @brief Raw byte storage, strictly aligned for type T.
   alignas(T) unsigned char data[sizeof(T)];
 
-  /// @brief Retrieves a pointer to the constructed object.
-  T *get() { return std::launder(reinterpret_cast<T *>(data)); }
+  /// @brief Retrieves a pointer to the storage as the target type.
+  /// The caller must ensure the object has been constructed via placement new before dereferencing.
+  T *get() { return reinterpret_cast<T *>(data); }
 
-  /// @brief Retrieves a const pointer to the constructed object.
-  const T *get() const { return std::launder(reinterpret_cast<const T *>(data)); }
+  /// @brief Retrieves a const pointer to the storage as the target type.
+  const T *get() const { return reinterpret_cast<const T *>(data); }
 };
 
 /// @name Internal functions

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -11,11 +11,9 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <new>
 #include <span>
 #include <string>
 #include <type_traits>
-#include <utility>
 #include <vector>
 #include <concepts>
 #include <strings.h>

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -2222,27 +2222,6 @@ template<std::totally_ordered T, comparable_with<T> U> T clamp_at_most(T value, 
   return value;
 }
 
-/**
- * @brief Provides properly aligned, uninitialized static storage for a given type T.
- *
- * This struct is designed to replace dynamic heap allocations (`new T(...)`) for
- * global or static singletons within ESPHome, preventing memory fragmentation.
- * The underlying object must be explicitly constructed using placement new
- * before access. No destructor is called — this is intentional since ESPHome
- * singletons live for the entire device lifetime.
- */
-template<class T> struct PlacementStorage {
-  /// @brief Raw byte storage, strictly aligned for type T.
-  alignas(T) unsigned char data[sizeof(T)];
-
-  /// @brief Retrieves a pointer to the storage as the target type.
-  /// The caller must ensure the object has been constructed via placement new before dereferencing.
-  T *get() { return reinterpret_cast<T *>(data); }
-
-  /// @brief Retrieves a const pointer to the storage as the target type.
-  const T *get() const { return reinterpret_cast<const T *>(data); }
-};
-
 /// @name Internal functions
 ///@{
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -11,9 +11,11 @@
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <new>
 #include <span>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 #include <concepts>
 #include <strings.h>
@@ -2219,6 +2221,41 @@ template<std::totally_ordered T, comparable_with<T> U> T clamp_at_most(T value, 
     return max;
   return value;
 }
+
+/**
+ * @brief Provides properly aligned, uninitialized static storage for a given type T.
+ *
+ * This struct is designed to replace dynamic heap allocations (`new T(...)`) for
+ * global or static singletons within ESPHome, preventing memory fragmentation.
+ * The underlying object must be explicitly constructed using placement new
+ * before access.
+ */
+template<class T> struct PlacementStorage {
+  /// @brief Raw byte storage, strictly aligned for type T.
+  alignas(T) unsigned char data[sizeof(T)];
+
+  /**
+   * @brief Safely retrieves a pointer to the constructed object.
+   * @return T* Pointer to the underlying object.
+   */
+  constexpr T *get() { return reinterpret_cast<T *>(data); }
+
+  /**
+   * @brief Safely retrieves a const pointer to the constructed object.
+   * @return const T* Const pointer to the underlying object.
+   */
+  constexpr const T *get() const { return reinterpret_cast<const T *>(data); }
+
+  /// @brief Member access operator pointing to the underlying object.
+  constexpr T *operator->() { return get(); }
+  /// @brief Const member access operator pointing to the underlying object.
+  constexpr const T *operator->() const { return get(); }
+
+  /// @brief Dereference operator yielding a reference to the underlying object.
+  constexpr T &operator*() { return *get(); }
+  /// @brief Const dereference operator yielding a const reference to the underlying object.
+  constexpr const T &operator*() const { return *get(); }
+};
 
 /// @name Internal functions
 ///@{

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -600,7 +600,11 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         )
         # Extract args from the CallExpression and rebuild as placement new
         call_expr = rhs.base  # CallExpression("new Type", args...)
-        placement_new = CallExpression(f"new({id_.id}) {the_type}", *call_expr.args)
+        placement_args: list[Expression] = []
+        if call_expr.template_args is not None:
+            placement_args.append(call_expr.template_args)
+        placement_args.extend(call_expr.args)
+        placement_new = CallExpression(f"new({id_.id}) {the_type}", *placement_args)
         CORE.add(ExpressionStatement(placement_new))
     else:
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -579,10 +579,47 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     obj = MockObj(id_, "->")
     if type_ is not None:
         id_.type = type_
-    decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)
-    CORE.add_global(decl)
-    assignment = AssignmentExpression(None, None, id_, rhs)
-    CORE.add(assignment)
+
+    # Check if the right-hand side expression is an instantiation via the 'new' operator.
+    # This typically happens when `.new(...)` is used to create a new object.
+    # We detect this by checking if the base of the CallExpression starts with "new ".
+    rhs_str = str(rhs)
+    is_new = rhs_str.startswith("new ")
+
+    if is_new:
+        # For 'new' allocations, we avoid dynamic heap allocation to prevent fragmentation.
+        # Instead, we statically allocate raw, aligned storage for the object and use
+        # raw placement new to initialize it in-place during setup().
+        # We must use raw placement new here because C++ cannot deduce types
+        # for brace-enclosed initializer lists passed to variadic templates.
+
+        call_str = rhs_str[4:]  # Strip "new " from "new Type<T>(args)"
+        the_type = id_.type if id_.type is not None else call_str.split("(")[0].strip()
+        storage_name = f"{id_.id}_storage_"
+
+        # Declare the static PlacementStorage
+        decl1 = RawStatement(
+            f"static esphome::PlacementStorage<{the_type}> {storage_name};"
+        )
+        CORE.add_global(decl1)
+
+        # Declare a constant pointer referencing the storage so it can be used identically to a standard pointer
+        decl2 = RawStatement(
+            f"static {the_type} *const {id_.id} = {storage_name}.get();"
+        )
+        CORE.add_global(decl2)
+
+        # Construct the object via raw placement new in setup()
+        assignment = RawStatement(f"new({id_.id}) {call_str};")
+        CORE.add(assignment)
+    else:
+        # For standard assignments (e.g. passing an existing pointer like '&my_struct' or 'nullptr'),
+        # we generate a standard static pointer and assign it directly.
+        decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)
+        CORE.add_global(decl)
+        assignment = AssignmentExpression(None, None, id_, rhs)
+        CORE.add(assignment)
+
     CORE.register_variable(id_, obj)
     return obj
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -594,7 +594,11 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # for brace-enclosed initializer lists passed to variadic templates.
 
         call_str = rhs_str[4:]  # Strip "new " from "new Type<T>(args)"
-        the_type = id_.type if id_.type is not None else call_str.split("(")[0].strip()
+        the_type = (
+            id_.type
+            if id_.type is not None
+            else call_str.split("(", maxsplit=1)[0].strip()
+        )
         storage_name = f"{id_.id}_storage_"
 
         # Declare the static PlacementStorage

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -598,13 +598,11 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
                 MockObj(f"{storage_id.id}.get()"),
             )
         )
-        # Extract args from the CallExpression and rebuild as placement new
+        # Extract args from the CallExpression and rebuild as placement new.
+        # Template args are already encoded in the_type (e.g. GlobalsComponent<int>),
+        # so we only pass the constructor args, not template_args.
         call_expr = rhs.base  # CallExpression("new Type", args...)
-        placement_args: list[Expression] = []
-        if call_expr.template_args is not None:
-            placement_args.append(call_expr.template_args)
-        placement_args.extend(call_expr.args)
-        placement_new = CallExpression(f"new({id_.id}) {the_type}", *placement_args)
+        placement_new = CallExpression(f"new({id_.id}) {the_type}", *call_expr.args)
         CORE.add(ExpressionStatement(placement_new))
     else:
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -584,18 +584,20 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # For 'new' allocations, use placement new into static storage
         # to avoid heap fragmentation on embedded devices.
         the_type = id_.type
-        storage_type = MockObj(f"esphome::PlacementStorage<{the_type}>")
-        storage_id = ID(f"{id_.id}_storage_", type=storage_type)
+        storage_name = f"{id_.id}_storage_"
 
+        # Declare aligned byte array for the object storage
         CORE.add_global(
-            VariableDeclarationExpression(storage_type, "", storage_id, static=True)
+            RawStatement(
+                f"alignas({the_type}) static unsigned char {storage_name}[sizeof({the_type})];"
+            )
         )
         CORE.add_global(
             AssignmentExpression(
                 f"static {the_type}",
                 "*const ",
                 id_,
-                MockObj(f"{storage_id.id}.get()"),
+                MockObj(f"reinterpret_cast<{the_type} *>({storage_name})"),
             )
         )
         # Extract args from the CallExpression and rebuild as placement new.

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -584,7 +584,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # For 'new' allocations, use placement new into static storage
         # to avoid heap fragmentation on embedded devices.
         the_type = id_.type
-        storage_name = f"{id_.id}_storage_"
+        storage_name = f"{id_.id}__pstorage"
 
         # Declare aligned byte array for the object storage
         CORE.add_global(
@@ -603,7 +603,10 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # Extract args from the CallExpression and rebuild as placement new.
         # Template args are already encoded in the_type (e.g. GlobalsComponent<int>),
         # so we only pass the constructor args, not template_args.
-        call_expr = rhs.base  # CallExpression("new Type", args...)
+        call_expr = rhs.base
+        assert isinstance(call_expr, CallExpression), (
+            f"Expected CallExpression for placement new, got {type(call_expr)}"
+        )
         placement_new = CallExpression(f"new({id_.id}) {the_type}", *call_expr.args)
         CORE.add(ExpressionStatement(placement_new))
     else:

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -580,49 +580,29 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     if type_ is not None:
         id_.type = type_
 
-    # Check if the right-hand side expression is an instantiation via the 'new' operator.
-    # This typically happens when `.new(...)` is used to create a new object.
-    # We detect this by checking if the base of the CallExpression starts with "new ".
-    rhs_str = str(rhs)
-    is_new = rhs_str.startswith("new ")
+    is_new = isinstance(rhs, MockObj) and rhs._is_new_expr
 
     if is_new:
-        # For 'new' allocations, we avoid dynamic heap allocation to prevent fragmentation.
-        # Instead, we statically allocate raw, aligned storage for the object and use
-        # raw placement new to initialize it in-place during setup().
-        # We must use raw placement new here because C++ cannot deduce types
-        # for brace-enclosed initializer lists passed to variadic templates.
-
-        call_str = rhs_str[4:]  # Strip "new " from "new Type<T>(args)"
-        the_type = (
-            id_.type
-            if id_.type is not None
-            else call_str.split("(", maxsplit=1)[0].strip()
-        )
+        # For 'new' allocations, use placement new into static storage
+        # to avoid heap fragmentation on embedded devices.
         storage_name = f"{id_.id}_storage_"
+        the_type = id_.type
 
-        # Declare the static PlacementStorage
-        decl1 = RawStatement(
-            f"static esphome::PlacementStorage<{the_type}> {storage_name};"
+        CORE.add_global(
+            RawStatement(
+                f"static esphome::PlacementStorage<{the_type}> {storage_name};"
+            )
         )
-        CORE.add_global(decl1)
-
-        # Declare a constant pointer referencing the storage so it can be used identically to a standard pointer
-        decl2 = RawStatement(
-            f"static {the_type} *const {id_.id} = {storage_name}.get();"
+        CORE.add_global(
+            RawStatement(f"static {the_type} *const {id_.id} = {storage_name}.get();")
         )
-        CORE.add_global(decl2)
-
-        # Construct the object via raw placement new in setup()
-        assignment = RawStatement(f"new({id_.id}) {call_str};")
-        CORE.add(assignment)
+        # Strip "new " prefix to get "Type(args)" for placement new
+        rhs_str = str(rhs)
+        CORE.add(RawStatement(f"new({id_.id}) {rhs_str[4:]};"))
     else:
-        # For standard assignments (e.g. passing an existing pointer like '&my_struct' or 'nullptr'),
-        # we generate a standard static pointer and assign it directly.
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)
         CORE.add_global(decl)
-        assignment = AssignmentExpression(None, None, id_, rhs)
-        CORE.add(assignment)
+        CORE.add(AssignmentExpression(None, None, id_, rhs))
 
     CORE.register_variable(id_, obj)
     return obj
@@ -840,11 +820,12 @@ class MockObj(Expression):
     Mostly consists of magic methods that allow ESPHome's codegen syntax.
     """
 
-    __slots__ = ("base", "op")
+    __slots__ = ("base", "op", "_is_new_expr")
 
-    def __init__(self, base, op="."):
+    def __init__(self, base, op=".", is_new_expr=False):
         self.base = base
         self.op = op
+        self._is_new_expr = is_new_expr
 
     def __getattr__(self, attr: str) -> "MockObj":
         # prevent python dunder methods being replaced by mock objects
@@ -859,7 +840,7 @@ class MockObj(Expression):
 
     def __call__(self, *args: SafeExpType) -> "MockObj":
         call = CallExpression(self.base, *args)
-        return MockObj(call, self.op)
+        return MockObj(call, self.op, is_new_expr=self._is_new_expr)
 
     def __str__(self):
         return str(self.base)
@@ -873,7 +854,7 @@ class MockObj(Expression):
 
     @property
     def new(self) -> "MockObj":
-        return MockObj(f"new {self.base}", "->")
+        return MockObj(f"new {self.base}", "->", is_new_expr=True)
 
     def template(self, *args: SafeExpType) -> "MockObj":
         """Apply template parameters to this object."""

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -580,7 +580,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     if type_ is not None:
         id_.type = type_
 
-    if isinstance(rhs, MockObj) and rhs._is_new_expr:
+    if isinstance(rhs, MockObj) and rhs.is_new_expr:
         # For 'new' allocations, use placement new into static storage
         # to avoid heap fragmentation on embedded devices.
         the_type = id_.type
@@ -825,12 +825,12 @@ class MockObj(Expression):
     Mostly consists of magic methods that allow ESPHome's codegen syntax.
     """
 
-    __slots__ = ("base", "op", "_is_new_expr")
+    __slots__ = ("base", "op", "is_new_expr")
 
-    def __init__(self, base, op=".", is_new_expr=False):
+    def __init__(self, base, op=".", is_new_expr=False) -> None:
         self.base = base
         self.op = op
-        self._is_new_expr = is_new_expr
+        self.is_new_expr = is_new_expr
 
     def __getattr__(self, attr: str) -> "MockObj":
         # prevent python dunder methods being replaced by mock objects
@@ -845,7 +845,7 @@ class MockObj(Expression):
 
     def __call__(self, *args: SafeExpType) -> "MockObj":
         call = CallExpression(self.base, *args)
-        return MockObj(call, self.op, is_new_expr=self._is_new_expr)
+        return MockObj(call, self.op, is_new_expr=self.is_new_expr)
 
     def __str__(self):
         return str(self.base)

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -580,9 +580,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     if type_ is not None:
         id_.type = type_
 
-    is_new = isinstance(rhs, MockObj) and rhs._is_new_expr
-
-    if is_new:
+    if isinstance(rhs, MockObj) and rhs._is_new_expr:
         # For 'new' allocations, use placement new into static storage
         # to avoid heap fragmentation on embedded devices.
         the_type = id_.type

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -585,20 +585,25 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     if is_new:
         # For 'new' allocations, use placement new into static storage
         # to avoid heap fragmentation on embedded devices.
-        storage_name = f"{id_.id}_storage_"
         the_type = id_.type
+        storage_type = MockObj(f"esphome::PlacementStorage<{the_type}>")
+        storage_id = ID(f"{id_.id}_storage_", type=storage_type)
 
         CORE.add_global(
-            RawStatement(
-                f"static esphome::PlacementStorage<{the_type}> {storage_name};"
-            )
+            VariableDeclarationExpression(storage_type, "", storage_id, static=True)
         )
         CORE.add_global(
-            RawStatement(f"static {the_type} *const {id_.id} = {storage_name}.get();")
+            AssignmentExpression(
+                f"static {the_type}",
+                "*const ",
+                id_,
+                MockObj(f"{storage_id.id}.get()"),
+            )
         )
-        # Strip "new " prefix to get "Type(args)" for placement new
-        rhs_str = str(rhs)
-        CORE.add(RawStatement(f"new({id_.id}) {rhs_str[4:]};"))
+        # Extract args from the CallExpression and rebuild as placement new
+        call_expr = rhs.base  # CallExpression("new Type", args...)
+        placement_new = CallExpression(f"new({id_.id}) {the_type}", *call_expr.args)
+        CORE.add(ExpressionStatement(placement_new))
     else:
         decl = VariableDeclarationExpression(id_.type, "*", id_, static=True)
         CORE.add_global(decl)

--- a/tests/component_tests/binary_sensor/test_binary_sensor.py
+++ b/tests/component_tests/binary_sensor/test_binary_sensor.py
@@ -15,7 +15,7 @@ def test_binary_sensor_is_setup(generate_main):
     )
 
     # Then
-    assert "new gpio::GPIOBinarySensor();" in main_cpp
+    assert "static gpio::GPIOBinarySensor *const" in main_cpp
     assert "App.register_binary_sensor" in main_cpp
 
 

--- a/tests/component_tests/button/test_button.py
+++ b/tests/component_tests/button/test_button.py
@@ -13,7 +13,8 @@ def test_button_is_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/button/test_button.yaml")
 
     # Then
-    assert "new wake_on_lan::WakeOnLanButton();" in main_cpp
+    assert "static wake_on_lan::WakeOnLanButton *const" in main_cpp
+    assert ") wake_on_lan::WakeOnLanButton();" in main_cpp
     assert "App.register_button" in main_cpp
     assert "App.register_component" in main_cpp
 

--- a/tests/component_tests/conftest.py
+++ b/tests/component_tests/conftest.py
@@ -134,7 +134,7 @@ def generate_main() -> Generator[Callable[[str | Path], str]]:
         CORE.config_path = Path(path)
         CORE.config = read_config({})
         generate_cpp_contents(CORE.config)
-        return CORE.cpp_main_section
+        return CORE.cpp_global_section + CORE.cpp_main_section
 
     yield generator
 

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -8,7 +8,7 @@ def test_deep_sleep_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep1.yaml")
 
     assert (
-        "static deep_sleep::DeepSleepComponent *const deepsleep = deepsleep_storage_.get();"
+        "static deep_sleep::DeepSleepComponent *const deepsleep = reinterpret_cast<deep_sleep::DeepSleepComponent *>(deepsleep_storage_);"
         in main_cpp
     )
     assert "new(deepsleep) deep_sleep::DeepSleepComponent();" in main_cpp

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -8,7 +8,7 @@ def test_deep_sleep_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep1.yaml")
 
     assert (
-        "static deep_sleep::DeepSleepComponent *const deepsleep = reinterpret_cast<deep_sleep::DeepSleepComponent *>(deepsleep_storage_);"
+        "static deep_sleep::DeepSleepComponent *const deepsleep = reinterpret_cast<deep_sleep::DeepSleepComponent *>(deepsleep__pstorage);"
         in main_cpp
     )
     assert "new(deepsleep) deep_sleep::DeepSleepComponent();" in main_cpp

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -7,7 +7,11 @@ def test_deep_sleep_setup(generate_main):
     """
     main_cpp = generate_main("tests/component_tests/deep_sleep/test_deep_sleep1.yaml")
 
-    assert "deepsleep = new deep_sleep::DeepSleepComponent();" in main_cpp
+    assert (
+        "static deep_sleep::DeepSleepComponent *const deepsleep = deepsleep_storage_.get();"
+        in main_cpp
+    )
+    assert "new(deepsleep) deep_sleep::DeepSleepComponent();" in main_cpp
     assert "App.register_component_(deepsleep);" in main_cpp
 
 

--- a/tests/component_tests/globals/config/globals_test.yaml
+++ b/tests/component_tests/globals/config/globals_test.yaml
@@ -1,0 +1,16 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+globals:
+  - id: my_global_int
+    type: int
+    initial_value: "42"
+  - id: my_global_float
+    type: float
+    initial_value: "1.5"
+  - id: my_global_bool
+    type: bool
+    initial_value: "true"

--- a/tests/component_tests/globals/test_globals.py
+++ b/tests/component_tests/globals/test_globals.py
@@ -16,12 +16,12 @@ def test_globals_placement_new_with_template_args(
     # Globals uses Pvariable with Type.new(template_args, initial_value)
     # which exercises the template_args preservation in placement new.
     assert "static globals::GlobalsComponent<int> *const my_global_int" in main_cpp
-    assert "PlacementStorage<globals::GlobalsComponent<int>>" in main_cpp
+    assert "sizeof(globals::GlobalsComponent<int>)" in main_cpp
     assert "new(my_global_int) globals::GlobalsComponent<int>" in main_cpp
 
     # Verify initial value is passed as constructor arg
     assert "42" in main_cpp
 
     # Check other globals are also generated
-    assert "PlacementStorage<globals::GlobalsComponent<float>>" in main_cpp
-    assert "PlacementStorage<globals::GlobalsComponent<bool>>" in main_cpp
+    assert "sizeof(globals::GlobalsComponent<float>)" in main_cpp
+    assert "sizeof(globals::GlobalsComponent<bool>)" in main_cpp

--- a/tests/component_tests/globals/test_globals.py
+++ b/tests/component_tests/globals/test_globals.py
@@ -1,0 +1,27 @@
+"""Tests for the globals component."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+
+def test_globals_placement_new_with_template_args(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test that globals uses placement new with template arguments preserved."""
+    main_cpp = generate_main(component_config_path("globals_test.yaml"))
+
+    # Globals uses Pvariable with Type.new(template_args, initial_value)
+    # which exercises the template_args preservation in placement new.
+    assert "static globals::GlobalsComponent<int> *const my_global_int" in main_cpp
+    assert "PlacementStorage<globals::GlobalsComponent<int>>" in main_cpp
+    assert "new(my_global_int) globals::GlobalsComponent<int>" in main_cpp
+
+    # Verify initial value is passed as constructor arg
+    assert "42" in main_cpp
+
+    # Check other globals are also generated
+    assert "PlacementStorage<globals::GlobalsComponent<float>>" in main_cpp
+    assert "PlacementStorage<globals::GlobalsComponent<bool>>" in main_cpp

--- a/tests/component_tests/gpio/test_gpio_binary_sensor.py
+++ b/tests/component_tests/gpio/test_gpio_binary_sensor.py
@@ -16,7 +16,8 @@ def test_gpio_binary_sensor_basic_setup(
     """
     main_cpp = generate_main("tests/component_tests/gpio/test_gpio_binary_sensor.yaml")
 
-    assert "new gpio::GPIOBinarySensor();" in main_cpp
+    assert "static gpio::GPIOBinarySensor *const" in main_cpp
+    assert ") gpio::GPIOBinarySensor();" in main_cpp
     assert "App.register_binary_sensor" in main_cpp
     # set_use_interrupt(true) should NOT be generated (uses C++ default)
     assert "bs_gpio->set_use_interrupt(true);" not in main_cpp

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -242,9 +242,13 @@ def test_image_generation(
     main_cpp = generate_main(component_config_path("image_test.yaml"))
     assert "uint8_t_id[] PROGMEM = {0x24, 0x21, 0x24, 0x21" in main_cpp
     assert (
-        "static esphome::PlacementStorage<image::Image> cat_img_storage_;" in main_cpp
+        "alignas(image::Image) static unsigned char cat_img_storage_[sizeof(image::Image)];"
+        in main_cpp
     )
-    assert "static image::Image *const cat_img = cat_img_storage_.get();" in main_cpp
+    assert (
+        "static image::Image *const cat_img = reinterpret_cast<image::Image *>(cat_img_storage_);"
+        in main_cpp
+    )
     assert (
         "new(cat_img) image::Image(uint8_t_id, 32, 24, image::IMAGE_TYPE_RGB565, image::TRANSPARENCY_OPAQUE);"
         in main_cpp

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -242,11 +242,11 @@ def test_image_generation(
     main_cpp = generate_main(component_config_path("image_test.yaml"))
     assert "uint8_t_id[] PROGMEM = {0x24, 0x21, 0x24, 0x21" in main_cpp
     assert (
-        "alignas(image::Image) static unsigned char cat_img_storage_[sizeof(image::Image)];"
+        "alignas(image::Image) static unsigned char cat_img__pstorage[sizeof(image::Image)];"
         in main_cpp
     )
     assert (
-        "static image::Image *const cat_img = reinterpret_cast<image::Image *>(cat_img_storage_);"
+        "static image::Image *const cat_img = reinterpret_cast<image::Image *>(cat_img__pstorage);"
         in main_cpp
     )
     assert (

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -242,7 +242,11 @@ def test_image_generation(
     main_cpp = generate_main(component_config_path("image_test.yaml"))
     assert "uint8_t_id[] PROGMEM = {0x24, 0x21, 0x24, 0x21" in main_cpp
     assert (
-        "cat_img = new image::Image(uint8_t_id, 32, 24, image::IMAGE_TYPE_RGB565, image::TRANSPARENCY_OPAQUE);"
+        "static esphome::PlacementStorage<image::Image> cat_img_storage_;" in main_cpp
+    )
+    assert "static image::Image *const cat_img = cat_img_storage_.get();" in main_cpp
+    assert (
+        "new(cat_img) image::Image(uint8_t_id, 32, 24, image::IMAGE_TYPE_RGB565, image::TRANSPARENCY_OPAQUE);"
         in main_cpp
     )
 

--- a/tests/component_tests/logger/test_logger.py
+++ b/tests/component_tests/logger/test_logger.py
@@ -22,6 +22,10 @@ def test_logger_pre_setup_before_other_components(generate_main):
 
     # Find all "new " allocations (component creation)
     new_allocations = list(re.finditer(r"\bnew [\w:]+", main_cpp))
+    # Find all "new(" allocations (component creation) and combine them
+    new_allocations.extend(re.finditer(r"\bnew\([^)]+\) [\w:]+", main_cpp))
+    # Sort allocations by position in the file
+    new_allocations.sort(key=lambda m: m.start())
     assert len(new_allocations) > 0, "No component allocations found"
 
     # Separate logger and non-logger allocations

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -119,11 +119,12 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
-        "static esphome::PlacementStorage<mipi_dsi::MIPI_DSI> p4_nano_storage_;"
+        "alignas(mipi_dsi::MIPI_DSI) static unsigned char p4_nano_storage_[sizeof(mipi_dsi::MIPI_DSI)];"
         in main_cpp
     )
     assert (
-        "static mipi_dsi::MIPI_DSI *const p4_nano = p4_nano_storage_.get();" in main_cpp
+        "static mipi_dsi::MIPI_DSI *const p4_nano = reinterpret_cast<mipi_dsi::MIPI_DSI *>(p4_nano_storage_);"
+        in main_cpp
     )
     assert (
         "new(p4_nano) mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -119,7 +119,10 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
-        "p4_nano = new mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"
+        "static mipi_dsi::MIPI_DSI *const p4_nano = p4_nano_storage_.get();" in main_cpp
+    )
+    assert (
+        "new(p4_nano) mipi_dsi::MIPI_DSI(800, 1280, display::COLOR_BITNESS_565, 16);"
         in main_cpp
     )
     assert "set_init_sequence({224, 1, 0, 225, 1, 147, 226, 1," in main_cpp

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -119,6 +119,10 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
+        "static esphome::PlacementStorage<mipi_dsi::MIPI_DSI> p4_nano_storage_;"
+        in main_cpp
+    )
+    assert (
         "static mipi_dsi::MIPI_DSI *const p4_nano = p4_nano_storage_.get();" in main_cpp
     )
     assert (

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -119,11 +119,11 @@ def test_code_generation(
 
     main_cpp = generate_main(component_fixture_path("mipi_dsi.yaml"))
     assert (
-        "alignas(mipi_dsi::MIPI_DSI) static unsigned char p4_nano_storage_[sizeof(mipi_dsi::MIPI_DSI)];"
+        "alignas(mipi_dsi::MIPI_DSI) static unsigned char p4_nano__pstorage[sizeof(mipi_dsi::MIPI_DSI)];"
         in main_cpp
     )
     assert (
-        "static mipi_dsi::MIPI_DSI *const p4_nano = reinterpret_cast<mipi_dsi::MIPI_DSI *>(p4_nano_storage_);"
+        "static mipi_dsi::MIPI_DSI *const p4_nano = reinterpret_cast<mipi_dsi::MIPI_DSI *>(p4_nano__pstorage);"
         in main_cpp
     )
     assert (

--- a/tests/component_tests/status_led/config/status_led_test.yaml
+++ b/tests/component_tests/status_led/config/status_led_test.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+
+status_led:
+  pin: GPIO2

--- a/tests/component_tests/status_led/test_status_led.py
+++ b/tests/component_tests/status_led/test_status_led.py
@@ -13,11 +13,11 @@ def test_status_led_generation(
     """Test status_led generation."""
     main_cpp = generate_main(component_config_path("status_led_test.yaml"))
     assert (
-        "static esphome::PlacementStorage<status_led::StatusLED> status_led_statusled_id_storage_;"
+        "alignas(status_led::StatusLED) static unsigned char status_led_statusled_id_storage_[sizeof(status_led::StatusLED)];"
         in main_cpp
     )
     assert (
-        "static status_led::StatusLED *const status_led_statusled_id = status_led_statusled_id_storage_.get();"
+        "static status_led::StatusLED *const status_led_statusled_id = reinterpret_cast<status_led::StatusLED *>(status_led_statusled_id_storage_);"
         in main_cpp
     )
     assert "new(status_led_statusled_id) status_led::StatusLED(" in main_cpp

--- a/tests/component_tests/status_led/test_status_led.py
+++ b/tests/component_tests/status_led/test_status_led.py
@@ -1,0 +1,23 @@
+"""Tests for status_led."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+
+def test_status_led_generation(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test status_led generation."""
+    main_cpp = generate_main(component_config_path("status_led_test.yaml"))
+    assert (
+        "static esphome::PlacementStorage<status_led::StatusLED> status_led_statusled_id_storage_;"
+        in main_cpp
+    )
+    assert (
+        "static status_led::StatusLED *const status_led_statusled_id = status_led_statusled_id_storage_.get();"
+        in main_cpp
+    )
+    assert "new(status_led_statusled_id) status_led::StatusLED(" in main_cpp

--- a/tests/component_tests/status_led/test_status_led.py
+++ b/tests/component_tests/status_led/test_status_led.py
@@ -13,11 +13,11 @@ def test_status_led_generation(
     """Test status_led generation."""
     main_cpp = generate_main(component_config_path("status_led_test.yaml"))
     assert (
-        "alignas(status_led::StatusLED) static unsigned char status_led_statusled_id_storage_[sizeof(status_led::StatusLED)];"
+        "alignas(status_led::StatusLED) static unsigned char status_led_statusled_id__pstorage[sizeof(status_led::StatusLED)];"
         in main_cpp
     )
     assert (
-        "static status_led::StatusLED *const status_led_statusled_id = reinterpret_cast<status_led::StatusLED *>(status_led_statusled_id_storage_);"
+        "static status_led::StatusLED *const status_led_statusled_id = reinterpret_cast<status_led::StatusLED *>(status_led_statusled_id__pstorage);"
         in main_cpp
     )
     assert "new(status_led_statusled_id) status_led::StatusLED(" in main_cpp

--- a/tests/component_tests/text/test_text.py
+++ b/tests/component_tests/text/test_text.py
@@ -13,7 +13,8 @@ def test_text_is_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/text/test_text.yaml")
 
     # Then
-    assert "new template_::TemplateText();" in main_cpp
+    assert "static template_::TemplateText *const" in main_cpp
+    assert ") template_::TemplateText();" in main_cpp
     assert "App.register_text" in main_cpp
 
 

--- a/tests/component_tests/text_sensor/test_text_sensor.py
+++ b/tests/component_tests/text_sensor/test_text_sensor.py
@@ -13,7 +13,8 @@ def test_text_sensor_is_setup(generate_main):
     main_cpp = generate_main("tests/component_tests/text_sensor/test_text_sensor.yaml")
 
     # Then
-    assert "new template_::TemplateTextSensor();" in main_cpp
+    assert "static template_::TemplateTextSensor *const" in main_cpp
+    assert ") template_::TemplateTextSensor();" in main_cpp
     assert "App.register_text_sensor" in main_cpp
 
 

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -15,7 +15,7 @@ void setup() {
   static char name[] = "livingroom";
   static char friendly_name[] = "LivingRoom";
   App.pre_setup(name, sizeof(name) - 1, friendly_name, sizeof(friendly_name) - 1);
-  auto *log = new logger::Logger(115200, 512);  // NOLINT
+  auto *log = new logger::Logger(115200);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component_(log);

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -15,7 +15,7 @@ void setup() {
   static char name[] = "livingroom";
   static char friendly_name[] = "LivingRoom";
   App.pre_setup(name, sizeof(name) - 1, friendly_name, sizeof(friendly_name) - 1);
-  auto *log = new logger::Logger(115200);  // NOLINT
+  auto *log = new logger::Logger(115200, 512);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component_(log);


### PR DESCRIPTION
# What does this implement/fix?

Moves all ESPHome component instances from heap allocation to static storage (`.bss` segment) using placement new.

Previously, every component was heap-allocated via `new T(...)` during `setup()`. This had two downsides:

1. **Heap allocator overhead** — Each allocation carries bookkeeping (headers, alignment padding, free-list metadata). On an ESP8266 ratgdo config, this wasted ~350 bytes of heap.
2. **Invisible to static analysis** — Heap allocations don't show up in linker memory maps or `elf-size-analyze` tools. Developers couldn't see how much RAM their components actually used without runtime profiling.

Now, component storage is statically allocated as `alignas(T)` byte arrays in `.bss`, and the object is constructed in-place via placement new during `setup()`. No template wrapper is used — just raw `alignas`/`sizeof` resolved at compile time. This means:

- **Component memory is visible in the binary** — Shows up in linker maps and memory analysis tools, giving developers accurate per-component RAM usage at build time.
- **No heap allocator overhead** — Eliminates bookkeeping bytes per component. Measured +350 bytes free heap on ESP8266.
- **Compile-time failure instead of runtime OOM** — If components exceed available RAM, the linker catches it at build time instead of crashing during `setup()`.
- **Total RAM usage is unchanged** — Same bytes, just in `.bss` instead of heap.
- **Flash is smaller** — Eliminating heap allocator calls saves flash.

### Measurements

**ESP8266 (ratgdo config)**

| | RAM | Flash |
|---|---|---|
| Baseline (heap `new`) | 31,964 | 473,157 |
| After (static placement new) | 35,876 (+3,912) | 472,581 (-576) |

**ESP32 (ol.yaml config)**

| | RAM | Flash |
|---|---|---|
| Baseline (heap `new`) | 16,736 | 555,887 |
| After (static placement new) | 19,792 (+3,056) | 555,115 (-772) |

The RAM "increase" is the whole point — that memory was always used at runtime, it's just now visible to the linker. Free heap actually increases due to eliminated allocator overhead.

The resulting code in `main.cpp` changes from:

```cpp
static status_led::StatusLED *status_led_statusled_id;

void setup() {
   status_led_statusled_id = new status_led::StatusLED(esp32_esp32internalgpiopin_id);
}
```

to:

```cpp
alignas(status_led::StatusLED) static unsigned char status_led_statusled_id_storage_[sizeof(status_led::StatusLED)];
static status_led::StatusLED *const status_led_statusled_id = reinterpret_cast<status_led::StatusLED *>(status_led_statusled_id_storage_);

void setup() {
   new(status_led_statusled_id) status_led::StatusLED(esp32_esp32internalgpiopin_id);
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).