### PR TITLE
[light] Fix incorrect mode change handling on transition to off

### DIFF
--- a/esphome/components/light/transformers.h
+++ b/esphome/components/light/transformers.h
@@ -27,7 +27,7 @@ class LightTransitionTransformer : public LightTransformer {
     }
 
     // When changing color mode, go through off state, as color modes are orthogonal and there can't be two active.
-    if (this->start_values_.get_color_mode() != this->target_values_.get_color_mode()) {
+    if (this->start_values_.get_color_mode() != this->end_values_.get_color_mode()) {
       this->changing_color_mode_ = true;
       this->intermediate_values_ = this->start_values_;
       this->intermediate_values_.set_state(false);
@@ -39,8 +39,8 @@ class LightTransitionTransformer : public LightTransformer {
 
     // Halfway through, when intermediate state (off) is reached, flip it to the target, but remain off.
     if (this->changing_color_mode_ && p > 0.5f &&
-        this->intermediate_values_.get_color_mode() != this->target_values_.get_color_mode()) {
-      this->intermediate_values_ = this->target_values_;
+        this->intermediate_values_.get_color_mode() != this->end_values_.get_color_mode()) {
+      this->intermediate_values_ = this->end_values_;
       this->intermediate_values_.set_state(false);
     }
 


### PR DESCRIPTION
# What does this implement/fix?

The color_mode comparison incorrectly compared the start color_mode to the 'target_values_' color_mode. In the special case of a on-to-off transition, the target of the transition is stored in 'end_values_'.

As a result, the transition incorrectly used an intermediate state, even though it was not required.

Additionally, the transition incorrectly used the 'target_values_' state for the second half of a color_mode change transition. Both issues combined resulted in a color_mode change during the second half of the transition, manifesting in incorrect interpolations.

Use 'end_values_' instead of 'target_values_', so the case distinction use the same values as the actual transition.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
