### PR TITLE
[esp8266] Add enable_scanf_float option

### DIFF
--- a/esphome/components/esp8266/__init__.py
+++ b/esphome/components/esp8266/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+import re
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
@@ -18,8 +19,9 @@ from esphome.const import (
     PLATFORM_ESP8266,
     ThreadModel,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CORE, CoroPriority, Lambda, coroutine_with_priority
 from esphome.helpers import copy_file_if_changed
+from esphome.types import ConfigType
 
 from .boards import BOARDS, ESP8266_LD_SCRIPTS
 from .const import (
@@ -40,10 +42,40 @@ from .const import (
 )
 from .gpio import PinInitialState, add_pin_initial_states_array
 
+CONF_ENABLE_SCANF_FLOAT = "enable_scanf_float"
+# Heuristically matches scanf/sscanf calls with float format specifiers.
+# Standard scanf float conversions: %f %F %e %E %g %G %a %A
+# With optional modifiers: %*f (suppression), %8f (width), %lf %Lf (length)
+# Also matches non-standard patterns like %.2f as a heuristic — these are
+# invalid in scanf but users may write them by analogy with printf.
+# Uses [^;]*? to stay within a single statement, preventing false positives
+# from e.g. sscanf(buf, "%d", &x); printf("%f", val);
+_SCANF_FLOAT_RE = re.compile(r"scanf\s*\([^;]*?%[*\d.]*[hlL]*[feEgGaAF]")
+
 CODEOWNERS = ["@esphome/core"]
 _LOGGER = logging.getLogger(__name__)
 AUTO_LOAD = ["preferences"]
 IS_TARGET_PLATFORM = True
+
+
+def lambdas_use_scanf_float(config: ConfigType) -> bool:
+    """Check if any lambda in the config uses scanf with a float format specifier.
+
+    Comments are stripped before matching to avoid false positives from
+    commented-out code. The cost of a false positive is only ~8KB flash.
+    """
+    stack: list = [config]
+    while stack:
+        obj = stack.pop()
+        if isinstance(obj, Lambda):
+            src = obj.comment_remover(obj.value)
+            if _SCANF_FLOAT_RE.search(src):
+                return True
+        elif isinstance(obj, dict):
+            stack.extend(obj.values())
+        elif isinstance(obj, list):
+            stack.extend(obj)
+    return False
 
 
 def set_core_data(config):
@@ -181,6 +213,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_ENABLE_SERIAL): cv.boolean,
             cv.Optional(CONF_ENABLE_SERIAL1): cv.boolean,
             cv.Optional(CONF_ENABLE_FULL_PRINTF, default=False): cv.boolean,
+            cv.Optional(CONF_ENABLE_SCANF_FLOAT): cv.boolean,
         }
     ),
     set_core_data,
@@ -201,16 +234,23 @@ async def to_code(config):
     cg.add_define("ESPHOME_VARIANT", "ESP8266")
     cg.add_define(ThreadModel.SINGLE)
 
-    cg.add_platformio_option(
-        "extra_scripts",
-        [
-            "pre:testing_mode.py",
-            "pre:exclude_updater.py",
-            "pre:exclude_waveform.py",
-            "pre:remove_float_scanf.py",
-            "post:post_build.py",
-        ],
-    )
+    enable_scanf_float = config.get(CONF_ENABLE_SCANF_FLOAT)
+    if enable_scanf_float is None and lambdas_use_scanf_float(CORE.config):
+        enable_scanf_float = True
+        _LOGGER.warning(
+            "Lambda uses scanf with a float format specifier; "
+            "enabling scanf float support (~8KB flash)"
+        )
+
+    extra_scripts = [
+        "pre:testing_mode.py",
+        "pre:exclude_updater.py",
+        "pre:exclude_waveform.py",
+    ]
+    if not enable_scanf_float:
+        extra_scripts.append("pre:remove_float_scanf.py")
+    extra_scripts.append("post:post_build.py")
+    cg.add_platformio_option("extra_scripts", extra_scripts)
 
     conf = config[CONF_FRAMEWORK]
     cg.add_platformio_option("framework", "arduino")

--- a/tests/components/esp8266/test.esp8266-ard.yaml
+++ b/tests/components/esp8266/test.esp8266-ard.yaml
@@ -14,3 +14,6 @@ esphome:
         assert(x == 95);
         x = clamp_at_most(x, 40);
         assert(x == 40);
