### PR TITLE
[sensor] Use std::array in ValueList/FilterOut/ThrottleWithPriority filters

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -381,7 +381,7 @@ async def filter_out_filter_to_code(config, filter_id):
     if not isinstance(config, list):
         config = [config]
     template_ = [await cg.templatable(x, [], float) for x in config]
-    return cg.new_Pvariable(filter_id, template_)
+    return cg.new_Pvariable(filter_id, cg.TemplateArguments(len(template_)), template_)
 
 
 QUANTILE_SCHEMA = cv.All(
@@ -650,7 +650,9 @@ async def throttle_with_priority_filter_to_code(config, filter_id):
     if not isinstance(config[CONF_VALUE], list):
         config[CONF_VALUE] = [config[CONF_VALUE]]
     template_ = [await cg.templatable(x, [], float) for x in config[CONF_VALUE]]
-    return cg.new_Pvariable(filter_id, config[CONF_TIMEOUT], template_)
+    return cg.new_Pvariable(
+        filter_id, cg.TemplateArguments(len(template_)), config[CONF_TIMEOUT], template_
+    )
 
 
 HEARTBEAT_SCHEMA = cv.Schema(

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -246,16 +246,14 @@ bool value_list_matches_any(Sensor *parent, float sensor_value, const Templatabl
   return false;
 }
 
-bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_inputs) {
+bool throttle_check_with_priority(uint32_t &last_input, uint32_t min_time_between_inputs, bool is_prioritized) {
   const uint32_t now = App.get_loop_component_start_time();
-  if (last_input == 0 || now - last_input >= min_time_between_inputs) {
+  if (last_input == 0 || now - last_input >= min_time_between_inputs || is_prioritized) {
     last_input = now;
     return true;
   }
   return false;
 }
-
-void throttle_update_timestamp(uint32_t &last_input) { last_input = App.get_loop_component_start_time(); }
 
 // ThrottleFilter
 ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs) : min_time_between_inputs_(min_time_between_inputs) {}

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -246,23 +246,24 @@ bool value_list_matches_any(Sensor *parent, float sensor_value, const Templatabl
   return false;
 }
 
-optional<float> throttle_with_priority_new_value(Sensor *parent, float value, const TemplatableValue<float> *values,
-                                                 size_t count, uint32_t &last_input, uint32_t min_time_between_inputs) {
-  const uint32_t now = App.get_loop_component_start_time();
-  if (last_input == 0 || now - last_input >= min_time_between_inputs ||
-      value_list_matches_any(parent, value, values, count)) {
-    last_input = now;
-    return value;
-  }
-  return {};
-}
-
 // ThrottleFilter
 ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs) : min_time_between_inputs_(min_time_between_inputs) {}
 optional<float> ThrottleFilter::new_value(float value) {
   const uint32_t now = App.get_loop_component_start_time();
   if (this->last_input_ == 0 || now - this->last_input_ >= min_time_between_inputs_) {
     this->last_input_ = now;
+    return value;
+  }
+  return {};
+}
+
+// ThrottleWithPriorityFilter helper (non-template, keeps App access in .cpp)
+optional<float> throttle_with_priority_new_value(Sensor *parent, float value, const TemplatableValue<float> *values,
+                                                 size_t count, uint32_t &last_input, uint32_t min_time_between_inputs) {
+  const uint32_t now = App.get_loop_component_start_time();
+  if (last_input == 0 || now - last_input >= min_time_between_inputs ||
+      value_list_matches_any(parent, value, values, count)) {
+    last_input = now;
     return value;
   }
   return {};

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -246,13 +246,15 @@ bool value_list_matches_any(Sensor *parent, float sensor_value, const Templatabl
   return false;
 }
 
-bool throttle_check_with_priority(uint32_t &last_input, uint32_t min_time_between_inputs, bool is_prioritized) {
+optional<float> throttle_with_priority_new_value(Sensor *parent, float value, const TemplatableValue<float> *values,
+                                                 size_t count, uint32_t &last_input, uint32_t min_time_between_inputs) {
   const uint32_t now = App.get_loop_component_start_time();
-  if (last_input == 0 || now - last_input >= min_time_between_inputs || is_prioritized) {
+  if (last_input == 0 || now - last_input >= min_time_between_inputs ||
+      value_list_matches_any(parent, value, values, count)) {
     last_input = now;
-    return true;
+    return value;
   }
-  return false;
+  return {};
 }
 
 // ThrottleFilter

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -255,6 +255,8 @@ bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_i
   return false;
 }
 
+void throttle_update_timestamp(uint32_t &last_input) { last_input = App.get_loop_component_start_time(); }
+
 // ThrottleFilter
 ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs) : min_time_between_inputs_(min_time_between_inputs) {}
 optional<float> ThrottleFilter::new_value(float value) {

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -222,16 +222,14 @@ MultiplyFilter::MultiplyFilter(TemplatableValue<float> multiplier) : multiplier_
 
 optional<float> MultiplyFilter::new_value(float value) { return value * this->multiplier_.value(); }
 
-// ValueListFilter (base class)
-ValueListFilter::ValueListFilter(std::initializer_list<TemplatableValue<float>> values) : values_(values) {}
-
-bool ValueListFilter::value_matches_any_(float sensor_value) {
-  int8_t accuracy = this->parent_->get_accuracy_decimals();
+// ValueListFilter helper (non-template, shared by all ValueListFilter<N> instantiations)
+bool value_list_matches_any(Sensor *parent, float sensor_value, const TemplatableValue<float> *values, size_t count) {
+  int8_t accuracy = parent->get_accuracy_decimals();
   float accuracy_mult = pow10_int(accuracy);
   float rounded_sensor = roundf(accuracy_mult * sensor_value);
 
-  for (auto &filter_value : this->values_) {
-    float fv = filter_value.value();
+  for (size_t i = 0; i < count; i++) {
+    float fv = values[i].value();
 
     // Handle NaN comparison
     if (std::isnan(fv)) {
@@ -248,14 +246,13 @@ bool ValueListFilter::value_matches_any_(float sensor_value) {
   return false;
 }
 
-// FilterOutValueFilter
-FilterOutValueFilter::FilterOutValueFilter(std::initializer_list<TemplatableValue<float>> values_to_filter_out)
-    : ValueListFilter(values_to_filter_out) {}
-
-optional<float> FilterOutValueFilter::new_value(float value) {
-  if (this->value_matches_any_(value))
-    return {};   // Filter out
-  return value;  // Pass through
+bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_inputs) {
+  const uint32_t now = App.get_loop_component_start_time();
+  if (last_input == 0 || now - last_input >= min_time_between_inputs) {
+    last_input = now;
+    return true;
+  }
+  return false;
 }
 
 // ThrottleFilter
@@ -263,22 +260,6 @@ ThrottleFilter::ThrottleFilter(uint32_t min_time_between_inputs) : min_time_betw
 optional<float> ThrottleFilter::new_value(float value) {
   const uint32_t now = App.get_loop_component_start_time();
   if (this->last_input_ == 0 || now - this->last_input_ >= min_time_between_inputs_) {
-    this->last_input_ = now;
-    return value;
-  }
-  return {};
-}
-
-// ThrottleWithPriorityFilter
-ThrottleWithPriorityFilter::ThrottleWithPriorityFilter(
-    uint32_t min_time_between_inputs, std::initializer_list<TemplatableValue<float>> prioritized_values)
-    : ValueListFilter(prioritized_values), min_time_between_inputs_(min_time_between_inputs) {}
-
-optional<float> ThrottleWithPriorityFilter::new_value(float value) {
-  const uint32_t now = App.get_loop_component_start_time();
-  // Allow value through if: no previous input, time expired, or is prioritized
-  if (this->last_input_ == 0 || now - this->last_input_ >= min_time_between_inputs_ ||
-      this->value_matches_any_(value)) {
     this->last_input_ = now;
     return value;
   }

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -378,9 +378,12 @@ class ThrottleFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
-/// Returns true if throttle should allow the value through (time expired or first input).
-/// Updates last_input in-place. Implementation in filter.cpp (accesses App without circular include).
+/// Returns true if throttle time has expired or this is the first input.
+/// Implementation in filter.cpp (accesses App without circular include).
 bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_inputs);
+
+/// Update last_input timestamp to current loop time. Implementation in filter.cpp.
+void throttle_update_timestamp(uint32_t &last_input);
 
 /// Same as 'throttle' but will immediately publish values contained in `value_to_prioritize`.
 template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> {
@@ -392,6 +395,7 @@ template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> 
   optional<float> new_value(float value) override {
     if (throttle_check_and_update(this->last_input_, this->min_time_between_inputs_) ||
         this->value_matches_any_(value)) {
+      throttle_update_timestamp(this->last_input_);
       return value;
     }
     return {};

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -378,12 +378,9 @@ class ThrottleFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
-/// Returns true if throttle time has expired or this is the first input.
-/// Implementation in filter.cpp (accesses App without circular include).
-bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_inputs);
-
-/// Update last_input timestamp to current loop time. Implementation in filter.cpp.
-void throttle_update_timestamp(uint32_t &last_input);
+/// Check throttle and optionally allow prioritized values through.
+/// Always updates last_input when returning true. Implementation in filter.cpp.
+bool throttle_check_with_priority(uint32_t &last_input, uint32_t min_time_between_inputs, bool is_prioritized);
 
 /// Same as 'throttle' but will immediately publish values contained in `value_to_prioritize`.
 template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> {
@@ -393,9 +390,8 @@ template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> 
       : ValueListFilter<N>(prioritized_values), min_time_between_inputs_(min_time_between_inputs) {}
 
   optional<float> new_value(float value) override {
-    if (throttle_check_and_update(this->last_input_, this->min_time_between_inputs_) ||
-        this->value_matches_any_(value)) {
-      throttle_update_timestamp(this->last_input_);
+    if (throttle_check_with_priority(this->last_input_, this->min_time_between_inputs_,
+                                     this->value_matches_any_(value))) {
       return value;
     }
     return {};

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -3,6 +3,7 @@
 #include "esphome/core/defines.h"
 #ifdef USE_SENSOR_FILTER
 
+#include <array>
 #include <utility>
 #include <vector>
 #include "esphome/core/automation.h"
@@ -328,28 +329,42 @@ class MultiplyFilter : public Filter {
   TemplatableValue<float> multiplier_;
 };
 
-/** Base class for filters that compare sensor values against a list of configured values.
+/// Non-template helper for value matching (implementation in filter.cpp)
+bool value_list_matches_any(Sensor *parent, float sensor_value, const TemplatableValue<float> *values, size_t count);
+
+/** Base class for filters that compare sensor values against a fixed list of configured values.
  *
- * This base class provides common functionality for filters that need to check if a sensor
- * value matches any value in a configured list, with proper handling of NaN values and
- * accuracy-based rounding for comparisons.
+ * Templated on N (the number of values) so the list is stored inline in a std::array,
+ * avoiding heap allocation and the overhead of FixedVector.
+ *
+ * @tparam N Number of values in the filter list, set by code generation to match
+ *           the exact number of values configured in YAML.
  */
-class ValueListFilter : public Filter {
+template<size_t N> class ValueListFilter : public Filter {
  protected:
-  explicit ValueListFilter(std::initializer_list<TemplatableValue<float>> values);
+  explicit ValueListFilter(std::initializer_list<TemplatableValue<float>> values) {
+    init_array_from(this->values_, values);
+  }
 
   /// Check if sensor value matches any configured value (with accuracy rounding)
-  bool value_matches_any_(float sensor_value);
+  bool value_matches_any_(float sensor_value) {
+    return value_list_matches_any(this->parent_, sensor_value, this->values_.data(), N);
+  }
 
-  FixedVector<TemplatableValue<float>> values_;
+  std::array<TemplatableValue<float>, N> values_{};
 };
 
 /// A simple filter that only forwards the filter chain if it doesn't receive `value_to_filter_out`.
-class FilterOutValueFilter : public ValueListFilter {
+template<size_t N> class FilterOutValueFilter : public ValueListFilter<N> {
  public:
-  explicit FilterOutValueFilter(std::initializer_list<TemplatableValue<float>> values_to_filter_out);
+  explicit FilterOutValueFilter(std::initializer_list<TemplatableValue<float>> values_to_filter_out)
+      : ValueListFilter<N>(values_to_filter_out) {}
 
-  optional<float> new_value(float value) override;
+  optional<float> new_value(float value) override {
+    if (this->value_matches_any_(value))
+      return {};   // Filter out
+    return value;  // Pass through
+  }
 };
 
 class ThrottleFilter : public Filter {
@@ -363,13 +378,24 @@ class ThrottleFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
+/// Returns true if throttle should allow the value through (time expired or first input).
+/// Updates last_input in-place. Implementation in filter.cpp (accesses App without circular include).
+bool throttle_check_and_update(uint32_t &last_input, uint32_t min_time_between_inputs);
+
 /// Same as 'throttle' but will immediately publish values contained in `value_to_prioritize`.
-class ThrottleWithPriorityFilter : public ValueListFilter {
+template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> {
  public:
   explicit ThrottleWithPriorityFilter(uint32_t min_time_between_inputs,
-                                      std::initializer_list<TemplatableValue<float>> prioritized_values);
+                                      std::initializer_list<TemplatableValue<float>> prioritized_values)
+      : ValueListFilter<N>(prioritized_values), min_time_between_inputs_(min_time_between_inputs) {}
 
-  optional<float> new_value(float value) override;
+  optional<float> new_value(float value) override {
+    if (throttle_check_and_update(this->last_input_, this->min_time_between_inputs_) ||
+        this->value_matches_any_(value)) {
+      return value;
+    }
+    return {};
+  }
 
  protected:
   uint32_t last_input_{0};

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -378,9 +378,9 @@ class ThrottleFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
-/// Check throttle and optionally allow prioritized values through.
-/// Always updates last_input when returning true. Implementation in filter.cpp.
-bool throttle_check_with_priority(uint32_t &last_input, uint32_t min_time_between_inputs, bool is_prioritized);
+/// Non-template helper for ThrottleWithPriorityFilter (implementation in filter.cpp)
+optional<float> throttle_with_priority_new_value(Sensor *parent, float value, const TemplatableValue<float> *values,
+                                                 size_t count, uint32_t &last_input, uint32_t min_time_between_inputs);
 
 /// Same as 'throttle' but will immediately publish values contained in `value_to_prioritize`.
 template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> {
@@ -390,11 +390,8 @@ template<size_t N> class ThrottleWithPriorityFilter : public ValueListFilter<N> 
       : ValueListFilter<N>(prioritized_values), min_time_between_inputs_(min_time_between_inputs) {}
 
   optional<float> new_value(float value) override {
-    if (throttle_check_with_priority(this->last_input_, this->min_time_between_inputs_,
-                                     this->value_matches_any_(value))) {
-      return value;
-    }
-    return {};
+    return throttle_with_priority_new_value(this->parent_, value, this->values_.data(), N, this->last_input_,
+                                            this->min_time_between_inputs_);
   }
 
  protected:

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstdarg>
 #include <cstdint>
@@ -496,6 +497,23 @@ template<typename T, size_t MAX_CAPACITY = std::numeric_limits<uint16_t>::max()>
   index_type count_{0};
   index_type capacity_{0};
 };
+
+/// Initialize a std::array from an initializer_list. Uses memcpy for trivially copyable types (optimal codegen),
+/// falls back to element-wise copy for non-trivially copyable types (e.g. TemplatableValue).
+/// N is set by code generation; assert catches mismatches in debug/integration tests.
+template<typename T, size_t N> inline void init_array_from(std::array<T, N> &dest, std::initializer_list<T> src) {
+#ifdef ESPHOME_DEBUG
+  assert(src.size() == N);
+#endif
+  if constexpr (std::is_trivially_copyable_v<T>) {
+    __builtin_memcpy(dest.data(), src.begin(), N * sizeof(T));
+  } else {
+    size_t i = 0;
+    for (const auto &v : src) {
+      dest[i++] = v;
+    }
+  }
+}
 
 /// Fixed-capacity vector - allocates once at runtime, never reallocates
 /// This avoids std::vector template overhead (_M_realloc_insert, _M_default_append)


### PR DESCRIPTION
# What does this implement/fix?

> **⚠️ CI memory impact will be misleading.** BSS increases are data moving from heap to BSS — total RAM is always reduced (heap savings are not measured by CI). Flash increases only occur when the test YAML uses multiple different N values, causing separate template instantiations. Real configs typically use one N value per filter type, so flash impact is zero or negative.

Template `ValueListFilter`, `FilterOutValueFilter`, and `ThrottleWithPriorityFilter` on `N` (the number of configured values) so the value list is stored in a `std::array<TemplatableValue<float>, N>` instead of `FixedVector<TemplatableValue<float>>`.

Non-template helpers `value_list_matches_any()` and `get_loop_component_start_time()` are defined in `filter.cpp` so the matching logic and `App` access are not duplicated per instantiation.

### Real-world impact (Apollo R PRO-1 ETH, ESP32-S3)

This config has 64 `throttle_with_priority` filters, all with N=1. Single N value = zero template duplication.

| Metric | Baseline | After | Change |
|--------|----------|-------|--------|
| **RAM (BSS)** | 40,116 B | 39,860 B | **-256 B** |
| **Flash** | 786,843 B | 786,819 B | **-24 B** |
| **Free heap (on-device)** | 296,660 B | 298,128 B | **+1,468 B** |

The +1,468 bytes free heap is the true net savings — BSS reduction plus 64 eliminated heap allocations plus allocator overhead, all measured in one number.

### CI flash note

The CI test YAML exercises multiple different N values (e.g. `filter_out: 42.0` vs `filter_out: [0.0, 42.0, 100.0]`), which causes separate template instantiations. Real configs typically use one N value per filter type, resulting in zero flash duplication.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: template
    name: "Test Sensor"
    lambda: return 42.0;
    update_interval: 1s
    filters:
      - filter_out: [0.0, nan]
      - throttle_with_priority:
          timeout: 1000ms
          value: [0.0, 42.0]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). Existing component tests in `tests/components/sensor/` exercise these filters. Integration tests in `tests/integration/test_sensor_filters_value_list.py` verify filter_out and throttle_with_priority end-to-end.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).