### PR TITLE
[uart] Rename `FlushResult` to `UARTFlushResult` with `UART_FLUSH_RESULT_` prefix

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1519,16 +1519,16 @@ void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
       resp.instance = msg.instance;
       resp.type = enums::SERIAL_PROXY_REQUEST_TYPE_FLUSH;
       switch (proxies[msg.instance]->flush_port()) {
-        case uart::FlushResult::SUCCESS:
+        case uart::UARTFlushResult::UART_FLUSH_RESULT_SUCCESS:
           resp.status = enums::SERIAL_PROXY_STATUS_OK;
           break;
-        case uart::FlushResult::ASSUMED_SUCCESS:
+        case uart::UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS:
           resp.status = enums::SERIAL_PROXY_STATUS_ASSUMED_SUCCESS;
           break;
-        case uart::FlushResult::TIMEOUT:
+        case uart::UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT:
           resp.status = enums::SERIAL_PROXY_STATUS_TIMEOUT;
           break;
-        case uart::FlushResult::FAILED:
+        case uart::UARTFlushResult::UART_FLUSH_RESULT_FAILED:
           resp.status = enums::SERIAL_PROXY_STATUS_ERROR;
           break;
       }

--- a/esphome/components/ble_nus/ble_nus.cpp
+++ b/esphome/components/ble_nus/ble_nus.cpp
@@ -103,17 +103,17 @@ size_t BLENUS::available() {
 #endif
 }
 
