### PR TITLE
[light] Move normal state logging to VERBOSE

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -385,7 +385,7 @@ void LightCall::transform_parameters_() {
       !(this->color_mode_ & ColorCapability::WHITE) &&                                  //
       !(this->color_mode_ & ColorCapability::COLOR_TEMPERATURE) &&                      //
       min_mireds > 0.0f && max_mireds > 0.0f) {
-    ESP_LOGD(TAG, "'%s': setting cold/warm white channels using white/color temperature values",
+    ESP_LOGV(TAG, "'%s': setting cold/warm white channels using white/color temperature values",
              this->parent_->get_name().c_str());
     // Only compute cold_white/warm_white from color_temperature if they're not already explicitly set.
     // This is important for state restoration, where both color_temperature and cold_white/warm_white
@@ -432,7 +432,7 @@ ColorMode LightCall::compute_color_mode_() {
 
   // Don't change if the current mode is in the intersection (suitable AND supported)
   if (ColorModeMask::mask_contains(intersection, current_mode)) {
-    ESP_LOGI(TAG, "'%s': color mode not specified; retaining %s", this->parent_->get_name().c_str(),
+    ESP_LOGV(TAG, "'%s': color mode not specified; retaining %s", this->parent_->get_name().c_str(),
              LOG_STR_ARG(color_mode_to_human(current_mode)));
     return current_mode;
   }
@@ -440,7 +440,7 @@ ColorMode LightCall::compute_color_mode_() {
   // Use the preferred suitable mode.
   if (intersection != 0) {
     ColorMode mode = ColorModeMask::first_value_from_mask(intersection);
-    ESP_LOGI(TAG, "'%s': color mode not specified; using %s", this->parent_->get_name().c_str(),
+    ESP_LOGV(TAG, "'%s': color mode not specified; using %s", this->parent_->get_name().c_str(),
              LOG_STR_ARG(color_mode_to_human(mode)));
     return mode;
   }


### PR DESCRIPTION
# What does this implement/fix?

Move three log messages in `LightCall` from DEBUG/INFO to VERBOSE to match the convention established in #15155.

These logs were added as development aids in the original color mode implementation (#2012) but fire on normal operational paths:

- **`transform_parameters_()` ESP_LOGD** — fires on every light call that sends `color_temperature` on a CWWW light. This is the primary path for MQTT clients and YAML automations using `color_temperature`.
- **`compute_color_mode_()` ESP_LOGI (×2)** — fires on every call without an explicit color mode. As the original PR #2012 noted: *"We'll need to keep accepting LightCalls without a color mode (i.e. the legacy API). This is used by the MQTT API (where HA doesn't send the color mode for some reason) [...] and primarily the light.turn_on, light.turn_off, and light.control actions users have in their YAML."*

Verified against the Home Assistant MQTT light source (`homeassistant/components/mqtt/light/schema_json.py`): HA's MQTT JSON schema **never sends `color_mode` in command payloads** — it only appears in state messages from the device. For color temperature changes, HA sends `{"state":"ON","color_temp":90}` with no color mode and no CW/WW conversion. So every MQTT light command hits `compute_color_mode_()`, and every color temp change on a CWWW light additionally hits `transform_parameters_()`.

Home Assistant's native API avoids these paths since API 1.6 by sending color_mode explicitly and converting color temp to CW/WW client-side, but MQTT is the second most common integration and hits both paths on every state change.

The new light benchmarks in #15176 show the impact: `LightCall_ColorTemperature` (MQTT path) runs at 12M/s vs `LightCall_ColdWarmWhite` (HA API path) at 52M/s — a **4× overhead** from the DEBUG log formatting alone.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — logging level change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).