### PR TITLE
[core] Use compile-time HasElse parameter in IfAction

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -415,9 +415,7 @@ async def if_action_to_code(
 ) -> MockObj:
     has_else = CONF_ELSE in config
     # Prepend HasElse bool to template arguments: IfAction<HasElse, Ts...>
-    if_template_arg = cg.TemplateArguments(
-        cg.RawExpression("true" if has_else else "false"), *template_arg
-    )
+    if_template_arg = cg.TemplateArguments(has_else, *template_arg)
     cond_conf = next(el for el in config if el in (CONF_ANY, CONF_ALL, CONF_CONDITION))
     condition = await build_condition(config[cond_conf], template_arg, args)
     var = cg.new_Pvariable(action_id, if_template_arg, condition)

--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -413,13 +413,18 @@ async def if_action_to_code(
     template_arg: cg.TemplateArguments,
     args: TemplateArgsType,
 ) -> MockObj:
+    has_else = CONF_ELSE in config
+    # Prepend HasElse bool to template arguments: IfAction<HasElse, Ts...>
+    if_template_arg = cg.TemplateArguments(
+        cg.RawExpression("true" if has_else else "false"), *template_arg
+    )
     cond_conf = next(el for el in config if el in (CONF_ANY, CONF_ALL, CONF_CONDITION))
     condition = await build_condition(config[cond_conf], template_arg, args)
-    var = cg.new_Pvariable(action_id, template_arg, condition)
+    var = cg.new_Pvariable(action_id, if_template_arg, condition)
     if CONF_THEN in config:
         actions = await build_action_list(config[CONF_THEN], template_arg, args)
         cg.add(var.add_then(actions))
-    if CONF_ELSE in config:
+    if has_else:
         actions = await build_action_list(config[CONF_ELSE], template_arg, args)
         cg.add(var.add_else(actions))
     return var

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -264,7 +264,7 @@ template<typename... Ts> class WhileLoopContinuation : public Action<Ts...> {
   WhileAction<Ts...> *parent_;
 };
 
-template<typename... Ts> class IfAction : public Action<Ts...> {
+template<bool HasElse, typename... Ts> class IfAction : public Action<Ts...> {
  public:
   explicit IfAction(Condition<Ts...> *condition) : condition_(condition) {}
 
@@ -273,27 +273,25 @@ template<typename... Ts> class IfAction : public Action<Ts...> {
     this->then_.add_action(new ContinuationAction<Ts...>(this));
   }
 
-  void add_else(const std::initializer_list<Action<Ts...> *> &actions) {
+  void add_else(const std::initializer_list<Action<Ts...> *> &actions) requires(HasElse) {
     this->else_.add_actions(actions);
     this->else_.add_action(new ContinuationAction<Ts...>(this));
   }
 
   void play_complex(const Ts &...x) override {
     this->num_running_++;
-    bool res = this->condition_->check(x...);
-    if (res) {
-      if (this->then_.empty()) {
-        this->play_next_(x...);
-      } else if (this->num_running_ > 0) {
+    if (this->condition_->check(x...)) {
+      if (!this->then_.empty() && this->num_running_ > 0) {
         this->then_.play(x...);
+        return;
       }
-    } else {
-      if (this->else_.empty()) {
-        this->play_next_(x...);
-      } else if (this->num_running_ > 0) {
+    } else if constexpr (HasElse) {
+      if (!this->else_.empty() && this->num_running_ > 0) {
         this->else_.play(x...);
+        return;
       }
     }
+    this->play_next_(x...);
   }
 
   void play(const Ts &...x) override { /* ignore - see play_complex */
@@ -301,13 +299,16 @@ template<typename... Ts> class IfAction : public Action<Ts...> {
 
   void stop() override {
     this->then_.stop();
-    this->else_.stop();
+    if constexpr (HasElse) {
+      this->else_.stop();
+    }
   }
 
  protected:
   Condition<Ts...> *condition_;
   ActionList<Ts...> then_;
-  ActionList<Ts...> else_;
+  struct NoElse {};
+  [[no_unique_address]] std::conditional_t<HasElse, ActionList<Ts...>, NoElse> else_;
 };
 
 template<typename... Ts> class WhileAction : public Action<Ts...> {


### PR DESCRIPTION
# What does this implement/fix?

`IfAction` is one of the most common automation primitives — every `if:` block in YAML creates one. Each instance is 32 bytes, with 8 bytes allocated for the `else_` ActionList even when no `else:` branch exists. In practice, most `if:` blocks have no `else:`.

This PR adds a `bool HasElse` template parameter to `IfAction`. When `false` (no else branch), the `else_` member is replaced by an empty struct with `[[no_unique_address]]`, reducing each instance from 32 to 24 bytes. The codegen already knows at generation time whether an `else:` branch exists and passes the appropriate template argument.

The `play_complex` method uses `if constexpr (HasElse)` to eliminate the else code path entirely when not needed, and the control flow has been flattened with early returns to reduce nesting.

**Before:** `IfAction<Ts...>` = 32 bytes always
**After:** `IfAction<false, Ts...>` = 24 bytes (no else), `IfAction<true, Ts...>` = 32 bytes (with else)

**Savings: 8 bytes per `IfAction` without an else branch.**

Measured on real configs:
- **Apollo R PRO-1** (ESP32-S3): 10 IfActions, 8 without else = **64 bytes saved**
- **ratgdo garage door** (ESP8266): 3 IfActions, 0 with else = **24 bytes saved**

The existing `test_continuation_actions` integration test fully covers both paths — it tests `if/then/else` (uses `IfAction<true>`), `if/then` without else (uses `IfAction<false>`), and nested if/else combinations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — existing if/else automations work identically.
# IfAction<false> is used automatically when no else: branch exists.
button:
  - platform: template
    name: "Test"
    on_press:
      - if:
          condition:
            lambda: 'return true;'
          then:
            - logger.log: "condition true"
          # No else: branch — uses IfAction<false>, saving 8 bytes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Existing `test_continuation_actions` integration test covers both `IfAction<true>` and `IfAction<false>` paths.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).