### PR TITLE
[dht] Code clean-up

### DIFF
--- a/esphome/components/dht/dht.cpp
+++ b/esphome/components/dht/dht.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace dht {
+namespace esphome::dht {
 
 static const char *const TAG = "dht";
 
@@ -45,16 +44,13 @@ void DHT::update() {
   }
 
   if (success) {
-    ESP_LOGD(TAG, "Temperature %.1f°C Humidity %.1f%%", temperature, humidity);
-
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(temperature);
     if (this->humidity_sensor_ != nullptr)
       this->humidity_sensor_->publish_state(humidity);
     this->status_clear_warning();
   } else {
-    ESP_LOGW(TAG, "Invalid readings! Check pin number and pull-up resistor%s.",
-             this->is_auto_detect_ ? " and try manually specifying the model" : "");
+    ESP_LOGW(TAG, "Invalid readings");
     if (this->temperature_sensor_ != nullptr)
       this->temperature_sensor_->publish_state(NAN);
     if (this->humidity_sensor_ != nullptr)
@@ -73,8 +69,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   *temperature = NAN;
 
   int error_code = 0;
-  int8_t i = 0;
-  uint8_t data[5] = {0, 0, 0, 0, 0};
+  uint8_t data[5] = {};
 
 #ifndef USE_ESP32
   this->pin_.pin_mode(gpio::FLAG_OUTPUT);
@@ -107,7 +102,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
     uint8_t bit = 7;
     uint8_t byte = 0;
 
-    for (i = -1; i < 40; i++) {
+    // On 32-bit Xtensa/RISC-V cores, int8_t would require masking/sign-extension for comparisons
+    // vs. native int. Using int i is native word size — small win in the timing-critical section.
+    for (int i = -1; i < 40; i++) {
       uint32_t start_time = micros();
 
       // Wait for rising edge
@@ -156,11 +153,9 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
       }
     }
   }
-  if (!report_errors && error_code != 0)
-    return false;
-
-  if (error_code) {
-    ESP_LOGW(TAG, ESP_LOG_MSG_COMM_FAIL);
+  if (error_code != 0) {
+    if (report_errors)
+      ESP_LOGW(TAG, ESP_LOG_MSG_COMM_FAIL);
     return false;
   }
 
@@ -177,7 +172,7 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
 
   if (checksum_a != data[4] && checksum_b != data[4]) {
     if (report_errors) {
-      ESP_LOGW(TAG, "Checksum invalid: %u!=%u", checksum_a, data[4]);
+      ESP_LOGW(TAG, "Invalid checksum");
     }
     return false;
   }
@@ -234,5 +229,4 @@ bool HOT IRAM_ATTR DHT::read_sensor_(float *temperature, float *humidity, bool r
   return true;
 }
 
-}  // namespace dht
-}  // namespace esphome
+}  // namespace esphome::dht

--- a/esphome/components/dht/dht.h
+++ b/esphome/components/dht/dht.h
@@ -4,10 +4,9 @@
 #include "esphome/core/hal.h"
 #include "esphome/components/sensor/sensor.h"
 
-namespace esphome {
-namespace dht {
+namespace esphome::dht {
 
-enum DHTModel {
+enum DHTModel : uint8_t {
   DHT_MODEL_AUTO_DETECT = 0,
   DHT_MODEL_DHT11,
   DHT_MODEL_DHT22,
@@ -42,7 +41,6 @@ class DHT : public PollingComponent {
     this->t_pin_ = pin;
     this->pin_ = pin->to_isr();
   }
-  void set_model(DHTModel model) { model_ = model; }
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
   void set_humidity_sensor(sensor::Sensor *humidity_sensor) { humidity_sensor_ = humidity_sensor; }
 
@@ -55,13 +53,12 @@ class DHT : public PollingComponent {
  protected:
   bool read_sensor_(float *temperature, float *humidity, bool report_errors);
 
+  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *humidity_sensor_{nullptr};
   InternalGPIOPin *t_pin_;
   ISRInternalGPIOPin pin_;
   DHTModel model_{DHT_MODEL_AUTO_DETECT};
   bool is_auto_detect_{false};
-  sensor::Sensor *temperature_sensor_{nullptr};
-  sensor::Sensor *humidity_sensor_{nullptr};
 };
 
-}  // namespace dht
-}  // namespace esphome
+}  // namespace esphome::dht


### PR DESCRIPTION
# What does this implement/fix?

Minor code quality clean-up for the DHT component:

- Use `namespace esphome::dht` style (C++17) in both `.h` and `.cpp`
- Add `: uint8_t` underlying type to `DHTModel` enum
- Remove dead `set_model()` setter (generated code always calls `set_dht_model()`; `set_model` also had a latent bug — it didn't update `is_auto_detect_`)
- Move sensor pointer fields to the top of the `protected` section
- Scope loop variable `i` to the `for` loop; use `int` instead of `int8_t` (native word size on 32-bit Xtensa/RISC-V — small win in the `IRAM_ATTR` timing loop)
- Simplify `data[5]` initialisation to `{}`
- Merge redundant dual `error_code` checks into a single block
- Simplify warning messages (remove `printf`-style formatting from checksum error, remove auto-detect hint from invalid-readings warning)
- Remove `ESP_LOGD` on successful read (not needed; values are already visible via sensor state)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: dht
    pin: GPIO4
    model: DHT22
    temperature:
      name: "Temperature"
    humidity:
      name: "Humidity"
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).