### PR TITLE
[core] Fix clean-all to handle custom build paths

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -455,8 +455,7 @@ def _get_custom_build_dir(item: Path, data_dir: Path) -> Path | None:
     esphome_conf = raw.get("esphome", {})
     if not isinstance(esphome_conf, dict):
         return None
-    build_path = esphome_conf.get("build_path")
-    if build_path:
+    if build_path := esphome_conf.get("build_path"):
         return data_dir / build_path
     return None
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -18,7 +18,6 @@ from esphome.core import CORE, EsphomeError
 from esphome.helpers import (
     copy_file_if_changed,
     cpp_string_escape,
-    get_str_env,
     is_ha_addon,
     read_file,
     rmtree,
@@ -473,10 +472,10 @@ def clean_all(configuration: list[str]):
             data_dirs.append(item / ".esphome")
     if is_ha_addon():
         data_dirs.append(Path("/data"))
-    if "ESPHOME_DATA_DIR" in os.environ:
-        data_dirs.append(Path(get_str_env("ESPHOME_DATA_DIR", None)))
-    if "ESPHOME_BUILD_PATH" in os.environ:
-        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", None)))
+    if os.environ.get("ESPHOME_DATA_DIR"):
+        data_dirs.append(Path(os.environ["ESPHOME_DATA_DIR"]))
+    if os.environ.get("ESPHOME_BUILD_PATH"):
+        data_dirs.append(Path(os.environ["ESPHOME_BUILD_PATH"]))
 
     # Clean build dir
     for dir in data_dirs:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -468,8 +468,7 @@ def clean_all(configuration: list[str]):
         if item.is_file() and item.suffix in (".yaml", ".yml"):
             data_dir = item.parent / ".esphome"
             data_dirs.append(data_dir)
-            custom = _get_custom_build_dir(item, data_dir)
-            if custom:
+            if custom := _get_custom_build_dir(item, data_dir):
                 data_dirs.append(custom)
         else:
             data_dirs.append(item / ".esphome")

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -476,7 +476,7 @@ def clean_all(configuration: list[str]):
     if "ESPHOME_DATA_DIR" in os.environ:
         data_dirs.append(Path(get_str_env("ESPHOME_DATA_DIR", None)))
     if "ESPHOME_BUILD_PATH" in os.environ:
-        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", "build")))
+        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", None)))
 
     # Clean build dir
     for dir in data_dirs:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -472,10 +472,10 @@ def clean_all(configuration: list[str]):
             data_dirs.append(item / ".esphome")
     if is_ha_addon():
         data_dirs.append(Path("/data"))
-    if os.environ.get("ESPHOME_DATA_DIR"):
-        data_dirs.append(Path(os.environ["ESPHOME_DATA_DIR"]))
-    if os.environ.get("ESPHOME_BUILD_PATH"):
-        data_dirs.append(Path(os.environ["ESPHOME_BUILD_PATH"]))
+    if env_data_dir := os.environ.get("ESPHOME_DATA_DIR"):
+        data_dirs.append(Path(env_data_dir))
+    if env_build_path := os.environ.get("ESPHOME_BUILD_PATH"):
+        data_dirs.append(Path(env_build_path))
 
     # Clean build dir
     for dir in data_dirs:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -441,30 +441,39 @@ def clean_build(clear_pio_cache: bool = True):
             rmtree(cache_dir)
 
 
-def clean_all(configuration: list[str]):
+def _get_custom_build_dir(item: Path, data_dir: Path) -> Path | None:
+    """Parse a YAML config to find a custom build directory."""
     from esphome import yaml_util
 
+    try:
+        raw = yaml_util.load_yaml(item)
+    except (EsphomeError, OSError) as e:
+        _LOGGER.debug("Could not parse %s to find build_path: %s", item, e)
+        return None
+    if not isinstance(raw, dict):
+        return None
+    esphome_conf = raw.get("esphome", {})
+    if not isinstance(esphome_conf, dict):
+        return None
+    build_path = esphome_conf.get("build_path")
+    if build_path:
+        return data_dir / build_path
+    name = esphome_conf.get("name", "")
+    if "ESPHOME_BUILD_PATH" in os.environ and name:
+        return data_dir / Path(get_str_env("ESPHOME_BUILD_PATH", "build")) / name
+    return None
+
+
+def clean_all(configuration: list[str]):
     data_dirs = []
     for config in configuration:
         item = Path(config)
         if item.is_file() and item.suffix in (".yaml", ".yml"):
             data_dir = item.parent / ".esphome"
             data_dirs.append(data_dir)
-            # Check for custom build_path in YAML config
-            try:
-                raw = yaml_util.load_yaml(item)
-                if isinstance(raw, dict):
-                    esphome_conf = raw.get("esphome", {})
-                    if isinstance(esphome_conf, dict):
-                        build_path = esphome_conf.get("build_path")
-                        name = esphome_conf.get("name", "")
-                        if build_path:
-                            data_dirs.append(data_dir / build_path)
-                        elif "ESPHOME_BUILD_PATH" in os.environ and name:
-                            env_path = Path(get_str_env("ESPHOME_BUILD_PATH", "build"))
-                            data_dirs.append(data_dir / env_path / name)
-            except (EsphomeError, OSError) as e:
-                _LOGGER.debug("Could not parse %s to find build_path: %s", item, e)
+            custom = _get_custom_build_dir(item, data_dir)
+            if custom:
+                data_dirs.append(custom)
         else:
             data_dirs.append(item / ".esphome")
     if is_ha_addon():

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -463,8 +463,8 @@ def clean_all(configuration: list[str]):
                         elif "ESPHOME_BUILD_PATH" in os.environ and name:
                             env_path = Path(get_str_env("ESPHOME_BUILD_PATH", "build"))
                             data_dirs.append(data_dir / env_path / name)
-            except (EsphomeError, OSError):
-                pass
+            except (EsphomeError, OSError) as e:
+                _LOGGER.debug("Could not parse %s to find build_path: %s", item, e)
         else:
             data_dirs.append(item / ".esphome")
     if is_ha_addon():

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -442,17 +442,30 @@ def clean_build(clear_pio_cache: bool = True):
 
 
 def clean_all(configuration: list[str]):
+    from esphome import yaml_util
+
     data_dirs = []
     for config in configuration:
         item = Path(config)
         if item.is_file() and item.suffix in (".yaml", ".yml"):
             data_dirs.append(item.parent / ".esphome")
+            # Check for build_path in YAML config
+            try:
+                raw = yaml_util.load_yaml(item)
+                if isinstance(raw, dict):
+                    build_path = raw.get("esphome", {}).get("build_path")
+                    if build_path:
+                        data_dirs.append(Path(build_path))
+            except Exception:
+                pass
         else:
             data_dirs.append(item / ".esphome")
     if is_ha_addon():
         data_dirs.append(Path("/data"))
     if "ESPHOME_DATA_DIR" in os.environ:
         data_dirs.append(Path(get_str_env("ESPHOME_DATA_DIR", None)))
+    if "ESPHOME_BUILD_PATH" in os.environ:
+        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", None)))
 
     # Clean build dir
     for dir in data_dirs:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -458,9 +458,6 @@ def _get_custom_build_dir(item: Path, data_dir: Path) -> Path | None:
     build_path = esphome_conf.get("build_path")
     if build_path:
         return data_dir / build_path
-    name = esphome_conf.get("name", "")
-    if "ESPHOME_BUILD_PATH" in os.environ and name:
-        return data_dir / Path(get_str_env("ESPHOME_BUILD_PATH", "build")) / name
     return None
 
 
@@ -480,6 +477,8 @@ def clean_all(configuration: list[str]):
         data_dirs.append(Path("/data"))
     if "ESPHOME_DATA_DIR" in os.environ:
         data_dirs.append(Path(get_str_env("ESPHOME_DATA_DIR", None)))
+    if "ESPHOME_BUILD_PATH" in os.environ:
+        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", "build")))
 
     # Clean build dir
     for dir in data_dirs:

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -448,15 +448,22 @@ def clean_all(configuration: list[str]):
     for config in configuration:
         item = Path(config)
         if item.is_file() and item.suffix in (".yaml", ".yml"):
-            data_dirs.append(item.parent / ".esphome")
-            # Check for build_path in YAML config
+            data_dir = item.parent / ".esphome"
+            data_dirs.append(data_dir)
+            # Check for custom build_path in YAML config
             try:
                 raw = yaml_util.load_yaml(item)
                 if isinstance(raw, dict):
-                    build_path = raw.get("esphome", {}).get("build_path")
-                    if build_path:
-                        data_dirs.append(Path(build_path))
-            except Exception:
+                    esphome_conf = raw.get("esphome", {})
+                    if isinstance(esphome_conf, dict):
+                        build_path = esphome_conf.get("build_path")
+                        name = esphome_conf.get("name", "")
+                        if build_path:
+                            data_dirs.append(data_dir / build_path)
+                        elif "ESPHOME_BUILD_PATH" in os.environ and name:
+                            env_path = Path(get_str_env("ESPHOME_BUILD_PATH", "build"))
+                            data_dirs.append(data_dir / env_path / name)
+            except (EsphomeError, OSError):
                 pass
         else:
             data_dirs.append(item / ".esphome")
@@ -464,8 +471,6 @@ def clean_all(configuration: list[str]):
         data_dirs.append(Path("/data"))
     if "ESPHOME_DATA_DIR" in os.environ:
         data_dirs.append(Path(get_str_env("ESPHOME_DATA_DIR", None)))
-    if "ESPHOME_BUILD_PATH" in os.environ:
-        data_dirs.append(Path(get_str_env("ESPHOME_BUILD_PATH", None)))
 
     # Clean build dir
     for dir in data_dirs:

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -966,6 +966,31 @@ def test_clean_all_with_env_build_path(
 
 
 @patch("esphome.writer.CORE")
+def test_clean_all_ignores_empty_env_vars(
+    mock_core: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Test clean_all ignores empty ESPHOME_BUILD_PATH/ESPHOME_DATA_DIR."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create a file in cwd that must NOT be cleaned
+    marker = tmp_path / "important.txt"
+    marker.write_text("do not delete")
+
+    from esphome.writer import clean_all
+
+    with patch.dict(
+        os.environ,
+        {"ESPHOME_BUILD_PATH": "", "ESPHOME_DATA_DIR": ""},
+    ):
+        clean_all([str(config_dir)])
+
+    # Empty env vars must not cause cwd to be cleaned
+    assert marker.exists()
+
+
+@patch("esphome.writer.CORE")
 def test_clean_all(
     mock_core: MagicMock,
     tmp_path: Path,

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -872,11 +872,11 @@ def test_clean_all_with_yaml_build_path(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test clean_all cleans build_path specified in YAML config."""
+    """Test clean_all cleans absolute build_path specified in YAML config."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
-    # Create a custom build path directory with contents
+    # Create an absolute custom build path directory with contents
     custom_build = tmp_path / "custom_build"
     custom_build.mkdir()
     (custom_build / "firmware.bin").write_text("x")
@@ -885,6 +885,7 @@ def test_clean_all_with_yaml_build_path(
     (sub / "file.txt").write_text("x")
 
     yaml_file = config_dir / "test.yaml"
+    # Absolute build_path: data_dir / absolute = absolute (Python Path behavior)
     yaml_file.write_text(f"esphome:\n  name: test\n  build_path: {custom_build}\n")
 
     # Also create the normal .esphome dir
@@ -937,7 +938,7 @@ def test_clean_all_with_env_build_path(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test clean_all cleans ESPHOME_BUILD_PATH directory."""
+    """Test clean_all cleans ESPHOME_BUILD_PATH/<name> directory."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
@@ -945,23 +946,31 @@ def test_clean_all_with_env_build_path(
     build_dir.mkdir()
     (build_dir / "dummy.txt").write_text("x")
 
-    # Create env build path directory
-    env_build = tmp_path / "env_build"
+    # ESPHOME_BUILD_PATH is a base; actual build dir is <base>/<name>
+    # With absolute path: data_dir / absolute / name = absolute / name
+    env_base = tmp_path / "env_builds"
+    env_base.mkdir()
+    env_build = env_base / "mydevice"
     env_build.mkdir()
     (env_build / "firmware.bin").write_text("x")
+
+    yaml_file = config_dir / "test.yaml"
+    yaml_file.write_text("esphome:\n  name: mydevice\n")
 
     from esphome.writer import clean_all
 
     with (
         caplog.at_level("INFO"),
-        patch.dict(os.environ, {"ESPHOME_BUILD_PATH": str(env_build)}),
+        patch.dict(os.environ, {"ESPHOME_BUILD_PATH": str(env_base)}),
     ):
-        clean_all([str(config_dir)])
+        clean_all([str(yaml_file)])
 
-    # Both should be cleaned
+    # .esphome and ESPHOME_BUILD_PATH/<name> should be cleaned
     assert not (build_dir / "dummy.txt").exists()
     assert env_build.exists()
     assert not (env_build / "firmware.bin").exists()
+    # Base dir should NOT be cleaned (only per-device subdir)
+    assert env_base.exists()
 
 
 @patch("esphome.writer.CORE")

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -867,6 +867,104 @@ def test_clean_all_with_yaml_file(
 
 
 @patch("esphome.writer.CORE")
+def test_clean_all_with_yaml_build_path(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all cleans build_path specified in YAML config."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    # Create a custom build path directory with contents
+    custom_build = tmp_path / "custom_build"
+    custom_build.mkdir()
+    (custom_build / "firmware.bin").write_text("x")
+    sub = custom_build / "subdir"
+    sub.mkdir()
+    (sub / "file.txt").write_text("x")
+
+    yaml_file = config_dir / "test.yaml"
+    yaml_file.write_text(f"esphome:\n  name: test\n  build_path: {custom_build}\n")
+
+    # Also create the normal .esphome dir
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+    (build_dir / "dummy.txt").write_text("x")
+
+    from esphome.writer import clean_all
+
+    with caplog.at_level("INFO"):
+        clean_all([str(yaml_file)])
+
+    # Both .esphome and custom build_path should be cleaned
+    assert build_dir.exists()
+    assert not (build_dir / "dummy.txt").exists()
+    assert custom_build.exists()
+    assert not (custom_build / "firmware.bin").exists()
+    assert not sub.exists()
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_with_yaml_parse_error(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all still cleans .esphome when YAML parse fails."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    yaml_file = config_dir / "test.yaml"
+    yaml_file.write_text("invalid: yaml: content: [")
+
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+    (build_dir / "dummy.txt").write_text("x")
+
+    from esphome.writer import clean_all
+
+    with caplog.at_level("INFO"):
+        clean_all([str(yaml_file)])
+
+    # .esphome should still be cleaned despite YAML parse failure
+    assert build_dir.exists()
+    assert not (build_dir / "dummy.txt").exists()
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_with_env_build_path(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all cleans ESPHOME_BUILD_PATH directory."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+
+    build_dir = config_dir / ".esphome"
+    build_dir.mkdir()
+    (build_dir / "dummy.txt").write_text("x")
+
+    # Create env build path directory
+    env_build = tmp_path / "env_build"
+    env_build.mkdir()
+    (env_build / "firmware.bin").write_text("x")
+
+    from esphome.writer import clean_all
+
+    with (
+        caplog.at_level("INFO"),
+        patch.dict(os.environ, {"ESPHOME_BUILD_PATH": str(env_build)}),
+    ):
+        clean_all([str(config_dir)])
+
+    # Both should be cleaned
+    assert not (build_dir / "dummy.txt").exists()
+    assert env_build.exists()
+    assert not (env_build / "firmware.bin").exists()
+
+
+@patch("esphome.writer.CORE")
 def test_clean_all(
     mock_core: MagicMock,
     tmp_path: Path,

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -938,7 +938,7 @@ def test_clean_all_with_env_build_path(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test clean_all cleans ESPHOME_BUILD_PATH/<name> directory."""
+    """Test clean_all cleans ESPHOME_BUILD_PATH directory."""
     config_dir = tmp_path / "config"
     config_dir.mkdir()
 
@@ -946,31 +946,23 @@ def test_clean_all_with_env_build_path(
     build_dir.mkdir()
     (build_dir / "dummy.txt").write_text("x")
 
-    # ESPHOME_BUILD_PATH is a base; actual build dir is <base>/<name>
-    # With absolute path: data_dir / absolute / name = absolute / name
-    env_base = tmp_path / "env_builds"
-    env_base.mkdir()
-    env_build = env_base / "mydevice"
+    # Create env build path directory
+    env_build = tmp_path / "env_build"
     env_build.mkdir()
     (env_build / "firmware.bin").write_text("x")
-
-    yaml_file = config_dir / "test.yaml"
-    yaml_file.write_text("esphome:\n  name: mydevice\n")
 
     from esphome.writer import clean_all
 
     with (
         caplog.at_level("INFO"),
-        patch.dict(os.environ, {"ESPHOME_BUILD_PATH": str(env_base)}),
+        patch.dict(os.environ, {"ESPHOME_BUILD_PATH": str(env_build)}),
     ):
-        clean_all([str(yaml_file)])
+        clean_all([str(config_dir)])
 
-    # .esphome and ESPHOME_BUILD_PATH/<name> should be cleaned
+    # Both should be cleaned
     assert not (build_dir / "dummy.txt").exists()
     assert env_build.exists()
     assert not (env_build / "firmware.bin").exists()
-    # Base dir should NOT be cleaned (only per-device subdir)
-    assert env_base.exists()
 
 
 @patch("esphome.writer.CORE")


### PR DESCRIPTION
# What does this implement/fix?

`clean-all` did not clean build artifacts when a custom `build_path` was configured in the YAML config or via the `ESPHOME_BUILD_PATH` environment variable. This parses the YAML to extract `build_path` and also checks the env variable so all build directories are cleaned.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: test
  build_path: /custom/build/path
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).