### PR TITLE
[st25r] Add ST25R NFC reader component family

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -479,6 +479,11 @@ esphome/components/ssd1331_base/* @kbx81
 esphome/components/ssd1331_spi/* @kbx81
 esphome/components/ssd1351_base/* @kbx81
 esphome/components/ssd1351_spi/* @kbx81
+esphome/components/st25r/* @JohnMcLear
+esphome/components/st25r300/* @JohnMcLear
+esphome/components/st25r300_spi/* @JohnMcLear
+esphome/components/st25r_i2c/* @JohnMcLear
+esphome/components/st25r_spi/* @JohnMcLear
 esphome/components/st7567_base/* @latonita
 esphome/components/st7567_i2c/* @latonita
 esphome/components/st7567_spi/* @latonita
@@ -486,11 +491,6 @@ esphome/components/st7701s/* @clydebarrow
 esphome/components/st7735/* @SenexCrenshaw
 esphome/components/st7789v/* @kbx81
 esphome/components/st7920/* @marsjan155
-esphome/components/st25r/* @JohnMcLear
-esphome/components/st25r_i2c/* @JohnMcLear
-esphome/components/st25r_spi/* @JohnMcLear
-esphome/components/st25r300/* @JohnMcLear
-esphome/components/st25r300_spi/* @JohnMcLear
 esphome/components/statsd/* @Links2004
 esphome/components/stts22h/* @B48D81EFCC
 esphome/components/substitutions/* @esphome/core

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -486,6 +486,11 @@ esphome/components/st7701s/* @clydebarrow
 esphome/components/st7735/* @SenexCrenshaw
 esphome/components/st7789v/* @kbx81
 esphome/components/st7920/* @marsjan155
+esphome/components/st25r/* @JohnMcLear
+esphome/components/st25r_i2c/* @JohnMcLear
+esphome/components/st25r_spi/* @JohnMcLear
+esphome/components/st25r300/* @JohnMcLear
+esphome/components/st25r300_spi/* @JohnMcLear
 esphome/components/statsd/* @Links2004
 esphome/components/stts22h/* @B48D81EFCC
 esphome/components/substitutions/* @esphome/core

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -1,30 +1,34 @@
 from esphome import automation, pins
 import esphome.codegen as cg
+from esphome.components import binary_sensor as binary_sensor_, sensor as sensor_
 import esphome.config_validation as cv
-from esphome.components import binary_sensor as binary_sensor_
-from esphome.components import sensor as sensor_
 from esphome.const import (
     CONF_ID,
+    CONF_IRQ_PIN,
     CONF_ON_TAG,
     CONF_ON_TAG_REMOVED,
-    CONF_TRIGGER_ID,
-    CONF_IRQ_PIN,
     CONF_RESET_PIN,
     CONF_STATUS,
+    CONF_TRIGGER_ID,
 )
 
 CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["binary_sensor", "sensor", "nfc"]
 MULTI_CONF = True
 
+
 def _validate_mifare_key(value):
     value = cv.string_strict(value)
     if len(value) != 12:
-        raise cv.Invalid(f"Mifare key must be exactly 12 hex characters, got {len(value)}")
+        raise cv.Invalid(
+            f"Mifare key must be exactly 12 hex characters, got {len(value)}"
+        )
     try:
         int(value, 16)
     except ValueError as err:
-        raise cv.Invalid("Mifare key must contain only hex characters (0-9, A-F)") from err
+        raise cv.Invalid(
+            "Mifare key must contain only hex characters (0-9, A-F)"
+        ) from err
     return value.upper()
 
 
@@ -75,7 +79,9 @@ ST25R_SCHEMA = cv.Schema(
         cv.Optional(CONF_ANT_TUNE_A, default=0x80): cv.int_range(min=0, max=255),
         cv.Optional(CONF_ANT_TUNE_B, default=0x40): cv.int_range(min=0, max=255),
         cv.Optional(CONF_HEALTH_CHECK_ENABLED, default=True): cv.boolean,
-        cv.Optional(CONF_HEALTH_CHECK_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
+        cv.Optional(
+            CONF_HEALTH_CHECK_INTERVAL, default="60s"
+        ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_MAX_FAILED_CHECKS, default=3): cv.int_range(min=1, max=255),
         cv.Optional(CONF_AUTO_RESET_ON_FAILURE, default=True): cv.boolean,
         cv.Optional(CONF_NFCV_ENABLED, default=True): cv.boolean,
@@ -136,16 +142,13 @@ async def setup_st25r(var, config):
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_TAG_REMOVED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_removed_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
+
 
 @automation.register_action(
     "st25r.ndef_write",
@@ -164,7 +167,9 @@ async def st25r_ndef_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     cg.add(var.set_parent(parent))
     template_ = await cg.process_lambda(
-        config["ndef_message"], args, return_type=cg.RawExpression("esphome::nfc::NdefMessage *")
+        config["ndef_message"],
+        args,
+        return_type=cg.RawExpression("esphome::nfc::NdefMessage *"),
     )
     cg.add(var.set_message(template_))
     cg.add(var.set_format(config["format"]))

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -1,0 +1,187 @@
+from esphome import automation, pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor as binary_sensor_
+from esphome.components import sensor as sensor_
+from esphome.const import (
+    CONF_ID,
+    CONF_ON_TAG,
+    CONF_ON_TAG_REMOVED,
+    CONF_TRIGGER_ID,
+    CONF_IRQ_PIN,
+    CONF_RESET_PIN,
+    CONF_STATUS,
+)
+
+CODEOWNERS = ["@JohnMcLear"]
+AUTO_LOAD = ["binary_sensor", "sensor", "nfc"]
+MULTI_CONF = True
+
+def _validate_mifare_key(value):
+    value = cv.string_strict(value)
+    if len(value) != 12:
+        raise cv.Invalid(f"Mifare key must be exactly 12 hex characters, got {len(value)}")
+    try:
+        int(value, 16)
+    except ValueError as err:
+        raise cv.Invalid("Mifare key must contain only hex characters (0-9, A-F)") from err
+    return value.upper()
+
+
+CONF_ST25R_ID = "st25r_id"
+CONF_RF_FIELD_ENABLED = "rf_field_enabled"
+CONF_RF_POWER = "rf_power"
+CONF_SUPPLY_3V3 = "supply_3v3"
+CONF_RX_GAIN_BOOST = "rx_gain_boost"
+CONF_FIELD_STRENGTH = "field_strength"
+CONF_MIFARE_KEY_A = "mifare_key_a"
+CONF_MIFARE_KEY_B = "mifare_key_b"
+CONF_MISS_THRESHOLD = "miss_threshold"
+CONF_ANT_TUNE_A = "ant_tune_a"
+CONF_ANT_TUNE_B = "ant_tune_b"
+CONF_HEALTH_CHECK_ENABLED = "health_check_enabled"
+CONF_HEALTH_CHECK_INTERVAL = "health_check_interval"
+CONF_MAX_FAILED_CHECKS = "max_failed_checks"
+CONF_AUTO_RESET_ON_FAILURE = "auto_reset_on_failure"
+CONF_NFCV_ENABLED = "nfcv_enabled"
+CONF_NFCB_ENABLED = "nfcb_enabled"
+CONF_AAT_ENABLED = "aat_enabled"
+
+st25r_ns = cg.esphome_ns.namespace("st25r")
+ST25R = st25r_ns.class_("ST25R", cg.PollingComponent)
+
+ST25RTagTrigger = st25r_ns.class_(
+    "ST25RTagTrigger", automation.Trigger.template(cg.std_string)
+)
+ST25RTagRemovedTrigger = st25r_ns.class_(
+    "ST25RTagRemovedTrigger", automation.Trigger.template(cg.std_string)
+)
+
+NDEFWriteAction = st25r_ns.class_("NDEFWriteAction", automation.Action)
+CleanTagAction = st25r_ns.class_("CleanTagAction", automation.Action)
+
+ST25R_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(ST25R),
+        cv.Optional(CONF_IRQ_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_RF_FIELD_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_SUPPLY_3V3, default=True): cv.boolean,
+        cv.Optional(CONF_RX_GAIN_BOOST, default=False): cv.boolean,
+        cv.Optional(CONF_MIFARE_KEY_A, default="FFFFFFFFFFFF"): _validate_mifare_key,
+        cv.Optional(CONF_MIFARE_KEY_B, default="FFFFFFFFFFFF"): _validate_mifare_key,
+        cv.Optional(CONF_MISS_THRESHOLD, default=3): cv.int_range(min=1, max=255),
+        cv.Optional(CONF_ANT_TUNE_A, default=0x80): cv.int_range(min=0, max=255),
+        cv.Optional(CONF_ANT_TUNE_B, default=0x40): cv.int_range(min=0, max=255),
+        cv.Optional(CONF_HEALTH_CHECK_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_HEALTH_CHECK_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_MAX_FAILED_CHECKS, default=3): cv.int_range(min=1, max=255),
+        cv.Optional(CONF_AUTO_RESET_ON_FAILURE, default=True): cv.boolean,
+        cv.Optional(CONF_NFCV_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_NFCB_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_AAT_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_STATUS): binary_sensor_.binary_sensor_schema(),
+        cv.Optional(CONF_FIELD_STRENGTH): sensor_.sensor_schema(),
+        cv.Optional(CONF_ON_TAG): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25RTagRemovedTrigger),
+            }
+        ),
+    }
+).extend(cv.polling_component_schema("1s"))
+
+
+async def setup_st25r(var, config):
+    await cg.register_component(var, config)
+    
+    if CONF_IRQ_PIN in config:
+        irq = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])
+        cg.add(var.set_irq_pin(irq))
+
+    if CONF_RESET_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset))
+    
+    cg.add(var.set_rf_field_enabled(config[CONF_RF_FIELD_ENABLED]))
+    cg.add(var.set_rf_power(config[CONF_RF_POWER]))
+    cg.add(var.set_supply_3v3(config[CONF_SUPPLY_3V3]))
+    cg.add(var.set_rx_gain_boost(config[CONF_RX_GAIN_BOOST]))
+    cg.add(var.set_mifare_key_a(int(config[CONF_MIFARE_KEY_A], 16)))
+    cg.add(var.set_mifare_key_b(int(config[CONF_MIFARE_KEY_B], 16)))
+    cg.add(var.set_miss_threshold(config[CONF_MISS_THRESHOLD]))
+    cg.add(var.set_ant_tune_a(config[CONF_ANT_TUNE_A]))
+    cg.add(var.set_ant_tune_b(config[CONF_ANT_TUNE_B]))
+    cg.add(var.set_health_check_enabled(config[CONF_HEALTH_CHECK_ENABLED]))
+    cg.add(var.set_health_check_interval(config[CONF_HEALTH_CHECK_INTERVAL]))
+    cg.add(var.set_max_failed_checks(config[CONF_MAX_FAILED_CHECKS]))
+    cg.add(var.set_auto_reset_on_failure(config[CONF_AUTO_RESET_ON_FAILURE]))
+    cg.add(var.set_nfcv_enabled(config[CONF_NFCV_ENABLED]))
+    cg.add(var.set_nfcb_enabled(config[CONF_NFCB_ENABLED]))
+    cg.add(var.set_aat_enabled(config[CONF_AAT_ENABLED]))
+
+    if CONF_STATUS in config:
+        sens = await binary_sensor_.new_binary_sensor(config[CONF_STATUS])
+        cg.add(var.set_status_binary_sensor(sens))
+
+    if CONF_FIELD_STRENGTH in config:
+        sens = await sensor_.new_sensor(config[CONF_FIELD_STRENGTH])
+        cg.add(var.set_field_strength_sensor(sens))
+
+    for conf in config.get(CONF_ON_TAG, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )
+
+    for conf in config.get(CONF_ON_TAG_REMOVED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_removed_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )
+
+@automation.register_action(
+    "st25r.ndef_write",
+    NDEFWriteAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(ST25R),
+            cv.Required("ndef_message"): cv.lambda_,
+            cv.Optional("format", default=False): cv.boolean,
+        },
+        key="ndef_message",
+    ),
+)
+async def st25r_ndef_write_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(var.set_parent(parent))
+    template_ = await cg.process_lambda(
+        config["ndef_message"], args, return_type=cg.RawExpression("esphome::nfc::NdefMessage *")
+    )
+    cg.add(var.set_message(template_))
+    cg.add(var.set_format(config["format"]))
+    return var
+
+
+@automation.register_action(
+    "st25r.clean_tag",
+    CleanTagAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(ST25R),
+        },
+    ),
+)
+async def st25r_clean_tag_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(var.set_parent(parent))
+    return var

--- a/esphome/components/st25r/__init__.py
+++ b/esphome/components/st25r/__init__.py
@@ -99,7 +99,7 @@ ST25R_SCHEMA = cv.Schema(
 
 async def setup_st25r(var, config):
     await cg.register_component(var, config)
-    
+
     if CONF_IRQ_PIN in config:
         irq = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])
         cg.add(var.set_irq_pin(irq))
@@ -107,7 +107,7 @@ async def setup_st25r(var, config):
     if CONF_RESET_PIN in config:
         reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
         cg.add(var.set_reset_pin(reset))
-    
+
     cg.add(var.set_rf_field_enabled(config[CONF_RF_FIELD_ENABLED]))
     cg.add(var.set_rf_power(config[CONF_RF_POWER]))
     cg.add(var.set_supply_3v3(config[CONF_SUPPLY_3V3]))

--- a/esphome/components/st25r/binary_sensor.py
+++ b/esphome/components/st25r/binary_sensor.py
@@ -1,0 +1,47 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_UID
+from esphome.core import HexInt
+
+from . import CONF_ST25R_ID, ST25R, st25r_ns
+
+DEPENDENCIES = ["st25r"]
+
+
+def validate_uid(value):
+    value = cv.string_strict(value)
+    for x in value.split("-"):
+        if len(x) != 2:
+            raise cv.Invalid(
+                "Each part (separated by '-') of the UID must be two characters long."
+            )
+        try:
+            x = int(x, 16)
+        except ValueError as err:
+            raise cv.Invalid(
+                "Valid characters for parts of a UID are 0123456789ABCDEF."
+            ) from err
+        if x < 0 or x > 255:
+            raise cv.Invalid(
+                "Valid values for UID parts (separated by '-') are 00 to FF"
+            )
+    return value
+
+
+ST25RBinarySensor = st25r_ns.class_("ST25RBinarySensor", binary_sensor.BinarySensor)
+
+CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(ST25RBinarySensor).extend(
+    {
+        cv.GenerateID(CONF_ST25R_ID): cv.use_id(ST25R),
+        cv.Required(CONF_UID): validate_uid,
+    }
+)
+
+
+async def to_code(config):
+    var = await binary_sensor.new_binary_sensor(config)
+    hub = await cg.get_variable(config[CONF_ST25R_ID])
+    cg.add(hub.register_tag(var))
+    addr = [HexInt(int(x, 16)) for x in config[CONF_UID].split("-")]
+    cg.add(var.set_uid(addr))

--- a/esphome/components/st25r/binary_sensor.py
+++ b/esphome/components/st25r/binary_sensor.py
@@ -20,7 +20,7 @@ def validate_uid(value):
             x = int(x, 16)
         except ValueError as err:
             raise cv.Invalid(
-                "Valid characters for parts of a UID are 0123456789ABCDEF."
+                "Valid characters for parts of a UID are 0-9, A-F (case-insensitive)."
             ) from err
         if x < 0 or x > 255:
             raise cv.Invalid(

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -12,6 +12,9 @@
 #include "crypto1.h"
 #include <cstring>
 
+namespace esphome {
+namespace st25r {
+
 // ── LFSR feedback polynomial masks ─────────────────────────────────────────
 // The 48-bit Crypto1 LFSR uses two interleaved 24-bit words (odd/even).
 // These masks select the tap positions in each half-word; the new LFSR bit is
@@ -110,3 +113,6 @@ uint32_t prng_successor(uint32_t x, uint32_t n) {
     x = x >> 1 | (x >> 16 ^ x >> 18 ^ x >> 19 ^ x >> 21) << 31;
   return x = swapendian(x);
 }
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -19,10 +19,10 @@ namespace st25r {
 // The 48-bit Crypto1 LFSR uses two interleaved 24-bit words (odd/even).
 // These masks select the tap positions in each half-word; the new LFSR bit is
 // evenparity(LF_POLY_ODD & odd) XOR evenparity(LF_POLY_EVEN & even) XOR input.
-static constexpr uint32_t LF_POLY_ODD = 0x29CE5C;  //
-static constexpr uint32_t LF_POLY_EVEN = 0x870804; //
+static constexpr uint32_t LF_POLY_ODD = 0x29CE5C;   //
+static constexpr uint32_t LF_POLY_EVEN = 0x870804;  //
 
-#define crypto1_getbit(x, n)   (((x) >> (n)) & 1)
+#define crypto1_getbit(x, n) (((x) >> (n)) & 1)
 #define crypto1_bebit(x, n) crypto1_getbit((x), (n) ^ 24)
 
 static inline uint8_t evenparity32(uint32_t x) {
@@ -44,11 +44,11 @@ static inline uint8_t evenparity32(uint32_t x) {
 // the final lookup is into the 32-bit constant 0xEC57E80A.
 int crypto1_filter(uint32_t const x) {
   uint32_t f;
-  f  = 0xf22c0 >> (x        & 0xf) & 16;
-  f |= 0x6c9c0 >> (x >>  4  & 0xf) &  8;
-  f |= 0x3c8b0 >> (x >>  8  & 0xf) &  4;
-  f |= 0x1e458 >> (x >> 12  & 0xf) &  2;
-  f |= 0x0d938 >> (x >> 16  & 0xf) &  1;
+  f = 0xf22c0 >> (x & 0xf) & 16;
+  f |= 0x6c9c0 >> (x >> 4 & 0xf) & 8;
+  f |= 0x3c8b0 >> (x >> 8 & 0xf) & 4;
+  f |= 0x1e458 >> (x >> 12 & 0xf) & 2;
+  f |= 0x0d938 >> (x >> 16 & 0xf) & 1;
   return crypto1_getbit(0xEC57E80A, f);
 }
 
@@ -59,8 +59,8 @@ void crypto1_init(struct Crypto1State *s, uint64_t key) {
   s->odd = 0;
   s->even = 0;
   for (int i = 47; i > 0; i -= 2) {
-    s->odd  = s->odd  << 1 | crypto1_getbit(key, (i - 1) ^ 7);
-    s->even = s->even << 1 | crypto1_getbit(key,  i       ^ 7);
+    s->odd = s->odd << 1 | crypto1_getbit(key, (i - 1) ^ 7);
+    s->even = s->even << 1 | crypto1_getbit(key, i ^ 7);
   }
 }
 
@@ -69,9 +69,9 @@ uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted) {
   uint32_t feedin, t;
   uint8_t ret = (uint8_t) crypto1_filter(s->odd);
 
-  feedin  = ret & (uint32_t)(!!is_encrypted);
-  feedin ^= (uint32_t)(!!in);
-  feedin ^= LF_POLY_ODD  & s->odd;
+  feedin = ret & (uint32_t) (!!is_encrypted);
+  feedin ^= (uint32_t) (!!in);
+  feedin ^= LF_POLY_ODD & s->odd;
   feedin ^= LF_POLY_EVEN & s->even;
   s->even = s->even << 1 | evenparity32(feedin);
 
@@ -86,7 +86,7 @@ uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted) {
 uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted) {
   uint8_t ret = 0;
   for (int i = 0; i < 8; i++)
-    ret |= (uint8_t)(crypto1_bit(s, crypto1_getbit(in, i), is_encrypted) << i);
+    ret |= (uint8_t) (crypto1_bit(s, crypto1_getbit(in, i), is_encrypted) << i);
   return ret;
 }
 
@@ -94,7 +94,7 @@ uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted) {
 uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted) {
   uint32_t ret = 0;
   for (int i = 0; i < 32; i++)
-    ret |= (uint32_t)(crypto1_bit(s, crypto1_bebit(in, i), is_encrypted) << (24 ^ i));
+    ret |= (uint32_t) (crypto1_bit(s, crypto1_bebit(in, i), is_encrypted) << (24 ^ i));
   return ret;
 }
 

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -19,11 +19,11 @@ namespace st25r {
 // The 48-bit Crypto1 LFSR uses two interleaved 24-bit words (odd/even).
 // These masks select the tap positions in each half-word; the new LFSR bit is
 // evenparity(LF_POLY_ODD & odd) XOR evenparity(LF_POLY_EVEN & even) XOR input.
-#define LF_POLY_ODD  (0x29CE5C)
-#define LF_POLY_EVEN (0x870804)
+static constexpr uint32_t LF_POLY_ODD = 0x29CE5C;  //
+static constexpr uint32_t LF_POLY_EVEN = 0x870804; //
 
-#define BIT(x, n)   (((x) >> (n)) & 1)
-#define BEBIT(x, n) BIT((x), (n) ^ 24)
+#define crypto1_getbit(x, n)   (((x) >> (n)) & 1)
+#define crypto1_bebit(x, n) crypto1_getbit((x), (n) ^ 24)
 
 static inline uint8_t evenparity32(uint32_t x) {
 #if defined(__GNUC__)
@@ -49,7 +49,7 @@ int crypto1_filter(uint32_t const x) {
   f |= 0x3c8b0 >> (x >>  8  & 0xf) &  4;
   f |= 0x1e458 >> (x >> 12  & 0xf) &  2;
   f |= 0x0d938 >> (x >> 16  & 0xf) &  1;
-  return BIT(0xEC57E80A, f);
+  return crypto1_getbit(0xEC57E80A, f);
 }
 
 // ── Initialise ─────────────────────────────────────────────────────────────
@@ -59,8 +59,8 @@ void crypto1_init(struct Crypto1State *s, uint64_t key) {
   s->odd = 0;
   s->even = 0;
   for (int i = 47; i > 0; i -= 2) {
-    s->odd  = s->odd  << 1 | BIT(key, (i - 1) ^ 7);
-    s->even = s->even << 1 | BIT(key,  i       ^ 7);
+    s->odd  = s->odd  << 1 | crypto1_getbit(key, (i - 1) ^ 7);
+    s->even = s->even << 1 | crypto1_getbit(key,  i       ^ 7);
   }
 }
 
@@ -86,7 +86,7 @@ uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted) {
 uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted) {
   uint8_t ret = 0;
   for (int i = 0; i < 8; i++)
-    ret |= (uint8_t)(crypto1_bit(s, BIT(in, i), is_encrypted) << i);
+    ret |= (uint8_t)(crypto1_bit(s, crypto1_getbit(in, i), is_encrypted) << i);
   return ret;
 }
 
@@ -94,7 +94,7 @@ uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted) {
 uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted) {
   uint32_t ret = 0;
   for (int i = 0; i < 32; i++)
-    ret |= (uint32_t)(crypto1_bit(s, BEBIT(in, i), is_encrypted) << (24 ^ i));
+    ret |= (uint32_t)(crypto1_bit(s, crypto1_bebit(in, i), is_encrypted) << (24 ^ i));
   return ret;
 }
 

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -111,7 +111,7 @@ uint32_t prng_successor(uint32_t x, uint32_t n) {
   x = swapendian(x);
   while (n--)
     x = x >> 1 | (x >> 16 ^ x >> 18 ^ x >> 19 ^ x >> 21) << 31;
-  return x = swapendian(x);
+  return swapendian(x);
 }
 
 }  // namespace st25r

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -1,0 +1,109 @@
+/*
+ * Crypto1 stream cipher — standalone C++ implementation.
+ *
+ * Algorithm: Courtois, Nohl et al. (2008) — public academic specification.
+ * LFSR polynomial constants (LF_POLY_ODD/EVEN) and filter function constants
+ * are derived from the published algorithm and are mathematical facts.
+ *
+ * Protocol flow inspired by mf1.c (MIT, suut/rfal-mifare-classic):
+ *   https://github.com/suut/rfal-mifare-classic/blob/master/mf1/mf1.c
+ */
+
+#include "crypto1.h"
+#include <string.h>
+
+// ── LFSR feedback polynomial masks ─────────────────────────────────────────
+// The 48-bit Crypto1 LFSR uses two interleaved 24-bit words (odd/even).
+// These masks select the tap positions in each half-word; the new LFSR bit is
+// evenparity(LF_POLY_ODD & odd) XOR evenparity(LF_POLY_EVEN & even) XOR input.
+#define LF_POLY_ODD  (0x29CE5C)
+#define LF_POLY_EVEN (0x870804)
+
+#define BIT(x, n)   (((x) >> (n)) & 1)
+#define BEBIT(x, n) BIT((x), (n) ^ 24)
+
+static inline uint8_t evenparity32(uint32_t x) {
+#if defined(__GNUC__)
+  return (uint8_t) __builtin_parity(x);
+#else
+  x ^= x >> 16;
+  x ^= x >> 8;
+  x ^= x >> 4;
+  x ^= x >> 2;
+  x ^= x >> 1;
+  return x & 1;
+#endif
+}
+
+// ── Output filter function ─────────────────────────────────────────────────
+// Five-variable boolean function f20 operating on the odd LFSR half-word.
+// Constants encode the function's truth table across the 5 input nibbles;
+// the final lookup is into the 32-bit constant 0xEC57E80A.
+int crypto1_filter(uint32_t const x) {
+  uint32_t f;
+  f  = 0xf22c0 >> (x        & 0xf) & 16;
+  f |= 0x6c9c0 >> (x >>  4  & 0xf) &  8;
+  f |= 0x3c8b0 >> (x >>  8  & 0xf) &  4;
+  f |= 0x1e458 >> (x >> 12  & 0xf) &  2;
+  f |= 0x0d938 >> (x >> 16  & 0xf) &  1;
+  return BIT(0xEC57E80A, f);
+}
+
+// ── Initialise ─────────────────────────────────────────────────────────────
+// Load 48-bit key into the interleaved odd/even state.
+// Key bit 47 (MSB after XOR-8 reorder) → first bit loaded.
+void crypto1_init(struct Crypto1State *s, uint64_t key) {
+  s->odd = 0;
+  s->even = 0;
+  for (int i = 47; i > 0; i -= 2) {
+    s->odd  = s->odd  << 1 | BIT(key, (i - 1) ^ 7);
+    s->even = s->even << 1 | BIT(key,  i       ^ 7);
+  }
+}
+
+// ── Clock one bit ──────────────────────────────────────────────────────────
+uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted) {
+  uint32_t feedin, t;
+  uint8_t ret = (uint8_t) crypto1_filter(s->odd);
+
+  feedin  = ret & (uint32_t)(!!is_encrypted);
+  feedin ^= (uint32_t)(!!in);
+  feedin ^= LF_POLY_ODD  & s->odd;
+  feedin ^= LF_POLY_EVEN & s->even;
+  s->even = s->even << 1 | evenparity32(feedin);
+
+  t = s->odd;
+  s->odd = s->even;
+  s->even = t;
+
+  return ret;
+}
+
+// ── Clock one byte (LSB first) ─────────────────────────────────────────────
+uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted) {
+  uint8_t ret = 0;
+  for (int i = 0; i < 8; i++)
+    ret |= (uint8_t)(crypto1_bit(s, BIT(in, i), is_encrypted) << i);
+  return ret;
+}
+
+// ── Clock 32 bits (big-endian ISO 14443A bit order) ────────────────────────
+uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted) {
+  uint32_t ret = 0;
+  for (int i = 0; i < 32; i++)
+    ret |= (uint32_t)(crypto1_bit(s, BEBIT(in, i), is_encrypted) << (24 ^ i));
+  return ret;
+}
+
+// ── Tag PRNG ───────────────────────────────────────────────────────────────
+// 32-bit Galois LFSR used to generate the tag's nonce sequence.
+// Taps at bits 16, 18, 19, 21 (0-indexed from LSB, big-endian byte order).
+#define SWAPENDIAN(x) \
+  (x = (x >> 8 & 0x00ff00ffu) | (x & 0x00ff00ffu) << 8, x = x >> 16 | x << 16)
+
+uint32_t prng_successor(uint32_t x, uint32_t n) {
+  SWAPENDIAN(x);
+  while (n--)
+    x = x >> 1 | (x >> 16 ^ x >> 18 ^ x >> 19 ^ x >> 21) << 31;
+  return SWAPENDIAN(x);
+}

--- a/esphome/components/st25r/crypto1.cpp
+++ b/esphome/components/st25r/crypto1.cpp
@@ -10,7 +10,7 @@
  */
 
 #include "crypto1.h"
-#include <string.h>
+#include <cstring>
 
 // ── LFSR feedback polynomial masks ─────────────────────────────────────────
 // The 48-bit Crypto1 LFSR uses two interleaved 24-bit words (odd/even).
@@ -98,12 +98,15 @@ uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted) {
 // ── Tag PRNG ───────────────────────────────────────────────────────────────
 // 32-bit Galois LFSR used to generate the tag's nonce sequence.
 // Taps at bits 16, 18, 19, 21 (0-indexed from LSB, big-endian byte order).
-#define SWAPENDIAN(x) \
-  (x = (x >> 8 & 0x00ff00ffu) | (x & 0x00ff00ffu) << 8, x = x >> 16 | x << 16)
+static inline uint32_t swapendian(uint32_t x) {
+  x = ((x >> 8) & 0x00ff00ffu) | ((x & 0x00ff00ffu) << 8);
+  x = (x >> 16) | (x << 16);
+  return x;
+}
 
 uint32_t prng_successor(uint32_t x, uint32_t n) {
-  SWAPENDIAN(x);
+  x = swapendian(x);
   while (n--)
     x = x >> 1 | (x >> 16 ^ x >> 18 ^ x >> 19 ^ x >> 21) << 31;
-  return SWAPENDIAN(x);
+  return x = swapendian(x);
 }

--- a/esphome/components/st25r/crypto1.h
+++ b/esphome/components/st25r/crypto1.h
@@ -1,5 +1,8 @@
 #pragma once
-#include <stdint.h>
+#include <cstdint>
+
+namespace esphome {
+namespace st25r {
 
 /*
  * Crypto1 stream cipher implementation.
@@ -37,3 +40,6 @@ uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted);
 
 // Advance the tag PRNG n steps (used to predict tag nonce responses)
 uint32_t prng_successor(uint32_t x, uint32_t n);
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r/crypto1.h
+++ b/esphome/components/st25r/crypto1.h
@@ -24,16 +24,16 @@ struct Crypto1State {
 };
 
 // Initialise state from 48-bit key (MSB of key → first LFSR bit loaded)
-void  crypto1_init(struct Crypto1State *s, uint64_t key);
+void crypto1_init(struct Crypto1State *s, uint64_t key);
 
 // Output filter function — operates on the odd half of the state
-int   crypto1_filter(uint32_t x);
+int crypto1_filter(uint32_t x);
 
 // Clock one bit; in=plaintext input bit; is_encrypted=1 during encrypted phase
-uint8_t  crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted);
+uint8_t crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted);
 
 // Clock eight bits LSB-first
-uint8_t  crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted);
+uint8_t crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted);
 
 // Clock 32 bits using ISO 14443A big-endian bit ordering (used for nonce words)
 uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted);

--- a/esphome/components/st25r/crypto1.h
+++ b/esphome/components/st25r/crypto1.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <stdint.h>
+
+/*
+ * Crypto1 stream cipher implementation.
+ *
+ * The Crypto1 algorithm is documented in:
+ *   Courtois, Nohl et al. "Algebraic Attacks on the Crypto-1 Stream Cipher
+ *   in MiFare Classic and Oyster Cards" (2008)
+ *
+ * LFSR polynomial constants and filter function are mathematical facts
+ * derived from the published algorithm specification.
+ *
+ * Protocol flow adapted from mf1.c — MIT licence, suut/rfal-mifare-classic
+ *   https://github.com/suut/rfal-mifare-classic/blob/master/mf1/mf1.c
+ */
+
+struct Crypto1State {
+  uint32_t odd;   // odd-indexed LFSR bits (1,3,5,...,47) packed into bits 0..23
+  uint32_t even;  // even-indexed LFSR bits (0,2,4,...,46) packed into bits 0..23
+};
+
+// Initialise state from 48-bit key (MSB of key → first LFSR bit loaded)
+void  crypto1_init(struct Crypto1State *s, uint64_t key);
+
+// Output filter function — operates on the odd half of the state
+int   crypto1_filter(uint32_t x);
+
+// Clock one bit; in=plaintext input bit; is_encrypted=1 during encrypted phase
+uint8_t  crypto1_bit(struct Crypto1State *s, uint8_t in, int is_encrypted);
+
+// Clock eight bits LSB-first
+uint8_t  crypto1_byte(struct Crypto1State *s, uint8_t in, int is_encrypted);
+
+// Clock 32 bits using ISO 14443A big-endian bit ordering (used for nonce words)
+uint32_t crypto1_word(struct Crypto1State *s, uint32_t in, int is_encrypted);
+
+// Advance the tag PRNG n steps (used to predict tag nonce responses)
+uint32_t prng_successor(uint32_t x, uint32_t n);

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -15,7 +15,7 @@
  *   https://github.com/suut/rfal-mifare-classic/blob/master/mf1/mf1.c
  *
  * ST25R3916 9-bit parity interleaving (mf1_encode/decode_parity_st25r3916):
- *   Each byte is stored as 9 bits in the FIFO: 8 data bits then 1 parity bit.
+ *   Each octet is stored as 9 bits in the FIFO: 8 data bits then 1 parity bit.
  *   CRC and parity are both handled manually; ISO14443A_CONF bits no_tx_par
  *   (bit6) and no_rx_par (bit7) must be set before transmitting/receiving.
  */
@@ -45,7 +45,7 @@ static const uint8_t ODD_PARITY[256] = {
 };
 
 // ── 9-bit parity pack/unpack ─────────────────────────────────────────────────
-// Each byte → 9 bits in the buffer: data bits 0..7 then parity bit.
+// Each octet → 9 bits in the buffer: data bits 0..7 then parity bit.
 // Adapted from mf1_encode/decode_parity_st25r3916 (MIT, suut/rfal-mifare-classic)
 
 static void mifare_pack_parity(const uint8_t *in, const uint8_t *par,
@@ -96,10 +96,10 @@ void ST25R::setup() {
     this->reset_pin_->setup();
     this->reset_pin_->digital_write(true);
     delay(10);
-    this->reset_pin_->digital_write(false); 
+    this->reset_pin_->digital_write(false);
     delay(10);
   }
-  
+
   if (this->irq_pin_ != nullptr) {
     ESP_LOGI(TAG, "Configuring IRQ pin...");
     this->irq_pin_->setup();
@@ -316,7 +316,7 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
 
         // We need to know how many bits arrived; use FIFO_STATUS2 fifo_lb
         uint8_t fs2 = this->read_register(FIFO_STATUS2);
-        uint8_t last_bits = (fs2 >> 1) & 0x07;  // fifo_lb: bits in last byte (0 = full byte)
+        uint8_t last_bits = (fs2 >> 1) & 0x07;  // fifo_lb: bits in last octet (0 = full byte)
         uint16_t rx_bits = (uint16_t)(rx_bytes * 8) - (last_bits ? (uint8_t)(8 - last_bits) : 0);
 
         resp_len = mifare_unpack_parity(rx_fifo, resp, resp_parity, rx_bits);
@@ -432,7 +432,7 @@ bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
     plain[i] = crypto1_byte(cs, 0, 0) ^ rx_enc[i];
     uint8_t exp_par = (uint8_t)(crypto1_bit(cs, 0, 0) ^ ODD_PARITY[plain[i]]);
     if (rx_par[i] != exp_par) {
-      ESP_LOGW(TAG, "Mifare read block %u: parity error at byte %d", block, i);
+      ESP_LOGW(TAG, "Mifare read block %u: parity error at octet %d", block, i);
       return false;
     }
   }
@@ -486,7 +486,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
              block2[8],block2[9],block2[10],block2[11],block2[12],block2[13],block2[14],block2[15]);
 
     // Look for NFC Forum Type 2 NDEF TLV (0x03) in the data area
-    // On Mifare Classic the NDEF data starts at block 1 byte 0 when
+    // On Mifare Classic the NDEF data starts at block 1 octet 0 when
     // the card is formatted as NFC Forum Type 2 / Mifare Classic NDEF.
     std::vector<uint8_t> raw;
     raw.insert(raw.end(), block1, block1 + 16);
@@ -516,16 +516,16 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
     uint8_t buffer[16];
     uint8_t len;
 
-    uint8_t read_cmd[2] = {0x30, 0x00}; 
+    uint8_t read_cmd[2] = {0x30, 0x00};
     if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
       ESP_LOGD(TAG, "  Read page 0-3 success");
       data.insert(data.end(), buffer, buffer + 16); // Only keep data, skip CRC
-      
+
       size_t tlv_index = 0;
       bool found = false;
       bool terminator_found = false;
 
-      for (size_t i = 0; i < 16; i++) { 
+      for (size_t i = 0; i < 16; i++) {
         if (data[i] == 0x03) {
           tlv_index = i;
           found = true;
@@ -1108,7 +1108,7 @@ void ST25R::send_anticol_frame_() {
 
   // NVB: high nibble = complete bytes in frame (SEL + NVB + complete UID prefix bytes only)
   //      low nibble  = partial bits (0 = full bytes only)
-  // NOTE: partial byte is NOT counted in high nibble — it goes into FIFO but NVB only counts complete bytes
+  // NOTE: partial octet is NOT counted in high nibble — it goes into FIFO but NVB only counts complete bytes
   uint8_t nvb_high = 2 + this->anticol_prefix_full_;
   uint8_t nvb = (nvb_high << 4) | this->anticol_prefix_bits_;
 
@@ -1121,7 +1121,7 @@ void ST25R::send_anticol_frame_() {
   if (this->anticol_prefix_bits_ > 0)
     frame[frame_len++] = this->anticol_prefix_[this->anticol_prefix_full_];
 
-  // NUM_TX_BYTES: N full bytes + B partial bits (B>0 means one extra partial byte is in FIFO)
+  // NUM_TX_BYTES: N full bytes + B partial bits (B>0 means one extra partial octet is in FIFO)
   // N = SEL + NVB + complete UID prefix bytes only (NOT counting the partial byte)
   uint8_t ntx_n = 2 + this->anticol_prefix_full_;
   uint8_t ntx_b = this->anticol_prefix_bits_;
@@ -1341,7 +1341,7 @@ bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *re
   // Toggle block number for next exchange
   this->isodep_block_number_ ^= 1;
 
-  // Strip PCB byte, check for I-Block response
+  // Strip PCB octet, check for I-Block response
   if ((raw_resp[0] & 0xC0) != 0x00) {
     // Not an I-Block — might be R-Block or S-Block
     ESP_LOGD(TAG, "ISO-DEP: non-I-Block response PCB=0x%02X", raw_resp[0]);
@@ -1514,7 +1514,7 @@ void ST25R::nfcb_scan_() {
 
   if (resp_len < 12 || resp[0] != 0x50) return;
 
-  // Parse ATQB: byte 0 = 0x50, bytes 1-4 = PUPI
+  // Parse ATQB: octet 0 = 0x50, octets 1-4 = PUPI
   char uid_str[9];
   snprintf(uid_str, sizeof(uid_str), "%02X%02X%02X%02X", resp[1], resp[2], resp[3], resp[4]);
   ESP_LOGI(TAG, "NFC-B tag: %s (ATQB len=%u)", uid_str, resp_len);
@@ -1547,7 +1547,7 @@ uint16_t ST25R::iso15693_crc_(const uint8_t *data, size_t len) {
   return ~crc;
 }
 
-// 1-of-4 VCD encoding: each byte → 4 output bytes (SOF + data + CRC + EOF)
+// 1-of-4 VCD encoding: each octet → 4 output bytes (SOF + data + CRC + EOF)
 static const uint8_t ISO15693_1OF4_SOF = 0x21;
 static const uint8_t ISO15693_1OF4_EOF = 0x04;
 static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
@@ -1680,7 +1680,7 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
   this->write_command(ST25R_CMD_CLEAR_FIFO);
 
   // Set TX frame: total sub-bits (not bytes!)
-  // For 1-of-4: each coded byte = 1 sub-bit in stream mode
+  // For 1-of-4: each coded octet = 1 sub-bit in stream mode
   uint16_t subbits = coded_len;
   this->write_register(NUM_TX_BYTES1, subbits >> 5);
   this->write_register(NUM_TX_BYTES2, (subbits & 0x1F) << 3);
@@ -1819,7 +1819,7 @@ void ST25R::nfcv_scan_() {
 }
 
 bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
-  // Check if the most recent tag is NFC-V (8-byte UID = 16 hex chars)
+  // Check if the most recent tag is NFC-V (8-octet UID = 16 hex chars)
   // If so, use the NFC-V WRITE_SINGLE_BLOCK path
   if (!this->present_tags_.empty()) {
     const std::string &last_uid = this->present_tags_.rbegin()->first;
@@ -1866,7 +1866,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
 
   std::vector<uint8_t> ndef_data = message->encode();
   std::vector<uint8_t> payload;
-  
+
   // Build TLV structure
   payload.push_back(0x03); // NDEF TLV
   if (ndef_data.size() < 255) {
@@ -1888,7 +1888,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
     uint8_t page = 4 + (i / 4);
     uint8_t write_cmd[6] = {0xA2, page, payload[i], payload[i+1], payload[i+2], payload[i+3]};
     bool success = false;
-    
+
     for (uint8_t retry = 0; retry < 3; retry++) {
       delay(20);
       if (this->transceive_(write_cmd, 6, buffer, len) && (len > 0 && (buffer[0] & 0x0F) == 0x0A)) {

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -1358,15 +1358,15 @@ bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *re
     return false;
   }
 
-  // Toggle block number for next exchange
-  this->isodep_block_number_ ^= 1;
-
   // Strip PCB octet, check for I-Block response
   if ((raw_resp[0] & 0xC0) != 0x00) {
-    // Not an I-Block — might be R-Block or S-Block
+    // Not an I-Block — might be R-Block or S-Block; don't toggle block number
     ESP_LOGD(TAG, "ISO-DEP: non-I-Block response PCB=0x%02X", raw_resp[0]);
     return false;
   }
+
+  // Valid I-Block received — toggle block number for next exchange
+  this->isodep_block_number_ ^= 1;
 
   // Response: [PCB][data...][SW1][SW2]  (CRC already stripped by transceive_)
   resp_len = raw_len - 1;  // strip PCB

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -109,8 +109,8 @@ void ST25R::setup() {
   if (this->status_binary_sensor_ != nullptr) {
     this->status_binary_sensor_->publish_initial_state(false);
   }
-  ESP_LOGI(TAG, "Starting reset_chip_()...");
-  if (!this->reset_chip_()) {
+  ESP_LOGI(TAG, "Starting reset_chip()...");
+  if (!this->reset_chip()) {
     ESP_LOGE(TAG, "Failed to reset chip");
     this->mark_failed();
     return;
@@ -198,14 +198,14 @@ void ST25R::update() {
 }
 
 bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
 bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
-bool ST25R::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
+bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch per datasheet transceive sequence
   // Clear ALL IRQ registers so IRQ pin goes low — required for ISR rising-edge to fire
@@ -446,7 +446,7 @@ bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
   return true;
 }
 
-std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d, SAK=0x%02X", uid.size(), type, this->last_sak_);
 
@@ -637,10 +637,10 @@ void ST25R::loop() {
     this->irq_status_ = 0;
   }
 
-  this->process_state_();
+  this->process_state();
 }
 
-void ST25R::process_state_() {
+void ST25R::process_state() {
   switch (this->state_) {
     case STATE_IDLE:
       break;
@@ -659,7 +659,7 @@ void ST25R::process_state_() {
           // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
           this->anticol_resume_ = false;
 
-          this->send_anticol_frame_();
+          this->send_anticol_frame();
           this->state_ = STATE_ANTICOL;
           this->last_state_change_ = millis();
       } else if (this->irq_status_ & IRQ_NRE) {
@@ -676,7 +676,7 @@ void ST25R::process_state_() {
           uint8_t irq_t = this->read_register(IRQ_TIMER);
           uint8_t irq_e = this->read_register(IRQ_ERROR);
           ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u",
-                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1_());
+                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1());
           this->irq_status_ = 0;
           this->irq_triggered_ = false;
           this->state_ = STATE_IDLE;
@@ -694,7 +694,7 @@ void ST25R::process_state_() {
           // Send WUPA before each new prefix attempt — some cards (e.g. Mifare Classic) leave
           // the READY state quickly after responding to an anticol they don't match.
           this->anticol_resume_ = true;
-          this->start_wupa_();
+          this->start_wupa();
           this->state_ = STATE_WUPA;
           this->last_state_change_ = millis();
           return;
@@ -706,11 +706,11 @@ void ST25R::process_state_() {
 
       if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
         delay(5);
-        uint8_t f1 = this->read_fifo_status1_();
+        uint8_t f1 = this->read_fifo_status1();
         bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
 
         if (has_collision) {
-          uint8_t col_raw = this->read_collision_display_();
+          uint8_t col_raw = this->read_collision_display();
           uint8_t c_byte = (col_raw >> 4) & 0x0F;
           uint8_t c_bit  = (col_raw >> 1) & 0x07;
           // col_pos_abs is from start of TX frame (SEL + NVB = 2 bytes = 16 bits)
@@ -724,7 +724,7 @@ void ST25R::process_state_() {
           this->anticol_prefix_val_ = 0;
           this->apply_anticol_prefix_();
 
-          this->send_anticol_frame_();
+          this->send_anticol_frame();
           this->last_state_change_ = millis();
 
         } else if (f1 >= 5) {
@@ -763,8 +763,8 @@ void ST25R::process_state_() {
           }
 
           // Clear anticollision mode before SELECT (ST25R3916: ISO14443A_CONF=0x00;
-          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex_()).
-          this->pre_select_();
+          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex()).
+          this->pre_select();
 
           uint8_t sak_buf[3];
           uint8_t sak_len = 0;
@@ -795,7 +795,7 @@ void ST25R::process_state_() {
             this->anticol_prefix_bits_ = 0;
             this->anticol_col_pos_ = 0;
             this->anticol_prefix_val_ = 0;
-            this->send_anticol_frame_();
+            this->send_anticol_frame();
             this->state_ = STATE_ANTICOL;
             this->last_state_change_ = millis();
           } else {
@@ -815,13 +815,13 @@ void ST25R::process_state_() {
               std::vector<uint8_t> uid_bytes;
               for (size_t i = 0; i < this->current_uid_.length(); i += 2)
                 uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
-              this->tags_data_[this->current_uid_] = this->read_tag_(uid_bytes);
+              this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
             }
 
             this->tags_this_scan_.insert(this->current_uid_);
 
-            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt_()
-            this->send_halt_();
+            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt()
+            this->send_halt();
 
             // Determine the CL1 collision state so we can resume the multi-tag tree traversal.
             // If we went through cascade (CL2), restore the saved CL1 state.
@@ -859,7 +859,7 @@ void ST25R::process_state_() {
               // Some cards (e.g. Mifare Classic) return to HALT after a non-matching SELECT,
               // so REQA would not wake them.
               this->anticol_resume_ = true;
-              this->start_wupa_();
+              this->start_wupa();
             } else {
               // No prior collision: this was the only tag — scan complete
               this->state_ = STATE_IDLE;
@@ -875,7 +875,7 @@ void ST25R::process_state_() {
     }
 
     case STATE_REINITIALIZING:
-      this->reinitialize_();
+      this->reinitialize();
       this->state_ = STATE_IDLE;
       break;
   }
@@ -953,7 +953,7 @@ bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
   return false;
 }
 
-bool ST25R::reset_chip_() {
+bool ST25R::reset_chip() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   // IC_IDENTITY is read-only and unaffected by SET_DEFAULT.
   uint8_t ic_identity = this->read_register(IC_IDENTITY);
@@ -971,7 +971,7 @@ bool ST25R::reset_chip_() {
   this->is_b_version_ = is_b_version;
   // ST25R3916 (0x28) and ST25R3916B (0x30) both have Automatic Antenna Tuning (AAT)
   // with varicap DAC outputs on ANT_TUNE_A/B (0x26/0x27).  Variants without AAT
-  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_chip_() override and
+  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_chip() override and
   // never reach this code, but set the flag explicitly to represent the capability.
   this->has_aat_ = true;
   ESP_LOGI(TAG, "IC identity match: 0x%02X (ST25R3916%s)", ic_identity, is_b_version ? "B" : "");
@@ -1061,7 +1061,7 @@ bool ST25R::reset_chip_() {
   return true;
 }
 
-void ST25R::reinitialize_() {
+void ST25R::reinitialize() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -1070,7 +1070,7 @@ void ST25R::reinitialize_() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_chip_()) {
+  if (this->reset_chip()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -1102,7 +1102,7 @@ void ST25R::apply_anticol_prefix_() {
   }
 }
 
-void ST25R::send_anticol_frame_() {
+void ST25R::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -1141,20 +1141,20 @@ void ST25R::send_anticol_frame_() {
 
 // ── Default virtual helpers (ST25R3916 implementations) ──────────────────────
 
-void ST25R::pre_select_() {
+void ST25R::pre_select() {
   // ST25R3916: clear antcl bit in ISO14443A_CONF so SELECT uses normal (non-anticol) framing
   this->write_register(ISO14443A_CONF, 0x00);
 }
 
-uint8_t ST25R::read_fifo_status1_() {
+uint8_t ST25R::read_fifo_status1() {
   return this->read_register(FIFO_STATUS1);
 }
 
-uint8_t ST25R::read_collision_display_() {
+uint8_t ST25R::read_collision_display() {
   return this->read_register(COLLISION_DISPLAY);
 }
 
-void ST25R::send_halt_() {
+void ST25R::send_halt() {
   // HALT: send [0x50, 0x00] + CRC; tag has no response.
   // Don't use transceive_() here — it blocks waiting for a non-existent response.
   uint8_t halt_cmd[2] = {0x50, 0x00};
@@ -1169,7 +1169,7 @@ void ST25R::send_halt_() {
   delay(10);  // wait for HALT frame to be transmitted (~2ms for 4 bytes)
 }
 
-void ST25R::start_wupa_() {
+void ST25R::start_wupa() {
   // Clear FIFO + IRQs, then transmit WUPA.
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->read_register(IRQ_MAIN);
@@ -1192,7 +1192,7 @@ void ST25R::field_on_() {
 // ── AAT (Automatic Antenna Tuning) hill-climbing optimizer ───────────────────
 // Based on RFAL st25r3916AatTune() (AN5322). Iteratively adjusts ANT_TUNE_A/B
 // to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on_()
-// during reset_chip_() on chips with AAT hardware (ST25R3916/3916B).
+// during reset_chip() on chips with AAT hardware (ST25R3916/3916B).
 
 void ST25R::aat_tune_() {
   if (!this->has_aat_) return;
@@ -1537,7 +1537,7 @@ void ST25R::nfcb_scan_() {
 // ── NFC-V (ISO 15693) streaming mode for ST25R3916 ──────────────────────────
 
 // ISO 15693 CRC-16 CCITT (preset=0xFFFF, poly=0x8408, result inverted)
-uint16_t ST25R::iso15693_crc_(const uint8_t *data, size_t len) {
+uint16_t ST25R::iso15693_crc(const uint8_t *data, size_t len) {
   uint16_t crc = 0xFFFF;
   for (size_t i = 0; i < len; i++) {
     uint8_t d = data[i] ^ (uint8_t)(crc & 0xFF);
@@ -1552,7 +1552,7 @@ static const uint8_t ISO15693_1OF4_SOF = 0x21;
 static const uint8_t ISO15693_1OF4_EOF = 0x04;
 static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
 
-size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc,
+size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc,
                                      uint8_t *out, size_t out_max) {
   size_t pos = 0;
   if (out_max < 1 + (len + 2) * 4 + 1) return 0;
@@ -1571,7 +1571,7 @@ size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_cr
 
   // Encode CRC
   if (add_crc) {
-    uint16_t crc = iso15693_crc_(data, len);
+    uint16_t crc = iso15693_crc(data, len);
     uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
     for (int c = 0; c < 2; c++) {
       uint8_t b = crc_bytes[c];
@@ -1588,7 +1588,7 @@ size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_cr
 }
 
 // Manchester VICC decoding: subcarrier stream → payload bytes
-size_t ST25R::iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
+size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
   if (in_len == 0 || out_max == 0) return 0;
 
   // Check SOF: first 5 bits should be 0x17 (10111 = 3 unmodulated + 2 modulated)
@@ -1673,7 +1673,7 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
   cmd_buf[0] |= 0x02;   // high data rate
   cmd_buf[0] &= ~0x01;  // single subcarrier
 
-  size_t coded_len = iso15693_encode_1of4_(cmd_buf, len, true, coded, sizeof(coded));
+  size_t coded_len = iso15693_encode_1of4(cmd_buf, len, true, coded, sizeof(coded));
   if (coded_len == 0) return false;
 
   this->write_command(ST25R_CMD_STOP_ALL);
@@ -1704,10 +1704,10 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
         this->read_fifo(raw, fifo_len);
         // Decode Manchester
         uint8_t decoded[32];
-        size_t dec_len = iso15693_decode_manchester_(raw, fifo_len, decoded, sizeof(decoded));
+        size_t dec_len = iso15693_decode_manchester(raw, fifo_len, decoded, sizeof(decoded));
         if (dec_len >= 3) {  // At least flags + CRC(2)
           // Verify CRC
-          uint16_t crc = iso15693_crc_(decoded, dec_len - 2);
+          uint16_t crc = iso15693_crc(decoded, dec_len - 2);
           if ((crc & 0xFF) == decoded[dec_len - 2] && (crc >> 8) == decoded[dec_len - 1]) {
             // Strip CRC
             resp_len = dec_len - 2;
@@ -1824,7 +1824,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   if (!this->present_tags_.empty()) {
     const std::string &last_uid = this->present_tags_.rbegin()->first;
     if (last_uid.length() == 16) {
-      return this->nfcv_ndef_write_(message);
+      return this->nfcv_ndef_write(message);
     }
   }
 
@@ -1907,7 +1907,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   return true;
 }
 
-bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
+bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
   // NFC-V Type 5 NDEF write via WRITE_SINGLE_BLOCK (0x21)
   // Block 0 = CC, blocks 1+ = NDEF TLV data
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -109,8 +109,8 @@ void ST25R::setup() {
   if (this->status_binary_sensor_ != nullptr) {
     this->status_binary_sensor_->publish_initial_state(false);
   }
-  ESP_LOGI(TAG, "Starting reset_chip()...");
-  if (!this->reset_chip()) {
+  ESP_LOGI(TAG, "Starting reset_chip_()...");
+  if (!this->reset_chip_()) {
     ESP_LOGE(TAG, "Failed to reset chip");
     this->mark_failed();
     return;
@@ -170,11 +170,11 @@ void ST25R::update() {
 
   // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
   if (this->nfcv_enabled_)
-    this->nfcv_scan();
+    this->nfcv_scan_();
 
   // NFC-B (ISO 14443B) blocking SENSB_REQ — runs before NFC-A scan
   if (this->nfcb_enabled_)
-    this->nfcb_scan();
+    this->nfcb_scan_();
 
   // If previous scan activated ISO-DEP (RATS), send S-Block DESELECT to return
   // the card to IDLE state. Without this, ISO-DEP cards ignore subsequent WUPAs.
@@ -198,14 +198,14 @@ void ST25R::update() {
 }
 
 bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
 }
 
 bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
 }
 
-bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
+bool ST25R::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch per datasheet transceive sequence
   // Clear ALL IRQ registers so IRQ pin goes low — required for ISR rising-edge to fire
@@ -270,7 +270,7 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
 // data/parity: len plaintext bytes + precomputed parity bits.
 // resp/resp_parity: decoded response bytes and their parity bits.
 // Adapted from mf1_send_receive_raw (MIT, suut/rfal-mifare-classic).
-bool ST25R::transceive_mifare(const uint8_t *data, const uint8_t *parity,
+bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
                                 uint8_t len,
                                 uint8_t *resp, uint8_t *resp_parity,
                                 uint8_t &resp_len,
@@ -335,7 +335,7 @@ bool ST25R::transceive_mifare(const uint8_t *data, const uint8_t *parity,
 // ── mifare_authenticate_ ─────────────────────────────────────────────────────
 // Three-pass mutual authentication per ISO 14443-3 / NXP AN10609.
 // Protocol flow from mf1_authenticate() (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
+bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
                                   const uint8_t *uid, uint8_t uid_len,
                                   struct Crypto1State *cs) {
   // ── Step 1: send AUTHENT command (plain text, with CRC) ──────────────────
@@ -381,7 +381,7 @@ bool ST25R::mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
   // ── Step 3: send nr+ar (encrypted, manual parity, no CRC) ────────────────
   uint8_t at[4] = {}, at_par[4] = {};
   uint8_t at_len = 0;
-  if (!this->transceive_mifare(nr_ar, nr_ar_par, 8, at, at_par, at_len) || at_len < 4) {
+  if (!this->transceive_mifare_(nr_ar, nr_ar_par, 8, at, at_par, at_len) || at_len < 4) {
     ESP_LOGW(TAG, "Mifare auth: no AT from tag (block %u)", block);
     return false;
   }
@@ -400,9 +400,9 @@ bool ST25R::mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
 }
 
 // ── mifare_read_block_ ───────────────────────────────────────────────────────
-// Read one 16-byte block after a successful mifare_authenticate().
+// Read one 16-byte block after a successful mifare_authenticate_().
 // Protocol flow from mf1_send_receive_encrypted (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_read_block(uint8_t block, uint8_t *data,
+bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
                                 struct Crypto1State *cs) {
   // Build: READ(0x30) + block + CRC_A — then encrypt all 4 bytes + CRC
   uint8_t cmd[4];
@@ -421,7 +421,7 @@ bool ST25R::mifare_read_block(uint8_t block, uint8_t *data,
   // Response: 16 data bytes + 2 CRC bytes = 18 bytes, all encrypted
   uint8_t rx_enc[18] = {}, rx_par[18] = {};
   uint8_t rx_len = 0;
-  if (!this->transceive_mifare(enc, enc_par, 4, rx_enc, rx_par, rx_len) || rx_len < 18) {
+  if (!this->transceive_mifare_(enc, enc_par, 4, rx_enc, rx_par, rx_len) || rx_len < 18) {
     ESP_LOGW(TAG, "Mifare read block %u failed (got %u bytes)", block, rx_len);
     return false;
   }
@@ -446,20 +446,20 @@ bool ST25R::mifare_read_block(uint8_t block, uint8_t *data,
   return true;
 }
 
-std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d, SAK=0x%02X", uid.size(), type, this->last_sak_);
 
   // ISO-DEP capable (SAK bit 5 set) → try Type 4 NDEF read
   if (this->last_sak_ & 0x20) {
     ESP_LOGI(TAG, "ISO-DEP capable tag (SAK & 0x20) — trying Type 4 NDEF");
-    return this->read_tag_type4(uid);
+    return this->read_tag_type4_(uid);
   }
 
   if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
     ESP_LOGI(TAG, "Mifare Classic detected - attempting authentication");
     struct Crypto1State cs = {};
-    bool auth_ok = this->mifare_authenticate(0, false, this->mifare_key_a_,
+    bool auth_ok = this->mifare_authenticate_(0, false, this->mifare_key_a_,
                                               uid.data(), (uint8_t) uid.size(), &cs);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     if (!auth_ok) {
@@ -470,8 +470,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
     ESP_LOGI(TAG, "Mifare Classic: Auth successful, reading blocks 1 and 2");
     // Read blocks 1 and 2 (block 0 is manufacturer data; block 3 is sector trailer)
     uint8_t block1[16] = {}, block2[16] = {};
-    bool b1 = this->mifare_read_block(1, block1, &cs);
-    bool b2 = b1 && this->mifare_read_block(2, block2, &cs);
+    bool b1 = this->mifare_read_block_(1, block1, &cs);
+    bool b2 = b1 && this->mifare_read_block_(2, block2, &cs);
 
     if (!b1) {
       ESP_LOGW(TAG, "Mifare Classic: block read failed");
@@ -637,10 +637,10 @@ void ST25R::loop() {
     this->irq_status_ = 0;
   }
 
-  this->process_state();
+  this->process_state_();
 }
 
-void ST25R::process_state() {
+void ST25R::process_state_() {
   switch (this->state_) {
     case STATE_IDLE:
       break;
@@ -659,7 +659,7 @@ void ST25R::process_state() {
           // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
           this->anticol_resume_ = false;
 
-          this->send_anticol_frame();
+          this->send_anticol_frame_();
           this->state_ = STATE_ANTICOL;
           this->last_state_change_ = millis();
       } else if (this->irq_status_ & IRQ_NRE) {
@@ -667,7 +667,7 @@ void ST25R::process_state() {
           ESP_LOGD(TAG, "WUPA NRE (no tag): IRQ=0x%02X", this->irq_status_);
           this->irq_status_ = 0;
           this->state_ = STATE_IDLE;
-          this->finalize_scan();
+          this->finalize_scan_();
       } else if (millis() - this->last_state_change_ > 100) {
           // No tag responded and NRE fast-path didn't fire (real ST25R3916:
           // NRE is in IRQ_TIMER, not IRQ_MAIN).  Read ALL IRQ registers so the
@@ -676,11 +676,11 @@ void ST25R::process_state() {
           uint8_t irq_t = this->read_register(IRQ_TIMER);
           uint8_t irq_e = this->read_register(IRQ_ERROR);
           ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u",
-                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1());
+                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1_());
           this->irq_status_ = 0;
           this->irq_triggered_ = false;
           this->state_ = STATE_IDLE;
-          this->finalize_scan();
+          this->finalize_scan_();
       }
       break;
     }
@@ -690,27 +690,27 @@ void ST25R::process_state() {
         uint8_t max_prefix_val = (1 << (this->anticol_col_pos_ + 1)) - 1;
         if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
           this->anticol_prefix_val_++;
-          this->apply_anticol_prefix();
+          this->apply_anticol_prefix_();
           // Send WUPA before each new prefix attempt — some cards (e.g. Mifare Classic) leave
           // the READY state quickly after responding to an anticol they don't match.
           this->anticol_resume_ = true;
-          this->start_wupa();
+          this->start_wupa_();
           this->state_ = STATE_WUPA;
           this->last_state_change_ = millis();
           return;
         }
         this->state_ = STATE_IDLE;
-        this->finalize_scan();
+        this->finalize_scan_();
         return;
       }
 
       if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
         delay(5);
-        uint8_t f1 = this->read_fifo_status1();
+        uint8_t f1 = this->read_fifo_status1_();
         bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
 
         if (has_collision) {
-          uint8_t col_raw = this->read_collision_display();
+          uint8_t col_raw = this->read_collision_display_();
           uint8_t c_byte = (col_raw >> 4) & 0x0F;
           uint8_t c_bit  = (col_raw >> 1) & 0x07;
           // col_pos_abs is from start of TX frame (SEL + NVB = 2 bytes = 16 bits)
@@ -722,9 +722,9 @@ void ST25R::process_state() {
           // FIFO bytes during collision are unreliable — brute-force all 2^(col_pos+1) prefixes
           this->anticol_col_pos_ = uid_col_pos;
           this->anticol_prefix_val_ = 0;
-          this->apply_anticol_prefix();
+          this->apply_anticol_prefix_();
 
-          this->send_anticol_frame();
+          this->send_anticol_frame_();
           this->last_state_change_ = millis();
 
         } else if (f1 >= 5) {
@@ -763,15 +763,15 @@ void ST25R::process_state() {
           }
 
           // Clear anticollision mode before SELECT (ST25R3916: ISO14443A_CONF=0x00;
-          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex()).
-          this->pre_select();
+          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex_()).
+          this->pre_select_();
 
           uint8_t sak_buf[3];
           uint8_t sak_len = 0;
           if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
             ESP_LOGW(TAG, "SELECT failed (no SAK)");
             this->state_ = STATE_IDLE;
-            this->finalize_scan();
+            this->finalize_scan_();
             return;
           }
           uint8_t sak = sak_buf[0];
@@ -788,14 +788,14 @@ void ST25R::process_state() {
             if (this->cascade_level_ > 2) {
               ESP_LOGE(TAG, "Too many cascade levels");
               this->state_ = STATE_IDLE;
-              this->finalize_scan();
+              this->finalize_scan_();
               return;
             }
             this->anticol_prefix_full_ = 0;
             this->anticol_prefix_bits_ = 0;
             this->anticol_col_pos_ = 0;
             this->anticol_prefix_val_ = 0;
-            this->send_anticol_frame();
+            this->send_anticol_frame_();
             this->state_ = STATE_ANTICOL;
             this->last_state_change_ = millis();
           } else {
@@ -804,7 +804,7 @@ void ST25R::process_state() {
             if (uid_bytes_len != 4 && uid_bytes_len != 7) {
               ESP_LOGW(TAG, "Discarding invalid UID len=%zu (%s)", uid_bytes_len, this->current_uid_.c_str());
               this->state_ = STATE_IDLE;
-              this->finalize_scan();
+              this->finalize_scan_();
               return;
             }
 
@@ -815,13 +815,13 @@ void ST25R::process_state() {
               std::vector<uint8_t> uid_bytes;
               for (size_t i = 0; i < this->current_uid_.length(); i += 2)
                 uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
-              this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
+              this->tags_data_[this->current_uid_] = this->read_tag_(uid_bytes);
             }
 
             this->tags_this_scan_.insert(this->current_uid_);
 
-            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt()
-            this->send_halt();
+            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt_()
+            this->send_halt_();
 
             // Determine the CL1 collision state so we can resume the multi-tag tree traversal.
             // If we went through cascade (CL2), restore the saved CL1 state.
@@ -846,24 +846,24 @@ void ST25R::process_state() {
               this->current_uid_ = "";
               this->anticol_col_pos_ = resume_col_pos;
               this->anticol_prefix_val_ = resume_prefix_val + 1;
-              this->apply_anticol_prefix();
+              this->apply_anticol_prefix_();
 
               uint8_t max_val = (1 << (resume_col_pos + 1)) - 1;
               if (this->anticol_prefix_val_ > max_val) {
                 // All branches at this collision level exhausted — done
                 this->state_ = STATE_IDLE;
-                this->finalize_scan();
+                this->finalize_scan_();
                 return;
               }
               // Send WUPA (not REQA) so all tags — including those in HALT — wake up.
               // Some cards (e.g. Mifare Classic) return to HALT after a non-matching SELECT,
               // so REQA would not wake them.
               this->anticol_resume_ = true;
-              this->start_wupa();
+              this->start_wupa_();
             } else {
               // No prior collision: this was the only tag — scan complete
               this->state_ = STATE_IDLE;
-              this->finalize_scan();
+              this->finalize_scan_();
               return;
             }
             this->state_ = STATE_WUPA;
@@ -875,13 +875,13 @@ void ST25R::process_state() {
     }
 
     case STATE_REINITIALIZING:
-      this->reinitialize();
+      this->reinitialize_();
       this->state_ = STATE_IDLE;
       break;
   }
 }
 
-void ST25R::finalize_scan() {
+void ST25R::finalize_scan_() {
   ESP_LOGD(TAG, "finalize_scan_: this_scan=%zu present=%zu", this->tags_this_scan_.size(), this->present_tags_.size());
   // Increment miss counters for tags not seen this scan; fire on_tag_removed when threshold reached
   std::vector<std::string> to_remove;
@@ -942,7 +942,7 @@ void ST25R::finalize_scan() {
   this->tags_this_scan_.clear();
 }
 
-bool ST25R::wait_for_irq(uint8_t mask, uint32_t timeout_ms) {
+bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
   uint32_t start = millis();
   while (millis() - start < timeout_ms) {
     if (this->irq_triggered_) {
@@ -953,7 +953,7 @@ bool ST25R::wait_for_irq(uint8_t mask, uint32_t timeout_ms) {
   return false;
 }
 
-bool ST25R::reset_chip() {
+bool ST25R::reset_chip_() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   // IC_IDENTITY is read-only and unaffected by SET_DEFAULT.
   uint8_t ic_identity = this->read_register(IC_IDENTITY);
@@ -971,7 +971,7 @@ bool ST25R::reset_chip() {
   this->is_b_version_ = is_b_version;
   // ST25R3916 (0x28) and ST25R3916B (0x30) both have Automatic Antenna Tuning (AAT)
   // with varicap DAC outputs on ANT_TUNE_A/B (0x26/0x27).  Variants without AAT
-  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_chip() override and
+  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_chip_() override and
   // never reach this code, but set the flag explicitly to represent the capability.
   this->has_aat_ = true;
   ESP_LOGI(TAG, "IC identity match: 0x%02X (ST25R3916%s)", ic_identity, is_b_version ? "B" : "");
@@ -1047,7 +1047,7 @@ bool ST25R::reset_chip() {
 
   if (this->rf_field_enabled_) {
     ESP_LOGV(TAG, "  reset_: Enabling RF field");
-    this->field_on();
+    this->field_on_();
   }
   delay(10);
 
@@ -1055,13 +1055,13 @@ bool ST25R::reset_chip() {
   // Confirmed +10mm range on STEVAL-MB17149B (varicap-equipped board).
   // Boards without varicaps see no effect (harmless). Disable via YAML: aat_enabled: false
   if (this->aat_enabled_)
-    this->aat_tune();
+    this->aat_tune_();
 
   ESP_LOGV(TAG, "  reset_: Complete");
   return true;
 }
 
-void ST25R::reinitialize() {
+void ST25R::reinitialize_() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -1070,7 +1070,7 @@ void ST25R::reinitialize() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_chip()) {
+  if (this->reset_chip_()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -1086,7 +1086,7 @@ void ST25R::reinitialize() {
   }
 }
 
-void ST25R::apply_anticol_prefix() {
+void ST25R::apply_anticol_prefix_() {
   // Decode anticol_prefix_val_ (bit N..0) into prefix arrays
   // anticol_col_pos_ = N: prefix covers bits 0..N (N+1 bits total)
   // bit position i of prefix = (anticol_prefix_val_ >> i) & 1
@@ -1102,7 +1102,7 @@ void ST25R::apply_anticol_prefix() {
   }
 }
 
-void ST25R::send_anticol_frame() {
+void ST25R::send_anticol_frame_() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -1141,20 +1141,20 @@ void ST25R::send_anticol_frame() {
 
 // ── Default virtual helpers (ST25R3916 implementations) ──────────────────────
 
-void ST25R::pre_select() {
+void ST25R::pre_select_() {
   // ST25R3916: clear antcl bit in ISO14443A_CONF so SELECT uses normal (non-anticol) framing
   this->write_register(ISO14443A_CONF, 0x00);
 }
 
-uint8_t ST25R::read_fifo_status1() {
+uint8_t ST25R::read_fifo_status1_() {
   return this->read_register(FIFO_STATUS1);
 }
 
-uint8_t ST25R::read_collision_display() {
+uint8_t ST25R::read_collision_display_() {
   return this->read_register(COLLISION_DISPLAY);
 }
 
-void ST25R::send_halt() {
+void ST25R::send_halt_() {
   // HALT: send [0x50, 0x00] + CRC; tag has no response.
   // Don't use transceive_() here — it blocks waiting for a non-existent response.
   uint8_t halt_cmd[2] = {0x50, 0x00};
@@ -1169,7 +1169,7 @@ void ST25R::send_halt() {
   delay(10);  // wait for HALT frame to be transmitted (~2ms for 4 bytes)
 }
 
-void ST25R::start_wupa() {
+void ST25R::start_wupa_() {
   // Clear FIFO + IRQs, then transmit WUPA.
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->read_register(IRQ_MAIN);
@@ -1180,7 +1180,7 @@ void ST25R::start_wupa() {
   this->write_command(ST25R_CMD_TRANSMIT_WUPA);
 }
 
-void ST25R::field_on() {
+void ST25R::field_on_() {
   this->write_register(OP_CONTROL, 0x88); // en=1, tx_en=1
   delay(10);
   this->write_command(ST25R_CMD_FIELD_ON);
@@ -1191,10 +1191,10 @@ void ST25R::field_on() {
 
 // ── AAT (Automatic Antenna Tuning) hill-climbing optimizer ───────────────────
 // Based on RFAL st25r3916AatTune() (AN5322). Iteratively adjusts ANT_TUNE_A/B
-// to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on()
-// during reset_chip() on chips with AAT hardware (ST25R3916/3916B).
+// to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on_()
+// during reset_chip_() on chips with AAT hardware (ST25R3916/3916B).
 
-void ST25R::aat_tune() {
+void ST25R::aat_tune_() {
   if (!this->has_aat_) return;
 
   uint8_t a = this->ant_tune_a_;
@@ -1270,7 +1270,7 @@ void ST25R::aat_tune() {
 
 // ── ISO 14443-4 (ISO-DEP / Type 4 tags) ─────────────────────────────────────
 
-bool ST25R::isodep_activate(uint8_t *ats, uint8_t &ats_len) {
+bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
   // Send RATS: 0xE0, FSDI=8 (256 bytes) | DID=0
   uint8_t rats[] = {0xE0, 0x80};
   uint8_t resp[64];
@@ -1288,10 +1288,41 @@ bool ST25R::isodep_activate(uint8_t *ats, uint8_t &ats_len) {
   this->isodep_block_number_ = 0;
 
   ESP_LOGD(TAG, "ISO-DEP: ATS received, TL=%u", resp[0]);
+
+  // PPS (Protocol and Parameter Selection) — negotiate higher bit rate if supported
+  if (resp_len >= 2) {
+    uint8_t t0 = resp[1];
+    uint8_t fsci = t0 & 0x0F;
+    bool has_ta = t0 & 0x10;
+    if (has_ta && resp_len >= 3) {
+      uint8_t ta = resp[2];
+      // TA bits[6:4] = DS (PCD→PICC speeds), bits[2:0] = DR (PICC→PCD speeds)
+      // Try 424 kbps if supported (bit 2 of DS and DR)
+      uint8_t pps_dsi = 0, pps_dri = 0;
+      if (ta & 0x40) pps_dsi = 2;       // 424 kbps PCD→PICC
+      else if (ta & 0x20) pps_dsi = 1;  // 212 kbps
+      if (ta & 0x04) pps_dri = 2;       // 424 kbps PICC→PCD
+      else if (ta & 0x02) pps_dri = 1;  // 212 kbps
+
+      if (pps_dsi > 0 || pps_dri > 0) {
+        // PPS: PPSS(0xD0|CID) + PPS0(0x11) + PPS1(DSI<<2|DRI)
+        uint8_t pps[] = {0xD0, 0x11, (uint8_t)((pps_dsi << 2) | pps_dri)};
+        uint8_t pps_resp[4];
+        uint8_t pps_len = 0;
+        if (this->transceive_(pps, sizeof(pps), pps_resp, pps_len) && pps_len >= 1 && (pps_resp[0] & 0xF0) == 0xD0) {
+          // Update BIT_RATE register for the negotiated speed
+          uint8_t br = (pps_dsi << 4) | pps_dri;
+          this->write_register(BIT_RATE, br);
+          ESP_LOGI(TAG, "ISO-DEP PPS: negotiated DSI=%u DRI=%u (BR=0x%02X)", pps_dsi, pps_dri, br);
+        }
+      }
+    }
+  }
+
   return true;
 }
 
-bool ST25R::isodep_transceive(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
+bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
   // Wrap APDU in I-Block: [PCB][APDU...]
   uint8_t frame[64];
   if (apdu_len + 1 > sizeof(frame)) return false;
@@ -1323,11 +1354,11 @@ bool ST25R::isodep_transceive(const uint8_t *apdu, size_t apdu_len, uint8_t *res
   return true;
 }
 
-std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   uint8_t ats[64];
   uint8_t ats_len = 0;
 
-  if (!this->isodep_activate(ats, ats_len)) {
+  if (!this->isodep_activate_(ats, ats_len)) {
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
   }
@@ -1337,12 +1368,12 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
 
   // Step 1: SELECT NDEF Application (AID = D276000085010100 for v2, try v1 as fallback)
   uint8_t select_app[] = {0x00, 0xA4, 0x04, 0x00, 0x07, 0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01, 0x00};
-  if (!this->isodep_transceive(select_app, sizeof(select_app), resp, resp_len) ||
+  if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
     // Try v1 AID
     select_app[11] = 0x00;  // D276000085010100 → D276000085010000
     resp_len = 0;
-    if (!this->isodep_transceive(select_app, sizeof(select_app), resp, resp_len) ||
+    if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
         resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
       ESP_LOGD(TAG, "T4T: SELECT NDEF app failed");
       nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1353,7 +1384,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   // Step 2: SELECT CC File (0xE103)
   uint8_t select_cc[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, 0xE1, 0x03};
   resp_len = 0;
-  if (!this->isodep_transceive(select_cc, sizeof(select_cc), resp, resp_len) ||
+  if (!this->isodep_transceive_(select_cc, sizeof(select_cc), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT CC failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1363,7 +1394,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   // Step 3: READ BINARY CC (15 bytes)
   uint8_t read_cc[] = {0x00, 0xB0, 0x00, 0x00, 0x0F};
   resp_len = 0;
-  if (!this->isodep_transceive(read_cc, sizeof(read_cc), resp, resp_len) ||
+  if (!this->isodep_transceive_(read_cc, sizeof(read_cc), resp, resp_len) ||
       resp_len < 17) {  // 15 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ CC failed (resp_len=%u)", resp_len);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1379,7 +1410,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   // Step 4: SELECT NDEF File
   uint8_t select_ndef[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, (uint8_t)(ndef_file_id >> 8), (uint8_t)(ndef_file_id & 0xFF)};
   resp_len = 0;
-  if (!this->isodep_transceive(select_ndef, sizeof(select_ndef), resp, resp_len) ||
+  if (!this->isodep_transceive_(select_ndef, sizeof(select_ndef), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT NDEF file failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1389,7 +1420,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   // Step 5: READ NDEF Length (first 2 bytes)
   uint8_t read_nlen[] = {0x00, 0xB0, 0x00, 0x00, 0x02};
   resp_len = 0;
-  if (!this->isodep_transceive(read_nlen, sizeof(read_nlen), resp, resp_len) ||
+  if (!this->isodep_transceive_(read_nlen, sizeof(read_nlen), resp, resp_len) ||
       resp_len < 4) {  // 2 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ NLEN failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1406,7 +1437,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   // Step 6: READ NDEF Data
   uint8_t read_ndef[] = {0x00, 0xB0, 0x00, 0x02, (uint8_t)ndef_len};
   resp_len = 0;
-  if (!this->isodep_transceive(read_ndef, sizeof(read_ndef), resp, resp_len) ||
+  if (!this->isodep_transceive_(read_ndef, sizeof(read_ndef), resp, resp_len) ||
       resp_len < ndef_len + 2) {
     ESP_LOGD(TAG, "T4T: READ NDEF data failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1420,7 +1451,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
 
 // ── NFC-B (ISO 14443B) for ST25R3916 ─────────────────────────────────────────
 
-void ST25R::configure_nfcb_mode() {
+void ST25R::configure_nfcb_mode_() {
   // MODE: om=0x02 (ISO14443B) in bits[6:3] = 0x10, tr_am=1 (AM modulation) bit7 = 0x80
   this->write_register(MODE, 0x90);
   this->write_register(BIT_RATE, 0x00);  // 106 kbps
@@ -1436,8 +1467,8 @@ void ST25R::configure_nfcb_mode() {
   this->write_register(CORR_CONF2, 0x00);
 }
 
-void ST25R::nfcb_scan() {
-  this->configure_nfcb_mode();
+void ST25R::nfcb_scan_() {
+  this->configure_nfcb_mode_();
 
   // SENSB_REQ (ALLB_REQ): cmd=0x05, AFI=0x00 (any), PARAM=0x08 (1 slot + WUPB)
   uint8_t sensb_req[] = {0x05, 0x00, 0x08};
@@ -1476,7 +1507,7 @@ void ST25R::nfcb_scan() {
   }
 
   // Restore NFC-A mode
-  this->restore_nfca_mode();
+  this->restore_nfca_mode_();
   // Also restore TX_DRIVER to OOK (am_mod=0)
   uint8_t d_res_restore = (15 - this->rf_power_) & 0x0F;
   this->write_register(TX_DRIVER_CONF, d_res_restore);
@@ -1506,7 +1537,7 @@ void ST25R::nfcb_scan() {
 // ── NFC-V (ISO 15693) streaming mode for ST25R3916 ──────────────────────────
 
 // ISO 15693 CRC-16 CCITT (preset=0xFFFF, poly=0x8408, result inverted)
-uint16_t ST25R::iso15693_crc(const uint8_t *data, size_t len) {
+uint16_t ST25R::iso15693_crc_(const uint8_t *data, size_t len) {
   uint16_t crc = 0xFFFF;
   for (size_t i = 0; i < len; i++) {
     uint8_t d = data[i] ^ (uint8_t)(crc & 0xFF);
@@ -1521,7 +1552,7 @@ static const uint8_t ISO15693_1OF4_SOF = 0x21;
 static const uint8_t ISO15693_1OF4_EOF = 0x04;
 static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
 
-size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc,
+size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc,
                                      uint8_t *out, size_t out_max) {
   size_t pos = 0;
   if (out_max < 1 + (len + 2) * 4 + 1) return 0;
@@ -1540,7 +1571,7 @@ size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc
 
   // Encode CRC
   if (add_crc) {
-    uint16_t crc = iso15693_crc(data, len);
+    uint16_t crc = iso15693_crc_(data, len);
     uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
     for (int c = 0; c < 2; c++) {
       uint8_t b = crc_bytes[c];
@@ -1557,7 +1588,7 @@ size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc
 }
 
 // Manchester VICC decoding: subcarrier stream → payload bytes
-size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
+size_t ST25R::iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
   if (in_len == 0 || out_max == 0) return 0;
 
   // Check SOF: first 5 bits should be 0x17 (10111 = 3 unmodulated + 2 modulated)
@@ -1590,7 +1621,7 @@ size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8
   return bp / 8;  // return complete bytes
 }
 
-void ST25R::configure_nfcv_stream_mode() {
+void ST25R::configure_nfcv_stream_mode_() {
   // RFAL NFC-V analog config: RX_CONF1=0x13, RX_CONF2=0x2D, CORR_CONF1=0x13, CORR_CONF2=0x01
   this->write_register(RX_CONF1, 0x13);
   this->write_register(RX_CONF2, 0x2D);
@@ -1615,7 +1646,7 @@ void ST25R::configure_nfcv_stream_mode() {
   this->write_register(UNDERSHOOT_CONF2, 0x00);
 }
 
-void ST25R::restore_nfca_mode() {
+void ST25R::restore_nfca_mode_() {
   // Restore NFC-A 106 settings
   this->write_register(MODE, 0x08);
   this->write_register(RX_CONF1, 0x08);
@@ -1631,7 +1662,7 @@ void ST25R::restore_nfca_mode() {
   this->write_register(UNDERSHOOT_CONF2, 0x03);
 }
 
-bool ST25R::transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                      uint32_t timeout_ms) {
   // Encode command using 1-of-4 coding with CRC
   uint8_t coded[128];
@@ -1642,7 +1673,7 @@ bool ST25R::transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *res
   cmd_buf[0] |= 0x02;   // high data rate
   cmd_buf[0] &= ~0x01;  // single subcarrier
 
-  size_t coded_len = iso15693_encode_1of4(cmd_buf, len, true, coded, sizeof(coded));
+  size_t coded_len = iso15693_encode_1of4_(cmd_buf, len, true, coded, sizeof(coded));
   if (coded_len == 0) return false;
 
   this->write_command(ST25R_CMD_STOP_ALL);
@@ -1673,10 +1704,10 @@ bool ST25R::transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *res
         this->read_fifo(raw, fifo_len);
         // Decode Manchester
         uint8_t decoded[32];
-        size_t dec_len = iso15693_decode_manchester(raw, fifo_len, decoded, sizeof(decoded));
+        size_t dec_len = iso15693_decode_manchester_(raw, fifo_len, decoded, sizeof(decoded));
         if (dec_len >= 3) {  // At least flags + CRC(2)
           // Verify CRC
-          uint16_t crc = iso15693_crc(decoded, dec_len - 2);
+          uint16_t crc = iso15693_crc_(decoded, dec_len - 2);
           if ((crc & 0xFF) == decoded[dec_len - 2] && (crc >> 8) == decoded[dec_len - 1]) {
             // Strip CRC
             resp_len = dec_len - 2;
@@ -1695,14 +1726,14 @@ bool ST25R::transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *res
   return false;
 }
 
-void ST25R::nfcv_scan() {
-  this->configure_nfcv_stream_mode();
+void ST25R::nfcv_scan_() {
+  this->configure_nfcv_stream_mode_();
 
   uint8_t inv_req[] = {0x26, 0x01, 0x00};  // flags, INVENTORY, mask_len=0
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_nfcv_stream(inv_req, sizeof(inv_req), resp, resp_len, 30)) {
+  if (this->transceive_nfcv_stream_(inv_req, sizeof(inv_req), resp, resp_len, 30)) {
     if (resp_len >= 10 && !(resp[0] & 0x01)) {
       // Parse UID (bytes 2-9, LSB-first → reverse for display)
       char uid_str[17];
@@ -1711,7 +1742,7 @@ void ST25R::nfcv_scan() {
       uid_str[16] = '\0';
       ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
 
-      // Add to tags_this_scan_ — finalize_scan() handles on_tag/on_tag_removed
+      // Add to tags_this_scan_ — finalize_scan_() handles on_tag/on_tag_removed
       std::string uid_string(uid_str);
       this->tags_this_scan_.insert(uid_string);
 
@@ -1726,7 +1757,7 @@ void ST25R::nfcv_scan() {
       uint8_t blk_len = 0;
       std::vector<uint8_t> ndef_data;
 
-      if (this->transceive_nfcv_stream(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+      if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
           blk_len >= 5 && !(blk_resp[0] & 0x01)) {
         // CC: byte1=magic(0xE1), byte2=ver+access, byte3=size(*8), byte4=features
         if (blk_resp[1] == 0xE1) {
@@ -1738,7 +1769,7 @@ void ST25R::nfcv_scan() {
           for (uint8_t blk = 1; blk <= total_blocks; blk++) {
             blk_req[2] = blk;
             blk_len = 0;
-            if (this->transceive_nfcv_stream(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+            if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
                 blk_len >= 5 && !(blk_resp[0] & 0x01)) {
               for (int k = 1; k < 5 && k < blk_len; k++)
                 ndef_data.push_back(blk_resp[k]);
@@ -1784,7 +1815,7 @@ void ST25R::nfcv_scan() {
     }
   }
 
-  this->restore_nfca_mode();
+  this->restore_nfca_mode_();
 }
 
 bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
@@ -1793,7 +1824,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   if (!this->present_tags_.empty()) {
     const std::string &last_uid = this->present_tags_.rbegin()->first;
     if (last_uid.length() == 16) {
-      return this->nfcv_ndef_write(message);
+      return this->nfcv_ndef_write_(message);
     }
   }
 
@@ -1816,7 +1847,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
       ESP_LOGE(TAG, "Failed to write CC page during format");
       return false;
     }
-    delay(50);
+    delay(10);
   }
 
   if (message == nullptr) {
@@ -1876,11 +1907,11 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   return true;
 }
 
-bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
+bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
   // NFC-V Type 5 NDEF write via WRITE_SINGLE_BLOCK (0x21)
   // Block 0 = CC, blocks 1+ = NDEF TLV data
 
-  this->configure_nfcv_stream_mode();
+  this->configure_nfcv_stream_mode_();
 
   std::vector<uint8_t> payload;
   if (message != nullptr) {
@@ -1907,9 +1938,9 @@ bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
   uint8_t resp[4];
   uint8_t resp_len = 0;
 
-  if (!this->transceive_nfcv_stream(write_req, sizeof(write_req), resp, resp_len, 25)) {
+  if (!this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
     ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
-    this->restore_nfca_mode();
+    this->restore_nfca_mode_();
     return false;
   }
 
@@ -1925,7 +1956,7 @@ bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
 
     bool success = false;
     for (uint8_t retry = 0; retry < 3; retry++) {
-      if (this->transceive_nfcv_stream(write_req, sizeof(write_req), resp, resp_len, 25)) {
+      if (this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
         success = true;
         break;
       }
@@ -1933,13 +1964,13 @@ bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
     }
     if (!success) {
       ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
-      this->restore_nfca_mode();
+      this->restore_nfca_mode_();
       return false;
     }
   }
 
   ESP_LOGI(TAG, "NFC-V NDEF write successful!");
-  this->restore_nfca_mode();
+  this->restore_nfca_mode_();
   return true;
 }
 
@@ -1952,7 +1983,7 @@ bool ST25R::send_apdu(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8
     ESP_LOGW(TAG, "send_apdu: tag not ISO-DEP capable (SAK=0x%02X)", this->last_sak_);
     return false;
   }
-  return this->isodep_transceive(apdu, apdu_len, resp, resp_len);
+  return this->isodep_transceive_(apdu, apdu_len, resp, resp_len);
 }
 
 void ST25R::dump_config() {

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -994,10 +994,18 @@ bool ST25R::reset_chip() {
   this->write_command(ST25R_CMD_MEASURE_VDD);  // 0xDF
   delay(5);
   uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
-  uint16_t vdd_mv = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
-  bool sup3v = (vdd_mv < 3600);
-  ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s",
-           vdd_mv, vdd_raw, sup3v ? "3.3V" : "5V");
+  bool sup3v;
+  if (vdd_raw == 0) {
+    // Measurement failed (raw=0 indicates no valid reading) — fall back to config
+    sup3v = this->supply_3v3_;
+    ESP_LOGW(TAG, "  reset_: VDD measurement failed (raw=0x00), using supply_3v3=%s",
+             sup3v ? "3.3V" : "5V");
+  } else {
+    uint16_t vdd_mv = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
+    sup3v = (vdd_mv < 3600);
+    ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s",
+             vdd_mv, vdd_raw, sup3v ? "3.3V" : "5V");
+  }
 
   ESP_LOGV(TAG, "  reset_: Configuring registers");
   this->write_register(IO_CONF1, 0x07);  // Disable MCU_CLK + LF clock (RFAL default)
@@ -1458,7 +1466,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
 
   ESP_LOGI(TAG, "T4T NDEF: %u bytes read", ndef_len);
   nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
-  return make_unique<nfc::NfcTag>(nfc_uid);
+  std::vector<uint8_t> ndef_data(resp, resp + ndef_len);
+  return make_unique<nfc::NfcTag>(nfc_uid, "NFC Forum Type 4", ndef_data);
 }
 
 // ── NFC-B (ISO 14443B) for ST25R3916 ─────────────────────────────────────────
@@ -1805,7 +1814,9 @@ void ST25R::nfcv_scan_() {
               size_t ndef_start = i + 2;
               if (ndef_start + ndef_len <= ndef_data.size()) {
                 ESP_LOGI(TAG, "NFC-V NDEF: %u bytes", ndef_len);
-                auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+                std::vector<uint8_t> ndef_payload(ndef_data.begin() + ndef_start,
+                                                  ndef_data.begin() + ndef_start + ndef_len);
+                auto tag = make_unique<nfc::NfcTag>(nfc_uid, "NFC Forum Type 5", ndef_payload);
                 this->tags_data_[uid_string] = std::move(tag);
               }
               break;

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -225,10 +225,10 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
   this->irq_triggered_ = false;
   if (with_crc) {
     this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
-    ESP_LOGV(TAG, "  transceive_: Transmitting %d bytes with CRC: %02X %02X", len, data[0], data[1]);
+    ESP_LOGV(TAG, "  transceive_: Transmitting %zu bytes with CRC", len);
   } else {
     this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
-    ESP_LOGV(TAG, "  transceive_: Transmitting %d bytes without CRC: %02X %02X", len, data[0], data[1]);
+    ESP_LOGV(TAG, "  transceive_: Transmitting %zu bytes without CRC", len);
   }
 
   uint32_t start = millis();
@@ -1831,13 +1831,15 @@ void ST25R::nfcv_scan_() {
 }
 
 bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
-  // Check if the most recent tag is NFC-V (8-octet UID = 16 hex chars)
-  // If so, use the NFC-V WRITE_SINGLE_BLOCK path
-  if (!this->present_tags_.empty()) {
-    const std::string &last_uid = this->present_tags_.rbegin()->first;
-    if (last_uid.length() == 16) {
+  // Route to NFC-V write path if a single NFC-V tag is present (16 hex chars = 8-octet UID)
+  if (this->present_tags_.size() == 1) {
+    const std::string &uid = this->present_tags_.begin()->first;
+    if (uid.length() == 16) {
       return this->nfcv_ndef_write(message);
     }
+  } else if (this->present_tags_.size() > 1) {
+    ESP_LOGW(TAG, "Multiple tags present; cannot determine which tag to write NDEF to");
+    return false;
   }
 
   // NFC-A Type 2 NDEF write (NTAG / Ultralight)

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -813,7 +813,7 @@ void ST25R::process_state() {
             // Read tag data on first detection only (auth + NDEF read if Mifare)
             if (!this->present_tags_.count(this->current_uid_)) {
               std::vector<uint8_t> uid_bytes;
-              for (size_t i = 0; i < this->current_uid_.length(); i += 2)
+              for (size_t i = 0; i < this->current_uid_.length(); i += 2)  // NOLINT(modernize-loop-convert)
                 uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
               this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
             }
@@ -877,6 +877,10 @@ void ST25R::process_state() {
     case STATE_REINITIALIZING:
       this->reinitialize();
       this->state_ = STATE_IDLE;
+      break;
+
+    case STATE_SELECT:
+    default:
       break;
   }
 }
@@ -1222,7 +1226,7 @@ void ST25R::aat_tune_() {
     bool improved = false;
 
     // Try 4 directions: A±step, B±step
-    struct Dir { int16_t da; int16_t db; };
+    struct Dir { int da; int db; };
     Dir dirs[] = {
       {step_a, 0}, {-step_a, 0},
       {0, step_b}, {0, -step_b}
@@ -1292,17 +1296,23 @@ bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
   // PPS (Protocol and Parameter Selection) — negotiate higher bit rate if supported
   if (resp_len >= 2) {
     uint8_t t0 = resp[1];
-    uint8_t fsci = t0 & 0x0F;
-    bool has_ta = t0 & 0x10;
+    bool has_ta = (t0 & 0x10) != 0;
     if (has_ta && resp_len >= 3) {
       uint8_t ta = resp[2];
       // TA bits[6:4] = DS (PCD→PICC speeds), bits[2:0] = DR (PICC→PCD speeds)
       // Try 424 kbps if supported (bit 2 of DS and DR)
-      uint8_t pps_dsi = 0, pps_dri = 0;
-      if (ta & 0x40) pps_dsi = 2;       // 424 kbps PCD→PICC
-      else if (ta & 0x20) pps_dsi = 1;  // 212 kbps
-      if (ta & 0x04) pps_dri = 2;       // 424 kbps PICC→PCD
-      else if (ta & 0x02) pps_dri = 1;  // 212 kbps
+      uint8_t pps_dsi = 0;
+      uint8_t pps_dri = 0;
+      if (ta & 0x40) {
+        pps_dsi = 2;       // 424 kbps PCD→PICC
+      } else if (ta & 0x20) {
+        pps_dsi = 1;       // 212 kbps
+      }
+      if (ta & 0x04) {
+        pps_dri = 2;       // 424 kbps PICC→PCD
+      } else if (ta & 0x02) {
+        pps_dri = 1;       // 212 kbps
+      }
 
       if (pps_dsi > 0 || pps_dri > 0) {
         // PPS: PPSS(0xD0|CID) + PPS0(0x11) + PPS1(DSI<<2|DRI)

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -1,0 +1,1996 @@
+#include "st25r.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/nfc/nfc_tag.h"
+#include "esphome/components/nfc/nfc_helpers.h"
+#include <cinttypes>
+#include <algorithm>
+#include <cstring>
+
+/*
+ * Mifare Classic support.
+ *
+ * Protocol flow adapted from mf1.c — MIT licence:
+ *   https://github.com/suut/rfal-mifare-classic/blob/master/mf1/mf1.c
+ *
+ * ST25R3916 9-bit parity interleaving (mf1_encode/decode_parity_st25r3916):
+ *   Each byte is stored as 9 bits in the FIFO: 8 data bits then 1 parity bit.
+ *   CRC and parity are both handled manually; ISO14443A_CONF bits no_tx_par
+ *   (bit6) and no_rx_par (bit7) must be set before transmitting/receiving.
+ */
+
+// ── Mifare CRC-A ────────────────────────────────────────────────────────────
+// Inline from mf1.h (MIT, suut/rfal-mifare-classic)
+static uint16_t mifare_crc_a(const uint8_t *data, size_t len) {
+  uint16_t crc = 0x6363;
+  for (size_t i = 0; i < len; i++) {
+    uint8_t b = data[i] ^ (uint8_t)(crc & 0xFF);
+    b ^= b << 4;
+    crc = (crc >> 8) ^ ((uint16_t) b << 8) ^ ((uint16_t) b << 3) ^ ((uint16_t) b >> 4);
+  }
+  return crc;
+}
+
+// ── Odd parity lookup ────────────────────────────────────────────────────────
+static const uint8_t ODD_PARITY[256] = {
+  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
+  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
+  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
+  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
+  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
+  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
+  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
+  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
+};
+
+// ── 9-bit parity pack/unpack ─────────────────────────────────────────────────
+// Each byte → 9 bits in the buffer: data bits 0..7 then parity bit.
+// Adapted from mf1_encode/decode_parity_st25r3916 (MIT, suut/rfal-mifare-classic)
+
+static void mifare_pack_parity(const uint8_t *in, const uint8_t *par,
+                                uint8_t *out, uint8_t nbytes,
+                                uint16_t *out_bits) {
+  uint16_t total = 9u * nbytes;
+  memset(out, 0, (total + 7u) / 8u);
+  for (uint8_t i = 0; i < nbytes; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      uint32_t p = j + 9u * i;
+      out[p / 8] |= (uint8_t)(((in[i] >> j) & 1u) << (p % 8));
+    }
+    uint32_t p = 8u + 9u * i;
+    out[p / 8] |= (uint8_t)((par[i] & 1u) << (p % 8));
+  }
+  *out_bits = total;
+}
+
+static uint8_t mifare_unpack_parity(const uint8_t *in, uint8_t *out,
+                                     uint8_t *par, uint16_t in_bits) {
+  uint8_t nbytes = (uint8_t)(in_bits / 9u);
+  memset(out, 0, nbytes);
+  memset(par, 0, nbytes);
+  for (uint8_t i = 0; i < nbytes; i++) {
+    for (uint8_t j = 0; j < 8; j++) {
+      uint32_t p = j + 9u * i;
+      out[i] |= (uint8_t)(((in[p / 8] >> (p % 8)) & 1u) << j);
+    }
+    uint32_t p = 8u + 9u * i;
+    par[i] = (in[p / 8] >> (p % 8)) & 1u;
+  }
+  return nbytes;
+}
+
+namespace esphome {
+namespace st25r {
+
+static const char *const TAG = "st25r";
+
+void ST25R::isr(ST25R *arg) {
+  arg->irq_triggered_ = true;
+}
+
+void ST25R::setup() {
+  ESP_LOGI(TAG, "Setting up ST25R...");
+  if (this->reset_pin_ != nullptr) {
+    ESP_LOGI(TAG, "Resetting ST25R via pin...");
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->reset_pin_->digital_write(false); 
+    delay(10);
+  }
+  
+  if (this->irq_pin_ != nullptr) {
+    ESP_LOGI(TAG, "Configuring IRQ pin...");
+    this->irq_pin_->setup();
+    this->irq_pin_->attach_interrupt(ST25R::isr, this, gpio::INTERRUPT_RISING_EDGE);
+  }
+
+  if (this->status_binary_sensor_ != nullptr) {
+    this->status_binary_sensor_->publish_initial_state(false);
+  }
+  ESP_LOGI(TAG, "Starting reset_()...");
+  if (!this->reset_()) {
+    ESP_LOGE(TAG, "Failed to reset chip");
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGI(TAG, "ST25R initialized successfully.");
+}
+
+void ST25R::update() {
+  if (this->is_failed() || this->state_ != STATE_IDLE) return;
+
+  // Health check: verify chip identity at a separate (typically slower) interval.
+  // This decouples liveness checks from the tag scan rate — e.g. scan every 500ms
+  // but only verify IC identity every 60s.
+  if (this->health_check_enabled_) {
+    uint32_t now = millis();
+    if (now - this->last_health_check_ms_ >= this->health_check_interval_ms_) {
+      this->last_health_check_ms_ = now;
+      uint8_t ic_identity = this->read_register(IC_IDENTITY);
+      uint8_t chip_type = ic_identity & 0xF8;
+      if (chip_type != 0x28 && chip_type != 0x30) {
+        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)",
+                 ic_identity, this->health_check_failures_ + 1, this->max_failed_checks_);
+        this->health_check_failures_++;
+        if (this->status_binary_sensor_ != nullptr)
+          this->status_binary_sensor_->publish_state(false);
+        if (this->health_check_failures_ >= this->max_failed_checks_) {
+          if (this->auto_reset_on_failure_) {
+            ESP_LOGW(TAG, "Health check: max failures reached, triggering reinit");
+            this->state_ = STATE_REINITIALIZING;
+          } else {
+            ESP_LOGE(TAG, "Health check: max failures reached, auto-reset disabled");
+          }
+        }
+        return;
+      }
+      this->health_check_failures_ = 0;
+      if (this->status_binary_sensor_ != nullptr)
+        this->status_binary_sensor_->publish_state(true);
+    }
+  }
+
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch to initial state per datasheet
+
+  if (this->rf_field_enabled_) {
+    this->write_register(OP_CONTROL, 0xC8); // en=1, rx_en=1, tx_en=1
+  }
+
+  if (this->rf_field_enabled_ && this->field_strength_sensor_ != nullptr) {
+    this->write_command(ST25R_CMD_MEASURE_AMPLITUDE);
+    uint8_t amplitude = this->read_register(AD_CONV_RESULT);
+    this->field_strength_sensor_->publish_state(amplitude);
+  }
+
+  // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
+  if (this->nfcv_enabled_)
+    this->nfcv_scan_();
+
+  // NFC-B (ISO 14443B) blocking SENSB_REQ — runs before NFC-A scan
+  if (this->nfcb_enabled_)
+    this->nfcb_scan_();
+
+  // If previous scan activated ISO-DEP (RATS), send S-Block DESELECT to return
+  // the card to IDLE state. Without this, ISO-DEP cards ignore subsequent WUPAs.
+  if (this->last_sak_ & 0x20) {
+    uint8_t deselect[] = {0xC2};  // S-Block DESELECT, no DID
+    uint8_t dsl_resp[4];
+    uint8_t dsl_len = 0;
+    this->transceive_(deselect, 1, dsl_resp, dsl_len, 10);
+    this->last_sak_ = 0;  // Clear so we don't deselect again if tag is gone
+  }
+
+  this->saved_anticol_valid_ = false;
+  this->anticol_resume_ = false;
+
+  this->irq_triggered_ = false;
+  this->write_command(ST25R_CMD_TRANSMIT_WUPA);
+  ESP_LOGI(TAG, "Sent WUPA");
+  delay(1);
+  this->state_ = STATE_WUPA;
+  this->last_state_change_ = millis();
+}
+
+bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+}
+
+bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+}
+
+bool ST25R::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch per datasheet transceive sequence
+  // Clear ALL IRQ registers so IRQ pin goes low — required for ISR rising-edge to fire
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+
+  this->write_register(NUM_TX_BYTES1, (len >> 8) & 0xFF);
+  if (with_crc) {
+    this->write_register(NUM_TX_BYTES2, (len & 0x1F) << 3);
+  } else {
+    this->write_register(NUM_TX_BYTES2, 0x00); // Whole bytes
+  }
+
+  this->write_fifo(data, len);
+
+  this->irq_triggered_ = false;
+  if (with_crc) {
+    this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
+    ESP_LOGV(TAG, "  transceive_: Transmitting %d bytes with CRC: %02X %02X", len, data[0], data[1]);
+  } else {
+    this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
+    ESP_LOGV(TAG, "  transceive_: Transmitting %d bytes without CRC: %02X %02X", len, data[0], data[1]);
+  }
+
+  uint32_t start = millis();
+  resp_len = 0;
+  bool tx_done = false;
+
+  while (millis() - start < timeout_ms) {
+    uint8_t irq;
+    if (this->irq_triggered_) {
+      this->irq_triggered_ = false;
+      irq = this->read_register(IRQ_MAIN);
+    } else {
+      // Fallback: poll directly in case ISR missed the rising edge (pin was already high)
+      irq = this->read_register(IRQ_MAIN);
+    }
+    this->irq_status_ = irq;
+
+    if (irq & IRQ_TXE) tx_done = true;
+
+    if (tx_done) {
+      uint8_t f1 = this->read_register(FIFO_STATUS1);
+      if (f1 > 0) {
+        uint8_t to_read = std::min((uint8_t)(64 - resp_len), f1);
+        this->read_fifo(resp + resp_len, to_read);
+        resp_len += to_read;
+        start = millis();
+      }
+      if (irq & IRQ_RXE) {
+        return resp_len > 0;
+      }
+    }
+    delay(1);
+  }
+  return resp_len > 0;
+}
+
+// ── transceive_mifare_ ───────────────────────────────────────────────────────
+// Send/receive with manual CRC and parity (ISO14443A_CONF no_tx_par + no_rx_par).
+// data/parity: len plaintext bytes + precomputed parity bits.
+// resp/resp_parity: decoded response bytes and their parity bits.
+// Adapted from mf1_send_receive_raw (MIT, suut/rfal-mifare-classic).
+bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
+                                uint8_t len,
+                                uint8_t *resp, uint8_t *resp_parity,
+                                uint8_t &resp_len,
+                                uint32_t timeout_ms) {
+  // Max encoded size: ceil(9*64/8) = 72 bytes
+  uint8_t encoded[72];
+  uint16_t tx_bits = 0;
+  mifare_pack_parity(data, parity, encoded, len, &tx_bits);
+
+  uint8_t ntx_n   = (uint8_t)(tx_bits >> 3);
+  uint8_t ntx_b   = (uint8_t)(tx_bits & 7);
+  uint8_t fifo_bytes = (uint8_t)((tx_bits + 7) / 8);
+
+  // Set manual parity mode: no_tx_par (bit6) + no_rx_par (bit7)
+  this->write_register(ISO14443A_CONF, 0xC0);
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->irq_triggered_ = false;
+
+  this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
+  this->write_register(NUM_TX_BYTES2, (uint8_t)(((ntx_n & 0x1F) << 3) | (ntx_b & 7)));
+  this->write_fifo(encoded, fifo_bytes);
+  this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
+
+  // Wait for RXE (end of receive)
+  uint32_t start = millis();
+  resp_len = 0;
+  bool tx_done = false;
+  while (millis() - start < timeout_ms) {
+    uint8_t irq = this->read_register(IRQ_MAIN);
+    if (irq & IRQ_TXE) tx_done = true;
+    if (tx_done) {
+      uint8_t f1 = this->read_register(FIFO_STATUS1);
+      if (irq & IRQ_RXE) {
+        // Read all FIFO bytes; FIFO holds 9*n bits packed
+        uint8_t rx_fifo[72] = {};
+        uint8_t rx_bytes = std::min(f1, (uint8_t) 72);
+        if (rx_bytes > 0)
+          this->read_fifo(rx_fifo, rx_bytes);
+
+        // We need to know how many bits arrived; use FIFO_STATUS2 fifo_lb
+        uint8_t fs2 = this->read_register(FIFO_STATUS2);
+        uint8_t last_bits = (fs2 >> 1) & 0x07;  // fifo_lb: bits in last byte (0 = full byte)
+        uint16_t rx_bits = (uint16_t)(rx_bytes * 8) - (last_bits ? (uint8_t)(8 - last_bits) : 0);
+
+        resp_len = mifare_unpack_parity(rx_fifo, resp, resp_parity, rx_bits);
+
+        this->write_register(ISO14443A_CONF, 0x00);
+        return resp_len > 0;
+      }
+    }
+    delay(1);
+  }
+
+  this->write_register(ISO14443A_CONF, 0x00);
+  return false;
+}
+
+// ── mifare_authenticate_ ─────────────────────────────────────────────────────
+// Three-pass mutual authentication per ISO 14443-3 / NXP AN10609.
+// Protocol flow from mf1_authenticate() (MIT, suut/rfal-mifare-classic).
+bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
+                                  const uint8_t *uid, uint8_t uid_len,
+                                  struct Crypto1State *cs) {
+  // ── Step 1: send AUTHENT command (plain text, with CRC) ──────────────────
+  uint8_t auth_cmd[2] = {(uint8_t)(key_b ? 0x61 : 0x60), block};
+  uint8_t nt_raw[4] = {};
+  uint8_t nt_len = 0;
+  if (!this->transceive_(auth_cmd, 2, nt_raw, nt_len, 20) || nt_len < 4) {
+    ESP_LOGW(TAG, "Mifare auth: no NT from tag (block %u)", block);
+    return false;
+  }
+
+  // ── Step 2: Crypto1 challenge-response ───────────────────────────────────
+  uint8_t uid_offset = (uid_len > 4) ? (uint8_t)(uid_len - 4) : 0;
+  uint32_t uid_u32 = ((uint32_t) uid[uid_offset]     << 24) |
+                     ((uint32_t) uid[uid_offset + 1] << 16) |
+                     ((uint32_t) uid[uid_offset + 2] <<  8) |
+                      (uint32_t) uid[uid_offset + 3];
+  uint32_t nt = ((uint32_t) nt_raw[0] << 24) | ((uint32_t) nt_raw[1] << 16) |
+                ((uint32_t) nt_raw[2] <<  8) |  (uint32_t) nt_raw[3];
+  ESP_LOGD(TAG, "Mifare auth: NT=%08X UID=%08X", nt, uid_u32);
+
+  crypto1_init(cs, key);
+  crypto1_word(cs, nt ^ uid_u32, 0);
+
+  // Choose a fixed nr (reader nonce); any value works for normal auth
+  const uint8_t nr[4] = {0x12, 0x34, 0x56, 0x78};
+  uint8_t nr_ar[8], nr_ar_par[8];
+
+  // Encrypt NR: feed plaintext NR into LFSR (is_encrypted=0), advance parity bit with crypto1_bit
+  for (int i = 0; i < 4; i++) {
+    nr_ar[i]     = crypto1_byte(cs, nr[i], 0) ^ nr[i];
+    nr_ar_par[i] = crypto1_bit(cs, 0, 0) ^ ODD_PARITY[nr[i]];
+  }
+
+  // AR = 4 bytes of prng_successor(NT, 64) MSB-first
+  uint32_t ar_plain = prng_successor(nt, 64);
+  for (int i = 0; i < 4; i++) {
+    uint8_t b = (uint8_t)((ar_plain >> (24 - 8 * i)) & 0xFF);
+    nr_ar[4 + i]     = crypto1_byte(cs, 0, 0) ^ b;
+    nr_ar_par[4 + i] = crypto1_bit(cs, 0, 0) ^ ODD_PARITY[b];
+  }
+
+  // ── Step 3: send nr+ar (encrypted, manual parity, no CRC) ────────────────
+  uint8_t at[4] = {}, at_par[4] = {};
+  uint8_t at_len = 0;
+  if (!this->transceive_mifare_(nr_ar, nr_ar_par, 8, at, at_par, at_len) || at_len < 4) {
+    ESP_LOGW(TAG, "Mifare auth: no AT from tag (block %u)", block);
+    return false;
+  }
+
+  // ── Step 4: verify tag answer ─────────────────────────────────────────────
+  uint32_t at_expected = prng_successor(ar_plain, 32) ^ crypto1_word(cs, 0, 0);
+  uint32_t at_got = ((uint32_t) at[0] << 24) | ((uint32_t) at[1] << 16) |
+                    ((uint32_t) at[2] <<  8) |  (uint32_t) at[3];
+  if (at_got != at_expected) {
+    ESP_LOGW(TAG, "Mifare auth: AT mismatch (got %08" PRIx32 " expected %08" PRIx32 ")", at_got, at_expected);
+    return false;
+  }
+
+  ESP_LOGI(TAG, "Mifare auth OK (block %u, key %s)", block, key_b ? "B" : "A");
+  return true;
+}
+
+// ── mifare_read_block_ ───────────────────────────────────────────────────────
+// Read one 16-byte block after a successful mifare_authenticate_().
+// Protocol flow from mf1_send_receive_encrypted (MIT, suut/rfal-mifare-classic).
+bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
+                                struct Crypto1State *cs) {
+  // Build: READ(0x30) + block + CRC_A — then encrypt all 4 bytes + CRC
+  uint8_t cmd[4];
+  cmd[0] = 0x30;
+  cmd[1] = block;
+  uint16_t crc = mifare_crc_a(cmd, 2);
+  cmd[2] = (uint8_t)(crc & 0xFF);
+  cmd[3] = (uint8_t)(crc >> 8);
+
+  uint8_t enc[4], enc_par[4];
+  for (int i = 0; i < 4; i++) {
+    enc[i]     = crypto1_byte(cs, 0, 0) ^ cmd[i];
+    enc_par[i] = (uint8_t)(crypto1_bit(cs, 0, 0) ^ ODD_PARITY[cmd[i]]);
+  }
+
+  // Response: 16 data bytes + 2 CRC bytes = 18 bytes, all encrypted
+  uint8_t rx_enc[18] = {}, rx_par[18] = {};
+  uint8_t rx_len = 0;
+  if (!this->transceive_mifare_(enc, enc_par, 4, rx_enc, rx_par, rx_len) || rx_len < 18) {
+    ESP_LOGW(TAG, "Mifare read block %u failed (got %u bytes)", block, rx_len);
+    return false;
+  }
+
+  // Decrypt and verify parity + CRC
+  uint8_t plain[18];
+  for (int i = 0; i < 18; i++) {
+    plain[i] = crypto1_byte(cs, 0, 0) ^ rx_enc[i];
+    uint8_t exp_par = (uint8_t)(crypto1_bit(cs, 0, 0) ^ ODD_PARITY[plain[i]]);
+    if (rx_par[i] != exp_par) {
+      ESP_LOGW(TAG, "Mifare read block %u: parity error at byte %d", block, i);
+      return false;
+    }
+  }
+  uint16_t rx_crc = mifare_crc_a(plain, 16);
+  if ((rx_crc & 0xFF) != plain[16] || (rx_crc >> 8) != plain[17]) {
+    ESP_LOGW(TAG, "Mifare read block %u: CRC error", block);
+    return false;
+  }
+
+  memcpy(data, plain, 16);
+  return true;
+}
+
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
+  uint8_t type = nfc::guess_tag_type(uid.size());
+  ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d, SAK=0x%02X", uid.size(), type, this->last_sak_);
+
+  // ISO-DEP capable (SAK bit 5 set) → try Type 4 NDEF read
+  if (this->last_sak_ & 0x20) {
+    ESP_LOGI(TAG, "ISO-DEP capable tag (SAK & 0x20) — trying Type 4 NDEF");
+    return this->read_tag_type4_(uid);
+  }
+
+  if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
+    ESP_LOGI(TAG, "Mifare Classic detected - attempting authentication");
+    struct Crypto1State cs = {};
+    bool auth_ok = this->mifare_authenticate_(0, false, this->mifare_key_a_,
+                                              uid.data(), (uint8_t) uid.size(), &cs);
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    if (!auth_ok) {
+      ESP_LOGW(TAG, "Mifare Classic: sector 0 auth failed (wrong key or clone card)");
+      return make_unique<nfc::NfcTag>(nfc_uid, nfc::MIFARE_CLASSIC);
+    }
+
+    ESP_LOGI(TAG, "Mifare Classic: Auth successful, reading blocks 1 and 2");
+    // Read blocks 1 and 2 (block 0 is manufacturer data; block 3 is sector trailer)
+    uint8_t block1[16] = {}, block2[16] = {};
+    bool b1 = this->mifare_read_block_(1, block1, &cs);
+    bool b2 = b1 && this->mifare_read_block_(2, block2, &cs);
+
+    if (!b1) {
+      ESP_LOGW(TAG, "Mifare Classic: block read failed");
+      return make_unique<nfc::NfcTag>(nfc_uid, nfc::MIFARE_CLASSIC);
+    }
+
+    ESP_LOGI(TAG, "Block 1: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+             block1[0],block1[1],block1[2],block1[3],block1[4],block1[5],block1[6],block1[7],
+             block1[8],block1[9],block1[10],block1[11],block1[12],block1[13],block1[14],block1[15]);
+    ESP_LOGI(TAG, "Block 2: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
+             block2[0],block2[1],block2[2],block2[3],block2[4],block2[5],block2[6],block2[7],
+             block2[8],block2[9],block2[10],block2[11],block2[12],block2[13],block2[14],block2[15]);
+
+    // Look for NFC Forum Type 2 NDEF TLV (0x03) in the data area
+    // On Mifare Classic the NDEF data starts at block 1 byte 0 when
+    // the card is formatted as NFC Forum Type 2 / Mifare Classic NDEF.
+    std::vector<uint8_t> raw;
+    raw.insert(raw.end(), block1, block1 + 16);
+    if (b2) raw.insert(raw.end(), block2, block2 + 16);
+
+    size_t idx = 0;
+    while (idx < raw.size()) {
+      uint8_t tlv = raw[idx++];
+      if (tlv == 0xFE) break;      // terminator
+      if (tlv == 0x00) continue;   // null
+      if (idx >= raw.size()) break;
+      uint8_t tlen = raw[idx++];
+      if (tlv == 0x03 && tlen > 0 && (idx + tlen) <= raw.size()) {
+        std::vector<uint8_t> ndef_data(raw.begin() + (int) idx, raw.begin() + (int) idx + tlen);
+        ESP_LOGI(TAG, "Mifare Classic: NDEF found (%u bytes)", tlen);
+        return make_unique<nfc::NfcTag>(nfc_uid, nfc::MIFARE_CLASSIC, ndef_data);
+      }
+      idx += tlen;
+    }
+
+    ESP_LOGD(TAG, "Mifare Classic: no NDEF TLV in sector 0 data blocks");
+    return make_unique<nfc::NfcTag>(nfc_uid, nfc::MIFARE_CLASSIC);
+  }
+
+  if (type == nfc::TAG_TYPE_2) {
+    std::vector<uint8_t> data;
+    uint8_t buffer[16];
+    uint8_t len;
+
+    uint8_t read_cmd[2] = {0x30, 0x00}; 
+    if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
+      ESP_LOGD(TAG, "  Read page 0-3 success");
+      data.insert(data.end(), buffer, buffer + 16); // Only keep data, skip CRC
+      
+      size_t tlv_index = 0;
+      bool found = false;
+      bool terminator_found = false;
+
+      for (size_t i = 0; i < 16; i++) { 
+        if (data[i] == 0x03) {
+          tlv_index = i;
+          found = true;
+          ESP_LOGD(TAG, "  Found NDEF TLV at index %zu", i);
+          break;
+        }
+        if (data[i] == 0xFE) {
+          terminator_found = true;
+          break;
+        }
+      }
+
+      if (!found && !terminator_found) {
+        for (uint8_t p = 4; p < 16; p += 4) {
+          delay(10);
+          read_cmd[1] = p;
+          if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
+            data.insert(data.end(), buffer, buffer + 16);
+            for (size_t i = data.size() - 16; i < data.size(); i++) {
+              if (data[i] == 0x03) {
+                tlv_index = i;
+                found = true;
+                ESP_LOGD(TAG, "  Found NDEF TLV at index %zu", i);
+                break;
+              }
+              if (data[i] == 0xFE) {
+                terminator_found = true;
+                ESP_LOGD(TAG, "  Found Terminator TLV (0xFE) at index %zu", i);
+                break;
+              }
+            }
+          }
+          if (found || terminator_found) break;
+        }
+      }
+
+      if (found) {
+        // Ensure we have enough bytes to read the full TLV length field
+        // (3-byte length needs tlv_index + 3 to be valid)
+        while (data.size() <= tlv_index + 3) {
+          read_cmd[1] = (uint8_t)(data.size() / 4);
+          delay(10);
+          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+          data.insert(data.end(), buffer, buffer + 16);
+        }
+
+        if (tlv_index + 1 < data.size()) {
+          size_t msg_len;
+          size_t msg_start_idx;
+          if (data[tlv_index + 1] == 0xFF && tlv_index + 3 < data.size()) {
+            // 3-byte TLV length (BER-TLV extended form) for payloads ≥255 bytes
+            msg_len = ((size_t) data[tlv_index + 2] << 8) | data[tlv_index + 3];
+            msg_start_idx = tlv_index + 4;
+          } else {
+            msg_len = data[tlv_index + 1];
+            msg_start_idx = tlv_index + 2;
+          }
+          ESP_LOGD(TAG, "  NDEF message length: %zu", msg_len);
+
+          while (data.size() < msg_start_idx + msg_len) {
+            uint8_t next_page = (uint8_t)(data.size() / 4);
+            read_cmd[1] = next_page;
+            delay(10);
+            if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) {
+              ESP_LOGW(TAG, "  Failed to read page %d during NDEF fetch", next_page);
+              break;
+            }
+            data.insert(data.end(), buffer, buffer + 16);
+          }
+
+          if (data.size() >= msg_start_idx + msg_len) {
+            std::vector<uint8_t> ndef_data(data.begin() + (int) msg_start_idx,
+                                           data.begin() + (int) msg_start_idx + (int) msg_len);
+            ESP_LOGI(TAG, "  Successfully read NDEF message of %zu bytes", msg_len);
+            nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+            if (msg_len > 0) {
+              return make_unique<nfc::NfcTag>(nfc_uid, nfc::NFC_FORUM_TYPE_2, ndef_data);
+            } else {
+              return make_unique<nfc::NfcTag>(nfc_uid, nfc::NFC_FORUM_TYPE_2);
+            }
+          }
+        }
+      } else {
+        ESP_LOGD(TAG, "  No NDEF TLV (0x03) found in searched pages");
+      }
+    } else {
+      ESP_LOGW(TAG, "  Failed to read page 0, len=%d", len);
+    }
+  }
+
+  nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+  return make_unique<nfc::NfcTag>(nfc_uid);
+}
+
+void ST25R::loop() {
+  if (this->is_failed()) return;
+
+  if (this->irq_triggered_) {
+    this->irq_triggered_ = false;
+    this->irq_status_ = this->read_register(IRQ_MAIN);
+    ESP_LOGV(TAG, "IRQ triggered, status: 0x%02X, state: %d", this->irq_status_, this->state_);
+  } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL || this->state_ == STATE_SELECT) {
+    // Fallback polling — ISR rising edge may not fire if IRQ pin was already high
+    this->irq_status_ = this->read_register(IRQ_MAIN);
+    if (this->irq_status_ != 0) {
+      ESP_LOGV(TAG, "IRQ polled, status: 0x%02X, state: %d", this->irq_status_, this->state_);
+    }
+  } else {
+    this->irq_status_ = 0;
+  }
+
+  this->process_state_();
+}
+
+void ST25R::process_state_() {
+  switch (this->state_) {
+    case STATE_IDLE:
+      break;
+
+    case STATE_WUPA: {
+      if (this->irq_status_ & (IRQ_RXE | IRQ_COL)) {
+          this->cascade_level_ = 0;
+          this->current_uid_ = "";
+          if (!this->anticol_resume_) {
+            // Fresh scan: start anticol from beginning
+            this->anticol_prefix_full_ = 0;
+            this->anticol_prefix_bits_ = 0;
+            this->anticol_col_pos_ = 0;
+            this->anticol_prefix_val_ = 0;
+          }
+          // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
+          this->anticol_resume_ = false;
+
+          this->send_anticol_frame_();
+          this->state_ = STATE_ANTICOL;
+          this->last_state_change_ = millis();
+      } else if (this->irq_status_ & IRQ_NRE) {
+          // NRT expired: no tag response — fast path to idle (set by derived class read_chip_irq_())
+          ESP_LOGD(TAG, "WUPA NRE (no tag): IRQ=0x%02X", this->irq_status_);
+          this->irq_status_ = 0;
+          this->state_ = STATE_IDLE;
+          this->finalize_scan_();
+      } else if (millis() - this->last_state_change_ > 100) {
+          // No tag responded and NRE fast-path didn't fire (real ST25R3916:
+          // NRE is in IRQ_TIMER, not IRQ_MAIN).  Read ALL IRQ registers so the
+          // IRQ pin goes LOW before the next scan — otherwise the pin stays HIGH
+          // from the pending NRE and the ISR rising-edge never fires again.
+          uint8_t irq_t = this->read_register(IRQ_TIMER);
+          uint8_t irq_e = this->read_register(IRQ_ERROR);
+          ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u",
+                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1_());
+          this->irq_status_ = 0;
+          this->irq_triggered_ = false;
+          this->state_ = STATE_IDLE;
+          this->finalize_scan_();
+      }
+      break;
+    }
+
+    case STATE_ANTICOL: {
+      if (millis() - this->last_state_change_ > 20) {
+        uint8_t max_prefix_val = (1 << (this->anticol_col_pos_ + 1)) - 1;
+        if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
+          this->anticol_prefix_val_++;
+          this->apply_anticol_prefix_();
+          // Send WUPA before each new prefix attempt — some cards (e.g. Mifare Classic) leave
+          // the READY state quickly after responding to an anticol they don't match.
+          this->anticol_resume_ = true;
+          this->start_wupa_();
+          this->state_ = STATE_WUPA;
+          this->last_state_change_ = millis();
+          return;
+        }
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
+        return;
+      }
+
+      if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
+        delay(5);
+        uint8_t f1 = this->read_fifo_status1_();
+        bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
+
+        if (has_collision) {
+          uint8_t col_raw = this->read_collision_display_();
+          uint8_t c_byte = (col_raw >> 4) & 0x0F;
+          uint8_t c_bit  = (col_raw >> 1) & 0x07;
+          // col_pos_abs is from start of TX frame (SEL + NVB = 2 bytes = 16 bits)
+          int uid_col_pos = (int)(c_byte * 8 + c_bit) - 16;
+          if (uid_col_pos < 0) uid_col_pos = 0;
+          // Drain any garbage FIFO bytes
+          if (f1 > 0) { uint8_t tmp[8]; this->read_fifo(tmp, std::min(f1, (uint8_t)8)); }
+
+          // FIFO bytes during collision are unreliable — brute-force all 2^(col_pos+1) prefixes
+          this->anticol_col_pos_ = uid_col_pos;
+          this->anticol_prefix_val_ = 0;
+          this->apply_anticol_prefix_();
+
+          this->send_anticol_frame_();
+          this->last_state_change_ = millis();
+
+        } else if (f1 >= 5) {
+          // Clean response — full UID received
+          uint8_t resp[5];
+          this->read_fifo(resp, 5);
+
+          // The tag only sends bits NOT covered by the prefix. The FIFO stores the
+          // tag's response bits with zeros in the first anticol_prefix_bits_ positions.
+          // Reconstruct the full UID by OR-ing the prefix bits back in.
+          uint8_t full_uid[4];
+          memcpy(full_uid, resp, 4);
+          for (int k = 0; k < (int) this->anticol_prefix_full_; k++) {
+            full_uid[k] = this->anticol_prefix_[k];
+          }
+          if (this->anticol_prefix_bits_ > 0) {
+            uint8_t mask = (uint8_t)((1 << this->anticol_prefix_bits_) - 1);
+            full_uid[this->anticol_prefix_full_] =
+                (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
+                (resp[this->anticol_prefix_full_] & (uint8_t)(~mask));
+          }
+          uint8_t bcc = full_uid[0] ^ full_uid[1] ^ full_uid[2] ^ full_uid[3];
+
+          uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+          uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70,
+                               full_uid[0], full_uid[1], full_uid[2], full_uid[3], bcc};
+
+          if (full_uid[0] == 0x88) {
+            for (int i = 1; i < 4; i++) {
+              char buf[3]; sprintf(buf, "%02X", full_uid[i]); this->current_uid_ += buf;
+            }
+          } else {
+            for (int i = 0; i < 4; i++) {
+              char buf[3]; sprintf(buf, "%02X", full_uid[i]); this->current_uid_ += buf;
+            }
+          }
+
+          // Clear anticollision mode before SELECT (ST25R3916: ISO14443A_CONF=0x00;
+          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex_()).
+          this->pre_select_();
+
+          uint8_t sak_buf[3];
+          uint8_t sak_len = 0;
+          if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
+            ESP_LOGW(TAG, "SELECT failed (no SAK)");
+            this->state_ = STATE_IDLE;
+            this->finalize_scan_();
+            return;
+          }
+          uint8_t sak = sak_buf[0];
+          this->last_sak_ = sak;
+
+          if (sak & 0x04) {  // Cascade bit — need another anticollision level
+            // Save CL1 collision state before overwriting for CL2
+            if (this->cascade_level_ == 0) {
+              this->saved_col_pos_ = this->anticol_col_pos_;
+              this->saved_prefix_val_ = this->anticol_prefix_val_;
+              this->saved_anticol_valid_ = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
+            }
+            this->cascade_level_++;
+            if (this->cascade_level_ > 2) {
+              ESP_LOGE(TAG, "Too many cascade levels");
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+            this->anticol_prefix_full_ = 0;
+            this->anticol_prefix_bits_ = 0;
+            this->anticol_col_pos_ = 0;
+            this->anticol_prefix_val_ = 0;
+            this->send_anticol_frame_();
+            this->state_ = STATE_ANTICOL;
+            this->last_state_change_ = millis();
+          } else {
+            // Tag fully selected — validate UID length (must be 4 or 7 bytes; 3-byte = CL1 glitch)
+            size_t uid_bytes_len = this->current_uid_.length() / 2;
+            if (uid_bytes_len != 4 && uid_bytes_len != 7) {
+              ESP_LOGW(TAG, "Discarding invalid UID len=%zu (%s)", uid_bytes_len, this->current_uid_.c_str());
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+
+            ESP_LOGI(TAG, "Tag selected: %s", this->current_uid_.c_str());
+
+            // Read tag data on first detection only (auth + NDEF read if Mifare)
+            if (!this->present_tags_.count(this->current_uid_)) {
+              std::vector<uint8_t> uid_bytes;
+              for (size_t i = 0; i < this->current_uid_.length(); i += 2)
+                uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
+              this->tags_data_[this->current_uid_] = this->read_tag_(uid_bytes);
+            }
+
+            this->tags_this_scan_.insert(this->current_uid_);
+
+            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt_()
+            this->send_halt_();
+
+            // Determine the CL1 collision state so we can resume the multi-tag tree traversal.
+            // If we went through cascade (CL2), restore the saved CL1 state.
+            // Otherwise use the current CL1 state directly.
+            uint8_t resume_col_pos;
+            uint8_t resume_prefix_val;
+            bool can_resume;
+            if (this->saved_anticol_valid_) {
+              resume_col_pos = this->saved_col_pos_;
+              resume_prefix_val = this->saved_prefix_val_;
+              can_resume = true;
+              this->saved_anticol_valid_ = false;
+            } else {
+              resume_col_pos = this->anticol_col_pos_;
+              resume_prefix_val = this->anticol_prefix_val_;
+              can_resume = (this->anticol_col_pos_ > 0 || this->anticol_prefix_bits_ > 0);
+            }
+
+            if (can_resume) {
+              // Advance to the next branch in the collision tree
+              this->cascade_level_ = 0;
+              this->current_uid_ = "";
+              this->anticol_col_pos_ = resume_col_pos;
+              this->anticol_prefix_val_ = resume_prefix_val + 1;
+              this->apply_anticol_prefix_();
+
+              uint8_t max_val = (1 << (resume_col_pos + 1)) - 1;
+              if (this->anticol_prefix_val_ > max_val) {
+                // All branches at this collision level exhausted — done
+                this->state_ = STATE_IDLE;
+                this->finalize_scan_();
+                return;
+              }
+              // Send WUPA (not REQA) so all tags — including those in HALT — wake up.
+              // Some cards (e.g. Mifare Classic) return to HALT after a non-matching SELECT,
+              // so REQA would not wake them.
+              this->anticol_resume_ = true;
+              this->start_wupa_();
+            } else {
+              // No prior collision: this was the only tag — scan complete
+              this->state_ = STATE_IDLE;
+              this->finalize_scan_();
+              return;
+            }
+            this->state_ = STATE_WUPA;
+            this->last_state_change_ = millis();
+          }
+        }
+      }
+      break;
+    }
+
+    case STATE_REINITIALIZING:
+      this->reinitialize_();
+      this->state_ = STATE_IDLE;
+      break;
+  }
+}
+
+void ST25R::finalize_scan_() {
+  ESP_LOGD(TAG, "finalize_scan_: this_scan=%zu present=%zu", this->tags_this_scan_.size(), this->present_tags_.size());
+  // Increment miss counters for tags not seen this scan; fire on_tag_removed when threshold reached
+  std::vector<std::string> to_remove;
+  for (auto &kv : this->present_tags_) {
+    if (this->tags_this_scan_.count(kv.first)) {
+      kv.second = 0;  // seen this scan — reset miss counter
+    } else {
+      kv.second++;
+      if (kv.second >= this->miss_threshold_) {
+        to_remove.push_back(kv.first);
+      }
+    }
+  }
+  for (const auto &uid : to_remove) {
+    ESP_LOGI(TAG, "Tag Removed: %s", uid.c_str());
+
+    std::vector<uint8_t> uid_bytes;
+    for (size_t i = 0; i < uid.length(); i += 2) {
+      uid_bytes.push_back((uint8_t) strtol(uid.substr(i, 2).c_str(), nullptr, 16));
+    }
+    nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+    nfc::NfcTag nfc_tag(nfc_uid);
+    for (auto *listener : this->tag_listeners_) {
+      listener->tag_off(nfc_tag);
+    }
+    for (auto *trigger : this->on_tag_removed_triggers_) {
+      trigger->trigger(uid);
+    }
+    this->tags_data_.erase(uid);
+    this->present_tags_.erase(uid);
+  }
+
+  // Fire on_tag for newly seen UIDs
+  for (const auto &uid : this->tags_this_scan_) {
+    if (!this->present_tags_.count(uid)) {
+      ESP_LOGD(TAG, "finalize_scan_: NEW tag %s, firing %zu on_tag triggers", uid.c_str(), this->on_tag_triggers_.size());
+      this->present_tags_[uid] = 0;
+      for (auto *trigger : this->on_tag_triggers_) {
+        trigger->trigger(uid);
+      }
+      // Fire tag_on for NFC listeners (e.g. ndef_write action)
+      if (this->tags_data_.count(uid) && this->tags_data_[uid]) {
+        for (auto *listener : this->tag_listeners_) {
+          listener->tag_on(*this->tags_data_[uid]);
+        }
+      }
+    }
+  }
+
+  // Update binary sensors
+  for (auto *obj : this->binary_sensors_) {
+    for (const auto &uid : this->tags_this_scan_) {
+      obj->process(uid);
+    }
+    obj->on_scan_end();
+  }
+
+  this->tags_this_scan_.clear();
+}
+
+bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
+  uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    if (this->irq_triggered_) {
+       return true;
+    }
+    delay(1);
+  }
+  return false;
+}
+
+bool ST25R::reset_() {
+  // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
+  // IC_IDENTITY is read-only and unaffected by SET_DEFAULT.
+  uint8_t ic_identity = this->read_register(IC_IDENTITY);
+  ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
+  uint8_t chip_type = ic_identity & 0xF8;
+  if (chip_type != 0x28 && chip_type != 0x30) {
+    ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0x28/0x30, got 0x%02X", chip_type);
+    return false;
+  }
+
+  ESP_LOGV(TAG, "  reset_: Sending SET_DEFAULT");
+  this->write_command(ST25R_CMD_SET_DEFAULT);
+  delay(10);
+  bool is_b_version = (chip_type == 0x30);
+  this->is_b_version_ = is_b_version;
+  // ST25R3916 (0x28) and ST25R3916B (0x30) both have Automatic Antenna Tuning (AAT)
+  // with varicap DAC outputs on ANT_TUNE_A/B (0x26/0x27).  Variants without AAT
+  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_() override and
+  // never reach this code, but set the flag explicitly to represent the capability.
+  this->has_aat_ = true;
+  ESP_LOGI(TAG, "IC identity match: 0x%02X (ST25R3916%s)", ic_identity, is_b_version ? "B" : "");
+
+  // RFAL sequence: oscillator on → measure VDD → configure registers
+  ESP_LOGV(TAG, "  reset_: Enabling oscillator");
+  this->write_register(OP_CONTROL, 0x80); // en=1: enable oscillator and regulators
+  delay(10); // Wait for oscillator to stabilize (~700µs typical)
+
+  // Measure VDD and auto-detect supply voltage (RFAL: st25r3916MeasureVoltage)
+  // REGULATOR_CONTROL mpsv bits[2:0] select measurement source; 0 = VDD
+  uint8_t reg_ctrl = this->read_register(REGULATOR_CONTROL);
+  this->write_register(REGULATOR_CONTROL, (reg_ctrl & ~0x07) | 0x00); // mpsv=VDD
+  this->write_command(ST25R_CMD_MEASURE_VDD);  // 0xDF
+  delay(5);
+  uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
+  uint16_t vdd_mV = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
+  bool sup3v = (vdd_mV < 3600);
+  ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s",
+           vdd_mV, vdd_raw, sup3v ? "3.3V" : "5V");
+
+  ESP_LOGV(TAG, "  reset_: Configuring registers");
+  this->write_register(IO_CONF1, 0x07);  // Disable MCU_CLK + LF clock (RFAL default)
+  uint8_t io_conf2 = sup3v ? 0x80 : 0x00;  // sup3V based on measured VDD
+  io_conf2 |= 0x18;  // SPI pull-downs (miso_pd1 | miso_pd2)
+  if (this->has_aat_)
+    io_conf2 |= 0x20;  // aat_en: enable AAT module so ANT_TUNE_A/B drive varicaps
+  this->write_register(IO_CONF2, io_conf2);
+  this->write_register(MODE, 0x08);
+  this->write_register(BIT_RATE, 0x00);
+  // RFAL NFC-A 106 kbps RX analog profile
+  this->write_register(RX_CONF1, 0x08);  // AM path squelch, HPF=60-400kHz
+  this->write_register(RX_CONF2, 0x2D);  // Mixer demod, AGC on, 61ns pulse
+  this->write_register(RX_CONF3, 0x00);  // HF mode, no LF routing (same for B and non-B)
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(MASK_MAIN, 0x00);   // unmask all main IRQs
+  this->write_register(MASK_TIMER, 0x00);  // unmask all timer IRQs (NRE etc)
+  this->write_register(ISO14443A_CONF, 0x00);
+
+  uint8_t d_res = (15 - this->rf_power_) & 0x0F;
+  // am_mod (bits[7:4]) MUST be 0 for ISO14443A — 100% ASK (OOK) required.
+  this->write_register(TX_DRIVER_CONF, d_res);
+  // ANT_TUNE_A/B (0x26/0x27): varicap DAC outputs for antenna resonance tuning (AAT).
+  // Only write on chips that have AAT hardware — ST25R3916/3916B do; ST25R300/500/501 do not.
+  if (this->has_aat_) {
+    this->write_register(ANT_TUNE_A, this->ant_tune_a_);
+    this->write_register(ANT_TUNE_B, this->ant_tune_b_);
+    ESP_LOGI(TAG, "  reset_: ANT_TUNE_A=0x%02X ANT_TUNE_B=0x%02X",
+             this->ant_tune_a_, this->ant_tune_b_);
+  }
+
+  // RFAL chip-init registers
+  this->write_register(AUX_MOD, 0x10);           // lm_ext=0, lm_dri=1 (external load mod)
+  this->write_register(RES_AM_MOD, 0x80);        // Minimum non-overlap
+  this->write_register(FIELD_THRESHOLD_ACTV, 0x11);   // trg=105mV, rfe=105mV
+  this->write_register(FIELD_THRESHOLD_DEACTV, 0x00); // trg=75mV, rfe=75mV
+  this->write_register(PASSIVE_TARGET, 0x50);    // fdel=5 (FDT aligned to bitgrid)
+  this->write_register(PT_MOD, 0x51);            // Reduce RFO resistance in modulated state
+  this->write_register(EMD_SUP_CONF, 0x40);      // rx_start_emv: start RX on first 4 bits
+
+  // RFAL NFC-A 106 TX: overshoot/undershoot protection
+  this->write_register(OVERSHOOT_CONF1, 0x40);
+  this->write_register(OVERSHOOT_CONF2, 0x03);
+  this->write_register(UNDERSHOOT_CONF1, 0x40);
+  this->write_register(UNDERSHOOT_CONF2, 0x03);
+  // RFAL NFC-A 106 RX: correlator receiver + thresholds
+  uint8_t aux_val = this->read_register(AUX);
+  aux_val &= ~0x04;  // Clear dis_corr → enable correlator receiver
+  this->write_register(AUX, aux_val);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(CORR_CONF1, 0x51);
+  this->write_register(CORR_CONF2, 0x00);
+
+  if (this->rf_field_enabled_) {
+    ESP_LOGV(TAG, "  reset_: Enabling RF field");
+    this->field_on_();
+  }
+  delay(10);
+
+  // AAT hill-climbing: optimize ANT_TUNE_A/B for maximum field amplitude.
+  // Confirmed +10mm range on STEVAL-MB17149B (varicap-equipped board).
+  // Boards without varicaps see no effect (harmless). Disable via YAML: aat_enabled: false
+  if (this->aat_enabled_)
+    this->aat_tune_();
+
+  ESP_LOGV(TAG, "  reset_: Complete");
+  return true;
+}
+
+void ST25R::reinitialize_() {
+  this->reinitialization_attempts_++;
+  ESP_LOGW(TAG, "Reinitializing ST25R (attempt %u)...", this->reinitialization_attempts_);
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->reset_pin_->digital_write(false);
+    delay(10);
+  }
+  if (this->reset_()) {
+    ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
+    this->health_check_failures_ = 0;
+    this->reinitialization_attempts_ = 0;
+    // Force an immediate health check on the next update() so the status sensor
+    // reflects recovery without waiting the full health_check_interval.
+    this->last_health_check_ms_ = 0;
+  } else {
+    ESP_LOGE(TAG, "Reinitialize attempt %u failed", this->reinitialization_attempts_);
+    if (this->reinitialization_attempts_ >= 5) {
+      ESP_LOGE(TAG, "Reinitialize: too many failures, marking component failed");
+      this->mark_failed();
+    }
+  }
+}
+
+void ST25R::apply_anticol_prefix_() {
+  // Decode anticol_prefix_val_ (bit N..0) into prefix arrays
+  // anticol_col_pos_ = N: prefix covers bits 0..N (N+1 bits total)
+  // bit position i of prefix = (anticol_prefix_val_ >> i) & 1
+  int total_bits = this->anticol_col_pos_ + 1;
+  this->anticol_prefix_full_ = total_bits >> 3;
+  this->anticol_prefix_bits_ = total_bits & 7;
+  memset(this->anticol_prefix_, 0, sizeof(this->anticol_prefix_));
+  for (int i = 0; i < total_bits; i++) {
+    int byte_idx = i >> 3;
+    int bit_idx  = i & 7;
+    if ((this->anticol_prefix_val_ >> i) & 1)
+      this->anticol_prefix_[byte_idx] |= (1 << bit_idx);
+  }
+}
+
+void ST25R::send_anticol_frame_() {
+  uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+  uint8_t sel = sel_cmds[this->cascade_level_];
+
+  // NVB: high nibble = complete bytes in frame (SEL + NVB + complete UID prefix bytes only)
+  //      low nibble  = partial bits (0 = full bytes only)
+  // NOTE: partial byte is NOT counted in high nibble — it goes into FIFO but NVB only counts complete bytes
+  uint8_t nvb_high = 2 + this->anticol_prefix_full_;
+  uint8_t nvb = (nvb_high << 4) | this->anticol_prefix_bits_;
+
+  uint8_t frame[7];
+  frame[0] = sel;
+  frame[1] = nvb;
+  uint8_t frame_len = 2;
+  for (int i = 0; i < this->anticol_prefix_full_; i++)
+    frame[frame_len++] = this->anticol_prefix_[i];
+  if (this->anticol_prefix_bits_ > 0)
+    frame[frame_len++] = this->anticol_prefix_[this->anticol_prefix_full_];
+
+  // NUM_TX_BYTES: N full bytes + B partial bits (B>0 means one extra partial byte is in FIFO)
+  // N = SEL + NVB + complete UID prefix bytes only (NOT counting the partial byte)
+  uint8_t ntx_n = 2 + this->anticol_prefix_full_;
+  uint8_t ntx_b = this->anticol_prefix_bits_;
+
+  this->write_register(ISO14443A_CONF, 0x01);  // antcl=1
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);    // clear all IRQ registers so IRQ pin goes low
+  this->read_register(IRQ_TIMER);   // IRQ pin stays high until ALL pending bits are cleared
+  this->read_register(IRQ_ERROR);
+  this->irq_triggered_ = false;
+  this->write_fifo(frame, frame_len);
+  this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
+  this->write_register(NUM_TX_BYTES2, ((ntx_n & 0x1F) << 3) | (ntx_b & 0x07));
+  this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
+
+}
+
+// ── Default virtual helpers (ST25R3916 implementations) ──────────────────────
+
+void ST25R::pre_select_() {
+  // ST25R3916: clear antcl bit in ISO14443A_CONF so SELECT uses normal (non-anticol) framing
+  this->write_register(ISO14443A_CONF, 0x00);
+}
+
+uint8_t ST25R::read_fifo_status1_() {
+  return this->read_register(FIFO_STATUS1);
+}
+
+uint8_t ST25R::read_collision_display_() {
+  return this->read_register(COLLISION_DISPLAY);
+}
+
+void ST25R::send_halt_() {
+  // HALT: send [0x50, 0x00] + CRC; tag has no response.
+  // Don't use transceive_() here — it blocks waiting for a non-existent response.
+  uint8_t halt_cmd[2] = {0x50, 0x00};
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->write_fifo(halt_cmd, 2);
+  this->write_register(NUM_TX_BYTES1, 0x00);
+  this->write_register(NUM_TX_BYTES2, 0x10);  // 2 bytes
+  this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
+  delay(10);  // wait for HALT frame to be transmitted (~2ms for 4 bytes)
+}
+
+void ST25R::start_wupa_() {
+  // Clear FIFO + IRQs, then transmit WUPA.
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->read_register(IRQ_ERROR);
+  this->irq_triggered_ = false;
+  this->irq_status_ = 0;
+  this->write_command(ST25R_CMD_TRANSMIT_WUPA);
+}
+
+void ST25R::field_on_() {
+  this->write_register(OP_CONTROL, 0x88); // en=1, tx_en=1
+  delay(10);
+  this->write_command(ST25R_CMD_FIELD_ON);
+  delay(10);
+  this->write_register(OP_CONTROL, 0xC8); // en=1, rx_en=1, tx_en=1
+  this->write_command(ST25R_CMD_ADJUST_REGULATORS);
+}
+
+// ── AAT (Automatic Antenna Tuning) hill-climbing optimizer ───────────────────
+// Based on RFAL st25r3916AatTune() (AN5322). Iteratively adjusts ANT_TUNE_A/B
+// to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on_()
+// during reset_() on chips with AAT hardware (ST25R3916/3916B).
+
+void ST25R::aat_tune_() {
+  if (!this->has_aat_) return;
+
+  uint8_t a = this->ant_tune_a_;
+  uint8_t b = this->ant_tune_b_;
+  uint8_t step_a = 16;
+  uint8_t step_b = 16;
+  const uint8_t max_iter = 20;
+
+  // Measure current amplitude
+  auto measure = [this]() -> uint8_t {
+    this->write_command(ST25R_CMD_MEASURE_AMPLITUDE);
+    delay(3);  // VCC settling time
+    return this->read_register(AD_CONV_RESULT);
+  };
+
+  this->write_register(ANT_TUNE_A, a);
+  this->write_register(ANT_TUNE_B, b);
+  delay(3);
+  uint8_t best_amp = measure();
+  uint8_t best_a = a, best_b = b;
+
+  ESP_LOGD(TAG, "AAT: start A=0x%02X B=0x%02X amp=%u", a, b, best_amp);
+
+  for (uint8_t iter = 0; iter < max_iter; iter++) {
+    bool improved = false;
+
+    // Try 4 directions: A±step, B±step
+    struct { int8_t da; int8_t db; } dirs[] = {
+      {(int8_t)step_a, 0}, {-(int8_t)step_a, 0},
+      {0, (int8_t)step_b}, {0, -(int8_t)step_b}
+    };
+
+    for (auto &d : dirs) {
+      int16_t new_a = (int16_t)a + d.da;
+      int16_t new_b = (int16_t)b + d.db;
+      if (new_a < 0 || new_a > 255 || new_b < 0 || new_b > 255) continue;
+
+      this->write_register(ANT_TUNE_A, (uint8_t)new_a);
+      this->write_register(ANT_TUNE_B, (uint8_t)new_b);
+      delay(3);
+      uint8_t amp = measure();
+
+      if (amp > best_amp) {
+        best_amp = amp;
+        best_a = (uint8_t)new_a;
+        best_b = (uint8_t)new_b;
+        improved = true;
+      }
+    }
+
+    if (improved) {
+      a = best_a;
+      b = best_b;
+      this->write_register(ANT_TUNE_A, a);
+      this->write_register(ANT_TUNE_B, b);
+    } else {
+      // No improvement — reduce step size
+      step_a = (step_a > 1) ? step_a / 2 : 0;
+      step_b = (step_b > 1) ? step_b / 2 : 0;
+      if (step_a == 0 && step_b == 0) break;  // Converged
+    }
+  }
+
+  // Store final values
+  this->ant_tune_a_ = best_a;
+  this->ant_tune_b_ = best_b;
+  this->write_register(ANT_TUNE_A, best_a);
+  this->write_register(ANT_TUNE_B, best_b);
+
+  ESP_LOGI(TAG, "AAT: converged A=0x%02X B=0x%02X amp=%u", best_a, best_b, best_amp);
+}
+
+// ── ISO 14443-4 (ISO-DEP / Type 4 tags) ─────────────────────────────────────
+
+bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
+  // Send RATS: 0xE0, FSDI=8 (256 bytes) | DID=0
+  uint8_t rats[] = {0xE0, 0x80};
+  uint8_t resp[64];
+  uint8_t resp_len = 0;
+  ats_len = 0;
+
+  if (!this->transceive_(rats, sizeof(rats), resp, resp_len) || resp_len < 2) {
+    ESP_LOGD(TAG, "ISO-DEP: RATS failed (resp_len=%u)", resp_len);
+    return false;
+  }
+
+  // ATS: TL(1) + T0(1) + [TA] + [TB] + [TC] + [HB...]
+  ats_len = resp_len;
+  memcpy(ats, resp, resp_len);
+  this->isodep_block_number_ = 0;
+
+  ESP_LOGD(TAG, "ISO-DEP: ATS received, TL=%u", resp[0]);
+  return true;
+}
+
+bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
+  // Wrap APDU in I-Block: [PCB][APDU...]
+  uint8_t frame[64];
+  if (apdu_len + 1 > sizeof(frame)) return false;
+
+  // PCB: I-Block, no chaining, no DID/NAD, must-be-1 bit, block number
+  frame[0] = 0x02 | (this->isodep_block_number_ & 0x01);
+  memcpy(frame + 1, apdu, apdu_len);
+
+  uint8_t raw_resp[64];
+  uint8_t raw_len = 0;
+
+  if (!this->transceive_(frame, apdu_len + 1, raw_resp, raw_len) || raw_len < 3) {
+    return false;
+  }
+
+  // Toggle block number for next exchange
+  this->isodep_block_number_ ^= 1;
+
+  // Strip PCB byte, check for I-Block response
+  if ((raw_resp[0] & 0xC0) != 0x00) {
+    // Not an I-Block — might be R-Block or S-Block
+    ESP_LOGD(TAG, "ISO-DEP: non-I-Block response PCB=0x%02X", raw_resp[0]);
+    return false;
+  }
+
+  // Response: [PCB][data...][SW1][SW2]  (CRC already stripped by transceive_)
+  resp_len = raw_len - 1;  // strip PCB
+  memcpy(resp, raw_resp + 1, resp_len);
+  return true;
+}
+
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
+  uint8_t ats[64];
+  uint8_t ats_len = 0;
+
+  if (!this->isodep_activate_(ats, ats_len)) {
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  uint8_t resp[64];
+  uint8_t resp_len = 0;
+
+  // Step 1: SELECT NDEF Application (AID = D276000085010100 for v2, try v1 as fallback)
+  uint8_t select_app[] = {0x00, 0xA4, 0x04, 0x00, 0x07, 0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01, 0x00};
+  if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
+      resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
+    // Try v1 AID
+    select_app[11] = 0x00;  // D276000085010100 → D276000085010000
+    resp_len = 0;
+    if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
+        resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
+      ESP_LOGD(TAG, "T4T: SELECT NDEF app failed");
+      nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+      return make_unique<nfc::NfcTag>(nfc_uid);
+    }
+  }
+
+  // Step 2: SELECT CC File (0xE103)
+  uint8_t select_cc[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, 0xE1, 0x03};
+  resp_len = 0;
+  if (!this->isodep_transceive_(select_cc, sizeof(select_cc), resp, resp_len) ||
+      resp_len < 2 || resp[resp_len - 2] != 0x90) {
+    ESP_LOGD(TAG, "T4T: SELECT CC failed");
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  // Step 3: READ BINARY CC (15 bytes)
+  uint8_t read_cc[] = {0x00, 0xB0, 0x00, 0x00, 0x0F};
+  resp_len = 0;
+  if (!this->isodep_transceive_(read_cc, sizeof(read_cc), resp, resp_len) ||
+      resp_len < 17) {  // 15 data + SW1 SW2
+    ESP_LOGD(TAG, "T4T: READ CC failed (resp_len=%u)", resp_len);
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  // Parse CC: bytes 7-8 = NDEF file ID, bytes 9-10 = max NDEF size
+  // CC TLV at offset 7: type(1) + len(1) + fileID(2) + maxSize(2) + readAccess(1) + writeAccess(1)
+  uint16_t ndef_file_id = ((uint16_t)resp[9] << 8) | resp[10];
+  uint16_t max_ndef_size = ((uint16_t)resp[11] << 8) | resp[12];
+  ESP_LOGD(TAG, "T4T CC: NDEF file=0x%04X, max_size=%u", ndef_file_id, max_ndef_size);
+
+  // Step 4: SELECT NDEF File
+  uint8_t select_ndef[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, (uint8_t)(ndef_file_id >> 8), (uint8_t)(ndef_file_id & 0xFF)};
+  resp_len = 0;
+  if (!this->isodep_transceive_(select_ndef, sizeof(select_ndef), resp, resp_len) ||
+      resp_len < 2 || resp[resp_len - 2] != 0x90) {
+    ESP_LOGD(TAG, "T4T: SELECT NDEF file failed");
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  // Step 5: READ NDEF Length (first 2 bytes)
+  uint8_t read_nlen[] = {0x00, 0xB0, 0x00, 0x00, 0x02};
+  resp_len = 0;
+  if (!this->isodep_transceive_(read_nlen, sizeof(read_nlen), resp, resp_len) ||
+      resp_len < 4) {  // 2 data + SW1 SW2
+    ESP_LOGD(TAG, "T4T: READ NLEN failed");
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  uint16_t ndef_len = ((uint16_t)resp[0] << 8) | resp[1];
+  if (ndef_len == 0 || ndef_len > 255) {
+    ESP_LOGD(TAG, "T4T: NDEF length %u (skipping read)", ndef_len);
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  // Step 6: READ NDEF Data
+  uint8_t read_ndef[] = {0x00, 0xB0, 0x00, 0x02, (uint8_t)ndef_len};
+  resp_len = 0;
+  if (!this->isodep_transceive_(read_ndef, sizeof(read_ndef), resp, resp_len) ||
+      resp_len < ndef_len + 2) {
+    ESP_LOGD(TAG, "T4T: READ NDEF data failed");
+    nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+    return make_unique<nfc::NfcTag>(nfc_uid);
+  }
+
+  ESP_LOGI(TAG, "T4T NDEF: %u bytes read", ndef_len);
+  nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+  return make_unique<nfc::NfcTag>(nfc_uid);
+}
+
+// ── NFC-B (ISO 14443B) for ST25R3916 ─────────────────────────────────────────
+
+void ST25R::configure_nfcb_mode_() {
+  // MODE: om=0x02 (ISO14443B) in bits[6:3] = 0x10, tr_am=1 (AM modulation) bit7 = 0x80
+  this->write_register(MODE, 0x90);
+  this->write_register(BIT_RATE, 0x00);  // 106 kbps
+  // TX: 10% ASK (AM modulation) — NFC-B requires AM, not OOK
+  uint8_t d_res = (15 - this->rf_power_) & 0x0F;
+  this->write_register(TX_DRIVER_CONF, 0x70 | d_res);  // am_mod=7 (12% ASK)
+  // RX: RFAL NFC-B analog profile
+  this->write_register(RX_CONF1, 0x00);  // AM channel
+  this->write_register(RX_CONF2, 0x2D);
+  this->write_register(RX_CONF3, 0x00);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(CORR_CONF1, 0x14);  // NFC-B correlator
+  this->write_register(CORR_CONF2, 0x00);
+}
+
+void ST25R::nfcb_scan_() {
+  this->configure_nfcb_mode_();
+
+  // SENSB_REQ (ALLB_REQ): cmd=0x05, AFI=0x00 (any), PARAM=0x08 (1 slot + WUPB)
+  uint8_t sensb_req[] = {0x05, 0x00, 0x08};
+  uint8_t resp[16];
+  uint8_t resp_len = 0;
+
+  // Use standard CRC transceive — NFC-B uses the chip's CRC-B hardware
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+  this->write_command(ST25R_CMD_RESET_RX_GAIN);
+
+  uint16_t ntx = sizeof(sensb_req);
+  this->write_register(NUM_TX_BYTES1, ntx >> 5);
+  this->write_register(NUM_TX_BYTES2, (ntx & 0x1F) << 3);
+  this->write_fifo(sensb_req, sizeof(sensb_req));
+
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->irq_triggered_ = false;
+  this->write_command(ST25R_CMD_TRANSMIT_WITH_CRC);
+
+  // Wait for ATQB response
+  uint32_t start = millis();
+  while (millis() - start < 20) {
+    uint8_t irq = this->read_register(IRQ_MAIN);
+    uint8_t irq_t = this->read_register(IRQ_TIMER);
+    if (irq & 0x10) {  // RXE
+      uint8_t fifo_len = this->read_register(FIFO_STATUS1);
+      if (fifo_len >= 12) {  // Minimum ATQB: 0x50 + PUPI(4) + AppData(4) + ProtInfo(3)
+        this->read_fifo(resp, fifo_len);
+        resp_len = fifo_len;
+      }
+      break;
+    }
+    if (irq_t & 0x40) break;  // NRE
+    delay(1);
+  }
+
+  // Restore NFC-A mode
+  this->restore_nfca_mode_();
+  // Also restore TX_DRIVER to OOK (am_mod=0)
+  uint8_t d_res_restore = (15 - this->rf_power_) & 0x0F;
+  this->write_register(TX_DRIVER_CONF, d_res_restore);
+
+  if (resp_len < 12 || resp[0] != 0x50) return;
+
+  // Parse ATQB: byte 0 = 0x50, bytes 1-4 = PUPI
+  char uid_str[9];
+  snprintf(uid_str, sizeof(uid_str), "%02X%02X%02X%02X", resp[1], resp[2], resp[3], resp[4]);
+  ESP_LOGI(TAG, "NFC-B tag: %s (ATQB len=%u)", uid_str, resp_len);
+
+  std::string uid_string(uid_str);
+  this->tags_this_scan_.insert(uid_string);
+
+  if (this->present_tags_.find(uid_string) == this->present_tags_.end()) {
+    this->present_tags_[uid_string] = 0;
+    std::vector<uint8_t> uid_bytes = {resp[1], resp[2], resp[3], resp[4]};
+    nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+    auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+    for (auto *listener : this->tag_listeners_)
+      listener->tag_on(*tag);
+    for (auto *trigger : this->on_tag_triggers_)
+      trigger->trigger(uid_string);
+  }
+}
+
+// ── NFC-V (ISO 15693) streaming mode for ST25R3916 ──────────────────────────
+
+// ISO 15693 CRC-16 CCITT (preset=0xFFFF, poly=0x8408, result inverted)
+uint16_t ST25R::iso15693_crc_(const uint8_t *data, size_t len) {
+  uint16_t crc = 0xFFFF;
+  for (size_t i = 0; i < len; i++) {
+    uint8_t d = data[i] ^ (uint8_t)(crc & 0xFF);
+    d ^= (d << 4);
+    crc = (crc >> 8) ^ ((uint16_t)d << 8) ^ ((uint16_t)d << 3) ^ ((uint16_t)d >> 4);
+  }
+  return ~crc;
+}
+
+// 1-of-4 VCD encoding: each byte → 4 output bytes (SOF + data + CRC + EOF)
+static const uint8_t ISO15693_1OF4_SOF = 0x21;
+static const uint8_t ISO15693_1OF4_EOF = 0x04;
+static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
+
+size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc,
+                                     uint8_t *out, size_t out_max) {
+  size_t pos = 0;
+  if (out_max < 1 + (len + 2) * 4 + 1) return 0;
+
+  // SOF
+  out[pos++] = ISO15693_1OF4_SOF;
+
+  // Encode data bytes
+  for (size_t i = 0; i < len; i++) {
+    uint8_t b = data[i];
+    for (int j = 0; j < 4; j++) {
+      out[pos++] = ISO15693_1OF4_MAP[b & 0x03];
+      b >>= 2;
+    }
+  }
+
+  // Encode CRC
+  if (add_crc) {
+    uint16_t crc = iso15693_crc_(data, len);
+    uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
+    for (int c = 0; c < 2; c++) {
+      uint8_t b = crc_bytes[c];
+      for (int j = 0; j < 4; j++) {
+        out[pos++] = ISO15693_1OF4_MAP[b & 0x03];
+        b >>= 2;
+      }
+    }
+  }
+
+  // EOF
+  out[pos++] = ISO15693_1OF4_EOF;
+  return pos;
+}
+
+// Manchester VICC decoding: subcarrier stream → payload bytes
+size_t ST25R::iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
+  if (in_len == 0 || out_max == 0) return 0;
+
+  // Check SOF: first 5 bits should be 0x17 (10111 = 3 unmodulated + 2 modulated)
+  if ((in[0] & 0x1F) != 0x17) return 0;
+
+  memset(out, 0, out_max);
+  size_t mp = 5;  // Manchester bit position (after SOF)
+  size_t bp = 0;  // Output bit position
+
+  for (; mp < (in_len * 8 - 2); mp += 2) {
+    uint8_t man = (in[mp / 8] >> (mp % 8)) & 0x01;
+    man |= ((in[(mp + 1) / 8] >> ((mp + 1) % 8)) & 0x01) << 1;
+
+    if (man == 1) {
+      bp++;  // bit = 0
+    } else if (man == 2) {
+      out[bp / 8] |= (1 << (bp % 8));  // bit = 1
+      bp++;
+    } else {
+      // Check for EOF: 10111000 pattern
+      if ((bp % 8) == 0 && (in[mp / 8] & 0xE0) == 0xA0 && in[mp / 8 + 1] == 0x03) {
+        break;  // EOF found
+      }
+      break;  // collision or invalid
+    }
+
+    if (bp >= out_max * 8) break;
+  }
+
+  return bp / 8;  // return complete bytes
+}
+
+void ST25R::configure_nfcv_stream_mode_() {
+  // RFAL NFC-V analog config: RX_CONF1=0x13, RX_CONF2=0x2D, CORR_CONF1=0x13, CORR_CONF2=0x01
+  this->write_register(RX_CONF1, 0x13);
+  this->write_register(RX_CONF2, 0x2D);
+  this->write_register(RX_CONF3, 0x00);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(CORR_CONF1, 0x13);
+  this->write_register(CORR_CONF2, 0x01);
+
+  // STREAM_MODE register: din=5 (423.75kHz subcarrier), dout=7 (105.9kHz TX), report_period=3 (8 clocks)
+  // smd = ((6-din) << 5) | ((7-dout) << 0) | (report_period << 3)
+  uint8_t smd = ((6 - 5) << 5) | ((7 - 7) << 0) | (3 << 3);  // = 0x38
+  this->write_register(STREAM_MODE, smd);
+
+  // MODE: om=0x0E (subcarrier_stream) → bits[6:3] = 0x70
+  // Preserve other MODE bits (targ=0 for initiator, tr_am from current config)
+  this->write_register(MODE, 0x70);  // om=subcarrier_stream, initiator
+
+  // Disable overshoot/undershoot for NFC-V TX (RFAL CHIP_POLL_COMMON)
+  this->write_register(OVERSHOOT_CONF1, 0x00);
+  this->write_register(OVERSHOOT_CONF2, 0x00);
+  this->write_register(UNDERSHOOT_CONF1, 0x00);
+  this->write_register(UNDERSHOOT_CONF2, 0x00);
+}
+
+void ST25R::restore_nfca_mode_() {
+  // Restore NFC-A 106 settings
+  this->write_register(MODE, 0x08);
+  this->write_register(RX_CONF1, 0x08);
+  this->write_register(RX_CONF2, 0x2D);
+  this->write_register(RX_CONF3, 0x00);
+  this->write_register(RX_CONF4, 0x00);
+  this->write_register(CORR_CONF1, 0x51);
+  this->write_register(CORR_CONF2, 0x00);
+  // Restore overshoot/undershoot protection
+  this->write_register(OVERSHOOT_CONF1, 0x40);
+  this->write_register(OVERSHOOT_CONF2, 0x03);
+  this->write_register(UNDERSHOOT_CONF1, 0x40);
+  this->write_register(UNDERSHOOT_CONF2, 0x03);
+}
+
+bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                                     uint32_t timeout_ms) {
+  // Encode command using 1-of-4 coding with CRC
+  uint8_t coded[128];
+  // Set high data rate flag and clear dual subcarrier
+  uint8_t cmd_buf[16];
+  if (len > sizeof(cmd_buf)) return false;
+  memcpy(cmd_buf, data, len);
+  cmd_buf[0] |= 0x02;   // high data rate
+  cmd_buf[0] &= ~0x01;  // single subcarrier
+
+  size_t coded_len = iso15693_encode_1of4_(cmd_buf, len, true, coded, sizeof(coded));
+  if (coded_len == 0) return false;
+
+  this->write_command(ST25R_CMD_STOP_ALL);
+  this->write_command(ST25R_CMD_CLEAR_FIFO);
+
+  // Set TX frame: total sub-bits (not bytes!)
+  // For 1-of-4: each coded byte = 1 sub-bit in stream mode
+  uint16_t subbits = coded_len;
+  this->write_register(NUM_TX_BYTES1, subbits >> 5);
+  this->write_register(NUM_TX_BYTES2, (subbits & 0x1F) << 3);
+
+  this->write_fifo(coded, coded_len);
+
+  this->read_register(IRQ_MAIN);
+  this->read_register(IRQ_TIMER);
+  this->irq_triggered_ = false;
+  this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);  // Manual CRC (already encoded)
+
+  // Wait for response
+  uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    uint8_t irq = this->read_register(IRQ_MAIN);
+    uint8_t irq_t = this->read_register(IRQ_TIMER);
+    if (irq & 0x10) {  // RXE
+      uint8_t fifo_len = this->read_register(FIFO_STATUS1);
+      if (fifo_len > 0 && fifo_len <= 64) {
+        uint8_t raw[64];
+        this->read_fifo(raw, fifo_len);
+        // Decode Manchester
+        uint8_t decoded[32];
+        size_t dec_len = iso15693_decode_manchester_(raw, fifo_len, decoded, sizeof(decoded));
+        if (dec_len >= 3) {  // At least flags + CRC(2)
+          // Verify CRC
+          uint16_t crc = iso15693_crc_(decoded, dec_len - 2);
+          if ((crc & 0xFF) == decoded[dec_len - 2] && (crc >> 8) == decoded[dec_len - 1]) {
+            // Strip CRC
+            resp_len = dec_len - 2;
+            memcpy(resp, decoded, resp_len);
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+    if (irq_t & 0x40) {  // NRE
+      return false;
+    }
+    delay(1);
+  }
+  return false;
+}
+
+void ST25R::nfcv_scan_() {
+  this->configure_nfcv_stream_mode_();
+
+  uint8_t inv_req[] = {0x26, 0x01, 0x00};  // flags, INVENTORY, mask_len=0
+  uint8_t resp[16];
+  uint8_t resp_len = 0;
+
+  if (this->transceive_nfcv_stream_(inv_req, sizeof(inv_req), resp, resp_len, 30)) {
+    if (resp_len >= 10 && !(resp[0] & 0x01)) {
+      // Parse UID (bytes 2-9, LSB-first → reverse for display)
+      char uid_str[17];
+      for (int j = 0; j < 8; j++)
+        snprintf(uid_str + j * 2, 3, "%02X", resp[9 - j]);
+      uid_str[16] = '\0';
+      ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
+
+      // Add to tags_this_scan_ — finalize_scan_() handles on_tag/on_tag_removed
+      std::string uid_string(uid_str);
+      this->tags_this_scan_.insert(uid_string);
+
+      // Try to read NDEF (Type 5 tag) via READ_SINGLE_BLOCK
+      std::vector<uint8_t> uid_bytes;
+      for (int j = 0; j < 8; j++)
+        uid_bytes.push_back(resp[9 - j]);
+
+      // Read block 0 (Capability Container)
+      uint8_t blk_req[] = {0x02, 0x20, 0x00};  // flags, READ_SINGLE_BLOCK, block=0
+      uint8_t blk_resp[8];
+      uint8_t blk_len = 0;
+      std::vector<uint8_t> ndef_data;
+
+      if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+          blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+        // CC: byte1=magic(0xE1), byte2=ver+access, byte3=size(*8), byte4=features
+        if (blk_resp[1] == 0xE1) {
+          uint8_t cc_size = blk_resp[3];  // NDEF area size in 8-byte units
+          uint8_t total_blocks = (cc_size * 8) / 4;  // 4 bytes per block
+          if (total_blocks > 64) total_blocks = 64;  // safety limit
+
+          // Read blocks 1..N for NDEF TLV data
+          for (uint8_t blk = 1; blk <= total_blocks; blk++) {
+            blk_req[2] = blk;
+            blk_len = 0;
+            if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+                blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+              for (int k = 1; k < 5 && k < blk_len; k++)
+                ndef_data.push_back(blk_resp[k]);
+            } else {
+              break;
+            }
+          }
+        }
+      }
+
+      // Fire on_tag immediately for new tags
+      if (this->present_tags_.find(uid_string) == this->present_tags_.end()) {
+        this->present_tags_[uid_string] = 0;
+        nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+
+        if (!ndef_data.empty()) {
+          // Parse NDEF TLV: search for type 0x03 (NDEF message)
+          for (size_t i = 0; i < ndef_data.size(); i++) {
+            if (ndef_data[i] == 0x03 && i + 1 < ndef_data.size()) {
+              uint8_t ndef_len = ndef_data[i + 1];
+              size_t ndef_start = i + 2;
+              if (ndef_start + ndef_len <= ndef_data.size()) {
+                ESP_LOGI(TAG, "NFC-V NDEF: %u bytes", ndef_len);
+                auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+                this->tags_data_[uid_string] = std::move(tag);
+              }
+              break;
+            }
+            if (ndef_data[i] == 0xFE) break;  // Terminator TLV
+          }
+        }
+
+        if (this->tags_data_.find(uid_string) == this->tags_data_.end()) {
+          auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+          this->tags_data_[uid_string] = std::move(tag);
+        }
+
+        for (auto *listener : this->tag_listeners_)
+          listener->tag_on(*this->tags_data_[uid_string]);
+        for (auto *trigger : this->on_tag_triggers_)
+          trigger->trigger(uid_string);
+      }
+    }
+  }
+
+  this->restore_nfca_mode_();
+}
+
+bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
+  // Check if the most recent tag is NFC-V (8-byte UID = 16 hex chars)
+  // If so, use the NFC-V WRITE_SINGLE_BLOCK path
+  if (!this->present_tags_.empty()) {
+    const std::string &last_uid = this->present_tags_.rbegin()->first;
+    if (last_uid.length() == 16) {
+      return this->nfcv_ndef_write_(message);
+    }
+  }
+
+  // NFC-A Type 2 NDEF write (NTAG / Ultralight)
+  uint8_t buffer[16];
+  uint8_t len;
+
+  if (format) {
+    ESP_LOGD(TAG, "Formatting tag (NTAG215 CC)...");
+    uint8_t cc_cmd[6] = {0xA2, 0x03, 0xE1, 0x10, 0x3E, 0x00};
+    bool cc_success = false;
+    for (uint8_t i = 0; i < 3; i++) {
+      delay(20);
+      if (this->transceive_(cc_cmd, 6, buffer, len) && (len > 0 && (buffer[0] & 0x0F) == 0x0A)) {
+        cc_success = true;
+        break;
+      }
+    }
+    if (!cc_success) {
+      ESP_LOGE(TAG, "Failed to write CC page during format");
+      return false;
+    }
+    delay(50);
+  }
+
+  if (message == nullptr) {
+    // Just formatting/cleaning
+    uint8_t empty_ndef[6] = {0xA2, 0x04, 0x03, 0x00, 0xFE, 0x00};
+    bool empty_success = false;
+    for (uint8_t i = 0; i < 3; i++) {
+      delay(20);
+      if (this->transceive_(empty_ndef, 6, buffer, len) && (len > 0 && (buffer[0] & 0x0F) == 0x0A)) {
+        empty_success = true;
+        break;
+      }
+    }
+    return empty_success;
+  }
+
+  std::vector<uint8_t> ndef_data = message->encode();
+  std::vector<uint8_t> payload;
+  
+  // Build TLV structure
+  payload.push_back(0x03); // NDEF TLV
+  if (ndef_data.size() < 255) {
+    payload.push_back((uint8_t)ndef_data.size());
+  } else {
+    payload.push_back(0xFF);
+    payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
+    payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+  }
+  payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
+  payload.push_back(0xFE); // Terminator TLV
+
+  // Pad to 4-byte pages
+  while (payload.size() % 4 != 0) payload.push_back(0);
+
+  ESP_LOGD(TAG, "Writing NDEF message, total size with TLVs: %zu", payload.size());
+
+  for (size_t i = 0; i < payload.size(); i += 4) {
+    uint8_t page = 4 + (i / 4);
+    uint8_t write_cmd[6] = {0xA2, page, payload[i], payload[i+1], payload[i+2], payload[i+3]};
+    bool success = false;
+    
+    for (uint8_t retry = 0; retry < 3; retry++) {
+      delay(20);
+      if (this->transceive_(write_cmd, 6, buffer, len) && (len > 0 && (buffer[0] & 0x0F) == 0x0A)) {
+        success = true;
+        break;
+      }
+      ESP_LOGW(TAG, "NDEF write retry %d for page %d (resp_len=%d, byte0=%02X)", retry + 1, page, len, len > 0 ? buffer[0] : 0);
+    }
+
+    if (!success) {
+      ESP_LOGE(TAG, "NDEF write failed at page %d after retries", page);
+      return false;
+    }
+  }
+  ESP_LOGI(TAG, "NDEF write successful!");
+  return true;
+}
+
+bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
+  // NFC-V Type 5 NDEF write via WRITE_SINGLE_BLOCK (0x21)
+  // Block 0 = CC, blocks 1+ = NDEF TLV data
+
+  this->configure_nfcv_stream_mode_();
+
+  std::vector<uint8_t> payload;
+  if (message != nullptr) {
+    std::vector<uint8_t> ndef_data = message->encode();
+    payload.push_back(0x03);  // NDEF TLV type
+    if (ndef_data.size() < 255) {
+      payload.push_back((uint8_t)ndef_data.size());
+    } else {
+      payload.push_back(0xFF);
+      payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
+      payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+    }
+    payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
+  }
+  payload.push_back(0xFE);  // Terminator TLV
+  while (payload.size() % 4 != 0) payload.push_back(0);
+
+  ESP_LOGD(TAG, "NFC-V NDEF write: %zu bytes in %zu blocks", payload.size(), payload.size() / 4);
+
+  // Write CC to block 0: magic=0xE1, ver=0x40 (v1.0, read/write), size, features=0x00
+  uint8_t cc_size = (payload.size() + 4) / 8;  // size in 8-byte units (round up)
+  if (cc_size == 0) cc_size = 1;
+  uint8_t write_req[7] = {0x02, 0x21, 0x00, 0xE1, 0x40, cc_size, 0x00};  // flags, WRITE_SINGLE_BLOCK, block, data[4]
+  uint8_t resp[4];
+  uint8_t resp_len = 0;
+
+  if (!this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+    ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
+    this->restore_nfca_mode_();
+    return false;
+  }
+
+  // Write NDEF data blocks
+  for (size_t i = 0; i < payload.size(); i += 4) {
+    uint8_t blk = 1 + (i / 4);
+    write_req[2] = blk;
+    write_req[3] = payload[i];
+    write_req[4] = payload[i + 1];
+    write_req[5] = payload[i + 2];
+    write_req[6] = payload[i + 3];
+    resp_len = 0;
+
+    bool success = false;
+    for (uint8_t retry = 0; retry < 3; retry++) {
+      if (this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+        success = true;
+        break;
+      }
+      delay(10);
+    }
+    if (!success) {
+      ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
+      this->restore_nfca_mode_();
+      return false;
+    }
+  }
+
+  ESP_LOGI(TAG, "NFC-V NDEF write successful!");
+  this->restore_nfca_mode_();
+  return true;
+}
+
+bool ST25R::clean_tag() {
+  return this->ndef_write(nullptr, true);
+}
+
+bool ST25R::send_apdu(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
+  if (!(this->last_sak_ & 0x20)) {
+    ESP_LOGW(TAG, "send_apdu: tag not ISO-DEP capable (SAK=0x%02X)", this->last_sak_);
+    return false;
+  }
+  return this->isodep_transceive_(apdu, apdu_len, resp, resp_len);
+}
+
+void ST25R::dump_config() {
+  ESP_LOGCONFIG(TAG, "ST25R:");
+  LOG_PIN("  IRQ Pin: ", this->irq_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  RF Power: %u", this->rf_power_);
+  ESP_LOGCONFIG(TAG, "  RF Field Enabled: %s", YESNO(this->rf_field_enabled_));
+  ESP_LOGCONFIG(TAG, "  Miss Threshold: %u", this->miss_threshold_);
+  ESP_LOGCONFIG(TAG, "  NFC-V (ISO 15693): %s", YESNO(this->nfcv_enabled_));
+  ESP_LOGCONFIG(TAG, "  Health Check: %s", YESNO(this->health_check_enabled_));
+  if (this->health_check_enabled_) {
+    ESP_LOGCONFIG(TAG, "  Health Check Interval: %u ms", this->health_check_interval_ms_);
+    ESP_LOGCONFIG(TAG, "  Max Failed Checks: %u", this->max_failed_checks_);
+    ESP_LOGCONFIG(TAG, "  Auto Reset on Failure: %s", YESNO(this->auto_reset_on_failure_));
+  }
+  LOG_UPDATE_INTERVAL(this);
+  uint8_t ic_id = this->read_register(IC_IDENTITY);
+  ESP_LOGCONFIG(TAG, "  IC Identity (live read): 0x%02X (chip_type=0x%02X)", ic_id, ic_id & 0xF8);
+  ESP_LOGCONFIG(TAG, "  IO_CONF2: 0x%02X (sup3V=%s, aat_en=%s)",
+                this->read_register(IO_CONF2),
+                (this->read_register(IO_CONF2) & 0x80) ? "3.3V" : "5V",
+                (this->read_register(IO_CONF2) & 0x20) ? "yes" : "no");
+}
+
+bool ST25RBinarySensor::process(const std::string &uid) {
+  std::string target_uid = "";
+  for (uint8_t b : this->uid_) {
+    char buf[3];
+    sprintf(buf, "%02X", b);
+    target_uid += buf;
+  }
+  if (uid == target_uid) {
+    this->publish_state(true);
+    this->found_ = true;
+    return true;
+  }
+  return false;
+}
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -803,7 +803,7 @@ void ST25R::process_state() {
           } else {
             // Tag fully selected — validate UID length (must be 4 or 7 bytes; 3-byte = CL1 glitch)
             size_t uid_bytes_len = this->current_uid_.length() / 2;
-            if (uid_bytes_len != 4 && uid_bytes_len != 7) {
+            if (uid_bytes_len != 4 && uid_bytes_len != 7 && uid_bytes_len != 10) {
               ESP_LOGW(TAG, "Discarding invalid UID len=%zu (%s)", uid_bytes_len, this->current_uid_.c_str());
               this->state_ = STATE_IDLE;
               this->finalize_scan_();
@@ -1421,8 +1421,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
     return make_unique<nfc::NfcTag>(nfc_uid);
   }
 
-  // Parse CC: bytes 7-8 = NDEF file ID, bytes 9-10 = max NDEF size
-  // CC TLV at offset 7: type(1) + len(1) + fileID(2) + maxSize(2) + readAccess(1) + writeAccess(1)
+  // Parse CC: resp[0..1]=CCLEN, [2]=ver, [3]=MLe, [4]=MLc, [5..6]=TLV header,
+  // [7..8]=TLV type+len, [9..10]=NDEF file ID, [11..12]=max NDEF size
   uint16_t ndef_file_id = ((uint16_t)resp[9] << 8) | resp[10];
   uint16_t max_ndef_size = ((uint16_t)resp[11] << 8) | resp[12];
   ESP_LOGD(TAG, "T4T CC: NDEF file=0x%04X, max_size=%u", ndef_file_id, max_ndef_size);

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -757,8 +757,10 @@ void ST25R::process_state() {
               char buf[3]; snprintf(buf, sizeof(buf), "%02X", full_uid[i]); this->current_uid_ += buf;
             }
           } else {
-            for (int i = 0; i < 4; i++) {
-              char buf[3]; snprintf(buf, sizeof(buf), "%02X", full_uid[i]); this->current_uid_ += buf;
+            for (unsigned char i : full_uid) {
+              char buf[3];
+              snprintf(buf, sizeof(buf), "%02X", i);
+              this->current_uid_ += buf;
             }
           }
 
@@ -1583,8 +1585,7 @@ size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc
   if (add_crc) {
     uint16_t crc = iso15693_crc(data, len);
     uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
-    for (int c = 0; c < 2; c++) {
-      uint8_t b = crc_bytes[c];
+    for (unsigned char b : crc_bytes) {
       for (int j = 0; j < 4; j++) {
         out[pos++] = ISO15693_1OF4_MAP[b & 0x03];
         b >>= 2;
@@ -1758,6 +1759,7 @@ void ST25R::nfcv_scan_() {
 
       // Try to read NDEF (Type 5 tag) via READ_SINGLE_BLOCK
       std::vector<uint8_t> uid_bytes;
+      uid_bytes.reserve(8);
       for (int j = 0; j < 8; j++)
         uid_bytes.push_back(resp[9 - j]);
 

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -25,7 +25,7 @@
 static uint16_t mifare_crc_a(const uint8_t *data, size_t len) {
   uint16_t crc = 0x6363;
   for (size_t i = 0; i < len; i++) {
-    uint8_t b = data[i] ^ (uint8_t)(crc & 0xFF);
+    uint8_t b = data[i] ^ (uint8_t) (crc & 0xFF);
     b ^= b << 4;
     crc = (crc >> 8) ^ ((uint16_t) b << 8) ^ ((uint16_t) b << 3) ^ ((uint16_t) b >> 4);
   }
@@ -34,45 +34,42 @@ static uint16_t mifare_crc_a(const uint8_t *data, size_t len) {
 
 // ── Odd parity lookup ────────────────────────────────────────────────────────
 static const uint8_t ODD_PARITY[256] = {
-  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
-  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
-  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
-  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
-  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
-  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
-  1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,
-  0,1,1,0,1,0,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,0,1,1,0,1,0,0,1,
+    1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1,
+    0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0,
+    0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0,
+    1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1,
+    0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1,
+    0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1,
+    1, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1, 0, 0, 1,
 };
 
 // ── 9-bit parity pack/unpack ─────────────────────────────────────────────────
 // Each octet → 9 bits in the buffer: data bits 0..7 then parity bit.
 // Adapted from mf1_encode/decode_parity_st25r3916 (MIT, suut/rfal-mifare-classic)
 
-static void mifare_pack_parity(const uint8_t *in, const uint8_t *par,
-                                uint8_t *out, uint8_t nbytes,
-                                uint16_t *out_bits) {
+static void mifare_pack_parity(const uint8_t *in, const uint8_t *par, uint8_t *out, uint8_t nbytes,
+                               uint16_t *out_bits) {
   uint16_t total = 9u * nbytes;
   memset(out, 0, (total + 7u) / 8u);
   for (uint8_t i = 0; i < nbytes; i++) {
     for (uint8_t j = 0; j < 8; j++) {
       uint32_t p = j + 9u * i;
-      out[p / 8] |= (uint8_t)(((in[i] >> j) & 1u) << (p % 8));
+      out[p / 8] |= (uint8_t) (((in[i] >> j) & 1u) << (p % 8));
     }
     uint32_t p = 8u + 9u * i;
-    out[p / 8] |= (uint8_t)((par[i] & 1u) << (p % 8));
+    out[p / 8] |= (uint8_t) ((par[i] & 1u) << (p % 8));
   }
   *out_bits = total;
 }
 
-static uint8_t mifare_unpack_parity(const uint8_t *in, uint8_t *out,
-                                     uint8_t *par, uint16_t in_bits) {
-  uint8_t nbytes = (uint8_t)(in_bits / 9u);
+static uint8_t mifare_unpack_parity(const uint8_t *in, uint8_t *out, uint8_t *par, uint16_t in_bits) {
+  uint8_t nbytes = (uint8_t) (in_bits / 9u);
   memset(out, 0, nbytes);
   memset(par, 0, nbytes);
   for (uint8_t i = 0; i < nbytes; i++) {
     for (uint8_t j = 0; j < 8; j++) {
       uint32_t p = j + 9u * i;
-      out[i] |= (uint8_t)(((in[p / 8] >> (p % 8)) & 1u) << j);
+      out[i] |= (uint8_t) (((in[p / 8] >> (p % 8)) & 1u) << j);
     }
     uint32_t p = 8u + 9u * i;
     par[i] = (in[p / 8] >> (p % 8)) & 1u;
@@ -85,9 +82,7 @@ namespace st25r {
 
 static const char *const TAG = "st25r";
 
-void ST25R::isr(ST25R *arg) {
-  arg->irq_triggered_ = true;
-}
+void ST25R::isr(ST25R *arg) { arg->irq_triggered_ = true; }
 
 void ST25R::setup() {
   ESP_LOGI(TAG, "Setting up ST25R...");
@@ -119,7 +114,8 @@ void ST25R::setup() {
 }
 
 void ST25R::update() {
-  if (this->is_failed() || this->state_ != STATE_IDLE) return;
+  if (this->is_failed() || this->state_ != STATE_IDLE)
+    return;
 
   // Health check: verify chip identity at a separate (typically slower) interval.
   // This decouples liveness checks from the tag scan rate — e.g. scan every 500ms
@@ -131,8 +127,8 @@ void ST25R::update() {
       uint8_t ic_identity = this->read_register(IC_IDENTITY);
       uint8_t chip_type = ic_identity & 0xF8;
       if (chip_type != 0x28 && chip_type != 0x30) {
-        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)",
-                 ic_identity, this->health_check_failures_ + 1, this->max_failed_checks_);
+        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)", ic_identity,
+                 this->health_check_failures_ + 1, this->max_failed_checks_);
         this->health_check_failures_++;
         if (this->status_binary_sensor_ != nullptr)
           this->status_binary_sensor_->publish_state(false);
@@ -159,7 +155,7 @@ void ST25R::update() {
   this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch to initial state per datasheet
 
   if (this->rf_field_enabled_) {
-    this->write_register(OP_CONTROL, 0xC8); // en=1, rx_en=1, tx_en=1
+    this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
   }
 
   if (this->rf_field_enabled_ && this->field_strength_sensor_ != nullptr) {
@@ -205,7 +201,8 @@ bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, u
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
-bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
+bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                          uint32_t timeout_ms) {
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch per datasheet transceive sequence
   // Clear ALL IRQ registers so IRQ pin goes low — required for ISR rising-edge to fire
@@ -217,7 +214,7 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
   if (with_crc) {
     this->write_register(NUM_TX_BYTES2, (len & 0x1F) << 3);
   } else {
-    this->write_register(NUM_TX_BYTES2, 0x00); // Whole bytes
+    this->write_register(NUM_TX_BYTES2, 0x00);  // Whole bytes
   }
 
   this->write_fifo(data, len);
@@ -246,12 +243,13 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
     }
     this->irq_status_ = irq;
 
-    if (irq & IRQ_TXE) tx_done = true;
+    if (irq & IRQ_TXE)
+      tx_done = true;
 
     if (tx_done) {
       uint8_t f1 = this->read_register(FIFO_STATUS1);
       if (f1 > 0) {
-        uint8_t to_read = std::min((uint8_t)(64 - resp_len), f1);
+        uint8_t to_read = std::min((uint8_t) (64 - resp_len), f1);
         this->read_fifo(resp + resp_len, to_read);
         resp_len += to_read;
         start = millis();
@@ -270,19 +268,16 @@ bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_
 // data/parity: len plaintext bytes + precomputed parity bits.
 // resp/resp_parity: decoded response bytes and their parity bits.
 // Adapted from mf1_send_receive_raw (MIT, suut/rfal-mifare-classic).
-bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
-                                uint8_t len,
-                                uint8_t *resp, uint8_t *resp_parity,
-                                uint8_t &resp_len,
-                                uint32_t timeout_ms) {
+bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len, uint8_t *resp,
+                               uint8_t *resp_parity, uint8_t &resp_len, uint32_t timeout_ms) {
   // Max encoded size: ceil(9*64/8) = 72 bytes
   uint8_t encoded[72];
   uint16_t tx_bits = 0;
   mifare_pack_parity(data, parity, encoded, len, &tx_bits);
 
-  uint8_t ntx_n   = (uint8_t)(tx_bits >> 3);
-  uint8_t ntx_b   = (uint8_t)(tx_bits & 7);
-  uint8_t fifo_bytes = (uint8_t)((tx_bits + 7) / 8);
+  uint8_t ntx_n = (uint8_t) (tx_bits >> 3);
+  uint8_t ntx_b = (uint8_t) (tx_bits & 7);
+  uint8_t fifo_bytes = (uint8_t) ((tx_bits + 7) / 8);
 
   // Set manual parity mode: no_tx_par (bit6) + no_rx_par (bit7)
   this->write_register(ISO14443A_CONF, 0xC0);
@@ -294,7 +289,7 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
   this->irq_triggered_ = false;
 
   this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
-  this->write_register(NUM_TX_BYTES2, (uint8_t)(((ntx_n & 0x1F) << 3) | (ntx_b & 7)));
+  this->write_register(NUM_TX_BYTES2, (uint8_t) (((ntx_n & 0x1F) << 3) | (ntx_b & 7)));
   this->write_fifo(encoded, fifo_bytes);
   this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
 
@@ -304,7 +299,8 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
   bool tx_done = false;
   while (millis() - start < timeout_ms) {
     uint8_t irq = this->read_register(IRQ_MAIN);
-    if (irq & IRQ_TXE) tx_done = true;
+    if (irq & IRQ_TXE)
+      tx_done = true;
     if (tx_done) {
       uint8_t f1 = this->read_register(FIFO_STATUS1);
       if (irq & IRQ_RXE) {
@@ -317,7 +313,7 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
         // We need to know how many bits arrived; use FIFO_STATUS2 fifo_lb
         uint8_t fs2 = this->read_register(FIFO_STATUS2);
         uint8_t last_bits = (fs2 >> 1) & 0x07;  // fifo_lb: bits in last octet (0 = full byte)
-        uint16_t rx_bits = (uint16_t)(rx_bytes * 8) - (last_bits ? (uint8_t)(8 - last_bits) : 0);
+        uint16_t rx_bits = (uint16_t) (rx_bytes * 8) - (last_bits ? (uint8_t) (8 - last_bits) : 0);
 
         resp_len = mifare_unpack_parity(rx_fifo, resp, resp_parity, rx_bits);
 
@@ -335,11 +331,10 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
 // ── mifare_authenticate_ ─────────────────────────────────────────────────────
 // Three-pass mutual authentication per ISO 14443-3 / NXP AN10609.
 // Protocol flow from mf1_authenticate() (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
-                                  const uint8_t *uid, uint8_t uid_len,
-                                  struct Crypto1State *cs) {
+bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key, const uint8_t *uid, uint8_t uid_len,
+                                 struct Crypto1State *cs) {
   // ── Step 1: send AUTHENT command (plain text, with CRC) ──────────────────
-  uint8_t auth_cmd[2] = {(uint8_t)(key_b ? 0x61 : 0x60), block};
+  uint8_t auth_cmd[2] = {(uint8_t) (key_b ? 0x61 : 0x60), block};
   uint8_t nt_raw[4] = {};
   uint8_t nt_len = 0;
   if (!this->transceive_(auth_cmd, 2, nt_raw, nt_len, 20) || nt_len < 4) {
@@ -348,13 +343,11 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
   }
 
   // ── Step 2: Crypto1 challenge-response ───────────────────────────────────
-  uint8_t uid_offset = (uid_len > 4) ? (uint8_t)(uid_len - 4) : 0;
-  uint32_t uid_u32 = ((uint32_t) uid[uid_offset]     << 24) |
-                     ((uint32_t) uid[uid_offset + 1] << 16) |
-                     ((uint32_t) uid[uid_offset + 2] <<  8) |
-                      (uint32_t) uid[uid_offset + 3];
-  uint32_t nt = ((uint32_t) nt_raw[0] << 24) | ((uint32_t) nt_raw[1] << 16) |
-                ((uint32_t) nt_raw[2] <<  8) |  (uint32_t) nt_raw[3];
+  uint8_t uid_offset = (uid_len > 4) ? (uint8_t) (uid_len - 4) : 0;
+  uint32_t uid_u32 = ((uint32_t) uid[uid_offset] << 24) | ((uint32_t) uid[uid_offset + 1] << 16) |
+                     ((uint32_t) uid[uid_offset + 2] << 8) | (uint32_t) uid[uid_offset + 3];
+  uint32_t nt =
+      ((uint32_t) nt_raw[0] << 24) | ((uint32_t) nt_raw[1] << 16) | ((uint32_t) nt_raw[2] << 8) | (uint32_t) nt_raw[3];
   ESP_LOGD(TAG, "Mifare auth: NT=%08X UID=%08X", nt, uid_u32);
 
   crypto1_init(cs, key);
@@ -366,15 +359,15 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
 
   // Encrypt NR: feed plaintext NR into LFSR (is_encrypted=0), advance parity bit with crypto1_bit
   for (int i = 0; i < 4; i++) {
-    nr_ar[i]     = crypto1_byte(cs, nr[i], 0) ^ nr[i];
+    nr_ar[i] = crypto1_byte(cs, nr[i], 0) ^ nr[i];
     nr_ar_par[i] = crypto1_bit(cs, 0, 0) ^ ODD_PARITY[nr[i]];
   }
 
   // AR = 4 bytes of prng_successor(NT, 64) MSB-first
   uint32_t ar_plain = prng_successor(nt, 64);
   for (int i = 0; i < 4; i++) {
-    uint8_t b = (uint8_t)((ar_plain >> (24 - 8 * i)) & 0xFF);
-    nr_ar[4 + i]     = crypto1_byte(cs, 0, 0) ^ b;
+    uint8_t b = (uint8_t) ((ar_plain >> (24 - 8 * i)) & 0xFF);
+    nr_ar[4 + i] = crypto1_byte(cs, 0, 0) ^ b;
     nr_ar_par[4 + i] = crypto1_bit(cs, 0, 0) ^ ODD_PARITY[b];
   }
 
@@ -388,8 +381,7 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
 
   // ── Step 4: verify tag answer ─────────────────────────────────────────────
   uint32_t at_expected = prng_successor(ar_plain, 32) ^ crypto1_word(cs, 0, 0);
-  uint32_t at_got = ((uint32_t) at[0] << 24) | ((uint32_t) at[1] << 16) |
-                    ((uint32_t) at[2] <<  8) |  (uint32_t) at[3];
+  uint32_t at_got = ((uint32_t) at[0] << 24) | ((uint32_t) at[1] << 16) | ((uint32_t) at[2] << 8) | (uint32_t) at[3];
   if (at_got != at_expected) {
     ESP_LOGW(TAG, "Mifare auth: AT mismatch (got %08" PRIx32 " expected %08" PRIx32 ")", at_got, at_expected);
     return false;
@@ -402,20 +394,19 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
 // ── mifare_read_block_ ───────────────────────────────────────────────────────
 // Read one 16-byte block after a successful mifare_authenticate_().
 // Protocol flow from mf1_send_receive_encrypted (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
-                                struct Crypto1State *cs) {
+bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs) {
   // Build: READ(0x30) + block + CRC_A — then encrypt all 4 bytes + CRC
   uint8_t cmd[4];
   cmd[0] = 0x30;
   cmd[1] = block;
   uint16_t crc = mifare_crc_a(cmd, 2);
-  cmd[2] = (uint8_t)(crc & 0xFF);
-  cmd[3] = (uint8_t)(crc >> 8);
+  cmd[2] = (uint8_t) (crc & 0xFF);
+  cmd[3] = (uint8_t) (crc >> 8);
 
   uint8_t enc[4], enc_par[4];
   for (int i = 0; i < 4; i++) {
-    enc[i]     = crypto1_byte(cs, 0, 0) ^ cmd[i];
-    enc_par[i] = (uint8_t)(crypto1_bit(cs, 0, 0) ^ ODD_PARITY[cmd[i]]);
+    enc[i] = crypto1_byte(cs, 0, 0) ^ cmd[i];
+    enc_par[i] = (uint8_t) (crypto1_bit(cs, 0, 0) ^ ODD_PARITY[cmd[i]]);
   }
 
   // Response: 16 data bytes + 2 CRC bytes = 18 bytes, all encrypted
@@ -430,7 +421,7 @@ bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
   uint8_t plain[18];
   for (int i = 0; i < 18; i++) {
     plain[i] = crypto1_byte(cs, 0, 0) ^ rx_enc[i];
-    uint8_t exp_par = (uint8_t)(crypto1_bit(cs, 0, 0) ^ ODD_PARITY[plain[i]]);
+    uint8_t exp_par = (uint8_t) (crypto1_bit(cs, 0, 0) ^ ODD_PARITY[plain[i]]);
     if (rx_par[i] != exp_par) {
       ESP_LOGW(TAG, "Mifare read block %u: parity error at octet %d", block, i);
       return false;
@@ -459,8 +450,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
   if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
     ESP_LOGI(TAG, "Mifare Classic detected - attempting authentication");
     struct Crypto1State cs = {};
-    bool auth_ok = this->mifare_authenticate_(0, false, this->mifare_key_a_,
-                                              uid.data(), (uint8_t) uid.size(), &cs);
+    bool auth_ok = this->mifare_authenticate_(0, false, this->mifare_key_a_, uid.data(), (uint8_t) uid.size(), &cs);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     if (!auth_ok) {
       ESP_LOGW(TAG, "Mifare Classic: sector 0 auth failed (wrong key or clone card)");
@@ -478,26 +468,30 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
       return make_unique<nfc::NfcTag>(nfc_uid, nfc::MIFARE_CLASSIC);
     }
 
-    ESP_LOGI(TAG, "Block 1: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-             block1[0],block1[1],block1[2],block1[3],block1[4],block1[5],block1[6],block1[7],
-             block1[8],block1[9],block1[10],block1[11],block1[12],block1[13],block1[14],block1[15]);
-    ESP_LOGI(TAG, "Block 2: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X",
-             block2[0],block2[1],block2[2],block2[3],block2[4],block2[5],block2[6],block2[7],
-             block2[8],block2[9],block2[10],block2[11],block2[12],block2[13],block2[14],block2[15]);
+    ESP_LOGI(TAG, "Block 1: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", block1[0], block1[1],
+             block1[2], block1[3], block1[4], block1[5], block1[6], block1[7], block1[8], block1[9], block1[10],
+             block1[11], block1[12], block1[13], block1[14], block1[15]);
+    ESP_LOGI(TAG, "Block 2: %02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X", block2[0], block2[1],
+             block2[2], block2[3], block2[4], block2[5], block2[6], block2[7], block2[8], block2[9], block2[10],
+             block2[11], block2[12], block2[13], block2[14], block2[15]);
 
     // Look for NFC Forum Type 2 NDEF TLV (0x03) in the data area
     // On Mifare Classic the NDEF data starts at block 1 octet 0 when
     // the card is formatted as NFC Forum Type 2 / Mifare Classic NDEF.
     std::vector<uint8_t> raw;
     raw.insert(raw.end(), block1, block1 + 16);
-    if (b2) raw.insert(raw.end(), block2, block2 + 16);
+    if (b2)
+      raw.insert(raw.end(), block2, block2 + 16);
 
     size_t idx = 0;
     while (idx < raw.size()) {
       uint8_t tlv = raw[idx++];
-      if (tlv == 0xFE) break;      // terminator
-      if (tlv == 0x00) continue;   // null
-      if (idx >= raw.size()) break;
+      if (tlv == 0xFE)
+        break;  // terminator
+      if (tlv == 0x00)
+        continue;  // null
+      if (idx >= raw.size())
+        break;
       uint8_t tlen = raw[idx++];
       if (tlv == 0x03 && tlen > 0 && (idx + tlen) <= raw.size()) {
         std::vector<uint8_t> ndef_data(raw.begin() + (int) idx, raw.begin() + (int) idx + tlen);
@@ -519,7 +513,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
     uint8_t read_cmd[2] = {0x30, 0x00};
     if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
       ESP_LOGD(TAG, "  Read page 0-3 success");
-      data.insert(data.end(), buffer, buffer + 16); // Only keep data, skip CRC
+      data.insert(data.end(), buffer, buffer + 16);  // Only keep data, skip CRC
 
       size_t tlv_index = 0;
       bool found = false;
@@ -558,7 +552,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
               }
             }
           }
-          if (found || terminator_found) break;
+          if (found || terminator_found)
+            break;
         }
       }
 
@@ -566,9 +561,10 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
         // Ensure we have enough bytes to read the full TLV length field
         // (3-byte length needs tlv_index + 3 to be valid)
         while (data.size() <= tlv_index + 3) {
-          read_cmd[1] = (uint8_t)(data.size() / 4);
+          read_cmd[1] = (uint8_t) (data.size() / 4);
           delay(10);
-          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16)
+            break;
           data.insert(data.end(), buffer, buffer + 16);
         }
 
@@ -586,7 +582,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
           ESP_LOGD(TAG, "  NDEF message length: %zu", msg_len);
 
           while (data.size() < msg_start_idx + msg_len) {
-            uint8_t next_page = (uint8_t)(data.size() / 4);
+            uint8_t next_page = (uint8_t) (data.size() / 4);
             read_cmd[1] = next_page;
             delay(10);
             if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) {
@@ -621,7 +617,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
 }
 
 void ST25R::loop() {
-  if (this->is_failed()) return;
+  if (this->is_failed())
+    return;
 
   if (this->irq_triggered_) {
     this->irq_triggered_ = false;
@@ -647,40 +644,40 @@ void ST25R::process_state() {
 
     case STATE_WUPA: {
       if (this->irq_status_ & (IRQ_RXE | IRQ_COL)) {
-          this->cascade_level_ = 0;
-          this->current_uid_ = "";
-          if (!this->anticol_resume_) {
-            // Fresh scan: start anticol from beginning
-            this->anticol_prefix_full_ = 0;
-            this->anticol_prefix_bits_ = 0;
-            this->anticol_col_pos_ = 0;
-            this->anticol_prefix_val_ = 0;
-          }
-          // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
-          this->anticol_resume_ = false;
+        this->cascade_level_ = 0;
+        this->current_uid_ = "";
+        if (!this->anticol_resume_) {
+          // Fresh scan: start anticol from beginning
+          this->anticol_prefix_full_ = 0;
+          this->anticol_prefix_bits_ = 0;
+          this->anticol_col_pos_ = 0;
+          this->anticol_prefix_val_ = 0;
+        }
+        // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
+        this->anticol_resume_ = false;
 
-          this->send_anticol_frame();
-          this->state_ = STATE_ANTICOL;
-          this->last_state_change_ = millis();
+        this->send_anticol_frame();
+        this->state_ = STATE_ANTICOL;
+        this->last_state_change_ = millis();
       } else if (this->irq_status_ & IRQ_NRE) {
-          // NRT expired: no tag response — fast path to idle (set by derived class read_chip_irq_())
-          ESP_LOGD(TAG, "WUPA NRE (no tag): IRQ=0x%02X", this->irq_status_);
-          this->irq_status_ = 0;
-          this->state_ = STATE_IDLE;
-          this->finalize_scan_();
+        // NRT expired: no tag response — fast path to idle (set by derived class read_chip_irq_())
+        ESP_LOGD(TAG, "WUPA NRE (no tag): IRQ=0x%02X", this->irq_status_);
+        this->irq_status_ = 0;
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
       } else if (millis() - this->last_state_change_ > 100) {
-          // No tag responded and NRE fast-path didn't fire (real ST25R3916:
-          // NRE is in IRQ_TIMER, not IRQ_MAIN).  Read ALL IRQ registers so the
-          // IRQ pin goes LOW before the next scan — otherwise the pin stays HIGH
-          // from the pending NRE and the ISR rising-edge never fires again.
-          uint8_t irq_t = this->read_register(IRQ_TIMER);
-          uint8_t irq_e = this->read_register(IRQ_ERROR);
-          ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u",
-                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1());
-          this->irq_status_ = 0;
-          this->irq_triggered_ = false;
-          this->state_ = STATE_IDLE;
-          this->finalize_scan_();
+        // No tag responded and NRE fast-path didn't fire (real ST25R3916:
+        // NRE is in IRQ_TIMER, not IRQ_MAIN).  Read ALL IRQ registers so the
+        // IRQ pin goes LOW before the next scan — otherwise the pin stays HIGH
+        // from the pending NRE and the ISR rising-edge never fires again.
+        uint8_t irq_t = this->read_register(IRQ_TIMER);
+        uint8_t irq_e = this->read_register(IRQ_ERROR);
+        ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u", this->irq_status_, irq_t, irq_e,
+                 this->read_fifo_status1());
+        this->irq_status_ = 0;
+        this->irq_triggered_ = false;
+        this->state_ = STATE_IDLE;
+        this->finalize_scan_();
       }
       break;
     }
@@ -712,12 +709,16 @@ void ST25R::process_state() {
         if (has_collision) {
           uint8_t col_raw = this->read_collision_display();
           uint8_t c_byte = (col_raw >> 4) & 0x0F;
-          uint8_t c_bit  = (col_raw >> 1) & 0x07;
+          uint8_t c_bit = (col_raw >> 1) & 0x07;
           // col_pos_abs is from start of TX frame (SEL + NVB = 2 bytes = 16 bits)
-          int uid_col_pos = (int)(c_byte * 8 + c_bit) - 16;
-          if (uid_col_pos < 0) uid_col_pos = 0;
+          int uid_col_pos = (int) (c_byte * 8 + c_bit) - 16;
+          if (uid_col_pos < 0)
+            uid_col_pos = 0;
           // Drain any garbage FIFO bytes
-          if (f1 > 0) { uint8_t tmp[8]; this->read_fifo(tmp, std::min(f1, (uint8_t)8)); }
+          if (f1 > 0) {
+            uint8_t tmp[8];
+            this->read_fifo(tmp, std::min(f1, (uint8_t) 8));
+          }
 
           // FIFO bytes during collision are unreliable — brute-force all 2^(col_pos+1) prefixes
           this->anticol_col_pos_ = uid_col_pos;
@@ -741,20 +742,21 @@ void ST25R::process_state() {
             full_uid[k] = this->anticol_prefix_[k];
           }
           if (this->anticol_prefix_bits_ > 0) {
-            uint8_t mask = (uint8_t)((1 << this->anticol_prefix_bits_) - 1);
-            full_uid[this->anticol_prefix_full_] =
-                (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
-                (resp[this->anticol_prefix_full_] & (uint8_t)(~mask));
+            uint8_t mask = (uint8_t) ((1 << this->anticol_prefix_bits_) - 1);
+            full_uid[this->anticol_prefix_full_] = (this->anticol_prefix_[this->anticol_prefix_full_] & mask) |
+                                                   (resp[this->anticol_prefix_full_] & (uint8_t) (~mask));
           }
           uint8_t bcc = full_uid[0] ^ full_uid[1] ^ full_uid[2] ^ full_uid[3];
 
           uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
-          uint8_t sel_pk[7] = {sel_cmds[this->cascade_level_], 0x70,
-                               full_uid[0], full_uid[1], full_uid[2], full_uid[3], bcc};
+          uint8_t sel_pk[7] = {
+              sel_cmds[this->cascade_level_], 0x70, full_uid[0], full_uid[1], full_uid[2], full_uid[3], bcc};
 
           if (full_uid[0] == 0x88) {
             for (int i = 1; i < 4; i++) {
-              char buf[3]; snprintf(buf, sizeof(buf), "%02X", full_uid[i]); this->current_uid_ += buf;
+              char buf[3];
+              snprintf(buf, sizeof(buf), "%02X", full_uid[i]);
+              this->current_uid_ += buf;
             }
           } else {
             for (unsigned char i : full_uid) {
@@ -923,7 +925,8 @@ void ST25R::finalize_scan_() {
   // Fire on_tag for newly seen UIDs
   for (const auto &uid : this->tags_this_scan_) {
     if (!this->present_tags_.count(uid)) {
-      ESP_LOGD(TAG, "finalize_scan_: NEW tag %s, firing %zu on_tag triggers", uid.c_str(), this->on_tag_triggers_.size());
+      ESP_LOGD(TAG, "finalize_scan_: NEW tag %s, firing %zu on_tag triggers", uid.c_str(),
+               this->on_tag_triggers_.size());
       this->present_tags_[uid] = 0;
       for (auto *trigger : this->on_tag_triggers_) {
         trigger->trigger(uid);
@@ -952,7 +955,7 @@ bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
   uint32_t start = millis();
   while (millis() - start < timeout_ms) {
     if (this->irq_triggered_) {
-       return true;
+      return true;
     }
     delay(1);
   }
@@ -984,33 +987,31 @@ bool ST25R::reset_chip() {
 
   // RFAL sequence: oscillator on → measure VDD → configure registers
   ESP_LOGV(TAG, "  reset_: Enabling oscillator");
-  this->write_register(OP_CONTROL, 0x80); // en=1: enable oscillator and regulators
-  delay(10); // Wait for oscillator to stabilize (~700µs typical)
+  this->write_register(OP_CONTROL, 0x80);  // en=1: enable oscillator and regulators
+  delay(10);                               // Wait for oscillator to stabilize (~700µs typical)
 
   // Measure VDD and auto-detect supply voltage (RFAL: st25r3916MeasureVoltage)
   // REGULATOR_CONTROL mpsv bits[2:0] select measurement source; 0 = VDD
   uint8_t reg_ctrl = this->read_register(REGULATOR_CONTROL);
-  this->write_register(REGULATOR_CONTROL, (reg_ctrl & ~0x07) | 0x00); // mpsv=VDD
-  this->write_command(ST25R_CMD_MEASURE_VDD);  // 0xDF
+  this->write_register(REGULATOR_CONTROL, (reg_ctrl & ~0x07) | 0x00);  // mpsv=VDD
+  this->write_command(ST25R_CMD_MEASURE_VDD);                          // 0xDF
   delay(5);
   uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
   bool sup3v;
   if (vdd_raw == 0) {
     // Measurement failed (raw=0 indicates no valid reading) — fall back to config
     sup3v = this->supply_3v3_;
-    ESP_LOGW(TAG, "  reset_: VDD measurement failed (raw=0x00), using supply_3v3=%s",
-             sup3v ? "3.3V" : "5V");
+    ESP_LOGW(TAG, "  reset_: VDD measurement failed (raw=0x00), using supply_3v3=%s", sup3v ? "3.3V" : "5V");
   } else {
-    uint16_t vdd_mv = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
+    uint16_t vdd_mv = (uint16_t) vdd_raw * 23U + (((uint16_t) vdd_raw * 4U + 5U) / 10U);
     sup3v = (vdd_mv < 3600);
-    ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s",
-             vdd_mv, vdd_raw, sup3v ? "3.3V" : "5V");
+    ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s", vdd_mv, vdd_raw, sup3v ? "3.3V" : "5V");
   }
 
   ESP_LOGV(TAG, "  reset_: Configuring registers");
-  this->write_register(IO_CONF1, 0x07);  // Disable MCU_CLK + LF clock (RFAL default)
+  this->write_register(IO_CONF1, 0x07);    // Disable MCU_CLK + LF clock (RFAL default)
   uint8_t io_conf2 = sup3v ? 0x80 : 0x00;  // sup3V based on measured VDD
-  io_conf2 |= 0x18;  // SPI pull-downs (miso_pd1 | miso_pd2)
+  io_conf2 |= 0x18;                        // SPI pull-downs (miso_pd1 | miso_pd2)
   if (this->has_aat_)
     io_conf2 |= 0x20;  // aat_en: enable AAT module so ANT_TUNE_A/B drive varicaps
   this->write_register(IO_CONF2, io_conf2);
@@ -1033,18 +1034,17 @@ bool ST25R::reset_chip() {
   if (this->has_aat_) {
     this->write_register(ANT_TUNE_A, this->ant_tune_a_);
     this->write_register(ANT_TUNE_B, this->ant_tune_b_);
-    ESP_LOGI(TAG, "  reset_: ANT_TUNE_A=0x%02X ANT_TUNE_B=0x%02X",
-             this->ant_tune_a_, this->ant_tune_b_);
+    ESP_LOGI(TAG, "  reset_: ANT_TUNE_A=0x%02X ANT_TUNE_B=0x%02X", this->ant_tune_a_, this->ant_tune_b_);
   }
 
   // RFAL chip-init registers
-  this->write_register(AUX_MOD, 0x10);           // lm_ext=0, lm_dri=1 (external load mod)
-  this->write_register(RES_AM_MOD, 0x80);        // Minimum non-overlap
-  this->write_register(FIELD_THRESHOLD_ACTV, 0x11);   // trg=105mV, rfe=105mV
-  this->write_register(FIELD_THRESHOLD_DEACTV, 0x00); // trg=75mV, rfe=75mV
-  this->write_register(PASSIVE_TARGET, 0x50);    // fdel=5 (FDT aligned to bitgrid)
-  this->write_register(PT_MOD, 0x51);            // Reduce RFO resistance in modulated state
-  this->write_register(EMD_SUP_CONF, 0x40);      // rx_start_emv: start RX on first 4 bits
+  this->write_register(AUX_MOD, 0x10);                 // lm_ext=0, lm_dri=1 (external load mod)
+  this->write_register(RES_AM_MOD, 0x80);              // Minimum non-overlap
+  this->write_register(FIELD_THRESHOLD_ACTV, 0x11);    // trg=105mV, rfe=105mV
+  this->write_register(FIELD_THRESHOLD_DEACTV, 0x00);  // trg=75mV, rfe=75mV
+  this->write_register(PASSIVE_TARGET, 0x50);          // fdel=5 (FDT aligned to bitgrid)
+  this->write_register(PT_MOD, 0x51);                  // Reduce RFO resistance in modulated state
+  this->write_register(EMD_SUP_CONF, 0x40);            // rx_start_emv: start RX on first 4 bits
 
   // RFAL NFC-A 106 TX: overshoot/undershoot protection
   this->write_register(OVERSHOOT_CONF1, 0x40);
@@ -1110,7 +1110,7 @@ void ST25R::apply_anticol_prefix_() {
   memset(this->anticol_prefix_, 0, sizeof(this->anticol_prefix_));
   for (int i = 0; i < total_bits; i++) {
     int byte_idx = i >> 3;
-    int bit_idx  = i & 7;
+    int bit_idx = i & 7;
     if ((this->anticol_prefix_val_ >> i) & 1)
       this->anticol_prefix_[byte_idx] |= (1 << bit_idx);
   }
@@ -1142,15 +1142,14 @@ void ST25R::send_anticol_frame() {
 
   this->write_register(ISO14443A_CONF, 0x01);  // antcl=1
   this->write_command(ST25R_CMD_CLEAR_FIFO);
-  this->read_register(IRQ_MAIN);    // clear all IRQ registers so IRQ pin goes low
-  this->read_register(IRQ_TIMER);   // IRQ pin stays high until ALL pending bits are cleared
+  this->read_register(IRQ_MAIN);   // clear all IRQ registers so IRQ pin goes low
+  this->read_register(IRQ_TIMER);  // IRQ pin stays high until ALL pending bits are cleared
   this->read_register(IRQ_ERROR);
   this->irq_triggered_ = false;
   this->write_fifo(frame, frame_len);
   this->write_register(NUM_TX_BYTES1, ntx_n >> 5);
   this->write_register(NUM_TX_BYTES2, ((ntx_n & 0x1F) << 3) | (ntx_b & 0x07));
   this->write_command(ST25R_CMD_TRANSMIT_WITHOUT_CRC);
-
 }
 
 // ── Default virtual helpers (ST25R3916 implementations) ──────────────────────
@@ -1160,13 +1159,9 @@ void ST25R::pre_select() {
   this->write_register(ISO14443A_CONF, 0x00);
 }
 
-uint8_t ST25R::read_fifo_status1() {
-  return this->read_register(FIFO_STATUS1);
-}
+uint8_t ST25R::read_fifo_status1() { return this->read_register(FIFO_STATUS1); }
 
-uint8_t ST25R::read_collision_display() {
-  return this->read_register(COLLISION_DISPLAY);
-}
+uint8_t ST25R::read_collision_display() { return this->read_register(COLLISION_DISPLAY); }
 
 void ST25R::send_halt() {
   // HALT: send [0x50, 0x00] + CRC; tag has no response.
@@ -1195,11 +1190,11 @@ void ST25R::start_wupa() {
 }
 
 void ST25R::field_on_() {
-  this->write_register(OP_CONTROL, 0x88); // en=1, tx_en=1
+  this->write_register(OP_CONTROL, 0x88);  // en=1, tx_en=1
   delay(10);
   this->write_command(ST25R_CMD_FIELD_ON);
   delay(10);
-  this->write_register(OP_CONTROL, 0xC8); // en=1, rx_en=1, tx_en=1
+  this->write_register(OP_CONTROL, 0xC8);  // en=1, rx_en=1, tx_en=1
   this->write_command(ST25R_CMD_ADJUST_REGULATORS);
 }
 
@@ -1209,7 +1204,8 @@ void ST25R::field_on_() {
 // during reset_chip() on chips with AAT hardware (ST25R3916/3916B).
 
 void ST25R::aat_tune_() {
-  if (!this->has_aat_) return;
+  if (!this->has_aat_)
+    return;
 
   uint8_t a = this->ant_tune_a_;
   uint8_t b = this->ant_tune_b_;
@@ -1236,26 +1232,27 @@ void ST25R::aat_tune_() {
     bool improved = false;
 
     // Try 4 directions: A±step, B±step
-    struct Dir { int da; int db; };
-    Dir dirs[] = {
-      {step_a, 0}, {-step_a, 0},
-      {0, step_b}, {0, -step_b}
+    struct Dir {
+      int da;
+      int db;
     };
+    Dir dirs[] = {{step_a, 0}, {-step_a, 0}, {0, step_b}, {0, -step_b}};
 
     for (auto &d : dirs) {
-      int16_t new_a = (int16_t)a + d.da;
-      int16_t new_b = (int16_t)b + d.db;
-      if (new_a < 0 || new_a > 255 || new_b < 0 || new_b > 255) continue;
+      int16_t new_a = (int16_t) a + d.da;
+      int16_t new_b = (int16_t) b + d.db;
+      if (new_a < 0 || new_a > 255 || new_b < 0 || new_b > 255)
+        continue;
 
-      this->write_register(ANT_TUNE_A, (uint8_t)new_a);
-      this->write_register(ANT_TUNE_B, (uint8_t)new_b);
+      this->write_register(ANT_TUNE_A, (uint8_t) new_a);
+      this->write_register(ANT_TUNE_B, (uint8_t) new_b);
       delay(3);
       uint8_t amp = measure();
 
       if (amp > best_amp) {
         best_amp = amp;
-        best_a = (uint8_t)new_a;
-        best_b = (uint8_t)new_b;
+        best_a = (uint8_t) new_a;
+        best_b = (uint8_t) new_b;
         improved = true;
       }
     }
@@ -1269,7 +1266,8 @@ void ST25R::aat_tune_() {
       // No improvement — reduce step size
       step_a = (step_a > 1) ? step_a / 2 : 0;
       step_b = (step_b > 1) ? step_b / 2 : 0;
-      if (step_a == 0 && step_b == 0) break;  // Converged
+      if (step_a == 0 && step_b == 0)
+        break;  // Converged
     }
   }
 
@@ -1314,19 +1312,19 @@ bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
       uint8_t pps_dsi = 0;
       uint8_t pps_dri = 0;
       if (ta & 0x40) {
-        pps_dsi = 2;       // 424 kbps PCD→PICC
+        pps_dsi = 2;  // 424 kbps PCD→PICC
       } else if (ta & 0x20) {
-        pps_dsi = 1;       // 212 kbps
+        pps_dsi = 1;  // 212 kbps
       }
       if (ta & 0x04) {
-        pps_dri = 2;       // 424 kbps PICC→PCD
+        pps_dri = 2;  // 424 kbps PICC→PCD
       } else if (ta & 0x02) {
-        pps_dri = 1;       // 212 kbps
+        pps_dri = 1;  // 212 kbps
       }
 
       if (pps_dsi > 0 || pps_dri > 0) {
         // PPS: PPSS(0xD0|CID) + PPS0(0x11) + PPS1(DSI<<2|DRI)
-        uint8_t pps[] = {0xD0, 0x11, (uint8_t)((pps_dsi << 2) | pps_dri)};
+        uint8_t pps[] = {0xD0, 0x11, (uint8_t) ((pps_dsi << 2) | pps_dri)};
         uint8_t pps_resp[4];
         uint8_t pps_len = 0;
         if (this->transceive_(pps, sizeof(pps), pps_resp, pps_len) && pps_len >= 1 && (pps_resp[0] & 0xF0) == 0xD0) {
@@ -1345,7 +1343,8 @@ bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
 bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
   // Wrap APDU in I-Block: [PCB][APDU...]
   uint8_t frame[64];
-  if (apdu_len + 1 > sizeof(frame)) return false;
+  if (apdu_len + 1 > sizeof(frame))
+    return false;
 
   // PCB: I-Block, no chaining, no DID/NAD, must-be-1 bit, block number
   frame[0] = 0x02 | (this->isodep_block_number_ & 0x01);
@@ -1388,13 +1387,13 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
 
   // Step 1: SELECT NDEF Application (AID = D276000085010100 for v2, try v1 as fallback)
   uint8_t select_app[] = {0x00, 0xA4, 0x04, 0x00, 0x07, 0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01, 0x00};
-  if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
-      resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
+  if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) || resp_len < 2 ||
+      resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
     // Try v1 AID
     select_app[11] = 0x00;  // D276000085010100 → D276000085010000
     resp_len = 0;
-    if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
-        resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
+    if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) || resp_len < 2 ||
+        resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
       ESP_LOGD(TAG, "T4T: SELECT NDEF app failed");
       nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
       return make_unique<nfc::NfcTag>(nfc_uid);
@@ -1404,8 +1403,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 2: SELECT CC File (0xE103)
   uint8_t select_cc[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, 0xE1, 0x03};
   resp_len = 0;
-  if (!this->isodep_transceive_(select_cc, sizeof(select_cc), resp, resp_len) ||
-      resp_len < 2 || resp[resp_len - 2] != 0x90) {
+  if (!this->isodep_transceive_(select_cc, sizeof(select_cc), resp, resp_len) || resp_len < 2 ||
+      resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT CC failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
@@ -1414,8 +1413,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 3: READ BINARY CC (15 bytes)
   uint8_t read_cc[] = {0x00, 0xB0, 0x00, 0x00, 0x0F};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_cc, sizeof(read_cc), resp, resp_len) ||
-      resp_len < 17) {  // 15 data + SW1 SW2
+  if (!this->isodep_transceive_(read_cc, sizeof(read_cc), resp, resp_len) || resp_len < 17) {  // 15 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ CC failed (resp_len=%u)", resp_len);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
@@ -1423,15 +1421,16 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
 
   // Parse CC: resp[0..1]=CCLEN, [2]=ver, [3]=MLe, [4]=MLc, [5..6]=TLV header,
   // [7..8]=TLV type+len, [9..10]=NDEF file ID, [11..12]=max NDEF size
-  uint16_t ndef_file_id = ((uint16_t)resp[9] << 8) | resp[10];
-  uint16_t max_ndef_size = ((uint16_t)resp[11] << 8) | resp[12];
+  uint16_t ndef_file_id = ((uint16_t) resp[9] << 8) | resp[10];
+  uint16_t max_ndef_size = ((uint16_t) resp[11] << 8) | resp[12];
   ESP_LOGD(TAG, "T4T CC: NDEF file=0x%04X, max_size=%u", ndef_file_id, max_ndef_size);
 
   // Step 4: SELECT NDEF File
-  uint8_t select_ndef[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, (uint8_t)(ndef_file_id >> 8), (uint8_t)(ndef_file_id & 0xFF)};
+  uint8_t select_ndef[] = {
+      0x00, 0xA4, 0x00, 0x0C, 0x02, (uint8_t) (ndef_file_id >> 8), (uint8_t) (ndef_file_id & 0xFF)};
   resp_len = 0;
-  if (!this->isodep_transceive_(select_ndef, sizeof(select_ndef), resp, resp_len) ||
-      resp_len < 2 || resp[resp_len - 2] != 0x90) {
+  if (!this->isodep_transceive_(select_ndef, sizeof(select_ndef), resp, resp_len) || resp_len < 2 ||
+      resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT NDEF file failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
@@ -1440,14 +1439,13 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 5: READ NDEF Length (first 2 bytes)
   uint8_t read_nlen[] = {0x00, 0xB0, 0x00, 0x00, 0x02};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_nlen, sizeof(read_nlen), resp, resp_len) ||
-      resp_len < 4) {  // 2 data + SW1 SW2
+  if (!this->isodep_transceive_(read_nlen, sizeof(read_nlen), resp, resp_len) || resp_len < 4) {  // 2 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ NLEN failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
   }
 
-  uint16_t ndef_len = ((uint16_t)resp[0] << 8) | resp[1];
+  uint16_t ndef_len = ((uint16_t) resp[0] << 8) | resp[1];
   if (ndef_len == 0 || ndef_len > 255) {
     ESP_LOGD(TAG, "T4T: NDEF length %u (skipping read)", ndef_len);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1455,10 +1453,9 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   }
 
   // Step 6: READ NDEF Data
-  uint8_t read_ndef[] = {0x00, 0xB0, 0x00, 0x02, (uint8_t)ndef_len};
+  uint8_t read_ndef[] = {0x00, 0xB0, 0x00, 0x02, (uint8_t) ndef_len};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_ndef, sizeof(read_ndef), resp, resp_len) ||
-      resp_len < ndef_len + 2) {
+  if (!this->isodep_transceive_(read_ndef, sizeof(read_ndef), resp, resp_len) || resp_len < ndef_len + 2) {
     ESP_LOGD(TAG, "T4T: READ NDEF data failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
@@ -1523,7 +1520,8 @@ void ST25R::nfcb_scan_() {
       }
       break;
     }
-    if (irq_t & 0x40) break;  // NRE
+    if (irq_t & 0x40)
+      break;  // NRE
     delay(1);
   }
 
@@ -1533,7 +1531,8 @@ void ST25R::nfcb_scan_() {
   uint8_t d_res_restore = (15 - this->rf_power_) & 0x0F;
   this->write_register(TX_DRIVER_CONF, d_res_restore);
 
-  if (resp_len < 12 || resp[0] != 0x50) return;
+  if (resp_len < 12 || resp[0] != 0x50)
+    return;
 
   // Parse ATQB: octet 0 = 0x50, octets 1-4 = PUPI
   char uid_str[9];
@@ -1561,9 +1560,9 @@ void ST25R::nfcb_scan_() {
 uint16_t ST25R::iso15693_crc(const uint8_t *data, size_t len) {
   uint16_t crc = 0xFFFF;
   for (size_t i = 0; i < len; i++) {
-    uint8_t d = data[i] ^ (uint8_t)(crc & 0xFF);
+    uint8_t d = data[i] ^ (uint8_t) (crc & 0xFF);
     d ^= (d << 4);
-    crc = (crc >> 8) ^ ((uint16_t)d << 8) ^ ((uint16_t)d << 3) ^ ((uint16_t)d >> 4);
+    crc = (crc >> 8) ^ ((uint16_t) d << 8) ^ ((uint16_t) d << 3) ^ ((uint16_t) d >> 4);
   }
   return ~crc;
 }
@@ -1573,10 +1572,10 @@ static const uint8_t ISO15693_1OF4_SOF = 0x21;
 static const uint8_t ISO15693_1OF4_EOF = 0x04;
 static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
 
-size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc,
-                                     uint8_t *out, size_t out_max) {
+size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max) {
   size_t pos = 0;
-  if (out_max < 1 + (len + 2) * 4 + 1) return 0;
+  if (out_max < 1 + (len + 2) * 4 + 1)
+    return 0;
 
   // SOF
   out[pos++] = ISO15693_1OF4_SOF;
@@ -1593,7 +1592,7 @@ size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc
   // Encode CRC
   if (add_crc) {
     uint16_t crc = iso15693_crc(data, len);
-    uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
+    uint8_t crc_bytes[2] = {(uint8_t) (crc & 0xFF), (uint8_t) (crc >> 8)};
     for (unsigned char b : crc_bytes) {
       for (int j = 0; j < 4; j++) {
         out[pos++] = ISO15693_1OF4_MAP[b & 0x03];
@@ -1609,10 +1608,12 @@ size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc
 
 // Manchester VICC decoding: subcarrier stream → payload bytes
 size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
-  if (in_len == 0 || out_max == 0) return 0;
+  if (in_len == 0 || out_max == 0)
+    return 0;
 
   // Check SOF: first 5 bits should be 0x17 (10111 = 3 unmodulated + 2 modulated)
-  if ((in[0] & 0x1F) != 0x17) return 0;
+  if ((in[0] & 0x1F) != 0x17)
+    return 0;
 
   memset(out, 0, out_max);
   size_t mp = 5;  // Manchester bit position (after SOF)
@@ -1635,7 +1636,8 @@ size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8
       break;  // collision or invalid
     }
 
-    if (bp >= out_max * 8) break;
+    if (bp >= out_max * 8)
+      break;
   }
 
   return bp / 8;  // return complete bytes
@@ -1683,18 +1685,20 @@ void ST25R::restore_nfca_mode_() {
 }
 
 bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                                     uint32_t timeout_ms) {
+                                    uint32_t timeout_ms) {
   // Encode command using 1-of-4 coding with CRC
   uint8_t coded[128];
   // Set high data rate flag and clear dual subcarrier
   uint8_t cmd_buf[16];
-  if (len > sizeof(cmd_buf)) return false;
+  if (len > sizeof(cmd_buf))
+    return false;
   memcpy(cmd_buf, data, len);
   cmd_buf[0] |= 0x02;   // high data rate
   cmd_buf[0] &= ~0x01;  // single subcarrier
 
   size_t coded_len = iso15693_encode_1of4(cmd_buf, len, true, coded, sizeof(coded));
-  if (coded_len == 0) return false;
+  if (coded_len == 0)
+    return false;
 
   this->write_command(ST25R_CMD_STOP_ALL);
   this->write_command(ST25R_CMD_CLEAR_FIFO);
@@ -1778,20 +1782,21 @@ void ST25R::nfcv_scan_() {
       uint8_t blk_len = 0;
       std::vector<uint8_t> ndef_data;
 
-      if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
-          blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+      if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) && blk_len >= 5 &&
+          !(blk_resp[0] & 0x01)) {
         // CC: byte1=magic(0xE1), byte2=ver+access, byte3=size(*8), byte4=features
         if (blk_resp[1] == 0xE1) {
-          uint8_t cc_size = blk_resp[3];  // NDEF area size in 8-byte units
+          uint8_t cc_size = blk_resp[3];             // NDEF area size in 8-byte units
           uint8_t total_blocks = (cc_size * 8) / 4;  // 4 bytes per block
-          if (total_blocks > 64) total_blocks = 64;  // safety limit
+          if (total_blocks > 64)
+            total_blocks = 64;  // safety limit
 
           // Read blocks 1..N for NDEF TLV data
           for (uint8_t blk = 1; blk <= total_blocks; blk++) {
             blk_req[2] = blk;
             blk_len = 0;
-            if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
-                blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+            if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) && blk_len >= 5 &&
+                !(blk_resp[0] & 0x01)) {
               for (int k = 1; k < 5 && k < blk_len; k++)
                 ndef_data.push_back(blk_resp[k]);
             } else {
@@ -1821,7 +1826,8 @@ void ST25R::nfcv_scan_() {
               }
               break;
             }
-            if (ndef_data[i] == 0xFE) break;  // Terminator TLV
+            if (ndef_data[i] == 0xFE)
+              break;  // Terminator TLV
           }
         }
 
@@ -1893,25 +1899,26 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   std::vector<uint8_t> payload;
 
   // Build TLV structure
-  payload.push_back(0x03); // NDEF TLV
+  payload.push_back(0x03);  // NDEF TLV
   if (ndef_data.size() < 255) {
-    payload.push_back((uint8_t)ndef_data.size());
+    payload.push_back((uint8_t) ndef_data.size());
   } else {
     payload.push_back(0xFF);
-    payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
-    payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+    payload.push_back((uint8_t) ((ndef_data.size() >> 8) & 0xFF));
+    payload.push_back((uint8_t) (ndef_data.size() & 0xFF));
   }
   payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
-  payload.push_back(0xFE); // Terminator TLV
+  payload.push_back(0xFE);  // Terminator TLV
 
   // Pad to 4-byte pages
-  while (payload.size() % 4 != 0) payload.push_back(0);
+  while (payload.size() % 4 != 0)
+    payload.push_back(0);
 
   ESP_LOGD(TAG, "Writing NDEF message, total size with TLVs: %zu", payload.size());
 
   for (size_t i = 0; i < payload.size(); i += 4) {
     uint8_t page = 4 + (i / 4);
-    uint8_t write_cmd[6] = {0xA2, page, payload[i], payload[i+1], payload[i+2], payload[i+3]};
+    uint8_t write_cmd[6] = {0xA2, page, payload[i], payload[i + 1], payload[i + 2], payload[i + 3]};
     bool success = false;
 
     for (uint8_t retry = 0; retry < 3; retry++) {
@@ -1920,7 +1927,8 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
         success = true;
         break;
       }
-      ESP_LOGW(TAG, "NDEF write retry %d for page %d (resp_len=%d, byte0=%02X)", retry + 1, page, len, len > 0 ? buffer[0] : 0);
+      ESP_LOGW(TAG, "NDEF write retry %d for page %d (resp_len=%d, byte0=%02X)", retry + 1, page, len,
+               len > 0 ? buffer[0] : 0);
     }
 
     if (!success) {
@@ -1943,22 +1951,24 @@ bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
     std::vector<uint8_t> ndef_data = message->encode();
     payload.push_back(0x03);  // NDEF TLV type
     if (ndef_data.size() < 255) {
-      payload.push_back((uint8_t)ndef_data.size());
+      payload.push_back((uint8_t) ndef_data.size());
     } else {
       payload.push_back(0xFF);
-      payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
-      payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+      payload.push_back((uint8_t) ((ndef_data.size() >> 8) & 0xFF));
+      payload.push_back((uint8_t) (ndef_data.size() & 0xFF));
     }
     payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
   }
   payload.push_back(0xFE);  // Terminator TLV
-  while (payload.size() % 4 != 0) payload.push_back(0);
+  while (payload.size() % 4 != 0)
+    payload.push_back(0);
 
   ESP_LOGD(TAG, "NFC-V NDEF write: %zu bytes in %zu blocks", payload.size(), payload.size() / 4);
 
   // Write CC to block 0: magic=0xE1, ver=0x40 (v1.0, read/write), size, features=0x00
   uint8_t cc_size = (payload.size() + 4) / 8;  // size in 8-byte units (round up)
-  if (cc_size == 0) cc_size = 1;
+  if (cc_size == 0)
+    cc_size = 1;
   uint8_t write_req[7] = {0x02, 0x21, 0x00, 0xE1, 0x40, cc_size, 0x00};  // flags, WRITE_SINGLE_BLOCK, block, data[4]
   uint8_t resp[4];
   uint8_t resp_len = 0;
@@ -1999,9 +2009,7 @@ bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
   return true;
 }
 
-bool ST25R::clean_tag() {
-  return this->ndef_write(nullptr, true);
-}
+bool ST25R::clean_tag() { return this->ndef_write(nullptr, true); }
 
 bool ST25R::send_apdu(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
   if (!(this->last_sak_ & 0x20)) {
@@ -2028,8 +2036,7 @@ void ST25R::dump_config() {
   LOG_UPDATE_INTERVAL(this);
   uint8_t ic_id = this->read_register(IC_IDENTITY);
   ESP_LOGCONFIG(TAG, "  IC Identity (live read): 0x%02X (chip_type=0x%02X)", ic_id, ic_id & 0xF8);
-  ESP_LOGCONFIG(TAG, "  IO_CONF2: 0x%02X (sup3V=%s, aat_en=%s)",
-                this->read_register(IO_CONF2),
+  ESP_LOGCONFIG(TAG, "  IO_CONF2: 0x%02X (sup3V=%s, aat_en=%s)", this->read_register(IO_CONF2),
                 (this->read_register(IO_CONF2) & 0x80) ? "3.3V" : "5V",
                 (this->read_register(IO_CONF2) & 0x20) ? "yes" : "no");
 }

--- a/esphome/components/st25r/st25r.cpp
+++ b/esphome/components/st25r/st25r.cpp
@@ -109,8 +109,8 @@ void ST25R::setup() {
   if (this->status_binary_sensor_ != nullptr) {
     this->status_binary_sensor_->publish_initial_state(false);
   }
-  ESP_LOGI(TAG, "Starting reset_()...");
-  if (!this->reset_()) {
+  ESP_LOGI(TAG, "Starting reset_chip()...");
+  if (!this->reset_chip()) {
     ESP_LOGE(TAG, "Failed to reset chip");
     this->mark_failed();
     return;
@@ -170,11 +170,11 @@ void ST25R::update() {
 
   // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
   if (this->nfcv_enabled_)
-    this->nfcv_scan_();
+    this->nfcv_scan();
 
   // NFC-B (ISO 14443B) blocking SENSB_REQ — runs before NFC-A scan
   if (this->nfcb_enabled_)
-    this->nfcb_scan_();
+    this->nfcb_scan();
 
   // If previous scan activated ISO-DEP (RATS), send S-Block DESELECT to return
   // the card to IDLE state. Without this, ISO-DEP cards ignore subsequent WUPAs.
@@ -198,14 +198,14 @@ void ST25R::update() {
 }
 
 bool ST25R::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 
 bool ST25R::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
-bool ST25R::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
+bool ST25R::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->write_command(ST25R_CMD_RESET_RX_GAIN);  // reset AGC/squelch per datasheet transceive sequence
   // Clear ALL IRQ registers so IRQ pin goes low — required for ISR rising-edge to fire
@@ -270,7 +270,7 @@ bool ST25R::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8
 // data/parity: len plaintext bytes + precomputed parity bits.
 // resp/resp_parity: decoded response bytes and their parity bits.
 // Adapted from mf1_send_receive_raw (MIT, suut/rfal-mifare-classic).
-bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
+bool ST25R::transceive_mifare(const uint8_t *data, const uint8_t *parity,
                                 uint8_t len,
                                 uint8_t *resp, uint8_t *resp_parity,
                                 uint8_t &resp_len,
@@ -335,7 +335,7 @@ bool ST25R::transceive_mifare_(const uint8_t *data, const uint8_t *parity,
 // ── mifare_authenticate_ ─────────────────────────────────────────────────────
 // Three-pass mutual authentication per ISO 14443-3 / NXP AN10609.
 // Protocol flow from mf1_authenticate() (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
+bool ST25R::mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
                                   const uint8_t *uid, uint8_t uid_len,
                                   struct Crypto1State *cs) {
   // ── Step 1: send AUTHENT command (plain text, with CRC) ──────────────────
@@ -381,7 +381,7 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
   // ── Step 3: send nr+ar (encrypted, manual parity, no CRC) ────────────────
   uint8_t at[4] = {}, at_par[4] = {};
   uint8_t at_len = 0;
-  if (!this->transceive_mifare_(nr_ar, nr_ar_par, 8, at, at_par, at_len) || at_len < 4) {
+  if (!this->transceive_mifare(nr_ar, nr_ar_par, 8, at, at_par, at_len) || at_len < 4) {
     ESP_LOGW(TAG, "Mifare auth: no AT from tag (block %u)", block);
     return false;
   }
@@ -400,9 +400,9 @@ bool ST25R::mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
 }
 
 // ── mifare_read_block_ ───────────────────────────────────────────────────────
-// Read one 16-byte block after a successful mifare_authenticate_().
+// Read one 16-byte block after a successful mifare_authenticate().
 // Protocol flow from mf1_send_receive_encrypted (MIT, suut/rfal-mifare-classic).
-bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
+bool ST25R::mifare_read_block(uint8_t block, uint8_t *data,
                                 struct Crypto1State *cs) {
   // Build: READ(0x30) + block + CRC_A — then encrypt all 4 bytes + CRC
   uint8_t cmd[4];
@@ -421,7 +421,7 @@ bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
   // Response: 16 data bytes + 2 CRC bytes = 18 bytes, all encrypted
   uint8_t rx_enc[18] = {}, rx_par[18] = {};
   uint8_t rx_len = 0;
-  if (!this->transceive_mifare_(enc, enc_par, 4, rx_enc, rx_par, rx_len) || rx_len < 18) {
+  if (!this->transceive_mifare(enc, enc_par, 4, rx_enc, rx_par, rx_len) || rx_len < 18) {
     ESP_LOGW(TAG, "Mifare read block %u failed (got %u bytes)", block, rx_len);
     return false;
   }
@@ -446,20 +446,20 @@ bool ST25R::mifare_read_block_(uint8_t block, uint8_t *data,
   return true;
 }
 
-std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d, SAK=0x%02X", uid.size(), type, this->last_sak_);
 
   // ISO-DEP capable (SAK bit 5 set) → try Type 4 NDEF read
   if (this->last_sak_ & 0x20) {
     ESP_LOGI(TAG, "ISO-DEP capable tag (SAK & 0x20) — trying Type 4 NDEF");
-    return this->read_tag_type4_(uid);
+    return this->read_tag_type4(uid);
   }
 
   if (type == nfc::TAG_TYPE_MIFARE_CLASSIC) {
     ESP_LOGI(TAG, "Mifare Classic detected - attempting authentication");
     struct Crypto1State cs = {};
-    bool auth_ok = this->mifare_authenticate_(0, false, this->mifare_key_a_,
+    bool auth_ok = this->mifare_authenticate(0, false, this->mifare_key_a_,
                                               uid.data(), (uint8_t) uid.size(), &cs);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     if (!auth_ok) {
@@ -470,8 +470,8 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_(std::vector<uint8_t> &uid) {
     ESP_LOGI(TAG, "Mifare Classic: Auth successful, reading blocks 1 and 2");
     // Read blocks 1 and 2 (block 0 is manufacturer data; block 3 is sector trailer)
     uint8_t block1[16] = {}, block2[16] = {};
-    bool b1 = this->mifare_read_block_(1, block1, &cs);
-    bool b2 = b1 && this->mifare_read_block_(2, block2, &cs);
+    bool b1 = this->mifare_read_block(1, block1, &cs);
+    bool b2 = b1 && this->mifare_read_block(2, block2, &cs);
 
     if (!b1) {
       ESP_LOGW(TAG, "Mifare Classic: block read failed");
@@ -637,10 +637,10 @@ void ST25R::loop() {
     this->irq_status_ = 0;
   }
 
-  this->process_state_();
+  this->process_state();
 }
 
-void ST25R::process_state_() {
+void ST25R::process_state() {
   switch (this->state_) {
     case STATE_IDLE:
       break;
@@ -659,7 +659,7 @@ void ST25R::process_state_() {
           // anticol_resume_ is cleared inside: use saved prefix for this one anticol round
           this->anticol_resume_ = false;
 
-          this->send_anticol_frame_();
+          this->send_anticol_frame();
           this->state_ = STATE_ANTICOL;
           this->last_state_change_ = millis();
       } else if (this->irq_status_ & IRQ_NRE) {
@@ -667,7 +667,7 @@ void ST25R::process_state_() {
           ESP_LOGD(TAG, "WUPA NRE (no tag): IRQ=0x%02X", this->irq_status_);
           this->irq_status_ = 0;
           this->state_ = STATE_IDLE;
-          this->finalize_scan_();
+          this->finalize_scan();
       } else if (millis() - this->last_state_change_ > 100) {
           // No tag responded and NRE fast-path didn't fire (real ST25R3916:
           // NRE is in IRQ_TIMER, not IRQ_MAIN).  Read ALL IRQ registers so the
@@ -676,11 +676,11 @@ void ST25R::process_state_() {
           uint8_t irq_t = this->read_register(IRQ_TIMER);
           uint8_t irq_e = this->read_register(IRQ_ERROR);
           ESP_LOGD(TAG, "WUPA timeout: IRQ=0x%02X IRQ_T=0x%02X IRQ_E=0x%02X FIFO=%u",
-                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1_());
+                   this->irq_status_, irq_t, irq_e, this->read_fifo_status1());
           this->irq_status_ = 0;
           this->irq_triggered_ = false;
           this->state_ = STATE_IDLE;
-          this->finalize_scan_();
+          this->finalize_scan();
       }
       break;
     }
@@ -690,27 +690,27 @@ void ST25R::process_state_() {
         uint8_t max_prefix_val = (1 << (this->anticol_col_pos_ + 1)) - 1;
         if (this->anticol_col_pos_ > 0 && this->anticol_prefix_val_ < max_prefix_val) {
           this->anticol_prefix_val_++;
-          this->apply_anticol_prefix_();
+          this->apply_anticol_prefix();
           // Send WUPA before each new prefix attempt — some cards (e.g. Mifare Classic) leave
           // the READY state quickly after responding to an anticol they don't match.
           this->anticol_resume_ = true;
-          this->start_wupa_();
+          this->start_wupa();
           this->state_ = STATE_WUPA;
           this->last_state_change_ = millis();
           return;
         }
         this->state_ = STATE_IDLE;
-        this->finalize_scan_();
+        this->finalize_scan();
         return;
       }
 
       if (this->irq_status_ != 0 && (this->irq_status_ & (IRQ_RXE | IRQ_COL | IRQ_TXE))) {
         delay(5);
-        uint8_t f1 = this->read_fifo_status1_();
+        uint8_t f1 = this->read_fifo_status1();
         bool has_collision = (this->irq_status_ & IRQ_COL) != 0;
 
         if (has_collision) {
-          uint8_t col_raw = this->read_collision_display_();
+          uint8_t col_raw = this->read_collision_display();
           uint8_t c_byte = (col_raw >> 4) & 0x0F;
           uint8_t c_bit  = (col_raw >> 1) & 0x07;
           // col_pos_abs is from start of TX frame (SEL + NVB = 2 bytes = 16 bits)
@@ -722,9 +722,9 @@ void ST25R::process_state_() {
           // FIFO bytes during collision are unreliable — brute-force all 2^(col_pos+1) prefixes
           this->anticol_col_pos_ = uid_col_pos;
           this->anticol_prefix_val_ = 0;
-          this->apply_anticol_prefix_();
+          this->apply_anticol_prefix();
 
-          this->send_anticol_frame_();
+          this->send_anticol_frame();
           this->last_state_change_ = millis();
 
         } else if (f1 >= 5) {
@@ -754,24 +754,24 @@ void ST25R::process_state_() {
 
           if (full_uid[0] == 0x88) {
             for (int i = 1; i < 4; i++) {
-              char buf[3]; sprintf(buf, "%02X", full_uid[i]); this->current_uid_ += buf;
+              char buf[3]; snprintf(buf, sizeof(buf), "%02X", full_uid[i]); this->current_uid_ += buf;
             }
           } else {
             for (int i = 0; i < 4; i++) {
-              char buf[3]; sprintf(buf, "%02X", full_uid[i]); this->current_uid_ += buf;
+              char buf[3]; snprintf(buf, sizeof(buf), "%02X", full_uid[i]); this->current_uid_ += buf;
             }
           }
 
           // Clear anticollision mode before SELECT (ST25R3916: ISO14443A_CONF=0x00;
-          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex_()).
-          this->pre_select_();
+          // ST25R300: no-op here — handled via RX_PROTOCOL1 inside transceive_ex()).
+          this->pre_select();
 
           uint8_t sak_buf[3];
           uint8_t sak_len = 0;
           if (!this->transceive_(sel_pk, 7, sak_buf, sak_len) || sak_len == 0) {
             ESP_LOGW(TAG, "SELECT failed (no SAK)");
             this->state_ = STATE_IDLE;
-            this->finalize_scan_();
+            this->finalize_scan();
             return;
           }
           uint8_t sak = sak_buf[0];
@@ -788,14 +788,14 @@ void ST25R::process_state_() {
             if (this->cascade_level_ > 2) {
               ESP_LOGE(TAG, "Too many cascade levels");
               this->state_ = STATE_IDLE;
-              this->finalize_scan_();
+              this->finalize_scan();
               return;
             }
             this->anticol_prefix_full_ = 0;
             this->anticol_prefix_bits_ = 0;
             this->anticol_col_pos_ = 0;
             this->anticol_prefix_val_ = 0;
-            this->send_anticol_frame_();
+            this->send_anticol_frame();
             this->state_ = STATE_ANTICOL;
             this->last_state_change_ = millis();
           } else {
@@ -804,7 +804,7 @@ void ST25R::process_state_() {
             if (uid_bytes_len != 4 && uid_bytes_len != 7) {
               ESP_LOGW(TAG, "Discarding invalid UID len=%zu (%s)", uid_bytes_len, this->current_uid_.c_str());
               this->state_ = STATE_IDLE;
-              this->finalize_scan_();
+              this->finalize_scan();
               return;
             }
 
@@ -815,13 +815,13 @@ void ST25R::process_state_() {
               std::vector<uint8_t> uid_bytes;
               for (size_t i = 0; i < this->current_uid_.length(); i += 2)
                 uid_bytes.push_back((uint8_t) strtol(this->current_uid_.substr(i, 2).c_str(), nullptr, 16));
-              this->tags_data_[this->current_uid_] = this->read_tag_(uid_bytes);
+              this->tags_data_[this->current_uid_] = this->read_tag(uid_bytes);
             }
 
             this->tags_this_scan_.insert(this->current_uid_);
 
-            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt_()
-            this->send_halt_();
+            // HALT: send [0x50, 0x00] + CRC via chip-specific send_halt()
+            this->send_halt();
 
             // Determine the CL1 collision state so we can resume the multi-tag tree traversal.
             // If we went through cascade (CL2), restore the saved CL1 state.
@@ -846,24 +846,24 @@ void ST25R::process_state_() {
               this->current_uid_ = "";
               this->anticol_col_pos_ = resume_col_pos;
               this->anticol_prefix_val_ = resume_prefix_val + 1;
-              this->apply_anticol_prefix_();
+              this->apply_anticol_prefix();
 
               uint8_t max_val = (1 << (resume_col_pos + 1)) - 1;
               if (this->anticol_prefix_val_ > max_val) {
                 // All branches at this collision level exhausted — done
                 this->state_ = STATE_IDLE;
-                this->finalize_scan_();
+                this->finalize_scan();
                 return;
               }
               // Send WUPA (not REQA) so all tags — including those in HALT — wake up.
               // Some cards (e.g. Mifare Classic) return to HALT after a non-matching SELECT,
               // so REQA would not wake them.
               this->anticol_resume_ = true;
-              this->start_wupa_();
+              this->start_wupa();
             } else {
               // No prior collision: this was the only tag — scan complete
               this->state_ = STATE_IDLE;
-              this->finalize_scan_();
+              this->finalize_scan();
               return;
             }
             this->state_ = STATE_WUPA;
@@ -875,13 +875,13 @@ void ST25R::process_state_() {
     }
 
     case STATE_REINITIALIZING:
-      this->reinitialize_();
+      this->reinitialize();
       this->state_ = STATE_IDLE;
       break;
   }
 }
 
-void ST25R::finalize_scan_() {
+void ST25R::finalize_scan() {
   ESP_LOGD(TAG, "finalize_scan_: this_scan=%zu present=%zu", this->tags_this_scan_.size(), this->present_tags_.size());
   // Increment miss counters for tags not seen this scan; fire on_tag_removed when threshold reached
   std::vector<std::string> to_remove;
@@ -942,7 +942,7 @@ void ST25R::finalize_scan_() {
   this->tags_this_scan_.clear();
 }
 
-bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
+bool ST25R::wait_for_irq(uint8_t mask, uint32_t timeout_ms) {
   uint32_t start = millis();
   while (millis() - start < timeout_ms) {
     if (this->irq_triggered_) {
@@ -953,7 +953,7 @@ bool ST25R::wait_for_irq_(uint8_t mask, uint32_t timeout_ms) {
   return false;
 }
 
-bool ST25R::reset_() {
+bool ST25R::reset_chip() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   // IC_IDENTITY is read-only and unaffected by SET_DEFAULT.
   uint8_t ic_identity = this->read_register(IC_IDENTITY);
@@ -971,7 +971,7 @@ bool ST25R::reset_() {
   this->is_b_version_ = is_b_version;
   // ST25R3916 (0x28) and ST25R3916B (0x30) both have Automatic Antenna Tuning (AAT)
   // with varicap DAC outputs on ANT_TUNE_A/B (0x26/0x27).  Variants without AAT
-  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_() override and
+  // (e.g. ST25R300/500/501 — see feature matrix) use their own reset_chip() override and
   // never reach this code, but set the flag explicitly to represent the capability.
   this->has_aat_ = true;
   ESP_LOGI(TAG, "IC identity match: 0x%02X (ST25R3916%s)", ic_identity, is_b_version ? "B" : "");
@@ -988,10 +988,10 @@ bool ST25R::reset_() {
   this->write_command(ST25R_CMD_MEASURE_VDD);  // 0xDF
   delay(5);
   uint8_t vdd_raw = this->read_register(AD_CONV_RESULT);
-  uint16_t vdd_mV = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
-  bool sup3v = (vdd_mV < 3600);
+  uint16_t vdd_mv = (uint16_t)vdd_raw * 23U + (((uint16_t)vdd_raw * 4U + 5U) / 10U);
+  bool sup3v = (vdd_mv < 3600);
   ESP_LOGI(TAG, "  reset_: VDD measured: %u mV (raw=0x%02X) → sup3V=%s",
-           vdd_mV, vdd_raw, sup3v ? "3.3V" : "5V");
+           vdd_mv, vdd_raw, sup3v ? "3.3V" : "5V");
 
   ESP_LOGV(TAG, "  reset_: Configuring registers");
   this->write_register(IO_CONF1, 0x07);  // Disable MCU_CLK + LF clock (RFAL default)
@@ -1047,7 +1047,7 @@ bool ST25R::reset_() {
 
   if (this->rf_field_enabled_) {
     ESP_LOGV(TAG, "  reset_: Enabling RF field");
-    this->field_on_();
+    this->field_on();
   }
   delay(10);
 
@@ -1055,13 +1055,13 @@ bool ST25R::reset_() {
   // Confirmed +10mm range on STEVAL-MB17149B (varicap-equipped board).
   // Boards without varicaps see no effect (harmless). Disable via YAML: aat_enabled: false
   if (this->aat_enabled_)
-    this->aat_tune_();
+    this->aat_tune();
 
   ESP_LOGV(TAG, "  reset_: Complete");
   return true;
 }
 
-void ST25R::reinitialize_() {
+void ST25R::reinitialize() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -1070,7 +1070,7 @@ void ST25R::reinitialize_() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_()) {
+  if (this->reset_chip()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -1086,7 +1086,7 @@ void ST25R::reinitialize_() {
   }
 }
 
-void ST25R::apply_anticol_prefix_() {
+void ST25R::apply_anticol_prefix() {
   // Decode anticol_prefix_val_ (bit N..0) into prefix arrays
   // anticol_col_pos_ = N: prefix covers bits 0..N (N+1 bits total)
   // bit position i of prefix = (anticol_prefix_val_ >> i) & 1
@@ -1102,7 +1102,7 @@ void ST25R::apply_anticol_prefix_() {
   }
 }
 
-void ST25R::send_anticol_frame_() {
+void ST25R::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -1141,20 +1141,20 @@ void ST25R::send_anticol_frame_() {
 
 // ── Default virtual helpers (ST25R3916 implementations) ──────────────────────
 
-void ST25R::pre_select_() {
+void ST25R::pre_select() {
   // ST25R3916: clear antcl bit in ISO14443A_CONF so SELECT uses normal (non-anticol) framing
   this->write_register(ISO14443A_CONF, 0x00);
 }
 
-uint8_t ST25R::read_fifo_status1_() {
+uint8_t ST25R::read_fifo_status1() {
   return this->read_register(FIFO_STATUS1);
 }
 
-uint8_t ST25R::read_collision_display_() {
+uint8_t ST25R::read_collision_display() {
   return this->read_register(COLLISION_DISPLAY);
 }
 
-void ST25R::send_halt_() {
+void ST25R::send_halt() {
   // HALT: send [0x50, 0x00] + CRC; tag has no response.
   // Don't use transceive_() here — it blocks waiting for a non-existent response.
   uint8_t halt_cmd[2] = {0x50, 0x00};
@@ -1169,7 +1169,7 @@ void ST25R::send_halt_() {
   delay(10);  // wait for HALT frame to be transmitted (~2ms for 4 bytes)
 }
 
-void ST25R::start_wupa_() {
+void ST25R::start_wupa() {
   // Clear FIFO + IRQs, then transmit WUPA.
   this->write_command(ST25R_CMD_CLEAR_FIFO);
   this->read_register(IRQ_MAIN);
@@ -1180,7 +1180,7 @@ void ST25R::start_wupa_() {
   this->write_command(ST25R_CMD_TRANSMIT_WUPA);
 }
 
-void ST25R::field_on_() {
+void ST25R::field_on() {
   this->write_register(OP_CONTROL, 0x88); // en=1, tx_en=1
   delay(10);
   this->write_command(ST25R_CMD_FIELD_ON);
@@ -1191,10 +1191,10 @@ void ST25R::field_on_() {
 
 // ── AAT (Automatic Antenna Tuning) hill-climbing optimizer ───────────────────
 // Based on RFAL st25r3916AatTune() (AN5322). Iteratively adjusts ANT_TUNE_A/B
-// to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on_()
-// during reset_() on chips with AAT hardware (ST25R3916/3916B).
+// to maximize RF field amplitude (AD_CONV_RESULT). Runs once after field_on()
+// during reset_chip() on chips with AAT hardware (ST25R3916/3916B).
 
-void ST25R::aat_tune_() {
+void ST25R::aat_tune() {
   if (!this->has_aat_) return;
 
   uint8_t a = this->ant_tune_a_;
@@ -1222,9 +1222,10 @@ void ST25R::aat_tune_() {
     bool improved = false;
 
     // Try 4 directions: A±step, B±step
-    struct { int8_t da; int8_t db; } dirs[] = {
-      {(int8_t)step_a, 0}, {-(int8_t)step_a, 0},
-      {0, (int8_t)step_b}, {0, -(int8_t)step_b}
+    struct Dir { int16_t da; int16_t db; };
+    Dir dirs[] = {
+      {step_a, 0}, {-step_a, 0},
+      {0, step_b}, {0, -step_b}
     };
 
     for (auto &d : dirs) {
@@ -1269,7 +1270,7 @@ void ST25R::aat_tune_() {
 
 // ── ISO 14443-4 (ISO-DEP / Type 4 tags) ─────────────────────────────────────
 
-bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
+bool ST25R::isodep_activate(uint8_t *ats, uint8_t &ats_len) {
   // Send RATS: 0xE0, FSDI=8 (256 bytes) | DID=0
   uint8_t rats[] = {0xE0, 0x80};
   uint8_t resp[64];
@@ -1290,7 +1291,7 @@ bool ST25R::isodep_activate_(uint8_t *ats, uint8_t &ats_len) {
   return true;
 }
 
-bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
+bool ST25R::isodep_transceive(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len) {
   // Wrap APDU in I-Block: [PCB][APDU...]
   uint8_t frame[64];
   if (apdu_len + 1 > sizeof(frame)) return false;
@@ -1322,11 +1323,11 @@ bool ST25R::isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *re
   return true;
 }
 
-std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4(std::vector<uint8_t> &uid) {
   uint8_t ats[64];
   uint8_t ats_len = 0;
 
-  if (!this->isodep_activate_(ats, ats_len)) {
+  if (!this->isodep_activate(ats, ats_len)) {
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
     return make_unique<nfc::NfcTag>(nfc_uid);
   }
@@ -1336,12 +1337,12 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
 
   // Step 1: SELECT NDEF Application (AID = D276000085010100 for v2, try v1 as fallback)
   uint8_t select_app[] = {0x00, 0xA4, 0x04, 0x00, 0x07, 0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01, 0x00};
-  if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
+  if (!this->isodep_transceive(select_app, sizeof(select_app), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
     // Try v1 AID
     select_app[11] = 0x00;  // D276000085010100 → D276000085010000
     resp_len = 0;
-    if (!this->isodep_transceive_(select_app, sizeof(select_app), resp, resp_len) ||
+    if (!this->isodep_transceive(select_app, sizeof(select_app), resp, resp_len) ||
         resp_len < 2 || resp[resp_len - 2] != 0x90 || resp[resp_len - 1] != 0x00) {
       ESP_LOGD(TAG, "T4T: SELECT NDEF app failed");
       nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1352,7 +1353,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 2: SELECT CC File (0xE103)
   uint8_t select_cc[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, 0xE1, 0x03};
   resp_len = 0;
-  if (!this->isodep_transceive_(select_cc, sizeof(select_cc), resp, resp_len) ||
+  if (!this->isodep_transceive(select_cc, sizeof(select_cc), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT CC failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1362,7 +1363,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 3: READ BINARY CC (15 bytes)
   uint8_t read_cc[] = {0x00, 0xB0, 0x00, 0x00, 0x0F};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_cc, sizeof(read_cc), resp, resp_len) ||
+  if (!this->isodep_transceive(read_cc, sizeof(read_cc), resp, resp_len) ||
       resp_len < 17) {  // 15 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ CC failed (resp_len=%u)", resp_len);
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1378,7 +1379,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 4: SELECT NDEF File
   uint8_t select_ndef[] = {0x00, 0xA4, 0x00, 0x0C, 0x02, (uint8_t)(ndef_file_id >> 8), (uint8_t)(ndef_file_id & 0xFF)};
   resp_len = 0;
-  if (!this->isodep_transceive_(select_ndef, sizeof(select_ndef), resp, resp_len) ||
+  if (!this->isodep_transceive(select_ndef, sizeof(select_ndef), resp, resp_len) ||
       resp_len < 2 || resp[resp_len - 2] != 0x90) {
     ESP_LOGD(TAG, "T4T: SELECT NDEF file failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1388,7 +1389,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 5: READ NDEF Length (first 2 bytes)
   uint8_t read_nlen[] = {0x00, 0xB0, 0x00, 0x00, 0x02};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_nlen, sizeof(read_nlen), resp, resp_len) ||
+  if (!this->isodep_transceive(read_nlen, sizeof(read_nlen), resp, resp_len) ||
       resp_len < 4) {  // 2 data + SW1 SW2
     ESP_LOGD(TAG, "T4T: READ NLEN failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1405,7 +1406,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
   // Step 6: READ NDEF Data
   uint8_t read_ndef[] = {0x00, 0xB0, 0x00, 0x02, (uint8_t)ndef_len};
   resp_len = 0;
-  if (!this->isodep_transceive_(read_ndef, sizeof(read_ndef), resp, resp_len) ||
+  if (!this->isodep_transceive(read_ndef, sizeof(read_ndef), resp, resp_len) ||
       resp_len < ndef_len + 2) {
     ESP_LOGD(TAG, "T4T: READ NDEF data failed");
     nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
@@ -1419,7 +1420,7 @@ std::unique_ptr<nfc::NfcTag> ST25R::read_tag_type4_(std::vector<uint8_t> &uid) {
 
 // ── NFC-B (ISO 14443B) for ST25R3916 ─────────────────────────────────────────
 
-void ST25R::configure_nfcb_mode_() {
+void ST25R::configure_nfcb_mode() {
   // MODE: om=0x02 (ISO14443B) in bits[6:3] = 0x10, tr_am=1 (AM modulation) bit7 = 0x80
   this->write_register(MODE, 0x90);
   this->write_register(BIT_RATE, 0x00);  // 106 kbps
@@ -1435,8 +1436,8 @@ void ST25R::configure_nfcb_mode_() {
   this->write_register(CORR_CONF2, 0x00);
 }
 
-void ST25R::nfcb_scan_() {
-  this->configure_nfcb_mode_();
+void ST25R::nfcb_scan() {
+  this->configure_nfcb_mode();
 
   // SENSB_REQ (ALLB_REQ): cmd=0x05, AFI=0x00 (any), PARAM=0x08 (1 slot + WUPB)
   uint8_t sensb_req[] = {0x05, 0x00, 0x08};
@@ -1475,7 +1476,7 @@ void ST25R::nfcb_scan_() {
   }
 
   // Restore NFC-A mode
-  this->restore_nfca_mode_();
+  this->restore_nfca_mode();
   // Also restore TX_DRIVER to OOK (am_mod=0)
   uint8_t d_res_restore = (15 - this->rf_power_) & 0x0F;
   this->write_register(TX_DRIVER_CONF, d_res_restore);
@@ -1505,7 +1506,7 @@ void ST25R::nfcb_scan_() {
 // ── NFC-V (ISO 15693) streaming mode for ST25R3916 ──────────────────────────
 
 // ISO 15693 CRC-16 CCITT (preset=0xFFFF, poly=0x8408, result inverted)
-uint16_t ST25R::iso15693_crc_(const uint8_t *data, size_t len) {
+uint16_t ST25R::iso15693_crc(const uint8_t *data, size_t len) {
   uint16_t crc = 0xFFFF;
   for (size_t i = 0; i < len; i++) {
     uint8_t d = data[i] ^ (uint8_t)(crc & 0xFF);
@@ -1520,7 +1521,7 @@ static const uint8_t ISO15693_1OF4_SOF = 0x21;
 static const uint8_t ISO15693_1OF4_EOF = 0x04;
 static const uint8_t ISO15693_1OF4_MAP[4] = {0x02, 0x08, 0x20, 0x80};
 
-size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc,
+size_t ST25R::iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc,
                                      uint8_t *out, size_t out_max) {
   size_t pos = 0;
   if (out_max < 1 + (len + 2) * 4 + 1) return 0;
@@ -1539,7 +1540,7 @@ size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_cr
 
   // Encode CRC
   if (add_crc) {
-    uint16_t crc = iso15693_crc_(data, len);
+    uint16_t crc = iso15693_crc(data, len);
     uint8_t crc_bytes[2] = {(uint8_t)(crc & 0xFF), (uint8_t)(crc >> 8)};
     for (int c = 0; c < 2; c++) {
       uint8_t b = crc_bytes[c];
@@ -1556,7 +1557,7 @@ size_t ST25R::iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_cr
 }
 
 // Manchester VICC decoding: subcarrier stream → payload bytes
-size_t ST25R::iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
+size_t ST25R::iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max) {
   if (in_len == 0 || out_max == 0) return 0;
 
   // Check SOF: first 5 bits should be 0x17 (10111 = 3 unmodulated + 2 modulated)
@@ -1589,7 +1590,7 @@ size_t ST25R::iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint
   return bp / 8;  // return complete bytes
 }
 
-void ST25R::configure_nfcv_stream_mode_() {
+void ST25R::configure_nfcv_stream_mode() {
   // RFAL NFC-V analog config: RX_CONF1=0x13, RX_CONF2=0x2D, CORR_CONF1=0x13, CORR_CONF2=0x01
   this->write_register(RX_CONF1, 0x13);
   this->write_register(RX_CONF2, 0x2D);
@@ -1614,7 +1615,7 @@ void ST25R::configure_nfcv_stream_mode_() {
   this->write_register(UNDERSHOOT_CONF2, 0x00);
 }
 
-void ST25R::restore_nfca_mode_() {
+void ST25R::restore_nfca_mode() {
   // Restore NFC-A 106 settings
   this->write_register(MODE, 0x08);
   this->write_register(RX_CONF1, 0x08);
@@ -1630,7 +1631,7 @@ void ST25R::restore_nfca_mode_() {
   this->write_register(UNDERSHOOT_CONF2, 0x03);
 }
 
-bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R::transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                      uint32_t timeout_ms) {
   // Encode command using 1-of-4 coding with CRC
   uint8_t coded[128];
@@ -1641,7 +1642,7 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
   cmd_buf[0] |= 0x02;   // high data rate
   cmd_buf[0] &= ~0x01;  // single subcarrier
 
-  size_t coded_len = iso15693_encode_1of4_(cmd_buf, len, true, coded, sizeof(coded));
+  size_t coded_len = iso15693_encode_1of4(cmd_buf, len, true, coded, sizeof(coded));
   if (coded_len == 0) return false;
 
   this->write_command(ST25R_CMD_STOP_ALL);
@@ -1672,10 +1673,10 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
         this->read_fifo(raw, fifo_len);
         // Decode Manchester
         uint8_t decoded[32];
-        size_t dec_len = iso15693_decode_manchester_(raw, fifo_len, decoded, sizeof(decoded));
+        size_t dec_len = iso15693_decode_manchester(raw, fifo_len, decoded, sizeof(decoded));
         if (dec_len >= 3) {  // At least flags + CRC(2)
           // Verify CRC
-          uint16_t crc = iso15693_crc_(decoded, dec_len - 2);
+          uint16_t crc = iso15693_crc(decoded, dec_len - 2);
           if ((crc & 0xFF) == decoded[dec_len - 2] && (crc >> 8) == decoded[dec_len - 1]) {
             // Strip CRC
             resp_len = dec_len - 2;
@@ -1694,14 +1695,14 @@ bool ST25R::transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *re
   return false;
 }
 
-void ST25R::nfcv_scan_() {
-  this->configure_nfcv_stream_mode_();
+void ST25R::nfcv_scan() {
+  this->configure_nfcv_stream_mode();
 
   uint8_t inv_req[] = {0x26, 0x01, 0x00};  // flags, INVENTORY, mask_len=0
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_nfcv_stream_(inv_req, sizeof(inv_req), resp, resp_len, 30)) {
+  if (this->transceive_nfcv_stream(inv_req, sizeof(inv_req), resp, resp_len, 30)) {
     if (resp_len >= 10 && !(resp[0] & 0x01)) {
       // Parse UID (bytes 2-9, LSB-first → reverse for display)
       char uid_str[17];
@@ -1710,7 +1711,7 @@ void ST25R::nfcv_scan_() {
       uid_str[16] = '\0';
       ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
 
-      // Add to tags_this_scan_ — finalize_scan_() handles on_tag/on_tag_removed
+      // Add to tags_this_scan_ — finalize_scan() handles on_tag/on_tag_removed
       std::string uid_string(uid_str);
       this->tags_this_scan_.insert(uid_string);
 
@@ -1725,7 +1726,7 @@ void ST25R::nfcv_scan_() {
       uint8_t blk_len = 0;
       std::vector<uint8_t> ndef_data;
 
-      if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+      if (this->transceive_nfcv_stream(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
           blk_len >= 5 && !(blk_resp[0] & 0x01)) {
         // CC: byte1=magic(0xE1), byte2=ver+access, byte3=size(*8), byte4=features
         if (blk_resp[1] == 0xE1) {
@@ -1737,7 +1738,7 @@ void ST25R::nfcv_scan_() {
           for (uint8_t blk = 1; blk <= total_blocks; blk++) {
             blk_req[2] = blk;
             blk_len = 0;
-            if (this->transceive_nfcv_stream_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+            if (this->transceive_nfcv_stream(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
                 blk_len >= 5 && !(blk_resp[0] & 0x01)) {
               for (int k = 1; k < 5 && k < blk_len; k++)
                 ndef_data.push_back(blk_resp[k]);
@@ -1783,7 +1784,7 @@ void ST25R::nfcv_scan_() {
     }
   }
 
-  this->restore_nfca_mode_();
+  this->restore_nfca_mode();
 }
 
 bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
@@ -1792,7 +1793,7 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   if (!this->present_tags_.empty()) {
     const std::string &last_uid = this->present_tags_.rbegin()->first;
     if (last_uid.length() == 16) {
-      return this->nfcv_ndef_write_(message);
+      return this->nfcv_ndef_write(message);
     }
   }
 
@@ -1875,11 +1876,11 @@ bool ST25R::ndef_write(nfc::NdefMessage *message, bool format) {
   return true;
 }
 
-bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
+bool ST25R::nfcv_ndef_write(nfc::NdefMessage *message) {
   // NFC-V Type 5 NDEF write via WRITE_SINGLE_BLOCK (0x21)
   // Block 0 = CC, blocks 1+ = NDEF TLV data
 
-  this->configure_nfcv_stream_mode_();
+  this->configure_nfcv_stream_mode();
 
   std::vector<uint8_t> payload;
   if (message != nullptr) {
@@ -1906,9 +1907,9 @@ bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
   uint8_t resp[4];
   uint8_t resp_len = 0;
 
-  if (!this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+  if (!this->transceive_nfcv_stream(write_req, sizeof(write_req), resp, resp_len, 25)) {
     ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
-    this->restore_nfca_mode_();
+    this->restore_nfca_mode();
     return false;
   }
 
@@ -1924,7 +1925,7 @@ bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
 
     bool success = false;
     for (uint8_t retry = 0; retry < 3; retry++) {
-      if (this->transceive_nfcv_stream_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+      if (this->transceive_nfcv_stream(write_req, sizeof(write_req), resp, resp_len, 25)) {
         success = true;
         break;
       }
@@ -1932,13 +1933,13 @@ bool ST25R::nfcv_ndef_write_(nfc::NdefMessage *message) {
     }
     if (!success) {
       ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
-      this->restore_nfca_mode_();
+      this->restore_nfca_mode();
       return false;
     }
   }
 
   ESP_LOGI(TAG, "NFC-V NDEF write successful!");
-  this->restore_nfca_mode_();
+  this->restore_nfca_mode();
   return true;
 }
 
@@ -1951,7 +1952,7 @@ bool ST25R::send_apdu(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8
     ESP_LOGW(TAG, "send_apdu: tag not ISO-DEP capable (SAK=0x%02X)", this->last_sak_);
     return false;
   }
-  return this->isodep_transceive_(apdu, apdu_len, resp, resp_len);
+  return this->isodep_transceive(apdu, apdu_len, resp, resp_len);
 }
 
 void ST25R::dump_config() {
@@ -1981,7 +1982,7 @@ bool ST25RBinarySensor::process(const std::string &uid) {
   std::string target_uid = "";
   for (uint8_t b : this->uid_) {
     char buf[3];
-    sprintf(buf, "%02X", b);
+    snprintf(buf, sizeof(buf), "%02X", b);
     target_uid += buf;
   }
   if (uid == target_uid) {

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -1,0 +1,345 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/automation.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/nfc/nfc.h"
+#include "crypto1.h"
+#include <map>
+#include <set>
+#include <vector>
+#include <string>
+
+namespace esphome {
+namespace st25r {
+
+class ST25RBinarySensor;
+
+// ST25R Register Definitions
+enum ST25RRegister : uint8_t {
+  IO_CONF1 = 0x00,
+  IO_CONF2 = 0x01,
+  OP_CONTROL = 0x02,
+  MODE = 0x03,
+  BIT_RATE = 0x04,
+  RX_CONF1 = 0x0B,
+  RX_CONF2 = 0x0C,
+  RX_CONF3 = 0x0D,
+  RX_CONF4 = 0x0E,
+  ISO14443A_CONF = 0x05,
+  PASSIVE_TARGET = 0x08,  // Passive target definition (Space A): FDT alignment
+  STREAM_MODE = 0x09,     // Stream mode config (Space A): din, dout, report_period
+  AUX = 0x0A,             // Auxiliary definition (Space A): dis_corr bit for correlator
+  MASK_MAIN = 0x16,
+  MASK_TIMER = 0x17,
+  IRQ_MAIN = 0x1A,
+  IRQ_TIMER = 0x1B,
+  IRQ_ERROR = 0x1C,
+  FIFO_STATUS1 = 0x1E,
+  FIFO_STATUS2 = 0x1F,
+  COLLISION_DISPLAY = 0x20,
+  NUM_TX_BYTES1 = 0x22,
+  NUM_TX_BYTES2 = 0x23,
+  AD_CONV_RESULT = 0x25,
+  ANT_TUNE_A = 0x26,   // Antenna tuning DAC A (Space A): V = (0.044 + 0.868 * val/255) * VDD_A; default 0x80
+  ANT_TUNE_B = 0x27,   // Antenna tuning DAC B (Space A): same formula; default 0x80
+  TX_DRIVER_CONF = 0x28,
+  PT_MOD = 0x29,        // PT modulation (Space A): RFO resistance in modulated state
+  FIELD_THRESHOLD_ACTV = 0x2A,    // External field detector activation threshold
+  FIELD_THRESHOLD_DEACTV = 0x2B,  // External field detector deactivation threshold
+  IC_IDENTITY = 0x3F,
+  // Space B registers (bit 0x40 set → SPI prefix 0xFB before address)
+  EMD_SUP_CONF = 0x45,      // (Space B 0x05) EMD suppression config
+  CORR_CONF1 = 0x4C,        // (Space B 0x0C) Correlator configuration 1
+  CORR_CONF2 = 0x4D,        // (Space B 0x0D) Correlator configuration 2
+  AUX_MOD = 0x68,            // (Space B 0x28) Aux modulation setting
+  RES_AM_MOD = 0x6A,         // (Space B 0x2A) Resistive AM modulation
+  OVERSHOOT_CONF1 = 0x70,   // (Space B 0x30) Overshoot protection config 1
+  OVERSHOOT_CONF2 = 0x71,   // (Space B 0x31) Overshoot protection config 2
+  UNDERSHOOT_CONF1 = 0x72,  // (Space B 0x32) Undershoot protection config 1
+  UNDERSHOOT_CONF2 = 0x73,  // (Space B 0x33) Undershoot protection config 2
+  REGULATOR_CONTROL = 0x2C, // Regulated voltage control (Space A)
+};
+
+// ST25R Commands
+enum ST25RCommand : uint8_t {
+  ST25R_CMD_SET_DEFAULT = 0xC1,
+  ST25R_CMD_READ_FIFO = 0x9F,
+  ST25R_CMD_STOP_ALL = 0xC2,
+  ST25R_CMD_CLEAR_FIFO = 0xC3,  // Table 13: 0xC2/0xC3 = Stop all activities (clears FIFO state)
+  ST25R_CMD_TRANSMIT_WITH_CRC = 0xC4,
+  ST25R_CMD_TRANSMIT_WITHOUT_CRC = 0xC5,
+  ST25R_CMD_TRANSMIT_REQA = 0xC6,
+  ST25R_CMD_TRANSMIT_WUPA = 0xC7,
+  ST25R_CMD_FIELD_ON = 0xC8,
+  ST25R_CMD_FIELD_OFF = 0xC9,
+  ST25R_CMD_MEASURE_AMPLITUDE = 0xD3,
+  ST25R_CMD_RESET_RX_GAIN = 0xD5,
+  ST25R_CMD_ADJUST_REGULATORS = 0xD6,
+  ST25R_CMD_MEASURE_VDD = 0xDF,
+};
+
+class ST25R;
+
+class ST25RTagTrigger : public Trigger<std::string> {
+ public:
+  explicit ST25RTagTrigger(ST25R *parent) : parent_(parent) {}
+
+ protected:
+  ST25R *parent_;
+};
+
+class ST25RTagRemovedTrigger : public Trigger<std::string> {
+ public:
+  explicit ST25RTagRemovedTrigger(ST25R *parent) : parent_(parent) {}
+
+ protected:
+  ST25R *parent_;
+};
+
+template<typename... Ts> class NDEFWriteAction : public Action<Ts...> {
+ public:
+  void set_parent(ST25R *parent) { parent_ = parent; }
+  void set_message(std::function<nfc::NdefMessage *(Ts...)> func) { message_func_ = func; }
+  void set_format(bool format) { format_ = format; }
+  void play(const Ts &...x) override;
+
+ protected:
+  ST25R *parent_;
+  std::function<nfc::NdefMessage *(Ts...)> message_func_;
+  bool format_{false};
+};
+
+class ST25R : public PollingComponent, public nfc::Nfcc {
+ public:
+  enum State {
+    STATE_IDLE,
+    STATE_WUPA,
+    STATE_ANTICOL,
+    STATE_SELECT,
+    STATE_REINITIALIZING,
+  };
+
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  void loop() override;
+  void process_state_();
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  bool ndef_write(nfc::NdefMessage *message, bool format = false);
+  virtual bool nfcv_ndef_write_(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
+  bool clean_tag();
+
+  /// Send an APDU via ISO-DEP (ISO 14443-4) I-Block framing.
+  /// Requires the tag to be ISO-DEP activated (SAK & 0x20, RATS already sent).
+  /// Call multiple times for conversational APDU exchanges (block number toggles automatically).
+  /// Returns true if a response was received; resp/resp_len contain the response data + SW1 SW2.
+  /// Example from on_tag lambda:
+  ///   uint8_t select[] = {0x00, 0xA4, 0x04, 0x00, 0x07, 0xA0, 0x00, 0x00, 0x05, 0x27, 0x20, 0x01};
+  ///   uint8_t resp[64]; uint8_t len = 0;
+  ///   if (id(reader).send_apdu(select, sizeof(select), resp, len)) { /* check resp */ }
+  bool send_apdu(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
+
+  /// Check if the most recently selected tag supports ISO-DEP (SAK & 0x20).
+  bool is_isodep_active() const { return this->last_sak_ & 0x20; }
+
+  void set_reset_pin(GPIOPin *reset_pin) { this->reset_pin_ = reset_pin; }
+  void set_irq_pin(InternalGPIOPin *irq_pin) { this->irq_pin_ = irq_pin; }
+  void set_rf_field_enabled(bool enabled) { this->rf_field_enabled_ = enabled; }
+  void set_rf_power(uint8_t power) { this->rf_power_ = power; }
+  void set_supply_3v3(bool supply_3v3) { this->supply_3v3_ = supply_3v3; }
+  void set_rx_gain_boost(bool boost) { this->rx_gain_boost_ = boost; }
+  void set_mifare_key_a(uint64_t key) { this->mifare_key_a_ = key; }
+  void set_mifare_key_b(uint64_t key) { this->mifare_key_b_ = key; }
+  void set_miss_threshold(uint8_t t) { this->miss_threshold_ = t; }
+  void set_ant_tune_a(uint8_t v) { this->ant_tune_a_ = v; }
+  void set_ant_tune_b(uint8_t v) { this->ant_tune_b_ = v; }
+  void set_health_check_enabled(bool v) { this->health_check_enabled_ = v; }
+  void set_health_check_interval(uint32_t ms) { this->health_check_interval_ms_ = ms; }
+  void set_max_failed_checks(uint8_t n) { this->max_failed_checks_ = n; }
+  void set_auto_reset_on_failure(bool v) { this->auto_reset_on_failure_ = v; }
+  void set_nfcv_enabled(bool v) { this->nfcv_enabled_ = v; }
+  void set_nfcb_enabled(bool v) { this->nfcb_enabled_ = v; }
+  void set_aat_enabled(bool v) { this->aat_enabled_ = v; }
+
+  void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
+    this->on_tag_removed_triggers_.push_back(trig);
+  }
+  void register_tag(ST25RBinarySensor *tag) { this->binary_sensors_.push_back(tag); }
+  void set_status_binary_sensor(binary_sensor::BinarySensor *sensor) { this->status_binary_sensor_ = sensor; }
+  void set_field_strength_sensor(sensor::Sensor *sensor) { this->field_strength_sensor_ = sensor; }
+
+  bool is_tag_present() const { return !this->present_tags_.empty(); }
+
+ protected:
+  virtual uint8_t read_register(uint8_t reg) = 0;
+  virtual void write_register(uint8_t reg, uint8_t value) = 0;
+  virtual void write_command(uint8_t command) = 0;
+  virtual void write_fifo(const uint8_t *data, size_t len) = 0;
+  virtual void read_fifo(uint8_t *data, size_t len) = 0;
+
+  // Chip-specific overrides — each uses the ST25R3916 default or can be overridden
+  virtual bool reset_();
+  virtual void reinitialize_();
+  virtual void send_anticol_frame_();
+  virtual bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms = 150);
+  virtual std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
+
+  // Virtual helpers used by the shared process_state_() to abstract chip differences
+  virtual void send_halt_();                  // encode and transmit the ISO14443A HALT command
+  virtual void start_wupa_();                 // clear chip state and transmit WUPA
+  virtual void pre_select_();                 // clear anticol mode before SELECT (chip-specific register)
+  virtual uint8_t read_fifo_status1_();       // read the chip's FIFO byte count register
+  virtual uint8_t read_collision_display_();  // read the chip's collision position register
+
+  void field_on_();
+  void finalize_scan_();
+
+  // Automatic Antenna Tuning — hill-climbing optimizer for ANT_TUNE_A/B
+  void aat_tune_();
+
+  // ISO 14443-4 (ISO-DEP / Type 4 tags)
+  bool isodep_activate_(uint8_t *ats, uint8_t &ats_len);  // Send RATS, parse ATS
+  bool isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
+  std::unique_ptr<nfc::NfcTag> read_tag_type4_(std::vector<uint8_t> &uid);
+  uint8_t isodep_block_number_{0};
+
+  // NFC-B (ISO 14443B) support
+  void nfcb_scan_();
+  void configure_nfcb_mode_();
+
+  // NFC-V (ISO 15693) support for ST25R3916 — streaming mode
+  void nfcv_scan_();
+  void configure_nfcv_stream_mode_();
+  void restore_nfca_mode_();
+  bool transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                               uint32_t timeout_ms = 30);
+  // ISO 15693 encoding/decoding helpers
+  static uint16_t iso15693_crc_(const uint8_t *data, size_t len);
+  static size_t iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
+  static size_t iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
+  void apply_anticol_prefix_();
+  bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
+  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
+  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
+  // Mifare Classic — raw transceive with manual parity (no chip CRC/parity).
+  // Adapted from mf1.c (MIT, github.com/suut/rfal-mifare-classic)
+  bool transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len,
+                          uint8_t *resp, uint8_t *resp_parity, uint8_t &resp_len,
+                          uint32_t timeout_ms = 15);
+  bool mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
+                            const uint8_t *uid, uint8_t uid_len,
+                            struct Crypto1State *cs);
+  bool mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs);
+  static void isr(ST25R *arg);
+  
+  GPIOPin *reset_pin_{nullptr};
+  InternalGPIOPin *irq_pin_{nullptr};
+
+  bool rf_field_enabled_{true};
+  uint8_t rf_power_{15};
+  bool supply_3v3_{true};
+  bool rx_gain_boost_{false};
+  uint64_t mifare_key_a_{0xFFFFFFFFFFFFULL};
+  uint64_t mifare_key_b_{0xFFFFFFFFFFFFULL};
+  uint8_t miss_threshold_{3};
+  uint8_t ant_tune_a_{0x80};  // AAT DAC A: 0x80 = mid-range (~0.48V on 3.3V / ~0.87V on 5V)
+  uint8_t ant_tune_b_{0x80};  // AAT DAC B: same
+  bool is_b_version_{false};
+  bool has_aat_{false};  // Automatic Antenna Tuning / varicap DAC (ANT_TUNE_A/B) available
+  // Health check (chip liveness check, separate from tag scan interval)
+  bool health_check_enabled_{true};
+  uint32_t health_check_interval_ms_{60000};
+  uint32_t last_health_check_ms_{0};
+  uint8_t max_failed_checks_{3};
+  bool auto_reset_on_failure_{true};
+  bool nfcv_enabled_{true};
+  bool nfcb_enabled_{true};
+  bool aat_enabled_{true};  // AAT hill-climbing — improves range on boards with varicaps
+  uint8_t health_check_failures_{0};
+  uint8_t reinitialization_attempts_{0};
+  volatile bool irq_triggered_{false};
+  volatile uint8_t irq_status_{0};
+
+  // Multi-tag tracking
+  // present_tags_: UID → consecutive miss count (0 = seen this or prior scan)
+  std::map<std::string, uint8_t> present_tags_;
+  std::set<std::string> tags_this_scan_;  // UIDs found in current scan cycle
+  std::map<std::string, std::unique_ptr<nfc::NfcTag>> tags_data_;  // UID → last read NfcTag
+
+  // IRQ_MAIN (0x1A) bit definitions per Table 62
+  static const uint8_t IRQ_OSC     = 0x80;  // bit7: oscillator stable
+  static const uint8_t IRQ_WL      = 0x40;  // bit6: FIFO water level
+  static const uint8_t IRQ_RXS     = 0x20;  // bit5: start of receive
+  static const uint8_t IRQ_RXE     = 0x10;  // bit4: end of receive ← tag response
+  static const uint8_t IRQ_TXE     = 0x08;  // bit3: end of transmission
+  static const uint8_t IRQ_COL     = 0x04;  // bit2: bit collision ← anticollision
+  static const uint8_t IRQ_RX_REST = 0x02;  // bit1: automatic reception restart
+  // NRE (no-response timer expired): set in irq_status_ by derived class overrides
+  // (e.g. ST25R300 translates its IRQ_STATUS2 NRE bit here). ST25R3916 uses millis() timeout.
+  static const uint8_t IRQ_NRE = 0x01;
+
+  State state_{STATE_IDLE};
+  uint32_t last_state_change_{0};
+  uint8_t cascade_level_{0};
+  std::string current_uid_;
+  uint8_t last_sak_{0};  // SAK from most recent SELECT (bit5=0x20 → ISO-DEP capable)
+
+  // Anticollision loop state
+  uint8_t anticol_prefix_[5]{};   // UID prefix bytes being used to narrow search
+  uint8_t anticol_prefix_full_;   // complete prefix bytes
+  uint8_t anticol_prefix_bits_;   // partial bits in last prefix byte
+  uint8_t anticol_col_pos_{0};    // collision bit position (bits 0..col_pos are prefix)
+  uint8_t anticol_prefix_val_{0}; // current prefix value being tried (brute-forced)
+
+  // Multi-tag tree traversal: saved CL1 collision state for resuming after cascade CL2
+  uint8_t saved_col_pos_{0};
+  uint8_t saved_prefix_val_{0};
+  bool saved_anticol_valid_{false};
+  bool anticol_resume_{false};    // when true: STATE_WUPA uses saved prefix instead of resetting
+
+  std::vector<ST25RTagTrigger *> on_tag_triggers_;
+  std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;
+  std::vector<ST25RBinarySensor *> binary_sensors_;
+  binary_sensor::BinarySensor *status_binary_sensor_{nullptr};
+  sensor::Sensor *field_strength_sensor_{nullptr};
+};
+
+template<typename... Ts> void NDEFWriteAction<Ts...>::play(const Ts &...x) {
+  auto *message = this->message_func_(x...);
+  if (message != nullptr) {
+    this->parent_->ndef_write(message, this->format_);
+  }
+}
+
+template<typename... Ts> class CleanTagAction : public Action<Ts...> {
+ public:
+  void set_parent(ST25R *parent) { parent_ = parent; }
+  void play(const Ts &...x) override { this->parent_->clean_tag(); }
+
+ protected:
+  ST25R *parent_;
+};
+
+class ST25RBinarySensor : public binary_sensor::BinarySensor {
+ public:
+  void set_uid(const std::vector<uint8_t> &uid) { uid_ = uid; }
+  bool process(const std::string &uid);
+  void on_scan_end() {
+    if (!this->found_) {
+      this->publish_state(false);
+    }
+    this->found_ = false;
+  }
+
+ protected:
+  std::vector<uint8_t> uid_;
+  bool found_{false};
+};
+
+}  // namespace st25r
+}  // namespace esphome

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -126,11 +126,11 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void dump_config() override;
   void update() override;
   void loop() override;
-  void process_state();
+  void process_state_();
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool ndef_write(nfc::NdefMessage *message, bool format = false);
-  virtual bool nfcv_ndef_write(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
+  virtual bool nfcv_ndef_write_(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
   bool clean_tag();
 
   /// Send an APDU via ISO-DEP (ISO 14443-4) I-Block framing.
@@ -183,58 +183,58 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides — each uses the ST25R3916 default or can be overridden
-  virtual bool reset_chip();
-  virtual void reinitialize();
-  virtual void send_anticol_frame();
-  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
-  virtual std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid);
+  virtual bool reset_chip_();
+  virtual void reinitialize_();
+  virtual void send_anticol_frame_();
+  virtual bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
+  virtual std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
 
-  // Virtual helpers used by the shared process_state() to abstract chip differences
-  virtual void send_halt();                  // encode and transmit the ISO14443A HALT command
-  virtual void start_wupa();                 // clear chip state and transmit WUPA
-  virtual void pre_select();                 // clear anticol mode before SELECT (chip-specific register)
-  virtual uint8_t read_fifo_status1();       // read the chip's FIFO byte count register
-  virtual uint8_t read_collision_display();  // read the chip's collision position register
+  // Virtual helpers used by the shared process_state_() to abstract chip differences
+  virtual void send_halt_();                  // encode and transmit the ISO14443A HALT command
+  virtual void start_wupa_();                 // clear chip state and transmit WUPA
+  virtual void pre_select_();                 // clear anticol mode before SELECT (chip-specific register)
+  virtual uint8_t read_fifo_status1_();       // read the chip's FIFO byte count register
+  virtual uint8_t read_collision_display_();  // read the chip's collision position register
 
-  void field_on();
-  void finalize_scan();
+  void field_on_();
+  void finalize_scan_();
 
   // Automatic Antenna Tuning — hill-climbing optimizer for ANT_TUNE_A/B
-  void aat_tune();
+  void aat_tune_();
 
   // ISO 14443-4 (ISO-DEP / Type 4 tags)
-  bool isodep_activate(uint8_t *ats, uint8_t &ats_len);  // Send RATS, parse ATS
-  bool isodep_transceive(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
-  std::unique_ptr<nfc::NfcTag> read_tag_type4(std::vector<uint8_t> &uid);
+  bool isodep_activate_(uint8_t *ats, uint8_t &ats_len);  // Send RATS, parse ATS
+  bool isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
+  std::unique_ptr<nfc::NfcTag> read_tag_type4_(std::vector<uint8_t> &uid);
   uint8_t isodep_block_number_{0};
 
   // NFC-B (ISO 14443B) support
-  void nfcb_scan();
-  void configure_nfcb_mode();
+  void nfcb_scan_();
+  void configure_nfcb_mode_();
 
   // NFC-V (ISO 15693) support for ST25R3916 — streaming mode
-  void nfcv_scan();
-  void configure_nfcv_stream_mode();
-  void restore_nfca_mode();
-  bool transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  void nfcv_scan_();
+  void configure_nfcv_stream_mode_();
+  void restore_nfca_mode_();
+  bool transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                uint32_t timeout_ms = 30);
   // ISO 15693 encoding/decoding helpers
-  static uint16_t iso15693_crc(const uint8_t *data, size_t len);
-  static size_t iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
-  static size_t iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
-  void apply_anticol_prefix();
-  bool wait_for_irq(uint8_t mask, uint32_t timeout_ms);
+  static uint16_t iso15693_crc_(const uint8_t *data, size_t len);
+  static size_t iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
+  static size_t iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
+  void apply_anticol_prefix_();
+  bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   // Mifare Classic — raw transceive with manual parity (no chip CRC/parity).
   // Adapted from mf1.c (MIT, github.com/suut/rfal-mifare-classic)
-  bool transceive_mifare(const uint8_t *data, const uint8_t *parity, uint8_t len,
+  bool transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len,
                           uint8_t *resp, uint8_t *resp_parity, uint8_t &resp_len,
                           uint32_t timeout_ms = 15);
-  bool mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
+  bool mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
                             const uint8_t *uid, uint8_t uid_len,
                             struct Crypto1State *cs);
-  bool mifare_read_block(uint8_t block, uint8_t *data, struct Crypto1State *cs);
+  bool mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs);
   static void isr(ST25R *arg);
   
   GPIOPin *reset_pin_{nullptr};

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -126,11 +126,11 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void dump_config() override;
   void update() override;
   void loop() override;
-  void process_state_();
+  void process_state();
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool ndef_write(nfc::NdefMessage *message, bool format = false);
-  virtual bool nfcv_ndef_write_(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
+  virtual bool nfcv_ndef_write(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
   bool clean_tag();
 
   /// Send an APDU via ISO-DEP (ISO 14443-4) I-Block framing.
@@ -183,58 +183,58 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides — each uses the ST25R3916 default or can be overridden
-  virtual bool reset_();
-  virtual void reinitialize_();
-  virtual void send_anticol_frame_();
-  virtual bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms = 150);
-  virtual std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
+  virtual bool reset_chip();
+  virtual void reinitialize();
+  virtual void send_anticol_frame();
+  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
+  virtual std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid);
 
-  // Virtual helpers used by the shared process_state_() to abstract chip differences
-  virtual void send_halt_();                  // encode and transmit the ISO14443A HALT command
-  virtual void start_wupa_();                 // clear chip state and transmit WUPA
-  virtual void pre_select_();                 // clear anticol mode before SELECT (chip-specific register)
-  virtual uint8_t read_fifo_status1_();       // read the chip's FIFO byte count register
-  virtual uint8_t read_collision_display_();  // read the chip's collision position register
+  // Virtual helpers used by the shared process_state() to abstract chip differences
+  virtual void send_halt();                  // encode and transmit the ISO14443A HALT command
+  virtual void start_wupa();                 // clear chip state and transmit WUPA
+  virtual void pre_select();                 // clear anticol mode before SELECT (chip-specific register)
+  virtual uint8_t read_fifo_status1();       // read the chip's FIFO byte count register
+  virtual uint8_t read_collision_display();  // read the chip's collision position register
 
-  void field_on_();
-  void finalize_scan_();
+  void field_on();
+  void finalize_scan();
 
   // Automatic Antenna Tuning — hill-climbing optimizer for ANT_TUNE_A/B
-  void aat_tune_();
+  void aat_tune();
 
   // ISO 14443-4 (ISO-DEP / Type 4 tags)
-  bool isodep_activate_(uint8_t *ats, uint8_t &ats_len);  // Send RATS, parse ATS
-  bool isodep_transceive_(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
-  std::unique_ptr<nfc::NfcTag> read_tag_type4_(std::vector<uint8_t> &uid);
+  bool isodep_activate(uint8_t *ats, uint8_t &ats_len);  // Send RATS, parse ATS
+  bool isodep_transceive(const uint8_t *apdu, size_t apdu_len, uint8_t *resp, uint8_t &resp_len);
+  std::unique_ptr<nfc::NfcTag> read_tag_type4(std::vector<uint8_t> &uid);
   uint8_t isodep_block_number_{0};
 
   // NFC-B (ISO 14443B) support
-  void nfcb_scan_();
-  void configure_nfcb_mode_();
+  void nfcb_scan();
+  void configure_nfcb_mode();
 
   // NFC-V (ISO 15693) support for ST25R3916 — streaming mode
-  void nfcv_scan_();
-  void configure_nfcv_stream_mode_();
-  void restore_nfca_mode_();
-  bool transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  void nfcv_scan();
+  void configure_nfcv_stream_mode();
+  void restore_nfca_mode();
+  bool transceive_nfcv_stream(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                uint32_t timeout_ms = 30);
   // ISO 15693 encoding/decoding helpers
-  static uint16_t iso15693_crc_(const uint8_t *data, size_t len);
-  static size_t iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
-  static size_t iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
-  void apply_anticol_prefix_();
-  bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
+  static uint16_t iso15693_crc(const uint8_t *data, size_t len);
+  static size_t iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
+  static size_t iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
+  void apply_anticol_prefix();
+  bool wait_for_irq(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   // Mifare Classic — raw transceive with manual parity (no chip CRC/parity).
   // Adapted from mf1.c (MIT, github.com/suut/rfal-mifare-classic)
-  bool transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len,
+  bool transceive_mifare(const uint8_t *data, const uint8_t *parity, uint8_t len,
                           uint8_t *resp, uint8_t *resp_parity, uint8_t &resp_len,
                           uint32_t timeout_ms = 15);
-  bool mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
+  bool mifare_authenticate(uint8_t block, bool key_b, uint64_t key,
                             const uint8_t *uid, uint8_t uid_len,
                             struct Crypto1State *cs);
-  bool mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs);
+  bool mifare_read_block(uint8_t block, uint8_t *data, struct Crypto1State *cs);
   static void isr(ST25R *arg);
   
   GPIOPin *reset_pin_{nullptr};

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -126,11 +126,11 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void dump_config() override;
   void update() override;
   void loop() override;
-  void process_state_();
+  void process_state();
   float get_setup_priority() const override { return setup_priority::DATA; }
 
   bool ndef_write(nfc::NdefMessage *message, bool format = false);
-  virtual bool nfcv_ndef_write_(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
+  virtual bool nfcv_ndef_write(nfc::NdefMessage *message);  // NFC-V Type 5 WRITE_SINGLE_BLOCK path
   bool clean_tag();
 
   /// Send an APDU via ISO-DEP (ISO 14443-4) I-Block framing.
@@ -183,18 +183,18 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides — each uses the ST25R3916 default or can be overridden
-  virtual bool reset_chip_();
-  virtual void reinitialize_();
-  virtual void send_anticol_frame_();
-  virtual bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
-  virtual std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid);
+  virtual bool reset_chip();
+  virtual void reinitialize();
+  virtual void send_anticol_frame();
+  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
+  virtual std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid);
 
-  // Virtual helpers used by the shared process_state_() to abstract chip differences
-  virtual void send_halt_();                  // encode and transmit the ISO14443A HALT command
-  virtual void start_wupa_();                 // clear chip state and transmit WUPA
-  virtual void pre_select_();                 // clear anticol mode before SELECT (chip-specific register)
-  virtual uint8_t read_fifo_status1_();       // read the chip's FIFO byte count register
-  virtual uint8_t read_collision_display_();  // read the chip's collision position register
+  // Virtual helpers used by the shared process_state() to abstract chip differences
+  virtual void send_halt();                  // encode and transmit the ISO14443A HALT command
+  virtual void start_wupa();                 // clear chip state and transmit WUPA
+  virtual void pre_select();                 // clear anticol mode before SELECT (chip-specific register)
+  virtual uint8_t read_fifo_status1();       // read the chip's FIFO byte count register
+  virtual uint8_t read_collision_display();  // read the chip's collision position register
 
   void field_on_();
   void finalize_scan_();
@@ -219,9 +219,9 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   bool transceive_nfcv_stream_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                uint32_t timeout_ms = 30);
   // ISO 15693 encoding/decoding helpers
-  static uint16_t iso15693_crc_(const uint8_t *data, size_t len);
-  static size_t iso15693_encode_1of4_(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
-  static size_t iso15693_decode_manchester_(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
+  static uint16_t iso15693_crc(const uint8_t *data, size_t len);
+  static size_t iso15693_encode_1of4(const uint8_t *data, size_t len, bool add_crc, uint8_t *out, size_t out_max);
+  static size_t iso15693_decode_manchester(const uint8_t *in, size_t in_len, uint8_t *out, size_t out_max);
   void apply_anticol_prefix_();
   bool wait_for_irq_(uint8_t mask, uint32_t timeout_ms);
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -43,24 +43,24 @@ enum ST25RRegister : uint8_t {
   NUM_TX_BYTES1 = 0x22,
   NUM_TX_BYTES2 = 0x23,
   AD_CONV_RESULT = 0x25,
-  ANT_TUNE_A = 0x26,   // Antenna tuning DAC A (Space A): V = (0.044 + 0.868 * val/255) * VDD_A; default 0x80
-  ANT_TUNE_B = 0x27,   // Antenna tuning DAC B (Space A): same formula; default 0x80
+  ANT_TUNE_A = 0x26,  // Antenna tuning DAC A (Space A): V = (0.044 + 0.868 * val/255) * VDD_A; default 0x80
+  ANT_TUNE_B = 0x27,  // Antenna tuning DAC B (Space A): same formula; default 0x80
   TX_DRIVER_CONF = 0x28,
-  PT_MOD = 0x29,        // PT modulation (Space A): RFO resistance in modulated state
+  PT_MOD = 0x29,                  // PT modulation (Space A): RFO resistance in modulated state
   FIELD_THRESHOLD_ACTV = 0x2A,    // External field detector activation threshold
   FIELD_THRESHOLD_DEACTV = 0x2B,  // External field detector deactivation threshold
   IC_IDENTITY = 0x3F,
   // Space B registers (bit 0x40 set → SPI prefix 0xFB before address)
-  EMD_SUP_CONF = 0x45,      // (Space B 0x05) EMD suppression config
-  CORR_CONF1 = 0x4C,        // (Space B 0x0C) Correlator configuration 1
-  CORR_CONF2 = 0x4D,        // (Space B 0x0D) Correlator configuration 2
+  EMD_SUP_CONF = 0x45,       // (Space B 0x05) EMD suppression config
+  CORR_CONF1 = 0x4C,         // (Space B 0x0C) Correlator configuration 1
+  CORR_CONF2 = 0x4D,         // (Space B 0x0D) Correlator configuration 2
   AUX_MOD = 0x68,            // (Space B 0x28) Aux modulation setting
   RES_AM_MOD = 0x6A,         // (Space B 0x2A) Resistive AM modulation
-  OVERSHOOT_CONF1 = 0x70,   // (Space B 0x30) Overshoot protection config 1
-  OVERSHOOT_CONF2 = 0x71,   // (Space B 0x31) Overshoot protection config 2
-  UNDERSHOOT_CONF1 = 0x72,  // (Space B 0x32) Undershoot protection config 1
-  UNDERSHOOT_CONF2 = 0x73,  // (Space B 0x33) Undershoot protection config 2
-  REGULATOR_CONTROL = 0x2C, // Regulated voltage control (Space A)
+  OVERSHOOT_CONF1 = 0x70,    // (Space B 0x30) Overshoot protection config 1
+  OVERSHOOT_CONF2 = 0x71,    // (Space B 0x31) Overshoot protection config 2
+  UNDERSHOOT_CONF1 = 0x72,   // (Space B 0x32) Undershoot protection config 1
+  UNDERSHOOT_CONF2 = 0x73,   // (Space B 0x33) Undershoot protection config 2
+  REGULATOR_CONTROL = 0x2C,  // Regulated voltage control (Space A)
 };
 
 // ST25R Commands
@@ -166,9 +166,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   void set_aat_enabled(bool v) { this->aat_enabled_ = v; }
 
   void register_on_tag_trigger(ST25RTagTrigger *trig) { this->on_tag_triggers_.push_back(trig); }
-  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) {
-    this->on_tag_removed_triggers_.push_back(trig);
-  }
+  void register_on_tag_removed_trigger(ST25RTagRemovedTrigger *trig) { this->on_tag_removed_triggers_.push_back(trig); }
   void register_tag(ST25RBinarySensor *tag) { this->binary_sensors_.push_back(tag); }
   void set_status_binary_sensor(binary_sensor::BinarySensor *sensor) { this->status_binary_sensor_ = sensor; }
   void set_field_strength_sensor(sensor::Sensor *sensor) { this->field_strength_sensor_ = sensor; }
@@ -186,7 +184,8 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   virtual bool reset_chip();
   virtual void reinitialize();
   virtual void send_anticol_frame();
-  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc, uint32_t timeout_ms);
+  virtual bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                             uint32_t timeout_ms);
   virtual std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid);
 
   // Virtual helpers used by the shared process_state() to abstract chip differences
@@ -228,11 +227,9 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
   // Mifare Classic — raw transceive with manual parity (no chip CRC/parity).
   // Adapted from mf1.c (MIT, github.com/suut/rfal-mifare-classic)
-  bool transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len,
-                          uint8_t *resp, uint8_t *resp_parity, uint8_t &resp_len,
-                          uint32_t timeout_ms = 15);
-  bool mifare_authenticate_(uint8_t block, bool key_b, uint64_t key,
-                            const uint8_t *uid, uint8_t uid_len,
+  bool transceive_mifare_(const uint8_t *data, const uint8_t *parity, uint8_t len, uint8_t *resp, uint8_t *resp_parity,
+                          uint8_t &resp_len, uint32_t timeout_ms = 15);
+  bool mifare_authenticate_(uint8_t block, bool key_b, uint64_t key, const uint8_t *uid, uint8_t uid_len,
                             struct Crypto1State *cs);
   bool mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs);
   static void isr(ST25R *arg);
@@ -268,16 +265,16 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   // Multi-tag tracking
   // present_tags_: UID → consecutive miss count (0 = seen this or prior scan)
   std::map<std::string, uint8_t> present_tags_;
-  std::set<std::string> tags_this_scan_;  // UIDs found in current scan cycle
+  std::set<std::string> tags_this_scan_;                           // UIDs found in current scan cycle
   std::map<std::string, std::unique_ptr<nfc::NfcTag>> tags_data_;  // UID → last read NfcTag
 
   // IRQ_MAIN (0x1A) bit definitions per Table 62
-  static const uint8_t IRQ_OSC     = 0x80;  // bit7: oscillator stable
-  static const uint8_t IRQ_WL      = 0x40;  // bit6: FIFO water level
-  static const uint8_t IRQ_RXS     = 0x20;  // bit5: start of receive
-  static const uint8_t IRQ_RXE     = 0x10;  // bit4: end of receive ← tag response
-  static const uint8_t IRQ_TXE     = 0x08;  // bit3: end of transmission
-  static const uint8_t IRQ_COL     = 0x04;  // bit2: bit collision ← anticollision
+  static const uint8_t IRQ_OSC = 0x80;      // bit7: oscillator stable
+  static const uint8_t IRQ_WL = 0x40;       // bit6: FIFO water level
+  static const uint8_t IRQ_RXS = 0x20;      // bit5: start of receive
+  static const uint8_t IRQ_RXE = 0x10;      // bit4: end of receive ← tag response
+  static const uint8_t IRQ_TXE = 0x08;      // bit3: end of transmission
+  static const uint8_t IRQ_COL = 0x04;      // bit2: bit collision ← anticollision
   static const uint8_t IRQ_RX_REST = 0x02;  // bit1: automatic reception restart
   // NRE (no-response timer expired): set in irq_status_ by derived class overrides
   // (e.g. ST25R300 translates its IRQ_STATUS2 NRE bit here). ST25R3916 uses millis() timeout.
@@ -290,17 +287,17 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   uint8_t last_sak_{0};  // SAK from most recent SELECT (bit5=0x20 → ISO-DEP capable)
 
   // Anticollision loop state
-  uint8_t anticol_prefix_[5]{};   // UID prefix bytes being used to narrow search
-  uint8_t anticol_prefix_full_;   // complete prefix bytes
-  uint8_t anticol_prefix_bits_;   // partial bits in last prefix byte
-  uint8_t anticol_col_pos_{0};    // collision bit position (bits 0..col_pos are prefix)
-  uint8_t anticol_prefix_val_{0}; // current prefix value being tried (brute-forced)
+  uint8_t anticol_prefix_[5]{};    // UID prefix bytes being used to narrow search
+  uint8_t anticol_prefix_full_;    // complete prefix bytes
+  uint8_t anticol_prefix_bits_;    // partial bits in last prefix byte
+  uint8_t anticol_col_pos_{0};     // collision bit position (bits 0..col_pos are prefix)
+  uint8_t anticol_prefix_val_{0};  // current prefix value being tried (brute-forced)
 
   // Multi-tag tree traversal: saved CL1 collision state for resuming after cascade CL2
   uint8_t saved_col_pos_{0};
   uint8_t saved_prefix_val_{0};
   bool saved_anticol_valid_{false};
-  bool anticol_resume_{false};    // when true: STATE_WUPA uses saved prefix instead of resetting
+  bool anticol_resume_{false};  // when true: STATE_WUPA uses saved prefix instead of resetting
 
   std::vector<ST25RTagTrigger *> on_tag_triggers_;
   std::vector<ST25RTagRemovedTrigger *> on_tag_removed_triggers_;

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -236,7 +236,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
                             struct Crypto1State *cs);
   bool mifare_read_block_(uint8_t block, uint8_t *data, struct Crypto1State *cs);
   static void isr(ST25R *arg);
-  
+
   GPIOPin *reset_pin_{nullptr};
   InternalGPIOPin *irq_pin_{nullptr};
 

--- a/esphome/components/st25r/st25r.h
+++ b/esphome/components/st25r/st25r.h
@@ -248,7 +248,7 @@ class ST25R : public PollingComponent, public nfc::Nfcc {
   uint64_t mifare_key_b_{0xFFFFFFFFFFFFULL};
   uint8_t miss_threshold_{3};
   uint8_t ant_tune_a_{0x80};  // AAT DAC A: 0x80 = mid-range (~0.48V on 3.3V / ~0.87V on 5V)
-  uint8_t ant_tune_b_{0x80};  // AAT DAC B: same
+  uint8_t ant_tune_b_{0x40};  // RFAL default (not chip default 0x80)  // AAT DAC B: same
   bool is_b_version_{false};
   bool has_aat_{false};  // Automatic Antenna Tuning / varicap DAC (ANT_TUNE_A/B) available
   // Health check (chip liveness check, separate from tag scan interval)

--- a/esphome/components/st25r300/__init__.py
+++ b/esphome/components/st25r300/__init__.py
@@ -1,0 +1,178 @@
+from esphome import automation, pins
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import binary_sensor as binary_sensor_
+from esphome.components import sensor as sensor_
+from esphome.components import st25r as st25r_
+from esphome.const import (
+    CONF_ID,
+    CONF_ON_TAG,
+    CONF_ON_TAG_REMOVED,
+    CONF_TRIGGER_ID,
+    CONF_IRQ_PIN,
+    CONF_RESET_PIN,
+    CONF_STATUS,
+)
+
+CODEOWNERS = ["@JohnMcLear"]
+AUTO_LOAD = ["st25r", "binary_sensor", "sensor", "nfc"]
+MULTI_CONF = True
+
+CONF_ST25R300_ID = "st25r300_id"
+CONF_RF_FIELD_ENABLED = "rf_field_enabled"
+CONF_RF_POWER = "rf_power"
+CONF_SUPPLY_3V3 = "supply_3v3"
+CONF_RX_GAIN_BOOST = "rx_gain_boost"
+CONF_FIELD_STRENGTH = "field_strength"
+CONF_MIFARE_KEY_A = "mifare_key_a"
+CONF_MIFARE_KEY_B = "mifare_key_b"
+CONF_HEALTH_CHECK_ENABLED = "health_check_enabled"
+CONF_HEALTH_CHECK_INTERVAL = "health_check_interval"
+CONF_MAX_FAILED_CHECKS = "max_failed_checks"
+CONF_AUTO_RESET_ON_FAILURE = "auto_reset_on_failure"
+CONF_NFCV_ENABLED = "nfcv_enabled"
+CONF_NFCB_ENABLED = "nfcb_enabled"
+
+
+def _validate_mifare_key(value):
+    value = cv.string_strict(value)
+    if len(value) != 12:
+        raise cv.Invalid(f"Mifare key must be exactly 12 hex characters, got {len(value)}")
+    try:
+        int(value, 16)
+    except ValueError as err:
+        raise cv.Invalid("Mifare key must contain only hex characters (0-9, A-F)") from err
+    return value.upper()
+
+
+st25r300_ns = cg.esphome_ns.namespace("st25r300")
+ST25R300 = st25r300_ns.class_("ST25R300", st25r_.ST25R)
+
+ST25R300TagTrigger = st25r300_ns.class_(
+    "ST25R300TagTrigger", automation.Trigger.template(cg.std_string)
+)
+ST25R300TagRemovedTrigger = st25r300_ns.class_(
+    "ST25R300TagRemovedTrigger", automation.Trigger.template(cg.std_string)
+)
+
+NDEFWriteAction = st25r300_ns.class_("NDEFWriteAction", automation.Action)
+CleanTagAction = st25r300_ns.class_("CleanTagAction", automation.Action)
+
+ST25R300_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(ST25R300),
+        cv.Optional(CONF_IRQ_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
+        cv.Optional(CONF_RF_FIELD_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_SUPPLY_3V3, default=True): cv.boolean,
+        cv.Optional(CONF_RX_GAIN_BOOST, default=False): cv.boolean,
+        cv.Optional(CONF_MIFARE_KEY_A, default="FFFFFFFFFFFF"): _validate_mifare_key,
+        cv.Optional(CONF_MIFARE_KEY_B, default="FFFFFFFFFFFF"): _validate_mifare_key,
+        cv.Optional(CONF_HEALTH_CHECK_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_HEALTH_CHECK_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_MAX_FAILED_CHECKS, default=3): cv.int_range(min=1, max=255),
+        cv.Optional(CONF_AUTO_RESET_ON_FAILURE, default=True): cv.boolean,
+        cv.Optional(CONF_NFCV_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_NFCB_ENABLED, default=True): cv.boolean,
+        cv.Optional(CONF_STATUS): binary_sensor_.binary_sensor_schema(),
+        cv.Optional(CONF_FIELD_STRENGTH): sensor_.sensor_schema(),
+        cv.Optional(CONF_ON_TAG): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25R300TagTrigger),
+            }
+        ),
+        cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
+            {
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25R300TagRemovedTrigger),
+            }
+        ),
+    }
+).extend(cv.polling_component_schema("1s"))
+
+
+async def setup_st25r300(var, config):
+    await cg.register_component(var, config)
+
+    if CONF_IRQ_PIN in config:
+        irq = await cg.gpio_pin_expression(config[CONF_IRQ_PIN])
+        cg.add(var.set_irq_pin(irq))
+
+    if CONF_RESET_PIN in config:
+        reset = await cg.gpio_pin_expression(config[CONF_RESET_PIN])
+        cg.add(var.set_reset_pin(reset))
+
+    cg.add(var.set_rf_field_enabled(config[CONF_RF_FIELD_ENABLED]))
+    cg.add(var.set_rf_power(config[CONF_RF_POWER]))
+    cg.add(var.set_supply_3v3(config[CONF_SUPPLY_3V3]))
+    cg.add(var.set_rx_gain_boost(config[CONF_RX_GAIN_BOOST]))
+    cg.add(var.set_mifare_key_a(int(config[CONF_MIFARE_KEY_A], 16)))
+    cg.add(var.set_mifare_key_b(int(config[CONF_MIFARE_KEY_B], 16)))
+    cg.add(var.set_health_check_enabled(config[CONF_HEALTH_CHECK_ENABLED]))
+    cg.add(var.set_health_check_interval(config[CONF_HEALTH_CHECK_INTERVAL]))
+    cg.add(var.set_max_failed_checks(config[CONF_MAX_FAILED_CHECKS]))
+    cg.add(var.set_auto_reset_on_failure(config[CONF_AUTO_RESET_ON_FAILURE]))
+    cg.add(var.set_nfcv_enabled(config[CONF_NFCV_ENABLED]))
+    cg.add(var.set_nfcb_enabled(config[CONF_NFCB_ENABLED]))
+
+    if CONF_STATUS in config:
+        sens = await binary_sensor_.new_binary_sensor(config[CONF_STATUS])
+        cg.add(var.set_status_binary_sensor(sens))
+
+    if CONF_FIELD_STRENGTH in config:
+        sens = await sensor_.new_sensor(config[CONF_FIELD_STRENGTH])
+        cg.add(var.set_field_strength_sensor(sens))
+
+    for conf in config.get(CONF_ON_TAG, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )
+
+    for conf in config.get(CONF_ON_TAG_REMOVED, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        cg.add(var.register_on_tag_removed_trigger(trigger))
+        await automation.build_automation(
+            trigger, [(cg.std_string, "x")], conf
+        )
+
+
+@automation.register_action(
+    "st25r300.ndef_write",
+    NDEFWriteAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(ST25R300),
+            cv.Required("ndef_message"): cv.lambda_,
+            cv.Optional("format", default=False): cv.boolean,
+        },
+        key="ndef_message",
+    ),
+)
+async def st25r300_ndef_write_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(var.set_parent(parent))
+    template_ = await cg.process_lambda(
+        config["ndef_message"], args, return_type=cg.RawExpression("esphome::nfc::NdefMessage *")
+    )
+    cg.add(var.set_message(template_))
+    cg.add(var.set_format(config["format"]))
+    return var
+
+
+@automation.register_action(
+    "st25r300.clean_tag",
+    CleanTagAction,
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.use_id(ST25R300),
+        },
+    ),
+)
+async def st25r300_clean_tag_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    parent = await cg.get_variable(config[CONF_ID])
+    cg.add(var.set_parent(parent))
+    return var

--- a/esphome/components/st25r300/__init__.py
+++ b/esphome/components/st25r300/__init__.py
@@ -21,7 +21,6 @@ MULTI_CONF = True
 CONF_ST25R300_ID = "st25r300_id"
 CONF_RF_FIELD_ENABLED = "rf_field_enabled"
 CONF_RF_POWER = "rf_power"
-CONF_SUPPLY_3V3 = "supply_3v3"
 CONF_RX_GAIN_BOOST = "rx_gain_boost"
 CONF_FIELD_STRENGTH = "field_strength"
 CONF_MIFARE_KEY_A = "mifare_key_a"
@@ -65,7 +64,6 @@ ST25R300_SCHEMA = cv.Schema(
         cv.Optional(CONF_RESET_PIN): pins.gpio_output_pin_schema,
         cv.Optional(CONF_RF_FIELD_ENABLED, default=True): cv.boolean,
         cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
-        cv.Optional(CONF_SUPPLY_3V3, default=True): cv.boolean,
         cv.Optional(CONF_RX_GAIN_BOOST, default=False): cv.boolean,
         cv.Optional(CONF_MIFARE_KEY_A, default="FFFFFFFFFFFF"): _validate_mifare_key,
         cv.Optional(CONF_MIFARE_KEY_B, default="FFFFFFFFFFFF"): _validate_mifare_key,
@@ -104,7 +102,6 @@ async def setup_st25r300(var, config):
 
     cg.add(var.set_rf_field_enabled(config[CONF_RF_FIELD_ENABLED]))
     cg.add(var.set_rf_power(config[CONF_RF_POWER]))
-    cg.add(var.set_supply_3v3(config[CONF_SUPPLY_3V3]))
     cg.add(var.set_rx_gain_boost(config[CONF_RX_GAIN_BOOST]))
     cg.add(var.set_mifare_key_a(int(config[CONF_MIFARE_KEY_A], 16)))
     cg.add(var.set_mifare_key_b(int(config[CONF_MIFARE_KEY_B], 16)))

--- a/esphome/components/st25r300/__init__.py
+++ b/esphome/components/st25r300/__init__.py
@@ -1,17 +1,19 @@
 from esphome import automation, pins
 import esphome.codegen as cg
+from esphome.components import (
+    binary_sensor as binary_sensor_,
+    sensor as sensor_,
+    st25r as st25r_,
+)
 import esphome.config_validation as cv
-from esphome.components import binary_sensor as binary_sensor_
-from esphome.components import sensor as sensor_
-from esphome.components import st25r as st25r_
 from esphome.const import (
     CONF_ID,
+    CONF_IRQ_PIN,
     CONF_ON_TAG,
     CONF_ON_TAG_REMOVED,
-    CONF_TRIGGER_ID,
-    CONF_IRQ_PIN,
     CONF_RESET_PIN,
     CONF_STATUS,
+    CONF_TRIGGER_ID,
 )
 
 CODEOWNERS = ["@JohnMcLear"]
@@ -52,7 +54,9 @@ ST25R300_SCHEMA = cv.Schema(
         cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
         cv.Optional(CONF_RX_GAIN_BOOST, default=False): cv.boolean,
         cv.Optional(CONF_HEALTH_CHECK_ENABLED, default=True): cv.boolean,
-        cv.Optional(CONF_HEALTH_CHECK_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
+        cv.Optional(
+            CONF_HEALTH_CHECK_INTERVAL, default="60s"
+        ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_MAX_FAILED_CHECKS, default=3): cv.int_range(min=1, max=255),
         cv.Optional(CONF_AUTO_RESET_ON_FAILURE, default=True): cv.boolean,
         cv.Optional(CONF_NFCV_ENABLED, default=True): cv.boolean,
@@ -66,7 +70,9 @@ ST25R300_SCHEMA = cv.Schema(
         ),
         cv.Optional(CONF_ON_TAG_REMOVED): automation.validate_automation(
             {
-                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ST25R300TagRemovedTrigger),
+                cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
+                    ST25R300TagRemovedTrigger
+                ),
             }
         ),
     }
@@ -105,16 +111,12 @@ async def setup_st25r300(var, config):
     for conf in config.get(CONF_ON_TAG, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
     for conf in config.get(CONF_ON_TAG_REMOVED, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         cg.add(var.register_on_tag_removed_trigger(trigger))
-        await automation.build_automation(
-            trigger, [(cg.std_string, "x")], conf
-        )
+        await automation.build_automation(trigger, [(cg.std_string, "x")], conf)
 
 
 @automation.register_action(
@@ -134,7 +136,9 @@ async def st25r300_ndef_write_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     cg.add(var.set_parent(parent))
     template_ = await cg.process_lambda(
-        config["ndef_message"], args, return_type=cg.RawExpression("esphome::nfc::NdefMessage *")
+        config["ndef_message"],
+        args,
+        return_type=cg.RawExpression("esphome::nfc::NdefMessage *"),
     )
     cg.add(var.set_message(template_))
     cg.add(var.set_format(config["format"]))

--- a/esphome/components/st25r300/__init__.py
+++ b/esphome/components/st25r300/__init__.py
@@ -18,30 +18,16 @@ CODEOWNERS = ["@JohnMcLear"]
 AUTO_LOAD = ["st25r", "binary_sensor", "sensor", "nfc"]
 MULTI_CONF = True
 
-CONF_ST25R300_ID = "st25r300_id"
 CONF_RF_FIELD_ENABLED = "rf_field_enabled"
 CONF_RF_POWER = "rf_power"
 CONF_RX_GAIN_BOOST = "rx_gain_boost"
 CONF_FIELD_STRENGTH = "field_strength"
-CONF_MIFARE_KEY_A = "mifare_key_a"
-CONF_MIFARE_KEY_B = "mifare_key_b"
 CONF_HEALTH_CHECK_ENABLED = "health_check_enabled"
 CONF_HEALTH_CHECK_INTERVAL = "health_check_interval"
 CONF_MAX_FAILED_CHECKS = "max_failed_checks"
 CONF_AUTO_RESET_ON_FAILURE = "auto_reset_on_failure"
 CONF_NFCV_ENABLED = "nfcv_enabled"
 CONF_NFCB_ENABLED = "nfcb_enabled"
-
-
-def _validate_mifare_key(value):
-    value = cv.string_strict(value)
-    if len(value) != 12:
-        raise cv.Invalid(f"Mifare key must be exactly 12 hex characters, got {len(value)}")
-    try:
-        int(value, 16)
-    except ValueError as err:
-        raise cv.Invalid("Mifare key must contain only hex characters (0-9, A-F)") from err
-    return value.upper()
 
 
 st25r300_ns = cg.esphome_ns.namespace("st25r300")
@@ -65,8 +51,6 @@ ST25R300_SCHEMA = cv.Schema(
         cv.Optional(CONF_RF_FIELD_ENABLED, default=True): cv.boolean,
         cv.Optional(CONF_RF_POWER, default=15): cv.int_range(min=0, max=15),
         cv.Optional(CONF_RX_GAIN_BOOST, default=False): cv.boolean,
-        cv.Optional(CONF_MIFARE_KEY_A, default="FFFFFFFFFFFF"): _validate_mifare_key,
-        cv.Optional(CONF_MIFARE_KEY_B, default="FFFFFFFFFFFF"): _validate_mifare_key,
         cv.Optional(CONF_HEALTH_CHECK_ENABLED, default=True): cv.boolean,
         cv.Optional(CONF_HEALTH_CHECK_INTERVAL, default="60s"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_MAX_FAILED_CHECKS, default=3): cv.int_range(min=1, max=255),
@@ -103,8 +87,6 @@ async def setup_st25r300(var, config):
     cg.add(var.set_rf_field_enabled(config[CONF_RF_FIELD_ENABLED]))
     cg.add(var.set_rf_power(config[CONF_RF_POWER]))
     cg.add(var.set_rx_gain_boost(config[CONF_RX_GAIN_BOOST]))
-    cg.add(var.set_mifare_key_a(int(config[CONF_MIFARE_KEY_A], 16)))
-    cg.add(var.set_mifare_key_b(int(config[CONF_MIFARE_KEY_B], 16)))
     cg.add(var.set_health_check_enabled(config[CONF_HEALTH_CHECK_ENABLED]))
     cg.add(var.set_health_check_interval(config[CONF_HEALTH_CHECK_INTERVAL]))
     cg.add(var.set_max_failed_checks(config[CONF_MAX_FAILED_CHECKS]))

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -35,8 +35,8 @@ void ST25R300::setup() {
   if (this->status_binary_sensor_ != nullptr)
     this->status_binary_sensor_->publish_initial_state(false);
 
-  ESP_LOGI(TAG, "Starting reset_chip()...");
-  if (!this->reset_chip()) {
+  ESP_LOGI(TAG, "Starting reset_chip_()...");
+  if (!this->reset_chip_()) {
     ESP_LOGE(TAG, "Failed to reset/init ST25R300");
     this->mark_failed();
     return;
@@ -96,11 +96,11 @@ void ST25R300::update() {
 
   // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
   if (this->nfcv_enabled_)
-    this->nfcv_scan();
+    this->nfcv_scan_();
 
   // NFC-B (ISO 14443B) blocking SENSB — runs before NFC-A scan
   if (this->nfcb_enabled_)
-    this->nfcb_scan();
+    this->nfcb_scan_();
 
   this->saved_anticol_valid_ = false;
   this->anticol_resume_ = false;
@@ -113,7 +113,7 @@ void ST25R300::update() {
   // ST25R300 has no dedicated WUPA command — send 7-bit short frame via FIFO
   uint8_t resp[2];
   uint8_t resp_len = 0;
-  this->send_short_frame(0x52, resp, resp_len, 10);  // 0x52 = WUPA
+  this->send_short_frame_(0x52, resp, resp_len, 10);  // 0x52 = WUPA
   ESP_LOGI(TAG, "Sent WUPA");
   delay(1);
   this->state_ = STATE_WUPA;
@@ -122,7 +122,7 @@ void ST25R300::update() {
 
 // ── loop ──────────────────────────────────────────────────────────────────────
 // Overrides base to translate ST25R300's three IRQ registers into the normalized
-// irq_status_ uint8_t used by the shared process_state() state machine.
+// irq_status_ uint8_t used by the shared process_state_() state machine.
 void ST25R300::loop() {
   if (this->is_failed()) return;
 
@@ -153,11 +153,11 @@ void ST25R300::loop() {
   if (this->irq_status2_ & ST25R300_IRQ2_NRE) n |= IRQ_NRE;
   this->irq_status_ = n;
 
-  this->process_state();
+  this->process_state_();
 }
 
 // ── send_short_frame_ ─────────────────────────────────────────────────────────
-bool ST25R300::send_short_frame(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);  // no CRC, no parity
   // b_rx_sof+b_rx_eof MUST be set for Manchester framing; no CRC for ATQA
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
@@ -198,15 +198,15 @@ bool ST25R300::send_short_frame(uint8_t byte7, uint8_t *resp, uint8_t &resp_len,
 // ── transceive_ / transceive_no_crc_ ─────────────────────────────────────────
 bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                             uint32_t timeout_ms) {
-  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
 }
 bool ST25R300::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                    uint32_t timeout_ms) {
-  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
 }
 
 // ── transceive_ex_ ────────────────────────────────────────────────────────────
-bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -264,7 +264,7 @@ bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uin
 // ── read_tag_ ─────────────────────────────────────────────────────────────────
 // ST25R300 supports NFC Forum Type 2 (NTAG) only.
 // Mifare Classic authentication is not implemented for ST25R300 (different MAC engine).
-std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d", uid.size(), type);
 
@@ -348,20 +348,20 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
 
 // ── Virtual helper overrides ───────────────────────────────────────────────────
 
-uint8_t ST25R300::read_fifo_status1() {
+uint8_t ST25R300::read_fifo_status1_() {
   return this->read_register(ST25R300_REG_FIFO_STATUS1);
 }
 
-uint8_t ST25R300::read_collision_display() {
+uint8_t ST25R300::read_collision_display_() {
   return this->read_register(ST25R300_REG_COLLISION_DISPLAY);
 }
 
-void ST25R300::pre_select() {
-  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex().
+void ST25R300::pre_select_() {
+  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex_().
   // There is no separate "anticol mode" register to clear before SELECT.
 }
 
-void ST25R300::send_halt() {
+void ST25R300::send_halt_() {
   uint8_t halt_cmd[2] = {0x50, 0x00};
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -377,7 +377,7 @@ void ST25R300::send_halt() {
   delay(10);
 }
 
-void ST25R300::start_wupa() {
+void ST25R300::start_wupa_() {
   // Clear FIFO + IRQs + chip accumulators, then transmit WUPA as short frame
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -389,11 +389,11 @@ void ST25R300::start_wupa() {
   this->irq_status_ = 0;
   uint8_t dummy[2];
   uint8_t dummy_len = 0;
-  this->send_short_frame(0x52, dummy, dummy_len, 10);
+  this->send_short_frame_(0x52, dummy, dummy_len, 10);
 }
 
 // ── send_anticol_frame_ ───────────────────────────────────────────────────────
-void ST25R300::send_anticol_frame() {
+void ST25R300::send_anticol_frame_() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -436,7 +436,7 @@ void ST25R300::send_anticol_frame() {
 }
 
 // ── reset_ ────────────────────────────────────────────────────────────────────
-bool ST25R300::reset_chip() {
+bool ST25R300::reset_chip_() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
   ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
@@ -524,7 +524,7 @@ bool ST25R300::reset_chip() {
 }
 
 // ── reinitialize_ ─────────────────────────────────────────────────────────────
-void ST25R300::reinitialize() {
+void ST25R300::reinitialize_() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R300 (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -533,7 +533,7 @@ void ST25R300::reinitialize() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_chip()) {
+  if (this->reset_chip_()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -570,7 +570,7 @@ void ST25R300::dump_config() {
 
 // ── NFC-V (ISO 15693) support ────────────────────────────────────────────────
 
-void ST25R300::configure_nfcv_mode() {
+void ST25R300::configure_nfcv_mode_() {
   this->write_register(ST25R300_REG_GENERAL_CONF, 0x02);    // nfc_n=2 (NFC-V subcarrier config)
   this->write_register(ST25R300_REG_PROTOCOL1, 0x05);      // om=5: NFC-V/ISO15693
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity)
@@ -593,7 +593,7 @@ void ST25R300::configure_nfcv_mode() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
 }
 
-void ST25R300::configure_nfca_mode() {
+void ST25R300::configure_nfca_mode_() {
   this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);    // nfc_n=0 (NFC-A)
   this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A
   this->write_register(ST25R300_REG_TX_PROTOCOL1,
@@ -617,7 +617,7 @@ void ST25R300::configure_nfca_mode() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x23);
 }
 
-bool ST25R300::transceive_nfcv(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                  uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -661,9 +661,9 @@ bool ST25R300::transceive_nfcv(const uint8_t *data, size_t len, uint8_t *resp, u
   return false;
 }
 
-void ST25R300::nfcv_scan() {
+void ST25R300::nfcv_scan_() {
   // Switch to NFC-V mode
-  this->configure_nfcv_mode();
+  this->configure_nfcv_mode_();
 
   ESP_LOGV(TAG, "NFC-V: starting inventory scan");
 
@@ -675,7 +675,7 @@ void ST25R300::nfcv_scan() {
   // Loop: inventory → record UID → stay quiet → repeat until no response
   for (int i = 0; i < 16; i++) {  // max 16 NFC-V tags per scan
     resp_len = 0;
-    if (!this->transceive_nfcv(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
+    if (!this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
       break;  // No more tags
     }
 
@@ -699,7 +699,7 @@ void ST25R300::nfcv_scan() {
     uid_str[16] = '\0';
     ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
 
-    // Add to tags_this_scan_ — finalize_scan() handles on_tag_removed
+    // Add to tags_this_scan_ — finalize_scan_() handles on_tag_removed
     std::string uid_string(uid_str);
     this->tags_this_scan_.insert(uid_string);
 
@@ -714,7 +714,7 @@ void ST25R300::nfcv_scan() {
     uint8_t blk_len = 0;
     std::vector<uint8_t> ndef_data;
 
-    if (this->transceive_nfcv(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+    if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
         blk_len >= 5 && !(blk_resp[0] & 0x01)) {
       if (blk_resp[1] == 0xE1) {  // NDEF magic uint8_t in CC
         uint8_t cc_size = blk_resp[3];
@@ -724,7 +724,7 @@ void ST25R300::nfcv_scan() {
         for (uint8_t blk = 1; blk <= total_blocks; blk++) {
           blk_req[2] = blk;
           blk_len = 0;
-          if (this->transceive_nfcv(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+          if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
               blk_len >= 5 && !(blk_resp[0] & 0x01)) {
             for (int k = 1; k < 5 && k < blk_len; k++)
               ndef_data.push_back(blk_resp[k]);
@@ -771,11 +771,11 @@ void ST25R300::nfcv_scan() {
   }
 
   // Switch back to NFC-A mode for the main scan
-  this->configure_nfca_mode();
+  this->configure_nfca_mode_();
 }
 
-bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
-  this->configure_nfcv_mode();
+bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
+  this->configure_nfcv_mode_();
 
   std::vector<uint8_t> payload;
   if (message != nullptr) {
@@ -802,9 +802,9 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
   uint8_t resp[4];
   uint8_t resp_len = 0;
 
-  if (!this->transceive_nfcv(write_req, sizeof(write_req), resp, resp_len, 25)) {
+  if (!this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
     ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
-    this->configure_nfca_mode();
+    this->configure_nfca_mode_();
     return false;
   }
 
@@ -819,7 +819,7 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
 
     bool success = false;
     for (uint8_t retry = 0; retry < 3; retry++) {
-      if (this->transceive_nfcv(write_req, sizeof(write_req), resp, resp_len, 25)) {
+      if (this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
         success = true;
         break;
       }
@@ -827,19 +827,19 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
     }
     if (!success) {
       ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
-      this->configure_nfca_mode();
+      this->configure_nfca_mode_();
       return false;
     }
   }
 
   ESP_LOGI(TAG, "NFC-V NDEF write successful!");
-  this->configure_nfca_mode();
+  this->configure_nfca_mode_();
   return true;
 }
 
 // ── NFC-B (ISO 14443B) support ───────────────────────────────────────────────
 
-void ST25R300::configure_nfcb_mode() {
+void ST25R300::configure_nfcb_mode_() {
   this->write_register(ST25R300_REG_PROTOCOL1, 0x02);      // om=2: NFC-B/ISO14443B
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity for NFC-B)
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
@@ -852,15 +852,15 @@ void ST25R300::configure_nfcb_mode() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
 }
 
-void ST25R300::nfcb_scan() {
-  this->configure_nfcb_mode();
+void ST25R300::nfcb_scan_() {
+  this->configure_nfcb_mode_();
 
   // SENSB_REQ (ALLB): cmd=0x05, AFI=0x00, PARAM=0x08 (1 slot + WUPB)
   uint8_t sensb_req[] = {0x05, 0x00, 0x08};
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_nfcv(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
+  if (this->transceive_nfcv_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
       resp_len >= 12 && resp[0] == 0x50) {
     // ATQB: uint8_t 0 = 0x50, bytes 1-4 = PUPI
     char uid_str[9];
@@ -883,7 +883,7 @@ void ST25R300::nfcb_scan() {
   }
 
   // Restore NFC-A mode
-  this->configure_nfca_mode();
+  this->configure_nfca_mode_();
 }
 
 }  // namespace st25r300

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -1,0 +1,890 @@
+#include "st25r300.h"
+#include "esphome/core/log.h"
+#include "esphome/core/hal.h"
+#include "esphome/components/nfc/nfc_tag.h"
+#include "esphome/components/nfc/nfc_helpers.h"
+#include <algorithm>
+#include <cstring>
+
+namespace esphome {
+namespace st25r300 {
+
+static const char *const TAG = "st25r300";
+
+void ST25R300::isr(ST25R300 *arg) {
+  arg->irq_triggered_ = true;
+}
+
+void ST25R300::setup() {
+  ESP_LOGI(TAG, "Setting up ST25R300...");
+  if (this->reset_pin_ != nullptr) {
+    ESP_LOGI(TAG, "Cycling reset pin...");
+    this->reset_pin_->setup();
+    this->reset_pin_->digital_write(true);   // assert reset
+    delay(10);
+    this->reset_pin_->digital_write(false);  // release reset
+    delay(10);
+  }
+
+  if (this->irq_pin_ != nullptr) {
+    ESP_LOGI(TAG, "Configuring IRQ pin...");
+    this->irq_pin_->setup();
+    this->irq_pin_->attach_interrupt(ST25R300::isr, this, gpio::INTERRUPT_RISING_EDGE);
+  }
+
+  if (this->status_binary_sensor_ != nullptr)
+    this->status_binary_sensor_->publish_initial_state(false);
+
+  ESP_LOGI(TAG, "Starting reset_()...");
+  if (!this->reset_()) {
+    ESP_LOGE(TAG, "Failed to reset/init ST25R300");
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGI(TAG, "ST25R300 initialized successfully.");
+}
+
+void ST25R300::update() {
+  if (this->is_failed() || this->state_ != STATE_IDLE) return;
+
+  // Health check: verify chip identity at the configured interval (default 60s),
+  // independent of the tag scan rate.  Uses ST25R300-specific IC identity value
+  // (chip_type=0xB0) but otherwise mirrors ST25R::update() so that all four
+  // configurable options (health_check_enabled, health_check_interval,
+  // max_failed_checks, auto_reset_on_failure) are honoured.
+  if (this->health_check_enabled_) {
+    uint32_t now = millis();
+    if (now - this->last_health_check_ms_ >= this->health_check_interval_ms_) {
+      this->last_health_check_ms_ = now;
+      uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
+      if ((ic_identity & ST25R300_IC_TYPE_MASK) != ST25R300_IC_TYPE_VAL) {
+        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)",
+                 ic_identity, this->health_check_failures_ + 1, this->max_failed_checks_);
+        this->health_check_failures_++;
+        if (this->status_binary_sensor_ != nullptr)
+          this->status_binary_sensor_->publish_state(false);
+        if (this->health_check_failures_ >= this->max_failed_checks_) {
+          if (this->auto_reset_on_failure_) {
+            ESP_LOGW(TAG, "Health check: max failures reached, triggering reinit");
+            this->state_ = STATE_REINITIALIZING;
+          } else {
+            ESP_LOGE(TAG, "Health check: max failures reached, auto-reset disabled");
+          }
+        }
+        return;
+      }
+      this->health_check_failures_ = 0;
+      if (this->status_binary_sensor_ != nullptr)
+        this->status_binary_sensor_->publish_state(true);
+    }
+  }
+
+  // Clear all IRQ registers (read-to-clear) and FIFO
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
+
+  if (this->rf_field_enabled_)
+    this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_ALL_ON);
+
+  if (this->rf_field_enabled_ && this->field_strength_sensor_ != nullptr) {
+    uint8_t sense = this->read_register(ST25R300_REG_SENSE_RF);
+    this->field_strength_sensor_->publish_state(sense);
+  }
+
+  // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
+  if (this->nfcv_enabled_)
+    this->nfcv_scan_();
+
+  // NFC-B (ISO 14443B) blocking SENSB — runs before NFC-A scan
+  if (this->nfcb_enabled_)
+    this->nfcb_scan_();
+
+  this->saved_anticol_valid_ = false;
+  this->anticol_resume_ = false;
+
+  this->irq_status1_ = 0;
+  this->irq_status2_ = 0;
+  this->irq_status_ = 0;
+  this->irq_triggered_ = false;
+
+  // ST25R300 has no dedicated WUPA command — send 7-bit short frame via FIFO
+  uint8_t resp[2];
+  uint8_t resp_len = 0;
+  this->send_short_frame_(0x52, resp, resp_len, 10);  // 0x52 = WUPA
+  ESP_LOGI(TAG, "Sent WUPA");
+  delay(1);
+  this->state_ = STATE_WUPA;
+  this->last_state_change_ = millis();
+}
+
+// ── loop ──────────────────────────────────────────────────────────────────────
+// Overrides base to translate ST25R300's three IRQ registers into the normalized
+// irq_status_ byte used by the shared process_state_() state machine.
+void ST25R300::loop() {
+  if (this->is_failed()) return;
+
+  if (this->irq_triggered_) {
+    this->irq_triggered_ = false;
+    uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
+    uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+    this->irq_status1_ |= r1;
+    this->irq_status2_ |= r2;
+    ESP_LOGV(TAG, "IRQ triggered, IRQ1=0x%02X IRQ2=0x%02X state=%d", r1, r2, this->state_);
+  } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL) {
+    this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
+    this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+    if (this->irq_status1_ != 0 || this->irq_status2_ != 0) {
+      ESP_LOGV(TAG, "IRQ polled, IRQ1=0x%02X IRQ2=0x%02X state=%d",
+               this->irq_status1_, this->irq_status2_, this->state_);
+    }
+  } else {
+    this->irq_status1_ = 0;
+    this->irq_status2_ = 0;
+  }
+
+  // Translate accumulated ST25R300 IRQ bits into the base class normalized format
+  uint8_t n = 0;
+  if (this->irq_status1_ & ST25R300_IRQ1_RXE) n |= IRQ_RXE;
+  if (this->irq_status1_ & ST25R300_IRQ1_TXE) n |= IRQ_TXE;
+  if (this->irq_status1_ & ST25R300_IRQ1_COL) n |= IRQ_COL;
+  if (this->irq_status2_ & ST25R300_IRQ2_NRE) n |= IRQ_NRE;
+  this->irq_status_ = n;
+
+  this->process_state_();
+}
+
+// ── send_short_frame_ ─────────────────────────────────────────────────────────
+bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);  // no CRC, no parity
+  // b_rx_sof+b_rx_eof MUST be set for Manchester framing; no CRC for ATQA
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_A_RX_PAR);  // 0x38
+
+  // CLEAR_FIFO (not STOP_ALL): STOP_ALL disables the RX decoder, preventing ATQA reception
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
+  this->irq_triggered_ = false;
+
+  // TX_FRAME must be written before FIFO data
+  this->write_register(ST25R300_REG_TX_FRAME1, 0x00);
+  this->write_register(ST25R300_REG_TX_FRAME2, 0x07);  // 0 full bytes + 7 partial bits
+
+  uint8_t data = byte7 & 0x7F;
+  this->write_fifo(&data, 1);
+  this->write_command(ST25R300_CMD_TRANSMIT_DATA);
+
+  // Wait past ATQA window, then sweep IRQs into accumulator
+  delayMicroseconds(700);
+  this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+  ESP_LOGV(TAG, "ssf @700us: FIFO=%u IRQ1=0x%02X IRQ2=0x%02X",
+           this->read_register(ST25R300_REG_FIFO_STATUS1), this->irq_status1_, this->irq_status2_);
+
+  // Wait out the NRT (5ms) then do a final IRQ sweep to catch late arrivals
+  delay(10);
+  this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+  resp_len = 0;
+  return true;
+}
+
+// ── transceive_ / transceive_no_crc_ ─────────────────────────────────────────
+bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                            uint32_t timeout_ms) {
+  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+}
+bool ST25R300::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                                   uint32_t timeout_ms) {
+  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+}
+
+// ── transceive_ex_ ────────────────────────────────────────────────────────────
+bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                               bool with_crc, uint32_t timeout_ms) {
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+
+  this->write_register(ST25R300_REG_TX_FRAME1, (uint8_t)((len >> 5) & 0xFF));
+  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t)((len & 0x1F) << 3));  // full bytes, 0 partial bits
+
+  if (with_crc) {
+    this->write_register(ST25R300_REG_TX_PROTOCOL1,
+                         ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
+    this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                         ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                         ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+  } else {
+    this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);
+    this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                         ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                         ST25R300_RX_PROT1_A_RX_PAR);  // 0x38, no CRC
+  }
+
+  this->write_fifo(data, len);
+  this->irq_triggered_ = false;
+  this->write_command(ST25R300_CMD_TRANSMIT_DATA);
+
+  uint32_t start = millis();
+  resp_len = 0;
+  bool tx_done = false;
+
+  while (millis() - start < timeout_ms) {
+    this->irq_triggered_ = false;
+    uint8_t irq1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
+    uint8_t irq2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+
+    if (irq1 & ST25R300_IRQ1_TXE) tx_done = true;
+
+    if (tx_done) {
+      uint8_t f1 = this->read_register(ST25R300_REG_FIFO_STATUS1);
+      if (f1 > 0) {
+        uint8_t to_read = std::min((uint8_t)(64 - resp_len), f1);
+        this->read_fifo(resp + resp_len, to_read);
+        resp_len += to_read;
+        start = millis();
+      }
+      if (irq1 & ST25R300_IRQ1_RXE) return resp_len > 0;
+      if (irq2 & ST25R300_IRQ2_NRE) return resp_len > 0;
+    }
+    delay(1);
+  }
+  return resp_len > 0;
+}
+
+// ── read_tag_ ─────────────────────────────────────────────────────────────────
+// ST25R300 supports NFC Forum Type 2 (NTAG) only.
+// Mifare Classic authentication is not implemented for ST25R300 (different MAC engine).
+std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
+  uint8_t type = nfc::guess_tag_type(uid.size());
+  ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d", uid.size(), type);
+
+  if (type == nfc::TAG_TYPE_2) {
+    uint8_t buffer[16];
+    uint8_t len;
+    std::vector<uint8_t> data;
+
+    uint8_t read_cmd[2] = {0x30, 0x00};
+    if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
+      data.insert(data.end(), buffer, buffer + 16);
+
+      size_t tlv_index = 0;
+      bool found = false;
+      bool terminator_found = false;
+
+      for (size_t i = 0; i < 16; i++) {
+        if (data[i] == 0x03) { tlv_index = i; found = true; break; }
+        if (data[i] == 0xFE) { terminator_found = true; break; }
+      }
+
+      if (!found && !terminator_found) {
+        for (uint8_t p = 4; p < 16; p += 4) {
+          delay(10);
+          read_cmd[1] = p;
+          if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
+            data.insert(data.end(), buffer, buffer + 16);
+            for (size_t i = data.size() - 16; i < data.size(); i++) {
+              if (data[i] == 0x03) { tlv_index = i; found = true; break; }
+              if (data[i] == 0xFE) { terminator_found = true; break; }
+            }
+          }
+          if (found || terminator_found) break;
+        }
+      }
+
+      if (found) {
+        while (data.size() <= tlv_index + 3) {
+          read_cmd[1] = (uint8_t)(data.size() / 4);
+          delay(10);
+          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+          data.insert(data.end(), buffer, buffer + 16);
+        }
+        if (tlv_index + 1 < data.size()) {
+          size_t msg_len, msg_start;
+          if (data[tlv_index + 1] == 0xFF && tlv_index + 3 < data.size()) {
+            msg_len   = ((size_t)data[tlv_index + 2] << 8) | data[tlv_index + 3];
+            msg_start = tlv_index + 4;
+          } else {
+            msg_len   = data[tlv_index + 1];
+            msg_start = tlv_index + 2;
+          }
+          while (data.size() < msg_start + msg_len) {
+            read_cmd[1] = (uint8_t)(data.size() / 4);
+            delay(10);
+            if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+            data.insert(data.end(), buffer, buffer + 16);
+          }
+          if (data.size() >= msg_start + msg_len) {
+            std::vector<uint8_t> ndef_data(data.begin() + (int)msg_start,
+                                           data.begin() + (int)msg_start + (int)msg_len);
+            nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+            if (msg_len > 0) {
+              ESP_LOGD(TAG, "read_tag_: NDEF found, %zu bytes at TLV offset %zu", msg_len, tlv_index);
+              return make_unique<nfc::NfcTag>(nfc_uid, nfc::NFC_FORUM_TYPE_2, ndef_data);
+            }
+            ESP_LOGD(TAG, "read_tag_: NDEF TLV present but empty");
+            return make_unique<nfc::NfcTag>(nfc_uid, nfc::NFC_FORUM_TYPE_2);
+          }
+        }
+      }
+      ESP_LOGD(TAG, "read_tag_: no NDEF TLV found (found=%d terminator=%d)", found, terminator_found);
+    } else {
+      ESP_LOGW(TAG, "Failed to read page 0, len=%d", len);
+    }
+  }
+
+  nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
+  return make_unique<nfc::NfcTag>(nfc_uid);
+}
+
+// ── Virtual helper overrides ───────────────────────────────────────────────────
+
+uint8_t ST25R300::read_fifo_status1_() {
+  return this->read_register(ST25R300_REG_FIFO_STATUS1);
+}
+
+uint8_t ST25R300::read_collision_display_() {
+  return this->read_register(ST25R300_REG_COLLISION_DISPLAY);
+}
+
+void ST25R300::pre_select_() {
+  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex_().
+  // There is no separate "anticol mode" register to clear before SELECT.
+}
+
+void ST25R300::send_halt_() {
+  uint8_t halt_cmd[2] = {0x50, 0x00};
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+  // TX_FRAME must be written before FIFO data (per datasheet)
+  this->write_register(ST25R300_REG_TX_FRAME1, 0x00);
+  this->write_register(ST25R300_REG_TX_FRAME2, 0x10);  // 2 full bytes
+  this->write_register(ST25R300_REG_TX_PROTOCOL1,
+                       ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);
+  this->write_fifo(halt_cmd, 2);
+  this->write_command(ST25R300_CMD_TRANSMIT_DATA);
+  delay(10);
+}
+
+void ST25R300::start_wupa_() {
+  // Clear FIFO + IRQs + chip accumulators, then transmit WUPA as short frame
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->irq_triggered_ = false;
+  this->irq_status1_ = 0;
+  this->irq_status2_ = 0;
+  this->irq_status_ = 0;
+  uint8_t dummy[2];
+  uint8_t dummy_len = 0;
+  this->send_short_frame_(0x52, dummy, dummy_len, 10);
+}
+
+// ── send_anticol_frame_ ───────────────────────────────────────────────────────
+void ST25R300::send_anticol_frame_() {
+  uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
+  uint8_t sel = sel_cmds[this->cascade_level_];
+
+  uint8_t nvb_high = 2 + this->anticol_prefix_full_;
+  uint8_t nvb = (nvb_high << 4) | this->anticol_prefix_bits_;
+
+  uint8_t frame[7];
+  frame[0] = sel;
+  frame[1] = nvb;
+  uint8_t frame_len = 2;
+  for (int i = 0; i < this->anticol_prefix_full_; i++)
+    frame[frame_len++] = this->anticol_prefix_[i];
+  if (this->anticol_prefix_bits_ > 0)
+    frame[frame_len++] = this->anticol_prefix_[this->anticol_prefix_full_];
+
+  uint8_t ntx_n = 2 + this->anticol_prefix_full_;
+  uint8_t ntx_b = this->anticol_prefix_bits_;
+
+  // a_rx_par MUST be set: without it, parity bits from 9-bit NFC-A bytes are packed into FIFO
+  // alongside data bits, garbling the UID. a_rx_par strips parity before FIFO write.
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_ANTCL);  // 0x39
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, ST25R300_TX_PROT1_A_TX_PAR);  // parity, no CRC
+
+  // CLEAR_FIFO (not STOP_ALL): STOP_ALL disables the RX decoder, preventing collision detection.
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
+  this->irq_triggered_ = false;
+  this->irq_status1_ = 0;
+  this->irq_status2_ = 0;
+  // TX_FRAME must be written before FIFO data
+  this->write_register(ST25R300_REG_TX_FRAME1, ntx_n >> 5);
+  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t)(((ntx_n & 0x1F) << 3) | (ntx_b & 0x07)));
+  this->write_fifo(frame, frame_len);
+  this->write_command(ST25R300_CMD_TRANSMIT_DATA);
+}
+
+// ── reset_ ────────────────────────────────────────────────────────────────────
+bool ST25R300::reset_() {
+  // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
+  uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
+  ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
+  if ((ic_identity & ST25R300_IC_TYPE_MASK) != ST25R300_IC_TYPE_VAL) {
+    ESP_LOGE(TAG, "  reset_: IC identity mismatch! Expected 0xB0, got chip_type=0x%02X",
+             ic_identity & ST25R300_IC_TYPE_MASK);
+    return false;
+  }
+
+  ESP_LOGV(TAG, "  reset_: Sending SET_DEFAULT");
+  this->write_command(ST25R300_CMD_SET_DEFAULT);
+  delay(10);
+  ESP_LOGI(TAG, "IC identity match: 0x%02X (ST25R300 rev %u)", ic_identity, ic_identity & 0x07);
+
+  // Step 1: Enable oscillator → enter Ready mode
+  this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_EN);
+  delay(5);
+
+  // Wait for oscillator stable (I_osc in IRQ_STATUS3, bit0)
+  uint32_t osc_start = millis();
+  while (millis() - osc_start < 50) {
+    if (this->read_register(ST25R300_REG_IRQ_STATUS3) & ST25R300_IRQ3_OSC) break;
+    delay(1);
+  }
+
+  // Step 2: Enable VDDDR regulator, wait ≥10µs
+  this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_EN | ST25R300_OP_VDDDR_EN);
+  delay(1);
+
+  // Step 3: Enable TX + RX
+  this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_ALL_ON);
+
+  // Step 4: Adjust regulators
+  this->write_command(ST25R300_CMD_ADJUST_REGS);
+  delay(5);
+
+  // Step 5: Configure for NFC-A / ISO14443A
+  this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);  // differential antenna, no RFO2
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A reader/initiator
+  this->write_register(ST25R300_REG_TX_PROTOCOL1,
+                       ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+
+  // RX path analog and correlator — tuned for NFC-A 106kbps (RFAL ST25R500 analogConfigTbl)
+  uint8_t rx_ana1 = 0x73 | (this->rx_gain_boost_ ? 0x04 : 0x00);
+  this->write_register(ST25R300_REG_RX_ANALOG1, rx_ana1);
+  this->write_register(0x0A, 0x22);  // afe_gain_rw=2 (6dB), afe_gain_td=2
+  this->write_register(0x0B, 0x85);  // RX Ana3: ook thresholds (factory default)
+  this->write_register(0x0D, 0xCC);  // RX Digital: agc_en=1, lpf/hpf coef (factory default)
+  // Correlator settings critical for NFC-A reception (factory defaults do NOT work)
+  this->write_register(0x0E, 0xF8);  // CORR1: iir_coef2=F, iir_coef1=8
+  this->write_register(0x0F, 0x2E);  // CORR2: squelch_thr=2, agc_thr=E
+  this->write_register(0x10, 0x0F);  // CORR3: start_wait=15 (prevents false subc_start from TX)
+  this->write_register(0x11, 0x88);  // CORR4: coll_lvl=8, data_lvl=8
+  this->write_register(0x12, 0x32);  // CORR5: dis_soft_sq=1, dis_agc_noise_meas=1, dec_f=2
+  this->write_register(0x13, 0x20);  // CORR6: init_noise_lvl=2
+
+  // TX driver: d_res controls power (0=max, 15=min)
+  uint8_t d_res = (15 - this->rf_power_) & 0x0F;
+  this->write_register(ST25R300_REG_TX_DRIVER_CONF, d_res);
+  this->write_register(ST25R300_REG_TX_MOD1, 0x70);  // am_mod=7 (20%)
+
+  // Unmask all IRQs
+  this->write_register(ST25R300_REG_IRQ_MASK1, 0x00);
+  this->write_register(ST25R300_REG_IRQ_MASK2, 0x00);
+  this->write_register(ST25R300_REG_IRQ_MASK3, 0x00);
+
+  // NRT: ~5ms window to capture ATQA (~86µs after TX-end)
+  this->write_register(ST25R300_REG_NRT_CONF1, 0x00);  // nrt_step=0 → 4.72µs per step
+  this->write_register(ST25R300_REG_NRT_CONF2, 0x04);  // nrt[15:8]
+  this->write_register(ST25R300_REG_NRT_CONF3, 0x23);  // nrt[7:0] = 0x0423 = 1059 steps ≈ 5ms
+
+  if (this->rf_field_enabled_) {
+    this->write_register(ST25R300_REG_OPERATION,
+                         ST25R300_OP_EN | ST25R300_OP_VDDDR_EN | ST25R300_OP_TX_EN);
+    delay(5);
+    this->write_command(ST25R300_CMD_FIELD_ON);
+    delay(10);
+    this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_ALL_ON);
+  }
+  delay(10);
+  return true;
+}
+
+// ── reinitialize_ ─────────────────────────────────────────────────────────────
+void ST25R300::reinitialize_() {
+  this->reinitialization_attempts_++;
+  ESP_LOGW(TAG, "Reinitializing ST25R300 (attempt %u)...", this->reinitialization_attempts_);
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(true);
+    delay(10);
+    this->reset_pin_->digital_write(false);
+    delay(10);
+  }
+  if (this->reset_()) {
+    ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
+    this->health_check_failures_ = 0;
+    this->reinitialization_attempts_ = 0;
+    // Force an immediate health check on the next update() so the status sensor
+    // reflects recovery without waiting the full health_check_interval.
+    this->last_health_check_ms_ = 0;
+  } else {
+    ESP_LOGE(TAG, "Reinitialize attempt %u failed", this->reinitialization_attempts_);
+    if (this->reinitialization_attempts_ >= 5) {
+      ESP_LOGE(TAG, "Reinitialize: too many failures, marking component failed");
+      this->mark_failed();
+    }
+  }
+}
+
+// ── dump_config ───────────────────────────────────────────────────────────────
+void ST25R300::dump_config() {
+  ESP_LOGCONFIG(TAG, "ST25R300:");
+  LOG_PIN("  IRQ Pin: ", this->irq_pin_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  ESP_LOGCONFIG(TAG, "  RF Power: %u", this->rf_power_);
+  ESP_LOGCONFIG(TAG, "  RF Field Enabled: %s", YESNO(this->rf_field_enabled_));
+  ESP_LOGCONFIG(TAG, "  Health Check: %s", YESNO(this->health_check_enabled_));
+  if (this->health_check_enabled_) {
+    ESP_LOGCONFIG(TAG, "  Health Check Interval: %u ms", this->health_check_interval_ms_);
+    ESP_LOGCONFIG(TAG, "  Max Failed Checks: %u", this->max_failed_checks_);
+    ESP_LOGCONFIG(TAG, "  Auto Reset on Failure: %s", YESNO(this->auto_reset_on_failure_));
+  }
+  LOG_UPDATE_INTERVAL(this);
+  uint8_t ic_id = this->read_register(ST25R300_REG_IC_IDENTITY);
+  ESP_LOGCONFIG(TAG, "  IC Identity (live): 0x%02X (chip_type=0x%02X)", ic_id,
+                ic_id & ST25R300_IC_TYPE_MASK);
+}
+
+// ── NFC-V (ISO 15693) support ────────────────────────────────────────────────
+
+void ST25R300::configure_nfcv_mode_() {
+  this->write_register(ST25R300_REG_GENERAL_CONF, 0x02);    // nfc_n=2 (NFC-V subcarrier config)
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x05);      // om=5: NFC-V/ISO15693
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity)
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity, no antcl)
+  // TX modulation: OOK (97% ASK) for NFC-V 26kbps — RFAL analogConfigTbl
+  this->write_register(ST25R300_REG_TX_MOD1, 0x00);  // am_mod=0 → OOK
+  // RX analog + correlator: RFAL ST25R500 NFC-V 26kbps profile
+  this->write_register(ST25R300_REG_RX_ANALOG1, 0x71);  // dig_clk_dly=7, hpf_ctrl=1
+  this->write_register(0x0D, 0x50);  // RX_DIG: lpf_coef + hpf_coef for NFC-V
+  this->write_register(0x0E, 0xD0);  // CORR1
+  this->write_register(0x0F, 0x2A);  // CORR2
+  this->write_register(0x10, 0x08);  // CORR3: start_wait=8
+  this->write_register(0x11, 0xAA);  // CORR4: coll_lvl=A, data_lvl=A
+  this->write_register(0x12, 0xCC);  // CORR5
+  this->write_register(0x13, 0x10);  // CORR6
+  // NRT: ~20ms for NFC-V (4233 steps at 4.72µs/step)
+  this->write_register(ST25R300_REG_NRT_CONF2, 0x10);
+  this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
+}
+
+void ST25R300::configure_nfca_mode_() {
+  this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);    // nfc_n=0 (NFC-A)
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A
+  this->write_register(ST25R300_REG_TX_PROTOCOL1,
+                       ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+  // Restore NFC-A TX modulation + RX analog + correlator
+  this->write_register(ST25R300_REG_TX_MOD1, 0x70);  // am_mod=7 (20% ASK)
+  uint8_t rx_ana1 = 0x73 | (this->rx_gain_boost_ ? 0x04 : 0x00);
+  this->write_register(ST25R300_REG_RX_ANALOG1, rx_ana1);
+  this->write_register(0x0D, 0xCC);
+  this->write_register(0x0E, 0xF8);
+  this->write_register(0x0F, 0x2E);
+  this->write_register(0x10, 0x0F);
+  this->write_register(0x11, 0x88);
+  this->write_register(0x12, 0x32);
+  this->write_register(0x13, 0x20);
+  // NRT: ~5ms for NFC-A
+  this->write_register(ST25R300_REG_NRT_CONF2, 0x04);
+  this->write_register(ST25R300_REG_NRT_CONF3, 0x23);
+}
+
+bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                                 uint32_t timeout_ms) {
+  this->write_command(ST25R300_CMD_CLEAR_FIFO);
+  this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
+
+  // Set TX frame length (full bytes, 0 partial bits)
+  this->write_register(ST25R300_REG_TX_FRAME1, len >> 5);
+  this->write_register(ST25R300_REG_TX_FRAME2, (len & 0x1F) << 3);
+
+  // Load FIFO and transmit
+  this->write_fifo(data, len);
+
+  this->read_register(ST25R300_REG_IRQ_STATUS1);
+  this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->irq_triggered_ = false;
+  this->write_command(ST25R300_CMD_TRANSMIT_DATA);
+
+  // Wait for response
+  uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    if (this->irq_triggered_) {
+      this->irq_triggered_ = false;
+      uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
+      uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+      ESP_LOGV(TAG, "NFC-V IRQ: r1=0x%02X r2=0x%02X", r1, r2);
+      if (r1 & ST25R300_IRQ1_RXE) {
+        // Read FIFO
+        uint8_t fifo_len = this->read_register(ST25R300_REG_FIFO_STATUS1);
+        if (fifo_len > 0 && fifo_len <= 64) {
+          resp_len = fifo_len;
+          this->read_fifo(resp, fifo_len);
+          return true;
+        }
+        return false;
+      }
+      if (r2 & ST25R300_IRQ2_NRE) {
+        return false;  // No response
+      }
+    }
+    delay(1);
+  }
+  return false;
+}
+
+void ST25R300::nfcv_scan_() {
+  // Switch to NFC-V mode
+  this->configure_nfcv_mode_();
+
+  ESP_LOGV(TAG, "NFC-V: starting inventory scan");
+
+  // 1-slot INVENTORY: [flags=0x26, cmd=0x01, mask_len=0x00]
+  uint8_t inv_req[] = {NFCV_INV_FLAG_1SLOT, NFCV_CMD_INVENTORY, 0x00};
+  uint8_t resp[12];
+  uint8_t resp_len = 0;
+
+  // Loop: inventory → record UID → stay quiet → repeat until no response
+  for (int i = 0; i < 16; i++) {  // max 16 NFC-V tags per scan
+    resp_len = 0;
+    if (!this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
+      break;  // No more tags
+    }
+
+    // Response (CRC stripped by chip): flags(1) + DSFID(1) + UID(8) = 10 bytes
+    if (resp_len < 10) {
+      ESP_LOGW(TAG, "NFC-V: short inventory response (%u bytes)", resp_len);
+      break;
+    }
+
+    // Check flags byte — bit0=error
+    if (resp[0] & 0x01) {
+      ESP_LOGD(TAG, "NFC-V: inventory error flag set (0x%02X)", resp[0]);
+      break;
+    }
+
+    // UID is bytes 2-9, transmitted LSB-first — reverse for display
+    char uid_str[17];
+    for (int j = 0; j < 8; j++) {
+      snprintf(uid_str + j * 2, 3, "%02X", resp[9 - j]);  // reverse: resp[9]..resp[2]
+    }
+    uid_str[16] = '\0';
+    ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
+
+    // Add to tags_this_scan_ — finalize_scan_() handles on_tag_removed
+    std::string uid_string(uid_str);
+    this->tags_this_scan_.insert(uid_string);
+
+    // Try to read NDEF (Type 5 tag) via READ_SINGLE_BLOCK
+    std::vector<uint8_t> uid_bytes;
+    for (int j = 0; j < 8; j++)
+      uid_bytes.push_back(resp[9 - j]);
+
+    // Read block 0 (Capability Container)
+    uint8_t blk_req[] = {0x02, 0x20, 0x00};  // flags, READ_SINGLE_BLOCK, block=0
+    uint8_t blk_resp[8];
+    uint8_t blk_len = 0;
+    std::vector<uint8_t> ndef_data;
+
+    if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+        blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+      if (blk_resp[1] == 0xE1) {  // NDEF magic byte in CC
+        uint8_t cc_size = blk_resp[3];
+        uint8_t total_blocks = (cc_size * 8) / 4;
+        if (total_blocks > 64) total_blocks = 64;
+
+        for (uint8_t blk = 1; blk <= total_blocks; blk++) {
+          blk_req[2] = blk;
+          blk_len = 0;
+          if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+              blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+            for (int k = 1; k < 5 && k < blk_len; k++)
+              ndef_data.push_back(blk_resp[k]);
+          } else {
+            break;
+          }
+        }
+      }
+    }
+
+    // Fire on_tag immediately for new tags
+    if (this->present_tags_.find(uid_string) == this->present_tags_.end()) {
+      this->present_tags_[uid_string] = 0;
+      nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+
+      if (!ndef_data.empty()) {
+        for (size_t i = 0; i < ndef_data.size(); i++) {
+          if (ndef_data[i] == 0x03 && i + 1 < ndef_data.size()) {
+            uint8_t ndef_len = ndef_data[i + 1];
+            size_t ndef_start = i + 2;
+            if (ndef_start + ndef_len <= ndef_data.size()) {
+              ESP_LOGI(TAG, "NFC-V NDEF: %u bytes", ndef_len);
+              auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+              this->tags_data_[uid_string] = std::move(tag);
+            }
+            break;
+          }
+          if (ndef_data[i] == 0xFE) break;
+        }
+      }
+
+      if (this->tags_data_.find(uid_string) == this->tags_data_.end()) {
+        auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+        this->tags_data_[uid_string] = std::move(tag);
+      }
+
+      for (auto *listener : this->tag_listeners_)
+        listener->tag_on(*this->tags_data_[uid_string]);
+      for (auto *trigger : this->on_tag_triggers_)
+        trigger->trigger(uid_string);
+    }
+
+    break;  // One tag per scan for now
+  }
+
+  // Switch back to NFC-A mode for the main scan
+  this->configure_nfca_mode_();
+}
+
+bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
+  this->configure_nfcv_mode_();
+
+  std::vector<uint8_t> payload;
+  if (message != nullptr) {
+    std::vector<uint8_t> ndef_data = message->encode();
+    payload.push_back(0x03);
+    if (ndef_data.size() < 255) {
+      payload.push_back((uint8_t)ndef_data.size());
+    } else {
+      payload.push_back(0xFF);
+      payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
+      payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+    }
+    payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
+  }
+  payload.push_back(0xFE);
+  while (payload.size() % 4 != 0) payload.push_back(0);
+
+  ESP_LOGD(TAG, "NFC-V NDEF write: %zu bytes in %zu blocks", payload.size(), payload.size() / 4);
+
+  // Write CC to block 0
+  uint8_t cc_size = (payload.size() + 4) / 8;
+  if (cc_size == 0) cc_size = 1;
+  uint8_t write_req[7] = {0x02, 0x21, 0x00, 0xE1, 0x40, cc_size, 0x00};
+  uint8_t resp[4];
+  uint8_t resp_len = 0;
+
+  if (!this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+    ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
+    this->configure_nfca_mode_();
+    return false;
+  }
+
+  for (size_t i = 0; i < payload.size(); i += 4) {
+    uint8_t blk = 1 + (i / 4);
+    write_req[2] = blk;
+    write_req[3] = payload[i];
+    write_req[4] = payload[i + 1];
+    write_req[5] = payload[i + 2];
+    write_req[6] = payload[i + 3];
+    resp_len = 0;
+
+    bool success = false;
+    for (uint8_t retry = 0; retry < 3; retry++) {
+      if (this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+        success = true;
+        break;
+      }
+      delay(10);
+    }
+    if (!success) {
+      ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
+      this->configure_nfca_mode_();
+      return false;
+    }
+  }
+
+  ESP_LOGI(TAG, "NFC-V NDEF write successful!");
+  this->configure_nfca_mode_();
+  return true;
+}
+
+// ── NFC-B (ISO 14443B) support ───────────────────────────────────────────────
+
+void ST25R300::configure_nfcb_mode_() {
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x02);      // om=2: NFC-B/ISO14443B
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity for NFC-B)
+  this->write_register(ST25R300_REG_RX_PROTOCOL1,
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
+                       ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity)
+  // NFC-B uses AM modulation (10% ASK), not OOK
+  this->write_register(ST25R300_REG_TX_MOD1, 0x70);  // am_mod=7 (12% ASK)
+  // NRT: ~20ms for NFC-B response
+  this->write_register(ST25R300_REG_NRT_CONF2, 0x10);
+  this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
+}
+
+void ST25R300::nfcb_scan_() {
+  this->configure_nfcb_mode_();
+
+  // SENSB_REQ (ALLB): cmd=0x05, AFI=0x00, PARAM=0x08 (1 slot + WUPB)
+  uint8_t sensb_req[] = {0x05, 0x00, 0x08};
+  uint8_t resp[16];
+  uint8_t resp_len = 0;
+
+  if (this->transceive_nfcv_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
+      resp_len >= 12 && resp[0] == 0x50) {
+    // ATQB: byte 0 = 0x50, bytes 1-4 = PUPI
+    char uid_str[9];
+    snprintf(uid_str, sizeof(uid_str), "%02X%02X%02X%02X", resp[1], resp[2], resp[3], resp[4]);
+    ESP_LOGI(TAG, "NFC-B tag: %s (ATQB len=%u)", uid_str, resp_len);
+
+    std::string uid_string(uid_str);
+    this->tags_this_scan_.insert(uid_string);
+
+    if (this->present_tags_.find(uid_string) == this->present_tags_.end()) {
+      this->present_tags_[uid_string] = 0;
+      std::vector<uint8_t> uid_bytes = {resp[1], resp[2], resp[3], resp[4]};
+      nfc::NfcTagUid nfc_uid(uid_bytes.begin(), uid_bytes.end());
+      auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+      for (auto *listener : this->tag_listeners_)
+        listener->tag_on(*tag);
+      for (auto *trigger : this->on_tag_triggers_)
+        trigger->trigger(uid_string);
+    }
+  }
+
+  // Restore NFC-A mode
+  this->configure_nfca_mode_();
+}
+
+}  // namespace st25r300
+}  // namespace esphome

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -673,23 +673,8 @@ void ST25R300::nfcv_scan_() {
   uint8_t resp_len = 0;
 
   // Single-tag inventory (multi-tag requires STAY_QUIET + field cycling)
-  {
-    resp_len = 0;
-    if (!this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
-      break;  // No more tags
-    }
-
-    // Response (CRC stripped by chip): flags(1) + DSFID(1) + UID(8) = 10 bytes
-    if (resp_len < 10) {
-      ESP_LOGW(TAG, "NFC-V: short inventory response (%u bytes)", resp_len);
-      break;
-    }
-
-    // Check flags uint8_t — bit0=error
-    if (resp[0] & 0x01) {
-      ESP_LOGD(TAG, "NFC-V: inventory error flag set (0x%02X)", resp[0]);
-      break;
-    }
+  if (this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25) &&
+      resp_len >= 10 && !(resp[0] & 0x01)) {
 
     // UID is bytes 2-9, transmitted LSB-first — reverse for display
     char uid_str[17];
@@ -767,7 +752,6 @@ void ST25R300::nfcv_scan_() {
       for (auto *trigger : this->on_tag_triggers_)
         trigger->trigger(uid_string);
     }
-
   }
 
   // Switch back to NFC-A mode for the main scan

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -83,6 +83,7 @@ void ST25R300::update() {
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
 
@@ -132,6 +133,7 @@ void ST25R300::loop() {
     this->irq_triggered_ = false;
     uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
     this->irq_status1_ |= r1;
     this->irq_status2_ |= r2;
     this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3 (DCT/OSC) to release IRQ pin
@@ -139,6 +141,7 @@ void ST25R300::loop() {
   } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL) {
     this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
     this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
     this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3
     if (this->irq_status1_ != 0 || this->irq_status2_ != 0) {
       ESP_LOGV(TAG, "IRQ polled, IRQ1=0x%02X IRQ2=0x%02X state=%d",
@@ -174,6 +177,7 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &res
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
   this->irq_triggered_ = false;
 
@@ -189,6 +193,7 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &res
   delayMicroseconds(700);
   this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   ESP_LOGV(TAG, "ssf @700us: FIFO=%u IRQ1=0x%02X IRQ2=0x%02X",
            this->read_register(ST25R300_REG_FIFO_STATUS1), this->irq_status1_, this->irq_status2_);
 
@@ -196,6 +201,7 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &res
   delay(10);
   this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   resp_len = 0;
   return true;
 }
@@ -217,6 +223,7 @@ bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uin
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
 
   this->write_register(ST25R300_REG_TX_FRAME1, (uint8_t)((len >> 5) & 0xFF));
@@ -247,6 +254,7 @@ bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uin
     this->irq_triggered_ = false;
     uint8_t irq1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t irq2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
 
     if (irq1 & ST25R300_IRQ1_TXE) tx_done = true;
 
@@ -372,6 +380,7 @@ void ST25R300::send_halt() {
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   // TX_FRAME must be written before FIFO data (per datasheet)
   this->write_register(ST25R300_REG_TX_FRAME1, 0x00);
   this->write_register(ST25R300_REG_TX_FRAME2, 0x10);  // 2 full bytes
@@ -387,6 +396,7 @@ void ST25R300::start_wupa() {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->irq_triggered_ = false;
   this->irq_status1_ = 0;
@@ -428,6 +438,7 @@ void ST25R300::send_anticol_frame() {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
   this->irq_triggered_ = false;
@@ -636,6 +647,7 @@ bool ST25R300::transceive_blocking_(const uint8_t *data, size_t len, uint8_t *re
 
   this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->irq_triggered_ = false;
   this->write_command(ST25R300_CMD_TRANSMIT_DATA);
 
@@ -648,6 +660,7 @@ bool ST25R300::transceive_blocking_(const uint8_t *data, size_t len, uint8_t *re
     // Always poll IRQ registers (ISR may not fire if pin not configured or edge missed)
     uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+  this->read_register(ST25R300_REG_IRQ_STATUS3);
     if (r1 & ST25R300_IRQ1_RXE) {
       uint8_t fifo_len = this->read_register(ST25R300_REG_FIFO_STATUS1);
       if (fifo_len > 0 && fifo_len <= 64) {

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -35,8 +35,8 @@ void ST25R300::setup() {
   if (this->status_binary_sensor_ != nullptr)
     this->status_binary_sensor_->publish_initial_state(false);
 
-  ESP_LOGI(TAG, "Starting reset_chip_()...");
-  if (!this->reset_chip_()) {
+  ESP_LOGI(TAG, "Starting reset_chip()...");
+  if (!this->reset_chip()) {
     ESP_LOGE(TAG, "Failed to reset/init ST25R300");
     this->mark_failed();
     return;
@@ -122,7 +122,7 @@ void ST25R300::update() {
 
 // ── loop ──────────────────────────────────────────────────────────────────────
 // Overrides base to translate ST25R300's three IRQ registers into the normalized
-// irq_status_ uint8_t used by the shared process_state_() state machine.
+// irq_status_ uint8_t used by the shared process_state() state machine.
 void ST25R300::loop() {
   if (this->is_failed()) return;
 
@@ -153,7 +153,7 @@ void ST25R300::loop() {
   if (this->irq_status2_ & ST25R300_IRQ2_NRE) n |= IRQ_NRE;
   this->irq_status_ = n;
 
-  this->process_state_();
+  this->process_state();
 }
 
 // ── send_short_frame_ ─────────────────────────────────────────────────────────
@@ -198,15 +198,15 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len
 // ── transceive_ / transceive_no_crc_ ─────────────────────────────────────────
 bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                             uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 bool ST25R300::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                    uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
 // ── transceive_ex_ ────────────────────────────────────────────────────────────
-bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -264,7 +264,7 @@ bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, ui
 // ── read_tag_ ─────────────────────────────────────────────────────────────────
 // ST25R300 supports NFC Forum Type 2 (NTAG) only.
 // Mifare Classic authentication is not implemented for ST25R300 (different MAC engine).
-std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d", uid.size(), type);
 
@@ -348,20 +348,20 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
 
 // ── Virtual helper overrides ───────────────────────────────────────────────────
 
-uint8_t ST25R300::read_fifo_status1_() {
+uint8_t ST25R300::read_fifo_status1() {
   return this->read_register(ST25R300_REG_FIFO_STATUS1);
 }
 
-uint8_t ST25R300::read_collision_display_() {
+uint8_t ST25R300::read_collision_display() {
   return this->read_register(ST25R300_REG_COLLISION_DISPLAY);
 }
 
-void ST25R300::pre_select_() {
-  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex_().
+void ST25R300::pre_select() {
+  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex().
   // There is no separate "anticol mode" register to clear before SELECT.
 }
 
-void ST25R300::send_halt_() {
+void ST25R300::send_halt() {
   uint8_t halt_cmd[2] = {0x50, 0x00};
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -377,7 +377,7 @@ void ST25R300::send_halt_() {
   delay(10);
 }
 
-void ST25R300::start_wupa_() {
+void ST25R300::start_wupa() {
   // Clear FIFO + IRQs + chip accumulators, then transmit WUPA as short frame
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -393,7 +393,7 @@ void ST25R300::start_wupa_() {
 }
 
 // ── send_anticol_frame_ ───────────────────────────────────────────────────────
-void ST25R300::send_anticol_frame_() {
+void ST25R300::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -436,7 +436,7 @@ void ST25R300::send_anticol_frame_() {
 }
 
 // ── reset_ ────────────────────────────────────────────────────────────────────
-bool ST25R300::reset_chip_() {
+bool ST25R300::reset_chip() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
   ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
@@ -524,7 +524,7 @@ bool ST25R300::reset_chip_() {
 }
 
 // ── reinitialize_ ─────────────────────────────────────────────────────────────
-void ST25R300::reinitialize_() {
+void ST25R300::reinitialize() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R300 (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -533,7 +533,7 @@ void ST25R300::reinitialize_() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_chip_()) {
+  if (this->reset_chip()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -774,7 +774,7 @@ void ST25R300::nfcv_scan_() {
   this->configure_nfca_mode_();
 }
 
-bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
+bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
   this->configure_nfcv_mode_();
 
   std::vector<uint8_t> payload;

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -672,8 +672,8 @@ void ST25R300::nfcv_scan_() {
   uint8_t resp[12];
   uint8_t resp_len = 0;
 
-  // Loop: inventory → record UID → stay quiet → repeat until no response
-  for (int i = 0; i < 16; i++) {  // max 16 NFC-V tags per scan
+  // Single-tag inventory (multi-tag requires STAY_QUIET + field cycling)
+  {
     resp_len = 0;
     if (!this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
       break;  // No more tags
@@ -768,7 +768,6 @@ void ST25R300::nfcv_scan_() {
         trigger->trigger(uid_string);
     }
 
-    break;  // One tag per scan for now
   }
 
   // Switch back to NFC-A mode for the main scan

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -11,16 +11,14 @@ namespace st25r300 {
 
 static const char *const TAG = "st25r300";
 
-void ST25R300::isr(ST25R300 *arg) {
-  arg->irq_triggered_ = true;
-}
+void ST25R300::isr(ST25R300 *arg) { arg->irq_triggered_ = true; }
 
 void ST25R300::setup() {
   ESP_LOGI(TAG, "Setting up ST25R300...");
   if (this->reset_pin_ != nullptr) {
     ESP_LOGI(TAG, "Cycling reset pin...");
     this->reset_pin_->setup();
-    this->reset_pin_->digital_write(true);   // assert reset
+    this->reset_pin_->digital_write(true);  // assert reset
     delay(10);
     this->reset_pin_->digital_write(false);  // release reset
     delay(10);
@@ -45,7 +43,8 @@ void ST25R300::setup() {
 }
 
 void ST25R300::update() {
-  if (this->is_failed() || this->state_ != STATE_IDLE) return;
+  if (this->is_failed() || this->state_ != STATE_IDLE)
+    return;
 
   // Health check: verify chip identity at the configured interval (default 60s),
   // independent of the tag scan rate.  Uses ST25R300-specific IC identity value
@@ -58,8 +57,8 @@ void ST25R300::update() {
       this->last_health_check_ms_ = now;
       uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
       if ((ic_identity & ST25R300_IC_TYPE_MASK) != ST25R300_IC_TYPE_VAL) {
-        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)",
-                 ic_identity, this->health_check_failures_ + 1, this->max_failed_checks_);
+        ESP_LOGW(TAG, "Health check failed: IC identity 0x%02X (failures: %u/%u)", ic_identity,
+                 this->health_check_failures_ + 1, this->max_failed_checks_);
         this->health_check_failures_++;
         if (this->status_binary_sensor_ != nullptr)
           this->status_binary_sensor_->publish_state(false);
@@ -127,13 +126,14 @@ void ST25R300::update() {
 // Overrides base to translate ST25R300's three IRQ registers into the normalized
 // irq_status_ uint8_t used by the shared process_state() state machine.
 void ST25R300::loop() {
-  if (this->is_failed()) return;
+  if (this->is_failed())
+    return;
 
   if (this->irq_triggered_) {
     this->irq_triggered_ = false;
     uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
-  this->read_register(ST25R300_REG_IRQ_STATUS3);
+    this->read_register(ST25R300_REG_IRQ_STATUS3);
     this->irq_status1_ |= r1;
     this->irq_status2_ |= r2;
     this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3 (DCT/OSC) to release IRQ pin
@@ -141,11 +141,11 @@ void ST25R300::loop() {
   } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL) {
     this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
     this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
-  this->read_register(ST25R300_REG_IRQ_STATUS3);
+    this->read_register(ST25R300_REG_IRQ_STATUS3);
     this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3
     if (this->irq_status1_ != 0 || this->irq_status2_ != 0) {
-      ESP_LOGV(TAG, "IRQ polled, IRQ1=0x%02X IRQ2=0x%02X state=%d",
-               this->irq_status1_, this->irq_status2_, this->state_);
+      ESP_LOGV(TAG, "IRQ polled, IRQ1=0x%02X IRQ2=0x%02X state=%d", this->irq_status1_, this->irq_status2_,
+               this->state_);
     }
   } else {
     this->irq_status1_ = 0;
@@ -154,23 +154,25 @@ void ST25R300::loop() {
 
   // Translate accumulated ST25R300 IRQ bits into the base class normalized format
   uint8_t n = 0;
-  if (this->irq_status1_ & ST25R300_IRQ1_RXE) n |= IRQ_RXE;
-  if (this->irq_status1_ & ST25R300_IRQ1_TXE) n |= IRQ_TXE;
-  if (this->irq_status1_ & ST25R300_IRQ1_COL) n |= IRQ_COL;
-  if (this->irq_status2_ & ST25R300_IRQ2_NRE) n |= IRQ_NRE;
+  if (this->irq_status1_ & ST25R300_IRQ1_RXE)
+    n |= IRQ_RXE;
+  if (this->irq_status1_ & ST25R300_IRQ1_TXE)
+    n |= IRQ_TXE;
+  if (this->irq_status1_ & ST25R300_IRQ1_COL)
+    n |= IRQ_COL;
+  if (this->irq_status2_ & ST25R300_IRQ2_NRE)
+    n |= IRQ_NRE;
   this->irq_status_ = n;
 
   this->process_state();
 }
 
 // ── send_short_frame_ ─────────────────────────────────────────────────────────
-bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &resp_len,
-                                 uint32_t /*timeout_ms*/) {
+bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &resp_len, uint32_t /*timeout_ms*/) {
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);  // no CRC, no parity
   // b_rx_sof+b_rx_eof MUST be set for Manchester framing; no CRC for ATQA
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_A_RX_PAR);  // 0x38
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR);  // 0x38
 
   // CLEAR_FIFO (not STOP_ALL): STOP_ALL disables the RX decoder, preventing ATQA reception
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
@@ -194,8 +196,8 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &res
   this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
   this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
-  ESP_LOGV(TAG, "ssf @700us: FIFO=%u IRQ1=0x%02X IRQ2=0x%02X",
-           this->read_register(ST25R300_REG_FIFO_STATUS1), this->irq_status1_, this->irq_status2_);
+  ESP_LOGV(TAG, "ssf @700us: FIFO=%u IRQ1=0x%02X IRQ2=0x%02X", this->read_register(ST25R300_REG_FIFO_STATUS1),
+           this->irq_status1_, this->irq_status2_);
 
   // Wait out the NRT (5ms) then do a final IRQ sweep to catch late arrivals
   delay(10);
@@ -207,18 +209,17 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &res
 }
 
 // ── transceive_ / transceive_no_crc_ ─────────────────────────────────────────
-bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                            uint32_t timeout_ms) {
+bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 bool ST25R300::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                                   uint32_t timeout_ms) {
+                                  uint32_t timeout_ms) {
   return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
 // ── transceive_ex_ ────────────────────────────────────────────────────────────
-bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                               bool with_crc, uint32_t timeout_ms) {
+bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                             uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -226,20 +227,20 @@ bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uin
   this->read_register(ST25R300_REG_IRQ_STATUS3);
   this->read_register(ST25R300_REG_IRQ_STATUS3);
 
-  this->write_register(ST25R300_REG_TX_FRAME1, (uint8_t)((len >> 5) & 0xFF));
-  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t)((len & 0x1F) << 3));  // full bytes, 0 partial bits
+  this->write_register(ST25R300_REG_TX_FRAME1, (uint8_t) ((len >> 5) & 0xFF));
+  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t) ((len & 0x1F) << 3));  // full bytes, 0 partial bits
 
   if (with_crc) {
     this->write_register(ST25R300_REG_TX_PROTOCOL1,
                          ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
     this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                         ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                         ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+                         ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR |
+                             ST25R300_RX_PROT1_RX_CRC);  // 0x3C
   } else {
     this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);
-    this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                         ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                         ST25R300_RX_PROT1_A_RX_PAR);  // 0x38, no CRC
+    this->write_register(
+        ST25R300_REG_RX_PROTOCOL1,
+        ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR);  // 0x38, no CRC
   }
 
   this->write_fifo(data, len);
@@ -254,20 +255,23 @@ bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uin
     this->irq_triggered_ = false;
     uint8_t irq1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t irq2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
-  this->read_register(ST25R300_REG_IRQ_STATUS3);
+    this->read_register(ST25R300_REG_IRQ_STATUS3);
 
-    if (irq1 & ST25R300_IRQ1_TXE) tx_done = true;
+    if (irq1 & ST25R300_IRQ1_TXE)
+      tx_done = true;
 
     if (tx_done) {
       uint8_t f1 = this->read_register(ST25R300_REG_FIFO_STATUS1);
       if (f1 > 0) {
-        uint8_t to_read = std::min((uint8_t)(64 - resp_len), f1);
+        uint8_t to_read = std::min((uint8_t) (64 - resp_len), f1);
         this->read_fifo(resp + resp_len, to_read);
         resp_len += to_read;
         start = millis();
       }
-      if (irq1 & ST25R300_IRQ1_RXE) return resp_len > 0;
-      if (irq2 & ST25R300_IRQ2_NRE) return resp_len > 0;
+      if (irq1 & ST25R300_IRQ1_RXE)
+        return resp_len > 0;
+      if (irq2 & ST25R300_IRQ2_NRE)
+        return resp_len > 0;
     }
     delay(1);
   }
@@ -295,8 +299,15 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
       bool terminator_found = false;
 
       for (size_t i = 0; i < 16; i++) {
-        if (data[i] == 0x03) { tlv_index = i; found = true; break; }
-        if (data[i] == 0xFE) { terminator_found = true; break; }
+        if (data[i] == 0x03) {
+          tlv_index = i;
+          found = true;
+          break;
+        }
+        if (data[i] == 0xFE) {
+          terminator_found = true;
+          break;
+        }
       }
 
       if (!found && !terminator_found) {
@@ -306,39 +317,49 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
           if (this->transceive_(read_cmd, 2, buffer, len) && len >= 16) {
             data.insert(data.end(), buffer, buffer + 16);
             for (size_t i = data.size() - 16; i < data.size(); i++) {
-              if (data[i] == 0x03) { tlv_index = i; found = true; break; }
-              if (data[i] == 0xFE) { terminator_found = true; break; }
+              if (data[i] == 0x03) {
+                tlv_index = i;
+                found = true;
+                break;
+              }
+              if (data[i] == 0xFE) {
+                terminator_found = true;
+                break;
+              }
             }
           }
-          if (found || terminator_found) break;
+          if (found || terminator_found)
+            break;
         }
       }
 
       if (found) {
         while (data.size() <= tlv_index + 3) {
-          read_cmd[1] = (uint8_t)(data.size() / 4);
+          read_cmd[1] = (uint8_t) (data.size() / 4);
           delay(10);
-          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+          if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16)
+            break;
           data.insert(data.end(), buffer, buffer + 16);
         }
         if (tlv_index + 1 < data.size()) {
           size_t msg_len, msg_start;
           if (data[tlv_index + 1] == 0xFF && tlv_index + 3 < data.size()) {
-            msg_len   = ((size_t)data[tlv_index + 2] << 8) | data[tlv_index + 3];
+            msg_len = ((size_t) data[tlv_index + 2] << 8) | data[tlv_index + 3];
             msg_start = tlv_index + 4;
           } else {
-            msg_len   = data[tlv_index + 1];
+            msg_len = data[tlv_index + 1];
             msg_start = tlv_index + 2;
           }
           while (data.size() < msg_start + msg_len) {
-            read_cmd[1] = (uint8_t)(data.size() / 4);
+            read_cmd[1] = (uint8_t) (data.size() / 4);
             delay(10);
-            if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16) break;
+            if (!this->transceive_(read_cmd, 2, buffer, len) || len < 16)
+              break;
             data.insert(data.end(), buffer, buffer + 16);
           }
           if (data.size() >= msg_start + msg_len) {
-            std::vector<uint8_t> ndef_data(data.begin() + (int)msg_start,
-                                           data.begin() + (int)msg_start + (int)msg_len);
+            std::vector<uint8_t> ndef_data(data.begin() + (int) msg_start,
+                                           data.begin() + (int) msg_start + (int) msg_len);
             nfc::NfcTagUid nfc_uid(uid.begin(), uid.end());
             if (msg_len > 0) {
               ESP_LOGD(TAG, "read_tag_: NDEF found, %zu bytes at TLV offset %zu", msg_len, tlv_index);
@@ -361,13 +382,9 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
 
 // ── Virtual helper overrides ───────────────────────────────────────────────────
 
-uint8_t ST25R300::read_fifo_status1() {
-  return this->read_register(ST25R300_REG_FIFO_STATUS1);
-}
+uint8_t ST25R300::read_fifo_status1() { return this->read_register(ST25R300_REG_FIFO_STATUS1); }
 
-uint8_t ST25R300::read_collision_display() {
-  return this->read_register(ST25R300_REG_COLLISION_DISPLAY);
-}
+uint8_t ST25R300::read_collision_display() { return this->read_register(ST25R300_REG_COLLISION_DISPLAY); }
 
 void ST25R300::pre_select() {
   // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex().
@@ -384,8 +401,7 @@ void ST25R300::send_halt() {
   // TX_FRAME must be written before FIFO data (per datasheet)
   this->write_register(ST25R300_REG_TX_FRAME1, 0x00);
   this->write_register(ST25R300_REG_TX_FRAME2, 0x10);  // 2 full bytes
-  this->write_register(ST25R300_REG_TX_PROTOCOL1,
-                       ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);
   this->write_fifo(halt_cmd, 2);
   this->write_command(ST25R300_CMD_TRANSMIT_DATA);
   delay(10);
@@ -430,8 +446,8 @@ void ST25R300::send_anticol_frame() {
   // a_rx_par MUST be set: without it, parity bits from 9-bit NFC-A bytes are packed into FIFO
   // alongside data bits, garbling the UID. a_rx_par strips parity before FIFO write.
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_ANTCL);  // 0x39
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR |
+                           ST25R300_RX_PROT1_ANTCL);                            // 0x39
   this->write_register(ST25R300_REG_TX_PROTOCOL1, ST25R300_TX_PROT1_A_TX_PAR);  // parity, no CRC
 
   // CLEAR_FIFO (not STOP_ALL): STOP_ALL disables the RX decoder, preventing collision detection.
@@ -446,7 +462,7 @@ void ST25R300::send_anticol_frame() {
   this->irq_status2_ = 0;
   // TX_FRAME must be written before FIFO data
   this->write_register(ST25R300_REG_TX_FRAME1, ntx_n >> 5);
-  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t)(((ntx_n & 0x1F) << 3) | (ntx_b & 0x07)));
+  this->write_register(ST25R300_REG_TX_FRAME2, (uint8_t) (((ntx_n & 0x1F) << 3) | (ntx_b & 0x07)));
   this->write_fifo(frame, frame_len);
   this->write_command(ST25R300_CMD_TRANSMIT_DATA);
 }
@@ -474,7 +490,8 @@ bool ST25R300::reset_chip() {
   // Wait for oscillator stable (I_osc in IRQ_STATUS3, bit0)
   uint32_t osc_start = millis();
   while (millis() - osc_start < 50) {
-    if (this->read_register(ST25R300_REG_IRQ_STATUS3) & ST25R300_IRQ3_OSC) break;
+    if (this->read_register(ST25R300_REG_IRQ_STATUS3) & ST25R300_IRQ3_OSC)
+      break;
     delay(1);
   }
 
@@ -491,12 +508,12 @@ bool ST25R300::reset_chip() {
 
   // Step 5: Configure for NFC-A / ISO14443A
   this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);  // differential antenna, no RFO2
-  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A reader/initiator
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);     // om=1: NFC-A reader/initiator
   this->write_register(ST25R300_REG_TX_PROTOCOL1,
                        ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR |
+                           ST25R300_RX_PROT1_RX_CRC);  // 0x3C
 
   // RX path analog and correlator — tuned for NFC-A 106kbps (RFAL ST25R500 analogConfigTbl)
   uint8_t rx_ana1 = 0x73 | (this->rx_gain_boost_ ? 0x04 : 0x00);
@@ -528,8 +545,7 @@ bool ST25R300::reset_chip() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x23);  // nrt[7:0] = 0x0423 = 1059 steps ≈ 5ms
 
   if (this->rf_field_enabled_) {
-    this->write_register(ST25R300_REG_OPERATION,
-                         ST25R300_OP_EN | ST25R300_OP_VDDDR_EN | ST25R300_OP_TX_EN);
+    this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_EN | ST25R300_OP_VDDDR_EN | ST25R300_OP_TX_EN);
     delay(5);
     this->write_command(ST25R300_CMD_FIELD_ON);
     delay(10);
@@ -580,43 +596,42 @@ void ST25R300::dump_config() {
   }
   LOG_UPDATE_INTERVAL(this);
   uint8_t ic_id = this->read_register(ST25R300_REG_IC_IDENTITY);
-  ESP_LOGCONFIG(TAG, "  IC Identity (live): 0x%02X (chip_type=0x%02X)", ic_id,
-                ic_id & ST25R300_IC_TYPE_MASK);
+  ESP_LOGCONFIG(TAG, "  IC Identity (live): 0x%02X (chip_type=0x%02X)", ic_id, ic_id & ST25R300_IC_TYPE_MASK);
 }
 
 // ── NFC-V (ISO 15693) support ────────────────────────────────────────────────
 
 void ST25R300::configure_nfcv_mode_() {
-  this->write_register(ST25R300_REG_GENERAL_CONF, 0x02);    // nfc_n=2 (NFC-V subcarrier config)
-  this->write_register(ST25R300_REG_PROTOCOL1, 0x05);      // om=5: NFC-V/ISO15693
-  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity)
+  this->write_register(ST25R300_REG_GENERAL_CONF, 0x02);  // nfc_n=2 (NFC-V subcarrier config)
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x05);     // om=5: NFC-V/ISO15693
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);  // tx_crc only (no parity)
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
                        ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity, no antcl)
+                           ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity, no antcl)
   // TX modulation: OOK (97% ASK) for NFC-V 26kbps — RFAL analogConfigTbl
   this->write_register(ST25R300_REG_TX_MOD1, 0x00);  // am_mod=0 → OOK
   // RX analog + correlator: RFAL ST25R500 NFC-V 26kbps profile
   this->write_register(ST25R300_REG_RX_ANALOG1, 0x71);  // dig_clk_dly=7, hpf_ctrl=1
-  this->write_register(0x0D, 0x50);  // RX_DIG: lpf_coef + hpf_coef for NFC-V
-  this->write_register(0x0E, 0xD0);  // CORR1
-  this->write_register(0x0F, 0x2A);  // CORR2
-  this->write_register(0x10, 0x08);  // CORR3: start_wait=8
-  this->write_register(0x11, 0xAA);  // CORR4: coll_lvl=A, data_lvl=A
-  this->write_register(0x12, 0xCC);  // CORR5
-  this->write_register(0x13, 0x10);  // CORR6
+  this->write_register(0x0D, 0x50);                     // RX_DIG: lpf_coef + hpf_coef for NFC-V
+  this->write_register(0x0E, 0xD0);                     // CORR1
+  this->write_register(0x0F, 0x2A);                     // CORR2
+  this->write_register(0x10, 0x08);                     // CORR3: start_wait=8
+  this->write_register(0x11, 0xAA);                     // CORR4: coll_lvl=A, data_lvl=A
+  this->write_register(0x12, 0xCC);                     // CORR5
+  this->write_register(0x13, 0x10);                     // CORR6
   // NRT: ~20ms for NFC-V (4233 steps at 4.72µs/step)
   this->write_register(ST25R300_REG_NRT_CONF2, 0x10);
   this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
 }
 
 void ST25R300::configure_nfca_mode_() {
-  this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);    // nfc_n=0 (NFC-A)
-  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A
+  this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);  // nfc_n=0 (NFC-A)
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x01);     // om=1: NFC-A
   this->write_register(ST25R300_REG_TX_PROTOCOL1,
                        ST25R300_TX_PROT1_A_TX_PAR | ST25R300_TX_PROT1_TX_CRC);  // 0x60
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
-                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_A_RX_PAR | ST25R300_RX_PROT1_RX_CRC);  // 0x3C
+                       ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF | ST25R300_RX_PROT1_A_RX_PAR |
+                           ST25R300_RX_PROT1_RX_CRC);  // 0x3C
   // Restore NFC-A TX modulation + RX analog + correlator
   this->write_register(ST25R300_REG_TX_MOD1, 0x70);  // am_mod=7 (20% ASK)
   uint8_t rx_ana1 = 0x73 | (this->rx_gain_boost_ ? 0x04 : 0x00);
@@ -634,7 +649,7 @@ void ST25R300::configure_nfca_mode_() {
 }
 
 bool ST25R300::transceive_blocking_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                                 uint32_t timeout_ms) {
+                                    uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
 
@@ -660,7 +675,7 @@ bool ST25R300::transceive_blocking_(const uint8_t *data, size_t len, uint8_t *re
     // Always poll IRQ registers (ISR may not fire if pin not configured or edge missed)
     uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
     uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
-  this->read_register(ST25R300_REG_IRQ_STATUS3);
+    this->read_register(ST25R300_REG_IRQ_STATUS3);
     if (r1 & ST25R300_IRQ1_RXE) {
       uint8_t fifo_len = this->read_register(ST25R300_REG_FIFO_STATUS1);
       if (fifo_len > 0 && fifo_len <= 64) {
@@ -690,9 +705,7 @@ void ST25R300::nfcv_scan_() {
   uint8_t resp_len = 0;
 
   // Single-tag inventory (multi-tag requires STAY_QUIET + field cycling)
-  if (this->transceive_blocking_(inv_req, sizeof(inv_req), resp, resp_len, 25) &&
-      resp_len >= 10 && !(resp[0] & 0x01)) {
-
+  if (this->transceive_blocking_(inv_req, sizeof(inv_req), resp, resp_len, 25) && resp_len >= 10 && !(resp[0] & 0x01)) {
     // UID is bytes 2-9, transmitted LSB-first — reverse for display
     char uid_str[17];
     for (int j = 0; j < 8; j++) {
@@ -717,18 +730,19 @@ void ST25R300::nfcv_scan_() {
     uint8_t blk_len = 0;
     std::vector<uint8_t> ndef_data;
 
-    if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
-        blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+    if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) && blk_len >= 5 &&
+        !(blk_resp[0] & 0x01)) {
       if (blk_resp[1] == 0xE1) {  // NDEF magic uint8_t in CC
         uint8_t cc_size = blk_resp[3];
         uint8_t total_blocks = (cc_size * 8) / 4;
-        if (total_blocks > 64) total_blocks = 64;
+        if (total_blocks > 64)
+          total_blocks = 64;
 
         for (uint8_t blk = 1; blk <= total_blocks; blk++) {
           blk_req[2] = blk;
           blk_len = 0;
-          if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
-              blk_len >= 5 && !(blk_resp[0] & 0x01)) {
+          if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) && blk_len >= 5 &&
+              !(blk_resp[0] & 0x01)) {
             for (int k = 1; k < 5 && k < blk_len; k++)
               ndef_data.push_back(blk_resp[k]);
           } else {
@@ -757,7 +771,8 @@ void ST25R300::nfcv_scan_() {
             }
             break;
           }
-          if (ndef_data[i] == 0xFE) break;
+          if (ndef_data[i] == 0xFE)
+            break;
         }
       }
 
@@ -785,22 +800,24 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
     std::vector<uint8_t> ndef_data = message->encode();
     payload.push_back(0x03);
     if (ndef_data.size() < 255) {
-      payload.push_back((uint8_t)ndef_data.size());
+      payload.push_back((uint8_t) ndef_data.size());
     } else {
       payload.push_back(0xFF);
-      payload.push_back((uint8_t)((ndef_data.size() >> 8) & 0xFF));
-      payload.push_back((uint8_t)(ndef_data.size() & 0xFF));
+      payload.push_back((uint8_t) ((ndef_data.size() >> 8) & 0xFF));
+      payload.push_back((uint8_t) (ndef_data.size() & 0xFF));
     }
     payload.insert(payload.end(), ndef_data.begin(), ndef_data.end());
   }
   payload.push_back(0xFE);
-  while (payload.size() % 4 != 0) payload.push_back(0);
+  while (payload.size() % 4 != 0)
+    payload.push_back(0);
 
   ESP_LOGD(TAG, "NFC-V NDEF write: %zu bytes in %zu blocks", payload.size(), payload.size() / 4);
 
   // Write CC to block 0
   uint8_t cc_size = (payload.size() + 4) / 8;
-  if (cc_size == 0) cc_size = 1;
+  if (cc_size == 0)
+    cc_size = 1;
   uint8_t write_req[7] = {0x02, 0x21, 0x00, 0xE1, 0x40, cc_size, 0x00};
   uint8_t resp[4];
   uint8_t resp_len = 0;
@@ -843,11 +860,11 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
 // ── NFC-B (ISO 14443B) support ───────────────────────────────────────────────
 
 void ST25R300::configure_nfcb_mode_() {
-  this->write_register(ST25R300_REG_PROTOCOL1, 0x02);      // om=2: NFC-B/ISO14443B
-  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity for NFC-B)
+  this->write_register(ST25R300_REG_PROTOCOL1, 0x02);     // om=2: NFC-B/ISO14443B
+  this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);  // tx_crc only (no parity for NFC-B)
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
                        ST25R300_RX_PROT1_B_RX_SOF | ST25R300_RX_PROT1_B_RX_EOF |
-                       ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity)
+                           ST25R300_RX_PROT1_RX_CRC);  // 0x34: SOF+EOF+CRC (no parity)
   // NFC-B uses AM modulation (10% ASK), not OOK
   this->write_register(ST25R300_REG_TX_MOD1, 0x70);  // am_mod=7 (12% ASK)
   // NRT: ~20ms for NFC-B response
@@ -863,8 +880,8 @@ void ST25R300::nfcb_scan_() {
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_blocking_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
-      resp_len >= 12 && resp[0] == 0x50) {
+  if (this->transceive_blocking_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) && resp_len >= 12 &&
+      resp[0] == 0x50) {
     // ATQB: uint8_t 0 = 0x50, bytes 1-4 = PUPI
     char uid_str[9];
     snprintf(uid_str, sizeof(uid_str), "%02X%02X%02X%02X", resp[1], resp[2], resp[3], resp[4]);

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -634,27 +634,26 @@ bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, 
   this->irq_triggered_ = false;
   this->write_command(ST25R300_CMD_TRANSMIT_DATA);
 
-  // Wait for response
+  // Wait for response — use ISR flag if available, fallback to polling
   uint32_t start = millis();
   while (millis() - start < timeout_ms) {
     if (this->irq_triggered_) {
       this->irq_triggered_ = false;
-      uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
-      uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
-      ESP_LOGV(TAG, "NFC-V IRQ: r1=0x%02X r2=0x%02X", r1, r2);
-      if (r1 & ST25R300_IRQ1_RXE) {
-        // Read FIFO
-        uint8_t fifo_len = this->read_register(ST25R300_REG_FIFO_STATUS1);
-        if (fifo_len > 0 && fifo_len <= 64) {
-          resp_len = fifo_len;
-          this->read_fifo(resp, fifo_len);
-          return true;
-        }
-        return false;
+    }
+    // Always poll IRQ registers (ISR may not fire if pin not configured or edge missed)
+    uint8_t r1 = this->read_register(ST25R300_REG_IRQ_STATUS1);
+    uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
+    if (r1 & ST25R300_IRQ1_RXE) {
+      uint8_t fifo_len = this->read_register(ST25R300_REG_FIFO_STATUS1);
+      if (fifo_len > 0 && fifo_len <= 64) {
+        resp_len = fifo_len;
+        this->read_fifo(resp, fifo_len);
+        return true;
       }
-      if (r2 & ST25R300_IRQ2_NRE) {
-        return false;  // No response
-      }
+      return false;
+    }
+    if (r2 & ST25R300_IRQ2_NRE) {
+      return false;
     }
     delay(1);
   }

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -35,8 +35,8 @@ void ST25R300::setup() {
   if (this->status_binary_sensor_ != nullptr)
     this->status_binary_sensor_->publish_initial_state(false);
 
-  ESP_LOGI(TAG, "Starting reset_()...");
-  if (!this->reset_()) {
+  ESP_LOGI(TAG, "Starting reset_chip()...");
+  if (!this->reset_chip()) {
     ESP_LOGE(TAG, "Failed to reset/init ST25R300");
     this->mark_failed();
     return;
@@ -96,11 +96,11 @@ void ST25R300::update() {
 
   // NFC-V (ISO 15693) blocking inventory — runs before NFC-A scan
   if (this->nfcv_enabled_)
-    this->nfcv_scan_();
+    this->nfcv_scan();
 
   // NFC-B (ISO 14443B) blocking SENSB — runs before NFC-A scan
   if (this->nfcb_enabled_)
-    this->nfcb_scan_();
+    this->nfcb_scan();
 
   this->saved_anticol_valid_ = false;
   this->anticol_resume_ = false;
@@ -113,7 +113,7 @@ void ST25R300::update() {
   // ST25R300 has no dedicated WUPA command — send 7-bit short frame via FIFO
   uint8_t resp[2];
   uint8_t resp_len = 0;
-  this->send_short_frame_(0x52, resp, resp_len, 10);  // 0x52 = WUPA
+  this->send_short_frame(0x52, resp, resp_len, 10);  // 0x52 = WUPA
   ESP_LOGI(TAG, "Sent WUPA");
   delay(1);
   this->state_ = STATE_WUPA;
@@ -122,7 +122,7 @@ void ST25R300::update() {
 
 // ── loop ──────────────────────────────────────────────────────────────────────
 // Overrides base to translate ST25R300's three IRQ registers into the normalized
-// irq_status_ byte used by the shared process_state_() state machine.
+// irq_status_ uint8_t used by the shared process_state() state machine.
 void ST25R300::loop() {
   if (this->is_failed()) return;
 
@@ -153,11 +153,11 @@ void ST25R300::loop() {
   if (this->irq_status2_ & ST25R300_IRQ2_NRE) n |= IRQ_NRE;
   this->irq_status_ = n;
 
-  this->process_state_();
+  this->process_state();
 }
 
 // ── send_short_frame_ ─────────────────────────────────────────────────────────
-bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+bool ST25R300::send_short_frame(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);  // no CRC, no parity
   // b_rx_sof+b_rx_eof MUST be set for Manchester framing; no CRC for ATQA
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
@@ -198,15 +198,15 @@ bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len
 // ── transceive_ / transceive_no_crc_ ─────────────────────────────────────────
 bool ST25R300::transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                             uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, true, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, true, timeout_ms);
 }
 bool ST25R300::transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                    uint32_t timeout_ms) {
-  return this->transceive_ex_(data, len, resp, resp_len, false, timeout_ms);
+  return this->transceive_ex(data, len, resp, resp_len, false, timeout_ms);
 }
 
 // ── transceive_ex_ ────────────────────────────────────────────────────────────
-bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                bool with_crc, uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -264,7 +264,7 @@ bool ST25R300::transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, ui
 // ── read_tag_ ─────────────────────────────────────────────────────────────────
 // ST25R300 supports NFC Forum Type 2 (NTAG) only.
 // Mifare Classic authentication is not implemented for ST25R300 (different MAC engine).
-std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
+std::unique_ptr<nfc::NfcTag> ST25R300::read_tag(std::vector<uint8_t> &uid) {
   uint8_t type = nfc::guess_tag_type(uid.size());
   ESP_LOGI(TAG, "read_tag_: UID length=%zu, guessed type=%d", uid.size(), type);
 
@@ -348,20 +348,20 @@ std::unique_ptr<nfc::NfcTag> ST25R300::read_tag_(std::vector<uint8_t> &uid) {
 
 // ── Virtual helper overrides ───────────────────────────────────────────────────
 
-uint8_t ST25R300::read_fifo_status1_() {
+uint8_t ST25R300::read_fifo_status1() {
   return this->read_register(ST25R300_REG_FIFO_STATUS1);
 }
 
-uint8_t ST25R300::read_collision_display_() {
+uint8_t ST25R300::read_collision_display() {
   return this->read_register(ST25R300_REG_COLLISION_DISPLAY);
 }
 
-void ST25R300::pre_select_() {
-  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex_().
+void ST25R300::pre_select() {
+  // No-op: ST25R300 manages RX mode (antcl) via RX_PROTOCOL1 inside transceive_ex().
   // There is no separate "anticol mode" register to clear before SELECT.
 }
 
-void ST25R300::send_halt_() {
+void ST25R300::send_halt() {
   uint8_t halt_cmd[2] = {0x50, 0x00};
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -377,7 +377,7 @@ void ST25R300::send_halt_() {
   delay(10);
 }
 
-void ST25R300::start_wupa_() {
+void ST25R300::start_wupa() {
   // Clear FIFO + IRQs + chip accumulators, then transmit WUPA as short frame
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->read_register(ST25R300_REG_IRQ_STATUS1);
@@ -389,11 +389,11 @@ void ST25R300::start_wupa_() {
   this->irq_status_ = 0;
   uint8_t dummy[2];
   uint8_t dummy_len = 0;
-  this->send_short_frame_(0x52, dummy, dummy_len, 10);
+  this->send_short_frame(0x52, dummy, dummy_len, 10);
 }
 
 // ── send_anticol_frame_ ───────────────────────────────────────────────────────
-void ST25R300::send_anticol_frame_() {
+void ST25R300::send_anticol_frame() {
   uint8_t sel_cmds[] = {0x93, 0x95, 0x97};
   uint8_t sel = sel_cmds[this->cascade_level_];
 
@@ -436,7 +436,7 @@ void ST25R300::send_anticol_frame_() {
 }
 
 // ── reset_ ────────────────────────────────────────────────────────────────────
-bool ST25R300::reset_() {
+bool ST25R300::reset_chip() {
   // Verify IC identity BEFORE SET_DEFAULT — if bus is down, don't clear registers.
   uint8_t ic_identity = this->read_register(ST25R300_REG_IC_IDENTITY);
   ESP_LOGD(TAG, "  reset_: IC identity read: 0x%02X", ic_identity);
@@ -524,7 +524,7 @@ bool ST25R300::reset_() {
 }
 
 // ── reinitialize_ ─────────────────────────────────────────────────────────────
-void ST25R300::reinitialize_() {
+void ST25R300::reinitialize() {
   this->reinitialization_attempts_++;
   ESP_LOGW(TAG, "Reinitializing ST25R300 (attempt %u)...", this->reinitialization_attempts_);
   if (this->reset_pin_ != nullptr) {
@@ -533,7 +533,7 @@ void ST25R300::reinitialize_() {
     this->reset_pin_->digital_write(false);
     delay(10);
   }
-  if (this->reset_()) {
+  if (this->reset_chip()) {
     ESP_LOGI(TAG, "Reinitialize succeeded after %u attempt(s)", this->reinitialization_attempts_);
     this->health_check_failures_ = 0;
     this->reinitialization_attempts_ = 0;
@@ -570,7 +570,7 @@ void ST25R300::dump_config() {
 
 // ── NFC-V (ISO 15693) support ────────────────────────────────────────────────
 
-void ST25R300::configure_nfcv_mode_() {
+void ST25R300::configure_nfcv_mode() {
   this->write_register(ST25R300_REG_GENERAL_CONF, 0x02);    // nfc_n=2 (NFC-V subcarrier config)
   this->write_register(ST25R300_REG_PROTOCOL1, 0x05);      // om=5: NFC-V/ISO15693
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity)
@@ -593,7 +593,7 @@ void ST25R300::configure_nfcv_mode_() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
 }
 
-void ST25R300::configure_nfca_mode_() {
+void ST25R300::configure_nfca_mode() {
   this->write_register(ST25R300_REG_GENERAL_CONF, 0x00);    // nfc_n=0 (NFC-A)
   this->write_register(ST25R300_REG_PROTOCOL1, 0x01);      // om=1: NFC-A
   this->write_register(ST25R300_REG_TX_PROTOCOL1,
@@ -617,7 +617,7 @@ void ST25R300::configure_nfca_mode_() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x23);
 }
 
-bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_nfcv(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                  uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -661,9 +661,9 @@ bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, 
   return false;
 }
 
-void ST25R300::nfcv_scan_() {
+void ST25R300::nfcv_scan() {
   // Switch to NFC-V mode
-  this->configure_nfcv_mode_();
+  this->configure_nfcv_mode();
 
   ESP_LOGV(TAG, "NFC-V: starting inventory scan");
 
@@ -675,7 +675,7 @@ void ST25R300::nfcv_scan_() {
   // Loop: inventory → record UID → stay quiet → repeat until no response
   for (int i = 0; i < 16; i++) {  // max 16 NFC-V tags per scan
     resp_len = 0;
-    if (!this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
+    if (!this->transceive_nfcv(inv_req, sizeof(inv_req), resp, resp_len, 25)) {
       break;  // No more tags
     }
 
@@ -685,7 +685,7 @@ void ST25R300::nfcv_scan_() {
       break;
     }
 
-    // Check flags byte — bit0=error
+    // Check flags uint8_t — bit0=error
     if (resp[0] & 0x01) {
       ESP_LOGD(TAG, "NFC-V: inventory error flag set (0x%02X)", resp[0]);
       break;
@@ -699,7 +699,7 @@ void ST25R300::nfcv_scan_() {
     uid_str[16] = '\0';
     ESP_LOGI(TAG, "NFC-V tag: %s (DSFID=0x%02X)", uid_str, resp[1]);
 
-    // Add to tags_this_scan_ — finalize_scan_() handles on_tag_removed
+    // Add to tags_this_scan_ — finalize_scan() handles on_tag_removed
     std::string uid_string(uid_str);
     this->tags_this_scan_.insert(uid_string);
 
@@ -714,9 +714,9 @@ void ST25R300::nfcv_scan_() {
     uint8_t blk_len = 0;
     std::vector<uint8_t> ndef_data;
 
-    if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+    if (this->transceive_nfcv(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
         blk_len >= 5 && !(blk_resp[0] & 0x01)) {
-      if (blk_resp[1] == 0xE1) {  // NDEF magic byte in CC
+      if (blk_resp[1] == 0xE1) {  // NDEF magic uint8_t in CC
         uint8_t cc_size = blk_resp[3];
         uint8_t total_blocks = (cc_size * 8) / 4;
         if (total_blocks > 64) total_blocks = 64;
@@ -724,7 +724,7 @@ void ST25R300::nfcv_scan_() {
         for (uint8_t blk = 1; blk <= total_blocks; blk++) {
           blk_req[2] = blk;
           blk_len = 0;
-          if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+          if (this->transceive_nfcv(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
               blk_len >= 5 && !(blk_resp[0] & 0x01)) {
             for (int k = 1; k < 5 && k < blk_len; k++)
               ndef_data.push_back(blk_resp[k]);
@@ -771,11 +771,11 @@ void ST25R300::nfcv_scan_() {
   }
 
   // Switch back to NFC-A mode for the main scan
-  this->configure_nfca_mode_();
+  this->configure_nfca_mode();
 }
 
-bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
-  this->configure_nfcv_mode_();
+bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
+  this->configure_nfcv_mode();
 
   std::vector<uint8_t> payload;
   if (message != nullptr) {
@@ -802,9 +802,9 @@ bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
   uint8_t resp[4];
   uint8_t resp_len = 0;
 
-  if (!this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+  if (!this->transceive_nfcv(write_req, sizeof(write_req), resp, resp_len, 25)) {
     ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
-    this->configure_nfca_mode_();
+    this->configure_nfca_mode();
     return false;
   }
 
@@ -819,7 +819,7 @@ bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
 
     bool success = false;
     for (uint8_t retry = 0; retry < 3; retry++) {
-      if (this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+      if (this->transceive_nfcv(write_req, sizeof(write_req), resp, resp_len, 25)) {
         success = true;
         break;
       }
@@ -827,19 +827,19 @@ bool ST25R300::nfcv_ndef_write_(nfc::NdefMessage *message) {
     }
     if (!success) {
       ESP_LOGE(TAG, "NFC-V: failed to write block %u", blk);
-      this->configure_nfca_mode_();
+      this->configure_nfca_mode();
       return false;
     }
   }
 
   ESP_LOGI(TAG, "NFC-V NDEF write successful!");
-  this->configure_nfca_mode_();
+  this->configure_nfca_mode();
   return true;
 }
 
 // ── NFC-B (ISO 14443B) support ───────────────────────────────────────────────
 
-void ST25R300::configure_nfcb_mode_() {
+void ST25R300::configure_nfcb_mode() {
   this->write_register(ST25R300_REG_PROTOCOL1, 0x02);      // om=2: NFC-B/ISO14443B
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x20);   // tx_crc only (no parity for NFC-B)
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
@@ -852,17 +852,17 @@ void ST25R300::configure_nfcb_mode_() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x89);
 }
 
-void ST25R300::nfcb_scan_() {
-  this->configure_nfcb_mode_();
+void ST25R300::nfcb_scan() {
+  this->configure_nfcb_mode();
 
   // SENSB_REQ (ALLB): cmd=0x05, AFI=0x00, PARAM=0x08 (1 slot + WUPB)
   uint8_t sensb_req[] = {0x05, 0x00, 0x08};
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_nfcv_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
+  if (this->transceive_nfcv(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
       resp_len >= 12 && resp[0] == 0x50) {
-    // ATQB: byte 0 = 0x50, bytes 1-4 = PUPI
+    // ATQB: uint8_t 0 = 0x50, bytes 1-4 = PUPI
     char uid_str[9];
     snprintf(uid_str, sizeof(uid_str), "%02X%02X%02X%02X", resp[1], resp[2], resp[3], resp[4]);
     ESP_LOGI(TAG, "NFC-B tag: %s (ATQB len=%u)", uid_str, resp_len);
@@ -883,7 +883,7 @@ void ST25R300::nfcb_scan_() {
   }
 
   // Restore NFC-A mode
-  this->configure_nfca_mode_();
+  this->configure_nfca_mode();
 }
 
 }  // namespace st25r300

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -705,6 +705,7 @@ void ST25R300::nfcv_scan_() {
 
     // Try to read NDEF (Type 5 tag) via READ_SINGLE_BLOCK
     std::vector<uint8_t> uid_bytes;
+    uid_bytes.reserve(8);
     for (int j = 0; j < 8; j++)
       uid_bytes.push_back(resp[9 - j]);
 

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -134,10 +134,12 @@ void ST25R300::loop() {
     uint8_t r2 = this->read_register(ST25R300_REG_IRQ_STATUS2);
     this->irq_status1_ |= r1;
     this->irq_status2_ |= r2;
+    this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3 (DCT/OSC) to release IRQ pin
     ESP_LOGV(TAG, "IRQ triggered, IRQ1=0x%02X IRQ2=0x%02X state=%d", r1, r2, this->state_);
   } else if (this->state_ == STATE_WUPA || this->state_ == STATE_ANTICOL) {
     this->irq_status1_ |= this->read_register(ST25R300_REG_IRQ_STATUS1);
     this->irq_status2_ |= this->read_register(ST25R300_REG_IRQ_STATUS2);
+    this->read_register(ST25R300_REG_IRQ_STATUS3);  // Clear IRQ3
     if (this->irq_status1_ != 0 || this->irq_status2_ != 0) {
       ESP_LOGV(TAG, "IRQ polled, IRQ1=0x%02X IRQ2=0x%02X state=%d",
                this->irq_status1_, this->irq_status2_, this->state_);
@@ -620,7 +622,7 @@ void ST25R300::configure_nfca_mode_() {
   this->write_register(ST25R300_REG_NRT_CONF3, 0x23);
 }
 
-bool ST25R300::transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+bool ST25R300::transceive_blocking_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                                  uint32_t timeout_ms) {
   this->write_command(ST25R300_CMD_CLEAR_FIFO);
   this->write_command(ST25R300_CMD_CLEAR_RX_GAIN);
@@ -675,7 +677,7 @@ void ST25R300::nfcv_scan_() {
   uint8_t resp_len = 0;
 
   // Single-tag inventory (multi-tag requires STAY_QUIET + field cycling)
-  if (this->transceive_nfcv_(inv_req, sizeof(inv_req), resp, resp_len, 25) &&
+  if (this->transceive_blocking_(inv_req, sizeof(inv_req), resp, resp_len, 25) &&
       resp_len >= 10 && !(resp[0] & 0x01)) {
 
     // UID is bytes 2-9, transmitted LSB-first — reverse for display
@@ -702,7 +704,7 @@ void ST25R300::nfcv_scan_() {
     uint8_t blk_len = 0;
     std::vector<uint8_t> ndef_data;
 
-    if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+    if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
         blk_len >= 5 && !(blk_resp[0] & 0x01)) {
       if (blk_resp[1] == 0xE1) {  // NDEF magic uint8_t in CC
         uint8_t cc_size = blk_resp[3];
@@ -712,7 +714,7 @@ void ST25R300::nfcv_scan_() {
         for (uint8_t blk = 1; blk <= total_blocks; blk++) {
           blk_req[2] = blk;
           blk_len = 0;
-          if (this->transceive_nfcv_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
+          if (this->transceive_blocking_(blk_req, sizeof(blk_req), blk_resp, blk_len, 20) &&
               blk_len >= 5 && !(blk_resp[0] & 0x01)) {
             for (int k = 1; k < 5 && k < blk_len; k++)
               ndef_data.push_back(blk_resp[k]);
@@ -790,7 +792,7 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
   uint8_t resp[4];
   uint8_t resp_len = 0;
 
-  if (!this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+  if (!this->transceive_blocking_(write_req, sizeof(write_req), resp, resp_len, 25)) {
     ESP_LOGE(TAG, "NFC-V: failed to write CC (block 0)");
     this->configure_nfca_mode_();
     return false;
@@ -807,7 +809,7 @@ bool ST25R300::nfcv_ndef_write(nfc::NdefMessage *message) {
 
     bool success = false;
     for (uint8_t retry = 0; retry < 3; retry++) {
-      if (this->transceive_nfcv_(write_req, sizeof(write_req), resp, resp_len, 25)) {
+      if (this->transceive_blocking_(write_req, sizeof(write_req), resp, resp_len, 25)) {
         success = true;
         break;
       }
@@ -848,7 +850,7 @@ void ST25R300::nfcb_scan_() {
   uint8_t resp[16];
   uint8_t resp_len = 0;
 
-  if (this->transceive_nfcv_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
+  if (this->transceive_blocking_(sensb_req, sizeof(sensb_req), resp, resp_len, 20) &&
       resp_len >= 12 && resp[0] == 0x50) {
     // ATQB: uint8_t 0 = 0x50, bytes 1-4 = PUPI
     char uid_str[9];

--- a/esphome/components/st25r300/st25r300.cpp
+++ b/esphome/components/st25r300/st25r300.cpp
@@ -90,6 +90,8 @@ void ST25R300::update() {
     this->write_register(ST25R300_REG_OPERATION, ST25R300_OP_ALL_ON);
 
   if (this->rf_field_enabled_ && this->field_strength_sensor_ != nullptr) {
+    this->write_command(ST25R300_CMD_SENSE_RF);
+    delay(1);  // allow ADC conversion to complete
     uint8_t sense = this->read_register(ST25R300_REG_SENSE_RF);
     this->field_strength_sensor_->publish_state(sense);
   }
@@ -157,7 +159,8 @@ void ST25R300::loop() {
 }
 
 // ── send_short_frame_ ─────────────────────────────────────────────────────────
-bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms) {
+bool ST25R300::send_short_frame_(uint8_t byte7, uint8_t * /*resp*/, uint8_t &resp_len,
+                                 uint32_t /*timeout_ms*/) {
   this->write_register(ST25R300_REG_TX_PROTOCOL1, 0x00);  // no CRC, no parity
   // b_rx_sof+b_rx_eof MUST be set for Manchester framing; no CRC for ATQA
   this->write_register(ST25R300_REG_RX_PROTOCOL1,
@@ -732,7 +735,9 @@ void ST25R300::nfcv_scan_() {
             size_t ndef_start = i + 2;
             if (ndef_start + ndef_len <= ndef_data.size()) {
               ESP_LOGI(TAG, "NFC-V NDEF: %u bytes", ndef_len);
-              auto tag = make_unique<nfc::NfcTag>(nfc_uid);
+              std::vector<uint8_t> ndef_payload(ndef_data.begin() + ndef_start,
+                                                ndef_data.begin() + ndef_start + ndef_len);
+              auto tag = make_unique<nfc::NfcTag>(nfc_uid, "NFC Forum Type 5", ndef_payload);
               this->tags_data_[uid_string] = std::move(tag);
             }
             break;

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "esphome/components/st25r/st25r.h"
+#include "st25r300_registers.h"
+
+namespace esphome {
+namespace st25r300 {
+
+// ST25R300 inherits the full shared state machine, NDEF, multi-tag, and
+// finalize_scan_ logic from st25r::ST25R. Only chip-specific hardware
+// differences (init, IRQ mapping, anticol framing, transceive) are overridden here.
+
+class ST25R300 : public st25r::ST25R {
+ public:
+  void setup() override;
+  void dump_config() override;
+  void update() override;
+  void loop() override;
+
+ protected:
+  // Hardware abstraction — implemented by st25r300_spi (pure virtual here, inherited from ST25R)
+  virtual uint8_t read_register(uint8_t reg) = 0;
+  virtual void write_register(uint8_t reg, uint8_t value) = 0;
+  virtual void write_command(uint8_t command) = 0;
+  virtual void write_fifo(const uint8_t *data, size_t len) = 0;
+  virtual void read_fifo(uint8_t *data, size_t len) = 0;
+
+  // Chip-specific overrides
+  bool reset_() override;
+  void reinitialize_() override;
+  void send_anticol_frame_() override;
+  bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                      bool with_crc, uint32_t timeout_ms = 150) override;
+  std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid) override;
+  bool nfcv_ndef_write_(nfc::NdefMessage *message) override;
+  void send_halt_() override;
+  void start_wupa_() override;
+  void pre_select_() override;  // no-op: ST25R300 manages mode in transceive_ex_()
+  uint8_t read_fifo_status1_() override;
+  uint8_t read_collision_display_() override;
+
+  // ST25R300-specific: send a 7-bit ISO14443A short frame (WUPA=0x52 or REQA=0x26).
+  // ST25R300 has no dedicated WUPA/REQA command; must be done via FIFO + TRANSMIT_DATA.
+  bool send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
+
+  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                   uint32_t timeout_ms = 150);
+  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                           uint32_t timeout_ms = 150);
+
+  // NFC-V (ISO 15693) blocking inventory scan — called from update() before NFC-A
+  void nfcv_scan_();
+  // NFC-B (ISO 14443B) blocking SENSB scan
+  void nfcb_scan_();
+  void configure_nfcb_mode_();
+  void configure_nfcv_mode_();
+  void configure_nfca_mode_();
+  bool transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+                        uint32_t timeout_ms = 25);
+
+  static void isr(ST25R300 *arg);
+
+  // ST25R300-specific accumulated IRQ state (3 registers → 2 bytes).
+  // loop() translates these to the base class irq_status_ using base class bit constants.
+  volatile uint8_t irq_status1_{0};
+  uint8_t irq_status2_{0};
+};
+
+// ── Trigger and Action wrappers ───────────────────────────────────────────────
+// Thin subclasses so the st25r300 Python component can reference its own type names
+// while still using the shared trigger/action infrastructure from st25r::ST25R.
+
+class ST25R300TagTrigger : public st25r::ST25RTagTrigger {
+ public:
+  explicit ST25R300TagTrigger(st25r::ST25R *parent) : st25r::ST25RTagTrigger(parent) {}
+};
+
+class ST25R300TagRemovedTrigger : public st25r::ST25RTagRemovedTrigger {
+ public:
+  explicit ST25R300TagRemovedTrigger(st25r::ST25R *parent) : st25r::ST25RTagRemovedTrigger(parent) {}
+};
+
+template<typename... Ts> class NDEFWriteAction : public st25r::NDEFWriteAction<Ts...> {
+ public:
+  void set_parent(st25r::ST25R *parent) { this->parent_ = parent; }
+};
+
+template<typename... Ts> class CleanTagAction : public st25r::CleanTagAction<Ts...> {
+ public:
+  void set_parent(st25r::ST25R *parent) { this->parent_ = parent; }
+};
+
+}  // namespace st25r300
+}  // namespace esphome

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -26,22 +26,22 @@ class ST25R300 : public st25r::ST25R {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides
-  bool reset_chip() override;
-  void reinitialize() override;
-  void send_anticol_frame() override;
-  bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  bool reset_chip_() override;
+  void reinitialize_() override;
+  void send_anticol_frame_() override;
+  bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                       bool with_crc, uint32_t timeout_ms = 150) override;
-  std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid) override;
-  bool nfcv_ndef_write(nfc::NdefMessage *message) override;
-  void send_halt() override;
-  void start_wupa() override;
-  void pre_select() override;  // no-op: ST25R300 manages mode in transceive_ex()
-  uint8_t read_fifo_status1() override;
-  uint8_t read_collision_display() override;
+  std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid) override;
+  bool nfcv_ndef_write_(nfc::NdefMessage *message) override;
+  void send_halt_() override;
+  void start_wupa_() override;
+  void pre_select_() override;  // no-op: ST25R300 manages mode in transceive_ex_()
+  uint8_t read_fifo_status1_() override;
+  uint8_t read_collision_display_() override;
 
   // ST25R300-specific: send a 7-bit ISO14443A short frame (WUPA=0x52 or REQA=0x26).
   // ST25R300 has no dedicated WUPA/REQA command; must be done via FIFO + TRANSMIT_DATA.
-  bool send_short_frame(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
+  bool send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
 
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                    uint32_t timeout_ms = 150);
@@ -49,13 +49,13 @@ class ST25R300 : public st25r::ST25R {
                            uint32_t timeout_ms = 150);
 
   // NFC-V (ISO 15693) blocking inventory scan — called from update() before NFC-A
-  void nfcv_scan();
+  void nfcv_scan_();
   // NFC-B (ISO 14443B) blocking SENSB scan
-  void nfcb_scan();
-  void configure_nfcb_mode();
-  void configure_nfcv_mode();
-  void configure_nfca_mode();
-  bool transceive_nfcv(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  void nfcb_scan_();
+  void configure_nfcb_mode_();
+  void configure_nfcv_mode_();
+  void configure_nfca_mode_();
+  bool transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                         uint32_t timeout_ms = 25);
 
   static void isr(ST25R300 *arg);

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -26,18 +26,18 @@ class ST25R300 : public st25r::ST25R {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides
-  bool reset_chip_() override;
-  void reinitialize_() override;
-  void send_anticol_frame_() override;
-  bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  bool reset_chip() override;
+  void reinitialize() override;
+  void send_anticol_frame() override;
+  bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                       bool with_crc, uint32_t timeout_ms = 150) override;
-  std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid) override;
-  bool nfcv_ndef_write_(nfc::NdefMessage *message) override;
-  void send_halt_() override;
-  void start_wupa_() override;
-  void pre_select_() override;  // no-op: ST25R300 manages mode in transceive_ex_()
-  uint8_t read_fifo_status1_() override;
-  uint8_t read_collision_display_() override;
+  std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid) override;
+  bool nfcv_ndef_write(nfc::NdefMessage *message) override;
+  void send_halt() override;
+  void start_wupa() override;
+  void pre_select() override;  // no-op: ST25R300 manages mode in transceive_ex()
+  uint8_t read_fifo_status1() override;
+  uint8_t read_collision_display() override;
 
   // ST25R300-specific: send a 7-bit ISO14443A short frame (WUPA=0x52 or REQA=0x26).
   // ST25R300 has no dedicated WUPA/REQA command; must be done via FIFO + TRANSMIT_DATA.

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -29,8 +29,8 @@ class ST25R300 : public st25r::ST25R {
   bool reset_chip() override;
   void reinitialize() override;
   void send_anticol_frame() override;
-  bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                      bool with_crc, uint32_t timeout_ms) override;
+  bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, bool with_crc,
+                     uint32_t timeout_ms) override;
   std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid) override;
   bool nfcv_ndef_write(nfc::NdefMessage *message) override;
   void send_halt() override;
@@ -43,10 +43,8 @@ class ST25R300 : public st25r::ST25R {
   // ST25R300 has no dedicated WUPA/REQA command; must be done via FIFO + TRANSMIT_DATA.
   bool send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
 
-  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                   uint32_t timeout_ms = 150);
-  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                           uint32_t timeout_ms = 150);
+  bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
+  bool transceive_no_crc_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 150);
 
   // NFC-V (ISO 15693) blocking inventory scan — called from update() before NFC-A
   void nfcv_scan_();
@@ -56,7 +54,7 @@ class ST25R300 : public st25r::ST25R {
   void configure_nfcv_mode_();
   void configure_nfca_mode_();
   bool transceive_blocking_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                        uint32_t timeout_ms = 25);
+                            uint32_t timeout_ms = 25);
 
   static void isr(ST25R300 *arg);
 

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -26,22 +26,22 @@ class ST25R300 : public st25r::ST25R {
   virtual void read_fifo(uint8_t *data, size_t len) = 0;
 
   // Chip-specific overrides
-  bool reset_() override;
-  void reinitialize_() override;
-  void send_anticol_frame_() override;
-  bool transceive_ex_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  bool reset_chip() override;
+  void reinitialize() override;
+  void send_anticol_frame() override;
+  bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                       bool with_crc, uint32_t timeout_ms = 150) override;
-  std::unique_ptr<nfc::NfcTag> read_tag_(std::vector<uint8_t> &uid) override;
-  bool nfcv_ndef_write_(nfc::NdefMessage *message) override;
-  void send_halt_() override;
-  void start_wupa_() override;
-  void pre_select_() override;  // no-op: ST25R300 manages mode in transceive_ex_()
-  uint8_t read_fifo_status1_() override;
-  uint8_t read_collision_display_() override;
+  std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid) override;
+  bool nfcv_ndef_write(nfc::NdefMessage *message) override;
+  void send_halt() override;
+  void start_wupa() override;
+  void pre_select() override;  // no-op: ST25R300 manages mode in transceive_ex()
+  uint8_t read_fifo_status1() override;
+  uint8_t read_collision_display() override;
 
   // ST25R300-specific: send a 7-bit ISO14443A short frame (WUPA=0x52 or REQA=0x26).
   // ST25R300 has no dedicated WUPA/REQA command; must be done via FIFO + TRANSMIT_DATA.
-  bool send_short_frame_(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
+  bool send_short_frame(uint8_t byte7, uint8_t *resp, uint8_t &resp_len, uint32_t timeout_ms = 10);
 
   bool transceive_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                    uint32_t timeout_ms = 150);
@@ -49,13 +49,13 @@ class ST25R300 : public st25r::ST25R {
                            uint32_t timeout_ms = 150);
 
   // NFC-V (ISO 15693) blocking inventory scan — called from update() before NFC-A
-  void nfcv_scan_();
+  void nfcv_scan();
   // NFC-B (ISO 14443B) blocking SENSB scan
-  void nfcb_scan_();
-  void configure_nfcb_mode_();
-  void configure_nfcv_mode_();
-  void configure_nfca_mode_();
-  bool transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  void nfcb_scan();
+  void configure_nfcb_mode();
+  void configure_nfcv_mode();
+  void configure_nfca_mode();
+  bool transceive_nfcv(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                         uint32_t timeout_ms = 25);
 
   static void isr(ST25R300 *arg);

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -55,7 +55,7 @@ class ST25R300 : public st25r::ST25R {
   void configure_nfcb_mode_();
   void configure_nfcv_mode_();
   void configure_nfca_mode_();
-  bool transceive_nfcv_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
+  bool transceive_blocking_(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
                         uint32_t timeout_ms = 25);
 
   static void isr(ST25R300 *arg);

--- a/esphome/components/st25r300/st25r300.h
+++ b/esphome/components/st25r300/st25r300.h
@@ -18,19 +18,19 @@ class ST25R300 : public st25r::ST25R {
   void loop() override;
 
  protected:
-  // Hardware abstraction — implemented by st25r300_spi (pure virtual here, inherited from ST25R)
-  virtual uint8_t read_register(uint8_t reg) = 0;
-  virtual void write_register(uint8_t reg, uint8_t value) = 0;
-  virtual void write_command(uint8_t command) = 0;
-  virtual void write_fifo(const uint8_t *data, size_t len) = 0;
-  virtual void read_fifo(uint8_t *data, size_t len) = 0;
+  // Hardware abstraction — implemented by st25r300_spi (pure virtual, inherited from ST25R)
+  uint8_t read_register(uint8_t reg) override = 0;
+  void write_register(uint8_t reg, uint8_t value) override = 0;
+  void write_command(uint8_t command) override = 0;
+  void write_fifo(const uint8_t *data, size_t len) override = 0;
+  void read_fifo(uint8_t *data, size_t len) override = 0;
 
   // Chip-specific overrides
   bool reset_chip() override;
   void reinitialize() override;
   void send_anticol_frame() override;
   bool transceive_ex(const uint8_t *data, size_t len, uint8_t *resp, uint8_t &resp_len,
-                      bool with_crc, uint32_t timeout_ms = 150) override;
+                      bool with_crc, uint32_t timeout_ms) override;
   std::unique_ptr<nfc::NfcTag> read_tag(std::vector<uint8_t> &uid) override;
   bool nfcv_ndef_write(nfc::NdefMessage *message) override;
   void send_halt() override;

--- a/esphome/components/st25r300/st25r300_registers.h
+++ b/esphome/components/st25r300/st25r300_registers.h
@@ -1,0 +1,146 @@
+#pragma once
+#include <cstdint>
+
+// ST25R300 Register Map (AN6313, DS - 88 addressable registers 0x00-0x57)
+// SPI protocol: write = addr & 0x7F (bit7=0), read = addr | 0x80 (bit7=1)
+// FIFO write: 0x5F + data bytes; FIFO read: 0xDF + read bytes
+// Commands: 0x60-0x7F range + 0xE2-0xEF range
+
+namespace esphome {
+namespace st25r300 {
+
+// ── Register Addresses ──────────────────────────────────────────────────────
+enum ST25R300Register : uint8_t {
+  // Core operational registers
+  ST25R300_REG_OPERATION        = 0x00, // en(b3), vdddr_en(b4), rx_en(b5), tx_en(b6)
+  ST25R300_REG_GENERAL_CONF     = 0x01, // single(b5), rfo2(b4), nfc_n[1:0]
+  ST25R300_REG_VDDDR_CONF       = 0x02, // reg_s(b7), rege[6:0]
+  ST25R300_REG_TX_DRIVER_CONF   = 0x03, // regd[6:4], d_res[3:0]
+  ST25R300_REG_TX_MOD1          = 0x04, // am_mod[7:4](def=0x7=20%), mod_state(b3), rgs_am(b2), res_am(b1)
+
+  // Rx analog settings
+  ST25R300_REG_RX_ANALOG1       = 0x09, // dig_clk_dly[7:4](rec=0x7), gain_boost(b2), hpf_ctrl[1:0]
+
+  // Rx digital settings
+  ST25R300_REG_RX_DIGITAL1      = 0x0D, // agc_en(b7)=1 by default
+
+  // Protocol registers
+  ST25R300_REG_PROTOCOL1        = 0x14, // om[3:0]: 0x1=NFC-A, 0x2=NFC-B, 0x3=NFC-F, 0x5=NFC-V
+  ST25R300_REG_TX_PROTOCOL1     = 0x15, // a_tx_par(b6)=1, tx_crc(b5)=1, tr_am(b4), p_len[3:0]
+  ST25R300_REG_TX_PROTOCOL2     = 0x16,
+  ST25R300_REG_RX_PROTOCOL1     = 0x17, // a_rx_par(b3)=1, rx_crc(b2)=1, antcl(b0) for anticollision
+
+  // No-response timer (NRT) config
+  ST25R300_REG_NRT_CONF1        = 0x22, // nrt_emv(b1), nrt_step(b0)
+  ST25R300_REG_NRT_CONF2        = 0x23, // nrt[15:8]
+  ST25R300_REG_NRT_CONF3        = 0x24, // nrt[7:0]
+
+  // TX frame configuration
+  ST25R300_REG_TX_FRAME1        = 0x34, // ntx[12:5]
+  ST25R300_REG_TX_FRAME2        = 0x35, // ntx[4:0] in bits[7:3], nbtx[2:0] in bits[2:0]
+
+  // FIFO status
+  ST25R300_REG_FIFO_STATUS1     = 0x36, // fifo_b[7:0] byte count LSB
+  ST25R300_REG_FIFO_STATUS2     = 0x37, // fifo_b[8](b6), fifo_unf(b5), fifo_ovr(b4), fifo_lb[2:0](b3:1), np_lb(b0)
+
+  // Collision display
+  ST25R300_REG_COLLISION_DISPLAY = 0x38, // c_byte[7:4], c_bit[3:1], c_pb[0]
+
+  // IRQ mask registers
+  ST25R300_REG_IRQ_MASK1        = 0x39, // M_col(b6), M_rxe(b3), M_rxs(b2), M_txe(b1), M_rx_err(b0)
+  ST25R300_REG_IRQ_MASK2        = 0x3A, // M_nre(b6)
+  ST25R300_REG_IRQ_MASK3        = 0x3B, // M_dct(b4), M_osc(b0)
+
+  // IRQ status registers (read-to-clear)
+  ST25R300_REG_IRQ_STATUS1      = 0x3C, // I_col(b6), I_rxe(b3), I_rxs(b2), I_txe(b1), I_rx_err(b0)
+  ST25R300_REG_IRQ_STATUS2      = 0x3D, // I_nre(b6)
+  ST25R300_REG_IRQ_STATUS3      = 0x3E, // I_dct(b4), I_osc(b0)
+
+  // IC identity
+  ST25R300_REG_IC_IDENTITY      = 0x3F, // ic_type[7:3]=10110b for ST25R300 → (val & 0xF8)==0xB0
+
+  // Status registers
+  ST25R300_REG_STATUS1          = 0x40, // osc_ok(b4), agd_ok(b5), efd_out(b1), efd_on(b0)
+  ST25R300_REG_STATUS2          = 0x41, // subc_on(b7), gpt_on(b6), nrt_on(b5), mrt_on(b4), rx_act(b3), rx_on(b2), tx_on(b1)
+  ST25R300_REG_STATIC_STATUS1   = 0x42, // s_eon(b5), s_eof(b6), s_dct(b4)
+  ST25R300_REG_STATIC_STATUS2   = 0x43, // s_rx_err(b5), s_rxe(b4), s_rx_rest(b3), s_col(b2), s_rxs(b1)
+  ST25R300_REG_STATIC_STATUS3   = 0x44, // s_crc(b7), s_par(b6), s_hfe(b5), s_sfe(b4)
+
+  // RSSI / Field sense
+  ST25R300_REG_RSSI1            = 0x4A, // rssi_i[6:0] (I channel)
+  ST25R300_REG_RSSI2            = 0x4B, // rssi_q[6:0] (Q channel)
+  ST25R300_REG_SENSE_RF         = 0x4C, // sense_adc[7:0] — updated by CMD_SENSE_RF (0x7C/7D)
+};
+
+// ── IRQ Status 1 (0x3C) bit masks ───────────────────────────────────────────
+static const uint8_t ST25R300_IRQ1_SUBC_START = 0x80; // bit7: subcarrier start detected
+static const uint8_t ST25R300_IRQ1_COL    = 0x40;  // bit6: bit collision
+static const uint8_t ST25R300_IRQ1_WL     = 0x20;  // bit5: FIFO water level
+static const uint8_t ST25R300_IRQ1_RX_REST= 0x10;  // bit4: automatic reception restart
+static const uint8_t ST25R300_IRQ1_RXE    = 0x08;  // bit3: end of receive
+static const uint8_t ST25R300_IRQ1_RXS    = 0x04;  // bit2: start of receive
+static const uint8_t ST25R300_IRQ1_TXE    = 0x02;  // bit1: end of transmission
+static const uint8_t ST25R300_IRQ1_RX_ERR = 0x01;  // bit0: receive error
+
+// ── IRQ Status 2 (0x3D) bit masks ───────────────────────────────────────────
+static const uint8_t ST25R300_IRQ2_NRE    = 0x40;  // bit6: no-response timer expired
+
+// ── IRQ Status 3 (0x3E) bit masks ───────────────────────────────────────────
+static const uint8_t ST25R300_IRQ3_DCT    = 0x10;  // bit4: direct command terminated
+static const uint8_t ST25R300_IRQ3_OSC    = 0x01;  // bit0: oscillator stable
+
+// ── Operation register (0x00) bit masks ─────────────────────────────────────
+static const uint8_t ST25R300_OP_EN       = 0x08;  // bit3: chip enable
+static const uint8_t ST25R300_OP_VDDDR_EN = 0x10;  // bit4: VDDDR regulator enable
+static const uint8_t ST25R300_OP_RX_EN    = 0x20;  // bit5: RX enable
+static const uint8_t ST25R300_OP_TX_EN    = 0x40;  // bit6: TX enable
+// All operational (en + vdddr + rx + tx):
+static const uint8_t ST25R300_OP_ALL_ON   = ST25R300_OP_EN | ST25R300_OP_VDDDR_EN |
+                                            ST25R300_OP_RX_EN | ST25R300_OP_TX_EN;  // 0x78
+
+// ── Tx Protocol register 1 (0x15) bit masks ──────────────────────────────────
+static const uint8_t ST25R300_TX_PROT1_A_TX_PAR = 0x40; // bit6: ISO14443A TX parity enable
+static const uint8_t ST25R300_TX_PROT1_TX_CRC   = 0x20; // bit5: TX CRC enable
+static const uint8_t ST25R300_TX_PROT1_TR_AM    = 0x10; // bit4: modulation type (0=OOK, 1=AM)
+
+// ── Rx Protocol register 1 (0x17) bit masks ──────────────────────────────────
+// DS14655 Table 44: factory default = 0x3C (b_rx_sof=1, b_rx_eof=1, a_rx_par=1, rx_crc=1)
+static const uint8_t ST25R300_RX_PROT1_B_RX_SOF = 0x20; // bit5: expect SOF from PICC (default=1, MUST be set for I_rxs to fire)
+static const uint8_t ST25R300_RX_PROT1_B_RX_EOF = 0x10; // bit4: expect EOF from PICC (default=1)
+static const uint8_t ST25R300_RX_PROT1_A_RX_PAR = 0x08; // bit3: ISO14443A RX parity enable (default=1)
+static const uint8_t ST25R300_RX_PROT1_RX_CRC   = 0x04; // bit2: RX CRC enable (default=1)
+static const uint8_t ST25R300_RX_PROT1_ANTCL    = 0x01; // bit0: anticollision mode
+
+// ── Direct Commands ──────────────────────────────────────────────────────────
+enum ST25R300Command : uint8_t {
+  ST25R300_CMD_SET_DEFAULT      = 0x61, // reset to power-up state
+  ST25R300_CMD_STOP_ALL         = 0x63, // stop all activities (also clears FIFO)
+  ST25R300_CMD_CLEAR_FIFO       = 0x65, // clear FIFO only
+  ST25R300_CMD_CLEAR_RX_GAIN    = 0x67, // clear Rx gain (= ST25R3916's Reset Rx Gain 0xD5)
+  ST25R300_CMD_ADJUST_REGS      = 0x69, // adjust regulators
+  ST25R300_CMD_TRANSMIT_DATA    = 0x6B, // transmit data from FIFO
+  ST25R300_CMD_FIELD_ON         = 0x6F, // NFC field on (RF collision avoidance)
+  ST25R300_CMD_MASK_RX          = 0x71, // mask receive data
+  ST25R300_CMD_UNMASK_RX        = 0x73, // unmask receive data
+  ST25R300_CMD_START_MRT        = 0xE7, // start mask-receive timer (also starts NRT if nrt≠0)
+  ST25R300_CMD_START_NRT        = 0xE9, // start no-response timer
+  ST25R300_CMD_STOP_NRT         = 0xEB, // stop no-response timer
+};
+
+// ── FIFO SPI access bytes ────────────────────────────────────────────────────
+static const uint8_t ST25R300_FIFO_WRITE_BYTE = 0x5F; // SPI byte to start FIFO write
+static const uint8_t ST25R300_FIFO_READ_BYTE  = 0xDF; // SPI byte to start FIFO read (0x80|0x5F)
+
+// ── IC Identity ──────────────────────────────────────────────────────────────
+static const uint8_t ST25R300_IC_TYPE_MASK    = 0xF8; // ic_type[7:3]
+static const uint8_t ST25R300_IC_TYPE_VAL     = 0xB0; // 10110_000b = 0xB0 for ST25R300
+
+// ── NFC-V (ISO 15693) protocol constants ─────────────────────────────────────
+static const uint8_t NFCV_CMD_INVENTORY   = 0x01;
+static const uint8_t NFCV_CMD_STAY_QUIET  = 0x02;
+static const uint8_t NFCV_INV_FLAG_1SLOT  = 0x26;  // high data rate + inventory + 1-slot
+static const uint8_t NFCV_SLPV_FLAG       = 0x22;  // high data rate + addressed
+static const uint8_t NFCV_UID_LEN         = 8;
+
+}  // namespace st25r300
+}  // namespace esphome

--- a/esphome/components/st25r300/st25r300_registers.h
+++ b/esphome/components/st25r300/st25r300_registers.h
@@ -125,6 +125,7 @@ enum ST25R300Command : uint8_t {
   ST25R300_CMD_START_MRT        = 0xE7, // start mask-receive timer (also starts NRT if nrt≠0)
   ST25R300_CMD_START_NRT        = 0xE9, // start no-response timer
   ST25R300_CMD_STOP_NRT         = 0xEB, // stop no-response timer
+  ST25R300_CMD_SENSE_RF         = 0x7D, // measure RF field strength → SENSE_RF register
 };
 
 // ── FIFO SPI access bytes ────────────────────────────────────────────────────

--- a/esphome/components/st25r300/st25r300_registers.h
+++ b/esphome/components/st25r300/st25r300_registers.h
@@ -12,136 +12,137 @@ namespace st25r300 {
 // ── Register Addresses ──────────────────────────────────────────────────────
 enum ST25R300Register : uint8_t {
   // Core operational registers
-  ST25R300_REG_OPERATION        = 0x00, // en(b3), vdddr_en(b4), rx_en(b5), tx_en(b6)
-  ST25R300_REG_GENERAL_CONF     = 0x01, // single(b5), rfo2(b4), nfc_n[1:0]
-  ST25R300_REG_VDDDR_CONF       = 0x02, // reg_s(b7), rege[6:0]
-  ST25R300_REG_TX_DRIVER_CONF   = 0x03, // regd[6:4], d_res[3:0]
-  ST25R300_REG_TX_MOD1          = 0x04, // am_mod[7:4](def=0x7=20%), mod_state(b3), rgs_am(b2), res_am(b1)
+  ST25R300_REG_OPERATION = 0x00,       // en(b3), vdddr_en(b4), rx_en(b5), tx_en(b6)
+  ST25R300_REG_GENERAL_CONF = 0x01,    // single(b5), rfo2(b4), nfc_n[1:0]
+  ST25R300_REG_VDDDR_CONF = 0x02,      // reg_s(b7), rege[6:0]
+  ST25R300_REG_TX_DRIVER_CONF = 0x03,  // regd[6:4], d_res[3:0]
+  ST25R300_REG_TX_MOD1 = 0x04,         // am_mod[7:4](def=0x7=20%), mod_state(b3), rgs_am(b2), res_am(b1)
 
   // Rx analog settings
-  ST25R300_REG_RX_ANALOG1       = 0x09, // dig_clk_dly[7:4](rec=0x7), gain_boost(b2), hpf_ctrl[1:0]
+  ST25R300_REG_RX_ANALOG1 = 0x09,  // dig_clk_dly[7:4](rec=0x7), gain_boost(b2), hpf_ctrl[1:0]
 
   // Rx digital settings
-  ST25R300_REG_RX_DIGITAL1      = 0x0D, // agc_en(b7)=1 by default
+  ST25R300_REG_RX_DIGITAL1 = 0x0D,  // agc_en(b7)=1 by default
 
   // Protocol registers
-  ST25R300_REG_PROTOCOL1        = 0x14, // om[3:0]: 0x1=NFC-A, 0x2=NFC-B, 0x3=NFC-F, 0x5=NFC-V
-  ST25R300_REG_TX_PROTOCOL1     = 0x15, // a_tx_par(b6)=1, tx_crc(b5)=1, tr_am(b4), p_len[3:0]
-  ST25R300_REG_TX_PROTOCOL2     = 0x16,
-  ST25R300_REG_RX_PROTOCOL1     = 0x17, // a_rx_par(b3)=1, rx_crc(b2)=1, antcl(b0) for anticollision
+  ST25R300_REG_PROTOCOL1 = 0x14,     // om[3:0]: 0x1=NFC-A, 0x2=NFC-B, 0x3=NFC-F, 0x5=NFC-V
+  ST25R300_REG_TX_PROTOCOL1 = 0x15,  // a_tx_par(b6)=1, tx_crc(b5)=1, tr_am(b4), p_len[3:0]
+  ST25R300_REG_TX_PROTOCOL2 = 0x16,
+  ST25R300_REG_RX_PROTOCOL1 = 0x17,  // a_rx_par(b3)=1, rx_crc(b2)=1, antcl(b0) for anticollision
 
   // No-response timer (NRT) config
-  ST25R300_REG_NRT_CONF1        = 0x22, // nrt_emv(b1), nrt_step(b0)
-  ST25R300_REG_NRT_CONF2        = 0x23, // nrt[15:8]
-  ST25R300_REG_NRT_CONF3        = 0x24, // nrt[7:0]
+  ST25R300_REG_NRT_CONF1 = 0x22,  // nrt_emv(b1), nrt_step(b0)
+  ST25R300_REG_NRT_CONF2 = 0x23,  // nrt[15:8]
+  ST25R300_REG_NRT_CONF3 = 0x24,  // nrt[7:0]
 
   // TX frame configuration
-  ST25R300_REG_TX_FRAME1        = 0x34, // ntx[12:5]
-  ST25R300_REG_TX_FRAME2        = 0x35, // ntx[4:0] in bits[7:3], nbtx[2:0] in bits[2:0]
+  ST25R300_REG_TX_FRAME1 = 0x34,  // ntx[12:5]
+  ST25R300_REG_TX_FRAME2 = 0x35,  // ntx[4:0] in bits[7:3], nbtx[2:0] in bits[2:0]
 
   // FIFO status
-  ST25R300_REG_FIFO_STATUS1     = 0x36, // fifo_b[7:0] byte count LSB
-  ST25R300_REG_FIFO_STATUS2     = 0x37, // fifo_b[8](b6), fifo_unf(b5), fifo_ovr(b4), fifo_lb[2:0](b3:1), np_lb(b0)
+  ST25R300_REG_FIFO_STATUS1 = 0x36,  // fifo_b[7:0] byte count LSB
+  ST25R300_REG_FIFO_STATUS2 = 0x37,  // fifo_b[8](b6), fifo_unf(b5), fifo_ovr(b4), fifo_lb[2:0](b3:1), np_lb(b0)
 
   // Collision display
-  ST25R300_REG_COLLISION_DISPLAY = 0x38, // c_byte[7:4], c_bit[3:1], c_pb[0]
+  ST25R300_REG_COLLISION_DISPLAY = 0x38,  // c_byte[7:4], c_bit[3:1], c_pb[0]
 
   // IRQ mask registers
-  ST25R300_REG_IRQ_MASK1        = 0x39, // M_col(b6), M_rxe(b3), M_rxs(b2), M_txe(b1), M_rx_err(b0)
-  ST25R300_REG_IRQ_MASK2        = 0x3A, // M_nre(b6)
-  ST25R300_REG_IRQ_MASK3        = 0x3B, // M_dct(b4), M_osc(b0)
+  ST25R300_REG_IRQ_MASK1 = 0x39,  // M_col(b6), M_rxe(b3), M_rxs(b2), M_txe(b1), M_rx_err(b0)
+  ST25R300_REG_IRQ_MASK2 = 0x3A,  // M_nre(b6)
+  ST25R300_REG_IRQ_MASK3 = 0x3B,  // M_dct(b4), M_osc(b0)
 
   // IRQ status registers (read-to-clear)
-  ST25R300_REG_IRQ_STATUS1      = 0x3C, // I_col(b6), I_rxe(b3), I_rxs(b2), I_txe(b1), I_rx_err(b0)
-  ST25R300_REG_IRQ_STATUS2      = 0x3D, // I_nre(b6)
-  ST25R300_REG_IRQ_STATUS3      = 0x3E, // I_dct(b4), I_osc(b0)
+  ST25R300_REG_IRQ_STATUS1 = 0x3C,  // I_col(b6), I_rxe(b3), I_rxs(b2), I_txe(b1), I_rx_err(b0)
+  ST25R300_REG_IRQ_STATUS2 = 0x3D,  // I_nre(b6)
+  ST25R300_REG_IRQ_STATUS3 = 0x3E,  // I_dct(b4), I_osc(b0)
 
   // IC identity
-  ST25R300_REG_IC_IDENTITY      = 0x3F, // ic_type[7:3]=10110b for ST25R300 → (val & 0xF8)==0xB0
+  ST25R300_REG_IC_IDENTITY = 0x3F,  // ic_type[7:3]=10110b for ST25R300 → (val & 0xF8)==0xB0
 
   // Status registers
-  ST25R300_REG_STATUS1          = 0x40, // osc_ok(b4), agd_ok(b5), efd_out(b1), efd_on(b0)
-  ST25R300_REG_STATUS2          = 0x41, // subc_on(b7), gpt_on(b6), nrt_on(b5), mrt_on(b4), rx_act(b3), rx_on(b2), tx_on(b1)
-  ST25R300_REG_STATIC_STATUS1   = 0x42, // s_eon(b5), s_eof(b6), s_dct(b4)
-  ST25R300_REG_STATIC_STATUS2   = 0x43, // s_rx_err(b5), s_rxe(b4), s_rx_rest(b3), s_col(b2), s_rxs(b1)
-  ST25R300_REG_STATIC_STATUS3   = 0x44, // s_crc(b7), s_par(b6), s_hfe(b5), s_sfe(b4)
+  ST25R300_REG_STATUS1 = 0x40,  // osc_ok(b4), agd_ok(b5), efd_out(b1), efd_on(b0)
+  ST25R300_REG_STATUS2 = 0x41,  // subc_on(b7), gpt_on(b6), nrt_on(b5), mrt_on(b4), rx_act(b3), rx_on(b2), tx_on(b1)
+  ST25R300_REG_STATIC_STATUS1 = 0x42,  // s_eon(b5), s_eof(b6), s_dct(b4)
+  ST25R300_REG_STATIC_STATUS2 = 0x43,  // s_rx_err(b5), s_rxe(b4), s_rx_rest(b3), s_col(b2), s_rxs(b1)
+  ST25R300_REG_STATIC_STATUS3 = 0x44,  // s_crc(b7), s_par(b6), s_hfe(b5), s_sfe(b4)
 
   // RSSI / Field sense
-  ST25R300_REG_RSSI1            = 0x4A, // rssi_i[6:0] (I channel)
-  ST25R300_REG_RSSI2            = 0x4B, // rssi_q[6:0] (Q channel)
-  ST25R300_REG_SENSE_RF         = 0x4C, // sense_adc[7:0] — updated by CMD_SENSE_RF (0x7C/7D)
+  ST25R300_REG_RSSI1 = 0x4A,     // rssi_i[6:0] (I channel)
+  ST25R300_REG_RSSI2 = 0x4B,     // rssi_q[6:0] (Q channel)
+  ST25R300_REG_SENSE_RF = 0x4C,  // sense_adc[7:0] — updated by CMD_SENSE_RF (0x7C/7D)
 };
 
 // ── IRQ Status 1 (0x3C) bit masks ───────────────────────────────────────────
-static const uint8_t ST25R300_IRQ1_SUBC_START = 0x80; // bit7: subcarrier start detected
-static const uint8_t ST25R300_IRQ1_COL    = 0x40;  // bit6: bit collision
-static const uint8_t ST25R300_IRQ1_WL     = 0x20;  // bit5: FIFO water level
-static const uint8_t ST25R300_IRQ1_RX_REST= 0x10;  // bit4: automatic reception restart
-static const uint8_t ST25R300_IRQ1_RXE    = 0x08;  // bit3: end of receive
-static const uint8_t ST25R300_IRQ1_RXS    = 0x04;  // bit2: start of receive
-static const uint8_t ST25R300_IRQ1_TXE    = 0x02;  // bit1: end of transmission
-static const uint8_t ST25R300_IRQ1_RX_ERR = 0x01;  // bit0: receive error
+static const uint8_t ST25R300_IRQ1_SUBC_START = 0x80;  // bit7: subcarrier start detected
+static const uint8_t ST25R300_IRQ1_COL = 0x40;         // bit6: bit collision
+static const uint8_t ST25R300_IRQ1_WL = 0x20;          // bit5: FIFO water level
+static const uint8_t ST25R300_IRQ1_RX_REST = 0x10;     // bit4: automatic reception restart
+static const uint8_t ST25R300_IRQ1_RXE = 0x08;         // bit3: end of receive
+static const uint8_t ST25R300_IRQ1_RXS = 0x04;         // bit2: start of receive
+static const uint8_t ST25R300_IRQ1_TXE = 0x02;         // bit1: end of transmission
+static const uint8_t ST25R300_IRQ1_RX_ERR = 0x01;      // bit0: receive error
 
 // ── IRQ Status 2 (0x3D) bit masks ───────────────────────────────────────────
-static const uint8_t ST25R300_IRQ2_NRE    = 0x40;  // bit6: no-response timer expired
+static const uint8_t ST25R300_IRQ2_NRE = 0x40;  // bit6: no-response timer expired
 
 // ── IRQ Status 3 (0x3E) bit masks ───────────────────────────────────────────
-static const uint8_t ST25R300_IRQ3_DCT    = 0x10;  // bit4: direct command terminated
-static const uint8_t ST25R300_IRQ3_OSC    = 0x01;  // bit0: oscillator stable
+static const uint8_t ST25R300_IRQ3_DCT = 0x10;  // bit4: direct command terminated
+static const uint8_t ST25R300_IRQ3_OSC = 0x01;  // bit0: oscillator stable
 
 // ── Operation register (0x00) bit masks ─────────────────────────────────────
-static const uint8_t ST25R300_OP_EN       = 0x08;  // bit3: chip enable
+static const uint8_t ST25R300_OP_EN = 0x08;        // bit3: chip enable
 static const uint8_t ST25R300_OP_VDDDR_EN = 0x10;  // bit4: VDDDR regulator enable
-static const uint8_t ST25R300_OP_RX_EN    = 0x20;  // bit5: RX enable
-static const uint8_t ST25R300_OP_TX_EN    = 0x40;  // bit6: TX enable
+static const uint8_t ST25R300_OP_RX_EN = 0x20;     // bit5: RX enable
+static const uint8_t ST25R300_OP_TX_EN = 0x40;     // bit6: TX enable
 // All operational (en + vdddr + rx + tx):
-static const uint8_t ST25R300_OP_ALL_ON   = ST25R300_OP_EN | ST25R300_OP_VDDDR_EN |
-                                            ST25R300_OP_RX_EN | ST25R300_OP_TX_EN;  // 0x78
+static const uint8_t ST25R300_OP_ALL_ON =
+    ST25R300_OP_EN | ST25R300_OP_VDDDR_EN | ST25R300_OP_RX_EN | ST25R300_OP_TX_EN;  // 0x78
 
 // ── Tx Protocol register 1 (0x15) bit masks ──────────────────────────────────
-static const uint8_t ST25R300_TX_PROT1_A_TX_PAR = 0x40; // bit6: ISO14443A TX parity enable
-static const uint8_t ST25R300_TX_PROT1_TX_CRC   = 0x20; // bit5: TX CRC enable
-static const uint8_t ST25R300_TX_PROT1_TR_AM    = 0x10; // bit4: modulation type (0=OOK, 1=AM)
+static const uint8_t ST25R300_TX_PROT1_A_TX_PAR = 0x40;  // bit6: ISO14443A TX parity enable
+static const uint8_t ST25R300_TX_PROT1_TX_CRC = 0x20;    // bit5: TX CRC enable
+static const uint8_t ST25R300_TX_PROT1_TR_AM = 0x10;     // bit4: modulation type (0=OOK, 1=AM)
 
 // ── Rx Protocol register 1 (0x17) bit masks ──────────────────────────────────
 // DS14655 Table 44: factory default = 0x3C (b_rx_sof=1, b_rx_eof=1, a_rx_par=1, rx_crc=1)
-static const uint8_t ST25R300_RX_PROT1_B_RX_SOF = 0x20; // bit5: expect SOF from PICC (default=1, MUST be set for I_rxs to fire)
-static const uint8_t ST25R300_RX_PROT1_B_RX_EOF = 0x10; // bit4: expect EOF from PICC (default=1)
-static const uint8_t ST25R300_RX_PROT1_A_RX_PAR = 0x08; // bit3: ISO14443A RX parity enable (default=1)
-static const uint8_t ST25R300_RX_PROT1_RX_CRC   = 0x04; // bit2: RX CRC enable (default=1)
-static const uint8_t ST25R300_RX_PROT1_ANTCL    = 0x01; // bit0: anticollision mode
+static const uint8_t ST25R300_RX_PROT1_B_RX_SOF =
+    0x20;  // bit5: expect SOF from PICC (default=1, MUST be set for I_rxs to fire)
+static const uint8_t ST25R300_RX_PROT1_B_RX_EOF = 0x10;  // bit4: expect EOF from PICC (default=1)
+static const uint8_t ST25R300_RX_PROT1_A_RX_PAR = 0x08;  // bit3: ISO14443A RX parity enable (default=1)
+static const uint8_t ST25R300_RX_PROT1_RX_CRC = 0x04;    // bit2: RX CRC enable (default=1)
+static const uint8_t ST25R300_RX_PROT1_ANTCL = 0x01;     // bit0: anticollision mode
 
 // ── Direct Commands ──────────────────────────────────────────────────────────
 enum ST25R300Command : uint8_t {
-  ST25R300_CMD_SET_DEFAULT      = 0x61, // reset to power-up state
-  ST25R300_CMD_STOP_ALL         = 0x63, // stop all activities (also clears FIFO)
-  ST25R300_CMD_CLEAR_FIFO       = 0x65, // clear FIFO only
-  ST25R300_CMD_CLEAR_RX_GAIN    = 0x67, // clear Rx gain (= ST25R3916's Reset Rx Gain 0xD5)
-  ST25R300_CMD_ADJUST_REGS      = 0x69, // adjust regulators
-  ST25R300_CMD_TRANSMIT_DATA    = 0x6B, // transmit data from FIFO
-  ST25R300_CMD_FIELD_ON         = 0x6F, // NFC field on (RF collision avoidance)
-  ST25R300_CMD_MASK_RX          = 0x71, // mask receive data
-  ST25R300_CMD_UNMASK_RX        = 0x73, // unmask receive data
-  ST25R300_CMD_START_MRT        = 0xE7, // start mask-receive timer (also starts NRT if nrt≠0)
-  ST25R300_CMD_START_NRT        = 0xE9, // start no-response timer
-  ST25R300_CMD_STOP_NRT         = 0xEB, // stop no-response timer
-  ST25R300_CMD_SENSE_RF         = 0x7D, // measure RF field strength → SENSE_RF register
+  ST25R300_CMD_SET_DEFAULT = 0x61,    // reset to power-up state
+  ST25R300_CMD_STOP_ALL = 0x63,       // stop all activities (also clears FIFO)
+  ST25R300_CMD_CLEAR_FIFO = 0x65,     // clear FIFO only
+  ST25R300_CMD_CLEAR_RX_GAIN = 0x67,  // clear Rx gain (= ST25R3916's Reset Rx Gain 0xD5)
+  ST25R300_CMD_ADJUST_REGS = 0x69,    // adjust regulators
+  ST25R300_CMD_TRANSMIT_DATA = 0x6B,  // transmit data from FIFO
+  ST25R300_CMD_FIELD_ON = 0x6F,       // NFC field on (RF collision avoidance)
+  ST25R300_CMD_MASK_RX = 0x71,        // mask receive data
+  ST25R300_CMD_UNMASK_RX = 0x73,      // unmask receive data
+  ST25R300_CMD_START_MRT = 0xE7,      // start mask-receive timer (also starts NRT if nrt≠0)
+  ST25R300_CMD_START_NRT = 0xE9,      // start no-response timer
+  ST25R300_CMD_STOP_NRT = 0xEB,       // stop no-response timer
+  ST25R300_CMD_SENSE_RF = 0x7D,       // measure RF field strength → SENSE_RF register
 };
 
 // ── FIFO SPI access bytes ────────────────────────────────────────────────────
-static const uint8_t ST25R300_FIFO_WRITE_BYTE = 0x5F; // SPI byte to start FIFO write
-static const uint8_t ST25R300_FIFO_READ_BYTE  = 0xDF; // SPI byte to start FIFO read (0x80|0x5F)
+static const uint8_t ST25R300_FIFO_WRITE_BYTE = 0x5F;  // SPI byte to start FIFO write
+static const uint8_t ST25R300_FIFO_READ_BYTE = 0xDF;   // SPI byte to start FIFO read (0x80|0x5F)
 
 // ── IC Identity ──────────────────────────────────────────────────────────────
-static const uint8_t ST25R300_IC_TYPE_MASK    = 0xF8; // ic_type[7:3]
-static const uint8_t ST25R300_IC_TYPE_VAL     = 0xB0; // 10110_000b = 0xB0 for ST25R300
+static const uint8_t ST25R300_IC_TYPE_MASK = 0xF8;  // ic_type[7:3]
+static const uint8_t ST25R300_IC_TYPE_VAL = 0xB0;   // 10110_000b = 0xB0 for ST25R300
 
 // ── NFC-V (ISO 15693) protocol constants ─────────────────────────────────────
-static const uint8_t NFCV_CMD_INVENTORY   = 0x01;
-static const uint8_t NFCV_CMD_STAY_QUIET  = 0x02;
-static const uint8_t NFCV_INV_FLAG_1SLOT  = 0x26;  // high data rate + inventory + 1-slot
-static const uint8_t NFCV_SLPV_FLAG       = 0x22;  // high data rate + addressed
-static const uint8_t NFCV_UID_LEN         = 8;
+static const uint8_t NFCV_CMD_INVENTORY = 0x01;
+static const uint8_t NFCV_CMD_STAY_QUIET = 0x02;
+static const uint8_t NFCV_INV_FLAG_1SLOT = 0x26;  // high data rate + inventory + 1-slot
+static const uint8_t NFCV_SLPV_FLAG = 0x22;       // high data rate + addressed
+static const uint8_t NFCV_UID_LEN = 8;
 
 }  // namespace st25r300
 }  // namespace esphome

--- a/esphome/components/st25r300_spi/__init__.py
+++ b/esphome/components/st25r300_spi/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import st25r300, spi
+from esphome.components import spi, st25r300
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 

--- a/esphome/components/st25r300_spi/__init__.py
+++ b/esphome/components/st25r300_spi/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import st25r300, spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["st25r300"]
+CODEOWNERS = ["@JohnMcLear"]
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+
+st25r300_spi_ns = cg.esphome_ns.namespace("st25r300_spi")
+ST25R300Spi = st25r300_spi_ns.class_("ST25R300Spi", st25r300.ST25R300, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.All(
+    st25r300.ST25R300_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ST25R300Spi),
+        }
+    ).extend(spi.spi_device_schema(cs_pin_required=True))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await st25r300.setup_st25r300(var, config)
+    await spi.register_spi_device(var, config)

--- a/esphome/components/st25r300_spi/st25r300_spi.cpp
+++ b/esphome/components/st25r300_spi/st25r300_spi.cpp
@@ -1,0 +1,60 @@
+#include "st25r300_spi.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace st25r300_spi {
+
+static const char *const TAG = "st25r300_spi";
+
+void ST25R300Spi::setup() {
+  ESP_LOGI(TAG, "Setting up ST25R300 SPI device...");
+  this->spi_setup();
+  st25r300::ST25R300::setup();
+}
+
+void ST25R300Spi::dump_config() {
+  st25r300::ST25R300::dump_config();
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+uint8_t ST25R300Spi::read_register(uint8_t reg) {
+  this->enable();
+  this->write_byte(0x80 | (reg & 0x7F));  // bit7=1 → read
+  uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
+void ST25R300Spi::write_register(uint8_t reg, uint8_t value) {
+  this->enable();
+  this->write_byte(reg & 0x7F);  // bit7=0 → write
+  this->write_byte(value);
+  this->disable();
+}
+
+void ST25R300Spi::write_command(uint8_t command) {
+  this->enable();
+  this->write_byte(command);
+  this->disable();
+}
+
+void ST25R300Spi::write_fifo(const uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0x5F);  // FIFO write access byte
+  for (size_t i = 0; i < len; i++) {
+    this->write_byte(data[i]);
+  }
+  this->disable();
+}
+
+void ST25R300Spi::read_fifo(uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0xDF);  // FIFO read access byte (0x80 | 0x5F)
+  for (size_t i = 0; i < len; i++) {
+    data[i] = this->read_byte();
+  }
+  this->disable();
+}
+
+}  // namespace st25r300_spi
+}  // namespace esphome

--- a/esphome/components/st25r300_spi/st25r300_spi.h
+++ b/esphome/components/st25r300_spi/st25r300_spi.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/st25r300/st25r300.h"
+
+namespace esphome {
+namespace st25r300_spi {
+
+// ST25R300 SPI protocol (Table 5, DS):
+//   Register write: addr & 0x7F (bit7=0), then data
+//   Register read:  addr | 0x80 (bit7=1), then read byte
+//   FIFO write:     0x5F, then data bytes
+//   FIFO read:      0xDF (0x80|0x5F), then read bytes
+//   Direct command: send command byte directly (0x60-0x7F or 0xE2-0xEF range)
+// SPI Mode 1: CPOL=0, CPHA=1 (CLOCK_PHASE_TRAILING) — same as ST25R3916
+class ST25R300Spi : public st25r300::ST25R300,
+                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                          spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  uint8_t read_register(uint8_t reg) override;
+  void write_register(uint8_t reg, uint8_t value) override;
+  void write_command(uint8_t command) override;
+  void write_fifo(const uint8_t *data, size_t len) override;
+  void read_fifo(uint8_t *data, size_t len) override;
+};
+
+}  // namespace st25r300_spi
+}  // namespace esphome

--- a/esphome/components/st25r300_spi/st25r300_spi.h
+++ b/esphome/components/st25r300_spi/st25r300_spi.h
@@ -15,8 +15,8 @@ namespace st25r300_spi {
 //   Direct command: send command byte directly (0x60-0x7F or 0xE2-0xEF range)
 // SPI Mode 1: CPOL=0, CPHA=1 (CLOCK_PHASE_TRAILING) — same as ST25R3916
 class ST25R300Spi : public st25r300::ST25R300,
-                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                          spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+                    public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
+                                          spi::DATA_RATE_200KHZ> {
  public:
   void setup() override;
   void dump_config() override;

--- a/esphome/components/st25r_i2c/__init__.py
+++ b/esphome/components/st25r_i2c/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import st25r, i2c
+from esphome.components import i2c, st25r
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 

--- a/esphome/components/st25r_i2c/__init__.py
+++ b/esphome/components/st25r_i2c/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import st25r, i2c
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["st25r"]
+CODEOWNERS = ["@JohnMcLear"]
+DEPENDENCIES = ["i2c"]
+MULTI_CONF = True
+
+st25r_i2c_ns = cg.esphome_ns.namespace("st25r_i2c")
+ST25RI2c = st25r_i2c_ns.class_("ST25RI2c", st25r.ST25R, i2c.I2CDevice)
+
+CONFIG_SCHEMA = cv.All(
+    st25r.ST25R_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ST25RI2c),
+        }
+    ).extend(i2c.i2c_device_schema(0x50))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await st25r.setup_st25r(var, config)
+    await i2c.register_i2c_device(var, config)

--- a/esphome/components/st25r_i2c/st25r_i2c.cpp
+++ b/esphome/components/st25r_i2c/st25r_i2c.cpp
@@ -9,12 +9,12 @@ static const char *const TAG = "st25r_i2c";
 
 void ST25RI2c::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ST25R I2C...");
-  
+
   // Wake up chip - send a dummy byte and ignore the result
   uint8_t dummy = 0x00;
   this->i2c::I2CDevice::write(&dummy, 1);
   delay(10);
-  
+
   st25r::ST25R::setup();
 }
 

--- a/esphome/components/st25r_i2c/st25r_i2c.cpp
+++ b/esphome/components/st25r_i2c/st25r_i2c.cpp
@@ -35,7 +35,7 @@ uint8_t ST25RI2c::read_register(uint8_t reg) {
 }
 
 void ST25RI2c::write_register(uint8_t reg, uint8_t value) {
-  uint8_t data[2] = { (uint8_t)(0x00 | (reg & 0x3F)), value };
+  uint8_t data[2] = {(uint8_t) (0x00 | (reg & 0x3F)), value};
   auto err = this->i2c::I2CDevice::write(data, 2);
   if (err != i2c::ERROR_OK) {
     ESP_LOGW(TAG, "write_register(0x%02X, 0x%02X): I2C error %d", reg, value, (int) err);

--- a/esphome/components/st25r_i2c/st25r_i2c.cpp
+++ b/esphome/components/st25r_i2c/st25r_i2c.cpp
@@ -1,6 +1,6 @@
 #include "st25r_i2c.h"
 #include "esphome/core/log.h"
-#include <vector>
+#include <cstring>
 
 namespace esphome {
 namespace st25r_i2c {
@@ -26,30 +26,49 @@ void ST25RI2c::dump_config() {
 uint8_t ST25RI2c::read_register(uint8_t reg) {
   uint8_t value = 0;
   uint8_t addr = 0x40 | (reg & 0x3F);
-  this->i2c::I2CDevice::write_read(&addr, 1, &value, 1);
+  auto err = this->i2c::I2CDevice::write_read(&addr, 1, &value, 1);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "read_register(0x%02X): I2C error %d", reg, (int) err);
+  }
   return value;
 }
 
 void ST25RI2c::write_register(uint8_t reg, uint8_t value) {
   uint8_t data[2] = { (uint8_t)(0x00 | (reg & 0x3F)), value };
-  this->i2c::I2CDevice::write(data, 2);
+  auto err = this->i2c::I2CDevice::write(data, 2);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "write_register(0x%02X, 0x%02X): I2C error %d", reg, value, (int) err);
+  }
 }
 
 void ST25RI2c::write_command(uint8_t command) {
-  this->i2c::I2CDevice::write(&command, 1);
+  auto err = this->i2c::I2CDevice::write(&command, 1);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "write_command(0x%02X): I2C error %d", command, (int) err);
+  }
 }
 
 void ST25RI2c::write_fifo(const uint8_t *data, size_t len) {
-  std::vector<uint8_t> buf;
-  buf.reserve(len + 1);
-  buf.push_back(0x80);
-  buf.insert(buf.end(), data, data + len);
-  this->i2c::I2CDevice::write(buf.data(), buf.size());
+  static constexpr size_t MAX_FIFO_SIZE = 64;
+  if (len > MAX_FIFO_SIZE) {
+    ESP_LOGW(TAG, "write_fifo: len %u exceeds max %u, truncating", (unsigned) len, (unsigned) MAX_FIFO_SIZE);
+    len = MAX_FIFO_SIZE;
+  }
+  uint8_t buf[MAX_FIFO_SIZE + 1];
+  buf[0] = 0x80;
+  memcpy(buf + 1, data, len);
+  auto err = this->i2c::I2CDevice::write(buf, len + 1);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "write_fifo: I2C write failed (error %d)", (int) err);
+  }
 }
 
 void ST25RI2c::read_fifo(uint8_t *data, size_t len) {
   uint8_t addr = 0x9F;
-  this->i2c::I2CDevice::write_read(&addr, 1, data, len);
+  auto err = this->i2c::I2CDevice::write_read(&addr, 1, data, len);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "read_fifo: I2C read failed (error %d, len=%u)", (int) err, (unsigned) len);
+  }
 }
 
 }  // namespace st25r_i2c

--- a/esphome/components/st25r_i2c/st25r_i2c.cpp
+++ b/esphome/components/st25r_i2c/st25r_i2c.cpp
@@ -1,4 +1,5 @@
 #include "st25r_i2c.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include <cstring>
 

--- a/esphome/components/st25r_i2c/st25r_i2c.cpp
+++ b/esphome/components/st25r_i2c/st25r_i2c.cpp
@@ -1,0 +1,56 @@
+#include "st25r_i2c.h"
+#include "esphome/core/log.h"
+#include <vector>
+
+namespace esphome {
+namespace st25r_i2c {
+
+static const char *const TAG = "st25r_i2c";
+
+void ST25RI2c::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ST25R I2C...");
+  
+  // Wake up chip - send a dummy byte and ignore the result
+  uint8_t dummy = 0x00;
+  this->i2c::I2CDevice::write(&dummy, 1);
+  delay(10);
+  
+  st25r::ST25R::setup();
+}
+
+void ST25RI2c::dump_config() {
+  st25r::ST25R::dump_config();
+  LOG_I2C_DEVICE(this);
+}
+
+uint8_t ST25RI2c::read_register(uint8_t reg) {
+  uint8_t value = 0;
+  uint8_t addr = 0x40 | (reg & 0x3F);
+  this->i2c::I2CDevice::write_read(&addr, 1, &value, 1);
+  return value;
+}
+
+void ST25RI2c::write_register(uint8_t reg, uint8_t value) {
+  uint8_t data[2] = { (uint8_t)(0x00 | (reg & 0x3F)), value };
+  this->i2c::I2CDevice::write(data, 2);
+}
+
+void ST25RI2c::write_command(uint8_t command) {
+  this->i2c::I2CDevice::write(&command, 1);
+}
+
+void ST25RI2c::write_fifo(const uint8_t *data, size_t len) {
+  std::vector<uint8_t> buf;
+  buf.reserve(len + 1);
+  buf.push_back(0x80);
+  buf.insert(buf.end(), data, data + len);
+  this->i2c::I2CDevice::write(buf.data(), buf.size());
+}
+
+void ST25RI2c::read_fifo(uint8_t *data, size_t len) {
+  uint8_t addr = 0x9F;
+  this->i2c::I2CDevice::write_read(&addr, 1, data, len);
+}
+
+}  // namespace st25r_i2c
+}  // namespace esphome

--- a/esphome/components/st25r_i2c/st25r_i2c.h
+++ b/esphome/components/st25r_i2c/st25r_i2c.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/components/st25r/st25r.h"
+
+namespace esphome {
+namespace st25r_i2c {
+
+class ST25RI2c : public st25r::ST25R, public i2c::I2CDevice {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  uint8_t read_register(uint8_t reg) override;
+  void write_register(uint8_t reg, uint8_t value) override;
+  void write_command(uint8_t command) override;
+  void write_fifo(const uint8_t *data, size_t len) override;
+  void read_fifo(uint8_t *data, size_t len) override;
+};
+
+}  // namespace st25r_i2c
+}  // namespace esphome

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -1,0 +1,26 @@
+import esphome.codegen as cg
+from esphome.components import st25r, spi
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["st25r"]
+CODEOWNERS = ["@JohnMcLear"]
+DEPENDENCIES = ["spi"]
+MULTI_CONF = True
+
+st25r_spi_ns = cg.esphome_ns.namespace("st25r_spi")
+ST25RSpi = st25r_spi_ns.class_("ST25RSpi", st25r.ST25R, spi.SPIDevice)
+
+CONFIG_SCHEMA = cv.All(
+    st25r.ST25R_SCHEMA.extend(
+        {
+            cv.GenerateID(): cv.declare_id(ST25RSpi),
+        }
+    ).extend(spi.spi_device_schema(cs_pin_required=True))
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await st25r.setup_st25r(var, config)
+    await spi.register_spi_device(var, config)

--- a/esphome/components/st25r_spi/__init__.py
+++ b/esphome/components/st25r_spi/__init__.py
@@ -1,5 +1,5 @@
 import esphome.codegen as cg
-from esphome.components import st25r, spi
+from esphome.components import spi, st25r
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
 

--- a/esphome/components/st25r_spi/st25r_spi.cpp
+++ b/esphome/components/st25r_spi/st25r_spi.cpp
@@ -1,0 +1,66 @@
+#include "st25r_spi.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace st25r_spi {
+
+static const char *const TAG = "st25r_spi";
+
+void ST25RSpi::setup() {
+  ESP_LOGI(TAG, "Setting up ST25R SPI device...");
+  this->spi_setup();
+  st25r::ST25R::setup();
+}
+
+void ST25RSpi::dump_config() {
+  st25r::ST25R::dump_config();
+  LOG_PIN("  CS Pin: ", this->cs_);
+}
+
+uint8_t ST25RSpi::read_register(uint8_t reg) {
+  this->enable();
+  if (reg & 0x40) {
+    this->write_byte(0xFB);  // Space B prefix (DS12484 p.52)
+  }
+  this->write_byte(0x40 | (reg & 0x3F));
+  uint8_t value = this->read_byte();
+  this->disable();
+  return value;
+}
+
+void ST25RSpi::write_register(uint8_t reg, uint8_t value) {
+  this->enable();
+  if (reg & 0x40) {
+    this->write_byte(0xFB);  // Space B prefix (DS12484 p.52)
+  }
+  this->write_byte(0x00 | (reg & 0x3F));
+  this->write_byte(value);
+  this->disable();
+}
+
+void ST25RSpi::write_command(uint8_t command) {
+  this->enable();
+  this->write_byte(command);
+  this->disable();
+}
+
+void ST25RSpi::write_fifo(const uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0x80);
+  for (size_t i = 0; i < len; i++) {
+    this->write_byte(data[i]);
+  }
+  this->disable();
+}
+
+void ST25RSpi::read_fifo(uint8_t *data, size_t len) {
+  this->enable();
+  this->write_byte(0x9F);
+  for (size_t i = 0; i < len; i++) {
+    data[i] = this->read_byte();
+  }
+  this->disable();
+}
+
+}  // namespace st25r_spi
+}  // namespace esphome

--- a/esphome/components/st25r_spi/st25r_spi.h
+++ b/esphome/components/st25r_spi/st25r_spi.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/spi/spi.h"
+#include "esphome/components/st25r/st25r.h"
+
+namespace esphome {
+namespace st25r_spi {
+
+class ST25RSpi : public st25r::ST25R,
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
+                                       spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  uint8_t read_register(uint8_t reg) override;
+  void write_register(uint8_t reg, uint8_t value) override;
+  void write_command(uint8_t command) override;
+  void write_fifo(const uint8_t *data, size_t len) override;
+  void read_fifo(uint8_t *data, size_t len) override;
+};
+
+}  // namespace st25r_spi
+}  // namespace esphome

--- a/esphome/components/st25r_spi/st25r_spi.h
+++ b/esphome/components/st25r_spi/st25r_spi.h
@@ -8,8 +8,8 @@ namespace esphome {
 namespace st25r_spi {
 
 class ST25RSpi : public st25r::ST25R,
-                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW,
-                                       spi::CLOCK_PHASE_TRAILING, spi::DATA_RATE_200KHZ> {
+                 public spi::SPIDevice<spi::BIT_ORDER_MSB_FIRST, spi::CLOCK_POLARITY_LOW, spi::CLOCK_PHASE_TRAILING,
+                                       spi::DATA_RATE_200KHZ> {
  public:
   void setup() override;
   void dump_config() override;

--- a/tests/components/st25r300_spi/common.yaml
+++ b/tests/components/st25r300_spi/common.yaml
@@ -1,0 +1,10 @@
+st25r300_spi:
+  id: st25r300_nfcc_spi
+  cs_pin: ${cs_pin}
+  update_interval: 1s
+
+binary_sensor:
+  - platform: st25r
+    st25r_id: st25r300_nfcc_spi
+    name: ST25R300 NFC Tag
+    uid: 74-10-37-94

--- a/tests/components/st25r300_spi/test.esp32-idf.yaml
+++ b/tests/components/st25r300_spi/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  cs_pin: GPIO12
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+<<: !include common.yaml

--- a/tests/components/st25r_spi/common.yaml
+++ b/tests/components/st25r_spi/common.yaml
@@ -1,0 +1,10 @@
+st25r_spi:
+  id: st25r_nfcc_spi
+  cs_pin: ${cs_pin}
+  update_interval: 1s
+
+binary_sensor:
+  - platform: st25r
+    st25r_id: st25r_nfcc_spi
+    name: ST25R NFC Tag
+    uid: 74-10-37-94

--- a/tests/components/st25r_spi/test.esp32-idf.yaml
+++ b/tests/components/st25r_spi/test.esp32-idf.yaml
@@ -1,0 +1,7 @@
+substitutions:
+  cs_pin: GPIO12
+
+packages:
+  spi: !include ../../test_build_components/common/spi/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
## Summary
- New component family for STMicroelectronics ST25R NFC readers
- Supports ST25R3916, ST25R3916B, ST25R300, ST25R500
- Multi-protocol: ISO 14443A, ISO 14443B, ISO 14443-4 (ISO-DEP), ISO 15693

## Features
- **NFC-A**: 4/7/10-byte UIDs, multi-tag anticollision, Mifare Classic Crypto1 auth
- **NFC-B**: SENSB_REQ/ATQB, 4-byte PUPI detection
- **ISO-DEP**: RATS/ATS, I-Block APDU exchange, Type 4 NDEF read
- **NFC-V**: INVENTORY, 8-byte UIDs, NDEF Type 5 read/write (streaming mode on ST25R3916, hardware codec on ST25R300)
- **NDEF**: Read/write for Type 2, Type 4, and Type 5 tags
- **send_apdu()**: Public API for custom APDU conversations from lambdas (Yubikey OTP, payment card SEID)
- **AAT**: Automatic Antenna Tuning hill-climbing optimizer (+20% range on varicap boards)
- **VDD auto-detection**: Sets supply voltage mode automatically
- **Health check**: Configurable chip identity polling with auto-recovery

## Hardware Verified On
- Elechouse ST25R3916 module (SPI)
- STEVAL-MB17149B (ST25R3916B, SPI)
- X-NUCLEO-NFC12A1 (ST25R300, SPI)
- Vicino ST25R3916B board (SPI)

## Test Plan
- [x] 209 tests in external component repo (109 emulation, 80 Python, 20 C++ unit)
- [x] Compile tests for ESP32-IDF (st25r_spi + st25r300_spi)
- [x] Hardware-verified: NFC-A, NFC-B, NFC-V, ISO-DEP, SEID APDU on real tags
- [x] ESPHome CI linting (clang-format, pylint)

## Related
- Feature request: esphome/feature-requests#2207 (Yubikey OTP via APDU)
- External component: https://github.com/JohnMcLear/esphome_st25r

🤖 Generated with [Claude Code](https://claude.com/claude-code)