### PR TITLE
[online_image] Migrate triggers to callback automation

### DIFF
--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -7,14 +7,7 @@ from esphome.components.const import CONF_REQUEST_HEADERS
 from esphome.components.http_request import CONF_HTTP_REQUEST_ID, HttpRequestComponent
 from esphome.components.image import CONF_TRANSPARENCY, add_metadata
 import esphome.config_validation as cv
-from esphome.const import (
-    CONF_BUFFER_SIZE,
-    CONF_ID,
-    CONF_ON_ERROR,
-    CONF_TRIGGER_ID,
-    CONF_TYPE,
-    CONF_URL,
-)
+from esphome.const import CONF_BUFFER_SIZE, CONF_ID, CONF_ON_ERROR, CONF_TYPE, CONF_URL
 from esphome.core import Lambda
 
 AUTO_LOAD = ["image", "runtime_image"]
@@ -41,14 +34,6 @@ ReleaseImageAction = online_image_ns.class_(
     "OnlineImageReleaseAction", automation.Action, cg.Parented.template(OnlineImage)
 )
 
-# Triggers
-DownloadFinishedTrigger = online_image_ns.class_(
-    "DownloadFinishedTrigger", automation.Trigger.template()
-)
-DownloadErrorTrigger = online_image_ns.class_(
-    "DownloadErrorTrigger", automation.Trigger.template()
-)
-
 
 ONLINE_IMAGE_SCHEMA = (
     runtime_image.runtime_image_schema(OnlineImage)
@@ -61,18 +46,8 @@ ONLINE_IMAGE_SCHEMA = (
             cv.Optional(CONF_REQUEST_HEADERS): cv.All(
                 cv.Schema({cv.string: cv.templatable(cv.string)})
             ),
-            cv.Optional(CONF_ON_DOWNLOAD_FINISHED): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                        DownloadFinishedTrigger
-                    ),
-                }
-            ),
-            cv.Optional(CONF_ON_ERROR): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DownloadErrorTrigger),
-                }
-            ),
+            cv.Optional(CONF_ON_DOWNLOAD_FINISHED): automation.validate_automation({}),
+            cv.Optional(CONF_ON_ERROR): automation.validate_automation({}),
         }
     )
     .extend(cv.polling_component_schema("never"))
@@ -165,9 +140,11 @@ async def to_code(config):
             cg.add(var.add_request_header(key, value))
 
     for conf in config.get(CONF_ON_DOWNLOAD_FINISHED, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [(bool, "cached")], conf)
+        await automation.build_callback_automation(
+            var, "add_on_finished_callback", [(bool, "cached")], conf
+        )
 
     for conf in config.get(CONF_ON_ERROR, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_callback_automation(
+            var, "add_on_error_callback", [], conf
+        )

--- a/esphome/components/online_image/online_image.h
+++ b/esphome/components/online_image/online_image.h
@@ -129,18 +129,4 @@ template<typename... Ts> class OnlineImageReleaseAction : public Action<Ts...> {
   OnlineImage *parent_;
 };
 
-class DownloadFinishedTrigger : public Trigger<bool> {
- public:
-  explicit DownloadFinishedTrigger(OnlineImage *parent) {
-    parent->add_on_finished_callback([this](bool cached) { this->trigger(cached); });
-  }
-};
-
-class DownloadErrorTrigger : public Trigger<> {
- public:
-  explicit DownloadErrorTrigger(OnlineImage *parent) {
-    parent->add_on_error_callback([this]() { this->trigger(); });
-  }
-};
-
 }  // namespace esphome::online_image


### PR DESCRIPTION
# What does this implement/fix?

Migrates `DownloadFinishedTrigger` and `DownloadErrorTrigger` to use `build_callback_automation()` from #15174, eliminating both trigger trampoline objects.

Removes the `DownloadFinishedTrigger` and `DownloadErrorTrigger` classes entirely from `online_image.h`. No callback signature changes needed — both are simple thin wrapper triggers.

- `DownloadFinishedTrigger` (`Trigger<bool>`) → default `TriggerForwarder<bool>` on `add_on_finished_callback`
- `DownloadErrorTrigger` (`Trigger<>`) → default `TriggerForwarder<>` on `add_on_error_callback`

**Depends on #15174**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #15174

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal optimization.
# All existing YAML configurations work identically.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).