### PR TITLE
[esp32] Patch DRAM segment for testing mode to fix grouped component test overflow

### DIFF
--- a/esphome/components/esp32/iram_fix.py.script
+++ b/esphome/components/esp32/iram_fix.py.script
@@ -9,32 +9,31 @@ TESTING_IRAM_SIZE = 0x200000  # 2MB
 TESTING_DRAM_SIZE = 0x200000  # 2MB
 
 
-def patch_segment(lines, segment_name, new_size):
-    """Patch a memory segment's length in linker script lines.
+def patch_segment(content, segment_name, new_size):
+    """Patch a memory segment's length in linker script content.
 
-    ESP-IDF format can be:
+    Handles both single-line and multi-line segment definitions, e.g.:
       iram0_0_seg (RX) : org = 0x40080000, len = 0x20000 + 0x0
-    or more complex with nested parentheses:
-      iram0_0_seg (RX) : org = (0x40370000 + 0x4000), len = ((...) + 0x8000 - 0x4000)
+    or split across lines:
+      dram0_0_seg (RW) : org = 0x3FFB0000 + 0xdb5c,
+                                       len = 0x2c200 - 0xdb5c
 
     Args:
-        lines: List of linker script lines
+        content: Full linker script content as string
         segment_name: Name of the segment (e.g., 'iram0_0_seg')
         new_size: New size as integer
 
     Returns:
-        True if patched, False otherwise
+        Tuple of (new_content, was_patched)
     """
-    # Match segment definition with any org expression (including nested parens)
-    # and capture everything up to and including "len = " so we can replace the len value
-    pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*.+?,\s*len\s*=\s*)(.+?)(\s*)$'
-    for i, line in enumerate(lines):
-        if segment_name in line and 'len' in line and (match := re.search(pattern, line)):
-            new_line = f"{match.group(1)}{new_size:#x}{match.group(3)}"
-            if new_line != line:
-                lines[i] = new_line
-                return True
-    return False
+    # Match segment name through to "len = <value>" allowing newlines between org and len
+    pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*.+?,\s*len\s*=\s*)(\S+[^\n]*)'
+    if match := re.search(pattern, content, re.DOTALL):
+        replacement = f"{match.group(1)}{new_size:#x}"
+        new_content = content[:match.start()] + replacement + content[match.end():]
+        if new_content != content:
+            return new_content, True
+    return content, False
 
 
 def patch_idf_linker_script(source, target, env):
@@ -63,19 +62,19 @@ def patch_idf_linker_script(source, target, env):
         print(f"ESPHome: Error reading linker script: {e}")
         return
 
-    lines = content.split('\n')
     patches = []
 
-    if patch_segment(lines, 'iram0_0_seg', TESTING_IRAM_SIZE):
+    content, patched = patch_segment(content, 'iram0_0_seg', TESTING_IRAM_SIZE)
+    if patched:
         patches.append(f"IRAM={TESTING_IRAM_SIZE:#x}")
 
-    if patch_segment(lines, 'dram0_0_seg', TESTING_DRAM_SIZE):
+    content, patched = patch_segment(content, 'dram0_0_seg', TESTING_DRAM_SIZE)
+    if patched:
         patches.append(f"DRAM={TESTING_DRAM_SIZE:#x}")
 
     if patches:
-        updated = '\n'.join(lines)
         with open(memory_ld, "w") as f:
-            f.write(updated)
+            f.write(content)
         print(f"ESPHome: Patched {', '.join(patches)} in {memory_ld} for testing mode")
     else:
         print(f"ESPHome: Warning - could not patch memory segments in {memory_ld}")

--- a/esphome/components/esp32/iram_fix.py.script
+++ b/esphome/components/esp32/iram_fix.py.script
@@ -4,12 +4,39 @@ import re
 # pylint: disable=E0602
 Import("env")  # noqa
 
-# IRAM size for testing mode (2MB - large enough to accommodate grouped tests)
-TESTING_IRAM_SIZE = 0x200000
+# Memory sizes for testing mode (large enough to accommodate grouped tests)
+TESTING_IRAM_SIZE = 0x200000  # 2MB
+TESTING_DRAM_SIZE = 0x200000  # 2MB
+
+
+def patch_segment(lines, segment_name, new_size):
+    """Patch a memory segment's length in linker script lines.
+
+    ESP-IDF format can be:
+      iram0_0_seg (RX) : org = 0x40080000, len = 0x20000 + 0x0
+    or more complex with nested parentheses:
+      iram0_0_seg (RX) : org = (0x40370000 + 0x4000), len = ((...) + 0x8000 - 0x4000)
+
+    Args:
+        lines: List of linker script lines
+        segment_name: Name of the segment (e.g., 'iram0_0_seg')
+        new_size: New size as integer
+
+    Returns:
+        True if patched, False otherwise
+    """
+    pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*(?:\([^)]+\)|0x[0-9a-fA-F]+)\s*,\s*len\s*=\s*)(.+?)(\s*)$'
+    for i, line in enumerate(lines):
+        if segment_name in line and 'len' in line:
+            match = re.search(pattern, line)
+            if match:
+                lines[i] = f"{match.group(1)}{new_size:#x}{match.group(3)}"
+                return True
+    return False
 
 
 def patch_idf_linker_script(source, target, env):
-    """Patch ESP-IDF linker script to increase IRAM size for testing mode."""
+    """Patch ESP-IDF linker script to increase IRAM and DRAM size for testing mode."""
     # Check if we're in testing mode by looking for the define
     build_flags = env.get("BUILD_FLAGS", [])
     testing_mode = any("-DESPHOME_TESTING_MODE" in flag for flag in build_flags)
@@ -34,36 +61,22 @@ def patch_idf_linker_script(source, target, env):
         print(f"ESPHome: Error reading linker script: {e}")
         return
 
-    # Check if this file contains iram0_0_seg
-    if 'iram0_0_seg' not in content:
-        print(f"ESPHome: Warning - iram0_0_seg not found in {memory_ld}")
-        return
-
-    # Look for iram0_0_seg definition and increase its length
-    # ESP-IDF format can be:
-    #   iram0_0_seg (RX) : org = 0x40080000, len = 0x20000 + 0x0
-    # or more complex with nested parentheses:
-    #   iram0_0_seg (RX) : org = (0x40370000 + 0x4000), len = (((0x403CB700 - (0x40378000 - 0x3FC88000)) - 0x3FC88000) + 0x8000 - 0x4000)
-    # We want to change len to TESTING_IRAM_SIZE for testing
-
-    # Use a more robust approach: find the line and manually parse it
     lines = content.split('\n')
-    for i, line in enumerate(lines):
-        if 'iram0_0_seg' in line and 'len' in line:
-            # Find the position of "len = " and replace everything after it until the end of the statement
-            match = re.search(r'(iram0_0_seg\s*\([^)]*\)\s*:\s*org\s*=\s*(?:\([^)]+\)|0x[0-9a-fA-F]+)\s*,\s*len\s*=\s*)(.+?)(\s*)$', line)
-            if match:
-                lines[i] = f"{match.group(1)}{TESTING_IRAM_SIZE:#x}{match.group(3)}"
-                break
+    patches = []
 
-    updated = '\n'.join(lines)
+    if patch_segment(lines, 'iram0_0_seg', TESTING_IRAM_SIZE):
+        patches.append(f"IRAM={TESTING_IRAM_SIZE:#x}")
 
-    if updated != content:
+    if patch_segment(lines, 'dram0_0_seg', TESTING_DRAM_SIZE):
+        patches.append(f"DRAM={TESTING_DRAM_SIZE:#x}")
+
+    if patches:
+        updated = '\n'.join(lines)
         with open(memory_ld, "w") as f:
             f.write(updated)
-        print(f"ESPHome: Patched IRAM size to {TESTING_IRAM_SIZE:#x} in {memory_ld} for testing mode")
+        print(f"ESPHome: Patched {', '.join(patches)} in {memory_ld} for testing mode")
     else:
-        print(f"ESPHome: Warning - could not patch iram0_0_seg in {memory_ld}")
+        print(f"ESPHome: Warning - could not patch memory segments in {memory_ld}")
 
 
 # Hook into the build process before linking

--- a/esphome/components/esp32/iram_fix.py.script
+++ b/esphome/components/esp32/iram_fix.py.script
@@ -25,13 +25,17 @@ def patch_segment(lines, segment_name, new_size):
     Returns:
         True if patched, False otherwise
     """
