### PR TITLE
[mixer] Fix memory leak in mixer task on stop/start cycles

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -597,172 +597,172 @@ void MixerSpeaker::audio_mixer_task(void *params) {
 
   xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STARTING);
 
-  std::unique_ptr<audio::AudioSinkTransferBuffer> output_transfer_buffer = audio::AudioSinkTransferBuffer::create(
-      this_mixer->audio_stream_info_.value().ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
+  {  // Ensure C++ objects fall out of scope to ensure proper cleanup before stopping the task
+    std::unique_ptr<audio::AudioSinkTransferBuffer> output_transfer_buffer = audio::AudioSinkTransferBuffer::create(
+        this_mixer->audio_stream_info_.value().ms_to_bytes(TRANSFER_BUFFER_DURATION_MS));
 
-  if (output_transfer_buffer == nullptr) {
-    xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPED | MIXER_TASK_ERR_ESP_NO_MEM);
+    if (output_transfer_buffer == nullptr) {
+      xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPED | MIXER_TASK_ERR_ESP_NO_MEM);
 
-    vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
-  }
-
-  output_transfer_buffer->set_sink(this_mixer->output_speaker_);
-
-  xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_RUNNING);
-
-  bool sent_finished = false;
-
-  // Pre-allocate vectors to avoid heap allocation in the loop (max 8 source speakers per schema)
-  FixedVector<SourceSpeaker *> speakers_with_data;
-  FixedVector<std::shared_ptr<audio::AudioSourceTransferBuffer>> transfer_buffers_with_data;
-  speakers_with_data.init(this_mixer->source_speakers_.size());
-  transfer_buffers_with_data.init(this_mixer->source_speakers_.size());
-
-  while (true) {
-    uint32_t event_group_bits = xEventGroupGetBits(this_mixer->event_group_);
-    if (event_group_bits & MIXER_TASK_COMMAND_STOP) {
-      break;
+      vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
     }
 
-    // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
-    output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS), false);
+    output_transfer_buffer->set_sink(this_mixer->output_speaker_);
 
-    const uint32_t output_frames_free =
-        this_mixer->audio_stream_info_.value().bytes_to_frames(output_transfer_buffer->free());
+    xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_RUNNING);
 
-    speakers_with_data.clear();
-    transfer_buffers_with_data.clear();
+    bool sent_finished = false;
 
