### PR TITLE
[version] Remove duplicate build_info_data.h include

### DIFF
--- a/esphome/components/version/version_text_sensor.cpp
+++ b/esphome/components/version/version_text_sensor.cpp
@@ -1,6 +1,5 @@
 #include "version_text_sensor.h"
 #include "esphome/core/application.h"
-#include "esphome/core/build_info_data.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/progmem.h"
@@ -36,7 +35,9 @@ void VersionTextSensor::setup() {
   if (!this->hide_timestamp_) {
     size_t len = strlen(version_str);
     ESPHOME_strncat_P(version_str, BUILT_STR, sizeof(version_str) - len - 1);
-    ESPHOME_strncat_P(version_str, ESPHOME_BUILD_TIME_STR, sizeof(version_str) - strlen(version_str) - 1);
+    char build_time_buf[Application::BUILD_TIME_STR_SIZE];
+    App.get_build_time_string(build_time_buf);
+    strncat(version_str, build_time_buf, sizeof(version_str) - strlen(version_str) - 1);
   }
 
   // The closing parenthesis is part of the config-hash suffix and must


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #14230: `version_text_sensor.cpp` includes `build_info_data.h` which changes every build (build time, config hash). This causes `version_text_sensor.cpp` to recompile on every build even when nothing in the version component changed.

Fix: remove the `build_info_data.h` include from `version_text_sensor.cpp` and use the existing `App.get_build_time_string()` API instead. Now only `application.cpp` includes `build_info_data.h`, so `version_text_sensor.cpp` is no longer recompiled every time.

Also eliminates duplicate `ESPHOME_BUILD_TIME_STR` and `ESPHOME_COMMENT_STR` symbols (~52 bytes) that were emitted into both translation units due to `static const` in a header.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #14230

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).