### PR TITLE
[modbus_controller] Fix wrong enum in function_code_to_register

### DIFF
--- a/esphome/components/modbus_controller/__init__.py
+++ b/esphome/components/modbus_controller/__init__.py
@@ -362,7 +362,7 @@ async def register_modbus_device(var, config):
 def function_code_to_register(function_code):
     FUNCTION_CODE_TYPE_MAP = {
         "read_coils": ModbusRegisterType.COIL,
-        "read_discrete_inputs": ModbusRegisterType.DISCRETE,
+        "read_discrete_inputs": ModbusRegisterType.DISCRETE_INPUT,
         "read_holding_registers": ModbusRegisterType.HOLDING,
         "read_input_registers": ModbusRegisterType.READ,
         "write_single_coil": ModbusRegisterType.COIL,


### PR DESCRIPTION
# What does this implement/fix?

`function_code_to_register()` used `ModbusRegisterType.DISCRETE` which doesn't exist in the C++ enum. Should be `ModbusRegisterType.DISCRETE_INPUT`. Would cause a compile error if anyone used `function_code: read_discrete_inputs`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).