### PR TITLE
[core] Improve clean-all with no arguments

### DIFF
--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -476,6 +476,16 @@ def clean_all(configuration: list[str]):
         data_dirs.append(Path(env_data_dir))
     if env_build_path := os.environ.get("ESPHOME_BUILD_PATH"):
         data_dirs.append(Path(env_build_path))
+    if not data_dirs:
+        # No config files or known data dirs, check current directory
+        cwd_esphome = Path.cwd() / ".esphome"
+        if cwd_esphome.is_dir():
+            data_dirs.append(cwd_esphome)
+        else:
+            _LOGGER.warning(
+                "No configuration files specified and no .esphome directory found in current directory. "
+                "Pass YAML files or a configuration directory to clean build artifacts."
+            )
 
     # Clean build dir
     for dir in data_dirs:

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -991,6 +991,47 @@ def test_clean_all_ignores_empty_env_vars(
 
 
 @patch("esphome.writer.CORE")
+def test_clean_all_no_args_with_esphome_dir(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all with no args cleans .esphome in cwd."""
+    esphome_dir = tmp_path / ".esphome"
+    esphome_dir.mkdir()
+    (esphome_dir / "dummy.txt").write_text("x")
+
+    from esphome.writer import clean_all
+
+    with (
+        caplog.at_level("INFO"),
+        patch("esphome.writer.Path.cwd", return_value=tmp_path),
+    ):
+        clean_all([])
+
+    assert esphome_dir.exists()
+    assert not (esphome_dir / "dummy.txt").exists()
+
+
+@patch("esphome.writer.CORE")
+def test_clean_all_no_args_no_esphome_dir(
+    mock_core: MagicMock,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test clean_all with no args and no .esphome dir warns."""
+    from esphome.writer import clean_all
+
+    with (
+        caplog.at_level("WARNING"),
+        patch("esphome.writer.Path.cwd", return_value=tmp_path),
+    ):
+        clean_all([])
+
+    assert "No configuration files specified" in caplog.text
+
+
+@patch("esphome.writer.CORE")
 def test_clean_all(
     mock_core: MagicMock,
     tmp_path: Path,


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #15146. When `clean-all` is run with no arguments and no env vars or HA addon, it now:

1. Checks for `.esphome` in the current directory and cleans it if found
2. Warns if no `.esphome` directory is found: "No configuration files specified and no .esphome directory found in current directory. Pass YAML files or a configuration directory to clean build artifacts."

Also moves the HA addon / env var checks before the config loop so `data_dirs` is populated first, then uses a single `if not data_dirs:` check for the fallback behavior.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).