### PR TITLE
[bmp581_base] Add support for BMP585

### DIFF
--- a/esphome/components/bmp581_base/bmp581_base.cpp
+++ b/esphome/components/bmp581_base/bmp581_base.cpp
@@ -126,7 +126,7 @@ void BMP581Component::setup() {
   }
 
   // verify id
-  if (chip_id != BMP581_ASIC_ID) {
+  if (chip_id != BMP581_ASIC_ID && chip_id != BMP585_ASIC_ID) {
     ESP_LOGE(TAG, "Unknown chip ID");
 
     this->error_code_ = ERROR_WRONG_CHIP_ID;

--- a/esphome/components/bmp581_base/bmp581_base.h
+++ b/esphome/components/bmp581_base/bmp581_base.h
@@ -8,6 +8,7 @@
 namespace esphome::bmp581_base {
 
 static const uint8_t BMP581_ASIC_ID = 0x50;  // BMP581's ASIC chip ID (page 51 of datasheet)
+static const uint8_t BMP585_ASIC_ID = 0x51;
 static const uint8_t RESET_COMMAND = 0xB6;   // Soft reset command
 
 // BMP581 Register Addresses

--- a/esphome/components/bmp581_base/bmp581_base.h
+++ b/esphome/components/bmp581_base/bmp581_base.h
@@ -9,7 +9,7 @@ namespace esphome::bmp581_base {
 
 static const uint8_t BMP581_ASIC_ID = 0x50;  // BMP581's ASIC chip ID (page 51 of datasheet)
 static const uint8_t BMP585_ASIC_ID = 0x51;
-static const uint8_t RESET_COMMAND = 0xB6;   // Soft reset command
+static const uint8_t RESET_COMMAND = 0xB6;  // Soft reset command
 
 // BMP581 Register Addresses
 enum {


### PR DESCRIPTION
# What does this implement/fix?

Add BMP585 support. BMP581 was already supported, but usage fails because of a new ASIC ID. 
In Boschs repository (https://github.com/boschsensortec/BMP5_SensorAPI/) and documents there is no difference between the devices, and I have successfully integrated it as an external component. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

Not related to issue

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6357

## Test Environment

- [X] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Identical to current implementation
```yaml
  - platform: bmp581_i2c
    pressure:
      name: "Air pressure"
      id: pressure_val
      accuracy_decimals: 1
      unit_of_measurement: "Pa"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
