### PR TITLE
[core] Remove indirection from ControllerRegistry dispatch

### DIFF
--- a/esphome/core/controller_registry.cpp
+++ b/esphome/core/controller_registry.cpp
@@ -10,24 +10,24 @@ StaticVector<Controller *, CONTROLLER_REGISTRY_MAX> ControllerRegistry::controll
 
 void ControllerRegistry::register_controller(Controller *controller) { controllers.push_back(controller); }
 
-void ControllerRegistry::notify(void *obj, DispatchFunc dispatch) {
-  for (auto *controller : controllers) {
-    dispatch(controller, obj);
-  }
-}
-
-// Macro for standard registry notification dispatch - calls on_<entity_name>_update()
-// Each wrapper passes a small trampoline lambda that calls the correct virtual method.
+// Each notify method directly iterates controllers and calls the virtual method.
+// This avoids the overhead of a shared noinline dispatch loop with function pointer
+// indirection. The loop is tiny (~20 bytes per entity type) so the flash cost of
+// duplicating it is negligible compared to eliminating two levels of indirection
+// (noinline call + function pointer) from every state publish.
 // NOLINTBEGIN(bugprone-macro-parentheses)
 #define CONTROLLER_REGISTRY_NOTIFY(entity_type, entity_name) \
   void ControllerRegistry::notify_##entity_name##_update(entity_type *obj) { \
-    notify(obj, [](Controller *c, void *o) { c->on_##entity_name##_update(static_cast<entity_type *>(o)); }); \
+    for (auto *controller : controllers) { \
+      controller->on_##entity_name##_update(obj); \
+    } \
   }
 
-// Macro for entities where controller method has no "_update" suffix (Event, Update)
 #define CONTROLLER_REGISTRY_NOTIFY_NO_UPDATE_SUFFIX(entity_type, entity_name) \
   void ControllerRegistry::notify_##entity_name(entity_type *obj) { \
-    notify(obj, [](Controller *c, void *o) { c->on_##entity_name(static_cast<entity_type *>(o)); }); \
+    for (auto *controller : controllers) { \
+      controller->on_##entity_name(obj); \
+    } \
   }
 // NOLINTEND(bugprone-macro-parentheses)
 

--- a/esphome/core/controller_registry.h
+++ b/esphome/core/controller_registry.h
@@ -146,8 +146,8 @@ class UpdateEntity;
  * entities call ControllerRegistry::notify_*_update() which iterates the small list
  * of registered controllers (typically 2: API and WebServer).
  *
- * Controllers read state directly from entities using existing accessors (obj->state, etc.)
- * rather than receiving it as callback parameters that were being ignored anyway.
+ * Each notify method directly iterates controllers and calls the virtual method,
+ * avoiding function pointer indirection for minimal dispatch overhead.
  *
  * Memory savings: 32 bytes per entity (2 controllers × 16 bytes std::function overhead)
  * Typical config (25 entities): ~780 bytes saved
@@ -247,21 +247,6 @@ class ControllerRegistry {
 #endif
 
  protected:
-  /** Type-erased dispatch function pointer.
-   *
-   * Each notify method passes a small trampoline that calls the
-   * correct virtual method on Controller. The shared notify() loop
-   * iterates controllers once, calling the trampoline for each.
-   */
-  using DispatchFunc = void (*)(Controller *, void *);
-
-  /** Shared dispatch loop - iterates controllers and calls dispatch for each.
-   *
-   * Marked noinline to ensure only one copy of the loop exists in flash,
-   * rather than being duplicated into each notify_*_update wrapper.
-   */
-  static void __attribute__((noinline)) notify(void *obj, DispatchFunc dispatch);
-
   static StaticVector<Controller *, CONTROLLER_REGISTRY_MAX> controllers;
 };
 


### PR DESCRIPTION
# What does this implement/fix?

Simplify `ControllerRegistry` dispatch by replacing the shared `noinline` type-erased `notify()` loop with direct virtual calls in each `notify_*_update` method.

The original design used a shared `noinline` dispatch function with function pointer trampolines and `void*` type erasure, intended to save flash by having only one copy of the loop. However, the compiler optimizes the direct approach better — the lambda trampolines and type erasure machinery actually cost more than duplicating the simple loop.

Results: 48 bytes smaller flash, [4% faster sensor publish path](https://codspeed.io/esphome/esphome/branches/controller-registry-direct-dispatch?utm_source=github&utm_medium=comment-v2&utm_content=button&uri=%3A%3Aesphome%3A%3Abenchmarks%3A%3ASensorPublish_NoCallbacks&runnerMode=Simulation&page=1) (below CodSpeed measurement threshold).

### Disassembly of the resulting `notify_sensor_update` (32 bytes, ESP32 IDF):

```asm
; a2 = obj (Sensor*)
entry   a1, 32
l32r    a7, ...             ; a7 = &controllers (StaticVector base)
l32i.n  a6, a7, 8           ; a6 = controllers.count_
addx4   a6, a6, a7          ; a6 = end pointer (computed once, hoisted)
; --- loop ---
bne     a6, a7, +5          ; while (iter != end) {
retw.n                      ;   return
l32i.n  a10, a7, 0          ;   controller = *iter
mov.n   a11, a2             ;   arg = obj
l32i.n  a8, a10, 0          ;   vtable = controller->vptr
addi.n  a7, a7, 4           ;   iter++
l32i.n  a8, a8, 4           ;   method = vtable[on_sensor_update]
callx8  a8                  ;   call method(obj)
j       loop                ; }
```

The remaining cost is the virtual dispatch (`l32i` vtable + `l32i` method + `callx8`) which cannot be eliminated since controllers (APIServer, WebServer) are different classes registered at runtime.

The full `publish_state` → `internal_send_state_to_frontend` path (14 + 51 = 65 bytes) compiles down to: store `raw_state`, set `has_state` flag, store `state`, check `LazyCallbackManager` pointer, call `notify_sensor_update`. All logging is compiled out in release builds. There is nothing left to optimize in this path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal cleanup
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).