### PR TITLE
[bl0942] Fix energy counter jump on chip reset

### DIFF
--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -163,9 +163,20 @@ void BL0942::received_package_(DataPacket *data) {
 
   // cf_cnt is only 24 bits, so track overflows
   uint32_t cf_cnt = (uint24_t) data->cf_cnt;
+  uint32_t prev_cf_cnt_24 = this->prev_cf_cnt_ & 0x00ffffff;
   cf_cnt |= this->prev_cf_cnt_ & 0xff000000;
   if (cf_cnt < this->prev_cf_cnt_) {
-    cf_cnt += 0x1000000;
+    if (prev_cf_cnt_24 > 0x800000) {
+      // Previous value was in the upper half of the 24-bit range,
+      // so this is likely a genuine overflow from 0xFFFFFF to 0x000000.
+      cf_cnt += 0x1000000;
+    } else {
+      // Previous value was low, so the BL0942 chip likely reset its
+      // counter (e.g. due to electrical disturbance). Don't treat as
+      // overflow — just continue from the new value to avoid a ~3MWh jump.
+      ESP_LOGW(TAG, "BL0942 energy counter unexpectedly decreased from %" PRIu32 " to %" PRIu32 ", assuming chip reset",
+               this->prev_cf_cnt_, cf_cnt);
+    }
   }
   this->prev_cf_cnt_ = cf_cnt;
 


### PR DESCRIPTION
# What does this implement/fix?

The BL0942 energy counter (`cf_cnt`) is a 24-bit value. The existing overflow tracking logic assumes any decrease in the counter is a genuine 24-bit overflow (0xFFFFFF → 0x000000) and adds 0x1000000 to the accumulated total. However, the BL0942 chip can reset its internal counter to 0 due to electrical disturbances (e.g., motor/compressor switching), which is not an overflow. This causes the energy value to jump by ~3MWh.

The fix distinguishes between a genuine overflow and a chip reset by checking whether the previous 24-bit counter value was in the upper half of the range (> 0x800000). A genuine overflow will always have the previous value near 0xFFFFFF, while a chip reset will have an arbitrary (usually small) previous value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15280

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a runtime bug fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).