### PR TITLE
[light] Replace initial_state storage with flash-resident callback

### DIFF
--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -265,8 +265,10 @@ async def setup_light_core_(light_var, config, output_var):
     if (initial_state_config := config.get(CONF_INITIAL_STATE)) is not None:
         # Emit a stateless lambda that constructs the initial state — values live
         # in flash as code, not stored in the LightState object (~40 bytes saved).
-        color_mode_str = initial_state_config.get(CONF_COLOR_MODE)
-        color_mode_expr = COLOR_MODES.get(color_mode_str, ColorMode.UNKNOWN)
+        # Map config string to C++ enum; defaults to UNKNOWN if not specified
+        color_mode_expr = COLOR_MODES.get(
+            initial_state_config.get(CONF_COLOR_MODE), ColorMode.UNKNOWN
+        )
         initial_state = LightStateRTCState(
             color_mode_expr,
             initial_state_config.get(CONF_STATE, False),

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -52,7 +52,6 @@ from .effects import (
     validate_effects,
 )
 from .types import (  # noqa
-    COLOR_MODES,
     AddressableLight,
     AddressableLightState,
     ColorMode,
@@ -265,12 +264,8 @@ async def setup_light_core_(light_var, config, output_var):
     if (initial_state_config := config.get(CONF_INITIAL_STATE)) is not None:
         # Emit a stateless lambda that constructs the initial state — values live
         # in flash as code, not stored in the LightState object (~40 bytes saved).
-        # Map config string to C++ enum; defaults to UNKNOWN if not specified
-        color_mode_expr = COLOR_MODES.get(
-            initial_state_config.get(CONF_COLOR_MODE), ColorMode.UNKNOWN
-        )
         initial_state = LightStateRTCState(
-            color_mode_expr,
+            initial_state_config.get(CONF_COLOR_MODE, ColorMode.UNKNOWN),
             initial_state_config.get(CONF_STATE, False),
             initial_state_config.get(CONF_BRIGHTNESS, 1.0),
             initial_state_config.get(CONF_COLOR_BRIGHTNESS, 1.0),

--- a/esphome/components/light/__init__.py
+++ b/esphome/components/light/__init__.py
@@ -38,7 +38,7 @@ from esphome.const import (
     CONF_WEB_SERVER,
     CONF_WHITE,
 )
-from esphome.core import CORE, ID, CoroPriority, HexInt, coroutine_with_priority
+from esphome.core import CORE, ID, CoroPriority, HexInt, Lambda, coroutine_with_priority
 from esphome.core.entity_helpers import entity_duplicate_validator, setup_entity
 from esphome.cpp_generator import MockObjClass
 
@@ -52,6 +52,7 @@ from .effects import (
     validate_effects,
 )
 from .types import (  # noqa
+    COLOR_MODES,
     AddressableLight,
     AddressableLightState,
     ColorMode,
@@ -262,8 +263,12 @@ async def setup_light_core_(light_var, config, output_var):
     cg.add(light_var.set_restore_mode(config[CONF_RESTORE_MODE]))
 
     if (initial_state_config := config.get(CONF_INITIAL_STATE)) is not None:
+        # Emit a stateless lambda that constructs the initial state — values live
+        # in flash as code, not stored in the LightState object (~40 bytes saved).
+        color_mode_str = initial_state_config.get(CONF_COLOR_MODE)
+        color_mode_expr = COLOR_MODES.get(color_mode_str, ColorMode.UNKNOWN)
         initial_state = LightStateRTCState(
-            initial_state_config.get(CONF_COLOR_MODE, ColorMode.UNKNOWN),
+            color_mode_expr,
             initial_state_config.get(CONF_STATE, False),
             initial_state_config.get(CONF_BRIGHTNESS, 1.0),
             initial_state_config.get(CONF_COLOR_BRIGHTNESS, 1.0),
@@ -275,7 +280,13 @@ async def setup_light_core_(light_var, config, output_var):
             initial_state_config.get(CONF_COLD_WHITE, 1.0),
             initial_state_config.get(CONF_WARM_WHITE, 1.0),
         )
-        cg.add(light_var.set_initial_state(initial_state))
+        args = [(LightStateRTCState.operator("ref"), "s")]
+        lamb = await cg.process_lambda(
+            Lambda(f"s = {initial_state};"),
+            args,
+            return_type=cg.void,
+        )
+        cg.add(light_var.set_initial_state(lamb))
 
     if (
         default_transition_length := config.get(CONF_DEFAULT_TRANSITION_LENGTH)

--- a/esphome/components/light/light_state.cpp
+++ b/esphome/components/light/light_state.cpp
@@ -37,8 +37,9 @@ void LightState::setup() {
 
   auto call = this->make_call();
   LightStateRTCState recovered{};
-  if (this->initial_state_.has_value()) {
-    recovered = *this->initial_state_;
+  if (this->initial_state_callback_) {
+    this->initial_state_callback_(recovered);
+    this->initial_state_callback_ = nullptr;  // One-shot — no longer needed
   }
   switch (this->restore_mode_) {
     case LIGHT_RESTORE_DEFAULT_OFF:
@@ -195,7 +196,7 @@ void LightState::set_flash_transition_length(uint32_t flash_transition_length) {
 uint32_t LightState::get_flash_transition_length() const { return this->flash_transition_length_; }
 void LightState::set_gamma_correct(float gamma_correct) { this->gamma_correct_ = gamma_correct; }
 void LightState::set_restore_mode(LightRestoreMode restore_mode) { this->restore_mode_ = restore_mode; }
-void LightState::set_initial_state(const LightStateRTCState &initial_state) { this->initial_state_ = initial_state; }
+void LightState::set_initial_state(void (*callback)(LightStateRTCState &)) { this->initial_state_callback_ = callback; }
 bool LightState::supports_effects() { return !this->effects_.empty(); }
 const FixedVector<LightEffect *> &LightState::get_effects() const { return this->effects_; }
 void LightState::add_effects(const std::initializer_list<LightEffect *> &effects) {

--- a/esphome/components/light/light_state.h
+++ b/esphome/components/light/light_state.h
@@ -188,8 +188,9 @@ class LightState : public EntityBase, public Component {
   /// Set the restore mode of this light
   void set_restore_mode(LightRestoreMode restore_mode);
 
-  /// Set the initial state of this light
-  void set_initial_state(const LightStateRTCState &initial_state);
+  /// Set a callback to populate the initial state defaults during setup.
+  /// The callback is called once, then cleared. Values live in flash as code.
+  void set_initial_state(void (*callback)(LightStateRTCState &));
 
   /// Return whether the light has any effects that meet the trait requirements.
   bool supports_effects();
@@ -342,8 +343,9 @@ class LightState : public EntityBase, public Component {
    */
   std::unique_ptr<std::vector<LightTargetStateReachedListener *>> target_state_reached_listeners_;
 
-  /// Initial state of the light.
-  optional<LightStateRTCState> initial_state_{};
+  /// Callback to populate initial state defaults — called once during setup, then cleared.
+  /// Values live in flash as function body; no per-instance data storage beyond this pointer.
+  void (*initial_state_callback_)(LightStateRTCState &){nullptr};
 
   /// Value for storing the index of the currently active effect. 0 if no effect is active
   uint32_t active_effect_index_{};

--- a/tests/integration/fixtures/light_initial_state.yaml
+++ b/tests/integration/fixtures/light_initial_state.yaml
@@ -1,0 +1,39 @@
+esphome:
+  name: light-initial-state-test
+host:
+api:  # Port will be automatically injected
+logger:
+  level: DEBUG
+
+output:
+  - platform: template
+    id: test_red
+    type: float
+    write_action:
+      - lambda: ""
+  - platform: template
+    id: test_green
+    type: float
+    write_action:
+      - lambda: ""
+  - platform: template
+    id: test_blue
+    type: float
+    write_action:
+      - lambda: ""
+
+light:
+  - platform: rgb
+    name: "Test Light"
+    id: test_light
+    red: test_red
+    green: test_green
+    blue: test_blue
+    restore_mode: ALWAYS_OFF
+    initial_state:
+      color_mode: RGB
+      state: true
+      brightness: 0.75
+      red: 1.0
+      green: 0.5
+      blue: 0.0

--- a/tests/integration/test_light_initial_state.py
+++ b/tests/integration/test_light_initial_state.py
@@ -1,0 +1,38 @@
+"""Integration test for light initial_state configuration.
+
+Tests that the initial_state values are correctly applied at boot when
+no saved preferences exist. The initial_state callback populates defaults
+that the restore logic uses as a fallback.
+"""
+
+import pytest
+
+from .state_utils import InitialStateHelper, require_entity
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_light_initial_state(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that initial_state values are applied at boot."""
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        entities, _ = await client.list_entities_services()
+        light = require_entity(entities, "test_light")
+
+        helper = InitialStateHelper(entities)
+        client.subscribe_states(helper.on_state_wrapper(lambda s: None))
+        await helper.wait_for_initial_states()
+
+        state = helper.initial_states[light.key]
+
+        # restore_mode: ALWAYS_OFF overrides state to false
+        assert state.state is False
+
+        # But the color values from initial_state should be applied
+        assert state.brightness == pytest.approx(0.75, abs=0.05)
+        assert state.red == pytest.approx(1.0, abs=0.01)
+        assert state.green == pytest.approx(0.5, abs=0.01)
+        assert state.blue == pytest.approx(0.0, abs=0.01)


### PR DESCRIPTION
# What does this implement/fix?

`LightState` stores an `optional<LightStateRTCState>` for the `initial_state:` config option. This struct (~44 bytes) is reserved inline in every `LightState` instance even when `initial_state:` is not configured — which is the vast majority of configs. It's only read once during `setup()` and then sits unused for the lifetime of the device.

This PR replaces the `optional<LightStateRTCState>` (44 bytes) with a function pointer (4 bytes) to a stateless lambda that populates the defaults. The lambda's constant values live in flash as code, not in the object.

**Before:** `optional<LightStateRTCState>` = 44 bytes per LightState, always reserved in the object layout
**After:** `void (*)(LightStateRTCState &)` = 4 bytes per LightState (null when unused)

**Savings: 40 bytes per LightState instance**, unconditionally.

### Measured results

**ESP8266 CI test config** (13 light instances, one uses `initial_state:`):
- RAM: **-576 bytes** (-1.62%) — 13 × 44 = 572 bytes
- Flash: +48 bytes — the one `initial_state:` lambda body in flash

**ESP8266 real device** (ratgdo garage door, 1 light, no `initial_state:`):
- RAM: **-40 bytes** — pure savings, no flash overhead
- Flash: -16 bytes

Configs without `initial_state:` (the vast majority) see pure RAM savings with no flash cost. Configs with `initial_state:` trade ~44 bytes of RAM per instance for ~137 bytes of shared flash for the lambda body — a good tradeoff since flash has far more headroom than RAM on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — initial_state: works identically.
light:
  - platform: rgb
    id: my_light
    red: red_output
    green: green_output
    blue: blue_output
    initial_state:
      color_mode: RGB
      state: true
      brightness: 0.5
      red: 1.0
      green: 0.0
      blue: 0.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (no user-facing changes)