### PR TITLE
[benchmark] Add climate publish_state and call benchmarks

### DIFF
--- a/tests/benchmarks/components/climate/__init__.py
+++ b/tests/benchmarks/components/climate/__init__.py
@@ -1,0 +1,5 @@
+from tests.testing_helpers import ComponentManifestOverride
+
+
+def override_manifest(manifest: ComponentManifestOverride) -> None:
+    manifest.enable_codegen()

--- a/tests/benchmarks/components/climate/bench_climate.cpp
+++ b/tests/benchmarks/components/climate/bench_climate.cpp
@@ -21,6 +21,8 @@ class BenchClimate : public climate::Climate {
 };
 
 // Helper to create a typical HVAC climate device for benchmarks.
+// Note: setup() is not called (no preferences backend), so save_state_()
+// is effectively a no-op. This benchmarks the call/validation path, not persistence.
 static void setup_hvac_climate(BenchClimate &climate) {
   climate.configure("test_climate");
   climate.traits_.set_supported_modes({
@@ -118,8 +120,8 @@ static void ClimateCall_SetTemperature(benchmark::State &state) {
 }
 BENCHMARK(ClimateCall_SetTemperature);
 
-// --- ClimateCall::perform() mode change with fan and preset ---
-// Exercises the full validation path with multiple fields set.
+// --- ClimateCall::perform() mode change with fan ---
+// Exercises the validation path with multiple fields set.
 
 static void ClimateCall_ModeChange(benchmark::State &state) {
   BenchClimate climate;

--- a/tests/benchmarks/components/climate/bench_climate.cpp
+++ b/tests/benchmarks/components/climate/bench_climate.cpp
@@ -1,0 +1,140 @@
+#include <benchmark/benchmark.h>
+
+#include "esphome/components/climate/climate.h"
+
+namespace esphome::benchmarks {
+
+// Inner iteration count to amortize CodSpeed instrumentation overhead.
+static constexpr int kInnerIterations = 2000;
+
+// Minimal Climate for benchmarking — control() is a no-op.
+class BenchClimate : public climate::Climate {
+ public:
+  void configure(const char *name) { this->configure_entity_(name, 0x12345678, 0); }
+
+  climate::ClimateTraits traits() override { return this->traits_; }
+
+  climate::ClimateTraits traits_;
+
+ protected:
+  void control(const climate::ClimateCall & /*call*/) override {}
+};
+
+// Helper to create a typical HVAC climate device for benchmarks.
+static void setup_hvac_climate(BenchClimate &climate) {
+  climate.configure("test_climate");
+  climate.traits_.set_supported_modes({
+      climate::CLIMATE_MODE_OFF,
+      climate::CLIMATE_MODE_HEAT_COOL,
+      climate::CLIMATE_MODE_COOL,
+      climate::CLIMATE_MODE_HEAT,
+      climate::CLIMATE_MODE_FAN_ONLY,
+  });
+  climate.traits_.set_supported_fan_modes({
+      climate::CLIMATE_FAN_AUTO,
+      climate::CLIMATE_FAN_LOW,
+      climate::CLIMATE_FAN_MEDIUM,
+      climate::CLIMATE_FAN_HIGH,
+  });
+  climate.traits_.set_supported_swing_modes({
+      climate::CLIMATE_SWING_OFF,
+      climate::CLIMATE_SWING_BOTH,
+      climate::CLIMATE_SWING_VERTICAL,
+      climate::CLIMATE_SWING_HORIZONTAL,
+  });
+  climate.traits_.set_supported_presets({
+      climate::CLIMATE_PRESET_NONE,
+      climate::CLIMATE_PRESET_HOME,
+      climate::CLIMATE_PRESET_AWAY,
+  });
+  climate.traits_.set_visual_min_temperature(16.0f);
+  climate.traits_.set_visual_max_temperature(30.0f);
+  climate.traits_.set_visual_target_temperature_step(0.5f);
+  climate.traits_.set_visual_current_temperature_step(0.1f);
+  climate.traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+}
+
+// --- Climate::publish_state() with temperature update ---
+// Measures the publish path for a thermostat reporting state —
+// the hot path during HVAC operation.
+
+static void ClimatePublish_State(benchmark::State &state) {
+  BenchClimate climate;
+  setup_hvac_climate(climate);
+  climate.mode = climate::CLIMATE_MODE_HEAT;
+  climate.action = climate::CLIMATE_ACTION_HEATING;
+  climate.target_temperature = 22.0f;
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      climate.current_temperature = 20.0f + static_cast<float>(i % 100) / 10.0f;
+      climate.publish_state();
+    }
+    benchmark::DoNotOptimize(climate.current_temperature);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ClimatePublish_State);
+
+// --- Climate::publish_state() with callback ---
+// Measures callback dispatch overhead.
+
+static void ClimatePublish_WithCallback(benchmark::State &state) {
+  BenchClimate climate;
+  setup_hvac_climate(climate);
+  climate.mode = climate::CLIMATE_MODE_HEAT;
+  climate.target_temperature = 22.0f;
+
+  uint64_t callback_count = 0;
+  climate.add_on_state_callback([&callback_count](climate::Climate & /*c*/) { callback_count++; });
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      climate.current_temperature = 20.0f + static_cast<float>(i % 100) / 10.0f;
+      climate.publish_state();
+    }
+    benchmark::DoNotOptimize(callback_count);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ClimatePublish_WithCallback);
+
+// --- ClimateCall::perform() set target temperature ---
+// The most common climate call — adjusting the thermostat setpoint.
+
+static void ClimateCall_SetTemperature(benchmark::State &state) {
+  BenchClimate climate;
+  setup_hvac_climate(climate);
+  climate.mode = climate::CLIMATE_MODE_HEAT;
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      float temp = 18.0f + static_cast<float>(i % 25) * 0.5f;
+      climate.make_call().set_target_temperature(temp).perform();
+    }
+    benchmark::DoNotOptimize(climate.target_temperature);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ClimateCall_SetTemperature);
+
+// --- ClimateCall::perform() mode change with fan and preset ---
+// Exercises the full validation path with multiple fields set.
+
+static void ClimateCall_ModeChange(benchmark::State &state) {
+  BenchClimate climate;
+  setup_hvac_climate(climate);
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      auto mode = (i % 2 == 0) ? climate::CLIMATE_MODE_HEAT : climate::CLIMATE_MODE_COOL;
+      auto fan = (i % 2 == 0) ? climate::CLIMATE_FAN_HIGH : climate::CLIMATE_FAN_LOW;
+      climate.make_call().set_mode(mode).set_fan_mode(fan).set_target_temperature(22.0f).perform();
+    }
+    benchmark::DoNotOptimize(climate.mode);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ClimateCall_ModeChange);
+
+}  // namespace esphome::benchmarks

--- a/tests/benchmarks/components/climate/benchmark.yaml
+++ b/tests/benchmarks/components/climate/benchmark.yaml
@@ -1,0 +1,1 @@
+climate:


### PR DESCRIPTION
# What does this implement/fix?

Add CodSpeed benchmarks for the climate component's `publish_state()` and `ClimateCall::perform()` paths. Climate has been a source of past performance issues due to its complex validation, multiple mode types (fan, swing, preset with custom variants), and state persistence on every publish.

Note: RTC persistence is not measured (no preferences backend in benchmark builds), so `save_state_()` is effectively a no-op. These benchmarks focus on the call/validation/publish path.

Benchmark cases:
- **ClimatePublish_State** — Publish with temperature update, the hot path during HVAC operation (mode, action, fan, current temp, target temp, callback, ControllerRegistry notification)
- **ClimatePublish_WithCallback** — Callback dispatch overhead through LazyCallbackManager
- **ClimateCall_SetTemperature** — The most common call: adjusting the thermostat setpoint (validation + control delegation)
- **ClimateCall_ModeChange** — Validation path with mode, fan mode, and target temperature all set simultaneously

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — benchmark only, no user-facing config
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).