### PR TITLE
[api] Add descriptive message to status warning when waiting for client

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -108,7 +108,7 @@ void APIServer::setup() {
   this->last_connected_ = App.get_loop_component_start_time();
   // Set warning status if reboot timeout is enabled
   if (this->reboot_timeout_ != 0) {
-    this->status_set_warning();
+    this->status_set_warning(LOG_STR("waiting for client connection"));
   }
 }
 
@@ -187,7 +187,7 @@ void APIServer::remove_client_(size_t client_index) {
 
   // Last client disconnected - set warning and start tracking for reboot timeout
   if (this->clients_.empty() && this->reboot_timeout_ != 0) {
-    this->status_set_warning();
+    this->status_set_warning(LOG_STR("waiting for client connection"));
     this->last_connected_ = App.get_loop_component_start_time();
   }
 


### PR DESCRIPTION
# What does this implement/fix?

The API component calls `status_set_warning()` without a message when no client is connected and reboot timeout is enabled. This results in a confusing log line:

```
[W][component:398]: api set Warning flag: unspecified
```

This replaces the no-arg calls with a descriptive message so users see:

```
[W][component:398]: api set Warning flag: waiting for client connection
```

This helps users understand that the warning is expected behavior (the device is waiting for Home Assistant to connect), rather than an unknown error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15140

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).