-    for (auto &speaker : this_mixer->source_speakers_) {
-      if (speaker->is_running() && !speaker->get_pause_state()) {
-        // Speaker is running and not paused, so it possibly can provide audio data
-        std::shared_ptr<audio::AudioSourceTransferBuffer> transfer_buffer = speaker->get_transfer_buffer().lock();
-        if (transfer_buffer.use_count() == 0) {
-          // No transfer buffer allocated, so skip processing this speaker
-          continue;
-        }
-        speaker->process_data_from_source(transfer_buffer, 0);  // Transfers and ducks audio from source ring buffers
+    // Pre-allocate vectors to avoid heap allocation in the loop (max 8 source speakers per schema)
+    FixedVector<SourceSpeaker *> speakers_with_data;
+    FixedVector<std::shared_ptr<audio::AudioSourceTransferBuffer>> transfer_buffers_with_data;
+    speakers_with_data.init(this_mixer->source_speakers_.size());
+    transfer_buffers_with_data.init(this_mixer->source_speakers_.size());
 
-        if (transfer_buffer->available() > 0) {
-          // Store the locked transfer buffers in their own vector to avoid releasing ownership until after the loop
-          transfer_buffers_with_data.push_back(transfer_buffer);
-          speakers_with_data.push_back(speaker);
+    while (true) {
+      uint32_t event_group_bits = xEventGroupGetBits(this_mixer->event_group_);
+      if (event_group_bits & MIXER_TASK_COMMAND_STOP) {
+        break;
+      }
+
+      // Never shift the data in the output transfer buffer to avoid unnecessary, slow data moves
+      output_transfer_buffer->transfer_data_to_sink(pdMS_TO_TICKS(TASK_DELAY_MS), false);
+
+      const uint32_t output_frames_free =
+          this_mixer->audio_stream_info_.value().bytes_to_frames(output_transfer_buffer->free());
+
+      speakers_with_data.clear();
+      transfer_buffers_with_data.clear();
+
+      for (auto &speaker : this_mixer->source_speakers_) {
+        if (speaker->is_running() && !speaker->get_pause_state()) {
+          // Speaker is running and not paused, so it possibly can provide audio data
+          std::shared_ptr<audio::AudioSourceTransferBuffer> transfer_buffer = speaker->get_transfer_buffer().lock();
+          if (transfer_buffer.use_count() == 0) {
+            // No transfer buffer allocated, so skip processing this speaker
+            continue;
+          }
+          speaker->process_data_from_source(transfer_buffer, 0);  // Transfers and ducks audio from source ring buffers
+
+          if (transfer_buffer->available() > 0) {
+            // Store the locked transfer buffers in their own vector to avoid releasing ownership until after the loop
+            transfer_buffers_with_data.push_back(transfer_buffer);
+            speakers_with_data.push_back(speaker);
+          }
         }
       }
-    }
 
-    if (transfer_buffers_with_data.empty()) {
-      // No audio available for transferring, block task temporarily
-      delay(TASK_DELAY_MS);
-      continue;
-    }
+      if (transfer_buffers_with_data.empty()) {
+        // No audio available for transferring, block task temporarily
+        delay(TASK_DELAY_MS);
+        continue;
+      }
 
-    uint32_t frames_to_mix = output_frames_free;
+      uint32_t frames_to_mix = output_frames_free;
 
-    if ((transfer_buffers_with_data.size() == 1) || this_mixer->queue_mode_) {
-      // Only one speaker has audio data, just copy samples over
+      if ((transfer_buffers_with_data.size() == 1) || this_mixer->queue_mode_) {
+        // Only one speaker has audio data, just copy samples over
 
-      audio::AudioStreamInfo active_stream_info = speakers_with_data[0]->get_audio_stream_info();
+        audio::AudioStreamInfo active_stream_info = speakers_with_data[0]->get_audio_stream_info();
 
-      if (active_stream_info.get_sample_rate() ==
-          this_mixer->output_speaker_->get_audio_stream_info().get_sample_rate()) {
-        // Speaker's sample rate matches the output speaker's, copy directly
+        if (active_stream_info.get_sample_rate() ==
+            this_mixer->output_speaker_->get_audio_stream_info().get_sample_rate()) {
+          // Speaker's sample rate matches the output speaker's, copy directly
 
-        const uint32_t frames_available_in_buffer =
-            active_stream_info.bytes_to_frames(transfer_buffers_with_data[0]->available());
-        frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
-        copy_frames(reinterpret_cast<int16_t *>(transfer_buffers_with_data[0]->get_buffer_start()), active_stream_info,
-                    reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end()),
-                    this_mixer->audio_stream_info_.value(), frames_to_mix);
+          const uint32_t frames_available_in_buffer =
+              active_stream_info.bytes_to_frames(transfer_buffers_with_data[0]->available());
+          frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
+          copy_frames(reinterpret_cast<int16_t *>(transfer_buffers_with_data[0]->get_buffer_start()),
+                      active_stream_info, reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end()),
+                      this_mixer->audio_stream_info_.value(), frames_to_mix);
 
-        // Set playback delay for newly contributing source
-        if (!speakers_with_data[0]->has_contributed_.load(std::memory_order_acquire)) {
-          speakers_with_data[0]->playback_delay_frames_.store(
-              this_mixer->frames_in_pipeline_.load(std::memory_order_acquire), std::memory_order_release);
-          speakers_with_data[0]->has_contributed_.store(true, std::memory_order_release);
+          // Set playback delay for newly contributing source
+          if (!speakers_with_data[0]->has_contributed_.load(std::memory_order_acquire)) {
+            speakers_with_data[0]->playback_delay_frames_.store(
+                this_mixer->frames_in_pipeline_.load(std::memory_order_acquire), std::memory_order_release);
+            speakers_with_data[0]->has_contributed_.store(true, std::memory_order_release);
+          }
+
+          // Update source speaker pending frames
+          speakers_with_data[0]->pending_playback_frames_.fetch_add(frames_to_mix, std::memory_order_release);
+          transfer_buffers_with_data[0]->decrease_buffer_length(active_stream_info.frames_to_bytes(frames_to_mix));
+
+          // Update output transfer buffer length and pipeline frame count
+          output_transfer_buffer->increase_buffer_length(
+              this_mixer->audio_stream_info_.value().frames_to_bytes(frames_to_mix));
+          this_mixer->frames_in_pipeline_.fetch_add(frames_to_mix, std::memory_order_release);
+        } else {
+          // Speaker's stream info doesn't match the output speaker's, so it's a new source speaker
+          if (!this_mixer->output_speaker_->is_stopped()) {
+            if (!sent_finished) {
+              this_mixer->output_speaker_->finish();
+              sent_finished = true;  // Avoid repeatedly sending the finish command
+            }
+          } else {
+            // Speaker has finished writing the current audio, update the stream information and restart the speaker
+            this_mixer->audio_stream_info_ =
+                audio::AudioStreamInfo(active_stream_info.get_bits_per_sample(), this_mixer->output_channels_,
+                                       active_stream_info.get_sample_rate());
+            this_mixer->output_speaker_->set_audio_stream_info(this_mixer->audio_stream_info_.value());
+            this_mixer->output_speaker_->start();
+            // Reset pipeline frame count since we're starting fresh with a new sample rate
+            this_mixer->frames_in_pipeline_.store(0, std::memory_order_release);
+            sent_finished = false;
+          }
+        }
+      } else {
+        // Determine how many frames to mix
+        for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
+          const uint32_t frames_available_in_buffer = speakers_with_data[i]->get_audio_stream_info().bytes_to_frames(
+              transfer_buffers_with_data[i]->available());
+          frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
+        }
+        int16_t *primary_buffer = reinterpret_cast<int16_t *>(transfer_buffers_with_data[0]->get_buffer_start());
+        audio::AudioStreamInfo primary_stream_info = speakers_with_data[0]->get_audio_stream_info();
+
+        // Mix two streams together
+        for (size_t i = 1; i < transfer_buffers_with_data.size(); ++i) {
+          mix_audio_samples(primary_buffer, primary_stream_info,
+                            reinterpret_cast<int16_t *>(transfer_buffers_with_data[i]->get_buffer_start()),
+                            speakers_with_data[i]->get_audio_stream_info(),
+                            reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end()),
+                            this_mixer->audio_stream_info_.value(), frames_to_mix);
+
+          if (i != transfer_buffers_with_data.size() - 1) {
+            // Need to mix more streams together, point primary buffer and stream info to the already mixed output
+            primary_buffer = reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end());
+            primary_stream_info = this_mixer->audio_stream_info_.value();
+          }
         }
 
-        // Update source speaker pending frames
-        speakers_with_data[0]->pending_playback_frames_.fetch_add(frames_to_mix, std::memory_order_release);
-        transfer_buffers_with_data[0]->decrease_buffer_length(active_stream_info.frames_to_bytes(frames_to_mix));
+        // Get current pipeline depth for delay calculation (before incrementing)
+        uint32_t current_pipeline_frames = this_mixer->frames_in_pipeline_.load(std::memory_order_acquire);
 
-        // Update output transfer buffer length and pipeline frame count
+        // Update source transfer buffer lengths and add new audio durations to the source speaker pending playbacks
+        for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
+          // Set playback delay for newly contributing sources
+          if (!speakers_with_data[i]->has_contributed_.load(std::memory_order_acquire)) {
+            speakers_with_data[i]->playback_delay_frames_.store(current_pipeline_frames, std::memory_order_release);
+            speakers_with_data[i]->has_contributed_.store(true, std::memory_order_release);
+          }
+
+          speakers_with_data[i]->pending_playback_frames_.fetch_add(frames_to_mix, std::memory_order_release);
+          transfer_buffers_with_data[i]->decrease_buffer_length(
+              speakers_with_data[i]->get_audio_stream_info().frames_to_bytes(frames_to_mix));
+        }
+
+        // Update output transfer buffer length and pipeline frame count (once, not per source)
         output_transfer_buffer->increase_buffer_length(
             this_mixer->audio_stream_info_.value().frames_to_bytes(frames_to_mix));
         this_mixer->frames_in_pipeline_.fetch_add(frames_to_mix, std::memory_order_release);
-      } else {
-        // Speaker's stream info doesn't match the output speaker's, so it's a new source speaker
-        if (!this_mixer->output_speaker_->is_stopped()) {
-          if (!sent_finished) {
-            this_mixer->output_speaker_->finish();
-            sent_finished = true;  // Avoid repeatedly sending the finish command
-          }
-        } else {
-          // Speaker has finished writing the current audio, update the stream information and restart the speaker
-          this_mixer->audio_stream_info_ =
-              audio::AudioStreamInfo(active_stream_info.get_bits_per_sample(), this_mixer->output_channels_,
-                                     active_stream_info.get_sample_rate());
-          this_mixer->output_speaker_->set_audio_stream_info(this_mixer->audio_stream_info_.value());
-          this_mixer->output_speaker_->start();
-          // Reset pipeline frame count since we're starting fresh with a new sample rate
-          this_mixer->frames_in_pipeline_.store(0, std::memory_order_release);
-          sent_finished = false;
-        }
       }
