### PR TITLE
[light] Validate effect names during config validation instead of codegen

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -128,6 +128,27 @@ def _get_or_create_gamma_table(gamma_correct):
     return fwd_arr
 
 
+def find_effect_index(effects: list, effect_name: str) -> int | None:
+    """Find the 1-based index of an effect by name (case-insensitive).
+
+    Returns the 1-based index if found, or None if not found.
+    """
+    effect_name_lower = effect_name.lower()
+    for i, effect_conf in enumerate(effects):
+        key = next(iter(effect_conf))
+        if effect_conf[key][CONF_NAME].lower() == effect_name_lower:
+            return i + 1
+    return None
+
+
+def available_effects_str(effects: list) -> str:
+    """Return a comma-separated string of available effect names."""
+    available = [
+        effect_conf[next(iter(effect_conf))][CONF_NAME] for effect_conf in effects
+    ]
+    return ", ".join(f"'{name}'" for name in available) if available else "none"
+
+
 def _final_validate(config: ConfigType) -> ConfigType:
     """Validate all recorded effect name references against their target lights."""
     data = _get_data()
@@ -145,26 +166,12 @@ def _final_validate(config: ConfigType) -> ConfigType:
             continue
 
         effects = light_config.get(CONF_EFFECTS, [])
-        effect_name_lower = ref.effect_name.lower()
 
-        found = False
-        for effect_conf in effects:
-            key = next(iter(effect_conf))
-            if effect_conf[key][CONF_NAME].lower() == effect_name_lower:
-                found = True
-                break
-
-        if not found:
-            available = [
-                effect_conf[next(iter(effect_conf))][CONF_NAME]
-                for effect_conf in effects
-            ]
-            available_str = (
-                ", ".join(f"'{name}'" for name in available) if available else "none"
-            )
+        if find_effect_index(effects, ref.effect_name) is None:
             raise cv.FinalExternalInvalid(
                 f"Effect '{ref.effect_name}' not found for light "
-                f"'{ref.light_id}'. Available effects: {available_str}",
+                f"'{ref.light_id}'. "
+                f"Available effects: {available_effects_str(effects)}",
                 path=[cv.ROOT_CONFIG_PATH] + ref.component_path,
             )
 

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -155,9 +155,14 @@ def _final_validate(config: ConfigType) -> ConfigType:
     if not data.effect_refs:
         return config
 
+    # Drain the list so we only validate once even though
+    # FINAL_VALIDATE_SCHEMA runs for each light platform instance.
+    refs = data.effect_refs
+    data.effect_refs = []
+
     fconf = fv.full_config.get()
 
