### PR TITLE
[test] Fix flakey ld2412 integration test race condition

### DIFF
--- a/tests/integration/test_uart_mock_ld2412.py
+++ b/tests/integration/test_uart_mock_ld2412.py
@@ -79,9 +79,15 @@ async def test_uart_mock_ld2412(
         ],
     )
 
-    # Signal when we see recovery frame values
+    # Signal when we see all recovery frame values
     recovery_received = collector.add_waiter(
-        lambda: pytest.approx(50.0) in collector.sensor_states["moving_distance"]
+        lambda: (
+            pytest.approx(50.0) in collector.sensor_states["moving_distance"]
+            and pytest.approx(75.0) in collector.sensor_states["still_distance"]
+            and pytest.approx(100.0) in collector.sensor_states["moving_energy"]
+            and pytest.approx(80.0) in collector.sensor_states["still_energy"]
+            and pytest.approx(50.0) in collector.sensor_states["detection_distance"]
+        )
     )
 
     async with (
@@ -150,23 +156,12 @@ async def test_uart_mock_ld2412(
         )
 
         # Recovery frame: moving=50, still=75, energy=100/80, detect=50
-        recovery_idx = next(
-            i
-            for i, v in enumerate(collector.sensor_states["moving_distance"])
-            if v == pytest.approx(50.0)
-        )
-        assert collector.sensor_states["still_distance"][recovery_idx] == pytest.approx(
-            75.0
-        )
-        assert collector.sensor_states["moving_energy"][recovery_idx] == pytest.approx(
-            100.0
-        )
-        assert collector.sensor_states["still_energy"][recovery_idx] == pytest.approx(
-            80.0
-        )
-        assert collector.sensor_states["detection_distance"][
-            recovery_idx
-        ] == pytest.approx(50.0)
+        # Check values exist (waiter already ensured all are present)
+        assert pytest.approx(50.0) in collector.sensor_states["moving_distance"]
+        assert pytest.approx(75.0) in collector.sensor_states["still_distance"]
+        assert pytest.approx(100.0) in collector.sensor_states["moving_energy"]
+        assert pytest.approx(80.0) in collector.sensor_states["still_energy"]
+        assert pytest.approx(50.0) in collector.sensor_states["detection_distance"]
 
         # Verify binary sensors detected targets (from Phase 1 frame)
         assert collector.binary_states["has_target"][0] is True


### PR DESCRIPTION
# What does this implement/fix?

Fix race condition in `test_uart_mock_ld2412` that caused intermittent `IndexError: list index out of range` failures.

The recovery waiter only checked for `moving_distance` containing `50.0`, but assertions used positional indexing (`still_distance[recovery_idx]`) into other sensor lists. Since sensor state updates arrive independently over the API, `still_distance` could have fewer entries than `moving_distance` when the waiter fired.

The fix waits for all recovery values across all sensors before asserting, and uses membership checks (`in`) instead of positional indexing.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (flakey test fix)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).