### PR TITLE
[bl0940] Fix energy reference default using wrong constant in legacy mode

### DIFF
--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -124,7 +124,7 @@ def set_reference_values(config):
         config.setdefault(CONF_VOLTAGE_REFERENCE, DEFAULT_BL0940_LEGACY_UREF)
         config.setdefault(CONF_CURRENT_REFERENCE, DEFAULT_BL0940_LEGACY_IREF)
         config.setdefault(CONF_POWER_REFERENCE, DEFAULT_BL0940_LEGACY_PREF)
-        config.setdefault(CONF_ENERGY_REFERENCE, DEFAULT_BL0940_LEGACY_PREF)
+        config.setdefault(CONF_ENERGY_REFERENCE, DEFAULT_BL0940_LEGACY_EREF)
     else:
         vref = config.get(CONF_VOLTAGE_REFERENCE, DEFAULT_BL0940_VREF)
         r_one = config.get(CONF_RESISTOR_ONE, DEFAULT_BL0940_R1)


### PR DESCRIPTION
# What does this implement/fix?

In legacy mode, the energy reference default was set to `DEFAULT_BL0940_LEGACY_PREF` (1430, the power reference) instead of `DEFAULT_BL0940_LEGACY_EREF` (12121, the energy reference). Copy-paste error from the line above. This causes energy readings to be off by approximately 8.5x in legacy mode.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — fixes default energy reference in legacy mode
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).