-    } else {
-      // Determine how many frames to mix
-      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
-        const uint32_t frames_available_in_buffer =
-            speakers_with_data[i]->get_audio_stream_info().bytes_to_frames(transfer_buffers_with_data[i]->available());
-        frames_to_mix = std::min(frames_to_mix, frames_available_in_buffer);
-      }
-      int16_t *primary_buffer = reinterpret_cast<int16_t *>(transfer_buffers_with_data[0]->get_buffer_start());
-      audio::AudioStreamInfo primary_stream_info = speakers_with_data[0]->get_audio_stream_info();
-
-      // Mix two streams together
-      for (size_t i = 1; i < transfer_buffers_with_data.size(); ++i) {
-        mix_audio_samples(primary_buffer, primary_stream_info,
-                          reinterpret_cast<int16_t *>(transfer_buffers_with_data[i]->get_buffer_start()),
-                          speakers_with_data[i]->get_audio_stream_info(),
-                          reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end()),
-                          this_mixer->audio_stream_info_.value(), frames_to_mix);
-
-        if (i != transfer_buffers_with_data.size() - 1) {
-          // Need to mix more streams together, point primary buffer and stream info to the already mixed output
-          primary_buffer = reinterpret_cast<int16_t *>(output_transfer_buffer->get_buffer_end());
-          primary_stream_info = this_mixer->audio_stream_info_.value();
-        }
-      }
-
-      // Get current pipeline depth for delay calculation (before incrementing)
-      uint32_t current_pipeline_frames = this_mixer->frames_in_pipeline_.load(std::memory_order_acquire);
-
-      // Update source transfer buffer lengths and add new audio durations to the source speaker pending playbacks
-      for (size_t i = 0; i < transfer_buffers_with_data.size(); ++i) {
-        // Set playback delay for newly contributing sources
-        if (!speakers_with_data[i]->has_contributed_.load(std::memory_order_acquire)) {
-          speakers_with_data[i]->playback_delay_frames_.store(current_pipeline_frames, std::memory_order_release);
-          speakers_with_data[i]->has_contributed_.store(true, std::memory_order_release);
-        }
-
-        speakers_with_data[i]->pending_playback_frames_.fetch_add(frames_to_mix, std::memory_order_release);
-        transfer_buffers_with_data[i]->decrease_buffer_length(
-            speakers_with_data[i]->get_audio_stream_info().frames_to_bytes(frames_to_mix));
-      }
-
-      // Update output transfer buffer length and pipeline frame count (once, not per source)
-      output_transfer_buffer->increase_buffer_length(
-          this_mixer->audio_stream_info_.value().frames_to_bytes(frames_to_mix));
-      this_mixer->frames_in_pipeline_.fetch_add(frames_to_mix, std::memory_order_release);
     }
-  }
 
-  xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPING);
+    xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPING);
+  }
 
   // Reset pipeline frame count since the task is stopping
   this_mixer->frames_in_pipeline_.store(0, std::memory_order_release);
-
-  output_transfer_buffer.reset();
 
   xEventGroupSetBits(this_mixer->event_group_, MIXER_TASK_STATE_STOPPED);
 


### PR DESCRIPTION
# What does this implement/fix?

Fix a memory leak in the mixer speaker task that leaked 20-80 bytes on each stop/start cycle.

The `audio_mixer_task` function creates heap-owning local variables (`FixedVector` objects and a `unique_ptr` transfer buffer) on the task stack. When the task exits its main loop, it calls `vTaskSuspend(nullptr)`, which suspends the task forever without returning, and the app's main loop thread deletes it from there. Since the function never returns, C++ destructors for these stack-local variables never run. When `task_.deallocate()` later frees the raw task stack, the heap allocations owned by these objects are orphaned.

The fix wraps the heap-owning locals in a block scope so their destructors run automatically when the scope exits, before `vTaskSuspend` is reached.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) -- [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) -- [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

not applicable (no config changes)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).