### PR TITLE
[uart] Fix debug callback missing peeked byte and reading past end

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -324,6 +324,9 @@ bool IDFUARTComponent::peek_byte(uint8_t *data) {
 }
 
 bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
+  if (len == 0) {
+    return false;
+  }
   size_t length_to_read = len;
   int32_t read_len = 0;
   if (!this->check_read_timeout_(len))
@@ -331,11 +334,10 @@ bool IDFUARTComponent::read_array(uint8_t *data, size_t len) {
   if (this->has_peek_) {
     length_to_read--;
     *data = this->peek_byte_;
-    data++;
     this->has_peek_ = false;
   }
   if (length_to_read > 0)
-    read_len = uart_read_bytes(this->uart_num_, data, length_to_read, 20 / portTICK_PERIOD_MS);
+    read_len = uart_read_bytes(this->uart_num_, data + (len - length_to_read), length_to_read, 20 / portTICK_PERIOD_MS);
 #ifdef USE_UART_DEBUGGER
   for (size_t i = 0; i < len; i++) {
     this->debug_callback_.call(UART_DIRECTION_RX, data[i]);

--- a/esphome/components/uart/uart_component_host.cpp
+++ b/esphome/components/uart/uart_component_host.cpp
@@ -235,16 +235,14 @@ bool HostUartComponent::read_array(uint8_t *data, size_t len) {
   }
   if (!this->check_read_timeout_(len))
     return false;
-  uint8_t *data_ptr = data;
   size_t length_to_read = len;
   if (this->has_peek_) {
     length_to_read--;
-    *data_ptr = this->peek_byte_;
-    data_ptr++;
+    *data = this->peek_byte_;
     this->has_peek_ = false;
   }
   if (length_to_read > 0) {
-    int sz = ::read(this->file_descriptor_, data_ptr, length_to_read);
+    int sz = ::read(this->file_descriptor_, data + (len - length_to_read), length_to_read);
     if (sz == -1) {
       this->update_error_(strerror(errno));
       return false;


### PR DESCRIPTION
# What does this implement/fix?

When `read_array` consumed a peeked byte, the `data` pointer was incremented before the debug callback loop. This caused two issues:

1. The peeked byte was skipped by the debug callback (never logged)
2. The loop read one byte past what was actually read by `uart_read_bytes`

Fix by not advancing the `data` pointer. Instead, offset the `uart_read_bytes` destination using the difference between the original and remaining length.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - fixes UART debug output when peek_byte is used
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).