### PR TITLE
[wifi] Reduce ESP8266 roaming scan dwell time to match ESP32

### DIFF
--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -668,18 +668,18 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   // nearby APs, not do a thorough survey. This also reduces off-channel time
   // which can cause Beacon Timeout disconnects on some APs.
   // Roaming times match the ESP32 IDF scan defaults.
-  static constexpr uint32_t SCAN_PASSIVE_DEFAULT = 500;
-  static constexpr uint32_t SCAN_PASSIVE_ROAMING = 300;
-  static constexpr uint32_t SCAN_ACTIVE_MIN_DEFAULT = 400;
-  static constexpr uint32_t SCAN_ACTIVE_MAX_DEFAULT = 500;
-  static constexpr uint32_t SCAN_ACTIVE_MIN_ROAMING = 100;
-  static constexpr uint32_t SCAN_ACTIVE_MAX_ROAMING = 300;
+  static constexpr uint32_t SCAN_PASSIVE_DEFAULT_MS = 500;
+  static constexpr uint32_t SCAN_PASSIVE_ROAMING_MS = 300;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_DEFAULT_MS = 400;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_DEFAULT_MS = 500;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_ROAMING_MS = 100;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_ROAMING_MS = 300;
   bool roaming = this->roaming_state_ == RoamingState::SCANNING;
   if (passive) {
-    config.scan_time.passive = roaming ? SCAN_PASSIVE_ROAMING : SCAN_PASSIVE_DEFAULT;
+    config.scan_time.passive = roaming ? SCAN_PASSIVE_ROAMING_MS : SCAN_PASSIVE_DEFAULT_MS;
   } else {
-    config.scan_time.active.min = roaming ? SCAN_ACTIVE_MIN_ROAMING : SCAN_ACTIVE_MIN_DEFAULT;
-    config.scan_time.active.max = roaming ? SCAN_ACTIVE_MAX_ROAMING : SCAN_ACTIVE_MAX_DEFAULT;
+    config.scan_time.active.min = roaming ? SCAN_ACTIVE_MIN_ROAMING_MS : SCAN_ACTIVE_MIN_DEFAULT_MS;
+    config.scan_time.active.max = roaming ? SCAN_ACTIVE_MAX_ROAMING_MS : SCAN_ACTIVE_MAX_DEFAULT_MS;
   }
 #endif
   bool ret = wifi_station_scan(&config, &WiFiComponent::s_wifi_scan_done_callback);

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -664,11 +664,22 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   config.show_hidden = 1;
 #if USE_ARDUINO_VERSION_CODE >= VERSION_CODE(2, 4, 0)
   config.scan_type = passive ? WIFI_SCAN_TYPE_PASSIVE : WIFI_SCAN_TYPE_ACTIVE;
+  // Use shorter dwell times for roaming scans - we only need to detect strong
+  // nearby APs, not do a thorough survey. This also reduces off-channel time
+  // which can cause Beacon Timeout disconnects on some APs.
+  // Roaming times match the ESP32 IDF scan defaults.
+  static constexpr uint32_t SCAN_PASSIVE_DEFAULT = 500;
+  static constexpr uint32_t SCAN_PASSIVE_ROAMING = 300;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_DEFAULT = 400;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_DEFAULT = 500;
+  static constexpr uint32_t SCAN_ACTIVE_MIN_ROAMING = 100;
+  static constexpr uint32_t SCAN_ACTIVE_MAX_ROAMING = 300;
+  bool roaming = this->roaming_state_ == RoamingState::SCANNING;
   if (passive) {
-    config.scan_time.passive = 500;
+    config.scan_time.passive = roaming ? SCAN_PASSIVE_ROAMING : SCAN_PASSIVE_DEFAULT;
   } else {
-    config.scan_time.active.min = 400;
-    config.scan_time.active.max = 500;
+    config.scan_time.active.min = roaming ? SCAN_ACTIVE_MIN_ROAMING : SCAN_ACTIVE_MIN_DEFAULT;
+    config.scan_time.active.max = roaming ? SCAN_ACTIVE_MAX_ROAMING : SCAN_ACTIVE_MAX_DEFAULT;
   }
 #endif
   bool ret = wifi_station_scan(&config, &WiFiComponent::s_wifi_scan_done_callback);


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #15126. ESP8266 roaming scans currently use 400-500ms dwell times per channel while ESP32 IDF uses 100-300ms. This reduces the ESP8266 roaming scan dwell times to match ESP32, cutting total off-channel time from ~6.5s to ~3.9s (13 channels) and reducing the chance of triggering Beacon Timeout disconnects on aggressive APs.

The longer dwell times (400-500ms) are preserved for initial connection scans where a thorough survey is needed. For roaming we only need to detect strong nearby same-SSID APs, so shorter dwell is sufficient.

We can't reduce dwell times further without breaking scan reliability, and we are not in control of AP settings, so this may not be enough to prevent Beacon Timeouts on all APs. #15126 ensures the roaming counter still progresses even when the AP disconnects.

Note: A previous attempt at shorter scan times existed but was removed in #14657 as dead code — the `first_scan` flag was initialized to `false` and never set to `true`, so the short path never executed. This implementation correctly uses the roaming state to determine when to use shorter times.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15124

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - internal scan timing optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


