### PR TITLE
[atm90e32] Fix phase angle precision loss and remove unused member

### DIFF
--- a/esphome/components/atm90e32/atm90e32.cpp
+++ b/esphome/components/atm90e32/atm90e32.cpp
@@ -550,8 +550,8 @@ float ATM90E32Component::get_phase_harmonic_active_power_(uint8_t phase) {
 }
 
 float ATM90E32Component::get_phase_angle_(uint8_t phase) {
-  uint16_t val = this->read16_(ATM90E32_REGISTER_PANGLE + phase) / 10.0;
-  return (val > 180) ? (float) (val - 360.0f) : (float) val;
+  float val = this->read16_(ATM90E32_REGISTER_PANGLE + phase) / 10.0f;
+  return (val > 180.0f) ? val - 360.0f : val;
 }
 
 float ATM90E32Component::get_phase_peak_current_(uint8_t phase) {

--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -134,7 +134,6 @@ class ATM90E32Component : public PollingComponent,
   void set_freq_status_text_sensor(text_sensor::TextSensor *sensor) { this->freq_status_text_sensor_ = sensor; }
 #endif
   uint16_t calculate_voltage_threshold(int line_freq, uint16_t ugain, float multiplier);
-  int32_t last_periodic_millis = millis();
 
  protected:
 #ifdef USE_NUMBER


### PR DESCRIPTION
# What does this implement/fix?

1. **Phase angle precision**: `get_phase_angle_()` divided the register value by 10.0 but stored the result in `uint16_t`, truncating the fractional part. For example, a register value of 1235 (123.5 degrees) would be stored as 123 instead of 123.5. Changed to `float` to preserve precision.

2. **Dead code**: Removed `last_periodic_millis` member which was initialized via `millis()` at static construction time but never used anywhere.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).