-    for ref in data.effect_refs:
+    for ref in refs:
         try:
             light_path = fconf.get_path_for_id(ref.light_id)[:-1]
             light_config = fconf.get_config_for_path(light_path)

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -24,6 +24,7 @@ from esphome.const import (
     CONF_ID,
     CONF_INITIAL_STATE,
     CONF_MQTT_ID,
+    CONF_NAME,
     CONF_ON_STATE,
     CONF_ON_TURN_OFF,
     CONF_ON_TURN_ON,
@@ -41,6 +42,8 @@ from esphome.const import (
 from esphome.core import CORE, ID, CoroPriority, HexInt, coroutine_with_priority
 from esphome.core.entity_helpers import entity_duplicate_validator, setup_entity
 from esphome.cpp_generator import MockObjClass
+import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 from .automation import LIGHT_STATE_SCHEMA
 from .effects import (
@@ -71,8 +74,18 @@ DOMAIN = "light"
 
 
 @dataclass
+class EffectRef:
+    """A pending effect name reference from a light action to validate."""
+
+    light_id: str
+    effect_name: str
+    component_path: list  # path_context when the action was validated
+
+
+@dataclass
 class LightData:
     gamma_tables: dict = field(default_factory=dict)  # gamma_value -> fwd_arr
+    effect_refs: list[EffectRef] = field(default_factory=list)
 
 
 def _get_data() -> LightData:
@@ -113,6 +126,52 @@ def _get_or_create_gamma_table(gamma_correct):
     fwd_arr = cg.progmem_array(fwd_id, forward)
     data.gamma_tables[gamma_correct] = fwd_arr
     return fwd_arr
+
+
+def _final_validate(config: ConfigType) -> ConfigType:
+    """Validate all recorded effect name references against their target lights."""
+    data = _get_data()
+    if not data.effect_refs:
+        return config
+
+    fconf = fv.full_config.get()
+
+    for ref in data.effect_refs:
+        try:
+            light_path = fconf.get_path_for_id(ref.light_id)[:-1]
+            light_config = fconf.get_config_for_path(light_path)
+        except KeyError:
+            # Light ID not found — ID validation will have already reported this
+            continue
+
+        effects = light_config.get(CONF_EFFECTS, [])
+        effect_name_lower = ref.effect_name.lower()
+
+        found = False
+        for effect_conf in effects:
+            key = next(iter(effect_conf))
+            if effect_conf[key][CONF_NAME].lower() == effect_name_lower:
+                found = True
+                break
+
+        if not found:
+            available = [
+                effect_conf[next(iter(effect_conf))][CONF_NAME]
+                for effect_conf in effects
+            ]
+            available_str = (
+                ", ".join(f"'{name}'" for name in available) if available else "none"
+            )
+            raise cv.FinalExternalInvalid(
+                f"Effect '{ref.effect_name}' not found for light "
+                f"'{ref.light_id}'. Available effects: {available_str}",
+                path=[cv.ROOT_CONFIG_PATH] + ref.component_path,
+            )
+
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 LightRestoreMode = light_ns.enum("LightRestoreMode")

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -77,7 +77,7 @@ DOMAIN = "light"
 class EffectRef:
     """A pending effect name reference from a light action to validate."""
 
-    light_id: str
+    light_id: ID
     effect_name: str
     component_path: list  # path_context when the action was validated
 

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -150,7 +150,11 @@ def available_effects_str(effects: list) -> str:
 
 
 def _final_validate(config: ConfigType) -> ConfigType:
-    """Validate all recorded effect name references against their target lights."""
+    """Validate all recorded effect name references against their target lights.
+
+    This runs once per light platform instance. If no light platform is configured,
+    this never runs — but the ID validator will catch the missing light ID separately.
+    """
     data = _get_data()
     if not data.effect_refs:
         return config

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -79,7 +79,7 @@ class EffectRef:
 
     light_id: ID
     effect_name: str
-    component_path: list  # path_context when the action was validated
+    component_path: list[str | int]  # path_context when the action was validated
 
 
 @dataclass

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -1,5 +1,6 @@
 from esphome import automation
 import esphome.codegen as cg
+from esphome.config import path_context
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BLUE,
@@ -26,7 +27,7 @@ from esphome.const import (
     CONF_WARM_WHITE,
     CONF_WHITE,
 )
-from esphome.core import CORE, Lambda
+from esphome.core import CORE, EsphomeError, Lambda
 from esphome.cpp_generator import LambdaExpression
 from esphome.types import ConfigType
 
@@ -98,6 +99,31 @@ LIGHT_CONTROL_ACTION_SCHEMA = LIGHT_STATE_SCHEMA.extend(
     }
 )
 
+
+def _record_effect_ref(config):
+    """Record a static effect name reference for later cross-component validation."""
+    if CONF_EFFECT not in config:
+        return config
+    effect = config[CONF_EFFECT]
+    if isinstance(effect, Lambda):
+        return config  # Lambda effects resolved at runtime
+    if effect.lower() == "none":
+        return config  # "None" is always valid
+
+    from . import EffectRef, _get_data
+
+    _get_data().effect_refs.append(
+        EffectRef(
+            light_id=config[CONF_ID],
+            effect_name=effect,
+            component_path=path_context.get(),
+        )
+    )
+    return config
+
+
+LIGHT_CONTROL_ACTION_SCHEMA.add_extra(_record_effect_ref)
+
 LIGHT_TURN_OFF_ACTION_SCHEMA = automation.maybe_simple_id(
     {
         cv.Required(CONF_ID): cv.use_id(LightState),
@@ -129,11 +155,21 @@ def _resolve_effect_index(config: ConfigType) -> int:
     light_id = config[CONF_ID]
     light_path = CORE.config.get_path_for_id(light_id)[:-1]
     light_config = CORE.config.get_config_for_path(light_path)
-    for i, effect_conf in enumerate(light_config.get(CONF_EFFECTS, [])):
+    effects = light_config.get(CONF_EFFECTS, [])
+    for i, effect_conf in enumerate(effects):
         key = next(iter(effect_conf))
         if effect_conf[key][CONF_NAME].lower() == effect_name:
             return i + 1
-    raise ValueError(f"Effect '{original_name}' not found in light '{light_id}'")
+    available = [
+        effect_conf[next(iter(effect_conf))][CONF_NAME] for effect_conf in effects
+    ]
+    available_str = (
+        ", ".join(f"'{name}'" for name in available) if available else "none"
+    )
+    raise EsphomeError(
+        f"Effect '{original_name}' not found for light '{light_id}'. "
+        f"Available effects: {available_str}"
+    )
 
 
 @automation.register_action(

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -18,7 +18,6 @@ from esphome.const import (
     CONF_LIMIT_MODE,
     CONF_MAX_BRIGHTNESS,
     CONF_MIN_BRIGHTNESS,
-    CONF_NAME,
     CONF_RANGE_FROM,
     CONF_RANGE_TO,
     CONF_RED,
@@ -148,29 +147,23 @@ def _resolve_effect_index(config: ConfigType) -> int:
     Effect index 0 means "None" (no effect). Effects are 1-indexed matching
     the C++ convention in LightState.
     """
+    from . import available_effects_str, find_effect_index
+
     original_name = config[CONF_EFFECT]
-    effect_name = original_name.lower()
-    if effect_name == "none":
+    if original_name.lower() == "none":
         return 0
     light_id = config[CONF_ID]
     light_path = CORE.config.get_path_for_id(light_id)[:-1]
     light_config = CORE.config.get_config_for_path(light_path)
     effects = light_config.get(CONF_EFFECTS, [])
-    for i, effect_conf in enumerate(effects):
-        key = next(iter(effect_conf))
-        if effect_conf[key][CONF_NAME].lower() == effect_name:
-            return i + 1
-    available = [
-        effect_conf[next(iter(effect_conf))][CONF_NAME] for effect_conf in effects
-    ]
-    available_str = (
-        ", ".join(f"'{name}'" for name in available) if available else "none"
-    )
+    index = find_effect_index(effects, original_name)
+    if index is not None:
+        return index
     # Should never reach here — effect names are validated during config
     # validation in FINAL_VALIDATE_SCHEMA. This is a safety net.
     raise EsphomeError(
         f"Effect '{original_name}' not found for light '{light_id}'. "
-        f"Available effects: {available_str}"
+        f"Available effects: {available_effects_str(effects)}"
     )
 
 

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -100,7 +100,7 @@ LIGHT_CONTROL_ACTION_SCHEMA = LIGHT_STATE_SCHEMA.extend(
 )
 
 
-def _record_effect_ref(config):
+def _record_effect_ref(config: ConfigType) -> ConfigType:
     """Record a static effect name reference for later cross-component validation."""
     if CONF_EFFECT not in config:
         return config

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -166,6 +166,8 @@ def _resolve_effect_index(config: ConfigType) -> int:
     available_str = (
         ", ".join(f"'{name}'" for name in available) if available else "none"
     )
+    # Should never reach here — effect names are validated during config
+    # validation in FINAL_VALIDATE_SCHEMA. This is a safety net.
     raise EsphomeError(
         f"Effect '{original_name}' not found for light '{light_id}'. "
         f"Available effects: {available_str}"

--- a/tests/component_tests/light/test_effect_validation.py
+++ b/tests/component_tests/light/test_effect_validation.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextvars import Token
+
 import pytest
 
 from esphome import config_validation as cv
@@ -17,275 +20,261 @@ from esphome.config import Config, path_context
 from esphome.const import CONF_EFFECT, CONF_EFFECTS, CONF_ID, CONF_NAME
 from esphome.core import ID, Lambda
 import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 
-def _make_effects(*names: str) -> list[dict]:
+def _make_effects(*names: str) -> list[dict[str, dict[str, str]]]:
     """Create a list of effect config dicts from names."""
     return [{f"effect_{i}": {CONF_NAME: name}} for i, name in enumerate(names)]
 
 
-class TestFindEffectIndex:
-    """Tests for find_effect_index helper."""
-
-    def test_found(self) -> None:
-        effects = _make_effects("Fast Pulse", "Slow Pulse")
-        assert find_effect_index(effects, "Fast Pulse") == 1
-        assert find_effect_index(effects, "Slow Pulse") == 2
-
-    def test_case_insensitive(self) -> None:
-        effects = _make_effects("Fast Pulse")
-        assert find_effect_index(effects, "fast pulse") == 1
-        assert find_effect_index(effects, "FAST PULSE") == 1
-
-    def test_not_found(self) -> None:
-        effects = _make_effects("Fast Pulse", "Slow Pulse")
-        assert find_effect_index(effects, "Missing") is None
-
-    def test_empty_effects(self) -> None:
-        assert find_effect_index([], "anything") is None
+# --- find_effect_index ---
 
 
-class TestAvailableEffectsStr:
-    """Tests for available_effects_str helper."""
-
-    def test_multiple(self) -> None:
-        effects = _make_effects("Fast Pulse", "Slow Pulse")
-        assert available_effects_str(effects) == "'Fast Pulse', 'Slow Pulse'"
-
-    def test_single(self) -> None:
-        effects = _make_effects("Fast Pulse")
-        assert available_effects_str(effects) == "'Fast Pulse'"
-
-    def test_empty(self) -> None:
-        assert available_effects_str([]) == "none"
+def test_find_effect_index_found() -> None:
+    effects = _make_effects("Fast Pulse", "Slow Pulse")
+    assert find_effect_index(effects, "Fast Pulse") == 1
+    assert find_effect_index(effects, "Slow Pulse") == 2
 
 
-class TestFinalValidateEffectRefs:
-    """Tests for _final_validate effect reference checking."""
+def test_find_effect_index_case_insensitive() -> None:
+    effects = _make_effects("Fast Pulse")
+    assert find_effect_index(effects, "fast pulse") == 1
+    assert find_effect_index(effects, "FAST PULSE") == 1
 
-    def test_valid_effect_passes(self) -> None:
-        """Valid effect name should not raise."""
-        data = _get_data()
-        light_id = ID("led1", is_declaration=True)
-        data.effect_refs = [
+
+def test_find_effect_index_not_found() -> None:
+    effects = _make_effects("Fast Pulse", "Slow Pulse")
+    assert find_effect_index(effects, "Missing") is None
+
+
+def test_find_effect_index_empty() -> None:
+    assert find_effect_index([], "anything") is None
+
+
+# --- available_effects_str ---
+
+
+def test_available_effects_str_multiple() -> None:
+    effects = _make_effects("Fast Pulse", "Slow Pulse")
+    assert available_effects_str(effects) == "'Fast Pulse', 'Slow Pulse'"
+
+
+def test_available_effects_str_single() -> None:
+    effects = _make_effects("Fast Pulse")
+    assert available_effects_str(effects) == "'Fast Pulse'"
+
+
+def test_available_effects_str_empty() -> None:
+    assert available_effects_str([]) == "none"
+
+
+# --- _final_validate ---
+
+
+def _setup_final_validate(
+    effect_refs: list[EffectRef],
+    light_configs: list[ConfigType],
+    declare_ids: list[tuple[ID, list[str | int]]],
+) -> Token:
+    """Set up CORE.data and fv.full_config for _final_validate tests."""
+    data = _get_data()
+    data.effect_refs = effect_refs
+
+    full_conf = Config()
+    full_conf["light"] = light_configs
+    for id_, path in declare_ids:
+        full_conf.declare_ids.append((id_, path))
+
+    return fv.full_config.set(full_conf)
+
+
+def test_final_validate_valid_effect() -> None:
+    """Valid effect name should not raise."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_final_validate(
+        effect_refs=[
             EffectRef(
-                light_id=light_id,
-                effect_name="Fast Pulse",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        full_conf["light"] = [
-            {
-                CONF_ID: light_id,
-                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
-            }
-        ]
-        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
-
-        token = fv.full_config.set(full_conf)
-        try:
-            _final_validate({})
-        finally:
-            fv.full_config.reset(token)
-
-    def test_invalid_effect_raises(self) -> None:
-        """Invalid effect name should raise FinalExternalInvalid."""
-        data = _get_data()
-        light_id = ID("led1", is_declaration=True)
-        data.effect_refs = [
-            EffectRef(
-                light_id=light_id,
-                effect_name="Nonexistent",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        full_conf["light"] = [
-            {
-                CONF_ID: light_id,
-                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
-            }
-        ]
-        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
-
-        token = fv.full_config.set(full_conf)
-        try:
-            with pytest.raises(cv.FinalExternalInvalid, match="Nonexistent"):
-                _final_validate({})
-        finally:
-            fv.full_config.reset(token)
-
-    def test_invalid_effect_lists_available(self) -> None:
-        """Error message should list available effects."""
-        data = _get_data()
-        light_id = ID("led1", is_declaration=True)
-        data.effect_refs = [
-            EffectRef(
-                light_id=light_id,
-                effect_name="Missing",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        full_conf["light"] = [
-            {
-                CONF_ID: light_id,
-                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
-            }
-        ]
-        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
-
-        token = fv.full_config.set(full_conf)
-        try:
-            with pytest.raises(
-                cv.FinalExternalInvalid, match="'Fast Pulse', 'Slow Pulse'"
-            ):
-                _final_validate({})
-        finally:
-            fv.full_config.reset(token)
-
-    def test_no_effects_on_light(self) -> None:
-        """Light with no effects should report 'none' as available."""
-        data = _get_data()
-        light_id = ID("led1", is_declaration=True)
-        data.effect_refs = [
-            EffectRef(
-                light_id=light_id,
-                effect_name="Missing",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        full_conf["light"] = [{CONF_ID: light_id}]
-        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
-
-        token = fv.full_config.set(full_conf)
-        try:
-            with pytest.raises(
-                cv.FinalExternalInvalid, match="Available effects: none"
-            ):
-                _final_validate({})
-        finally:
-            fv.full_config.reset(token)
-
-    def test_no_refs_is_noop(self) -> None:
-        """No stored refs should pass without error."""
-        data = _get_data()
-        data.effect_refs = []
+                light_id=light_id, effect_name="Fast Pulse", component_path=["esphome"]
+            ),
+        ],
+        light_configs=[
+            {CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse")}
+        ],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
         _final_validate({})
+    finally:
+        fv.full_config.reset(token)
 
-    def test_unknown_light_id_skipped(self) -> None:
-        """Refs to unknown light IDs should be silently skipped."""
-        data = _get_data()
-        data.effect_refs = [
+
+def test_final_validate_invalid_effect_raises() -> None:
+    """Invalid effect name should raise FinalExternalInvalid."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_final_validate(
+        effect_refs=[
             EffectRef(
-                light_id=ID("nonexistent", is_declaration=True),
-                effect_name="Missing",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        token = fv.full_config.set(full_conf)
-        try:
-            _final_validate({})  # Should not raise
-        finally:
-            fv.full_config.reset(token)
-
-    def test_drains_refs(self) -> None:
-        """Refs should be drained after validation to avoid redundant runs."""
-        data = _get_data()
-        light_id = ID("led1", is_declaration=True)
-        data.effect_refs = [
-            EffectRef(
-                light_id=light_id,
-                effect_name="Fast Pulse",
-                component_path=["esphome"],
-            )
-        ]
-
-        full_conf = Config()
-        full_conf["light"] = [
-            {
-                CONF_ID: light_id,
-                CONF_EFFECTS: _make_effects("Fast Pulse"),
-            }
-        ]
-        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
-
-        token = fv.full_config.set(full_conf)
-        try:
+                light_id=light_id, effect_name="Nonexistent", component_path=["esphome"]
+            ),
+        ],
+        light_configs=[
+            {CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse")}
+        ],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        with pytest.raises(cv.FinalExternalInvalid, match="Nonexistent"):
             _final_validate({})
-            assert data.effect_refs == []
-        finally:
-            fv.full_config.reset(token)
+    finally:
+        fv.full_config.reset(token)
 
 
-class TestRecordEffectRef:
-    """Tests for _record_effect_ref schema validator."""
+def test_final_validate_lists_available_effects() -> None:
+    """Error message should list available effects."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_final_validate(
+        effect_refs=[
+            EffectRef(
+                light_id=light_id, effect_name="Missing", component_path=["esphome"]
+            ),
+        ],
+        light_configs=[
+            {CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse")}
+        ],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        with pytest.raises(cv.FinalExternalInvalid, match="'Fast Pulse', 'Slow Pulse'"):
+            _final_validate({})
+    finally:
+        fv.full_config.reset(token)
 
-    def test_records_static_effect(self) -> None:
-        """Static effect name should be recorded."""
-        light_id = ID("led1", is_declaration=True)
-        token = path_context.set(["esphome"])
-        try:
-            config = {CONF_ID: light_id, CONF_EFFECT: "Fast Pulse"}
-            result = _record_effect_ref(config)
-            assert result is config
-            data = _get_data()
-            assert len(data.effect_refs) == 1
-            assert data.effect_refs[0].effect_name == "Fast Pulse"
-            assert data.effect_refs[0].light_id is light_id
-            assert data.effect_refs[0].component_path == ["esphome"]
-        finally:
-            path_context.reset(token)
 
-    def test_skips_lambda(self) -> None:
-        """Lambda effect should not be recorded."""
-        token = path_context.set(["esphome"])
-        try:
-            config = {
-                CONF_ID: ID("led1", is_declaration=True),
-                CONF_EFFECT: Lambda("return effect;"),
-            }
-            _record_effect_ref(config)
-            assert _get_data().effect_refs == []
-        finally:
-            path_context.reset(token)
+def test_final_validate_no_effects_on_light() -> None:
+    """Light with no effects should report 'none' as available."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_final_validate(
+        effect_refs=[
+            EffectRef(
+                light_id=light_id, effect_name="Missing", component_path=["esphome"]
+            ),
+        ],
+        light_configs=[{CONF_ID: light_id}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        with pytest.raises(cv.FinalExternalInvalid, match="Available effects: none"):
+            _final_validate({})
+    finally:
+        fv.full_config.reset(token)
 
-    def test_skips_none(self) -> None:
-        """Effect 'None' should not be recorded."""
-        token = path_context.set(["esphome"])
-        try:
-            config = {
-                CONF_ID: ID("led1", is_declaration=True),
-                CONF_EFFECT: "None",
-            }
-            _record_effect_ref(config)
-            assert _get_data().effect_refs == []
-        finally:
-            path_context.reset(token)
 
-    def test_skips_none_case_insensitive(self) -> None:
-        """Effect 'none' (lowercase) should not be recorded."""
-        token = path_context.set(["esphome"])
-        try:
-            config = {
-                CONF_ID: ID("led1", is_declaration=True),
-                CONF_EFFECT: "none",
-            }
-            _record_effect_ref(config)
-            assert _get_data().effect_refs == []
-        finally:
-            path_context.reset(token)
+def test_final_validate_no_refs_is_noop() -> None:
+    """No stored refs should pass without error."""
+    data = _get_data()
+    data.effect_refs = []
+    _final_validate({})
 
-    def test_skips_no_effect(self) -> None:
-        """Config without effect key should be a no-op."""
-        config = {CONF_ID: ID("led1", is_declaration=True)}
-        _record_effect_ref(config)
+
+def test_final_validate_unknown_light_id_skipped() -> None:
+    """Refs to unknown light IDs should be silently skipped."""
+    data = _get_data()
+    data.effect_refs = [
+        EffectRef(
+            light_id=ID("nonexistent", is_declaration=True),
+            effect_name="Missing",
+            component_path=["esphome"],
+        )
+    ]
+
+    full_conf = Config()
+    token = fv.full_config.set(full_conf)
+    try:
+        _final_validate({})
+    finally:
+        fv.full_config.reset(token)
+
+
+def test_final_validate_drains_refs() -> None:
+    """Refs should be drained after validation to avoid redundant runs."""
+    light_id = ID("led1", is_declaration=True)
+    token = _setup_final_validate(
+        effect_refs=[
+            EffectRef(
+                light_id=light_id, effect_name="Fast Pulse", component_path=["esphome"]
+            ),
+        ],
+        light_configs=[{CONF_ID: light_id, CONF_EFFECTS: _make_effects("Fast Pulse")}],
+        declare_ids=[(light_id, ["light", 0, CONF_ID])],
+    )
+    try:
+        _final_validate({})
         assert _get_data().effect_refs == []
+    finally:
+        fv.full_config.reset(token)
+
+
+# --- _record_effect_ref ---
+
+
+@pytest.fixture
+def _path_ctx() -> Generator[None]:
+    """Set path_context for _record_effect_ref tests."""
+    token = path_context.set(["esphome"])
+    yield
+    path_context.reset(token)
+
+
+@pytest.mark.usefixtures("_path_ctx")
+def test_record_effect_ref_static() -> None:
+    """Static effect name should be recorded."""
+    light_id = ID("led1", is_declaration=True)
+    config: ConfigType = {CONF_ID: light_id, CONF_EFFECT: "Fast Pulse"}
+    result = _record_effect_ref(config)
+    assert result is config
+    data = _get_data()
+    assert len(data.effect_refs) == 1
+    assert data.effect_refs[0].effect_name == "Fast Pulse"
+    assert data.effect_refs[0].light_id is light_id
+    assert data.effect_refs[0].component_path == ["esphome"]
+
+
+@pytest.mark.usefixtures("_path_ctx")
+def test_record_effect_ref_skips_lambda() -> None:
+    """Lambda effect should not be recorded."""
+    config: ConfigType = {
+        CONF_ID: ID("led1", is_declaration=True),
+        CONF_EFFECT: Lambda("return effect;"),
+    }
+    _record_effect_ref(config)
+    assert _get_data().effect_refs == []
+
+
+@pytest.mark.usefixtures("_path_ctx")
+def test_record_effect_ref_skips_none() -> None:
+    """Effect 'None' should not be recorded."""
+    config: ConfigType = {
+        CONF_ID: ID("led1", is_declaration=True),
+        CONF_EFFECT: "None",
+    }
+    _record_effect_ref(config)
+    assert _get_data().effect_refs == []
+
+
+@pytest.mark.usefixtures("_path_ctx")
+def test_record_effect_ref_skips_none_case_insensitive() -> None:
+    """Effect 'none' (lowercase) should not be recorded."""
+    config: ConfigType = {
+        CONF_ID: ID("led1", is_declaration=True),
+        CONF_EFFECT: "none",
+    }
+    _record_effect_ref(config)
+    assert _get_data().effect_refs == []
+
+
+def test_record_effect_ref_skips_no_effect_key() -> None:
+    """Config without effect key should be a no-op."""
+    config: ConfigType = {CONF_ID: ID("led1", is_declaration=True)}
+    _record_effect_ref(config)
+    assert _get_data().effect_refs == []

--- a/tests/component_tests/light/test_effect_validation.py
+++ b/tests/component_tests/light/test_effect_validation.py
@@ -12,9 +12,10 @@ from esphome.components.light import (
     available_effects_str,
     find_effect_index,
 )
-from esphome.config import Config
-from esphome.const import CONF_EFFECTS, CONF_ID, CONF_NAME
-from esphome.core import ID
+from esphome.components.light.automation import _record_effect_ref
+from esphome.config import Config, path_context
+from esphome.const import CONF_EFFECT, CONF_EFFECTS, CONF_ID, CONF_NAME
+from esphome.core import ID, Lambda
 import esphome.final_validate as fv
 
 
@@ -223,3 +224,68 @@ class TestFinalValidateEffectRefs:
             assert data.effect_refs == []
         finally:
             fv.full_config.reset(token)
+
+
+class TestRecordEffectRef:
+    """Tests for _record_effect_ref schema validator."""
+
+    def test_records_static_effect(self) -> None:
+        """Static effect name should be recorded."""
+        light_id = ID("led1", is_declaration=True)
+        token = path_context.set(["esphome"])
+        try:
+            config = {CONF_ID: light_id, CONF_EFFECT: "Fast Pulse"}
+            result = _record_effect_ref(config)
+            assert result is config
+            data = _get_data()
+            assert len(data.effect_refs) == 1
+            assert data.effect_refs[0].effect_name == "Fast Pulse"
+            assert data.effect_refs[0].light_id is light_id
+            assert data.effect_refs[0].component_path == ["esphome"]
+        finally:
+            path_context.reset(token)
+
+    def test_skips_lambda(self) -> None:
+        """Lambda effect should not be recorded."""
+        token = path_context.set(["esphome"])
+        try:
+            config = {
+                CONF_ID: ID("led1", is_declaration=True),
+                CONF_EFFECT: Lambda("return effect;"),
+            }
+            _record_effect_ref(config)
+            assert _get_data().effect_refs == []
+        finally:
+            path_context.reset(token)
+
+    def test_skips_none(self) -> None:
+        """Effect 'None' should not be recorded."""
+        token = path_context.set(["esphome"])
+        try:
+            config = {
+                CONF_ID: ID("led1", is_declaration=True),
+                CONF_EFFECT: "None",
+            }
+            _record_effect_ref(config)
+            assert _get_data().effect_refs == []
+        finally:
+            path_context.reset(token)
+
+    def test_skips_none_case_insensitive(self) -> None:
+        """Effect 'none' (lowercase) should not be recorded."""
+        token = path_context.set(["esphome"])
+        try:
+            config = {
+                CONF_ID: ID("led1", is_declaration=True),
+                CONF_EFFECT: "none",
+            }
+            _record_effect_ref(config)
+            assert _get_data().effect_refs == []
+        finally:
+            path_context.reset(token)
+
+    def test_skips_no_effect(self) -> None:
+        """Config without effect key should be a no-op."""
+        config = {CONF_ID: ID("led1", is_declaration=True)}
+        _record_effect_ref(config)
+        assert _get_data().effect_refs == []

--- a/tests/component_tests/light/test_effect_validation.py
+++ b/tests/component_tests/light/test_effect_validation.py
@@ -1,0 +1,225 @@
+"""Tests for light effect name validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from esphome import config_validation as cv
+from esphome.components.light import (
+    EffectRef,
+    _final_validate,
+    _get_data,
+    available_effects_str,
+    find_effect_index,
+)
+from esphome.config import Config
+from esphome.const import CONF_EFFECTS, CONF_ID, CONF_NAME
+from esphome.core import ID
+import esphome.final_validate as fv
+
+
+def _make_effects(*names: str) -> list[dict]:
+    """Create a list of effect config dicts from names."""
+    return [{f"effect_{i}": {CONF_NAME: name}} for i, name in enumerate(names)]
+
+
+class TestFindEffectIndex:
+    """Tests for find_effect_index helper."""
+
+    def test_found(self) -> None:
+        effects = _make_effects("Fast Pulse", "Slow Pulse")
+        assert find_effect_index(effects, "Fast Pulse") == 1
+        assert find_effect_index(effects, "Slow Pulse") == 2
+
+    def test_case_insensitive(self) -> None:
+        effects = _make_effects("Fast Pulse")
+        assert find_effect_index(effects, "fast pulse") == 1
+        assert find_effect_index(effects, "FAST PULSE") == 1
+
+    def test_not_found(self) -> None:
+        effects = _make_effects("Fast Pulse", "Slow Pulse")
+        assert find_effect_index(effects, "Missing") is None
+
+    def test_empty_effects(self) -> None:
+        assert find_effect_index([], "anything") is None
+
+
+class TestAvailableEffectsStr:
+    """Tests for available_effects_str helper."""
+
+    def test_multiple(self) -> None:
+        effects = _make_effects("Fast Pulse", "Slow Pulse")
+        assert available_effects_str(effects) == "'Fast Pulse', 'Slow Pulse'"
+
+    def test_single(self) -> None:
+        effects = _make_effects("Fast Pulse")
+        assert available_effects_str(effects) == "'Fast Pulse'"
+
+    def test_empty(self) -> None:
+        assert available_effects_str([]) == "none"
+
+
+class TestFinalValidateEffectRefs:
+    """Tests for _final_validate effect reference checking."""
+
+    def test_valid_effect_passes(self) -> None:
+        """Valid effect name should not raise."""
+        data = _get_data()
+        light_id = ID("led1", is_declaration=True)
+        data.effect_refs = [
+            EffectRef(
+                light_id=light_id,
+                effect_name="Fast Pulse",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        full_conf["light"] = [
+            {
+                CONF_ID: light_id,
+                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
+            }
+        ]
+        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
+
+        token = fv.full_config.set(full_conf)
+        try:
+            _final_validate({})
+        finally:
+            fv.full_config.reset(token)
+
+    def test_invalid_effect_raises(self) -> None:
+        """Invalid effect name should raise FinalExternalInvalid."""
+        data = _get_data()
+        light_id = ID("led1", is_declaration=True)
+        data.effect_refs = [
+            EffectRef(
+                light_id=light_id,
+                effect_name="Nonexistent",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        full_conf["light"] = [
+            {
+                CONF_ID: light_id,
+                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
+            }
+        ]
+        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
+
+        token = fv.full_config.set(full_conf)
+        try:
+            with pytest.raises(cv.FinalExternalInvalid, match="Nonexistent"):
+                _final_validate({})
+        finally:
+            fv.full_config.reset(token)
+
+    def test_invalid_effect_lists_available(self) -> None:
+        """Error message should list available effects."""
+        data = _get_data()
+        light_id = ID("led1", is_declaration=True)
+        data.effect_refs = [
+            EffectRef(
+                light_id=light_id,
+                effect_name="Missing",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        full_conf["light"] = [
+            {
+                CONF_ID: light_id,
+                CONF_EFFECTS: _make_effects("Fast Pulse", "Slow Pulse"),
+            }
+        ]
+        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
+
+        token = fv.full_config.set(full_conf)
+        try:
+            with pytest.raises(
+                cv.FinalExternalInvalid, match="'Fast Pulse', 'Slow Pulse'"
+            ):
+                _final_validate({})
+        finally:
+            fv.full_config.reset(token)
+
+    def test_no_effects_on_light(self) -> None:
+        """Light with no effects should report 'none' as available."""
+        data = _get_data()
+        light_id = ID("led1", is_declaration=True)
+        data.effect_refs = [
+            EffectRef(
+                light_id=light_id,
+                effect_name="Missing",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        full_conf["light"] = [{CONF_ID: light_id}]
+        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
+
+        token = fv.full_config.set(full_conf)
+        try:
+            with pytest.raises(
+                cv.FinalExternalInvalid, match="Available effects: none"
+            ):
+                _final_validate({})
+        finally:
+            fv.full_config.reset(token)
+
+    def test_no_refs_is_noop(self) -> None:
+        """No stored refs should pass without error."""
+        data = _get_data()
+        data.effect_refs = []
+        _final_validate({})
+
+    def test_unknown_light_id_skipped(self) -> None:
+        """Refs to unknown light IDs should be silently skipped."""
+        data = _get_data()
+        data.effect_refs = [
+            EffectRef(
+                light_id=ID("nonexistent", is_declaration=True),
+                effect_name="Missing",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        token = fv.full_config.set(full_conf)
+        try:
+            _final_validate({})  # Should not raise
+        finally:
+            fv.full_config.reset(token)
+
+    def test_drains_refs(self) -> None:
+        """Refs should be drained after validation to avoid redundant runs."""
+        data = _get_data()
+        light_id = ID("led1", is_declaration=True)
+        data.effect_refs = [
+            EffectRef(
+                light_id=light_id,
+                effect_name="Fast Pulse",
+                component_path=["esphome"],
+            )
+        ]
+
+        full_conf = Config()
+        full_conf["light"] = [
+            {
+                CONF_ID: light_id,
+                CONF_EFFECTS: _make_effects("Fast Pulse"),
+            }
+        ]
+        full_conf.declare_ids.append((light_id, ["light", 0, CONF_ID]))
+
+        token = fv.full_config.set(full_conf)
+        try:
+            _final_validate({})
+            assert data.effect_refs == []
+        finally:
+            fv.full_config.reset(token)


### PR DESCRIPTION
# What does this implement/fix?

Moves light effect name validation from code generation time to the config validation phase. Previously, referencing a non-existent effect name (e.g., `effect: "Factory Reset Coming Up"` on a light that only has "Fast Pulse" and "Slow Pulse") produced a raw Python `ValueError` traceback during codegen. Now it produces a clean config validation error with the list of available effects, enabling proper editor/dashboard line highlighting.

**How it works (follows the same pattern as pin validation in `esphome/pins.py`):**
- During action schema validation, static effect name references are recorded in `CORE.data["light"]` along with `path_context` for error location tracking
- During the light component's `FINAL_VALIDATE_SCHEMA`, recorded references are cross-checked against the target light's actual effects
- Invalid effect names raise `FinalExternalInvalid` with proper path info for editor highlighting (same granularity as pin validation — points to the parent component)
- The codegen-time `_resolve_effect_index` is kept as a safety net with an improved `EsphomeError` message

**Before (ugly traceback):**
```
File "/esphome/esphome/components/light/automation.py", line 136, in _resolve_effect_index
    raise ValueError(f"Effect '{original_name}' not found in light '{light_id}'")
ValueError: Effect 'Factory Reset Coming Up' not found in light 'led_internal'
```

**After (clean validation error):**
```
Failed config

esphome: None

  Effect 'Factory Reset Coming Up' not found for light 'led_internal'. Available effects: 'Fast Pulse', 'Slow Pulse'.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15106

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test
  on_boot:
    then:
      - light.turn_on:
          id: led_internal
          effect: "Nonexistent Effect"

light:
  - platform: esp32_rmt_led_strip
    id: led_internal
    pin: GPIO1
    num_leds: 1
    rmt_symbols: 192
    chipset: ws2812
    effects:
      - addressable_lambda:
          name: "Fast Pulse"
          update_interval: 10ms
          lambda: |-
            it[0] = Color(255, 0, 0);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).