### PR TITLE
[thermostat] Fix stale `max_runtime_exceeded` causing spurious supplemental heating/cooling

### DIFF
--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -606,6 +606,16 @@ void ThermostatClimate::switch_to_action_(climate::ClimateAction action, bool pu
 }
 
 void ThermostatClimate::switch_to_supplemental_action_(climate::ClimateAction action) {
+  // Always cancel max-runtime timers and clear exceeded flags when transitioning to idle/off,
+  // even if supplemental_action_ is already idle (early-return path). This prevents a stale
+  // heating_max_runtime_exceeded_ flag from triggering supplemental on the next heating cycle
+  // when HEATING_MAX_RUN_TIME fires while the main action is already IDLE.
+  if (action == climate::CLIMATE_ACTION_OFF || action == climate::CLIMATE_ACTION_IDLE) {
+    this->cancel_timer_(thermostat::THERMOSTAT_TIMER_COOLING_MAX_RUN_TIME);
+    this->cancel_timer_(thermostat::THERMOSTAT_TIMER_HEATING_MAX_RUN_TIME);
+    this->cooling_max_runtime_exceeded_ = false;
+    this->heating_max_runtime_exceeded_ = false;
+  }
   // setup_complete_ helps us ensure an action is called immediately after boot
   if ((action == this->supplemental_action_) && this->setup_complete_) {
     // already in target mode
@@ -975,8 +985,10 @@ void ThermostatClimate::cooling_on_timer_callback_() {
 void ThermostatClimate::fan_mode_timer_callback_() {
   ESP_LOGVV(TAG, "fan_mode timer expired");
   this->switch_to_fan_mode_(this->fan_mode.value_or(climate::CLIMATE_FAN_ON));
-  if (this->supports_fan_only_action_uses_fan_mode_timer_)
+  if (this->supports_fan_only_action_uses_fan_mode_timer_) {
     this->switch_to_action_(this->compute_action_());
+    this->switch_to_supplemental_action_(this->compute_supplemental_action_());
+  }
 }
 
 void ThermostatClimate::fanning_off_timer_callback_() {


### PR DESCRIPTION
# What does this implement/fix?

Two bugs in the thermostat component's supplemental action state machine that cause supplemental heating or cooling to engage immediately at the start of a new cycle, even when neither the delta condition nor the max-runtime condition has been met for that cycle.

**Root cause — stale `max_runtime_exceeded` flag:**

When a max-runtime timer (`HEATING_MAX_RUN_TIME` at index 6, `COOLING_MAX_RUN_TIME` at index 0) expires in the same `loop()` iteration as a higher-indexed timer (e.g. `HEATING_OFF` at index 7), the max-runtime callback fires first. If `this->action` is already `IDLE` at that moment (the system cycled off before max runtime elapsed in a previous cycle), `supplemental_heating_required_()` correctly returns `false` — but the subsequent call to `switch_to_supplemental_action_(IDLE)` hits the early-return guard at the top of the function because `supplemental_action_` is already `IDLE`. The `cancel_timer_()` and flag-clear logic inside the `switch` block is never reached, leaving `heating_max_runtime_exceeded_ = true`. When the next heating cycle starts, `supplemental_heating_required_()` sees the stale flag and immediately engages supplemental heat.

The same structural issue exists symmetrically for `cooling_max_runtime_exceeded_`.

This bug was always latent, but was exposed in practice by #13499 (commit `60968d311`), which changed `heating_required_()` and `cooling_required_()` to use inclusive `<=`/`>=` comparisons. Before that change, the system would not restart heating at the exact deadband boundary temperature, so it would always cool fractionally past it before restarting — giving enough temporal separation that the simultaneous timer-expiry scenario rarely triggered. After the change, the system restarts heating at exactly the boundary, which makes the race between the two timers observable in steady-state operation.

**Fix:** Move the max-runtime timer cancellation and exceeded-flag reset *ahead* of the early-return guard in `switch_to_supplemental_action_()`, so cleanup always runs when transitioning to `IDLE`/`OFF` regardless of the current `supplemental_action_` state.

**Secondary fix — `fan_mode_timer_callback_()` missing supplemental call:**

`fan_mode_timer_callback_()` calls `switch_to_action_()` (when `fan_only_action_uses_fan_mode_timer` is set) but never calls `switch_to_supplemental_action_()`. Every other timer callback calls both. This leaves the supplemental state inconsistent after a fan-mode timer transition.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing configuration changes.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: thermostat
    name: Thermostat
    sensor: temperature_sensor
    heat_action:
      - switch.turn_on: heat_stage_1
    supplemental_heat_action:
      - switch.turn_on: heat_stage_2
    idle_action:
      - switch.turn_off: heat_stage_1
      - switch.turn_off: heat_stage_2
    supplemental_heating_delta: 4°F
    max_heating_run_time: 45min
    min_heating_off_time: 5min
    min_heating_run_time: 5min
    heat_deadband: 1°F
    heat_overrun: 1°F
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).