### PR TITLE
[logger] Fix dummy_main.cpp Logger constructor for clang-tidy

### DIFF
--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -15,7 +15,7 @@ void setup() {
   static char name[] = "livingroom";
   static char friendly_name[] = "LivingRoom";
   App.pre_setup(name, sizeof(name) - 1, friendly_name, sizeof(friendly_name) - 1);
-  auto *log = new logger::Logger(115200);  // NOLINT
+  auto *log = new logger::Logger(115200, 512);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component_(log);


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `dummy_main.cpp` Logger constructor call to pass the required `task_log_buffer_size` argument. The clang-tidy CI uses `defines.h` which enables `USE_ESPHOME_TASK_LOG_BUFFER`, making the two-argument constructor the only visible one, causing a build error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).