### PR TITLE
[wifi] Fix roaming attempt counter reset on disconnect during scan

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -269,11 +269,11 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │                              │                                       │
 /// │               ┌──────────────┼──────────────┐                        │
 /// │               ↓              ↓              ↓                        │
-/// │         scan error    no better AP    +10 dB better AP               │
+/// │         disconnect    no better AP    +10 dB better AP               │
 /// │               │              │              │                        │
 /// │               ↓              ↓              ↓                        │
 /// │    ┌──────────────────────────────┐  ┌──────────────────────────┐    │
-/// │    │  → IDLE                      │  │        CONNECTING        │    │
+/// │    │  → RECONNECTING              │  │        CONNECTING        │    │
 /// │    │  (counter preserved)         │  │  (process_roaming_scan_) │    │
 /// │    └──────────────────────────────┘  └────────────┬─────────────┘    │
 /// │                                                  │                   │
@@ -296,7 +296,7 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │  Key behaviors:                                                      │
 /// │  - After 3 checks: attempts >= 3, stop checking                      │
 /// │  - Non-roaming disconnect: clear_roaming_state_() resets counter     │
-/// │  - Scan error (SCANNING→IDLE): counter preserved                     │
+/// │  - Disconnect during scan (SCANNING→RECONNECTING): counter preserved  │
 /// │  - Roaming success (CONNECTING→IDLE): counter reset (can roam again) │
 /// │  - Roaming fail (RECONNECTING→IDLE): counter preserved (ping-pong)   │
 /// └──────────────────────────────────────────────────────────────────────┘
@@ -2072,9 +2072,10 @@ void WiFiComponent::retry_connect() {
     ESP_LOGD(TAG, "Roam failed, reconnecting (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
     this->roaming_state_ = RoamingState::RECONNECTING;
   } else if (this->roaming_state_ == RoamingState::SCANNING) {
-    // Roam scan failed (e.g., scan error on ESP8266) - go back to idle, keep counter
-    ESP_LOGD(TAG, "Roam scan failed (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
-    this->roaming_state_ = RoamingState::IDLE;
+    // Disconnected during roam scan - transition to RECONNECTING so the attempts
+    // counter is preserved when reconnection succeeds (IDLE would reset it)
+    ESP_LOGD(TAG, "Disconnected during roam scan (attempt %u/%u)", this->roaming_attempts_, ROAMING_MAX_ATTEMPTS);
+    this->roaming_state_ = RoamingState::RECONNECTING;
   } else if (this->roaming_state_ == RoamingState::IDLE) {
     // Not a roaming-triggered reconnect, reset state
     this->clear_roaming_state_();


### PR DESCRIPTION
# What does this implement/fix?

When WiFi disconnects while a roaming scan is in progress, the SCANNING state was transitioning to IDLE in `retry_connect()`. When the device then reconnected, `check_connecting_finished()` treated the IDLE state as a normal connection and reset `roaming_attempts_` to 0. This caused the roaming counter to perpetually restart at 1/3 instead of progressing to 2/3, 3/3, creating an infinite loop of roaming scans every 5 minutes.

This is most likely to occur on ESP8266 where disconnect callbacks run immediately in SDK system context (setting `error_from_callback_` before the main loop can process scan results), compared to ESP32 IDF where events are queued and the scan-done event is typically processed before the disconnect.

Fix by transitioning to RECONNECTING instead of IDLE when a disconnect occurs during SCANNING. This preserves the attempts counter on successful reconnection, allowing the device to reach the 3-attempt limit and stop scanning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- https://ptb.discord.com/channels/429907082951524364/1485265230651982035

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes internal roaming state machine behavior
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).