### PR TITLE
[ld2450] Fix flaky integration test race condition

### DIFF
--- a/tests/integration/test_uart_mock_ld2450.py
+++ b/tests/integration/test_uart_mock_ld2450.py
@@ -83,11 +83,18 @@ async def test_uart_mock_ld2450(
         ],
     )
 
-    # Signal when we see recovery frame values (target 1 distance ≈ 500mm)
+    # Signal when we see all recovery frame values
+    # Must wait for ALL values to avoid race where some arrive after the waiter fires
     recovery_received = collector.add_waiter(
         lambda: (
             pytest.approx(500.0, abs=1.0)
             in collector.sensor_states["target_1_distance"]
+            and pytest.approx(300.0) in collector.sensor_states["target_1_x"]
+            and pytest.approx(400.0) in collector.sensor_states["target_1_y"]
+            and pytest.approx(30.0) in collector.sensor_states["target_1_speed"]
+            and pytest.approx(1.0) in collector.sensor_states["target_count"]
+            and pytest.approx(1.0) in collector.sensor_states["moving_target_count"]
+            and pytest.approx(0.0) in collector.sensor_states["still_target_count"]
         )
     )
 


### PR DESCRIPTION
# What does this implement/fix?

The LD2450 integration test `recovery_received` waiter only checked for `target_1_distance ≈ 500`, so the subsequent assertions on `target_count` (and other recovery values) could fail if those messages hadn't been received yet. This is the same race condition that was previously fixed in the LD2410 and LD2412 tests.

The fix waits for **all** recovery frame values in the waiter lambda before proceeding to assertions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A — fixes flaky CI

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — test-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).