### PR TITLE
[sx127x] Fix FIFO read corruption

### DIFF
--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -38,14 +38,18 @@ void SX127x::write_register_(uint8_t reg, uint8_t value) {
 void SX127x::read_fifo_(std::vector<uint8_t> &packet) {
   this->enable();
   this->write_byte(REG_FIFO & 0x7F);
-  this->read_array(packet.data(), packet.size());
+  for (auto &byte : packet) {
+    byte = this->transfer_byte(0x00);
+  }
   this->disable();
 }
 
 void SX127x::write_fifo_(const std::vector<uint8_t> &packet) {
   this->enable();
   this->write_byte(REG_FIFO | 0x80);
-  this->write_array(packet.data(), packet.size());
+  for (const auto &byte : packet) {
+    this->transfer_byte(byte);
+  }
   this->disable();
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes data corruption when reading packets from the SX127x FIFO. Certain byte values in received packets had their MSB (0x80 bit) flipped, causing incorrect data to be passed to listeners.

The issue occurs when using multi-byte SPI transactions (both `read_array` with null TX and `transfer_array` with zeroed TX/RX buffer) to burst-read the SX127x FIFO. The corruption is deterministic and data-dependent — specific byte values always have their MSB flipped.

The fix replaces `read_array` and `write_array` with `transfer_byte` loops in the FIFO access functions. Using individual single-byte SPI transactions within the same CS assertion eliminates the corruption.

**Key findings from testing:**
- `read_array` (null TX, multi-byte): **corrupts** MSB on specific bytes
- `transfer_array` (zero-filled TX=RX buffer, multi-byte): **corrupts** same bytes
- `transfer_byte(0x00)` in loop (single-byte transactions): **works perfectly**
- CC1101 on same ESP32 with same `read_array`: **no corruption**

This points to an interaction between the ESP32 SPI peripheral's multi-byte transaction handling and the SX127x chip specifically. The exact mechanism is unclear, but single-byte transactions reliably avoid it.

**Testing**: Sent a known packet (`a9 50 3d 4c 00 00 01 02 02 e0`) between two ESP32 devices:
- **Before**: received `a9 d0 3d 4c 00 00 01 02 02 60` (bytes 1 and 9 MSB flipped)
- **After**: received `a9 50 3d 4c 00 00 01 02 02 e0` (correct)

Fixes https://github.com/esphome/esphome/issues/14872

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/14872

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for config.yaml:

No config changes required.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under tests/ folder).