### PR TITLE
[logger] Warn when VERBOSE/VERY_VERBOSE logging is active

### DIFF
--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -248,12 +248,11 @@ void Logger::dump_config() {
   // Only the compiled log level matters — all log calls up to this level
   // are in the binary and will be formatted (vsnprintf) and block UART.
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-  ESP_LOGW(TAG, "VERY_VERBOSE logging is active. This will significantly impact device performance and may cause "
-                "connection instability. This level is intended for short-term debugging only. "
-                "Set the log level to DEBUG or lower for long-term use.");
+  ESP_LOGW(TAG, "VERY_VERBOSE logging is active — significant performance impact, short-term debugging only\n"
+                "  May cause connection instability. Set log level to DEBUG or lower for long-term use.");
 #elif ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-  ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
-                "debugging only. Set the log level to DEBUG or lower for long-term use.");
+  ESP_LOGI(TAG, "VERBOSE logging is active — performance impact, short-term debugging only\n"
+                "  Set log level to DEBUG or lower for long-term use.");
 #endif
 }
 

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -244,6 +244,10 @@ void Logger::dump_config() {
 #ifdef USE_ZEPHYR
   dump_crash_();
 #endif
+  // Warn users that VERBOSE/VERY_VERBOSE logging impacts performance.
+  // The compiled log level (ESPHOME_LOG_LEVEL) is what matters here — even if
+  // initial_level is set lower at runtime, log messages at the compiled level
+  // are still formatted (vsnprintf) and written to UART which is blocking.
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
   if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
     ESP_LOGW(TAG, "VERY_VERBOSE logging is active. This will significantly impact device performance and may cause "

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -245,23 +245,15 @@ void Logger::dump_config() {
   dump_crash_();
 #endif
   // Warn users that VERBOSE/VERY_VERBOSE logging impacts performance.
-  // The compiled log level (ESPHOME_LOG_LEVEL) is what matters here — even if
-  // initial_level is set lower at runtime, log messages at the compiled level
-  // are still formatted (vsnprintf) and written to UART which is blocking.
+  // Only the compiled log level matters — all log calls up to this level
+  // are in the binary and will be formatted (vsnprintf) and block UART.
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
-  if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
-    ESP_LOGW(TAG, "VERY_VERBOSE logging is active. This will significantly impact device performance and may cause "
-                  "connection instability. This level is intended for short-term debugging only. "
-                  "Set the log level to DEBUG or lower for long-term use.");
-  } else if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERBOSE) {
-    ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
-                  "debugging only. Set the log level to DEBUG or lower for long-term use.");
-  }
+  ESP_LOGW(TAG, "VERY_VERBOSE logging is active. This will significantly impact device performance and may cause "
+                "connection instability. This level is intended for short-term debugging only. "
+                "Set the log level to DEBUG or lower for long-term use.");
 #elif ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-  if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERBOSE) {
-    ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
-                  "debugging only. Set the log level to DEBUG or lower for long-term use.");
-  }
+  ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
+                "debugging only. Set the log level to DEBUG or lower for long-term use.");
 #endif
 }
 

--- a/esphome/components/logger/logger.cpp
+++ b/esphome/components/logger/logger.cpp
@@ -244,6 +244,21 @@ void Logger::dump_config() {
 #ifdef USE_ZEPHYR
   dump_crash_();
 #endif
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
+  if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERY_VERBOSE) {
+    ESP_LOGW(TAG, "VERY_VERBOSE logging is active. This will significantly impact device performance and may cause "
+                  "connection instability. This level is intended for short-term debugging only. "
+                  "Set the log level to DEBUG or lower for long-term use.");
+  } else if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERBOSE) {
+    ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
+                  "debugging only. Set the log level to DEBUG or lower for long-term use.");
+  }
+#elif ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+  if (this->current_level_ >= ESPHOME_LOG_LEVEL_VERBOSE) {
+    ESP_LOGI(TAG, "VERBOSE logging is active. This will impact device performance and is intended for short-term "
+                  "debugging only. Set the log level to DEBUG or lower for long-term use.");
+  }
+#endif
 }
 
 void Logger::set_log_level(uint8_t level) {


### PR DESCRIPTION
## What does this implement/fix?

Adds a warning at boot (in `dump_config()`) when the compiled log level is `VERBOSE` or `VERY_VERBOSE` to remind users these levels are intended for short-term debugging only and not for long-term production use.

- `VERY_VERBOSE`: `ESP_LOGW` — warns about significant performance impact and connection instability
- `VERBOSE`: `ESP_LOGI` — notes performance impact and short-term intent

Users frequently leave `VERBOSE` or `VERY_VERBOSE` enabled on production devices without understanding the consequences. These levels generate a massive volume of log output that blocks the event loop (UART writes are blocking on most platforms), consumes CPU time formatting strings, and can cause network timeouts and connection instability.

`VERY_VERBOSE` in particular has a history of causing serious issues:

- **Crashes on ESP8266** (#14970, #15077): VERY_VERBOSE caused boot crashes (`Fatal exception 28`) due to logging before the logger was initialized, effectively bricking remote devices.
- **Heap-buffer-overflow in protobuf dump** (#14721): The message dump code (only runs at VERY_VERBOSE) had a buffer overflow bug with `StringRef` fields not being null-terminated.
- **Excessive RAM usage on ESP8266** (78b10a24, 5e64e3a3): All protobuf dump strings (field names, message names, enum values) were stored in RAM instead of flash, meaning every API protobuf change increased RAM usage when compiled at VERY_VERBOSE.

With the recent move of state change logs from `DEBUG` to `VERBOSE` in #15155, the distinction between these levels is even more important to communicate clearly. `DEBUG` is now lightweight enough for production, but `VERBOSE`/`VERY_VERBOSE` are explicitly debugging tools.

Only the compiled log level matters here — all log calls up to that level are in the binary and will format (vsnprintf) and block UART regardless of the runtime `initial_level` setting. The warning is purely compile-time via `#if`/`#elif` guards so no code is added when compiled at a lower log level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Related to #14970, #15077, #14721, #15155

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6352

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
logger:
  level: VERBOSE
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).