+    - lambda: |-
+        float value = 0.0f;
+        sscanf("3.14", "%f", &value);

--- a/tests/unit_tests/components/test_esp8266.py
+++ b/tests/unit_tests/components/test_esp8266.py
@@ -1,0 +1,62 @@
+"""Tests for ESP8266 component."""
+
+import pytest
+
+from esphome.components.esp8266 import lambdas_use_scanf_float
+from esphome.core import Lambda
+from esphome.types import ConfigType
+
+
+@pytest.mark.parametrize(
+    ("src", "expected"),
+    [
+        # Basic float formats
+        ('sscanf(buf, "%f", &v)', True),
+        ('sscanf(buf, "%F", &v)', True),
+        ('sscanf(buf, "%e", &v)', True),
+        ('sscanf(buf, "%E", &v)', True),
+        ('sscanf(buf, "%g", &v)', True),
+        ('sscanf(buf, "%G", &v)', True),
+        ('sscanf(buf, "%a", &v)', True),
+        ('sscanf(buf, "%A", &v)', True),
+        # With modifiers
+        ('sscanf(buf, "%lf", &v)', True),
+        ('sscanf(buf, "%Lf", &v)', True),
+        ('sscanf(buf, "%8lf", &v)', True),
+        ('sscanf(buf, "%*f")', True),
+        ('sscanf(buf, "%.2f", &v)', True),
+        # Mixed formats
+        ('sscanf(buf, "%d,%f", &a, &b)', True),
+        # fscanf and std::sscanf
+        ('fscanf(fp, "%f", &v)', True),
+        ('std::sscanf(buf, "%f", &v)', True),
+        # Multi-line
+        ('sscanf(buf,\n"%f", &v)', True),
+        # No float format
+        ('sscanf(buf, "%d", &v)', False),
+        ('sscanf(buf, "%s", s)', False),
+        # printf not scanf
+        ('printf("%f", val)', False),
+        # %f in a different statement after scanf
+        ('sscanf(buf, "%d", &x); printf("%f", val);', False),
+        # scanf %f in comment only
+        ('// sscanf(buf, "%f", &v)\nsscanf(buf, "%d", &x)', False),
+        ('/* sscanf(buf, "%f") */\nsscanf(buf, "%d", &x)', False),
+    ],
+)
+def test_lambdas_use_scanf_float(src: str, expected: bool) -> None:
+    """Test scanf float detection in lambda source."""
+    config: ConfigType = {"test": [Lambda(src)]}
+    assert lambdas_use_scanf_float(config) is expected
+
+
+def test_lambdas_use_scanf_float_no_lambdas() -> None:
+    """Test with config containing no lambdas."""
+    config: ConfigType = {"key": "value", "list": [1, 2]}
+    assert lambdas_use_scanf_float(config) is False
+
+
+def test_lambdas_use_scanf_float_nested() -> None:
+    """Test detection in deeply nested config."""
+    config: ConfigType = {"a": {"b": {"c": [Lambda('sscanf(buf, "%f", &v)')]}}}
+    assert lambdas_use_scanf_float(config) is True


### PR DESCRIPTION
# What does this implement/fix?

Add an `enable_scanf_float` configuration option for ESP8266 that allows users to opt back into float support for `scanf()`/`sscanf()`.

By default, ESPHome removes the `-u _scanf_float` linker flag to save ~8 KB of flash. This means `sscanf()` with `%f` silently fails to parse floating-point numbers at runtime (no compiler error). Nothing in ESPHome itself uses scanf; this option is only needed for lambdas that use `sscanf()` with float format specifiers.

Additionally, lambdas are automatically scanned for scanf calls with float format specifiers (`%f`, `%.2f`, `%e`, etc.) and the flag is auto-enabled when detected — so most users won't need to set the option manually.

Note the flash and ram cost is only paid if the user turns it on or uses the float specifiers in a lambda

| Metric | Target Branch | This PR | Change |
|--------|--------------|---------|--------|
| **RAM** | 28,588 bytes | 28,692 bytes | 📈 🔸 +104 bytes (+0.36%) |
| **Flash** | 262,539 bytes | 274,651 bytes | 📈 🚨 +12,112 bytes (+4.61%) |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15278

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6359

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Explicit opt-in (usually not needed — auto-detected from lambdas)
esp8266:
  board: esp12e
  enable_scanf_float: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).