### PR TITLE
[time] Point to valid IANA timezone list on validation failure

### DIFF
--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -284,13 +284,23 @@ def validate_tz(value: str) -> str:
     tzfile = _load_tzdata(value)
     if tzfile is not None:
         value = _extract_tz_string(tzfile)
+        is_iana = True
+    else:
+        is_iana = False
 
     # Validate that the POSIX TZ string is parseable (skip empty strings)
     if value:
         try:
             parse_posix_tz_python(value)
         except ValueError as e:
-            raise cv.Invalid(f"Invalid POSIX timezone string '{value}': {e}") from e
+            if is_iana:
+                raise cv.Invalid(f"Invalid POSIX timezone string '{value}': {e}") from e
+            raise cv.Invalid(
+                f"Invalid POSIX timezone string '{value}': {e}. "
+                f"If you meant to use an IANA timezone, check the list of valid "
+                f"timezones at "
+                f"https://en.wikipedia.org/wiki/List_of_tz_database_time_zones"
+            ) from e
 
     return value
 


### PR DESCRIPTION
# What does this implement/fix?

When a timezone string fails POSIX parsing and wasn't found in tzdata (e.g., `Europe\Amsterdam` instead of `Europe/Amsterdam`), the error message now includes a link to the list of valid IANA timezones so users can find the correct timezone name.

Before:
```
Invalid POSIX timezone string 'Europe\Amsterdam': Expected offset after timezone name.
```

After:
```
Invalid POSIX timezone string 'Europe\Amsterdam': Expected offset after timezone name. If you meant to use an IANA timezone, check the list of valid timezones at https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
```

Reported on Discord: https://ptb.discord.com/channels/429907082951524364/1485570964938031294

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (reported on Discord)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: sntp
    timezone: Europe/Amsterdam
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).