### PR TITLE
[benchmark] Add BLE raw advertisement proto encode benchmarks

### DIFF
--- a/script/cpp_benchmark.py
+++ b/script/cpp_benchmark.py
@@ -21,6 +21,10 @@ BENCHMARKS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "components"
 # Path to /tests/benchmarks/core (always included, not a component)
 CORE_BENCHMARKS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "core"
 
+# Stub headers for ESP32-only components (e.g. bluetooth_proxy) that
+# allow benchmarks to compile on the host platform.
+STUBS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "stubs"
+
 PLATFORMIO_OPTIONS = {
     "build_unflags": [
         "-Os",  # remove default size-opt
@@ -29,6 +33,7 @@ PLATFORMIO_OPTIONS = {
         "-O2",  # optimize for speed (CodSpeed recommends RelWithDebInfo)
         "-g",  # debug symbols for profiling
         "-DUSE_BENCHMARK",  # disable WarnIfComponentBlockingGuard in finish()
+        f"-I{STUBS_DIR}",  # stub headers for ESP32-only components
     ],
     # Use deep+ LDF mode to ensure PlatformIO detects the benchmark
     # library dependency from nested includes.

--- a/tests/benchmarks/components/api/__init__.py
+++ b/tests/benchmarks/components/api/__init__.py
@@ -1,3 +1,4 @@
+import esphome.codegen as cg
 from tests.testing_helpers import ComponentManifestOverride
 
 
@@ -5,3 +6,16 @@ def override_manifest(manifest: ComponentManifestOverride) -> None:
     # api must run its to_code to define USE_API, USE_API_PLAINTEXT,
     # and add the noise-c library dependency.
     manifest.enable_codegen()
+
+    original_to_code = manifest.to_code
+
+    async def to_code(config):
+        await original_to_code(config)
+        # Enable BLE proto message types for benchmarks.  The real
+        # bluetooth_proxy component is ESP32-only; a lightweight stub
+        # header in tests/benchmarks/stubs/ satisfies the include.
+        cg.add_define("USE_BLUETOOTH_PROXY")
+        cg.add_define("BLUETOOTH_PROXY_MAX_CONNECTIONS", 3)
+        cg.add_define("BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE", 16)
+
+    manifest.to_code = to_code

--- a/tests/benchmarks/components/api/bench_proto_encode.cpp
+++ b/tests/benchmarks/components/api/bench_proto_encode.cpp
@@ -295,4 +295,93 @@ static void CalcAndEncode_DeviceInfoResponse_Fresh(benchmark::State &state) {
 }
 BENCHMARK(CalcAndEncode_DeviceInfoResponse_Fresh);
 
+// --- BluetoothLERawAdvertisementsResponse (12 adverts, highest-volume BLE message) ---
+
+#ifdef USE_BLUETOOTH_PROXY
+
+static BluetoothLERawAdvertisementsResponse make_ble_raw_advs_12() {
+  static const uint8_t fake_adv_data[] = {
+      0x02, 0x01, 0x06, 0x03, 0x03, 0x9F, 0xFE, 0x17, 0x16, 0x9F, 0xFE, 0x00, 0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  };
+  BluetoothLERawAdvertisementsResponse msg;
+  msg.advertisements_len = 12;
+  for (int i = 0; i < 12; i++) {
+    auto &adv = msg.advertisements[i];
+    adv.address = 0xAABBCCDD0000ULL + i;
+    adv.rssi = -60 - i;
+    adv.address_type = 1;
+    memcpy(adv.data, fake_adv_data, sizeof(fake_adv_data));
+    adv.data_len = sizeof(fake_adv_data);
+  }
+  return msg;
+}
+
+static void CalculateSize_BLERawAdvs12(benchmark::State &state) {
+  auto msg = make_ble_raw_advs_12();
+
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += msg.calculate_size();
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalculateSize_BLERawAdvs12);
+
+static void Encode_BLERawAdvs12(benchmark::State &state) {
+  auto msg = make_ble_raw_advs_12();
+  APIBuffer buffer;
+  uint32_t total_size = msg.calculate_size();
+  buffer.resize(total_size);
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+    }
+    benchmark::DoNotOptimize(buffer.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Encode_BLERawAdvs12);
+
+static void CalcAndEncode_BLERawAdvs12(benchmark::State &state) {
+  auto msg = make_ble_raw_advs_12();
+  APIBuffer buffer;
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      uint32_t size = msg.calculate_size();
+      buffer.resize(size);
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+    }
+    benchmark::DoNotOptimize(buffer.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalcAndEncode_BLERawAdvs12);
+
+static void CalcAndEncode_BLERawAdvs12_Fresh(benchmark::State &state) {
+  auto msg = make_ble_raw_advs_12();
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      APIBuffer buffer;
+      uint32_t size = msg.calculate_size();
+      buffer.resize(size);
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+      benchmark::DoNotOptimize(buffer.data());
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalcAndEncode_BLERawAdvs12_Fresh);
+
+#endif  // USE_BLUETOOTH_PROXY
+
 }  // namespace esphome::api::benchmarks

--- a/tests/benchmarks/stubs/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/tests/benchmarks/stubs/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -1,0 +1,38 @@
+// Stub for benchmark builds — provides the minimal interface that
+// api_connection.cpp needs when USE_BLUETOOTH_PROXY is defined,
+// without pulling in ESP32 BLE dependencies.
+#pragma once
+
+#include "esphome/components/api/api_pb2.h"
+
+namespace esphome {
+namespace api {
+class APIConnection;
+}  // namespace api
+
+namespace bluetooth_proxy {
+
+class BluetoothProxy {
+ public:
+  api::APIConnection *get_api_connection() const { return nullptr; }
+  void subscribe_api_connection(api::APIConnection *conn, uint32_t flags) {}
+  void unsubscribe_api_connection(api::APIConnection *conn) {}
+  void bluetooth_device_request(const api::BluetoothDeviceRequest &msg) {}
+  void bluetooth_gatt_read(const api::BluetoothGATTReadRequest &msg) {}
+  void bluetooth_gatt_write(const api::BluetoothGATTWriteRequest &msg) {}
+  void bluetooth_gatt_read_descriptor(const api::BluetoothGATTReadDescriptorRequest &msg) {}
+  void bluetooth_gatt_write_descriptor(const api::BluetoothGATTWriteDescriptorRequest &msg) {}
+  void bluetooth_gatt_send_services(const api::BluetoothGATTGetServicesRequest &msg) {}
+  void bluetooth_gatt_notify(const api::BluetoothGATTNotifyRequest &msg) {}
+  void send_connections_free(api::APIConnection *conn) {}
+  void bluetooth_scanner_set_mode(bool active) {}
+  void bluetooth_set_connection_params(const api::BluetoothSetConnectionParamsRequest &msg) {}
+  uint32_t get_feature_flags() const { return 0; }
+  void get_bluetooth_mac_address_pretty(char *buf) const { buf[0] = '\0'; }
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern BluetoothProxy *global_bluetooth_proxy;
+
+}  // namespace bluetooth_proxy
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

Add CodSpeed benchmarks for `BluetoothLERawAdvertisementsResponse` (12 advertisements), the highest-volume BLE proxy message. Covers `calculate_size`, `encode`, `calc+encode` (steady-state), and `calc+encode` (fresh buffer) paths.

To enable this on the host benchmark platform, a lightweight `bluetooth_proxy` stub header is added to `tests/benchmarks/stubs/` and the stubs directory is included in all benchmark builds. The api benchmark override defines `USE_BLUETOOTH_PROXY` and the required size constants so the proto message types compile without pulling in ESP32 BLE dependencies.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - benchmark only, no user-facing config
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).