### PR TITLE
[mcp9600] Fix setup success check using OR instead of AND

### DIFF
--- a/esphome/components/mcp9600/mcp9600.cpp
+++ b/esphome/components/mcp9600/mcp9600.cpp
@@ -40,20 +40,20 @@ void MCP9600Component::setup() {
   }
 
   bool success = this->write_byte(MCP9600_REGISTER_STATUS, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_SENSOR_CONFIG, uint8_t(0x00 | thermocouple_type_ << 4));
-  success |= this->write_byte(MCP9600_REGISTER_CONFIG, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT1_CONFIG, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT2_CONFIG, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT3_CONFIG, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT4_CONFIG, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT1_HYSTERESIS, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT2_HYSTERESIS, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT3_HYSTERESIS, 0x00);
-  success |= this->write_byte(MCP9600_REGISTER_ALERT4_HYSTERESIS, 0x00);
-  success |= this->write_byte_16(MCP9600_REGISTER_ALERT1_LIMIT, 0x0000);
-  success |= this->write_byte_16(MCP9600_REGISTER_ALERT2_LIMIT, 0x0000);
-  success |= this->write_byte_16(MCP9600_REGISTER_ALERT3_LIMIT, 0x0000);
-  success |= this->write_byte_16(MCP9600_REGISTER_ALERT4_LIMIT, 0x0000);
+  success &= this->write_byte(MCP9600_REGISTER_SENSOR_CONFIG, uint8_t(0x00 | thermocouple_type_ << 4));
+  success &= this->write_byte(MCP9600_REGISTER_CONFIG, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT1_CONFIG, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT2_CONFIG, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT3_CONFIG, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT4_CONFIG, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT1_HYSTERESIS, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT2_HYSTERESIS, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT3_HYSTERESIS, 0x00);
+  success &= this->write_byte(MCP9600_REGISTER_ALERT4_HYSTERESIS, 0x00);
+  success &= this->write_byte_16(MCP9600_REGISTER_ALERT1_LIMIT, 0x0000);
+  success &= this->write_byte_16(MCP9600_REGISTER_ALERT2_LIMIT, 0x0000);
+  success &= this->write_byte_16(MCP9600_REGISTER_ALERT3_LIMIT, 0x0000);
+  success &= this->write_byte_16(MCP9600_REGISTER_ALERT4_LIMIT, 0x0000);
 
   if (!success) {
     this->error_code_ = FAILED_TO_UPDATE_CONFIGURATION;


### PR DESCRIPTION
# What does this implement/fix?

The setup register writes used `|=` (OR) to accumulate the success flag. This means if any single I2C write succeeds, the whole setup is reported as successful even if other writes failed. Changed to `&=` (AND) so setup correctly fails if any write fails.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).