### PR TITLE
[automation] Remove actions_end_ pointer from ActionList to save RAM

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -422,7 +422,8 @@ template<typename... Ts> class ActionList {
     if (this->actions_begin_ == nullptr) {
       this->actions_begin_ = action;
     } else {
-      // Walk to end of chain - action lists are short and only built during setup()
+      // Walk to end of chain - action lists are short and only built during setup().
+      // Note: intentionally not using pointer-to-pointer idiom here as it generates larger code.
       auto *it = this->actions_begin_;
       while (it->next_ != nullptr)
         it = it->next_;

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -419,11 +419,15 @@ template<typename... Ts> class Action {
 template<typename... Ts> class ActionList {
  public:
   void add_action(Action<Ts...> *action) {
-    // Walk to end of chain - action lists are short and only built during setup()
-    Action<Ts...> **tail = &this->actions_begin_;
-    while (*tail != nullptr)
-      tail = &(*tail)->next_;
-    *tail = action;
+    if (this->actions_begin_ == nullptr) {
+      this->actions_begin_ = action;
+    } else {
+      // Walk to end of chain - action lists are short and only built during setup()
+      auto *it = this->actions_begin_;
+      while (it->next_ != nullptr)
+        it = it->next_;
+      it->next_ = action;
+    }
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
     // Find tail once, then append all actions in a single pass

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -420,14 +420,14 @@ template<typename... Ts> class ActionList {
  public:
   void add_action(Action<Ts...> *action) {
     // Walk to end of chain - action lists are short and only built during setup()
-    Action<Ts...> **tail = &this->actions_begin_;
+    Action<Ts...> **tail = &this->actions_;
     while (*tail != nullptr)
       tail = &(*tail)->next_;
     *tail = action;
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
     // Find tail once, then append all actions in a single pass
-    Action<Ts...> **tail = &this->actions_begin_;
+    Action<Ts...> **tail = &this->actions_;
     while (*tail != nullptr)
       tail = &(*tail)->next_;
     for (auto *action : actions) {
@@ -438,29 +438,29 @@ template<typename... Ts> class ActionList {
   // Force-inline: part of the Trigger→Automation→ActionList forwarding
   // chain collapsed to reduce automation call stack depth.
   inline void play(const Ts &...x) ESPHOME_ALWAYS_INLINE {
-    if (this->actions_begin_ != nullptr)
-      this->actions_begin_->play_complex(x...);
+    if (this->actions_ != nullptr)
+      this->actions_->play_complex(x...);
   }
   void play_tuple(const std::tuple<Ts...> &tuple) {
     this->play_tuple_(tuple, std::make_index_sequence<sizeof...(Ts)>{});
   }
   void stop() {
-    if (this->actions_begin_ != nullptr)
-      this->actions_begin_->stop_complex();
+    if (this->actions_ != nullptr)
+      this->actions_->stop_complex();
   }
-  bool empty() const { return this->actions_begin_ == nullptr; }
+  bool empty() const { return this->actions_ == nullptr; }
 
   /// Check if any action in this action list is currently running.
   bool is_running() {
-    if (this->actions_begin_ == nullptr)
+    if (this->actions_ == nullptr)
       return false;
-    return this->actions_begin_->is_running();
+    return this->actions_->is_running();
   }
   /// Return the number of actions in this action list that are currently running.
   int num_running() {
-    if (this->actions_begin_ == nullptr)
+    if (this->actions_ == nullptr)
       return 0;
-    return this->actions_begin_->num_running_total();
+    return this->actions_->num_running_total();
   }
 
  protected:
@@ -468,7 +468,7 @@ template<typename... Ts> class ActionList {
     this->play(std::get<S>(tuple)...);
   }
 
-  Action<Ts...> *actions_begin_{nullptr};
+  Action<Ts...> *actions_{nullptr};
 };
 
 template<typename... Ts> class Automation {

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -419,16 +419,11 @@ template<typename... Ts> class Action {
 template<typename... Ts> class ActionList {
  public:
   void add_action(Action<Ts...> *action) {
-    if (this->actions_begin_ == nullptr) {
-      this->actions_begin_ = action;
-    } else {
-      // Walk to end of chain - action lists are short and only built during setup().
-      // Note: intentionally not using pointer-to-pointer idiom here as it generates larger code.
-      auto *it = this->actions_begin_;
-      while (it->next_ != nullptr)
-        it = it->next_;
-      it->next_ = action;
-    }
+    // Walk to end of chain - action lists are short and only built during setup()
+    Action<Ts...> **tail = &this->actions_begin_;
+    while (*tail != nullptr)
+      tail = &(*tail)->next_;
+    *tail = action;
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
     // Find tail once, then append all actions in a single pass

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -430,8 +430,13 @@ template<typename... Ts> class ActionList {
     }
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
+    // Find tail once, then append all actions in a single pass
+    Action<Ts...> **tail = &this->actions_begin_;
+    while (*tail != nullptr)
+      tail = &(*tail)->next_;
     for (auto *action : actions) {
-      this->add_action(action);
+      *tail = action;
+      tail = &action->next_;
     }
   }
   // Force-inline: part of the Trigger→Automation→ActionList forwarding

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -419,12 +419,15 @@ template<typename... Ts> class Action {
 template<typename... Ts> class ActionList {
  public:
   void add_action(Action<Ts...> *action) {
-    if (this->actions_end_ == nullptr) {
+    if (this->actions_begin_ == nullptr) {
       this->actions_begin_ = action;
     } else {
-      this->actions_end_->next_ = action;
+      // Walk to end of chain - action lists are short and only built during setup()
+      auto *it = this->actions_begin_;
+      while (it->next_ != nullptr)
+        it = it->next_;
+      it->next_ = action;
     }
-    this->actions_end_ = action;
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
     for (auto *action : actions) {
@@ -465,7 +468,6 @@ template<typename... Ts> class ActionList {
   }
 
   Action<Ts...> *actions_begin_{nullptr};
-  Action<Ts...> *actions_end_{nullptr};
 };
 
 template<typename... Ts> class Automation {

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -419,15 +419,11 @@ template<typename... Ts> class Action {
 template<typename... Ts> class ActionList {
  public:
   void add_action(Action<Ts...> *action) {
-    if (this->actions_begin_ == nullptr) {
-      this->actions_begin_ = action;
-    } else {
-      // Walk to end of chain - action lists are short and only built during setup()
-      auto *it = this->actions_begin_;
-      while (it->next_ != nullptr)
-        it = it->next_;
-      it->next_ = action;
-    }
+    // Walk to end of chain - action lists are short and only built during setup()
+    Action<Ts...> **tail = &this->actions_begin_;
+    while (*tail != nullptr)
+      tail = &(*tail)->next_;
+    *tail = action;
   }
   void add_actions(const std::initializer_list<Action<Ts...> *> &actions) {
     // Find tail once, then append all actions in a single pass


### PR DESCRIPTION
# What does this implement/fix?

Remove the `actions_end_` tail pointer from `ActionList`, saving 4 bytes per instance on 32-bit platforms. The tail pointer has been there since the original C++ codebase merge in 2019 (commit abf45b11ce) — it was part of the initial design, likely carried over from a general-purpose linked list pattern without considering that action chains are tiny and only built once during `setup()`.

Both `add_action()` and `add_actions()` now use a pointer-to-pointer idiom to walk the chain and append. Action chains are typically 1-5 entries deep and this only runs during `setup()`, so the cost is negligible. `add_actions()` finds the tail once and appends all actions in a single O(N) pass.

To put the cost in perspective: a single `ESP_LOGD` call during setup (vsnprintf formatting, UART TX at 115200 baud, plus potential network sends to API/web_server clients) is orders of magnitude more expensive than all the pointer walks combined.

Also renames `actions_begin_` to `actions_` since there is no longer an `actions_end_` to contrast with.

`ActionList` is embedded in every `Automation`, and also in `IfAction` (2× — then + else), `WhileAction`, and `RepeatAction`. On a real-world config (Apollo R Pro 1 ETH) this adds up to:

- 13 `Automation` → 13 `ActionList`s
- 11 `IfAction` → 22 `ActionList`s (then + else)
- 1 `WhileAction` → 1 `ActionList`
- **Total: 36 × 4 = 144 bytes saved**

CI memory impact analysis on the API test config shows **168 bytes RAM saved**.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).