### PR TITLE
[mqtt] Fix const-correctness for trigger constructors

### DIFF
--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -366,14 +366,14 @@ class MQTTJsonMessageTrigger : public Trigger<JsonObjectConst> {
 
 class MQTTConnectTrigger : public Trigger<bool> {
  public:
-  explicit MQTTConnectTrigger(MQTTClientComponent *&client) {
+  explicit MQTTConnectTrigger(MQTTClientComponent *client) {
     client->set_on_connect([this](bool session_present) { this->trigger(session_present); });
   }
 };
 
 class MQTTDisconnectTrigger : public Trigger<MQTTClientDisconnectReason> {
  public:
-  explicit MQTTDisconnectTrigger(MQTTClientComponent *&client) {
+  explicit MQTTDisconnectTrigger(MQTTClientComponent *client) {
     client->set_on_disconnect([this](MQTTClientDisconnectReason reason) { this->trigger(reason); });
   }
 };


### PR DESCRIPTION
# What does this implement/fix?

`MQTTConnectTrigger` and `MQTTDisconnectTrigger` constructors took a non-const lvalue reference to a pointer (`MQTTClientComponent *&`), which fails when the generated code passes a const pointer (e.g., from placement new allocation in #15079). Changed to pass by value since the constructors only dereference the pointer, never modify it.

These were the only two instances of this pattern in the codebase.

Fixes CI failures in #14942.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes CI failures in https://github.com/esphome/esphome/pull/14942

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal fix
mqtt:
  on_connect:
    - logger.log: "Connected"
  on_disconnect:
    - logger.log: "Disconnected"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).