### PR TITLE
[core] Fix placement new storage name for templated types

### DIFF
--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -565,6 +565,29 @@ def new_variable(
     return obj
 
 
+def _extract_component_ns(type_str: str) -> str:
+    """Extract the component namespace from a fully-qualified C++ type string.
+
+    Strips leading ``esphome::`` and template arguments, then returns
+    the first namespace segment.  Falls back to ``"esphome"`` when the
+    type has no namespace qualifier (after stripping templates).
+
+    Examples::
+
+        esphome::dsmr::Dsmr                                        -> dsmr
+        esphome::logger::Logger                                     -> logger
+        esphome::Automation<std::optional<bool>, std::optional<bool>> -> esphome
+        Logger                                                      -> esphome
+    """
+    bare = type_str.removeprefix("esphome::")
+    # Strip template arguments before namespace extraction to avoid
+    # matching :: inside template params (e.g. Automation<std::optional<bool>>)
+    bare_no_template = bare.split("<", maxsplit=1)[0]
+    if "::" in bare_no_template:
+        return bare_no_template.split("::", maxsplit=1)[0].rstrip("_")
+    return "esphome"
+
+
 def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
     """Declare a new pointer variable in the code generation.
 
@@ -585,14 +608,7 @@ def Pvariable(id_: ID, rhs: SafeExpType, type_: "MockObj" = None) -> "MockObj":
         # to avoid heap fragmentation on embedded devices.
         the_type = id_.type
         # Extract component namespace from type for memory analysis attribution
-        type_str = str(the_type)
-        # Strip leading esphome:: to get the component namespace
-        # e.g. esphome::dsmr::Dsmr -> dsmr, logger::Logger -> logger
-        bare = type_str.removeprefix("esphome::")
-        if "::" in bare:
-            component_ns = bare.split("::", maxsplit=1)[0].rstrip("_")
-        else:
-            component_ns = "esphome"
+        component_ns = _extract_component_ns(str(the_type))
         storage_name = f"{component_ns}__{id_.id}__pstorage"
 
         # Declare aligned byte array for the object storage

--- a/tests/unit_tests/test_codegen.py
+++ b/tests/unit_tests/test_codegen.py
@@ -1,6 +1,7 @@
 import pytest
 
 from esphome import codegen as cg
+from esphome.cpp_generator import _extract_component_ns
 
 
 # Test interface remains the same.
@@ -75,3 +76,29 @@ from esphome import codegen as cg
 )
 def test_exists(attr):
     assert hasattr(cg, attr)
+
+
+@pytest.mark.parametrize(
+    ("type_str", "expected"),
+    (
+        ("esphome::dsmr::Dsmr", "dsmr"),
+        ("esphome::logger::Logger", "logger"),
+        ("esphome::web_server::WebServer", "web_server"),
+        ("esphome::deep_sleep::DeepSleep", "deep_sleep"),
+        ("esphome::Component", "esphome"),
+        ("Logger", "esphome"),
+        # Template types with :: in template args must not confuse extraction
+        (
+            "esphome::Automation<std::optional<bool>, std::optional<bool>>",
+            "esphome",
+        ),
+        (
+            "esphome::StatelessLambdaAction<std::optional<bool>, std::optional<bool>>",
+            "esphome",
+        ),
+        # Namespaced template type
+        ("esphome::sensor::Sensor<std::string>", "sensor"),
+    ),
+)
+def test_extract_component_ns(type_str, expected):
+    assert _extract_component_ns(type_str) == expected


### PR DESCRIPTION
# What does this implement/fix?

When `Pvariable` types contain template arguments with `::` (e.g. `Automation<std::optional<bool>>`), the namespace extraction logic for placement new storage names incorrectly split on `::` inside the template parameters. This produced invalid C++ identifiers like `Automation<std__automation_id__pstorage`, causing compilation failures.

The fix strips template arguments before extracting the namespace. The logic is extracted into a testable `_extract_component_ns` helper.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes binary_sensor esp8266-ard compilation failure in CI

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP8266

## Example entry for `config.yaml`:

```yaml
# N/A - internal codegen fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).