### PR TITLE
[sgp4x] Remove dead voc_baseline config option

### DIFF
--- a/esphome/components/sgp4x/sensor.py
+++ b/esphome/components/sgp4x/sensor.py
@@ -15,7 +15,6 @@ from esphome.const import (
     CONF_STORE_BASELINE,
     CONF_TEMPERATURE_SOURCE,
     CONF_VOC,
-    CONF_VOC_BASELINE,
     DEVICE_CLASS_AQI,
     ICON_RADIATOR,
     STATE_CLASS_MEASUREMENT,
@@ -83,7 +82,6 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ).extend(NOX_SENSOR),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
-            cv.Optional(CONF_VOC_BASELINE): cv.hex_uint16_t,
             cv.Optional(CONF_COMPENSATION): cv.Schema(
                 {
                     cv.Required(CONF_HUMIDITY_SOURCE): cv.use_id(sensor.Sensor),
@@ -111,9 +109,6 @@ async def to_code(config):
         cg.add(var.set_temperature_sensor(sens))
 
     cg.add(var.set_store_baseline(config[CONF_STORE_BASELINE]))
-
-    if CONF_VOC_BASELINE in config:
-        cg.add(var.set_voc_baseline(CONF_VOC_BASELINE))
 
     if CONF_VOC in config:
         sens = await sensor.new_sensor(config[CONF_VOC])


### PR DESCRIPTION
# What does this implement/fix?

Removes the `voc_baseline` config option from the sgp4x component. The C++ `set_voc_baseline()` method was never implemented — the option would cause a compile error if anyone used it. It was never documented either. Likely a leftover from the sgp30 component template.

The sgp4x component handles baseline storage automatically via preferences (`store_baseline: true`), making a manual baseline override unnecessary.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).