### PR TITLE
[nextion] Fix leading space in pressed color string commands

### DIFF
--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -106,7 +106,7 @@ void Nextion::set_component_pressed_foreground_color(const char *component, uint
 }
 
 void Nextion::set_component_pressed_foreground_color(const char *component, const char *color) {
-  this->add_no_result_to_queue_with_printf_("set_component_pressed_foreground_color", " %s.pco2=%s", component, color);
+  this->add_no_result_to_queue_with_printf_("set_component_pressed_foreground_color", "%s.pco2=%s", component, color);
 }
 
 void Nextion::set_component_pressed_foreground_color(const char *component, Color color) {
@@ -134,7 +134,7 @@ void Nextion::set_component_pressed_font_color(const char *component, uint16_t c
 }
 
 void Nextion::set_component_pressed_font_color(const char *component, const char *color) {
-  this->add_no_result_to_queue_with_printf_("set_component_pressed_font_color", " %s.pco2=%s", component, color);
+  this->add_no_result_to_queue_with_printf_("set_component_pressed_font_color", "%s.pco2=%s", component, color);
 }
 
 void Nextion::set_component_pressed_font_color(const char *component, Color color) {


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug where `set_component_pressed_foreground_color()` and `set_component_pressed_font_color()` could silently fail when called with a named color string (e.g. `"RED"`, `"BLUE"`).

The `const char *` overloads of both functions had a leading space in the format string (`" %s.pco2=%s"`), possibly causing the Nextion display to respond with `0x00` (invalid instruction) and discard the command. The `uint16_t` and `Color` overloads were not affected.

No logic change, no API change, no other files touched.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
