### PR TITLE
[esp32_ble_server] Fix set_value action with static data lists

### DIFF
--- a/esphome/components/esp32_ble_server/ble_server_automations.h
+++ b/esphome/components/esp32_ble_server/ble_server_automations.h
@@ -70,6 +70,7 @@ template<typename... Ts> class BLECharacteristicSetValueAction : public Action<T
  public:
   BLECharacteristicSetValueAction(BLECharacteristic *characteristic) : parent_(characteristic) {}
   TEMPLATABLE_VALUE(std::vector<uint8_t>, buffer)
+  void set_buffer(std::initializer_list<uint8_t> buffer) { this->buffer_ = std::vector<uint8_t>(buffer); }
   void set_buffer(ByteBuffer buffer) { this->set_buffer(buffer.get_data()); }
   void play(const Ts &...x) override {
     // If the listener is already set, do nothing
@@ -115,6 +116,7 @@ template<typename... Ts> class BLEDescriptorSetValueAction : public Action<Ts...
  public:
   BLEDescriptorSetValueAction(BLEDescriptor *descriptor) : parent_(descriptor) {}
   TEMPLATABLE_VALUE(std::vector<uint8_t>, buffer)
+  void set_buffer(std::initializer_list<uint8_t> buffer) { this->buffer_ = std::vector<uint8_t>(buffer); }
   void set_buffer(ByteBuffer buffer) { this->set_buffer(buffer.get_data()); }
   void play(const Ts &...x) override { this->parent_->set_value(this->buffer_.value(x...)); }
 

--- a/tests/components/esp32_ble_server/common.yaml
+++ b/tests/components/esp32_ble_server/common.yaml
@@ -69,3 +69,11 @@ esp32_ble_server:
               - ble_server.descriptor.set_value:
                   id: test_change_descriptor
                   value: !lambda return bytebuffer::ByteBuffer::wrap({0x03, 0x04, 0x05}).get_data();
+              - ble_server.characteristic.set_value:
+                  id: test_change_characteristic
+                  value:
+                    data: [0xfc, 0xef, 0xfe, 0x86]
+              - ble_server.descriptor.set_value:
+                  id: test_change_descriptor
+                  value:
+                    data: [0x01, 0x02, 0x03]


### PR DESCRIPTION
# What does this implement/fix?

The `TEMPLATABLE_VALUE` macro generates a `template<typename V> void set_buffer(V)` setter. C++ cannot deduce `V` from a brace-enclosed initializer list, so generated code like `set_buffer({0xfc, 0xef, 0xfe, 0x86})` fails to compile.

This adds an explicit `std::initializer_list<uint8_t>` overload to both `BLECharacteristicSetValueAction` and `BLEDescriptorSetValueAction` so the initializer list has a matching non-template overload.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15270

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_ble_server:
  services:
    - uuid: "0xce10"
      characteristics:
        - uuid: "0xce82"
          id: ble_char
          notify: true
          value:
            data: [0x00]

script:
  - id: write_ble
    then:
      - ble_server.characteristic.set_value:
          id: ble_char
          value:
            data: [0xfc, 0xef, 0xfe, 0x86]
      - ble_server.characteristic.notify:
          id: ble_char
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).