### PR TITLE
[wifi] Guard coex_background_scan with CONFIG_SOC_WIFI_SUPPORTED

### DIFF
--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -989,9 +989,11 @@ bool WiFiComponent::wifi_scan_start_(bool passive) {
   }
   // When scanning while connected (roaming), return to home channel between
   // each scanned channel to maintain the connection (helps with BLE/WiFi coexistence)
+#ifdef CONFIG_SOC_WIFI_SUPPORTED
   if (this->roaming_state_ == RoamingState::SCANNING) {
     config.coex_background_scan = true;
   }
+#endif
 
   esp_err_t err = esp_wifi_scan_start(&config, false);
   if (err != ESP_OK) {


### PR DESCRIPTION
# What does this implement/fix?

`coex_background_scan` in `wifi_scan_config_t` is only available on chips with native WiFi (CONFIG_SOC_WIFI_SUPPORTED). ESP32-P4 uses esp_hosted (external WiFi) and the struct does not have this field, causing a build failure.

Introduced in #15152.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).