### PR TITLE
[multiple] Fix misc hardware register bugs

### DIFF
--- a/esphome/components/mcp23008/mcp23008.cpp
+++ b/esphome/components/mcp23008/mcp23008.cpp
@@ -6,6 +6,8 @@ namespace mcp23008 {
 
 static const char *const TAG = "mcp23008";
 
+static constexpr uint8_t IOCON_ODR = 0x04;  // Open-drain output for INT pin
+
 void MCP23008::setup() {
   uint8_t iocon;
   if (!this->read_reg(mcp23x08_base::MCP23X08_IOCON, &iocon)) {
@@ -18,7 +20,7 @@ void MCP23008::setup() {
 
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x08_base::MCP23X08_IOCON, 0x04);
+    this->write_reg(mcp23x08_base::MCP23X08_IOCON, iocon | IOCON_ODR);
   }
 }
 

--- a/esphome/components/mcp23017/mcp23017.cpp
+++ b/esphome/components/mcp23017/mcp23017.cpp
@@ -6,6 +6,8 @@ namespace mcp23017 {
 
 static const char *const TAG = "mcp23017";
 
+static constexpr uint8_t IOCON_ODR = 0x04;  // Open-drain output for INT pin
+
 void MCP23017::setup() {
   uint8_t iocon;
   if (!this->read_reg(mcp23x17_base::MCP23X17_IOCONA, &iocon)) {
@@ -19,8 +21,8 @@ void MCP23017::setup() {
 
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, 0x04);
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, 0x04);
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, iocon | IOCON_ODR);
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, iocon | IOCON_ODR);
   }
 }
 

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -20,18 +20,20 @@ void MCP23S08::set_device_address(uint8_t device_addr) {
 void MCP23S08::setup() {
   this->spi_setup();
 
-  uint8_t iocon = IOCON_SEQOP | IOCON_HAEN;
-  if (this->open_drain_ints_) {
-    iocon |= IOCON_ODR;
-  }
+  // Enable HAEN (broadcast to all chips since HAEN isn't active yet)
   this->enable();
   this->transfer_byte(0b01000000);
   this->transfer_byte(mcp23x08_base::MCP23X08_IOCON);
-  this->transfer_byte(iocon);
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   // Read current output register state
   this->read_reg(mcp23x08_base::MCP23X08_OLAT, &this->olat_);
+
+  if (this->open_drain_ints_) {
+    // enable open-drain interrupt pins, 3.3V-safe (addressed, only this chip)
+    this->write_reg(mcp23x08_base::MCP23X08_IOCON, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
+  }
 }
 
 void MCP23S08::dump_config() {

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -20,20 +20,18 @@ void MCP23S08::set_device_address(uint8_t device_addr) {
 void MCP23S08::setup() {
   this->spi_setup();
 
+  uint8_t iocon = IOCON_SEQOP | IOCON_HAEN;
+  if (this->open_drain_ints_) {
+    iocon |= IOCON_ODR;
+  }
   this->enable();
-  uint8_t cmd = 0b01000000;
-  this->transfer_byte(cmd);
+  this->transfer_byte(0b01000000);
   this->transfer_byte(mcp23x08_base::MCP23X08_IOCON);
-  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
+  this->transfer_byte(iocon);
   this->disable();
 
   // Read current output register state
   this->read_reg(mcp23x08_base::MCP23X08_OLAT, &this->olat_);
-
-  if (this->open_drain_ints_) {
-    // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x08_base::MCP23X08_IOCON, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
-  }
 }
 
 void MCP23S08::dump_config() {

--- a/esphome/components/mcp23s08/mcp23s08.cpp
+++ b/esphome/components/mcp23s08/mcp23s08.cpp
@@ -6,6 +6,11 @@ namespace mcp23s08 {
 
 static const char *const TAG = "mcp23s08";
 
+// IOCON register bits
+static constexpr uint8_t IOCON_SEQOP = 0x20;  // Sequential operation mode
+static constexpr uint8_t IOCON_HAEN = 0x08;   // Hardware address enable
+static constexpr uint8_t IOCON_ODR = 0x04;    // Open-drain output for INT pin
+
 void MCP23S08::set_device_address(uint8_t device_addr) {
   if (device_addr != 0) {
     this->device_opcode_ |= ((device_addr & 0x03) << 1);
@@ -19,7 +24,7 @@ void MCP23S08::setup() {
   uint8_t cmd = 0b01000000;
   this->transfer_byte(cmd);
   this->transfer_byte(mcp23x08_base::MCP23X08_IOCON);
-  this->transfer_byte(0b00011000);  // Enable HAEN pins for addressing
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   // Read current output register state
@@ -27,7 +32,7 @@ void MCP23S08::setup() {
 
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x08_base::MCP23X08_IOCON, 0x04);
+    this->write_reg(mcp23x08_base::MCP23X08_IOCON, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
   }
 }
 

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -20,26 +20,28 @@ void MCP23S17::set_device_address(uint8_t device_addr) {
 void MCP23S17::setup() {
   this->spi_setup();
 
-  uint8_t iocon = IOCON_SEQOP | IOCON_HAEN;
-  if (this->open_drain_ints_) {
-    iocon |= IOCON_ODR;
-  }
-  // Write IOCON to addresses 0 and 4 since HAEN isn't enabled yet
+  // Enable HAEN (broadcast to addresses 0 and 4 since HAEN isn't active yet)
   this->enable();
   this->transfer_byte(0b01000000);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(iocon);
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   this->enable();
   this->transfer_byte(0b01001000);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(iocon);
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   // Read current output register state
   this->read_reg(mcp23x17_base::MCP23X17_OLATA, &this->olat_a_);
   this->read_reg(mcp23x17_base::MCP23X17_OLATB, &this->olat_b_);
+
+  if (this->open_drain_ints_) {
+    // enable open-drain interrupt pins, 3.3V-safe (addressed, only this chip)
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
+  }
 }
 
 void MCP23S17::dump_config() {

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -20,29 +20,26 @@ void MCP23S17::set_device_address(uint8_t device_addr) {
 void MCP23S17::setup() {
   this->spi_setup();
 
+  uint8_t iocon = IOCON_SEQOP | IOCON_HAEN;
+  if (this->open_drain_ints_) {
+    iocon |= IOCON_ODR;
+  }
+  // Write IOCON to both addresses (0 and 1) since HAEN isn't enabled yet
   this->enable();
-  uint8_t cmd = 0b01000000;
-  this->transfer_byte(cmd);
+  this->transfer_byte(0b01000000);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
+  this->transfer_byte(iocon);
   this->disable();
 
   this->enable();
-  cmd = 0b01001000;
-  this->transfer_byte(cmd);
+  this->transfer_byte(0b01001000);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
+  this->transfer_byte(iocon);
   this->disable();
 
   // Read current output register state
   this->read_reg(mcp23x17_base::MCP23X17_OLATA, &this->olat_a_);
   this->read_reg(mcp23x17_base::MCP23X17_OLATB, &this->olat_b_);
-
-  if (this->open_drain_ints_) {
-    // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
-  }
 }
 
 void MCP23S17::dump_config() {

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -6,6 +6,11 @@ namespace mcp23s17 {
 
 static const char *const TAG = "mcp23s17";
 
+// IOCON register bits
+static constexpr uint8_t IOCON_SEQOP = 0x20;  // Sequential operation mode
+static constexpr uint8_t IOCON_HAEN = 0x08;   // Hardware address enable
+static constexpr uint8_t IOCON_ODR = 0x04;    // Open-drain output for INT pin
+
 void MCP23S17::set_device_address(uint8_t device_addr) {
   if (device_addr != 0) {
     this->device_opcode_ |= ((device_addr & 0b111) << 1);
@@ -19,14 +24,14 @@ void MCP23S17::setup() {
   uint8_t cmd = 0b01000000;
   this->transfer_byte(cmd);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(0b00011000);  // Enable HAEN pins for addressing
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   this->enable();
   cmd = 0b01001000;
   this->transfer_byte(cmd);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);
-  this->transfer_byte(0b00011000);  // Enable HAEN pins for addressing
+  this->transfer_byte(IOCON_SEQOP | IOCON_HAEN);
   this->disable();
 
   // Read current output register state
@@ -35,8 +40,8 @@ void MCP23S17::setup() {
 
   if (this->open_drain_ints_) {
     // enable open-drain interrupt pins, 3.3V-safe
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, 0x04);
-    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, 0x04);
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONA, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
+    this->write_reg(mcp23x17_base::MCP23X17_IOCONB, IOCON_SEQOP | IOCON_HAEN | IOCON_ODR);
   }
 }
 

--- a/esphome/components/mcp23s17/mcp23s17.cpp
+++ b/esphome/components/mcp23s17/mcp23s17.cpp
@@ -24,7 +24,7 @@ void MCP23S17::setup() {
   if (this->open_drain_ints_) {
     iocon |= IOCON_ODR;
   }
-  // Write IOCON to both addresses (0 and 1) since HAEN isn't enabled yet
+  // Write IOCON to addresses 0 and 4 since HAEN isn't enabled yet
   this->enable();
   this->transfer_byte(0b01000000);
   this->transfer_byte(mcp23x17_base::MCP23X17_IOCONA);

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -126,21 +126,21 @@ void MMC5603Component::update() {
   int32_t raw_x = 0;
   raw_x |= buffer[0] << 12;
   raw_x |= buffer[1] << 4;
-  raw_x |= buffer[2] << 0;
+  raw_x |= (buffer[2] & 0x0F) << 0;
 
   const float x = 0.00625 * (raw_x - 524288);
 
   int32_t raw_y = 0;
   raw_y |= buffer[3] << 12;
   raw_y |= buffer[4] << 4;
-  raw_y |= buffer[5] << 0;
+  raw_y |= (buffer[5] & 0x0F) << 0;
 
   const float y = 0.00625 * (raw_y - 524288);
 
   int32_t raw_z = 0;
   raw_z |= buffer[6] << 12;
   raw_z |= buffer[7] << 4;
-  raw_z |= buffer[8] << 0;
+  raw_z |= (buffer[8] & 0x0F) << 0;
 
   const float z = 0.00625 * (raw_z - 524288);
 

--- a/esphome/components/mmc5603/mmc5603.cpp
+++ b/esphome/components/mmc5603/mmc5603.cpp
@@ -126,21 +126,21 @@ void MMC5603Component::update() {
   int32_t raw_x = 0;
   raw_x |= buffer[0] << 12;
   raw_x |= buffer[1] << 4;
-  raw_x |= (buffer[2] & 0x0F) << 0;
+  raw_x |= buffer[2] & 0x0F;
 
   const float x = 0.00625 * (raw_x - 524288);
 
   int32_t raw_y = 0;
   raw_y |= buffer[3] << 12;
   raw_y |= buffer[4] << 4;
-  raw_y |= (buffer[5] & 0x0F) << 0;
+  raw_y |= buffer[5] & 0x0F;
 
   const float y = 0.00625 * (raw_y - 524288);
 
   int32_t raw_z = 0;
   raw_z |= buffer[6] << 12;
   raw_z |= buffer[7] << 4;
-  raw_z |= (buffer[8] & 0x0F) << 0;
+  raw_z |= buffer[8] & 0x0F;
 
   const float z = 0.00625 * (raw_z - 524288);
 

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -309,7 +309,7 @@ void SX1509Component::set_debounce_keypad_(uint8_t time, uint8_t num_rows, uint8
   set_debounce_time_(time);
   for (uint16_t i = 0; i < num_rows; i++)
     set_debounce_pin_(i);
-  for (uint16_t i = 0; i < (8 + num_cols); i++)
+  for (uint16_t i = 8; i < 8 + num_cols; i++)
     set_debounce_pin_(i);
 }
 

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -309,8 +309,8 @@ void SX1509Component::set_debounce_keypad_(uint8_t time, uint8_t num_rows, uint8
   set_debounce_time_(time);
   for (uint16_t i = 0; i < num_rows; i++)
     set_debounce_pin_(i);
-  for (uint16_t i = 8; i < 8 + num_cols; i++)
-    set_debounce_pin_(i);
+  for (uint16_t i = 0; i < num_cols; i++)
+    set_debounce_pin_(i + 8);
 }
 
 }  // namespace sx1509


### PR DESCRIPTION
# What does this implement/fix?

Small hardware register bugs found during code review:

1. **mmc5603**: OUT2 registers (Xout2/Yout2/Zout2) only have 4 valid bits but the upper nibble was not masked, potentially corrupting magnetometer readings with undefined hardware bits.

2. **mcp23s08/mcp23s17**: Open-drain interrupt setup wrote IOCON with only the ODR bit, clearing the HAEN (Hardware Address Enable) bit that was set earlier in setup. This breaks multi-chip SPI configurations. Fixed by computing the full IOCON value once (SEQOP + HAEN + optional ODR) and writing it in a single transaction.

3. **mcp23008/mcp23017**: Same open-drain pattern on the I2C variants — wrote a flat 0x04 instead of preserving existing IOCON bits. Fixed by OR'ing ODR into the read-back IOCON value.

4. **sx1509**: Keypad debounce column loop started at pin 0 instead of pin 8. Columns are on pins 8-15 per the keypad engine, so debounce was applied to row pins redundantly instead of column pins.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).