### PR TITLE
[logger] Fix unit test and benchmark Logger constructor calls

### DIFF
--- a/tests/benchmarks/components/main.cpp
+++ b/tests/benchmarks/components/main.cpp
@@ -26,7 +26,7 @@ void setup() {
 
   // Log functions call global_logger->log_vprintf_() without a null check,
   // so we must set up a Logger before any test that triggers logging.
-  static esphome::logger::Logger test_logger(0);
+  static esphome::logger::Logger test_logger(0, 64);
   test_logger.set_log_level(ESPHOME_LOG_LEVEL);
   test_logger.pre_setup();
 

--- a/tests/components/main.cpp
+++ b/tests/components/main.cpp
@@ -22,7 +22,7 @@ void original_setup() {
 void setup() {
   // Log functions call global_logger->log_vprintf_() without a null check,
   // so we must set up a Logger before any test that triggers logging.
-  static esphome::logger::Logger test_logger(0);
+  static esphome::logger::Logger test_logger(0, 64);
   test_logger.set_log_level(ESPHOME_LOG_LEVEL);
   test_logger.pre_setup();
 


### PR DESCRIPTION
# What does this implement/fix?

Fix compilation of unit tests and benchmarks after #15071 changed the `Logger` constructor to require a `task_log_buffer_size` parameter. Uses 64 slots matching the host platform default to ensure thread-safe logging during tests.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes compilation after #15071

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).