### PR TITLE
2026.3.1

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.3.0
+PROJECT_NUMBER         = 2026.3.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
+++ b/esphome/components/analog_threshold/analog_threshold_binary_sensor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -64,7 +64,11 @@ static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS *
 // A stalled handshake from a buggy client or network glitch holds a connection
 // slot, which can prevent legitimate clients from reconnecting. Also hardens
 // against the less likely case of intentional connection slot exhaustion.
-static constexpr uint32_t HANDSHAKE_TIMEOUT_MS = 15000;
+//
+// 60s is intentionally high: on ESP8266 with power_save_mode: LIGHT and weak
+// WiFi (-70 dBm+), TCP retransmissions push real-world handshake times to
+// 28-30s. See https://github.com/esphome/esphome/issues/14999
+static constexpr uint32_t HANDSHAKE_TIMEOUT_MS = 60000;
 
 static constexpr auto ESPHOME_VERSION_REF = StringRef::from_lit(ESPHOME_VERSION);
 

--- a/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
+++ b/esphome/components/ble_client/sensor/ble_rssi_sensor.cpp
@@ -47,6 +47,8 @@ void BLEClientRSSISensor::gap_event_handler(esp_gap_ble_cb_event_t event, esp_bl
   switch (event) {
     // server response on RSSI request:
     case ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT:
+      if (!this->parent()->check_addr(param->read_rssi_cmpl.remote_addr))
+        return;
       if (param->read_rssi_cmpl.status == ESP_BT_STATUS_SUCCESS) {
         int8_t rssi = param->read_rssi_cmpl.rssi;
         ESP_LOGI(TAG, "ESP_GAP_BLE_READ_RSSI_COMPLETE_EVT RSSI: %d", rssi);

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -360,11 +360,16 @@ void ESP32TouchComponent::loop() {
   }
 
   // Publish initial OFF state for sensors that haven't received events yet
+  bool all_initial_published = true;
   for (auto *child : this->children_) {
     this->publish_initial_state_if_needed_(child, now);
+    if (!child->initial_state_published_) {
+      all_initial_published = false;
+    }
   }
 
-  if (!this->setup_mode_) {
+  // Only disable loop once all initial states are published
+  if (!this->setup_mode_ && all_initial_published) {
     this->disable_loop();
   }
 }

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -74,6 +74,10 @@ void HttpRequestUpdate::update() {
   }
   this->cancel_interval(INITIAL_CHECK_INTERVAL_ID);
 #ifdef USE_ESP32
+  if (this->update_task_handle_ != nullptr) {
+    ESP_LOGW(TAG, "Update check already in progress");
+    return;
+  }
   xTaskCreate(HttpRequestUpdate::update_task, "update_task", 8192, (void *) this, 1, &this->update_task_handle_);
 #else
   this->update_task(this);
@@ -204,6 +208,9 @@ defer:
   // both success and error paths to avoid multiple std::function instantiations.
   // Lambda captures only 2 pointers (8 bytes) — fits in std::function SBO on supported toolchains.
   this_update->defer([this_update, result]() {
+#ifdef USE_ESP32
+    this_update->update_task_handle_ = nullptr;
+#endif
     if (result->error_str != nullptr) {
       this_update->status_set_error(result->error_str);
       delete result;

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -534,10 +534,11 @@ void LD2450Component::handle_periodic_data_() {
     }
 #endif
 
-    // Store target info for zone target count
-    this->target_info_[index].x = tx;
-    this->target_info_[index].y = ty;
-    this->target_info_[index].is_moving = is_moving;
+    // Store target info for zone target count. Zero out untracked targets (td==0)
+    // so stale coordinates don't produce ghost counts in count_targets_in_zone_().
+    this->target_info_[index].x = (td > 0) ? tx : 0;
+    this->target_info_[index].y = (td > 0) ? ty : 0;
+    this->target_info_[index].is_moving = (td > 0) && is_moving;
 
   }  // End loop thru targets
 

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -81,18 +81,32 @@ def _get_data() -> LightData:
     return CORE.data[DOMAIN]
 
 
+def generate_gamma_table(gamma_correct: float) -> list[HexInt]:
+    """Generate a 256-entry uint16 gamma lookup table.
+
+    For gamma > 0, non-zero indices are clamped to a minimum of 1 to preserve
+    the invariant that non-zero input always produces non-zero output. Without
+    this, small brightness values (e.g. 1%) get quantized to exactly 0.0,
+    which breaks zero_means_zero logic in FloatOutput.
+    """
+    if gamma_correct > 0:
+        return [
+            HexInt(
+                max(1, min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
+                if i > 0
+                else HexInt(0)
+            )
+            for i in range(256)
+        ]
+    return [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+
+
 def _get_or_create_gamma_table(gamma_correct):
     data = _get_data()
     if gamma_correct in data.gamma_tables:
         return data.gamma_tables[gamma_correct]
 
-    if gamma_correct > 0:
-        forward = [
-            HexInt(min(65535, int(round((i / 255.0) ** gamma_correct * 65535))))
-            for i in range(256)
-        ]
-    else:
-        forward = [HexInt(int(round(i / 255.0 * 65535))) for i in range(256)]
+    forward = generate_gamma_table(gamma_correct)
 
     gamma_str = f"{gamma_correct}".replace(".", "_")
     fwd_id = ID(f"gamma_{gamma_str}_fwd", is_declaration=True, type=cg.uint16)

--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -154,6 +154,16 @@ class LightColorValues {
   }
 
   /// Convert these light color values to an CWWW representation with the given parameters.
+  ///
+  /// Note on gamma and constant_brightness: This method operates on the raw/internal channel
+  /// values stored in this object. For cold_white_ and warm_white_ specifically, these
+  /// may already be gamma-uncorrected when derived from a color_temperature value.
+  /// For constant_brightness=false, additional gamma for the output can be applied after
+  /// this method since gamma commutes with simple multiplication. For constant_brightness=true,
+  /// the caller (LightState::current_values_as_cwww) must apply gamma to the individual
+  /// channel values BEFORE the balancing formula, because the nonlinear max/sum ratio does
+  /// not commute with gamma. See LightState::current_values_as_cwww() for the correct
+  /// implementation.
   void as_cwww(float *cold_white, float *warm_white, bool constant_brightness = false) const {
     if (this->color_mode_ & ColorCapability::COLD_WARM_WHITE) {
       const float cw_level = this->cold_white_;

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -223,12 +223,11 @@ void LightState::current_values_as_rgbw(float *red, float *green, float *blue, f
 }
 void LightState::current_values_as_rgbww(float *red, float *green, float *blue, float *cold_white, float *warm_white,
                                          bool constant_brightness) {
-  this->current_values.as_rgbww(red, green, blue, cold_white, warm_white, constant_brightness);
+  this->current_values.as_rgb(red, green, blue);
   *red = this->gamma_correct_lut(*red);
   *green = this->gamma_correct_lut(*green);
   *blue = this->gamma_correct_lut(*blue);
-  *cold_white = this->gamma_correct_lut(*cold_white);
-  *warm_white = this->gamma_correct_lut(*warm_white);
+  this->current_values_as_cwww(cold_white, warm_white, constant_brightness);
 }
 void LightState::current_values_as_rgbct(float *red, float *green, float *blue, float *color_temperature,
                                          float *white_brightness) {
@@ -241,9 +240,45 @@ void LightState::current_values_as_rgbct(float *red, float *green, float *blue, 
   *white_brightness = this->gamma_correct_lut(*white_brightness);
 }
 void LightState::current_values_as_cwww(float *cold_white, float *warm_white, bool constant_brightness) {
-  this->current_values.as_cwww(cold_white, warm_white, constant_brightness);
-  *cold_white = this->gamma_correct_lut(*cold_white);
-  *warm_white = this->gamma_correct_lut(*warm_white);
+  if (!constant_brightness) {
+    // Without constant_brightness, gamma commutes with simple multiplication:
+    //   gamma(white_level * cw) = gamma(white_level) * gamma(cw)
+    // (since gamma(a*b) = (a*b)^g = a^g * b^g = gamma(a) * gamma(b))
+    // so applying gamma after is mathematically equivalent and simpler.
+    this->current_values.as_cwww(cold_white, warm_white, false);
+    *cold_white = this->gamma_correct_lut(*cold_white);
+    *warm_white = this->gamma_correct_lut(*warm_white);
+    return;
+  }
+
+  // For constant_brightness mode, gamma MUST be applied to the individual
+  // channel values BEFORE the balancing formula (max/sum ratio), not after.
+  //
+  // Why: The cold_white_ and warm_white_ values stored in LightColorValues
+  // are gamma-uncorrected (see transform_parameters_() which applies
+  // gamma_uncorrect to the linear CW/WW fractions derived from color
+  // temperature). Applying gamma_correct here recovers the original linear
+  // fractions, which the constant_brightness formula then uses to distribute
+  // power evenly. The max/sum formula ensures cold+warm PWM output sums to
+  // a constant, keeping total power (and perceived brightness) the same
+  // across all color temperatures.
+  //
+  // Applying gamma AFTER the formula would be incorrect because gamma is
+  // nonlinear: gamma(a/b) != gamma(a)/gamma(b), so the carefully balanced
+  // ratio would be distorted, causing a severe brightness dip at mid-range
+  // color temperatures.
+  const auto &v = this->current_values;
+  if (!(v.get_color_mode() & ColorCapability::COLD_WARM_WHITE)) {
+    *cold_white = *warm_white = 0;
+    return;
+  }
+
+  const float cw_level = this->gamma_correct_lut(v.get_cold_white());
+  const float ww_level = this->gamma_correct_lut(v.get_warm_white());
+  const float white_level = this->gamma_correct_lut(v.get_state() * v.get_brightness());
+  const float sum = cw_level > 0 || ww_level > 0 ? cw_level + ww_level : 1;  // Don't divide by zero.
+  *cold_white = white_level * std::max(cw_level, ww_level) * cw_level / sum;
+  *warm_white = white_level * std::max(cw_level, ww_level) * ww_level / sum;
 }
 void LightState::current_values_as_ct(float *color_temperature, float *white_brightness) {
   auto traits = this->get_traits();

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -331,11 +331,27 @@ async def to_code(config: ConfigType) -> None:
     CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
     tx_buffer_size = config[CONF_TX_BUFFER_SIZE]
     cg.add_define("ESPHOME_LOGGER_TX_BUFFER_SIZE", tx_buffer_size)
-    log = cg.new_Pvariable(
-        config[CONF_ID],
-        baud_rate,
-    )
-    if CORE.is_esp32:
+    # Determine task log buffer size and define USE_ESPHOME_TASK_LOG_BUFFER early
+    # so the constructor can allocate the buffer immediately, preventing a race
+    # where another task logs before the buffer is initialized.
+    task_log_buffer_size = 0
+    if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
+        task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
+    elif CORE.is_host:
+        task_log_buffer_size = 64  # Fixed 64 slots for host
+    if task_log_buffer_size > 0:
+        cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
+        log = cg.new_Pvariable(
+            config[CONF_ID],
+            baud_rate,
+            task_log_buffer_size,
+        )
+    else:
+        log = cg.new_Pvariable(
+            config[CONF_ID],
+            baud_rate,
+        )
+    if CORE.is_esp32 or CORE.is_host:
         cg.add(log.create_pthread_key())
     # set_uart_selection() must be called before pre_setup() because
     # pre_setup() switches on uart_ to decide which hardware to initialize
@@ -364,17 +380,10 @@ async def _late_logger_init(config: ConfigType) -> None:
     log = await cg.get_variable(config[CONF_ID])
     level = config[CONF_LEVEL]
     baud_rate: int = config[CONF_BAUD_RATE]
-    if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
-        task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
+    if CORE.using_zephyr:
+        task_log_buffer_size = config.get(CONF_TASK_LOG_BUFFER_SIZE, 0)
         if task_log_buffer_size > 0:
-            cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
-            cg.add(log.init_log_buffer(task_log_buffer_size))
-            if CORE.using_zephyr:
-                zephyr_add_prj_conf("MPSC_PBUF", True)
-    elif CORE.is_host:
-        cg.add(log.create_pthread_key())
-        cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
-        cg.add(log.init_log_buffer(64))  # Fixed 64 slots for host
+            zephyr_add_prj_conf("MPSC_PBUF", True)
 
     # Enable runtime tag levels if logs are configured or explicitly enabled
     logs_config = config[CONF_LOGS]

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -56,6 +56,7 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE, CoroPriority, Lambda, coroutine_with_priority
+from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
 logger_ns = cg.esphome_ns.namespace("logger")
@@ -323,12 +324,11 @@ CONFIG_SCHEMA = cv.All(
 )
 
 
-@coroutine_with_priority(CoroPriority.DIAGNOSTICS)
-async def to_code(config):
-    baud_rate = config[CONF_BAUD_RATE]
+@coroutine_with_priority(CoroPriority.EARLY_INIT)
+async def to_code(config: ConfigType) -> None:
+    baud_rate: int = config[CONF_BAUD_RATE]
     level = config[CONF_LEVEL]
     CORE.data.setdefault(CONF_LOGGER, {})[CONF_LEVEL] = level
-    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
     tx_buffer_size = config[CONF_TX_BUFFER_SIZE]
     cg.add_define("ESPHOME_LOGGER_TX_BUFFER_SIZE", tx_buffer_size)
     log = cg.new_Pvariable(
@@ -347,10 +347,23 @@ async def to_code(config):
                 HARDWARE_UART_TO_UART_SELECTION[config[CONF_HARDWARE_UART]]
             )
         )
-    # pre_setup() must be called before init_log_buffer() because
-    # init_log_buffer() calls disable_loop() which may log at VV level,
-    # and global_logger must be set before any logging occurs.
+    # pre_setup() sets global_logger and must run before any other code
+    # that may call ESP_LOG* (e.g. setup_preferences contains ESP_LOGVV).
     cg.add(log.pre_setup())
+    initial_level = LOG_LEVELS[config.get(CONF_INITIAL_LEVEL, level)]
+    cg.add(log.set_log_level(initial_level))
+
+    # Schedule the rest of logger setup at DIAGNOSTICS priority, after
+    # Application is constructed (CORE priority) but before most components.
+    CORE.add_job(_late_logger_init, config)
+
+
+@coroutine_with_priority(CoroPriority.DIAGNOSTICS)
+async def _late_logger_init(config: ConfigType) -> None:
+    """Finish logger setup after Application is constructed."""
+    log = await cg.get_variable(config[CONF_ID])
+    level = config[CONF_LEVEL]
+    baud_rate: int = config[CONF_BAUD_RATE]
     if CORE.is_esp32 or CORE.is_libretiny or CORE.is_nrf52:
         task_log_buffer_size = config[CONF_TASK_LOG_BUFFER_SIZE]
         if task_log_buffer_size > 0:
@@ -362,8 +375,6 @@ async def to_code(config):
         cg.add(log.create_pthread_key())
         cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
         cg.add(log.init_log_buffer(64))  # Fixed 64 slots for host
-
-    cg.add(log.set_log_level(initial_level))
 
     # Enable runtime tag levels if logs are configured or explicitly enabled
     logs_config = config[CONF_LOGS]

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -152,29 +152,25 @@ inline uint8_t Logger::level_for(const char *tag) {
   return this->current_level_;
 }
 
+#ifdef USE_ESPHOME_TASK_LOG_BUFFER
+Logger::Logger(uint32_t baud_rate, size_t task_log_buffer_size) : baud_rate_(baud_rate) {
+#else
 Logger::Logger(uint32_t baud_rate) : baud_rate_(baud_rate) {
+#endif
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
   this->main_task_ = xTaskGetCurrentTaskHandle();
 #elif defined(USE_ZEPHYR)
   this->main_task_ = k_current_get();
 #elif defined(USE_HOST)
-  this->main_thread_ = pthread_self();
+this->main_thread_ = pthread_self();
 #endif
-}
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-void Logger::init_log_buffer(size_t total_buffer_size) {
-  // Host uses slot count instead of byte size
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory) - allocated once, never freed
-  this->log_buffer_ = new logger::TaskLogBuffer(total_buffer_size);
-
-#if !(defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
-  // Start with loop disabled when using task buffer
-  // The loop will be enabled automatically when messages arrive
-  // Zephyr with USB CDC needs loop active to poll port readiness via cdc_loop_()
-  this->disable_loop_when_buffer_empty_();
+  this->log_buffer_ = new logger::TaskLogBuffer(task_log_buffer_size);
+  // Note: we don't disable loop here because the component isn't registered with App yet.
+  // The loop self-disables on its first iteration when it finds no messages to process.
 #endif
 }
-#endif
 
 #if defined(USE_ESPHOME_TASK_LOG_BUFFER) || (defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
 void Logger::loop() {

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -143,9 +143,10 @@ enum UARTSelection : uint8_t {
  */
 class Logger final : public Component {
  public:
-  explicit Logger(uint32_t baud_rate);
 #ifdef USE_ESPHOME_TASK_LOG_BUFFER
-  void init_log_buffer(size_t total_buffer_size);
+  explicit Logger(uint32_t baud_rate, size_t task_log_buffer_size);
+#else
+  explicit Logger(uint32_t baud_rate);
 #endif
 #if defined(USE_ESPHOME_TASK_LOG_BUFFER) || (defined(USE_ZEPHYR) && defined(USE_LOGGER_UART_SELECTION_USB_CDC))
   void loop() override;

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -28,6 +28,10 @@ namespace esphome::mqtt {
 
 static const char *const TAG = "mqtt";
 
+// Maximum number of MQTT component resends per loop iteration.
+// Limits work to avoid triggering the task watchdog on reconnect.
+static constexpr uint8_t MAX_RESENDS_PER_LOOP = 8;
+
 // Disconnect reason strings indexed by MQTTClientDisconnectReason enum (0-8)
 PROGMEM_STRING_TABLE(MQTTDisconnectReasonStrings, "TCP disconnected", "Unacceptable Protocol Version",
                      "Identifier Rejected", "Server Unavailable", "Malformed Credentials", "Not Authorized",
@@ -396,9 +400,16 @@ void MQTTClientComponent::loop() {
         this->resubscribe_subscriptions_();
 
         // Process pending resends for all MQTT components centrally
-        // This is more efficient than each component polling in its own loop
-        for (MQTTComponent *component : this->children_) {
-          component->process_resend();
+        // Limit work per loop iteration to avoid triggering task WDT on reconnect
+        {
+          uint8_t resend_count = 0;
+          for (MQTTComponent *component : this->children_) {
+            if (component->is_resend_pending()) {
+              component->process_resend();
+              if (++resend_count >= MAX_RESENDS_PER_LOOP)
+                break;
+            }
+          }
         }
       }
       break;

--- a/esphome/components/mqtt/mqtt_component.h
+++ b/esphome/components/mqtt/mqtt_component.h
@@ -147,6 +147,9 @@ class MQTTComponent : public Component {
   /// Internal method for the MQTT client base to schedule a resend of the state on reconnect.
   void schedule_resend_state();
 
+  /// Check if a resend is pending (called by MQTTClientComponent to rate-limit work)
+  bool is_resend_pending() const { return this->resend_state_; }
+
   /// Process pending resend if needed (called by MQTTClientComponent)
   void process_resend();
 

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -11,6 +11,7 @@
 #include <openthread/instance.h>
 #include <openthread/thread.h>
 
+#include <atomic>
 #include <optional>
 #include <vector>
 
@@ -28,6 +29,8 @@ class OpenThreadComponent : public Component {
   float get_setup_priority() const override { return setup_priority::WIFI; }
 
   bool is_connected() const { return this->connected_; }
+  /// Returns true once esp_openthread_init() has completed and the OT lock is usable.
+  bool is_lock_initialized() const { return this->lock_initialized_; }
   network::IPAddresses get_ip_addresses();
   std::optional<otIp6Address> get_omr_address();
   void ot_main();
@@ -51,6 +54,7 @@ class OpenThreadComponent : public Component {
   uint32_t poll_period_{0};
 #endif
   std::optional<int8_t> output_power_{};
+  std::atomic<bool> lock_initialized_{false};
   bool teardown_started_{false};
   bool teardown_complete_{false};
   bool connected_{false};

--- a/esphome/components/openthread/openthread_esp.cpp
+++ b/esphome/components/openthread/openthread_esp.cpp
@@ -8,6 +8,7 @@
 #include "esp_openthread_lock.h"
 
 #include "esp_task_wdt.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -81,6 +82,9 @@ void OpenThreadComponent::ot_main() {
   // Initialize the OpenThread stack
   // otLoggingSetLevel(OT_LOG_LEVEL_DEBG);
   ESP_ERROR_CHECK(esp_openthread_init(&config));
+  // Mark lock as initialized so InstanceLock callers know it's safe to acquire.
+  // Must be set after esp_openthread_init() which creates the internal semaphore.
+  this->lock_initialized_ = true;
   // Fetch OT instance once to avoid repeated call into OT stack
   otInstance *instance = esp_openthread_get_instance();
 
@@ -180,7 +184,8 @@ void OpenThreadComponent::ot_main() {
 
   esp_openthread_launch_mainloop();
 
-  // Clean up
+  // Clean up - reset lock flag before deinit destroys the semaphore
+  this->lock_initialized_ = false;
   esp_openthread_deinit();
   esp_openthread_netif_glue_deinit();
   esp_netif_destroy(openthread_netif);
@@ -210,6 +215,9 @@ network::IPAddresses OpenThreadComponent::get_ip_addresses() {
 otInstance *OpenThreadComponent::get_openthread_instance_() { return esp_openthread_get_instance(); }
 
 std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
+  if (!global_openthread_component->is_lock_initialized()) {
+    return {};
+  }
   if (esp_openthread_lock_acquire(delay)) {
     return InstanceLock();
   }
@@ -217,6 +225,18 @@ std::optional<InstanceLock> InstanceLock::try_acquire(int delay) {
 }
 
 InstanceLock InstanceLock::acquire() {
+  // Wait for the lock to be created by ot_main() before attempting to acquire it.
+  // esp_openthread_lock_acquire() will assert-crash if called before esp_openthread_init().
+  constexpr uint32_t lock_init_timeout_ms = 10000;
+  uint32_t start = millis();
+  while (!global_openthread_component->is_lock_initialized()) {
+    if (millis() - start > lock_init_timeout_ms) {
+      ESP_LOGE(TAG, "OpenThread lock not initialized after %" PRIu32 "ms, aborting", lock_init_timeout_ms);
+      abort();
+    }
+    delay(10);
+    esp_task_wdt_reset();
+  }
   while (!esp_openthread_lock_acquire(100)) {
     esp_task_wdt_reset();
   }

--- a/esphome/components/pmsx003/pmsx003.cpp
+++ b/esphome/components/pmsx003/pmsx003.cpp
@@ -95,10 +95,6 @@ void PMSX003Component::loop() {
         // Just go ahead and read stuff
         break;
     }
-  } else if (now - this->last_update_ < this->update_interval_) {
-    // Otherwise just leave the sensor powered up and come back when we hit the update
-    // time
-    return;
   }
 
   if (now - this->last_transmission_ >= 500) {
@@ -114,10 +110,11 @@ void PMSX003Component::loop() {
     this->read_byte(&this->data_[this->data_index_]);
     auto check = this->check_byte_();
     if (!check.has_value()) {
-      // finished
-      this->parse_data_();
+      if (this->update_interval_ > STABILISING_MS || now - this->last_update_ >= this->update_interval_) {
+        this->parse_data_();
+        this->last_update_ = now;
+      }
       this->data_index_ = 0;
-      this->last_update_ = now;
     } else if (!*check) {
       // wrong data
       this->data_index_ = 0;
@@ -138,7 +135,7 @@ optional<bool> PMSX003Component::check_byte_() {
       return true;
     }
 
-    ESP_LOGW(TAG, "Start character %u mismatch: 0x%02X != 0x%02X", index + 1, byte, START_CHARACTER_1);
+    ESP_LOGW(TAG, "Start character %u mismatch: 0x%02X != 0x%02X", index + 1, byte, start_char);
     return false;
   }
 

--- a/esphome/components/sdl/sdl_esphome.cpp
+++ b/esphome/components/sdl/sdl_esphome.cpp
@@ -5,6 +5,30 @@
 namespace esphome {
 namespace sdl {
 
+int Sdl::get_width() {
+  switch (this->rotation_) {
+    case display::DISPLAY_ROTATION_90_DEGREES:
+    case display::DISPLAY_ROTATION_270_DEGREES:
+      return this->get_height_internal();
+    case display::DISPLAY_ROTATION_0_DEGREES:
+    case display::DISPLAY_ROTATION_180_DEGREES:
+    default:
+      return this->get_width_internal();
+  }
+}
+
+int Sdl::get_height() {
+  switch (this->rotation_) {
+    case display::DISPLAY_ROTATION_0_DEGREES:
+    case display::DISPLAY_ROTATION_180_DEGREES:
+      return this->get_height_internal();
+    case display::DISPLAY_ROTATION_90_DEGREES:
+    case display::DISPLAY_ROTATION_270_DEGREES:
+    default:
+      return this->get_width_internal();
+  }
+}
+
 void Sdl::setup() {
   SDL_Init(SDL_INIT_VIDEO);
   this->window_ = SDL_CreateWindow(App.get_name().c_str(), this->pos_x_, this->pos_y_, this->width_, this->height_,
@@ -48,6 +72,19 @@ void Sdl::draw_pixels_at(int x_start, int y_start, int w, int h, const uint8_t *
 void Sdl::draw_pixel_at(int x, int y, Color color) {
   if (!this->get_clipping().inside(x, y))
     return;
+
+  if (this->rotation_ == display::DISPLAY_ROTATION_180_DEGREES) {
+    x = this->width_ - x - 1;
+    y = this->height_ - y - 1;
+  } else if (this->rotation_ == display::DISPLAY_ROTATION_90_DEGREES) {
+    auto tmp = x;
+    x = this->width_ - y - 1;
+    y = tmp;
+  } else if (this->rotation_ == display::DISPLAY_ROTATION_270_DEGREES) {
+    auto tmp = y;
+    y = this->height_ - x - 1;
+    x = tmp;
+  }
 
   SDL_Rect rect{x, y, 1, 1};
   auto data = (display::ColorUtil::color_to_565(color, display::COLOR_ORDER_RGB));

--- a/esphome/components/sdl/sdl_esphome.h
+++ b/esphome/components/sdl/sdl_esphome.h
@@ -33,8 +33,8 @@ class Sdl : public display::Display {
     this->pos_x_ = pos_x;
     this->pos_y_ = pos_y;
   }
-  int get_width() override { return this->width_; }
-  int get_height() override { return this->height_; }
+  int get_width() override;
+  int get_height() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void dump_config() override { LOG_DISPLAY("", "SDL", this); }
   void add_key_listener(int32_t keycode, std::function<void(bool)> &&callback) {

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -1,4 +1,5 @@
 #include "sht4x.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 
 namespace esphome {

--- a/esphome/components/sht4x/sht4x.cpp
+++ b/esphome/components/sht4x/sht4x.cpp
@@ -9,14 +9,12 @@ static const char *const TAG = "sht4x";
 static const uint8_t MEASURECOMMANDS[] = {0xFD, 0xF6, 0xE0};
 static const uint8_t SERIAL_NUMBER_COMMAND = 0x89;
 
-void SHT4XComponent::start_heater_() {
-  uint8_t cmd[] = {this->heater_command_};
-
-  ESP_LOGD(TAG, "Heater turning on");
-  if (this->write(cmd, 1) != i2c::ERROR_OK) {
-    this->status_set_error(LOG_STR("Failed to turn on heater"));
-  }
-}
+// Conversion constants from SHT4x datasheet
+static constexpr float TEMPERATURE_OFFSET = -45.0f;
+static constexpr float TEMPERATURE_SPAN = 175.0f;
+static constexpr float HUMIDITY_OFFSET = -6.0f;
+static constexpr float HUMIDITY_SPAN = 125.0f;
+static constexpr float RAW_MAX = 65535.0f;
 
 void SHT4XComponent::read_serial_number_() {
   uint16_t buffer[2];
@@ -39,8 +37,8 @@ void SHT4XComponent::setup() {
   this->read_serial_number_();
 
   if (std::isfinite(this->duty_cycle_) && this->duty_cycle_ > 0.0f) {
-    uint32_t heater_interval = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
-    ESP_LOGD(TAG, "Heater interval: %" PRIu32, heater_interval);
+    this->heater_interval_ = static_cast<uint32_t>(static_cast<uint16_t>(this->heater_time_) / this->duty_cycle_);
+    ESP_LOGD(TAG, "Heater interval: %" PRIu32, this->heater_interval_);
 
     if (this->heater_power_ == SHT4X_HEATERPOWER_HIGH) {
       if (this->heater_time_ == SHT4X_HEATERTIME_LONG) {
@@ -62,8 +60,6 @@ void SHT4XComponent::setup() {
       }
     }
     ESP_LOGD(TAG, "Heater command: %x", this->heater_command_);
-
-    this->set_interval(heater_interval, std::bind(&SHT4XComponent::start_heater_, this));
   }
 }
 
@@ -106,18 +102,26 @@ void SHT4XComponent::update() {
     // Evaluate and publish measurements
     if (this->temp_sensor_ != nullptr) {
       // Temp is contained in the first result word
-      float sensor_value_temp = buffer[0];
-      float temp = -45 + 175 * sensor_value_temp / 65535;
-
+      float temp = TEMPERATURE_OFFSET + TEMPERATURE_SPAN * static_cast<float>(buffer[0]) / RAW_MAX;
       this->temp_sensor_->publish_state(temp);
     }
 
     if (this->humidity_sensor_ != nullptr) {
       // Relative humidity is in the second result word
-      float sensor_value_rh = buffer[1];
-      float rh = -6 + 125 * sensor_value_rh / 65535;
-
+      float rh = HUMIDITY_OFFSET + HUMIDITY_SPAN * static_cast<float>(buffer[1]) / RAW_MAX;
       this->humidity_sensor_->publish_state(rh);
+    }
+
+    // Fire heater after measurement to maximize cooldown time before the next reading.
+    // The heater command produces a measurement that we don't need (datasheet 4.9).
+    if (this->heater_interval_ > 0) {
+      uint32_t now = millis();
+      if (now - this->last_heater_millis_ >= this->heater_interval_) {
+        ESP_LOGD(TAG, "Heater turning on");
+        if (this->write_command(this->heater_command_)) {
+          this->last_heater_millis_ = now;
+        }
+      }
     }
   });
 }

--- a/esphome/components/sht4x/sht4x.h
+++ b/esphome/components/sht4x/sht4x.h
@@ -35,9 +35,10 @@ class SHT4XComponent : public PollingComponent, public sensirion_common::Sensiri
   SHT4XHEATERTIME heater_time_;
   float duty_cycle_;
 
-  void start_heater_();
   void read_serial_number_();
   uint8_t heater_command_;
+  uint32_t heater_interval_{0};
+  uint32_t last_heater_millis_{0};
   uint32_t serial_number_;
 
   sensor::Sensor *temp_sensor_{nullptr};

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -59,15 +59,20 @@ _DST_RULE_TYPE_MAP = {
 
 def _load_tzdata(iana_key: str) -> bytes | None:
     # From https://tzdata.readthedocs.io/en/latest/#examples
+    if not iana_key:
+        return None
     try:
         package_loc, resource = iana_key.rsplit("/", 1)
     except ValueError:
-        return None
-    package = "tzdata.zoneinfo." + package_loc.replace("/", ".")
+        # Handle top-level timezone entries like "UTC", "GMT"
+        package = "tzdata.zoneinfo"
+        resource = iana_key
+    else:
+        package = "tzdata.zoneinfo." + package_loc.replace("/", ".")
 
     try:
         return (resources.files(package) / resource).read_bytes()
-    except (FileNotFoundError, ModuleNotFoundError):
+    except (FileNotFoundError, ModuleNotFoundError, IsADirectoryError):
         return None
 
 

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -30,12 +30,17 @@ enum UARTDirection {
 const LogString *parity_to_str(UARTParityOptions parity);
 
 /// Result of a flush() call.
+// Some vendor SDKs (e.g., Realtek) define SUCCESS as a macro.
+// Save and restore around the enum to avoid collisions with our scoped enum value.
+#pragma push_macro("SUCCESS")
+#undef SUCCESS
 enum class FlushResult {
   SUCCESS,          ///< Confirmed: all bytes left the TX FIFO.
   TIMEOUT,          ///< Confirmed: timed out before TX completed.
   FAILED,           ///< Confirmed: driver or hardware error.
   ASSUMED_SUCCESS,  ///< Platform cannot report result; success is assumed.
 };
+#pragma pop_macro("SUCCESS")
 
 class UARTComponent {
  public:

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -7,7 +7,9 @@
 #include "esphome/core/log.h"
 #include "esphome/core/gpio.h"
 #include "driver/gpio.h"
+#include "esp_private/gpio.h"
 #include "soc/gpio_num.h"
+#include "soc/uart_pins.h"
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
 #include "esphome/core/application.h"
@@ -20,6 +22,20 @@
 namespace esphome::uart {
 
 static const char *const TAG = "uart.idf";
+
+/// Check if a pin number matches one of the default UART0 GPIO pins.
+/// These pins may have residual IOMUX state from the ROM bootloader that
+/// must be cleared before UART reconfiguration.
+///
+/// ESP-IDF's uart_set_pin() has an asymmetry: when routing TX via GPIO matrix,
+/// it calls gpio_func_sel(PIN_FUNC_GPIO) to clear IOMUX, but for RX it only
+/// calls gpio_input_enable() which does NOT clear the IOMUX function select.
+/// If a default UART0 TX pin (configured as TX via IOMUX during boot) is later
+/// reassigned as RX via GPIO matrix, the old IOMUX TX function remains active,
+/// causing TX data to loop back into RX on the same pin.
+static constexpr bool is_default_uart0_pin(int8_t pin_num) {
+  return pin_num == U0TXD_GPIO_NUM || pin_num == U0RXD_GPIO_NUM;
+}
 
 uart_config_t IDFUARTComponent::get_config_() {
   uart_parity_t parity = UART_PARITY_DISABLE;
@@ -131,6 +147,19 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
+  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
+  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
+  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
+
+  // Clear residual IOMUX function on UART0 default pins left by the ROM bootloader.
+  // See is_default_uart0_pin() comment for details on the ESP-IDF uart_set_pin() bug.
+  if (is_default_uart0_pin(tx)) {
+    gpio_func_sel(static_cast<gpio_num_t>(tx), PIN_FUNC_GPIO);
+  }
+  if (is_default_uart0_pin(rx)) {
+    gpio_func_sel(static_cast<gpio_num_t>(rx), PIN_FUNC_GPIO);
+  }
+
   auto setup_pin_if_needed = [](InternalGPIOPin *pin) {
     if (!pin) {
       return;
@@ -145,10 +174,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
-
-  int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
-  int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
-  int8_t flow_control = this->flow_control_pin_ != nullptr ? this->flow_control_pin_->get_pin() : -1;
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {

--- a/esphome/components/ultrasonic/ultrasonic_sensor.cpp
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.cpp
@@ -6,11 +6,17 @@ namespace esphome::ultrasonic {
 
 static const char *const TAG = "ultrasonic.sensor";
 
+static constexpr uint32_t DEBOUNCE_US = 50;          // Ignore edges within 50us of each other (noise filtering)
+static constexpr uint32_t START_DELAY_US = 100;      // Ignore edges within 100us of trigger (filters bleed-through)
 static constexpr uint32_t START_TIMEOUT_US = 40000;  // Maximum time to wait for echo pulse to start
 
 void IRAM_ATTR UltrasonicSensorStore::gpio_intr(UltrasonicSensorStore *arg) {
   uint32_t now = micros();
-  if (arg->echo_pin_isr.digital_read()) {
+  // Ignore edges after measurement complete or too soon after trigger pulse
+  if (arg->echo_end || (now - arg->measurement_start_us) <= START_DELAY_US) {
+    return;
+  }
+  if (!arg->echo_start || (now - arg->echo_start_us) <= DEBOUNCE_US) {
     arg->echo_start_us = now;
     arg->echo_start = true;
   } else {
@@ -21,15 +27,14 @@ void IRAM_ATTR UltrasonicSensorStore::gpio_intr(UltrasonicSensorStore *arg) {
 
 void IRAM_ATTR UltrasonicSensorComponent::send_trigger_pulse_() {
   InterruptLock lock;
-  this->store_.echo_start_us = 0;
-  this->store_.echo_end_us = 0;
   this->store_.echo_start = false;
   this->store_.echo_end = false;
+  this->store_.measurement_start_us = micros();
   this->trigger_pin_isr_.digital_write(true);
   delayMicroseconds(this->pulse_time_us_);
   this->trigger_pin_isr_.digital_write(false);
   this->measurement_pending_ = true;
-  this->measurement_start_us_ = micros();
+  this->measurement_start_us_ = this->store_.measurement_start_us;
 }
 
 void UltrasonicSensorComponent::setup() {
@@ -37,7 +42,6 @@ void UltrasonicSensorComponent::setup() {
   this->trigger_pin_->digital_write(false);
   this->trigger_pin_isr_ = this->trigger_pin_->to_isr();
   this->echo_pin_->setup();
-  this->store_.echo_pin_isr = this->echo_pin_->to_isr();
   this->echo_pin_->attach_interrupt(UltrasonicSensorStore::gpio_intr, &this->store_, gpio::INTERRUPT_ANY_EDGE);
 }
 
@@ -77,17 +81,10 @@ void UltrasonicSensorComponent::loop() {
   }
 
   if (this->store_.echo_end) {
-    float result;
-    if (this->store_.echo_start) {
-      uint32_t pulse_duration = this->store_.echo_end_us - this->store_.echo_start_us;
-      ESP_LOGV(TAG, "pulse start took %" PRIu32 "us, echo took %" PRIu32 "us",
-               this->store_.echo_start_us - this->measurement_start_us_, pulse_duration);
-      result = UltrasonicSensorComponent::us_to_m(pulse_duration);
-      ESP_LOGD(TAG, "'%s' - Got distance: %.3f m", this->name_.c_str(), result);
-    } else {
-      ESP_LOGW(TAG, "'%s' - pulse end before pulse start, does the echo pin need to be inverted?", this->name_.c_str());
-      result = NAN;
-    }
+    uint32_t pulse_duration = this->store_.echo_end_us - this->store_.echo_start_us;
+    ESP_LOGV(TAG, "Echo took %" PRIu32 "us", pulse_duration);
+    float result = UltrasonicSensorComponent::us_to_m(pulse_duration);
+    ESP_LOGD(TAG, "'%s' - Got distance: %.3f m", this->name_.c_str(), result);
     this->publish_state(result);
     this->measurement_pending_ = false;
     return;

--- a/esphome/components/ultrasonic/ultrasonic_sensor.h
+++ b/esphome/components/ultrasonic/ultrasonic_sensor.h
@@ -11,8 +11,7 @@ namespace esphome::ultrasonic {
 struct UltrasonicSensorStore {
   static void gpio_intr(UltrasonicSensorStore *arg);
 
-  ISRInternalGPIOPin echo_pin_isr;
-  volatile uint32_t wait_start_us{0};
+  volatile uint32_t measurement_start_us{0};
   volatile uint32_t echo_start_us{0};
   volatile uint32_t echo_end_us{0};
   volatile bool echo_start{false};

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -120,7 +120,10 @@ void AsyncWebServer::begin() {
   if (this->server_) {
     this->end();
   }
+  // Default httpd stack is defined by ESP-IDF. Increase to accommodate SerializationBuffer's
+  // 640-byte stack buffer used by web_server JSON request handlers.
   httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+  config.stack_size = config.stack_size + 256;
   config.server_port = this->port_;
   config.uri_match_fn = [](const char * /*unused*/, const char * /*unused*/, size_t /*unused*/) { return true; };
   // Always enable LRU purging to handle socket exhaustion gracefully.

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -92,13 +92,23 @@ bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   return ret;
 }
 bool WiFiComponent::wifi_apply_power_save_() {
+  // ESP8266 sleep types have confusing names — LIGHT_SLEEP_T is the MORE aggressive mode.
+  // SDK enum: NONE_SLEEP_T=0, LIGHT_SLEEP_T=1, MODEM_SLEEP_T=2
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/tools/sdk/include/user_interface.h#L447-L451
+  // Arduino ESP32 compat confirms: WIFI_PS_MIN_MODEM=MODEM_SLEEP, WIFI_PS_MAX_MODEM=LIGHT_SLEEP
+  //   https://github.com/esp8266/Arduino/blob/3.1.2/libraries/ESP8266WiFi/src/ESP8266WiFiType.h#L53-L55
   sleep_type_t power_save;
   switch (this->power_save_) {
     case WIFI_POWER_SAVE_LIGHT:
-      power_save = LIGHT_SLEEP_T;
+      // MODEM_SLEEP_T: only the WiFi modem sleeps between DTIM beacons, CPU stays active.
+      // Matches ESP32's WIFI_PS_MIN_MODEM.
+      power_save = MODEM_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_HIGH:
-      power_save = MODEM_SLEEP_T;
+      // LIGHT_SLEEP_T: both WiFi modem AND CPU suspend between DTIM beacons.
+      // Most aggressive — prevents TCP processing during sleep. Matches ESP32's WIFI_PS_MAX_MODEM.
+      // See https://github.com/esphome/esphome/issues/14999
+      power_save = LIGHT_SLEEP_T;
       break;
     case WIFI_POWER_SAVE_NONE:
     default:

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.3.0"
+__version__ = "2026.3.1"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -587,7 +587,9 @@ async def _add_looping_components() -> None:
 
 @coroutine_with_priority(CoroPriority.CORE)
 async def to_code(config: ConfigType) -> None:
-    cg.add_global(cg.global_ns.namespace("esphome").using)
+    # using namespace esphome is hardcoded in writer.py to guarantee it
+    # precedes all variable declarations regardless of coroutine priority.
+
     # These can be used by user lambdas, put them to default scope
     cg.add_global(cg.RawExpression("using std::isnan"))
     cg.add_global(cg.RawExpression("using std::min"))

--- a/esphome/core/string_ref.h
+++ b/esphome/core/string_ref.h
@@ -76,6 +76,15 @@ class StringRef {
   constexpr bool empty() const { return len_ == 0; }
   constexpr const_reference operator[](size_type pos) const { return *(base_ + pos); }
 
+  /// Copy characters to destination buffer (std::string::copy-like, but returns 0 instead of throwing on out-of-range)
+  size_type copy(char *dest, size_type count, size_type pos = 0) const {
+    if (pos >= len_)
+      return 0;
+    size_type actual = (count > len_ - pos) ? len_ - pos : count;
+    std::memcpy(dest, base_ + pos, actual);
+    return actual;
+  }
+
   std::string str() const { return std::string(base_, len_); }
   const uint8_t *byte() const { return reinterpret_cast<const uint8_t *>(base_); }
 

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -283,19 +283,15 @@ void ESPTime::recalc_timestamp_local() {
   bool dst_valid = time::is_in_dst(utc_if_dst, tz);
   bool std_valid = !time::is_in_dst(utc_if_std, tz);
 
-  if (dst_valid && std_valid) {
-    // Ambiguous time (repeated hour during fall-back) - prefer standard time
-    this->timestamp = utc_if_std;
-  } else if (dst_valid) {
+  if (dst_valid && !std_valid) {
     // Only DST interpretation is valid
     this->timestamp = utc_if_dst;
-  } else if (std_valid) {
-    // Only standard interpretation is valid
-    this->timestamp = utc_if_std;
   } else {
-    // Invalid time (skipped hour during spring-forward)
-    // libc normalizes forward: 02:30 CST -> 08:30 UTC -> 03:30 CDT
-    // Using std offset achieves this since the UTC result falls during DST
+    // All other cases use standard offset:
+    // - Both valid (ambiguous fall-back repeated hour): prefer standard time
+    // - Only standard valid: straightforward
+    // - Neither valid (spring-forward skipped hour): std offset normalizes
+    //   forward to match libc mktime(), e.g. 02:30 CST -> 03:30 CDT
     this->timestamp = utc_if_std;
   }
 #else

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>

--- a/esphome/coroutine.py
+++ b/esphome/coroutine.py
@@ -63,7 +63,13 @@ class CoroPriority(enum.IntEnum):
     resolution during code generation.
     """
 
-    # Platform initialization - must run first
+    # Early init - runs before platform init and before Application exists.
+    # Currently used only to connect logging so ESP_LOG* calls work
+    # immediately in all subsequent phases.
+    # Examples: logger (1100)
+    EARLY_INIT = 1100
+
+    # Platform initialization
     # Examples: esp32, esp8266, rp2040
     PLATFORM = 1000
 
@@ -83,7 +89,7 @@ class CoroPriority(enum.IntEnum):
     CORE = 100
 
     # Diagnostic and debugging systems
-    # Examples: logger (90)
+    # Examples: debug component (90)
     DIAGNOSTICS = 90
 
     # Status and monitoring systems

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -381,7 +381,10 @@ def write_cpp(code_s):
         code_format = CPP_BASE_FORMAT
 
     copy_src_tree()
+    # using namespace esphome must precede all variable declarations since
+    # codegen types assume this namespace is in scope (esphome_ns = global_ns).
     global_s = '#include "esphome.h"\n'
+    global_s += "using namespace esphome;\n"
     global_s += CORE.cpp_global_section
 
     full_file = f"{code_format[0] + CPP_INCLUDE_BEGIN}\n{global_s}{CPP_INCLUDE_END}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ platformio==6.1.19
 esptool==5.2.0
 click==8.3.1
 esphome-dashboard==20260210.0
-aioesphomeapi==44.6.1
+aioesphomeapi==44.6.2
 zeroconf==0.148.0
 puremagic==1.30
 ruamel.yaml==0.19.1 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ platformio==6.1.19
 esptool==5.2.0
 click==8.3.1
 esphome-dashboard==20260210.0
-aioesphomeapi==44.5.2
+aioesphomeapi==44.6.0
 zeroconf==0.148.0
 puremagic==1.30
 ruamel.yaml==0.19.1 # dashboard_import

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ platformio==6.1.19
 esptool==5.2.0
 click==8.3.1
 esphome-dashboard==20260210.0
-aioesphomeapi==44.6.0
+aioesphomeapi==44.6.1
 zeroconf==0.148.0
 puremagic==1.30
 ruamel.yaml==0.19.1 # dashboard_import

--- a/tests/components/main.cpp
+++ b/tests/components/main.cpp
@@ -22,7 +22,7 @@ void original_setup() {
 void setup() {
   // Log functions call global_logger->log_vprintf_() without a null check,
   // so we must set up a Logger before any test that triggers logging.
-  static esphome::logger::Logger test_logger(0);
+  static esphome::logger::Logger test_logger(0, 64);
   test_logger.set_log_level(ESPHOME_LOG_LEVEL);
   test_logger.pre_setup();
 

--- a/tests/components/sht4x/common.yaml
+++ b/tests/components/sht4x/common.yaml
@@ -6,4 +6,8 @@ sensor:
     humidity:
       name: SHT4X Humidity
     address: 0x44
+    precision: High
+    heater_max_duty: 0.02
+    heater_power: High
+    heater_time: Long
     update_interval: 15s

--- a/tests/components/uart/test.rtl87xx-ard.yaml
+++ b/tests/components/uart/test.rtl87xx-ard.yaml
@@ -1,0 +1,14 @@
+uart:
+  - id: uart_id
+    tx_pin: PA23
+    rx_pin: PA18
+    baud_rate: 9600
+    data_bits: 8
+    parity: NONE
+    stop_bits: 1
+
+switch:
+  - platform: uart
+    name: "UART Switch"
+    uart_id: uart_id
+    data: [0x01, 0x02, 0x03]

--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -15,7 +15,7 @@ void setup() {
   static char name[] = "livingroom";
   static char friendly_name[] = "LivingRoom";
   App.pre_setup(name, sizeof(name) - 1, friendly_name, sizeof(friendly_name) - 1);
-  auto *log = new logger::Logger(115200);  // NOLINT
+  auto *log = new logger::Logger(115200, 512);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component_(log);

--- a/tests/integration/fixtures/light_constant_brightness.yaml
+++ b/tests/integration/fixtures/light_constant_brightness.yaml
@@ -1,0 +1,57 @@
+esphome:
+  name: light-cb-test
+host:
+api:  # Port will be automatically injected
+logger:
+  level: DEBUG
+
+output:
+  - platform: template
+    id: cb_cold_white_output
+    type: float
+    write_action:
+      - logger.log:
+          format: "CB_CW_OUTPUT:%.6f"
+          args: [state]
+  - platform: template
+    id: cb_warm_white_output
+    type: float
+    write_action:
+      - logger.log:
+          format: "CB_WW_OUTPUT:%.6f"
+          args: [state]
+  - platform: template
+    id: ncb_cold_white_output
+    type: float
+    write_action:
+      - logger.log:
+          format: "NCB_CW_OUTPUT:%.6f"
+          args: [state]
+  - platform: template
+    id: ncb_warm_white_output
+    type: float
+    write_action:
+      - logger.log:
+          format: "NCB_WW_OUTPUT:%.6f"
+          args: [state]
+
+light:
+  - platform: cwww
+    name: "Test CB Light"
+    id: test_cb_light
+    cold_white: cb_cold_white_output
+    warm_white: cb_warm_white_output
+    cold_white_color_temperature: 6536 K
+    warm_white_color_temperature: 2000 K
+    constant_brightness: true
+    gamma_correct: 2.8
+
+  - platform: cwww
+    name: "Test NCB Light"
+    id: test_ncb_light
+    cold_white: ncb_cold_white_output
+    warm_white: ncb_warm_white_output
+    cold_white_color_temperature: 6536 K
+    warm_white_color_temperature: 2000 K
+    constant_brightness: false
+    gamma_correct: 2.8

--- a/tests/integration/test_light_constant_brightness.py
+++ b/tests/integration/test_light_constant_brightness.py
@@ -1,0 +1,188 @@
+"""Integration test for constant_brightness with gamma correction.
+
+Tests both constant_brightness: true and false cwww lights with gamma
+correction in a single compilation to verify:
+- constant_brightness: true maintains constant total CW+WW power output
+- constant_brightness: false correctly varies total power across color temps
+
+This is a regression test for https://github.com/esphome/esphome/issues/15040
+where the gamma LUT refactor (#14123) broke constant_brightness by applying
+gamma after the balancing formula instead of before it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any
+
+from aioesphomeapi import EntityState, LightInfo, LightState
+import pytest
+
+from .state_utils import InitialStateHelper
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_light_constant_brightness(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test constant_brightness true and false behavior with gamma correction."""
+    # Track output values for both lights from log lines
+    cb_cw_pattern = re.compile(r"(?<!N)CB_CW_OUTPUT:([\d.]+)")
+    cb_ww_pattern = re.compile(r"(?<!N)CB_WW_OUTPUT:([\d.]+)")
+    ncb_cw_pattern = re.compile(r"NCB_CW_OUTPUT:([\d.]+)")
+    ncb_ww_pattern = re.compile(r"NCB_WW_OUTPUT:([\d.]+)")
+
+    latest: dict[str, float] = {
+        "cb_cw": 0.0,
+        "cb_ww": 0.0,
+        "ncb_cw": 0.0,
+        "ncb_ww": 0.0,
+    }
+
+    def on_log_line(line: str) -> None:
+        for pattern, key in [
+            (cb_cw_pattern, "cb_cw"),
+            (cb_ww_pattern, "cb_ww"),
+            (ncb_cw_pattern, "ncb_cw"),
+            (ncb_ww_pattern, "ncb_ww"),
+        ]:
+            match = pattern.search(line)
+            if match:
+                latest[key] = float(match.group(1))
+
+    loop = asyncio.get_running_loop()
+
+    async with (
+        run_compiled(yaml_config, line_callback=on_log_line),
+        api_client_connected() as client,
+    ):
+        entities, _ = await client.list_entities_services()
+        lights = [e for e in entities if isinstance(e, LightInfo)]
+        cb_light = next(e for e in lights if e.object_id.endswith("cb_light"))
+        ncb_light = next(e for e in lights if e.object_id.endswith("ncb_light"))
+
+        # Use InitialStateHelper to wait for initial state broadcast
+        initial_state_helper = InitialStateHelper(entities)
+
+        # Track state changes per light key
+        state_futures: dict[int, asyncio.Future[EntityState]] = {}
+
+        def on_state(state: EntityState) -> None:
+            if isinstance(state, LightState) and state.key in state_futures:
+                future = state_futures[state.key]
+                if not future.done():
+                    future.set_result(state)
+
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+
+        try:
+            await initial_state_helper.wait_for_initial_states()
+        except TimeoutError:
+            pytest.fail("Timeout waiting for initial states")
+
+        async def send_and_wait(
+            light_key: int, timeout: float = 5.0, **kwargs: Any
+        ) -> LightState:
+            """Send a light command and wait for the state response."""
+            state_futures[light_key] = loop.create_future()
+            client.light_command(key=light_key, **kwargs)
+            try:
+                return await asyncio.wait_for(state_futures[light_key], timeout=timeout)
+            except TimeoutError:
+                pytest.fail(f"Timeout waiting for light state after command: {kwargs}")
+
+        # --- Test constant_brightness: true ---
+
+        # Turn on CB light at full brightness
+        await send_and_wait(
+            cb_light.key,
+            state=True,
+            brightness=1.0,
+            color_temperature=153.0,
+            transition_length=0,
+        )
+
+        test_mireds = [
+            153.0,  # Pure cold white
+            200.0,  # Mostly cold
+            280.0,  # Mixed
+            326.5,  # Midpoint
+            400.0,  # Mostly warm
+            500.0,  # Pure warm white
+        ]
+
+        cb_totals: list[tuple[float, float, float]] = []
+        for mireds in test_mireds:
+            await send_and_wait(
+                cb_light.key, color_temperature=mireds, transition_length=0
+            )
+            cb_totals.append((mireds, latest["cb_cw"], latest["cb_ww"]))
+
+        # All totals should be approximately equal (constant brightness)
+        reference_total = next((cw + ww for _, cw, ww in cb_totals if cw + ww > 0), 0)
+        assert reference_total > 0, (
+            f"Reference total power is zero, CB light outputs not working. "
+            f"Values: {cb_totals}"
+        )
+
+        for mireds, cw, ww in cb_totals:
+            total = cw + ww
+            assert total == pytest.approx(reference_total, rel=0.05), (
+                f"constant_brightness: Total power at {mireds} mireds "
+                f"({total:.4f}) differs from reference ({reference_total:.4f}) "
+                f"by more than 5%. CW={cw:.4f}, WW={ww:.4f}. "
+                f"All values: {cb_totals}"
+            )
+
+        # --- Test constant_brightness: false ---
+
+        # Turn on NCB light at full brightness
+        await send_and_wait(
+            ncb_light.key,
+            state=True,
+            brightness=1.0,
+            color_temperature=153.0,
+            transition_length=0,
+        )
+
+        ncb_totals: list[tuple[float, float, float]] = []
+        for mireds in test_mireds:
+            await send_and_wait(
+                ncb_light.key, color_temperature=mireds, transition_length=0
+            )
+            ncb_totals.append((mireds, latest["ncb_cw"], latest["ncb_ww"]))
+
+        extreme_cw = ncb_totals[0]  # 153 mireds - pure cold
+        extreme_ww = ncb_totals[-1]  # 500 mireds - pure warm
+        midpoint = ncb_totals[3]  # 326.5 mireds - midpoint
+
+        # At pure cold white, WW should be ~0
+        assert extreme_cw[2] == pytest.approx(0.0, abs=0.01), (
+            f"Pure cold white should have WW~0, got WW={extreme_cw[2]:.4f}"
+        )
+        # At pure warm white, CW should be ~0
+        assert extreme_ww[1] == pytest.approx(0.0, abs=0.01), (
+            f"Pure warm white should have CW~0, got CW={extreme_ww[1]:.4f}"
+        )
+
+        # At midpoint, both channels should be non-zero
+        assert midpoint[1] > 0.05, f"Midpoint CW should be >0.05, got {midpoint[1]:.4f}"
+        assert midpoint[2] > 0.05, f"Midpoint WW should be >0.05, got {midpoint[2]:.4f}"
+
+        # Total power at midpoint should be higher than at the extremes
+        midpoint_total = midpoint[1] + midpoint[2]
+        extreme_cw_total = extreme_cw[1] + extreme_cw[2]
+        extreme_ww_total = extreme_ww[1] + extreme_ww[2]
+
+        assert midpoint_total > extreme_cw_total, (
+            f"Midpoint total ({midpoint_total:.4f}) should be > pure CW total "
+            f"({extreme_cw_total:.4f}). All values: {ncb_totals}"
+        )
+        assert midpoint_total > extreme_ww_total, (
+            f"Midpoint total ({midpoint_total:.4f}) should be > pure WW total "
+            f"({extreme_ww_total:.4f}). All values: {ncb_totals}"
+        )

--- a/tests/unit_tests/components/light/test_gamma_table.py
+++ b/tests/unit_tests/components/light/test_gamma_table.py
@@ -1,0 +1,117 @@
+"""Tests for the gamma LUT table generation."""
+
+import pytest
+
+from esphome.components.light import generate_gamma_table
+
+
+def _simulate_gamma_correct_lut(table: list[int], value: float) -> float:
+    """Simulate the C++ gamma_correct_lut interpolation from light_state.cpp."""
+    if value <= 0.0:
+        return 0.0
+    if value >= 1.0:
+        return 1.0
+    scaled = value * 255.0
+    idx = int(scaled)
+    if idx >= 255:
+        return table[255] / 65535.0
+    frac = scaled - idx
+    a = float(table[idx])
+    b = float(table[idx + 1])
+    return (a + frac * (b - a)) / 65535.0
+
+
+def test_table_length() -> None:
+    """Table must always have exactly 256 entries."""
+    table = generate_gamma_table(2.8)
+    assert len(table) == 256
+
+
+def test_index_zero_is_zero() -> None:
+    """Index 0 must be 0 so true off remains off."""
+    for gamma in (1.0, 2.0, 2.2, 2.8, 3.0):
+        table = generate_gamma_table(gamma)
+        assert table[0] == 0, f"gamma={gamma}"
+
+
+def test_index_255_is_max() -> None:
+    """Index 255 must be 65535 (full on)."""
+    for gamma in (1.0, 2.0, 2.2, 2.8, 3.0):
+        table = generate_gamma_table(gamma)
+        assert table[255] == 65535, f"gamma={gamma}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_nonzero_indices_are_nonzero(gamma: float) -> None:
+    """All indices > 0 must produce non-zero values.
+
+    This prevents zero_means_zero breakage: non-zero input must always
+    produce non-zero output so FloatOutput applies min_power scaling.
+    """
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert table[i] >= 1, f"gamma={gamma}, index {i}: got {table[i]}"
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_table_monotonically_nondecreasing(gamma: float) -> None:
+    """The gamma table must be monotonically non-decreasing."""
+    table = generate_gamma_table(gamma)
+    for i in range(1, 256):
+        assert table[i] >= table[i - 1], (
+            f"gamma={gamma}: table[{i}]={table[i]} < table[{i - 1}]={table[i - 1]}"
+        )
+
+
+def test_linear_gamma() -> None:
+    """With gamma=0 (linear), table should be evenly spaced."""
+    table = generate_gamma_table(0)
+    assert table[0] == 0
+    assert table[128] == round(128 / 255.0 * 65535)
+    assert table[255] == 65535
+
+
+@pytest.mark.parametrize("brightness", [0.01, 0.005, 0.001, 1 / 255])
+def test_small_brightness_nonzero_after_lut(brightness: float) -> None:
+    """Small but non-zero brightness must produce non-zero output through the LUT.
+
+    Regression test for #15055: with zero_means_zero=true, a gamma-corrected
+    value of exactly 0.0 causes FloatOutput to skip min_power scaling, turning
+    the LED off instead of to minimum brightness.
+    """
+    table = generate_gamma_table(2.8)
+    result = _simulate_gamma_correct_lut(table, brightness)
+    assert result > 0.0, (
+        f"brightness={brightness}: gamma LUT returned 0.0, would break zero_means_zero"
+    )
+
+
+@pytest.mark.parametrize("gamma", [1.0, 2.0, 2.2, 2.8, 3.0])
+def test_small_brightness_nonzero_all_gammas(gamma: float) -> None:
+    """1% brightness must be non-zero for all common gamma values."""
+    table = generate_gamma_table(gamma)
+    result = _simulate_gamma_correct_lut(table, 0.01)
+    assert result > 0.0, f"gamma={gamma}: 1% brightness returned 0.0"
+
+
+def test_lut_zero_returns_zero() -> None:
+    """LUT with input 0.0 must return 0.0."""
+    table = generate_gamma_table(2.8)
+    assert _simulate_gamma_correct_lut(table, 0.0) == 0.0
+
+
+def test_lut_one_returns_one() -> None:
+    """LUT with input 1.0 must return 1.0."""
+    table = generate_gamma_table(2.8)
+    assert _simulate_gamma_correct_lut(table, 1.0) == 1.0
+
+
+def test_lut_output_monotonically_nondecreasing() -> None:
+    """LUT output must be monotonically non-decreasing across the full range."""
+    table = generate_gamma_table(2.8)
+    prev = 0.0
+    for i in range(1001):
+        value = i / 1000.0
+        result = _simulate_gamma_correct_lut(table, value)
+        assert result >= prev, f"value={value}: result {result} < previous {prev}"
+        prev = result


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- Bump aioesphomeapi from 44.5.2 to 44.6.0 [esphome#14927](https://github.com/esphome/esphome/pull/14927)
- [http_request] Prevent double update task launch [esphome#14910](https://github.com/esphome/esphome/pull/14910)
- [ble_client] Fix RSSI sensor reporting same value for all clients [esphome#14939](https://github.com/esphome/esphome/pull/14939)
- [openthread] Guard InstanceLock against uninitialized semaphore [esphome#14940](https://github.com/esphome/esphome/pull/14940)
- Bump aioesphomeapi from 44.6.0 to 44.6.1 [esphome#14954](https://github.com/esphome/esphome/pull/14954)
- [time] Fix lookup of top-level IANA timezone keys like UTC and GMT [esphome#14952](https://github.com/esphome/esphome/pull/14952)
- [logger] Fix ESP8266 crash with VERY_VERBOSE log level [esphome#14980](https://github.com/esphome/esphome/pull/14980)
- [sdl] Fix get_width()/height() when rotation used [esphome#14950](https://github.com/esphome/esphome/pull/14950)
- [uart] Fix UART0 default pin IOMUX loopback on ESP32 [esphome#14978](https://github.com/esphome/esphome/pull/14978)
- [ld2450] Fix zone target counts including untracked ghost targets [esphome#15026](https://github.com/esphome/esphome/pull/15026)
- Bump aioesphomeapi from 44.6.1 to 44.6.2 [esphome#15027](https://github.com/esphome/esphome/pull/15027)
- [api] Increase noise handshake timeout to 60s for slow WiFi environments [esphome#15022](https://github.com/esphome/esphome/pull/15022)
- [wifi] Fix ESP8266 power_save_mode mapping (LIGHT/HIGH were swapped) [esphome#15029](https://github.com/esphome/esphome/pull/15029) (breaking-change)
- [esp32_touch] Fix initial state never published when sensor untouched [esphome#15032](https://github.com/esphome/esphome/pull/15032)
- [web_server] Increase httpd task stack size to prevent stack overflow [esphome#14997](https://github.com/esphome/esphome/pull/14997)
- [core] Add copy() method to StringRef for std::string compatibility [esphome#15028](https://github.com/esphome/esphome/pull/15028)
- [time] Fix timezone_offset() and recalc_timestamp_local() always returning UTC [esphome#14996](https://github.com/esphome/esphome/pull/14996)
- [analog_threshhold] add missing header [esphome#15058](https://github.com/esphome/esphome/pull/15058)
- [mqtt] Rate-limit component resends to prevent task WDT on reconnect [esphome#15061](https://github.com/esphome/esphome/pull/15061)
- [light] Fix constant_brightness broken by gamma LUT refactor [esphome#15048](https://github.com/esphome/esphome/pull/15048)
- [sht4x] Fix heater causing measurement jitter [esphome#15030](https://github.com/esphome/esphome/pull/15030)
- [uart] Fix RTL87xx compilation failure due to SUCCESS macro collision [esphome#15054](https://github.com/esphome/esphome/pull/15054)
- [light] Fix gamma LUT quantizing small brightness to zero [esphome#15060](https://github.com/esphome/esphome/pull/15060)
- [ultrasonic] Fix ISR edge detection with debounce and trigger filtering [esphome#15014](https://github.com/esphome/esphome/pull/15014)
- [logger] Fix race condition in task log buffer initialization [esphome#15071](https://github.com/esphome/esphome/pull/15071)
- [pmsx003] Keep active-mode reads aligned [esphome#14832](https://github.com/esphome/esphome/pull/14832)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
