### PR TITLE
[bme68x_bsec2] Fix warning spam, code clean-up

### DIFF
--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -6,10 +6,7 @@
 #ifdef USE_BSEC2
 #include "bme68x_bsec2.h"
 
-#include <string>
-
-namespace esphome {
-namespace bme68x_bsec2 {
+namespace esphome::bme68x_bsec2 {
 
 #define BME68X_BSEC2_ALGORITHM_OUTPUT_LOG(a) (a == ALGORITHM_OUTPUT_CLASSIFICATION ? "Classification" : "Regression")
 #define BME68X_BSEC2_OPERATING_AGE_LOG(o) (o == OPERATING_AGE_4D ? "4 days" : "28 days")
@@ -18,9 +15,19 @@ namespace bme68x_bsec2 {
 
 static const char *const TAG = "bme68x_bsec2.sensor";
 
-static const std::string IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
+static constexpr const char *const IAQ_ACCURACY_STATES[4] = {"Stabilizing", "Uncertain", "Calibrating", "Calibrated"};
+
+static bool is_no_new_data_warning(int8_t status) {
+#ifdef BME68X_W_NO_NEW_DATA
+  return status == BME68X_W_NO_NEW_DATA;
+#else
+  return status == 2;
+#endif
+}
 
 void BME68xBSEC2Component::setup() {
+  this->warn_if_blocking_over_ = 60;  // initial reads may block for up to 60ms
+
   this->bsec_status_ = bsec_init_m(&this->bsec_instance_);
   if (this->bsec_status_ != BSEC_OK) {
     this->mark_failed();
@@ -114,7 +121,8 @@ void BME68xBSEC2Component::loop() {
   } else {
     this->status_clear_error();
   }
-  if (this->bsec_status_ > BSEC_OK || this->bme68x_status_ > BME68X_OK) {
+  const bool has_bme68x_warning = this->bme68x_status_ > BME68X_OK && !is_no_new_data_warning(this->bme68x_status_);
+  if (this->bsec_status_ > BSEC_OK || has_bme68x_warning) {
     this->status_set_warning();
   } else {
     this->status_clear_warning();
@@ -130,7 +138,7 @@ void BME68xBSEC2Component::loop() {
 
 void BME68xBSEC2Component::set_config_(const uint8_t *config, uint32_t len) {
   if (len > BSEC_MAX_PROPERTY_BLOB_SIZE) {
-    ESP_LOGE(TAG, "Configuration is larger than BSEC_MAX_PROPERTY_BLOB_SIZE");
+    ESP_LOGE(TAG, "Configuration blob too large");
     this->mark_failed();
     return;
   }
@@ -212,14 +220,12 @@ void BME68xBSEC2Component::run_() {
   if (curr_time_ns < this->bsec_settings_.next_call) {
     return;
   }
-  uint8_t status;
-
   ESP_LOGV(TAG, "Performing sensor run");
 
   struct bme68x_conf bme68x_conf;
   this->bsec_status_ = bsec_sensor_control_m(&this->bsec_instance_, curr_time_ns, &this->bsec_settings_);
   if (this->bsec_status_ < BSEC_OK) {
-    ESP_LOGW(TAG, "Failed to fetch sensor control settings (BSEC2 error code %d)", this->bsec_status_);
+    ESP_LOGW(TAG, "Fetching control settings failed (BSEC2 error code %d)", this->bsec_status_);
     return;
   }
 
@@ -235,9 +241,9 @@ void BME68xBSEC2Component::run_() {
       this->bme68x_heatr_conf_.heatr_temp = this->bsec_settings_.heater_temperature;
       this->bme68x_heatr_conf_.heatr_dur = this->bsec_settings_.heater_duration;
 
-      // status = bme68x_set_op_mode(this->bsec_settings_.op_mode, &this->bme68x_);
-      status = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &this->bme68x_heatr_conf_, &this->bme68x_);
-      status = bme68x_set_op_mode(BME68X_FORCED_MODE, &this->bme68x_);
+      // this->bme68x_status_ = bme68x_set_op_mode(this->bsec_settings_.op_mode, &this->bme68x_);
+      this->bme68x_status_ = bme68x_set_heatr_conf(BME68X_FORCED_MODE, &this->bme68x_heatr_conf_, &this->bme68x_);
+      this->bme68x_status_ = bme68x_set_op_mode(BME68X_FORCED_MODE, &this->bme68x_);
       this->op_mode_ = BME68X_FORCED_MODE;
       ESP_LOGV(TAG, "Using forced mode");
 
@@ -259,9 +265,8 @@ void BME68xBSEC2Component::run_() {
             BSEC_TOTAL_HEAT_DUR -
             (bme68x_get_meas_dur(BME68X_PARALLEL_MODE, &bme68x_conf, &this->bme68x_) / INT64_C(1000));
 
-        status = bme68x_set_heatr_conf(BME68X_PARALLEL_MODE, &this->bme68x_heatr_conf_, &this->bme68x_);
-
-        status = bme68x_set_op_mode(BME68X_PARALLEL_MODE, &this->bme68x_);
+        this->bme68x_status_ = bme68x_set_heatr_conf(BME68X_PARALLEL_MODE, &this->bme68x_heatr_conf_, &this->bme68x_);
+        this->bme68x_status_ = bme68x_set_op_mode(BME68X_PARALLEL_MODE, &this->bme68x_);
         this->op_mode_ = BME68X_PARALLEL_MODE;
         ESP_LOGV(TAG, "Using parallel mode");
       }
@@ -282,23 +287,14 @@ void BME68xBSEC2Component::run_() {
     this->trigger_time_ns_ = curr_time_ns;
     this->set_timeout("read", meas_dur / 1000, [this]() { this->read_(this->trigger_time_ns_); });
   } else {
-    ESP_LOGV(TAG, "Measurement not required");
-    this->read_(curr_time_ns);
+    ESP_LOGV(TAG, "Measurement not required, queueing immediate read");
+    this->trigger_time_ns_ = curr_time_ns;
+    this->set_timeout("read", 0, [this]() { this->read_(this->trigger_time_ns_); });
   }
 }
 
 void BME68xBSEC2Component::read_(int64_t trigger_time_ns) {
   ESP_LOGV(TAG, "Reading data");
-
-  if (this->bsec_settings_.trigger_measurement) {
-    uint8_t current_op_mode;
-    this->bme68x_status_ = bme68x_get_op_mode(&current_op_mode, &this->bme68x_);
-
-    if (current_op_mode == BME68X_SLEEP_MODE) {
-      ESP_LOGV(TAG, "Still in sleep mode, doing nothing");
-      return;
-    }
-  }
 
   if (!this->bsec_settings_.process_data) {
     ESP_LOGV(TAG, "Data processing not required");
@@ -309,12 +305,16 @@ void BME68xBSEC2Component::read_(int64_t trigger_time_ns) {
   uint8_t nFields = 0;
   this->bme68x_status_ = bme68x_get_data(this->op_mode_, &data[0], &nFields, &this->bme68x_);
 
+  if (is_no_new_data_warning(this->bme68x_status_)) {
+    ESP_LOGV(TAG, "BME68X did not provide new data");
+    return;
+  }
   if (this->bme68x_status_ != BME68X_OK) {
-    ESP_LOGW(TAG, "Failed to get sensor data (BME68X error code %d)", this->bme68x_status_);
+    ESP_LOGW(TAG, "Fetching data failed (BME68X error code %d)", this->bme68x_status_);
     return;
   }
   if (nFields < 1) {
-    ESP_LOGD(TAG, "BME68X did not provide new data");
+    ESP_LOGV(TAG, "BME68X did not provide new fields");
     return;
   }
 
@@ -373,7 +373,7 @@ void BME68xBSEC2Component::read_(int64_t trigger_time_ns) {
     uint8_t num_outputs = BSEC_NUMBER_OUTPUTS;
     this->bsec_status_ = bsec_do_steps_m(&this->bsec_instance_, inputs, num_inputs, outputs, &num_outputs);
     if (this->bsec_status_ != BSEC_OK) {
-      ESP_LOGW(TAG, "BSEC2 failed to process signals (BSEC2 error code %d)", this->bsec_status_);
+      ESP_LOGW(TAG, "Signal processing failed (BSEC2 error code %d)", this->bsec_status_);
       return;
     }
     if (num_outputs < 1) {
@@ -474,7 +474,7 @@ void BME68xBSEC2Component::publish_sensor_(sensor::Sensor *sensor, float value, 
 #endif
 
 #ifdef USE_TEXT_SENSOR
-void BME68xBSEC2Component::publish_sensor_(text_sensor::TextSensor *sensor, const std::string &value) {
+void BME68xBSEC2Component::publish_sensor_(text_sensor::TextSensor *sensor, const char *value) {
   if (!sensor || (sensor->has_state() && sensor->state == value)) {
     return;
   }
@@ -526,6 +526,5 @@ void BME68xBSEC2Component::save_state_(uint8_t accuracy) {
   ESP_LOGI(TAG, "Saved state");
 }
 
-}  // namespace bme68x_bsec2
-}  // namespace esphome
+}  // namespace esphome::bme68x_bsec2
 #endif

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.h
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.h
@@ -19,8 +19,7 @@
 
 #include <bsec2.h>
 
-namespace esphome {
-namespace bme68x_bsec2 {
+namespace esphome::bme68x_bsec2 {
 
 enum AlgorithmOutput {
   ALGORITHM_OUTPUT_IAQ,
@@ -97,7 +96,7 @@ class BME68xBSEC2Component : public Component {
   void publish_sensor_(sensor::Sensor *sensor, float value, bool change_only = false);
 #endif
 #ifdef USE_TEXT_SENSOR
-  void publish_sensor_(text_sensor::TextSensor *sensor, const std::string &value);
+  void publish_sensor_(text_sensor::TextSensor *sensor, const char *value);
 #endif
 
   void load_state_();
@@ -108,39 +107,12 @@ class BME68xBSEC2Component : public Component {
   struct bme68x_dev bme68x_;
   bsec_bme_settings_t bsec_settings_;
   bsec_version_t version_;
-  uint8_t bsec_instance_[BSEC_INSTANCE_SIZE];
-
   struct bme68x_heatr_conf bme68x_heatr_conf_;
-  uint8_t op_mode_;  // operating mode of sensor
-  bsec_library_return_t bsec_status_{BSEC_OK};
-  int8_t bme68x_status_{BME68X_OK};
-
-  int64_t last_time_ms_{0};
-  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to help avoid heap allocation on supported 32-bit
-                                // toolchains with small std::function SBO
-  uint32_t millis_overflow_counter_{0};
 
   std::queue<std::function<void()>> queue_;
+  ESPPreferenceObject bsec_state_;
 
   uint8_t const *bsec2_configuration_{nullptr};
-  uint32_t bsec2_configuration_length_{0};
-  bool bsec2_blob_configured_{false};
-
-  ESPPreferenceObject bsec_state_;
-  uint32_t state_save_interval_ms_{21600000};  // 6 hours - 4 times a day
-  uint32_t last_state_save_ms_ = 0;
-
-  float temperature_offset_{0};
-
-  AlgorithmOutput algorithm_output_{ALGORITHM_OUTPUT_IAQ};
-  OperatingAge operating_age_{OPERATING_AGE_28D};
-  Voltage voltage_{VOLTAGE_3_3V};
-
-  SampleRate sample_rate_{SAMPLE_RATE_LP};  // Core/gas sample rate
-  SampleRate temperature_sample_rate_{SAMPLE_RATE_DEFAULT};
-  SampleRate pressure_sample_rate_{SAMPLE_RATE_DEFAULT};
-  SampleRate humidity_sample_rate_{SAMPLE_RATE_DEFAULT};
-
 #ifdef USE_SENSOR
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *pressure_sensor_{nullptr};
@@ -155,8 +127,32 @@ class BME68xBSEC2Component : public Component {
 #ifdef USE_TEXT_SENSOR
   text_sensor::TextSensor *iaq_accuracy_text_sensor_{nullptr};
 #endif
+
+  int64_t last_time_ms_{0};
+  int64_t trigger_time_ns_{0};  // Stored for set_timeout lambda to help avoid heap allocation on supported 32-bit
+                                // toolchains with small std::function SBO
+
+  uint32_t state_save_interval_ms_{21600000};  // 6 hours - 4 times a day
+  uint32_t last_state_save_ms_{0};
+  uint32_t millis_overflow_counter_{0};
+  uint32_t bsec2_configuration_length_{0};
+  bsec_library_return_t bsec_status_{BSEC_OK};
+
+  float temperature_offset_{0};
+
+  AlgorithmOutput algorithm_output_{ALGORITHM_OUTPUT_IAQ};
+  OperatingAge operating_age_{OPERATING_AGE_28D};
+  Voltage voltage_{VOLTAGE_3_3V};
+  SampleRate sample_rate_{SAMPLE_RATE_LP};  // Core/gas sample rate
+  SampleRate temperature_sample_rate_{SAMPLE_RATE_DEFAULT};
+  SampleRate pressure_sample_rate_{SAMPLE_RATE_DEFAULT};
+  SampleRate humidity_sample_rate_{SAMPLE_RATE_DEFAULT};
+
+  uint8_t bsec_instance_[BSEC_INSTANCE_SIZE];
+  uint8_t op_mode_;  // operating mode of sensor
+  int8_t bme68x_status_{BME68X_OK};
+  bool bsec2_blob_configured_{false};
 };
 
-}  // namespace bme68x_bsec2
-}  // namespace esphome
+}  // namespace esphome::bme68x_bsec2
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes spurious warnings logged by the `bme68x_bsec2` component:

```
[W][bme68x_bsec2.sensor:313]: Failed to get sensor data (BME68X error code 2)
[W][component:518]: bme68x_bsec2 took a long time for an operation (54 ms), max is 30 ms
[W][component:402]: bme68x_bsec2 set Warning flag: unspecified
```

The `BME68X_W_NO_NEW_DATA` status (error code 2) is a normal, non-error condition returned by the BME68X driver when the sensor hasn't produced a new measurement yet. Previously this was being propagated up as a warning condition (`status_set_warning()`), causing the "set Warning flag: unspecified" and "Failed to get sensor data" log lines to appear on nearly every sensor run.

**Changes:**
- Add `is_no_new_data_warning()` helper to detect `BME68X_W_NO_NEW_DATA` (with a fallback to the literal value `2` when the define is unavailable) and handle it gracefully by returning early with a `VERBOSE` log entry instead of a warning
- Exclude `BME68X_W_NO_NEW_DATA` from the condition that triggers `status_set_warning()`
- Set `warn_if_blocking_over_` to 60 ms during `setup()` to suppress the "took a long time" warning during the initial sensor read, which can legitimately block for ~54 ms
- Fix a bug where the "measurement not required" code path called `read_()` directly (blocking the loop), now uses `set_timeout("read", 0, ...)` for consistency with the normal path
- Remove the sleep-mode check in `read_()` that was doing an unnecessary `bme68x_get_op_mode()` call
- Replace local `status` variable with `this->bme68x_status_` so heater/op-mode errors are actually visible
- Code clean-up: collapse nested namespaces, replace `std::string` with `const char *` for `IAQ_ACCURACY_STATES` and `publish_sensor_()`, reorder fields for better struct layout, minor log message wording improvements

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing config changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bme68x_bsec2_i2c:
  address: 0x77
  algorithm_output: classification
  operating_age: 28d
  sample_rate: lp
  voltage: 3.3V
  temperature:
    name: BME68X Temperature
  pressure:
    name: BME68X Pressure
  humidity:
    name: BME68X Humidity
  iaq:
    name: BME68X IAQ
  iaq_accuracy:
    name: BME68X Accuracy
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).