### PR TITLE
[core] Reduce Action base class from 12 to 8 bytes with TrackedAction split

### DIFF
--- a/esphome/components/ble_client/automation.h
+++ b/esphome/components/ble_client/automation.h
@@ -94,7 +94,7 @@ class BLEClientNumericComparisonRequestTrigger : public Trigger<uint32_t>, publi
 };
 
 // implement the ble_client.ble_write action.
-template<typename... Ts> class BLEClientWriteAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientWriteAction : public TrackedAction<Ts...>, public BLEClientNode {
  public:
   BLEClientWriteAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);
@@ -315,7 +315,7 @@ template<typename... Ts> class BLEClientRemoveBondAction : public Action<Ts...> 
   BLEClient *parent_{nullptr};
 };
 
-template<typename... Ts> class BLEClientConnectAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientConnectAction : public TrackedAction<Ts...>, public BLEClientNode {
  public:
   BLEClientConnectAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);
@@ -364,7 +364,7 @@ template<typename... Ts> class BLEClientConnectAction : public Action<Ts...>, pu
   std::tuple<Ts...> var_{};
 };
 
-template<typename... Ts> class BLEClientDisconnectAction : public Action<Ts...>, public BLEClientNode {
+template<typename... Ts> class BLEClientDisconnectAction : public TrackedAction<Ts...>, public BLEClientNode {
  public:
   BLEClientDisconnectAction(BLEClient *ble_client) {
     ble_client->register_ble_node(this);

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -9,7 +9,7 @@
 
 namespace esphome::espnow {
 
-template<typename... Ts> class SendAction : public Action<Ts...>, public Parented<ESPNowComponent> {
+template<typename... Ts> class SendAction : public TrackedAction<Ts...>, public Parented<ESPNowComponent> {
   TEMPLATABLE_VALUE(peer_address_t, address);
   TEMPLATABLE_VALUE(std::vector<uint8_t>, data);
 

--- a/esphome/components/script/script.h
+++ b/esphome/components/script/script.h
@@ -272,7 +272,7 @@ template<class C, typename... Ts> class IsRunningCondition : public Condition<Ts
  * (e.g., rapid button presses, high-frequency sensor updates), so we use
  * queue-based storage for correctness.
  */
-template<class C, typename... Ts> class ScriptWaitAction : public Action<Ts...>, public Component {
+template<class C, typename... Ts> class ScriptWaitAction : public TrackedAction<Ts...>, public Component {
  public:
   ScriptWaitAction(C *script) : script_(script) {}
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -353,27 +353,15 @@ template<typename... Ts> class ActionList;
 template<typename... Ts> class Action {
  public:
   virtual void play_complex(const Ts &...x) {
-    this->num_running_++;
     this->play(x...);
     this->play_next_(x...);
   }
-  virtual void stop_complex() {
-    if (num_running_) {
-      this->stop();
-      this->num_running_ = 0;
-    }
-    this->stop_next_();
-  }
-  /// Check if this or any of the following actions are currently running.
-  virtual bool is_running() { return this->num_running_ > 0 || this->is_running_next_(); }
-
-  /// The total number of actions that are currently running in this plus any of
-  /// the following actions in the chain.
-  int num_running_total() {
-    int total = this->num_running_;
-    if (this->next_ != nullptr)
-      total += this->next_->num_running_total();
-    return total;
+  virtual void stop_complex() { this->stop_next_(); }
+  virtual bool is_running() { return this->is_running_next_(); }
+  virtual int num_running_total() {
+    if (this->next_ == nullptr)
+      return 0;
+    return this->next_->num_running_total();
   }
 
  protected:
@@ -382,11 +370,8 @@ template<typename... Ts> class Action {
 
   virtual void play(const Ts &...x) = 0;
   void play_next_(const Ts &...x) {
-    if (this->num_running_ > 0) {
-      this->num_running_--;
-      if (this->next_ != nullptr) {
-        this->next_->play_complex(x...);
-      }
+    if (this->next_ != nullptr) {
+      this->next_->play_complex(x...);
     }
   }
   template<size_t... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
@@ -410,9 +395,57 @@ template<typename... Ts> class Action {
   }
 
   Action<Ts...> *next_{nullptr};
+};
 
-  /// The number of instances of this sequence in the list of actions
-  /// that is currently being executed.
+/** Action that tracks execution count for actions that defer play_next_().
+ *
+ * Actions like DelayAction (timer callback) or WaitUntilAction (loop polling)
+ * may have play_next_() called after the initial play_complex() returns.
+ * The num_running_ counter guards against chaining after stop() is called
+ * between the initial call and the deferred callback.
+ *
+ * Adds 4 bytes (int num_running_) to the action instance.
+ * Only inherit from this if your action defers play_next_() to a later point.
+ */
+template<typename... Ts> class TrackedAction : public Action<Ts...> {
+ public:
+  void play_complex(const Ts &...x) override {
+    this->num_running_++;
+    this->play(x...);
+    this->play_next_(x...);
+  }
+  void stop_complex() override {
+    if (this->num_running_) {
+      this->stop();
+      this->num_running_ = 0;
+    }
+    this->stop_next_();
+  }
+  bool is_running() override { return this->num_running_ > 0 || this->is_running_next_(); }
+  int num_running_total() override {
+    int total = this->num_running_;
+    if (this->next_ != nullptr)
+      total += this->next_->num_running_total();
+    return total;
+  }
+
+ protected:
+  /// Shadows Action::play_next_ with a guarded version that checks num_running_.
+  void play_next_(const Ts &...x) {
+    if (this->num_running_ > 0) {
+      this->num_running_--;
+      if (this->next_ != nullptr) {
+        this->next_->play_complex(x...);
+      }
+    }
+  }
+  template<size_t... S> void play_next_tuple_(const std::tuple<Ts...> &tuple, std::index_sequence<S...> /*unused*/) {
+    this->play_next_(std::get<S>(tuple)...);
+  }
+  void play_next_tuple_(const std::tuple<Ts...> &tuple) {
+    this->play_next_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
+  }
+
   int num_running_{0};
 };
 

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -361,11 +361,11 @@ template<typename... Ts> class Action {
     this->stop_next_();
   }
   virtual bool is_running() { return this->is_running_next_(); }
-  virtual int num_running_total() {
-    if (this->next_ == nullptr)
-      return 0;
-    return this->next_->num_running_total();
-  }
+  /// Number of concurrent executions tracked by this action (0 for synchronous actions).
+  virtual int num_running() const { return 0; }
+
+  /// Get the next action in the chain (for ActionList traversal).
+  Action<Ts...> *get_next() const { return this->next_; }
 
  protected:
   friend ActionList<Ts...>;
@@ -425,12 +425,7 @@ template<typename... Ts> class TrackedAction : public Action<Ts...> {
     this->stop_next_();
   }
   bool is_running() override { return this->num_running_ > 0 || this->is_running_next_(); }
-  int num_running_total() override {
-    int total = this->num_running_;
-    if (this->next_ != nullptr)
-      total += this->next_->num_running_total();
-    return total;
-  }
+  int num_running() const override { return this->num_running_; }
 
  protected:
   /// Shadows Action::play_next_ with a guarded version that checks num_running_.
@@ -488,11 +483,13 @@ template<typename... Ts> class ActionList {
       return false;
     return this->actions_begin_->is_running();
   }
-  /// Return the number of actions in this action list that are currently running.
+  /// Return the total number of concurrent executions across all actions in this list.
   int num_running() {
-    if (this->actions_begin_ == nullptr)
-      return 0;
-    return this->actions_begin_->num_running_total();
+    int total = 0;
+    for (auto *action = this->actions_begin_; action != nullptr; action = action->get_next()) {
+      total += action->num_running();
+    }
+    return total;
   }
 
  protected:

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -356,7 +356,10 @@ template<typename... Ts> class Action {
     this->play(x...);
     this->play_next_(x...);
   }
-  virtual void stop_complex() { this->stop_next_(); }
+  virtual void stop_complex() {
+    this->stop();
+    this->stop_next_();
+  }
   virtual bool is_running() { return this->is_running_next_(); }
   virtual int num_running_total() {
     if (this->next_ == nullptr)

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -512,16 +512,23 @@ template<typename... Ts> class Automation {
 
   // Force-inline: part of the Trigger→Automation→ActionList forwarding
   // chain collapsed to reduce automation call stack depth.
-  inline void trigger(const Ts &...x) ESPHOME_ALWAYS_INLINE { this->actions_.play(x...); }
+  inline void trigger(const Ts &...x) ESPHOME_ALWAYS_INLINE {
+    this->executing_++;
+    this->actions_.play(x...);
+    this->executing_--;
+  }
 
-  bool is_running() { return this->actions_.is_running(); }
+  /// Tracks both synchronous execution (executing_ > 0) and deferred actions.
+  bool is_running() { return this->executing_ > 0 || this->actions_.is_running(); }
 
-  /// Return the number of actions in the action part of this automation that are currently running.
-  int num_running() { return this->actions_.num_running(); }
+  /// Count of concurrent executions: synchronous depth + deferred action count.
+  int num_running() { return this->executing_ + this->actions_.num_running(); }
 
  protected:
   Trigger<Ts...> *trigger_;
   ActionList<Ts...> actions_;
+  /// Tracks synchronous execution depth for reentrant safety (e.g., script calling itself).
+  int executing_{0};
 };
 
 }  // namespace esphome

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -171,7 +171,7 @@ class ProjectUpdateTrigger : public Trigger<std::string>, public Component {
 };
 #endif
 
-template<typename... Ts> class DelayAction : public Action<Ts...>, public Component {
+template<typename... Ts> class DelayAction : public TrackedAction<Ts...>, public Component {
  public:
   explicit DelayAction() = default;
 
@@ -279,14 +279,13 @@ template<bool HasElse, typename... Ts> class IfAction : public Action<Ts...> {
   }
 
   void play_complex(const Ts &...x) override {
-    this->num_running_++;
     if (this->condition_->check(x...)) {
-      if (!this->then_.empty() && this->num_running_ > 0) {
+      if (!this->then_.empty()) {
         this->then_.play(x...);
         return;
       }
     } else if constexpr (HasElse) {
-      if (!this->else_.empty() && this->num_running_ > 0) {
+      if (!this->else_.empty()) {
         this->else_.play(x...);
         return;
       }
@@ -311,7 +310,7 @@ template<bool HasElse, typename... Ts> class IfAction : public Action<Ts...> {
   [[no_unique_address]] std::conditional_t<HasElse, ActionList<Ts...>, NoElse> else_;
 };
 
-template<typename... Ts> class WhileAction : public Action<Ts...> {
+template<typename... Ts> class WhileAction : public TrackedAction<Ts...> {
  public:
   WhileAction(Condition<Ts...> *condition) : condition_(condition) {}
 
@@ -324,14 +323,11 @@ template<typename... Ts> class WhileAction : public Action<Ts...> {
 
   void play_complex(const Ts &...x) override {
     this->num_running_++;
-    // Initial condition check
     if (!this->condition_->check(x...)) {
-      // If new condition check failed, stop loop if running
       this->then_.stop();
       this->play_next_(x...);
       return;
     }
-
     if (this->num_running_ > 0) {
       this->then_.play(x...);
     }
@@ -350,10 +346,8 @@ template<typename... Ts> class WhileAction : public Action<Ts...> {
 // Implementation of WhileLoopContinuation::play
 template<typename... Ts> void WhileLoopContinuation<Ts...>::play(const Ts &...x) {
   if (this->parent_->num_running_ > 0 && this->parent_->condition_->check(x...)) {
-    // play again
     this->parent_->then_.play(x...);
   } else {
-    // condition false, play next
     this->parent_->play_next_(x...);
   }
 }
@@ -373,7 +367,7 @@ template<typename... Ts> class RepeatLoopContinuation : public Action<uint32_t, 
   RepeatAction<Ts...> *parent_;
 };
 
-template<typename... Ts> class RepeatAction : public Action<Ts...> {
+template<typename... Ts> class RepeatAction : public TrackedAction<Ts...> {
  public:
   TEMPLATABLE_VALUE(uint32_t, count)
 
@@ -419,7 +413,7 @@ template<typename... Ts> void RepeatLoopContinuation<Ts...>::play(const uint32_t
  * (e.g., rapid button presses, high-frequency sensor updates), so we use
  * queue-based storage for correctness.
  */
-template<typename... Ts> class WaitUntilAction : public Action<Ts...>, public Component {
+template<typename... Ts> class WaitUntilAction : public TrackedAction<Ts...>, public Component {
  public:
   WaitUntilAction(Condition<Ts...> *condition) : condition_(condition) {}
 

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -303,6 +303,18 @@ template<bool HasElse, typename... Ts> class IfAction : public Action<Ts...> {
     }
   }
 
+  bool is_running() override {
+    if (this->then_.is_running()) {
+      return true;
+    }
+    if constexpr (HasElse) {
+      if (this->else_.is_running()) {
+        return true;
+      }
+    }
+    return this->is_running_next_();
+  }
+
  protected:
   Condition<Ts...> *condition_;
   ActionList<Ts...> then_;


### PR DESCRIPTION
> **Chained on top of #15134** — rebase after that merges, then retarget to `dev`.

# What does this implement/fix?

The `Action` base class includes a `num_running_` counter (4 bytes) in every action instance, but only ~9 classes actually use it. The vast majority of actions are synchronous — they execute `play()` and immediately chain to the next action. The counter is dead weight for them.

This PR splits the hierarchy:
- **`Action`** (8 bytes) — lightweight base for synchronous actions. No counter, no guarded `play_next_()`.
- **`TrackedAction`** (12 bytes) — extends `Action` with `num_running_` and a shadowed `play_next_()` that guards against chaining after `stop()`. Only for actions that defer `play_next_()` to a later point (timers, loop callbacks, BLE callbacks).

**TrackedAction classes** (9 total, inheritance change only — no logic changes):

Truly async (defer `play_next_()` via timer/callback/loop):
- `DelayAction`, `WaitUntilAction`, `ScriptWaitAction`
- `BLEClientWriteAction`, `BLEClientConnectAction`, `BLEClientDisconnectAction`
- `espnow::SendAction`

Synchronous but use `num_running_` for loop stop detection (left on `TrackedAction` to minimize changes — could be refactored to a `bool stopped_` in a follow-up):
- `WhileAction` — continuation checks `num_running_ > 0` to break the loop on `stop()`
- `RepeatAction` — same pattern

**IfAction** has `num_running_` usage removed entirely — the counter check was always true immediately after the increment (dead code in synchronous single-threaded execution). Added `is_running()` override to check sub-branches.

**Reentrant safety:** The old per-Action `num_running_` also made `is_running()` return true during synchronous execution, which blocks reentrant script calls (e.g., circular `script.execute` references). Without a guard, circular scripts would crash the device via stack overflow instead of being silently blocked. The fix: an `executing_` counter on `Automation` (4 bytes per Automation, not per Action). This moves the overhead from many instances (Actions) to fewer instances (Automations) while preserving crash protection.

**Net savings: 4 bytes per synchronous Action instance minus 4 bytes per Automation instance.** Since configs have far more Actions than Automations, the net is positive.

Measured on real devices:

| Device | Platform | RAM saved | Flash cost |
|--------|----------|-----------|------------|
| Apollo R PRO-1 | ESP32-S3 (~44 sync actions, ~12 automations) | **-128 B** | +332 B |
| ratgdo garage door | ESP8266 (~18 sync actions, ~14 automations) | **-16 B** | +256 B |

The ESP8266 savings are modest because this config has many automations relative to actions. Configs with more automation actions (common for complex devices) will see proportionally larger savings.

The existing `test_continuation_actions` integration test covers if/then/else, while loops, and repeat — all affected paths.

## Migration guide for external components

Most external components are unaffected — only components that define custom action classes that access `num_running_` need a one-line change.

A GitHub code search found **zero external components** that access `num_running_` in custom Action subclasses. The only matches were vendored copies of ESPHome core (forks), not components extending the API. The migration guide below is provided for completeness.

**Does your component access `this->num_running_` in a custom Action subclass?** If yes, change the base class:

```cpp
// Before
template<typename... Ts> class MyAsyncAction : public Action<Ts...> {
  void play_complex(const Ts &...x) override {
    this->num_running_++;
    // ... deferred callback that later calls this->play_next_(x...);
  }
};

// After — just change Action to TrackedAction
template<typename... Ts> class MyAsyncAction : public TrackedAction<Ts...> {
  void play_complex(const Ts &...x) override {
    this->num_running_++;
    // ... deferred callback that later calls this->play_next_(x...);
  }
};
```

**No other changes needed.** `TrackedAction` provides the same `num_running_` field and `play_next_()` behavior as the old `Action` base class. Synchronous actions that don't use `num_running_` require zero changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — all automations work identically.
# Synchronous actions automatically use the lighter 8-byte base.
button:
  - platform: template
    name: "Test"
    on_press:
      - logger.log: "hello"  # StatelessLambdaAction: 8 bytes (was 12)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Existing `test_continuation_actions` integration test covers all affected paths (if/while/repeat with both sync and async action bodies).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).