### PR TITLE
[pid] Fix inverted debug log conditions and broken smoothing formula

### DIFF
--- a/esphome/components/pid/pid_autotuner.cpp
+++ b/esphome/components/pid/pid_autotuner.cpp
@@ -101,10 +101,10 @@ PIDAutotuner::PIDAutotuneResult PIDAutotuner::update(float setpoint, float proce
   if (!zc_symmetrical || !amplitude_convergent) {
     // The frequency/amplitude is not fully accurate yet, try to wait
     // until the fault clears, or terminate after a while anyway
-    if (zc_symmetrical) {
+    if (!zc_symmetrical) {
       ESP_LOGVV(TAG, "%s:   ZC is not symmetrical", this->id_.c_str());
     }
-    if (amplitude_convergent) {
+    if (!amplitude_convergent) {
       ESP_LOGVV(TAG, "%s:   Amplitude is not convergent", this->id_.c_str());
     }
     uint32_t phase = this->relay_function_.phase_count;

--- a/esphome/components/pid/pid_simulator.h
+++ b/esphome/components/pid/pid_simulator.h
@@ -59,7 +59,7 @@ class PIDSimulator : public PollingComponent, public output::FloatOutput {
       delayed_temps.erase(delayed_temps.begin());
     float prev_temp = this->delayed_temps[0];
     float alpha = 0.1f;
-    float ret = (1 - alpha) * prev_temp + alpha * prev_temp;
+    float ret = (1 - alpha) * prev_temp + alpha * temperature;
     return ret;
   }
 


### PR DESCRIPTION
# What does this implement/fix?

1. **Autotuner debug logs inverted**: The conditions for logging "ZC is not symmetrical" and "Amplitude is not convergent" were inverted — they logged when the condition was *true* instead of *false*. Missing `!` on both checks.

2. **Simulator smoothing formula broken**: `(1 - alpha) * prev_temp + alpha * prev_temp` simplifies to just `prev_temp` — no smoothing at all. The second term should use the current simulated `temperature`, not `prev_temp`. Fixed to `(1 - alpha) * prev_temp + alpha * temperature`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).