### PR TITLE
[text] Add text_sensor for read-only view of text component

### DIFF
--- a/esphome/components/text/text_sensor/__init__.py
+++ b/esphome/components/text/text_sensor/__init__.py
@@ -1,11 +1,9 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_SOURCE_ID
+from esphome.const import CONF_SOURCE_ID
 
 from .. import Text, text_ns
-
-CODEOWNERS = ["@clydebarrow"]
 
 TextTextSensor = text_ns.class_("TextTextSensor", text_sensor.TextSensor, cg.Component)
 
@@ -23,6 +21,5 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     source = await cg.get_variable(config[CONF_SOURCE_ID])
-    var = cg.new_Pvariable(config[CONF_ID], source)
-    await text_sensor.register_text_sensor(var, config)
+    var = await text_sensor.new_text_sensor(config, source)
     await cg.register_component(var, config)

--- a/esphome/components/text/text_sensor/__init__.py
+++ b/esphome/components/text/text_sensor/__init__.py
@@ -1,0 +1,28 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_SOURCE_ID
+
+from .. import Text, text_ns
+
+CODEOWNERS = ["@clydebarrow"]
+
+TextTextSensor = text_ns.class_("TextTextSensor", text_sensor.TextSensor, cg.Component)
+
+
+CONFIG_SCHEMA = (
+    text_sensor.text_sensor_schema(TextTextSensor)
+    .extend(
+        {
+            cv.Required(CONF_SOURCE_ID): cv.use_id(Text),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+
+async def to_code(config):
+    source = await cg.get_variable(config[CONF_SOURCE_ID])
+    var = cg.new_Pvariable(config[CONF_ID], source)
+    await text_sensor.register_text_sensor(var, config)
+    await cg.register_component(var, config)

--- a/esphome/components/text/text_sensor/text_text_sensor.cpp
+++ b/esphome/components/text/text_sensor/text_text_sensor.cpp
@@ -1,0 +1,16 @@
+#include "text_text_sensor.h"
+#include "esphome/core/log.h"
+
+namespace esphome::text {
+
+static const char *const TAG = "text.text_sensor";
+
+void TextTextSensor::setup() {
+  this->source_->add_on_state_callback([this](const std::string &value) { this->publish_state(value); });
+  if (this->source_->has_state())
+    this->publish_state(this->source_->state);
+}
+
+void TextTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Text Text Sensor", this); }
+
+}  // namespace esphome::text

--- a/esphome/components/text/text_sensor/text_text_sensor.h
+++ b/esphome/components/text/text_sensor/text_text_sensor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../text.h"
+#include "esphome/core/component.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome::text {
+
+class TextTextSensor : public text_sensor::TextSensor, public Component {
+ public:
+  explicit TextTextSensor(Text *source) : source_(source) {}
+  void setup() override;
+  void dump_config() override;
+
+ protected:
+  Text *source_;
+};
+
+}  // namespace esphome::text

--- a/tests/components/text/common.yaml
+++ b/tests/components/text/common.yaml
@@ -23,3 +23,8 @@ text:
     min_length: 8
     max_length: 32
     mode: password
+
+text_sensor:
+  - platform: text
+    name: "Test Text State"
+    source_id: test_text


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

In the same manner as `switch` has a `binary_sensor` platform, add a `text_sensor` implementation for `text` components. This allows the use of the data in contexts where a text sensor is required.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6321

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

text:
  - platform: lvgl
    widget: textarea_id
    id: text_id
    mode: text

text_sensor:
  - platform: text
    name: Text sensor
    source_id: text_id
    on_value:
      - lvgl.label.update:
          id: label_id
          text: !lambda return x;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
