### PR TITLE
[sgp4x] Fix NOx index_offset default (should be 1, not 100)

### DIFF
--- a/esphome/components/sgp4x/sensor.py
+++ b/esphome/components/sgp4x/sensor.py
@@ -44,20 +44,27 @@ def validate_sensors(config):
     return config
 
 
-GAS_SENSOR = cv.Schema(
-    {
-        cv.Optional(CONF_ALGORITHM_TUNING): cv.Schema(
-            {
-                cv.Optional(CONF_INDEX_OFFSET, default=100): cv.int_,
-                cv.Optional(CONF_LEARNING_TIME_OFFSET_HOURS, default=12): cv.int_,
-                cv.Optional(CONF_LEARNING_TIME_GAIN_HOURS, default=12): cv.int_,
-                cv.Optional(CONF_GATING_MAX_DURATION_MINUTES, default=720): cv.int_,
-                cv.Optional(CONF_STD_INITIAL, default=50): cv.int_,
-                cv.Optional(CONF_GAIN_FACTOR, default=230): cv.int_,
-            }
-        )
-    }
-)
+def _gas_sensor_schema(index_offset_default: int):
+    return cv.Schema(
+        {
+            cv.Optional(CONF_ALGORITHM_TUNING): cv.Schema(
+                {
+                    cv.Optional(
+                        CONF_INDEX_OFFSET, default=index_offset_default
+                    ): cv.int_,
+                    cv.Optional(CONF_LEARNING_TIME_OFFSET_HOURS, default=12): cv.int_,
+                    cv.Optional(CONF_LEARNING_TIME_GAIN_HOURS, default=12): cv.int_,
+                    cv.Optional(CONF_GATING_MAX_DURATION_MINUTES, default=720): cv.int_,
+                    cv.Optional(CONF_STD_INITIAL, default=50): cv.int_,
+                    cv.Optional(CONF_GAIN_FACTOR, default=230): cv.int_,
+                }
+            )
+        }
+    )
+
+
+VOC_SENSOR = _gas_sensor_schema(100)
+NOX_SENSOR = _gas_sensor_schema(1)
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -68,13 +75,13 @@ CONFIG_SCHEMA = cv.All(
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(GAS_SENSOR),
+            ).extend(VOC_SENSOR),
             cv.Optional(CONF_NOX): sensor.sensor_schema(
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ).extend(GAS_SENSOR),
+            ).extend(NOX_SENSOR),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
             cv.Optional(CONF_VOC_BASELINE): cv.hex_uint16_t,
             cv.Optional(CONF_COMPENSATION): cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

The `algorithm_tuning` schema used the same `index_offset` default of 100 for both VOC and NOx sensors. Per the Sensirion Gas Index Algorithm library, the correct defaults are:
- VOC: `index_offset = 100`
- NOx: `index_offset = 1`

This was a latent bug since the SGP41 support was added in 2022. Users never noticed because stored baselines masked the wrong initial offset. The issue became visible after #13054 changed the preferences hash computation (switching `fnv1a_hash_extend` from `std::to_string(serial)` to the integer directly), which invalidated all stored SGP4x baselines on upgrade to 2026.3.x. Without stored baselines, the algorithm starts fresh with the configured `index_offset`, and NOx incorrectly started at 100 instead of 1.

Fix by splitting the shared `GAS_SENSOR` schema into `VOC_SENSOR` (default 100) and `NOX_SENSOR` (default 1).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15205

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: sgp4x
    voc:
      name: "VOC Index"
      algorithm_tuning:
        learning_time_offset_hours: 12
    nox:
      name: "NOx Index"
      algorithm_tuning:
        learning_time_offset_hours: 12
        # index_offset now correctly defaults to 1 for NOx (was 100)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).