### PR TITLE
[remote_base] Fix gobox uint64_t format specifier

### DIFF
--- a/esphome/components/remote_base/gobox_protocol.cpp
+++ b/esphome/components/remote_base/gobox_protocol.cpp
@@ -1,5 +1,6 @@
 #include "gobox_protocol.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace remote_base {
@@ -25,7 +26,7 @@ void GoboxProtocol::encode(RemoteTransmitData *dst, const GoboxData &data) {
   dst->set_carrier_frequency(38000);
   dst->reserve((HEADER_SIZE + CODE_SIZE + 1) * 2);
   uint64_t code = (HEADER << CODE_SIZE) | (data.code & ((1UL << CODE_SIZE) - 1));
-  ESP_LOGI(TAG, "Send Gobox: code=0x%Lx", code);
+  ESP_LOGI(TAG, "Send Gobox: code=0x%016" PRIx64, code);
   for (int16_t i = (HEADER_SIZE + CODE_SIZE - 1); i >= 0; i--) {
     if (code & ((uint64_t) 1 << i)) {
       dst->item(BIT_MARK_US, BIT_ONE_SPACE_US);


### PR DESCRIPTION
# What does this implement/fix?

The gobox protocol log used `%Lx` (long double hex) for a `uint64_t` value. `%Lx` is not a valid integer format specifier — on GCC it typically reads only 32 bits, silently dropping the upper half of the code in log output. Changed to `PRIx64` with zero-padded 16-digit format.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).