### PR TITLE
[audio] Bump esp-audio-libs to 2.0.4

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -204,7 +204,7 @@ async def to_code(config):
 
     add_idf_component(
         name="esphome/esp-audio-libs",
-        ref="2.0.3",
+        ref="2.0.4",
     )
 
     data = _get_data()

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -2,7 +2,7 @@ dependencies:
   bblanchon/arduinojson:
     version: "7.4.2"
   esphome/esp-audio-libs:
-    version: 2.0.3
+    version: 2.0.4
   esphome/micro-opus:
     version: 0.3.6
   espressif/esp-dsp:


### PR DESCRIPTION
## What does this implement/fix?

Bumps esp-audio-libs from 2.0.3 to 2.0.4. Version 2.0.4 adds the missing `#include <stdint.h>` to `mp3_decoder.h`, fixing compilation with ESP-IDF 6.0 which ships GCC 15 and Picolibc where `uint32_t` is no longer pulled in transitively.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

No config changes needed - dependency version bump only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).