-uart::FlushResult BLENUS::flush() {
+uart::UARTFlushResult BLENUS::flush() {
   constexpr uint32_t timeout_500ms = 500;
   uint32_t start = millis();
   while (atomic_get(&this->tx_status_) != TX_DISABLED && !ring_buf_is_empty(&global_ble_tx_ring_buf)) {
     if (millis() - start > timeout_500ms) {
       ESP_LOGW(TAG, "Flush timeout");
-      return uart::FlushResult::TIMEOUT;
+      return uart::UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT;
     }
     delay(1);
   }
-  return uart::FlushResult::SUCCESS;
+  return uart::UARTFlushResult::UART_FLUSH_RESULT_SUCCESS;
 }
 
 void BLENUS::connected(bt_conn *conn, uint8_t err) {

--- a/esphome/components/ble_nus/ble_nus.h
+++ b/esphome/components/ble_nus/ble_nus.h
@@ -26,7 +26,7 @@ class BLENUS : public uart::UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override;
-  uart::FlushResult flush() override;
+  uart::UARTFlushResult flush() override;
   void check_logger_conflict() override {}
   void set_expose_log(bool expose_log) { this->expose_log_ = expose_log; }
 #ifdef USE_LOGGER

--- a/esphome/components/serial_proxy/serial_proxy.cpp
+++ b/esphome/components/serial_proxy/serial_proxy.cpp
@@ -165,7 +165,7 @@ uint32_t SerialProxy::get_modem_pins() const {
          (this->dtr_state_ ? SERIAL_PROXY_LINE_STATE_FLAG_DTR : 0u);
 }
 
-uart::FlushResult SerialProxy::flush_port() {
+uart::UARTFlushResult SerialProxy::flush_port() {
   ESP_LOGV(TAG, "Flushing serial proxy [%u]", this->instance_index_);
   return this->flush();
 }

--- a/esphome/components/serial_proxy/serial_proxy.h
+++ b/esphome/components/serial_proxy/serial_proxy.h
@@ -92,7 +92,7 @@ class SerialProxy : public uart::UARTDevice, public Component {
   uint32_t get_modem_pins() const;
 
   /// Flush the serial port (block until all TX data is sent)
-  uart::FlushResult flush_port();
+  uart::UARTFlushResult flush_port();
 
   /// Set the RTS GPIO pin (from YAML configuration)
   void set_rts_pin(GPIOPin *pin) { this->rts_pin_ = pin; }

--- a/esphome/components/uart/uart.h
+++ b/esphome/components/uart/uart.h
@@ -45,7 +45,7 @@ class UARTDevice {
 
   size_t available() { return this->parent_->available(); }
 
-  FlushResult flush() { return this->parent_->flush(); }
+  UARTFlushResult flush() { return this->parent_->flush(); }
 
   // Compat APIs
   int read() {

--- a/esphome/components/uart/uart_component.h
+++ b/esphome/components/uart/uart_component.h
@@ -30,17 +30,12 @@ enum UARTDirection {
 const LogString *parity_to_str(UARTParityOptions parity);
 
 /// Result of a flush() call.
-// Some vendor SDKs (e.g., Realtek) define SUCCESS as a macro.
-// Save and restore around the enum to avoid collisions with our scoped enum value.
-#pragma push_macro("SUCCESS")
-#undef SUCCESS
-enum class FlushResult {
-  SUCCESS,          ///< Confirmed: all bytes left the TX FIFO.
-  TIMEOUT,          ///< Confirmed: timed out before TX completed.
-  FAILED,           ///< Confirmed: driver or hardware error.
-  ASSUMED_SUCCESS,  ///< Platform cannot report result; success is assumed.
+enum class UARTFlushResult {
+  UART_FLUSH_RESULT_SUCCESS,          ///< Confirmed: all bytes left the TX FIFO.
+  UART_FLUSH_RESULT_TIMEOUT,          ///< Confirmed: timed out before TX completed.
+  UART_FLUSH_RESULT_FAILED,           ///< Confirmed: driver or hardware error.
+  UART_FLUSH_RESULT_ASSUMED_SUCCESS,  ///< Platform cannot report result; success is assumed.
 };
-#pragma pop_macro("SUCCESS")
 
 class UARTComponent {
  public:
@@ -87,8 +82,8 @@ class UARTComponent {
   virtual size_t available() = 0;
 
   // Pure virtual method to block until all bytes have been written to the UART bus.
-  // @return FlushResult indicating whether the flush was confirmed, timed out, failed, or assumed successful.
-  virtual FlushResult flush() = 0;
+  // @return UARTFlushResult indicating whether the flush was confirmed, timed out, failed, or assumed successful.
+  virtual UARTFlushResult flush() = 0;
 
   // Sets the maximum time to wait for TX to drain during flush().
   // Only meaningful on ESP32 (IDF). Other platforms ignore this value.

--- a/esphome/components/uart/uart_component_esp8266.cpp
+++ b/esphome/components/uart/uart_component_esp8266.cpp
@@ -213,14 +213,14 @@ size_t ESP8266UartComponent::available() {
     return this->sw_serial_->available();
   }
 }
-FlushResult ESP8266UartComponent::flush() {
+UARTFlushResult ESP8266UartComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   if (this->hw_serial_ != nullptr) {
     this->hw_serial_->flush();
   } else {
     this->sw_serial_->flush();
   }
-  return FlushResult::ASSUMED_SUCCESS;
+  return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
 }
 void ESP8266SoftwareSerial::setup(InternalGPIOPin *tx_pin, InternalGPIOPin *rx_pin, uint32_t baud_rate,
                                   uint8_t stop_bits, uint32_t data_bits, UARTParityOptions parity,

--- a/esphome/components/uart/uart_component_esp8266.h
+++ b/esphome/components/uart/uart_component_esp8266.h
@@ -58,7 +58,7 @@ class ESP8266UartComponent : public UARTComponent, public Component {
   bool read_array(uint8_t *data, size_t len) override;
 
   size_t available() override;
-  FlushResult flush() override;
+  UARTFlushResult flush() override;
 
   uint32_t get_config();
 

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -360,15 +360,15 @@ size_t IDFUARTComponent::available() {
   return available;
 }
 
-FlushResult IDFUARTComponent::flush() {
+UARTFlushResult IDFUARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   TickType_t ticks = this->flush_timeout_ms_ == 0 ? portMAX_DELAY : pdMS_TO_TICKS(this->flush_timeout_ms_);
   esp_err_t err = uart_wait_tx_done(this->uart_num_, ticks);
   if (err == ESP_OK)
-    return FlushResult::SUCCESS;
+    return UARTFlushResult::UART_FLUSH_RESULT_SUCCESS;
   if (err == ESP_ERR_TIMEOUT)
-    return FlushResult::TIMEOUT;
-  return FlushResult::FAILED;
+    return UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT;
+  return UARTFlushResult::UART_FLUSH_RESULT_FAILED;
 }
 
 void IDFUARTComponent::check_logger_conflict() {}

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -31,7 +31,7 @@ class IDFUARTComponent : public UARTComponent, public Component {
   bool read_array(uint8_t *data, size_t len) override;
 
   size_t available() override;
-  FlushResult flush() override;
+  UARTFlushResult flush() override;
 
   void set_flush_timeout(uint32_t flush_timeout_ms) override { this->flush_timeout_ms_ = flush_timeout_ms; }
 

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -274,13 +274,13 @@ size_t HostUartComponent::available() {
   return result;
 };
 
-FlushResult HostUartComponent::flush() {
+UARTFlushResult HostUartComponent::flush() {
   if (this->file_descriptor_ == -1) {
-    return FlushResult::ASSUMED_SUCCESS;
+    return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
   }
   tcflush(this->file_descriptor_, TCIOFLUSH);
   ESP_LOGV(TAG, "    Flushing");
-  return FlushResult::ASSUMED_SUCCESS;
+  return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
 }
 
 void HostUartComponent::update_error_(const std::string &error) {

--- a/esphome/components/uart/uart_component_host.h
+++ b/esphome/components/uart/uart_component_host.h
@@ -18,7 +18,7 @@ class HostUartComponent : public UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override;
-  FlushResult flush() override;
+  UARTFlushResult flush() override;
   void set_name(std::string port_name) { port_name_ = port_name; };
 
  protected:

--- a/esphome/components/uart/uart_component_libretiny.cpp
+++ b/esphome/components/uart/uart_component_libretiny.cpp
@@ -170,10 +170,10 @@ bool LibreTinyUARTComponent::read_array(uint8_t *data, size_t len) {
 }
 
 size_t LibreTinyUARTComponent::available() { return this->serial_->available(); }
-FlushResult LibreTinyUARTComponent::flush() {
+UARTFlushResult LibreTinyUARTComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   this->serial_->flush();
-  return FlushResult::ASSUMED_SUCCESS;
+  return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
 }
 
 void LibreTinyUARTComponent::check_logger_conflict() {

--- a/esphome/components/uart/uart_component_libretiny.h
+++ b/esphome/components/uart/uart_component_libretiny.h
@@ -22,7 +22,7 @@ class LibreTinyUARTComponent : public UARTComponent, public Component {
   bool read_array(uint8_t *data, size_t len) override;
 
   size_t available() override;
-  FlushResult flush() override;
+  UARTFlushResult flush() override;
 
   uint16_t get_config();
 

--- a/esphome/components/uart/uart_component_rp2040.cpp
+++ b/esphome/components/uart/uart_component_rp2040.cpp
@@ -208,10 +208,10 @@ bool RP2040UartComponent::read_array(uint8_t *data, size_t len) {
   return true;
 }
 size_t RP2040UartComponent::available() { return this->serial_->available(); }
-FlushResult RP2040UartComponent::flush() {
+UARTFlushResult RP2040UartComponent::flush() {
   ESP_LOGVV(TAG, "    Flushing");
   this->serial_->flush();
-  return FlushResult::ASSUMED_SUCCESS;
+  return UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
 }
 
 }  // namespace esphome::uart

--- a/esphome/components/uart/uart_component_rp2040.h
+++ b/esphome/components/uart/uart_component_rp2040.h
@@ -25,7 +25,7 @@ class RP2040UartComponent : public UARTComponent, public Component {
   bool read_array(uint8_t *data, size_t len) override;
 
   size_t available() override;
-  FlushResult flush() override;
+  UARTFlushResult flush() override;
 
   uint16_t get_config();
 

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm.h
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm.h
@@ -82,7 +82,7 @@ class USBCDCACMInstance : public uart::UARTComponent, public Parented<USBCDCACMC
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override;
-  uart::FlushResult flush() override;
+  uart::UARTFlushResult flush() override;
 
  protected:
   void check_logger_conflict() override;

--- a/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
+++ b/esphome/components/usb_cdc_acm/usb_cdc_acm_esp32.cpp
@@ -325,10 +325,10 @@ size_t USBCDCACMInstance::available() {
   return waiting + (this->has_peek_ ? 1 : 0);
 }
 
-uart::FlushResult USBCDCACMInstance::flush() {
+uart::UARTFlushResult USBCDCACMInstance::flush() {
   // Wait for TX ring buffer to be empty
   if (this->usb_tx_ringbuf_ == nullptr) {
-    return uart::FlushResult::ASSUMED_SUCCESS;
+    return uart::UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
   }
 
   UBaseType_t waiting = 1;
@@ -342,10 +342,10 @@ uart::FlushResult USBCDCACMInstance::flush() {
   // Also wait for USB to finish transmitting
   esp_err_t err = tinyusb_cdcacm_write_flush(static_cast<tinyusb_cdcacm_itf_t>(this->itf_), pdMS_TO_TICKS(100));
   if (err == ESP_OK)
-    return uart::FlushResult::SUCCESS;
+    return uart::UARTFlushResult::UART_FLUSH_RESULT_SUCCESS;
   if (err == ESP_ERR_TIMEOUT)
-    return uart::FlushResult::TIMEOUT;
-  return uart::FlushResult::FAILED;
+    return uart::UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT;
+  return uart::UARTFlushResult::UART_FLUSH_RESULT_FAILED;
 }
 
 void USBCDCACMInstance::check_logger_conflict() {}

--- a/esphome/components/usb_uart/usb_uart.cpp
+++ b/esphome/components/usb_uart/usb_uart.cpp
@@ -169,7 +169,7 @@ void USBUartChannel::write_array(const uint8_t *data, size_t len) {
   this->parent_->start_output(this);
 }
 
-uart::FlushResult USBUartChannel::flush() {
+uart::UARTFlushResult USBUartChannel::flush() {
   // Spin until the output queue is drained and the last USB transfer completes.
   // Safe to call from the main loop only.
   // The flush_timeout_ms_ timeout guards against a device that stops responding mid-flush;
@@ -181,8 +181,8 @@ uart::FlushResult USBUartChannel::flush() {
     yield();
   }
   if (!this->output_queue_.empty() || this->output_started_.load())
-    return uart::FlushResult::TIMEOUT;
-  return uart::FlushResult::SUCCESS;
+    return uart::UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT;
+  return uart::UARTFlushResult::UART_FLUSH_RESULT_SUCCESS;
 }
 
 bool USBUartChannel::peek_byte(uint8_t *data) {

--- a/esphome/components/usb_uart/usb_uart.h
+++ b/esphome/components/usb_uart/usb_uart.h
@@ -140,7 +140,7 @@ class USBUartChannel : public uart::UARTComponent, public Parented<USBUartCompon
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override { return this->input_buffer_.get_available(); }
-  uart::FlushResult flush() override;
+  uart::UARTFlushResult flush() override;
   void check_logger_conflict() override {}
   void set_parity(UARTParityOptions parity) { this->parity_ = parity; }
   void set_debug(bool debug) { this->debug_ = debug; }

--- a/esphome/components/weikai/weikai.cpp
+++ b/esphome/components/weikai/weikai.cpp
@@ -433,16 +433,16 @@ void WeikaiChannel::write_array(const uint8_t *buffer, size_t length) {
   this->reg(0).write_fifo(const_cast<uint8_t *>(buffer), length);
 }
 
-uart::FlushResult WeikaiChannel::flush() {
+uart::UARTFlushResult WeikaiChannel::flush() {
   uint32_t const start_time = millis();
   while (this->tx_fifo_is_not_empty_()) {  // wait until buffer empty
     if (millis() - start_time > 200) {
       ESP_LOGW(TAG, "WARNING flush timeout - still %d bytes not sent after 200 ms", this->tx_in_fifo_());
-      return uart::FlushResult::TIMEOUT;
+      return uart::UARTFlushResult::UART_FLUSH_RESULT_TIMEOUT;
     }
     yield();  // reschedule our thread to avoid blocking
   }
-  return uart::FlushResult::SUCCESS;
+  return uart::UARTFlushResult::UART_FLUSH_RESULT_SUCCESS;
 }
 
 size_t WeikaiChannel::xfer_fifo_to_buffer_() {

--- a/esphome/components/weikai/weikai.h
+++ b/esphome/components/weikai/weikai.h
@@ -380,7 +380,7 @@ class WeikaiChannel : public uart::UARTComponent {
   /// @details If we refer to Serial.flush() in Arduino it says: ** Waits for the transmission of outgoing serial data
   /// to complete. (Prior to Arduino 1.0, this the method was removing any buffered incoming serial data.). ** Therefore
   /// we wait until all bytes are gone with a timeout of 100 ms
-  uart::FlushResult flush() override;
+  uart::UARTFlushResult flush() override;
 
  protected:
   friend class WeikaiComponent;

--- a/tests/components/ld2450/common.h
+++ b/tests/components/ld2450/common.h
@@ -16,7 +16,7 @@ class MockUARTComponent : public uart::UARTComponent {
   MOCK_METHOD(bool, read_array, (uint8_t * data, size_t len), (override));
   MOCK_METHOD(bool, peek_byte, (uint8_t * data), (override));
   MOCK_METHOD(size_t, available, (), (override));
-  MOCK_METHOD(uart::FlushResult, flush, (), (override));
+  MOCK_METHOD(uart::UARTFlushResult, flush, (), (override));
   MOCK_METHOD(void, check_logger_conflict, (), (override));
 };
 

--- a/tests/components/uart/common.h
+++ b/tests/components/uart/common.h
@@ -30,7 +30,7 @@ class MockUARTComponent : public UARTComponent {
   MOCK_METHOD(bool, read_array, (uint8_t * data, size_t len), (override));
   MOCK_METHOD(bool, peek_byte, (uint8_t * data), (override));
   MOCK_METHOD(size_t, available, (), (override));
-  MOCK_METHOD(FlushResult, flush, (), (override));
+  MOCK_METHOD(UARTFlushResult, flush, (), (override));
   MOCK_METHOD(void, check_logger_conflict, (), (override));
 };
 

--- a/tests/integration/fixtures/external_components/uart_mock/uart_mock.cpp
+++ b/tests/integration/fixtures/external_components/uart_mock/uart_mock.cpp
@@ -153,9 +153,9 @@ bool MockUartComponent::read_array(uint8_t *data, size_t len) {
 
 size_t MockUartComponent::available() { return this->rx_buffer_.size(); }
 
-uart::FlushResult MockUartComponent::flush() {
+uart::UARTFlushResult MockUartComponent::flush() {
   // Nothing to flush in mock
-  return uart::FlushResult::ASSUMED_SUCCESS;
+  return uart::UARTFlushResult::UART_FLUSH_RESULT_ASSUMED_SUCCESS;
 }
 
 void MockUartComponent::set_rx_full_threshold(size_t rx_full_threshold) {

--- a/tests/integration/fixtures/external_components/uart_mock/uart_mock.h
+++ b/tests/integration/fixtures/external_components/uart_mock/uart_mock.h
@@ -28,7 +28,7 @@ class MockUartComponent : public uart::UARTComponent, public Component {
   bool peek_byte(uint8_t *data) override;
   bool read_array(uint8_t *data, size_t len) override;
   size_t available() override;
-  uart::FlushResult flush() override;
+  uart::UARTFlushResult flush() override;
   void set_rx_full_threshold(size_t rx_full_threshold) override;
   void set_rx_timeout(size_t rx_timeout) override;
 


### PR DESCRIPTION
# What does this implement/fix?

Renames the `FlushResult` scoped enum and its values to follow ESPHome's conventional component-prefix naming style (matching e.g. `UARTParityOptions` / `UART_CONFIG_PARITY_NONE`):

| Before | After |
|---|---|
| `FlushResult` | `UARTFlushResult` |
| `::SUCCESS` | `::UART_FLUSH_RESULT_SUCCESS` |
| `::TIMEOUT` | `::UART_FLUSH_RESULT_TIMEOUT` |
| `::FAILED` | `::UART_FLUSH_RESULT_FAILED` |
| `::ASSUMED_SUCCESS` | `::UART_FLUSH_RESULT_ASSUMED_SUCCESS` |

This also removes the `#pragma push_macro` / `#undef SUCCESS` / `#pragma pop_macro` workaround added in #15054 to avoid collisions with the Realtek RTL SDK's `#define SUCCESS 0` macro — with the new names the collision can no longer occur.

Discussed in #15054.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- relates to https://github.com/esphome/esphome/pull/15054

**Migration path:** External components implementing `flush()` must rename their returned type and enum values. Replace `FlushResult` with `UARTFlushResult` and prefix all enum values with `UART_` (e.g. `::SUCCESS` → `::UART_FLUSH_RESULT_SUCCESS`).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing configuration changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes — this is an internal API rename only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).