### PR TITLE
[waveshare_epaper] Implemented DIS08792E support

### DIFF
--- a/esphome/components/waveshare_epaper/display.py
+++ b/esphome/components/waveshare_epaper/display.py
@@ -123,6 +123,7 @@ WaveshareEPaper13P3InK = waveshare_epaper_ns.class_(
     "WaveshareEPaper13P3InK", WaveshareEPaper
 )
 GDEW0154M09 = waveshare_epaper_ns.class_("GDEW0154M09", WaveshareEPaper)
+DIS08792E = waveshare_epaper_ns.class_("DIS08792E", WaveshareEPaper)
 
 WaveshareEPaperTypeAModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeAModel")
 WaveshareEPaperTypeBModel = waveshare_epaper_ns.enum("WaveshareEPaperTypeBModel")
@@ -172,6 +173,7 @@ MODELS = {
     "2.13inv3": ("c", WaveshareEPaper2P13InV3),
     "1.54in-m5coreink-m09": ("b", GDEW0154M09),
     "13.3in-k": ("b", WaveshareEPaper13P3InK),
+    "dis08792e": ("c", DIS08792E),
 }
 
 RESET_PIN_REQUIRED_MODELS = ("2.13inv2", "2.13in-ttgo-b74")

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2545,7 +2545,8 @@ void GDEY042T81::dump_config() {
 // Product page:
 //  - https://www.elecrow.com/wiki/CrowPanel_ESP32_E-paper_5.79-inch_HMI_Display.html
 // Datasheet:
-//  - https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792/raw/master/Datasheet/SSD1683_Datasheet.pdf
+//  -
+//  https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792/raw/master/Datasheet/SSD1683_Datasheet.pdf
 // Reference code:
 //  - https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792
 // ========================================================
@@ -2584,13 +2585,13 @@ void DIS08792E::init_display_() {
 
   this->command(0x44);
   this->data(0);
-  this->data(this->get_height_internal()/2/8);
+  this->data(this->get_height_internal() / 2 / 8);
 
   this->command(0x45);
   this->data(0);
   this->data(0);
-  this->data((this->get_width_internal()-1) & 0xFF);
-  this->data((this->get_width_internal()-1) >> 8);
+  this->data((this->get_width_internal() - 1) & 0xFF);
+  this->data((this->get_width_internal() - 1) >> 8);
 
   this->command(0x4E);
   this->data(0);
@@ -2604,17 +2605,17 @@ void DIS08792E::init_display_() {
   this->data(0b110);
 
   this->command(0x44 | 0x80);
-  this->data(this->get_height_internal()/2/8);
+  this->data(this->get_height_internal() / 2 / 8);
   this->data(0);
 
   this->command(0x45 | 0x80);
   this->data(0);
   this->data(0);
-  this->data((this->get_width_internal()-1) & 0xFF);
-  this->data((this->get_width_internal()-1) >> 8);
+  this->data((this->get_width_internal() - 1) & 0xFF);
+  this->data((this->get_width_internal() - 1) >> 8);
 
   this->command(0x4E | 0x80);
-  this->data(this->get_height_internal()/2/8);
+  this->data(this->get_height_internal() / 2 / 8);
   this->command(0x4F | 0x80);
   this->data(0);
   this->data(0);
@@ -2624,7 +2625,7 @@ void DIS08792E::init_display_() {
 
 void DIS08792E::update_full_() {
   this->command(0x3C);
-  this->data(this->buffer_[0]?0b101:0b100);
+  this->data(this->buffer_[0] ? 0b101 : 0b100);
 
   this->command(0x21);
   this->data(0b01000000);
@@ -2664,27 +2665,27 @@ void HOT DIS08792E::display() {
     return;
   }
 
-  const uint32_t lines = this->get_height_internal()/8,    // 99 lines,
-                 line_bytes = this->get_width_internal();  // 272×8 pixels (= 272 bytes) each
+  const uint32_t lines = this->get_height_internal() / 8,  // 99 lines,
+      line_bytes = this->get_width_internal();             // 272×8 pixels (= 272 bytes) each
 
   this->command(0x24);
   this->start_data_();
-  this->write_array(this->buffer_, (lines/2 + 1)*line_bytes);  // lines 0-49
+  this->write_array(this->buffer_, (lines / 2 + 1) * line_bytes);  // lines 0-49
   this->end_data_();
 
   this->command(0x26);
   this->start_data_();
-  this->write_array(this->buffer_, (lines/2 + 1)*line_bytes);  // lines 0-49
+  this->write_array(this->buffer_, (lines / 2 + 1) * line_bytes);  // lines 0-49
   this->end_data_();
 
   this->command(0x24 | 0x80);
   this->start_data_();
-  this->write_array((this->buffer_ + lines/2*line_bytes), (lines/2 + 1)*line_bytes);  // lines 49-99
+  this->write_array((this->buffer_ + lines / 2 * line_bytes), (lines / 2 + 1) * line_bytes);  // lines 49-99
   this->end_data_();
 
   this->command(0x26 | 0x80);
   this->start_data_();
-  this->write_array((this->buffer_ + lines/2*line_bytes), (lines/2 + 1)*line_bytes);  // lines 49-99
+  this->write_array((this->buffer_ + lines / 2 * line_bytes), (lines / 2 + 1) * line_bytes);  // lines 49-99
   this->end_data_();
 
   if (this->full_update_every_ == 1 || this->at_update_ == 0) {
@@ -2704,7 +2705,7 @@ void HOT DIS08792E::draw_absolute_pixel_internal(int x, int y, Color color) {
   if (x < 0 || y < 0 || x >= this->get_width_internal() || y >= this->get_height_internal())
     return;
 
-  const uint32_t pos = (x + y/8*this->get_width_controller());
+  const uint32_t pos = (x + y / 8 * this->get_width_controller());
   const uint8_t subpos = (y & 0x07);
   if (!color.is_on()) {
     this->buffer_[pos] |= (0x80 >> subpos);

--- a/esphome/components/waveshare_epaper/waveshare_epaper.cpp
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.cpp
@@ -2540,6 +2540,192 @@ void GDEY042T81::dump_config() {
   LOG_UPDATE_INTERVAL(this);
 }
 
+// ========================================================
+//     CrowPanel 5.79in black/white DIS08792E (SSD1683)
+// Product page:
+//  - https://www.elecrow.com/wiki/CrowPanel_ESP32_E-paper_5.79-inch_HMI_Display.html
+// Datasheet:
+//  - https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792/raw/master/Datasheet/SSD1683_Datasheet.pdf
+// Reference code:
+//  - https://github.com/Elecrow-RD/CrowPanel-ESP32-5.79-E-paper-HMI-Display-with-272-792
+// ========================================================
+
+DIS08792E::DIS08792E() { this->reset_duration_ = 10; }
+
+void DIS08792E::initialize() {
+  this->init_display_();
+  ESP_LOGD(TAG, "Initialization complete, set the display to deep sleep");
+  this->deep_sleep();
+}
+
+void DIS08792E::reset_() {
+  if (this->reset_pin_ != nullptr) {
+    this->reset_pin_->digital_write(false);
+    delay(reset_duration_);  // NOLINT
+    this->reset_pin_->digital_write(true);
+    delay(reset_duration_);  // NOLINT
+  }
+}
+
+void DIS08792E::init_display_() {
+  this->reset_();
+  this->wait_until_idle_();
+
+  this->command(0x12);  // SWRESET
+  this->wait_until_idle_();
+
+  this->command(0x18);
+  this->data(0x80);
+
+  // Primary
+
+  this->command(0x11);
+  this->data(0b111);
+
+  this->command(0x44);
+  this->data(0);
+  this->data(this->get_height_internal()/2/8);
+
+  this->command(0x45);
+  this->data(0);
+  this->data(0);
+  this->data((this->get_width_internal()-1) & 0xFF);
+  this->data((this->get_width_internal()-1) >> 8);
+
+  this->command(0x4E);
+  this->data(0);
+  this->command(0x4F);
+  this->data(0);
+  this->data(0);
+
+  // Secondary
+
+  this->command(0x11 | 0x80);
+  this->data(0b110);
+
+  this->command(0x44 | 0x80);
+  this->data(this->get_height_internal()/2/8);
+  this->data(0);
+
+  this->command(0x45 | 0x80);
+  this->data(0);
+  this->data(0);
+  this->data((this->get_width_internal()-1) & 0xFF);
+  this->data((this->get_width_internal()-1) >> 8);
+
+  this->command(0x4E | 0x80);
+  this->data(this->get_height_internal()/2/8);
+  this->command(0x4F | 0x80);
+  this->data(0);
+  this->data(0);
+
+  this->wait_until_idle_();
+}
+
+void DIS08792E::update_full_() {
+  this->command(0x3C);
+  this->data(this->buffer_[0]?0b101:0b100);
+
+  this->command(0x21);
+  this->data(0b01000000);
+  this->data(0b10000);
+
+  this->command(0x22);
+  this->data(0xF7);
+  this->wait_until_idle_();
+
+  this->command(0x20);
+  this->wait_until_idle_();
+}
+
+void DIS08792E::update_part_() {
+  this->command(0x3C);
+  this->data(0x80);
+
+  this->command(0x21);
+  this->data(0b10000000);
+  this->data(0b10000);
+
+  this->command(0x22);
+  this->data(0xFF);
+  this->wait_until_idle_();
+
+  this->command(0x20);
+  this->wait_until_idle_();
+}
+
+void HOT DIS08792E::display() {
+  ESP_LOGD(TAG, "Wake up the display");
+  this->init_display_();
+
+  if (!this->wait_until_idle_()) {
+    this->status_set_warning();
+    ESP_LOGE(TAG, "Failed to perform update, display is busy");
+    return;
+  }
+
+  const uint32_t lines = this->get_height_internal()/8,    // 99 lines,
+                 line_bytes = this->get_width_internal();  // 272×8 pixels (= 272 bytes) each
+
+  this->command(0x24);
+  this->start_data_();
+  this->write_array(this->buffer_, (lines/2 + 1)*line_bytes);  // lines 0-49
+  this->end_data_();
+
+  this->command(0x26);
+  this->start_data_();
+  this->write_array(this->buffer_, (lines/2 + 1)*line_bytes);  // lines 0-49
+  this->end_data_();
+
+  this->command(0x24 | 0x80);
+  this->start_data_();
+  this->write_array((this->buffer_ + lines/2*line_bytes), (lines/2 + 1)*line_bytes);  // lines 49-99
+  this->end_data_();
+
+  this->command(0x26 | 0x80);
+  this->start_data_();
+  this->write_array((this->buffer_ + lines/2*line_bytes), (lines/2 + 1)*line_bytes);  // lines 49-99
+  this->end_data_();
+
+  if (this->full_update_every_ == 1 || this->at_update_ == 0) {
+    ESP_LOGD(TAG, "Full update");
+    this->update_full_();
+  } else {
+    ESP_LOGD(TAG, "Partial update");
+    this->update_part_();
+  }
+
+  this->at_update_ = (this->at_update_ + 1) % this->full_update_every_;
+  this->wait_until_idle_();
+  ESP_LOGD(TAG, "Set the display back to deep sleep");
+  this->deep_sleep();
+}
+void HOT DIS08792E::draw_absolute_pixel_internal(int x, int y, Color color) {
+  if (x < 0 || y < 0 || x >= this->get_width_internal() || y >= this->get_height_internal())
+    return;
+
+  const uint32_t pos = (x + y/8*this->get_width_controller());
+  const uint8_t subpos = (y & 0x07);
+  if (!color.is_on()) {
+    this->buffer_[pos] |= (0x80 >> subpos);
+  } else {
+    this->buffer_[pos] &= ~(0x80 >> subpos);
+  }
+}
+void DIS08792E::set_full_update_every(uint32_t full_update_every) { this->full_update_every_ = full_update_every; }
+int DIS08792E::get_width_internal() { return 272; }
+int DIS08792E::get_height_internal() { return 792; }
+uint32_t DIS08792E::idle_timeout_() { return 5000; }
+void DIS08792E::dump_config() {
+  LOG_DISPLAY("", "CrowPanel E-Paper", this);
+  ESP_LOGCONFIG(TAG, "  Model: 5.79in B/W DIS08792E");
+  ESP_LOGCONFIG(TAG, "  Full Update Every: %" PRIu32, this->full_update_every_);
+  LOG_PIN("  Reset Pin: ", this->reset_pin_);
+  LOG_PIN("  DC Pin: ", this->dc_pin_);
+  LOG_PIN("  Busy Pin: ", this->busy_pin_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
 static const uint8_t LUT_VCOM_DC_4_2[] = {
     0x00, 0x17, 0x00, 0x00, 0x00, 0x02, 0x00, 0x17, 0x17, 0x00, 0x00, 0x02, 0x00, 0x0A, 0x01,
     0x00, 0x00, 0x01, 0x00, 0x0E, 0x0E, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/esphome/components/waveshare_epaper/waveshare_epaper.h
+++ b/esphome/components/waveshare_epaper/waveshare_epaper.h
@@ -1099,5 +1099,38 @@ class WaveshareEPaper13P3InK : public WaveshareEPaper {
   uint32_t idle_timeout_() override;
 };
 
+class DIS08792E : public WaveshareEPaper {
+ public:
+  DIS08792E();
+
+  void initialize() override;
+
+  void display() override;
+
+  void dump_config() override;
+
+  void deep_sleep() override {
+    this->command(0x10);
+    this->data(0x01);
+  }
+
+  void set_full_update_every(uint32_t full_update_every);
+
+ protected:
+  uint32_t full_update_every_{30};
+  uint32_t at_update_{0};
+
+  int get_width_internal() override;
+  int get_height_internal() override;
+  uint32_t idle_timeout_() override;
+  void draw_absolute_pixel_internal(int x, int y, Color color) override;
+
+ private:
+  void reset_();
+  void update_full_();
+  void update_part_();
+  void init_display_();
+};
+
 }  // namespace waveshare_epaper
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

### [Elecrow CrowPanel E-paper 5.79"](https://www.elecrow.com/crowpanel-esp32-5-79-e-paper-hmi-display-with-272-792-resolution-black-white-color-driven-by-spi-interface.html) support.

Partial updates are implemented with no apparent ghosting.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

* Resolves esphome/feature-requests#2980

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
display:
  platform: waveshare_epaper
  model: dis08792e
  cs_pin: GPIO45
  dc_pin: GPIO46
  reset_pin: GPIO47
  busy_pin: GPIO48
  update_interval: 1s
  full_update_every: 3600
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).