### PR TITLE
[core] Fix area/device hash collision validation not running

### DIFF
--- a/esphome/config.py
+++ b/esphome/config.py
@@ -958,6 +958,23 @@ class FinalValidateValidationStep(ConfigValidationStep):
         fv.full_config.reset(token)
 
 
+class CoreFinalValidateStep(ConfigValidationStep):
+    """Run final validation on core esphome config (area/device hash collisions)."""
+
+    # Same priority as component final validate steps
+    priority = -20.0
+
+    def run(self, result: Config) -> None:
+        if result.errors:
+            return
+
+        token = fv.full_config.set(result)
+        with result.catch_error([CONF_ESPHOME]):
+            if CONF_ESPHOME in result:
+                core_config.validate_ids_and_references(result[CONF_ESPHOME])
+        fv.full_config.reset(token)
+
+
 class PinUseValidationCheck(ConfigValidationStep):
     """Check for pin reuse"""
 
@@ -1085,6 +1102,7 @@ def validate_config(
     for domain, conf in config.items():
         result.add_validation_step(LoadValidationStep(domain, conf))
     result.add_validation_step(IDPassValidationStep())
+    result.add_validation_step(CoreFinalValidateStep())
     result.add_validation_step(PinUseValidationCheck())
 
     result.add_validation_step(RemoveReferenceValidationStep())

--- a/esphome/core/config.py
+++ b/esphome/core/config.py
@@ -156,22 +156,22 @@ def validate_ids_and_references(config: ConfigType) -> ConfigType:
         hash_dict[hash_val] = id_obj.id
 
     # Collect all areas
-    all_areas: list[dict[str, str | core.ID]] = []
+    all_areas: list[tuple[dict[str, str | core.ID], str]] = []
     if CONF_AREA in config:
-        all_areas.append(config[CONF_AREA])
-    all_areas.extend(config[CONF_AREAS])
+        all_areas.append((config[CONF_AREA], CONF_AREA))
+    all_areas.extend((area, CONF_AREAS) for area in config.get(CONF_AREAS, []))
 
     # Validate area hash collisions and collect IDs
     area_hashes: dict[int, str] = {}
     area_ids: set[str] = set()
-    for area in all_areas:
+    for area, key in all_areas:
         area_id: core.ID = area[CONF_ID]
-        check_hash_collision(area_id, area_hashes, "Area", [CONF_AREAS, area_id.id])
+        check_hash_collision(area_id, area_hashes, "Area", [key, area_id.id])
         area_ids.add(area_id.id)
 
     # Validate device hash collisions and area references
     device_hashes: dict[int, str] = {}
-    for device in config[CONF_DEVICES]:
+    for device in config.get(CONF_DEVICES, []):
         device_id: core.ID = device[CONF_ID]
         check_hash_collision(
             device_id, device_hashes, "Device", [CONF_DEVICES, device_id.id]
@@ -327,9 +327,6 @@ CONFIG_SCHEMA = cv.All(
     ),
     validate_hostname,
 )
-
-
-FINAL_VALIDATE_SCHEMA = cv.All(validate_ids_and_references)
 
 
 PRELOAD_CONFIG_SCHEMA = cv.Schema(

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -1006,6 +1006,18 @@ def lint_log_in_header(fname, line, col, content):
     )
 
 
+@lint_content_find_check(
+    "FINAL_VALIDATE_SCHEMA",
+    include=["esphome/core/*.py"],
+    exclude=["esphome/core/entity_helpers.py"],
+)
+def lint_final_validate_in_core(fname, line, col, content):
+    return (
+        "FINAL_VALIDATE_SCHEMA in esphome/core/ is not picked up by the component loader. "
+        "Use CoreFinalValidateStep in esphome/config.py instead."
+    )
+
+
 def main():
     colorama.init()
 

--- a/tests/unit_tests/core/test_config.py
+++ b/tests/unit_tests/core/test_config.py
@@ -248,6 +248,24 @@ def test_area_id_hash_collision(
     )
 
 
+def test_area_singular_hash_collision(
+    yaml_file: Callable[[str], str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test that area hash collisions between singular area: and areas: list are detected."""
+    result = load_config_from_fixture(
+        yaml_file, "area_singular_hash_collision.yaml", FIXTURES_DIR
+    )
+    assert result is None
+
+    captured = capsys.readouterr()
+    assert (
+        "Area ID 'd6ka' with hash 3082558663 collides with existing area ID 'test_2258'"
+        in captured.out
+    )
+    # Error path should point to 'areas' (where the colliding entry is), not 'area'
+    assert "areas" in captured.out
+
+
 def test_device_duplicate_id(
     yaml_file: Callable[[str], str], capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit_tests/fixtures/core/config/area_singular_hash_collision.yaml
+++ b/tests/unit_tests/fixtures/core/config/area_singular_hash_collision.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test
+  area:
+    id: test_2258
+    name: "Area 1"
+  areas:
+    - id: d6ka
+      name: "Area 2"
+
+host:


### PR DESCRIPTION
# What does this implement/fix?

The `validate_ids_and_references` function (area/device hash collision detection) was defined in `esphome/core/config.py` with a `FINAL_VALIDATE_SCHEMA`, but the component loader only picks up `FINAL_VALIDATE_SCHEMA` from component modules (`esphome/components/*/`), not from core. The validation was never actually called — hash collisions between area or device IDs went undetected.

Fix by:
1. Adding a `CoreFinalValidateStep` in `esphome/config.py` that explicitly calls `validate_ids_and_references` during the validation pipeline
2. Removing the dead `FINAL_VALIDATE_SCHEMA` from `esphome/core/config.py`
3. Fixing the error path for singular `area:` (was always pointing to `areas:`)
4. Using `.get()` for `areas` and `devices` keys to handle configs that may not have them
5. Adding a CI lint check to prevent `FINAL_VALIDATE_SCHEMA` from being used in `esphome/core/` (since the component loader won't pick it up)
6. Adding a test for singular `area:` + `areas:` hash collision

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).