### PR TITLE
[light] Reorder LightState fields to eliminate padding

### DIFF
--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -322,22 +322,6 @@ class LightState : public EntityBase, public Component {
   FixedVector<LightEffect *> effects_;
   /// Object used to store the persisted values of the light.
   ESPPreferenceObject rtc_;
-  /// Value for storing the index of the currently active effect. 0 if no effect is active
-  uint32_t active_effect_index_{};
-  /// Default transition length for all transitions in ms.
-  uint32_t default_transition_length_{};
-  /// Transition length to use for flash transitions.
-  uint32_t flash_transition_length_{};
-  /// Gamma correction factor for the light.
-  float gamma_correct_{};
-#ifdef USE_LIGHT_GAMMA_LUT
-  const uint16_t *gamma_table_{nullptr};
-#endif  // USE_LIGHT_GAMMA_LUT
-
-  /// Whether the light value should be written in the next cycle.
-  bool next_write_{true};
-  // for effects, true if a transformer (transition) is active.
-  bool is_transformer_active_ = false;
 
   /** Listeners for remote values changes.
    *
@@ -361,6 +345,22 @@ class LightState : public EntityBase, public Component {
   /// Initial state of the light.
   optional<LightStateRTCState> initial_state_{};
 
+  /// Value for storing the index of the currently active effect. 0 if no effect is active
+  uint32_t active_effect_index_{};
+  /// Default transition length for all transitions in ms.
+  uint32_t default_transition_length_{};
+  /// Transition length to use for flash transitions.
+  uint32_t flash_transition_length_{};
+  /// Gamma correction factor for the light.
+  float gamma_correct_{};
+#ifdef USE_LIGHT_GAMMA_LUT
+  const uint16_t *gamma_table_{nullptr};
+#endif  // USE_LIGHT_GAMMA_LUT
+
+  /// Whether the light value should be written in the next cycle.
+  bool next_write_{true};
+  // for effects, true if a transformer (transition) is active.
+  bool is_transformer_active_ = false;
   /// Restore mode of the light.
   LightRestoreMode restore_mode_;
 };

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -360,7 +360,7 @@ class LightState : public EntityBase, public Component {
   /// Whether the light value should be written in the next cycle.
   bool next_write_{true};
   // for effects, true if a transformer (transition) is active.
-  bool is_transformer_active_ = false;
+  bool is_transformer_active_{false};
   /// Restore mode of the light.
   LightRestoreMode restore_mode_;
 };


### PR DESCRIPTION
# What does this implement/fix?

Reorders `LightState` protected fields to eliminate struct padding waste. Moves `restore_mode_` (uint8_t) next to `next_write_` (bool) and `is_transformer_active_` (bool) so all three pack into a single 4-byte aligned slot.

Previously `restore_mode_` sat alone at the end of the struct with 3 bytes of trailing padding.

Saves 4 bytes per `LightState` instance.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal optimization only
light:
  - platform: binary
    name: "Test Light"
    output: relay
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).