### PR TITLE
[esp32_ble_server] Fix wrong union member in STOP_EVT handler

### DIFF
--- a/esphome/components/esp32_ble_server/ble_service.cpp
+++ b/esphome/components/esp32_ble_server/ble_service.cpp
@@ -159,7 +159,7 @@ void BLEService::gatts_event_handler(esp_gatts_cb_event_t event, esp_gatt_if_t g
       break;
     }
     case ESP_GATTS_STOP_EVT: {
-      if (param->start.service_handle == this->handle_) {
+      if (param->stop.service_handle == this->handle_) {
         this->state_ = STOPPED;
       }
       break;


### PR DESCRIPTION
# What does this implement/fix?

In the `ESP_GATTS_STOP_EVT` handler, `param->start.service_handle` was used instead of `param->stop.service_handle`. Works by coincidence since both union members have `service_handle` at the same offset, but is technically accessing the wrong member.

Same pattern as #15236 (BLE client OPEN_EVT).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).