### PR TITLE
[bme68x_bsec2] Fix uninitialized bme68x_conf in measurement duration calculation

### DIFF
--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -276,8 +276,8 @@ void BME68xBSEC2Component::run_() {
   }
 
   if (this->bsec_settings_.trigger_measurement && this->bsec_settings_.op_mode != BME68X_SLEEP_MODE) {
-    uint32_t meas_dur = 0;
-    meas_dur = bme68x_get_meas_dur(this->op_mode_, &bme68x_conf, &this->bme68x_);
+    bme68x_get_conf(&bme68x_conf, &this->bme68x_);
+    uint32_t meas_dur = bme68x_get_meas_dur(this->op_mode_, &bme68x_conf, &this->bme68x_);
     ESP_LOGV(TAG, "Queueing read in %uus", meas_dur);
     this->trigger_time_ns_ = curr_time_ns;
     this->set_timeout("read", meas_dur / 1000, [this]() { this->read_(this->trigger_time_ns_); });


### PR DESCRIPTION
# What does this implement/fix?

`bme68x_conf` is declared on the stack uninitialized. In parallel mode, after the first measurement cycle, the mode hasn't changed so the switch branch that calls `bme68x_get_conf()` is skipped. The uninitialized struct is then passed to `bme68x_get_meas_dur()` which reads oversampling settings from it to compute the measurement duration — resulting in a wrong read timeout.

Fix by calling `bme68x_get_conf()` to read the current sensor config right before computing the measurement duration, so it always has valid data regardless of which switch branch ran.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).