### PR TITLE
[CI] Fix dummy main after logger constructor changes

### DIFF
--- a/tests/dummy_main.cpp
+++ b/tests/dummy_main.cpp
@@ -3,9 +3,9 @@
 // matter at all, as long as it compiles).
 // Not used during runtime nor for CI.
 
+#include <esphome/components/esphome/ota/ota_esphome.h>
 #include <esphome/components/gpio/switch/gpio_switch.h>
 #include <esphome/components/logger/logger.h>
-#include <esphome/components/esphome/ota/ota_esphome.h>
 #include <esphome/components/wifi/wifi_component.h>
 #include <esphome/core/application.h>
 
@@ -15,7 +15,7 @@ void setup() {
   static char name[] = "livingroom";
   static char friendly_name[] = "LivingRoom";
   App.pre_setup(name, sizeof(name) - 1, friendly_name, sizeof(friendly_name) - 1);
-  auto *log = new logger::Logger(115200);  // NOLINT
+  auto *log = new logger::Logger(115200, 64);  // NOLINT
   log->pre_setup();
   log->set_uart_selection(logger::UART_SELECTION_UART0);
   App.register_component_(log);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Fix CI dummy file after #15071

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
