### PR TITLE
[as5600] Remove dead angle/position sensor code

### DIFF
--- a/esphome/components/as5600/sensor/__init__.py
+++ b/esphome/components/as5600/sensor/__init__.py
@@ -2,11 +2,9 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
-    CONF_ANGLE,
     CONF_GAIN,
     CONF_ID,
     CONF_MAGNITUDE,
-    CONF_POSITION,
     CONF_STATUS,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_MAGNET,
@@ -21,7 +19,6 @@ DEPENDENCIES = ["as5600"]
 
 AS5600Sensor = as5600_ns.class_("AS5600Sensor", sensor.Sensor, cg.PollingComponent)
 
-CONF_RAW_ANGLE = "raw_angle"
 CONF_RAW_POSITION = "raw_position"
 CONF_SLOW_FILTER = "slow_filter"
 CONF_FAST_FILTER = "fast_filter"
@@ -88,18 +85,6 @@ async def to_code(config):
 
     if out_of_range_mode_config := config.get(CONF_OUT_OF_RANGE_MODE):
         cg.add(var.set_out_of_range_mode(out_of_range_mode_config))
-
-    if angle_config := config.get(CONF_ANGLE):
-        sens = await sensor.new_sensor(angle_config)
-        cg.add(var.set_angle_sensor(sens))
-
-    if raw_angle_config := config.get(CONF_RAW_ANGLE):
-        sens = await sensor.new_sensor(raw_angle_config)
-        cg.add(var.set_raw_angle_sensor(sens))
-
-    if position_config := config.get(CONF_POSITION):
-        sens = await sensor.new_sensor(position_config)
-        cg.add(var.set_position_sensor(sens))
 
     if raw_position_config := config.get(CONF_RAW_POSITION):
         sens = await sensor.new_sensor(raw_position_config)

--- a/esphome/components/as5600/sensor/as5600_sensor.cpp
+++ b/esphome/components/as5600/sensor/as5600_sensor.cpp
@@ -25,27 +25,10 @@ static const uint8_t REGISTER_MAGNITUDE = 0x1B;  // 16 bytes / R
 void AS5600Sensor::dump_config() {
   LOG_SENSOR("", "AS5600 Sensor", this);
   ESP_LOGCONFIG(TAG, "  Out of Range Mode: %u", this->out_of_range_mode_);
-  if (this->angle_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Angle Sensor", this->angle_sensor_);
-  }
-  if (this->raw_angle_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Raw Angle Sensor", this->raw_angle_sensor_);
-  }
-  if (this->position_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Position Sensor", this->position_sensor_);
-  }
-  if (this->raw_position_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Raw Position Sensor", this->raw_position_sensor_);
-  }
-  if (this->gain_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Gain Sensor", this->gain_sensor_);
-  }
-  if (this->magnitude_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Magnitude Sensor", this->magnitude_sensor_);
-  }
-  if (this->status_sensor_ != nullptr) {
-    LOG_SENSOR("  ", "Status Sensor", this->status_sensor_);
-  }
+  LOG_SENSOR("  ", "Raw Position Sensor", this->raw_position_sensor_);
+  LOG_SENSOR("  ", "Gain Sensor", this->gain_sensor_);
+  LOG_SENSOR("  ", "Magnitude Sensor", this->magnitude_sensor_);
+  LOG_SENSOR("  ", "Status Sensor", this->status_sensor_);
   LOG_UPDATE_INTERVAL(this);
 }
 

--- a/esphome/components/as5600/sensor/as5600_sensor.h
+++ b/esphome/components/as5600/sensor/as5600_sensor.h
@@ -15,9 +15,6 @@ class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, 
   void update() override;
   void dump_config() override;
 
-  void set_angle_sensor(sensor::Sensor *angle_sensor) { this->angle_sensor_ = angle_sensor; }
-  void set_raw_angle_sensor(sensor::Sensor *raw_angle_sensor) { this->raw_angle_sensor_ = raw_angle_sensor; }
-  void set_position_sensor(sensor::Sensor *position_sensor) { this->position_sensor_ = position_sensor; }
   void set_raw_position_sensor(sensor::Sensor *raw_position_sensor) {
     this->raw_position_sensor_ = raw_position_sensor;
   }
@@ -28,9 +25,6 @@ class AS5600Sensor : public PollingComponent, public Parented<AS5600Component>, 
   OutRangeMode get_out_of_range_mode() { return this->out_of_range_mode_; }
 
  protected:
-  sensor::Sensor *angle_sensor_{nullptr};
-  sensor::Sensor *raw_angle_sensor_{nullptr};
-  sensor::Sensor *position_sensor_{nullptr};
   sensor::Sensor *raw_position_sensor_{nullptr};
   sensor::Sensor *gain_sensor_{nullptr};
   sensor::Sensor *magnitude_sensor_{nullptr};


### PR DESCRIPTION
# What does this implement/fix?

Removes dead `angle`, `raw_angle`, and `position` sensor code from the as5600 component. These had C++ setters, members, and Python codegen but were never added to the config schema — the `to_code()` blocks could never execute and the sensors never published data.

Also removed redundant null checks around `LOG_SENSOR` macros in `dump_config()` — the macro already handles nullptr.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).