### PR TITLE
[multiple] Fix uninitialized members and error constant types

### DIFF
--- a/esphome/components/max44009/max44009.cpp
+++ b/esphome/components/max44009/max44009.cpp
@@ -8,17 +8,17 @@ namespace max44009 {
 static const char *const TAG = "max44009.sensor";
 
 // REGISTERS
-static const uint8_t MAX44009_REGISTER_CONFIGURATION = 0x02;
-static const uint8_t MAX44009_LUX_READING_HIGH = 0x03;
-static const uint8_t MAX44009_LUX_READING_LOW = 0x04;
+static constexpr uint8_t MAX44009_REGISTER_CONFIGURATION = 0x02;
+static constexpr uint8_t MAX44009_LUX_READING_HIGH = 0x03;
+static constexpr uint8_t MAX44009_LUX_READING_LOW = 0x04;
 // CONFIGURATION MASKS
-static const uint8_t MAX44009_CFG_CONTINUOUS = 0x80;
+static constexpr uint8_t MAX44009_CFG_CONTINUOUS = 0x80;
 // ERROR CODES
-static const uint8_t MAX44009_OK = 0;
-static const uint8_t MAX44009_ERROR_WIRE_REQUEST = -10;
-static const uint8_t MAX44009_ERROR_OVERFLOW = -20;
-static const uint8_t MAX44009_ERROR_HIGH_BYTE = -30;
-static const uint8_t MAX44009_ERROR_LOW_BYTE = -31;
+static constexpr int8_t MAX44009_OK = 0;
+static constexpr int8_t MAX44009_ERROR_WIRE_REQUEST = -10;
+static constexpr int8_t MAX44009_ERROR_OVERFLOW = -20;
+static constexpr int8_t MAX44009_ERROR_HIGH_BYTE = -30;
+static constexpr int8_t MAX44009_ERROR_LOW_BYTE = -31;
 
 void MAX44009Sensor::setup() {
   bool state_ok = false;

--- a/esphome/components/max44009/max44009.h
+++ b/esphome/components/max44009/max44009.h
@@ -28,8 +28,8 @@ class MAX44009Sensor : public sensor::Sensor, public PollingComponent, public i2
   uint8_t read_(uint8_t reg);
   void write_(uint8_t reg, uint8_t value);
 
-  int error_;
-  MAX44009Mode mode_;
+  int8_t error_{0};
+  MAX44009Mode mode_{MAX44009_MODE_AUTO};
 };
 
 }  // namespace max44009

--- a/esphome/components/modbus_controller/output/modbus_output.h
+++ b/esphome/components/modbus_controller/output/modbus_output.h
@@ -15,7 +15,7 @@ class ModbusFloatOutput : public output::FloatOutput, public Component, public S
     this->register_type = ModbusRegisterType::HOLDING;
     this->start_address = start_address;
     this->offset = offset;
-    this->bitmask = bitmask;
+    this->bitmask = 0xFFFFFFFF;
     this->register_count = register_count;
     this->sensor_value_type = value_type;
     this->skip_updates = 0;
@@ -47,7 +47,7 @@ class ModbusBinaryOutput : public output::BinaryOutput, public Component, public
   ModbusBinaryOutput(uint16_t start_address, uint8_t offset) {
     this->register_type = ModbusRegisterType::COIL;
     this->start_address = start_address;
-    this->bitmask = bitmask;
+    this->bitmask = 0xFFFFFFFF;
     this->sensor_value_type = SensorValueType::BIT;
     this->skip_updates = 0;
     this->register_count = 1;

--- a/esphome/components/tuya/climate/tuya_climate.h
+++ b/esphome/components/tuya/climate/tuya_climate.h
@@ -105,8 +105,8 @@ class TuyaClimate : public climate::Climate, public Component {
   optional<uint8_t> sleep_id_{};
   optional<float> eco_temperature_{};
   TuyaDatapointType eco_type_{};
-  uint8_t active_state_;
-  uint8_t fan_state_;
+  uint8_t active_state_{0};
+  uint8_t fan_state_{0};
   optional<uint8_t> swing_vertical_id_{};
   optional<uint8_t> swing_horizontal_id_{};
   optional<uint8_t> fan_speed_id_{};
@@ -119,9 +119,9 @@ class TuyaClimate : public climate::Climate, public Component {
   bool swing_horizontal_{false};
   bool heating_state_{false};
   bool cooling_state_{false};
-  float manual_temperature_;
-  bool eco_;
-  bool sleep_;
+  float manual_temperature_{NAN};
+  bool eco_{false};
+  bool sleep_{false};
   bool reports_fahrenheit_{false};
 };
 


### PR DESCRIPTION
# What does this implement/fix?

1. **tuya climate**: `active_state_`, `fan_state_`, `manual_temperature_`, `eco_`, `sleep_` were uninitialized. Before the first datapoint arrives from the Tuya MCU, these contain garbage values which could cause incorrect climate state to be published.

2. **max44009**: `error_` member (int) was uninitialized. Also, error constants were declared as `uint8_t` with negative values (-10, -20, -30, -31), causing them to wrap to 246, 236, 226, 225. Since `error_` is `int`, comparisons like `error_ == MAX44009_ERROR_WIRE_REQUEST` would compare int against uint8_t(246) — technically works due to implicit promotion but is misleading. Changed constants to `int` to match the member type.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).