### PR TITLE
[core] get_log_str: fix false-positive error on null-terminated strings with stricter compilers

### DIFF
--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -105,10 +105,10 @@ struct LogString;
     static const char *get_(uint8_t idx, uint8_t fallback) { \
       if (idx >= COUNT) \
         idx = fallback; \
-       // std::launder is used here to prevent the inter-procedural analysis that
-       // causes the false positive that the string is not null terminated
-      return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
-    } \
+      // std::launder is used here to prevent the inter-procedural analysis that
+      // causes the false positive that the string is not null terminated
+return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]);
+}  // namespace esphome \
     static ::ProgmemStr get_progmem_str(uint8_t idx, uint8_t fallback) { \
       return reinterpret_cast<::ProgmemStr>(get_(idx, fallback)); \
     } \

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -125,7 +125,7 @@ struct LogString;
     static const char *get_(uint8_t idx, uint8_t fallback) { \
       if (idx >= COUNT) \
         idx = fallback; \
-      return LAUNDER_STR(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
+      return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
     } \
     static ::ProgmemStr get_progmem_str(uint8_t idx, uint8_t fallback) { \
       return reinterpret_cast<::ProgmemStr>(get_(idx, fallback)); \

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -105,6 +105,8 @@ struct LogString;
     static const char *get_(uint8_t idx, uint8_t fallback) { \
       if (idx >= COUNT) \
         idx = fallback; \
+       // std::launder is used here to prevent the inter-procedural analysis that
+       // causes the false positive that the string is not null terminated
       return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
     } \
     static ::ProgmemStr get_progmem_str(uint8_t idx, uint8_t fallback) { \

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -105,10 +105,10 @@ struct LogString;
     static const char *get_(uint8_t idx, uint8_t fallback) { \
       if (idx >= COUNT) \
         idx = fallback; \
-      // std::launder is used here to prevent the inter-procedural analysis that
-      // causes the false positive that the string is not null terminated
-return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]);
-}  // namespace esphome \
+      /* std::launder is used here to prevent the inter-procedural analysis that */ \
+      /* causes the false positive that the string is not null terminated */ \
+      return std::launder(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
+    } \
     static ::ProgmemStr get_progmem_str(uint8_t idx, uint8_t fallback) { \
       return reinterpret_cast<::ProgmemStr>(get_(idx, fallback)); \
     } \

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <new>
 
 #include "esphome/core/hal.h"  // For PROGMEM definition
 
@@ -90,6 +91,26 @@ template<FixedString... Strs> struct ProgmemStringTable {
 // Forward declaration for LogString (defined in log.h)
 struct LogString;
 
+/**
+ * Hides the pointer's origin from the compiler's static analysis.
+ * Use this to suppress "not a nul-terminated string" warnings
+ * when you know the pointer is safe.
+ */
+#if __cplusplus >= 201703L
+// C++17 and above: Use the standard library
+#define LAUNDER_STR(p) std::launder(p)
+#elif defined(__GNUC__) || defined(__clang__)
+// Pre-C++17 or GCC/Clang: Use the assembly barrier
+#define LAUNDER_STR(p) \
+  ([](auto x) { \
+    __asm__("" : "+r"(x)); \
+    return x; \
+  }(p))
+#else
+// Fallback for other compilers/versions
+#define LAUNDER_STR(p) (p)
+#endif
+
 /// Instantiate a ProgmemStringTable with PROGMEM storage.
 /// Creates: Name::get_progmem_str(idx, fallback), Name::get_log_str(idx, fallback)
 /// If idx >= COUNT, returns string at fallback. Use LAST_INDEX for common patterns.
@@ -104,7 +125,7 @@ struct LogString;
     static const char *get_(uint8_t idx, uint8_t fallback) { \
       if (idx >= COUNT) \
         idx = fallback; \
-      return &BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]; \
+      return LAUNDER_STR(&BLOB[::esphome::progmem_read_byte(&OFFSETS[idx])]); \
     } \
     static ::ProgmemStr get_progmem_str(uint8_t idx, uint8_t fallback) { \
       return reinterpret_cast<::ProgmemStr>(get_(idx, fallback)); \

--- a/esphome/core/progmem.h
+++ b/esphome/core/progmem.h
@@ -91,26 +91,6 @@ template<FixedString... Strs> struct ProgmemStringTable {
 // Forward declaration for LogString (defined in log.h)
 struct LogString;
 
-/**
- * Hides the pointer's origin from the compiler's static analysis.
- * Use this to suppress "not a nul-terminated string" warnings
- * when you know the pointer is safe.
- */
-#if __cplusplus >= 201703L
-// C++17 and above: Use the standard library
-#define LAUNDER_STR(p) std::launder(p)
-#elif defined(__GNUC__) || defined(__clang__)
-// Pre-C++17 or GCC/Clang: Use the assembly barrier
-#define LAUNDER_STR(p) \
-  ([](auto x) { \
-    __asm__("" : "+r"(x)); \
-    return x; \
-  }(p))
-#else
-// Fallback for other compilers/versions
-#define LAUNDER_STR(p) (p)
-#endif
-
 /// Instantiate a ProgmemStringTable with PROGMEM storage.
 /// Creates: Name::get_progmem_str(idx, fallback), Name::get_log_str(idx, fallback)
 /// If idx >= COUNT, returns string at fallback. Use LAST_INDEX for common patterns.


### PR DESCRIPTION
# What does this implement/fix?

After the changes introduced in e88c9ba0661131f39d5ee3c9de77a6e48204b4c5, the compiler may incorrectly report an issue with a non–null-terminated string, depending on the compiler and optimization flags:

```
logger.cpp:268:19: error: '%s' directive argument is not a nul-terminated string [-Werror=format-overflow=]
  268 |     ESP_LOGW(TAG, "Cannot set log level higher than pre-compiled %s"
```

This can be reproduced here: https://godbolt.org/z/x8aa9qMEG
The same code compiles correctly without -Os: https://godbolt.org/z/e4qzP4dbj

One possible fix is to use __attribute__((noinline)) (suggested by @bdraco): https://godbolt.org/z/1qzGPG8Tb
Another option is to use a laundering mechanism: https://godbolt.org/z/q5KcfGvvY
The second approach allows the code to remain optimized without triggering the compiler issue.

<!-- Quick description and explanation of changes -->

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
