### PR TITLE
[shtcx] Code clean-up

### DIFF
--- a/esphome/components/shtcx/shtcx.cpp
+++ b/esphome/components/shtcx/shtcx.cpp
@@ -2,16 +2,15 @@
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
-namespace esphome {
-namespace shtcx {
+namespace esphome::shtcx {
 
 static const char *const TAG = "shtcx";
 
-static const uint16_t SHTCX_COMMAND_SLEEP = 0xB098;
-static const uint16_t SHTCX_COMMAND_WAKEUP = 0x3517;
-static const uint16_t SHTCX_COMMAND_READ_ID_REGISTER = 0xEFC8;
-static const uint16_t SHTCX_COMMAND_SOFT_RESET = 0x805D;
-static const uint16_t SHTCX_COMMAND_POLLING_H = 0x7866;
+static constexpr uint16_t SHTCX_COMMAND_SLEEP = 0xB098;
+static constexpr uint16_t SHTCX_COMMAND_WAKEUP = 0x3517;
+static constexpr uint16_t SHTCX_COMMAND_READ_ID_REGISTER = 0xEFC8;
+static constexpr uint16_t SHTCX_COMMAND_SOFT_RESET = 0x805D;
+static constexpr uint16_t SHTCX_COMMAND_POLLING_H = 0x7866;
 
 static const LogString *shtcx_type_to_string(SHTCXType type) {
   switch (type) {
@@ -91,8 +90,6 @@ void SHTCXComponent::update() {
     } else {
       temperature = 175.0f * float(raw_data[0]) / 65536.0f - 45.0f;
       humidity = 100.0f * float(raw_data[1]) / 65536.0f;
-
-      ESP_LOGD(TAG, "Temperature=%.2f°C Humidity=%.2f%%", temperature, humidity);
     }
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
@@ -117,5 +114,4 @@ void SHTCXComponent::wake_up() {
   delayMicroseconds(200);
 }
 
-}  // namespace shtcx
-}  // namespace esphome
+}  // namespace esphome::shtcx

--- a/esphome/components/shtcx/shtcx.h
+++ b/esphome/components/shtcx/shtcx.h
@@ -4,10 +4,13 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
 
-namespace esphome {
-namespace shtcx {
+namespace esphome::shtcx {
 
-enum SHTCXType { SHTCX_TYPE_SHTC3 = 0, SHTCX_TYPE_SHTC1, SHTCX_TYPE_UNKNOWN };
+enum SHTCXType : uint8_t {
+  SHTCX_TYPE_SHTC3 = 0,
+  SHTCX_TYPE_SHTC1,
+  SHTCX_TYPE_UNKNOWN,
+};
 
 /// This class implements support for the SHT3x-DIS family of temperature+humidity i2c sensors.
 class SHTCXComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
@@ -23,11 +26,10 @@ class SHTCXComponent : public PollingComponent, public sensirion_common::Sensiri
   void wake_up();
 
  protected:
-  SHTCXType type_;
-  uint16_t sensor_id_;
   sensor::Sensor *temperature_sensor_{nullptr};
   sensor::Sensor *humidity_sensor_{nullptr};
+  uint16_t sensor_id_;
+  SHTCXType type_;
 };
 
-}  // namespace shtcx
-}  // namespace esphome
+}  // namespace esphome::shtcx


### PR DESCRIPTION
# What does this implement/fix?

Minor code quality improvements to the `shtcx` component:

- Collapse nested namespace declarations into `namespace esphome::shtcx` (C++17 style)
- Change `static const` to `static constexpr` for command constants
- Add explicit `uint8_t` underlying type to `SHTCXType` enum
- Reorder protected fields (pointer members before scalar members)
- Remove redundant `ESP_LOGD` for temperature/humidity (values are already available via sensor publishing and `dump_config`)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: shtcx
    temperature:
      name: Temperature
    humidity:
      name: Humidity
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).