### PR TITLE
[sm2135] Fix copy-paste error in setup pin mode

### DIFF
--- a/esphome/components/sm2135/sm2135.cpp
+++ b/esphome/components/sm2135/sm2135.cpp
@@ -25,7 +25,7 @@ void SM2135::setup() {
   this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
   this->clock_pin_->setup();
   this->clock_pin_->digital_write(false);
-  this->data_pin_->pin_mode(gpio::FLAG_OUTPUT);
+  this->clock_pin_->pin_mode(gpio::FLAG_OUTPUT);
 
   this->data_pin_->pin_mode(gpio::FLAG_PULLUP);
   this->clock_pin_->pin_mode(gpio::FLAG_PULLUP);


### PR DESCRIPTION
# What does this implement/fix?

Line 28 set `data_pin_` to OUTPUT instead of `clock_pin_`. Copy-paste error — `clock_pin_` was the one that needed its mode set after `setup()` and `digital_write()`.

No functional impact since both pins are immediately switched to PULLUP mode on the next lines, but the intent was clearly to set clock_pin.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).