### PR TITLE
[wifi] Filter fast_connect by band_mode and use background scan for roaming

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2191,6 +2191,14 @@ bool WiFiComponent::load_fast_connect_settings_(WiFiAP &params) {
     params.set_hidden(false);
 
     ESP_LOGD(TAG, "Loaded fast_connect settings");
+#if defined(USE_ESP32) && defined(SOC_WIFI_SUPPORT_5G)
+    if ((this->band_mode_ == WIFI_BAND_MODE_5G_ONLY && fast_connect_save.channel < FIRST_5GHZ_CHANNEL) ||
+        (this->band_mode_ == WIFI_BAND_MODE_2G_ONLY && fast_connect_save.channel >= FIRST_5GHZ_CHANNEL)) {
+      ESP_LOGW(TAG, "Saved channel %u not allowed by band mode, ignoring fast_connect", fast_connect_save.channel);
+      this->selected_sta_index_ = -1;
+      return false;
+    }
+#endif
     return true;
   }
 

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -774,6 +774,8 @@ class WiFiComponent final : public Component {
   SemaphoreHandle_t high_performance_semaphore_{nullptr};
 #endif
 
+  static constexpr uint8_t FIRST_5GHZ_CHANNEL = 36;
+
   // Post-connect roaming constants
   static constexpr uint32_t ROAMING_CHECK_INTERVAL = 5 * 60 * 1000;  // 5 minutes
   static constexpr int8_t ROAMING_MIN_IMPROVEMENT = 10;              // dB

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -987,6 +987,11 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
     config.scan_time.active.min = 100;
     config.scan_time.active.max = 300;
   }
+  // When scanning while connected (roaming), return to home channel between
+  // each scanned channel to maintain the connection (helps with BLE/WiFi coexistence)
+  if (this->roaming_state_ == RoamingState::SCANNING) {
+    config.coex_background_scan = true;
+  }
 
   esp_err_t err = esp_wifi_scan_start(&config, false);
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

Two fixes for WiFi on 5GHz-capable ESP32 variants:

1. **Fast connect band filter**: If the saved fast_connect channel doesn't match the configured `band_mode` (e.g., a 2.4GHz channel saved but `band_mode: 5GHZ`), the saved channel is ignored and a full scan is performed instead.

2. **Background scan for roaming**: Sets `coex_background_scan = true` during roaming scans. This returns to the home channel between each scanned channel, maintaining the connection during the scan. This eliminates connection drops during roaming scans when BLE is active (e.g., bluetooth_proxy), at the cost of longer scan times (~19.7s vs ~18.8s).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15015

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
  band_mode: 5GHZ
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).