### PR TITLE
[esp32] Wrap vfprintf to fix printf stub on picolibc (IDF 6)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1587,7 +1587,7 @@ async def to_code(config):
         if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF]:
             cg.add_define("USE_FULL_PRINTF")
         else:
-            for symbol in ("vprintf", "printf", "fprintf"):
+            for symbol in ("vprintf", "printf", "fprintf", "vfprintf"):
                 cg.add_build_flag(f"-Wl,--wrap={symbol}")
     else:
         cg.add_build_flag("-DUSE_ARDUINO")

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -2,10 +2,11 @@
  * Linker wrap stubs for FILE*-based printf functions.
  *
  * ESP-IDF SDK components (gpio driver, ringbuf, log_write) reference
- * fprintf(), printf(), and vprintf() which pull in newlib's _vfprintf_r
- * (~11 KB). This is a separate implementation from _svfprintf_r (used by
- * snprintf/vsnprintf) that handles FILE* stream I/O with buffering and
- * locking.
+ * fprintf(), printf(), vprintf(), and vfprintf() which pull in the full
+ * printf implementation (~11 KB on newlib's _vfprintf_r, ~2.8 KB on
+ * picolibc's vfprintf). This is a separate implementation from the one
+ * used by snprintf/vsnprintf that handles FILE* stream I/O with buffering
+ * and locking.
  *
  * ESPHome replaces the ESP-IDF log handler via esp_log_set_vprintf_(),
  * so the SDK's vprintf() path is dead code at runtime. The fprintf()
@@ -68,6 +69,11 @@ int __wrap_printf(const char *fmt, ...) {
   int len = __wrap_vprintf(fmt, ap);
   va_end(ap);
   return len;
+}
+
+int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
+  char buf[PRINTF_BUFFER_SIZE];
+  return write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
 
 int __wrap_fprintf(FILE *stream, const char *fmt, ...) {

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -79,8 +79,7 @@ int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
 int __wrap_fprintf(FILE *stream, const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  char buf[PRINTF_BUFFER_SIZE];
-  int len = write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+  int len = __wrap_vfprintf(stream, fmt, ap);
   va_end(ap);
   return len;
 }


### PR DESCRIPTION
# What does this implement/fix?

ESP-IDF 6 uses picolibc instead of newlib. In newlib, `vfprintf` was a thin 36-byte trampoline to `_vfprintf_r`, so wrapping `printf`/`vprintf`/`fprintf` was sufficient to dead-code eliminate `_vfprintf_r` (~11 KB). In picolibc, `vfprintf` IS the heavy implementation (~2.8 KB) and is referenced directly by SDK components, so the existing wraps don't prevent it from being linked in.

This adds `vfprintf` to the linker wrap list and provides a `__wrap_vfprintf` stub, matching the existing pattern. Also refactors `__wrap_fprintf` to delegate to `__wrap_vfprintf` to avoid duplicating the buffer.

## Testing

Test config that exercises all wrapped functions from a lambda:

```yaml
esphome:
  name: test-printf-wrap
  on_boot:
    then:
      - lambda: |-
          printf("printf test: hello from printf %d\n", 42);
          vprintf("vprintf test: %s\n", (va_list){});
          fprintf(stdout, "fprintf test: hello from fprintf to stdout %s\n", "works");
          fprintf(stderr, "fprintf test: hello from fprintf to stderr %s\n", "works");
          // vfprintf is exercised indirectly through fprintf (which delegates to __wrap_vfprintf)
          ESP_LOGI("test", "ESP_LOGI still works fine");

esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: esp-idf

logger:
api:
wifi:
  ssid: MySSID
  password: password1
```

Verify with `nm` that picolibc's `vfprintf` is no longer present in the final binary.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #14770 (IDF 6 memory impact)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - the wrap is applied automatically.
# To disable: set enable_full_printf: true in esp32 advanced config.
esp32:
  framework:
    type: esp-idf
    advanced:
      enable_full_printf: false  # default
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).