-    pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*(?:\([^)]+\)|0x[0-9a-fA-F]+)\s*,\s*len\s*=\s*)(.+?)(\s*)$'
+    # Match segment definition with any org expression (including nested parens)
+    # and capture everything up to and including "len = " so we can replace the len value
+    pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*.+?,\s*len\s*=\s*)(.+?)(\s*)$'
     for i, line in enumerate(lines):
         if segment_name in line and 'len' in line:
             match = re.search(pattern, line)
             if match:
-                lines[i] = f"{match.group(1)}{new_size:#x}{match.group(3)}"
-                return True
+                new_line = f"{match.group(1)}{new_size:#x}{match.group(3)}"
+                if new_line != line:
+                    lines[i] = new_line
+                    return True
     return False
 
 

--- a/esphome/components/esp32/iram_fix.py.script
+++ b/esphome/components/esp32/iram_fix.py.script
@@ -29,12 +29,11 @@ def patch_segment(lines, segment_name, new_size):
     # and capture everything up to and including "len = " so we can replace the len value
     pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*.+?,\s*len\s*=\s*)(.+?)(\s*)$'
     for i, line in enumerate(lines):
-        if segment_name in line and 'len' in line:
-            if match := re.search(pattern, line):
-                new_line = f"{match.group(1)}{new_size:#x}{match.group(3)}"
-                if new_line != line:
-                    lines[i] = new_line
-                    return True
+        if segment_name in line and 'len' in line and (match := re.search(pattern, line)):
+            new_line = f"{match.group(1)}{new_size:#x}{match.group(3)}"
+            if new_line != line:
+                lines[i] = new_line
+                return True
     return False
 
 

--- a/esphome/components/esp32/iram_fix.py.script
+++ b/esphome/components/esp32/iram_fix.py.script
@@ -30,8 +30,7 @@ def patch_segment(lines, segment_name, new_size):
     pattern = rf'({re.escape(segment_name)}\s*\([^)]*\)\s*:\s*org\s*=\s*.+?,\s*len\s*=\s*)(.+?)(\s*)$'
     for i, line in enumerate(lines):
         if segment_name in line and 'len' in line:
-            match = re.search(pattern, line)
-            if match:
+            if match := re.search(pattern, line):
                 new_line = f"{match.group(1)}{new_size:#x}{match.group(3)}"
                 if new_line != line:
                     lines[i] = new_line


### PR DESCRIPTION
# What does this implement/fix?

The `iram_fix.py.script` already patched IRAM for testing mode but did not patch DRAM. Grouped component tests on ESP32 IDF overflow `dram0_0_seg` when many components (e.g. BLE-heavy + IDF-only like wireguard, bme680_bsec) are merged into a single build.

This extends the script to also enlarge `dram0_0_seg` to 2MB in testing mode, matching the approach used by ESP8266's `testing_mode.py.script`.

The segment patching logic is refactored into a shared `patch_segment()` helper to avoid duplication.

Overflow seen in CI: `region 'dram0_0_seg' overflowed by 13776 bytes`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a (CI failure in grouped component tests)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable - this is a build infrastructure fix for testing mode only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).