### PR TITLE
[rotary_encoder] Migrate triggers to callback automation

### DIFF
--- a/esphome/components/rotary_encoder/rotary_encoder.h
+++ b/esphome/components/rotary_encoder/rotary_encoder.h
@@ -118,19 +118,5 @@ template<typename... Ts> class RotaryEncoderSetValueAction : public Action<Ts...
   RotaryEncoderSensor *encoder_;
 };
 
-class RotaryEncoderClockwiseTrigger : public Trigger<> {
- public:
-  explicit RotaryEncoderClockwiseTrigger(RotaryEncoderSensor *parent) {
-    parent->add_on_clockwise_callback([this]() { this->trigger(); });
-  }
-};
-
-class RotaryEncoderAnticlockwiseTrigger : public Trigger<> {
- public:
-  explicit RotaryEncoderAnticlockwiseTrigger(RotaryEncoderSensor *parent) {
-    parent->add_on_anticlockwise_callback([this]() { this->trigger(); });
-  }
-};
-
 }  // namespace rotary_encoder
 }  // namespace esphome

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -10,7 +10,6 @@ from esphome.const import (
     CONF_PIN_B,
     CONF_RESOLUTION,
     CONF_RESTORE_MODE,
-    CONF_TRIGGER_ID,
     CONF_VALUE,
     ICON_ROTATE_RIGHT,
     UNIT_STEPS,
@@ -41,13 +40,6 @@ RotaryEncoderSensor = rotary_encoder_ns.class_(
 )
 RotaryEncoderSetValueAction = rotary_encoder_ns.class_(
     "RotaryEncoderSetValueAction", automation.Action
-)
-
-RotaryEncoderClockwiseTrigger = rotary_encoder_ns.class_(
-    "RotaryEncoderClockwiseTrigger", automation.Trigger
-)
-RotaryEncoderAnticlockwiseTrigger = rotary_encoder_ns.class_(
-    "RotaryEncoderAnticlockwiseTrigger", automation.Trigger
 )
 
 
@@ -81,20 +73,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_RESTORE_MODE, default="RESTORE_DEFAULT_ZERO"): cv.enum(
                 RESTORE_MODES, upper=True, space="_"
             ),
-            cv.Optional(CONF_ON_CLOCKWISE): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                        RotaryEncoderClockwiseTrigger
-                    ),
-                }
-            ),
-            cv.Optional(CONF_ON_ANTICLOCKWISE): automation.validate_automation(
-                {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
-                        RotaryEncoderAnticlockwiseTrigger
-                    ),
-                }
-            ),
+            cv.Optional(CONF_ON_CLOCKWISE): automation.validate_automation({}),
+            cv.Optional(CONF_ON_ANTICLOCKWISE): automation.validate_automation({}),
         }
     )
     .extend(cv.COMPONENT_SCHEMA),
@@ -123,11 +103,13 @@ async def to_code(config):
         cg.add(var.set_max_value(config[CONF_MAX_VALUE]))
 
     for conf in config.get(CONF_ON_CLOCKWISE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_callback_automation(
+            var, "add_on_clockwise_callback", [], conf
+        )
     for conf in config.get(CONF_ON_ANTICLOCKWISE, []):
-        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
-        await automation.build_automation(trigger, [], conf)
+        await automation.build_callback_automation(
+            var, "add_on_anticlockwise_callback", [], conf
+        )
 
 
 @automation.register_action(


### PR DESCRIPTION
# What does this implement/fix?

Migrates `RotaryEncoderClockwiseTrigger` and `RotaryEncoderAnticlockwiseTrigger` to use `build_callback_automation()` from #15174, eliminating both trigger trampoline objects.

Removes both trigger classes entirely from `rotary_encoder.h`. No callback signature changes needed — both are simple thin wrapper triggers with no extra state.

- `RotaryEncoderClockwiseTrigger` (`Trigger<>`) → default `TriggerForwarder<>` on `add_on_clockwise_callback`
- `RotaryEncoderAnticlockwiseTrigger` (`Trigger<>`) → default `TriggerForwarder<>` on `add_on_anticlockwise_callback`

**Depends on #15174**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #15174

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — this is an internal optimization.
# All existing YAML configurations work identically.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).