### PR TITLE
[ai] Add instructions regarding constructor parameters

### DIFF
--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -124,6 +124,25 @@ This document provides essential context for AI models interacting with this pro
     *   **Indentation:** Use spaces (two per indentation level), not tabs
     *   **Type aliases:** Prefer `using type_t = int;` over `typedef int type_t;`
     *   **Line length:** Wrap lines at no more than 120 characters
+    *   **Constructor parameters vs setters:** Component properties that are both **required** and **invariant** (never change after construction) should be constructor parameters rather than set via setter methods. This makes the dependency explicit and prevents use of the object in an incompletely-initialized state. In code generation, pass these as arguments to `cg.new_Pvariable()`.
+        ```cpp
+        // Good - required invariant dependency as constructor parameter
+        class TextTextSensor : public text_sensor::TextSensor, public Component {
+         public:
+          explicit TextTextSensor(text::Text *source) : source_(source) {}
+         protected:
+          text::Text *source_;
+        };
+        ```
+        ```cpp
+        // Bad - required invariant dependency as setter
+        class TextTextSensor : public text_sensor::TextSensor, public Component {
+         public:
+          void set_source(text::Text *source) { this->source_ = source; }
+         protected:
+          text::Text *source_{nullptr};
+        };
+        ```
 
 *   **Component Structure:**
     *   **Standard Files:**

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -124,7 +124,10 @@ This document provides essential context for AI models interacting with this pro
     *   **Indentation:** Use spaces (two per indentation level), not tabs
     *   **Type aliases:** Prefer `using type_t = int;` over `typedef int type_t;`
     *   **Line length:** Wrap lines at no more than 120 characters
-    *   **Constructor parameters vs setters:** Component properties that are both **required** and **invariant** (never change after construction) should be constructor parameters rather than set via setter methods. This makes the dependency explicit and prevents use of the object in an incompletely-initialized state. In code generation, pass these as arguments to `cg.new_Pvariable()`.
+    *   **Constructor parameters vs setters:** Component properties that are both **required** and **invariant**
+        (never change after construction) should be constructor parameters rather than set via setter methods.
+        This makes the dependency explicit and prevents use of the object in an incompletely-initialized state.
+        In code generation, pass these as arguments to `cg.new_Pvariable()`.
         ```cpp
         // Good - required invariant dependency as constructor parameter
         class TextTextSensor : public text_sensor::TextSensor, public Component {

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -127,7 +127,7 @@ This document provides essential context for AI models interacting with this pro
     *   **Constructor parameters vs setters:** Component properties that are both **required** and **invariant**
         (never change after construction) should be constructor parameters rather than set via setter methods.
         This makes the dependency explicit and prevents use of the object in an incompletely-initialized state.
-        In code generation, pass these as arguments to `cg.new_Pvariable()`.
+        In code generation, when calling `cg.new_Pvariable()` or the relevant helper function to create the component, pass these as arguments.
         ```cpp
         // Good - required invariant dependency as constructor parameter
         class SourceTextSensor : public text_sensor::TextSensor, public Component {

--- a/.ai/instructions.md
+++ b/.ai/instructions.md
@@ -130,16 +130,16 @@ This document provides essential context for AI models interacting with this pro
         In code generation, pass these as arguments to `cg.new_Pvariable()`.
         ```cpp
         // Good - required invariant dependency as constructor parameter
-        class TextTextSensor : public text_sensor::TextSensor, public Component {
+        class SourceTextSensor : public text_sensor::TextSensor, public Component {
          public:
-          explicit TextTextSensor(text::Text *source) : source_(source) {}
+          explicit SourceTextSensor(text::Text *source) : source_(source) {}
          protected:
           text::Text *source_;
         };
         ```
         ```cpp
         // Bad - required invariant dependency as setter
-        class TextTextSensor : public text_sensor::TextSensor, public Component {
+        class SourceTextSensor : public text_sensor::TextSensor, public Component {
          public:
           void set_source(text::Text *source) { this->source_ = source; }
          protected:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Direct AIs to use constructor parameters in preference to setters for required, invariant properties.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
