### PR TITLE
[api] Devirtualize protobuf decode field dispatch

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -31,6 +31,8 @@ bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) 
   }
   return true;
 }
+const ProtoDecodeFns HelloRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<HelloRequest>,
+                                                         proto_decode_length_tramp<HelloRequest>, nullptr};
 void HelloResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, this->api_version_major);
   buffer.encode_uint32(2, this->api_version_minor);
@@ -353,6 +355,8 @@ bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns CoverCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<CoverCommandRequest>, nullptr,
+                                                                proto_decode_32bit_tramp<CoverCommandRequest>};
 #endif
 #ifdef USE_FAN
 void ListEntitiesFanResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -483,6 +487,9 @@ bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns FanCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<FanCommandRequest>,
+                                                              proto_decode_length_tramp<FanCommandRequest>,
+                                                              proto_decode_32bit_tramp<FanCommandRequest>};
 #endif
 #ifdef USE_LIGHT
 void ListEntitiesLightResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -679,6 +686,9 @@ bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns LightCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<LightCommandRequest>,
+                                                                proto_decode_length_tramp<LightCommandRequest>,
+                                                                proto_decode_32bit_tramp<LightCommandRequest>};
 #endif
 #ifdef USE_SENSOR
 void ListEntitiesSensorResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -812,6 +822,8 @@ bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns SwitchCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SwitchCommandRequest>, nullptr, proto_decode_32bit_tramp<SwitchCommandRequest>};
 #endif
 #ifdef USE_TEXT_SENSOR
 void ListEntitiesTextSensorResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -876,6 +888,8 @@ bool SubscribeLogsRequest::decode_varint(uint32_t field_id, proto_varint_value_t
   }
   return true;
 }
+const ProtoDecodeFns SubscribeLogsRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<SubscribeLogsRequest>,
+                                                                 nullptr, nullptr};
 void SubscribeLogsResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->level));
   buffer.encode_bytes(3, this->message_ptr_, this->message_len_);
@@ -899,6 +913,8 @@ bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthD
   }
   return true;
 }
+const ProtoDecodeFns NoiseEncryptionSetKeyRequest::DECODE_FNS PROGMEM = {
+    nullptr, proto_decode_length_tramp<NoiseEncryptionSetKeyRequest>, nullptr};
 void NoiseEncryptionSetKeyResponse::encode(ProtoWriteBuffer &buffer) const { buffer.encode_bool(1, this->success); }
 uint32_t NoiseEncryptionSetKeyResponse::calculate_size() const {
   uint32_t size = 0;
@@ -1002,6 +1018,9 @@ bool HomeassistantActionResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
   return true;
 }
+const ProtoDecodeFns HomeassistantActionResponse::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<HomeassistantActionResponse>, proto_decode_length_tramp<HomeassistantActionResponse>,
+    nullptr};
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
 void SubscribeHomeAssistantStateResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1035,6 +1054,8 @@ bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDel
   }
   return true;
 }
+const ProtoDecodeFns HomeAssistantStateResponse::DECODE_FNS PROGMEM = {
+    nullptr, proto_decode_length_tramp<HomeAssistantStateResponse>, nullptr};
 #endif
 bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
@@ -1061,6 +1082,7 @@ bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   }
   return true;
 }
+const ProtoDecodeFns DSTRule::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<DSTRule>, nullptr, nullptr};
 bool ParsedTimezone::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -1087,6 +1109,8 @@ bool ParsedTimezone::decode_length(uint32_t field_id, ProtoLengthDelimited value
   }
   return true;
 }
+const ProtoDecodeFns ParsedTimezone::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ParsedTimezone>,
+                                                           proto_decode_length_tramp<ParsedTimezone>, nullptr};
 bool GetTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
@@ -1111,6 +1135,8 @@ bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns GetTimeResponse::DECODE_FNS PROGMEM = {nullptr, proto_decode_length_tramp<GetTimeResponse>,
+                                                            proto_decode_32bit_tramp<GetTimeResponse>};
 #ifdef USE_API_USER_DEFINED_ACTIONS
 void ListEntitiesServicesArgument::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_string(1, this->name);
@@ -1191,17 +1217,9 @@ bool ExecuteServiceArgument::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
-void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
-  uint32_t count_bool_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 6);
-  this->bool_array.init(count_bool_array);
-  uint32_t count_int_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 7);
-  this->int_array.init(count_int_array);
-  uint32_t count_float_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 8);
-  this->float_array.init(count_float_array);
-  uint32_t count_string_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 9);
-  this->string_array.init(count_string_array);
-  ProtoDecodableMessage::decode(buffer, length);
-}
+const ProtoDecodeFns ExecuteServiceArgument::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ExecuteServiceArgument>,
+                                                                   proto_decode_length_tramp<ExecuteServiceArgument>,
+                                                                   proto_decode_32bit_tramp<ExecuteServiceArgument>};
 bool ExecuteServiceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
@@ -1240,11 +1258,9 @@ bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
-void ExecuteServiceRequest::decode(const uint8_t *buffer, size_t length) {
-  uint32_t count_args = ProtoDecodableMessage::count_repeated_field(buffer, length, 2);
-  this->args.init(count_args);
-  ProtoDecodableMessage::decode(buffer, length);
-}
+const ProtoDecodeFns ExecuteServiceRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ExecuteServiceRequest>,
+                                                                  proto_decode_length_tramp<ExecuteServiceRequest>,
+                                                                  proto_decode_32bit_tramp<ExecuteServiceRequest>};
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
 void ExecuteServiceResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1326,6 +1342,8 @@ bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t v
   }
   return true;
 }
+const ProtoDecodeFns CameraImageRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<CameraImageRequest>, nullptr,
+                                                               nullptr};
 #endif
 #ifdef USE_CLIMATE
 void ListEntitiesClimateResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1559,6 +1577,9 @@ bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns ClimateCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ClimateCommandRequest>,
+                                                                  proto_decode_length_tramp<ClimateCommandRequest>,
+                                                                  proto_decode_32bit_tramp<ClimateCommandRequest>};
 #endif
 #ifdef USE_WATER_HEATER
 void ListEntitiesWaterHeaterResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1671,6 +1692,8 @@ bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
   }
   return true;
 }
+const ProtoDecodeFns WaterHeaterCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<WaterHeaterCommandRequest>, nullptr, proto_decode_32bit_tramp<WaterHeaterCommandRequest>};
 #endif
 #ifdef USE_NUMBER
 void ListEntitiesNumberResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1756,6 +1779,8 @@ bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns NumberCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<NumberCommandRequest>, nullptr, proto_decode_32bit_tramp<NumberCommandRequest>};
 #endif
 #ifdef USE_SELECT
 void ListEntitiesSelectResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1845,6 +1870,9 @@ bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns SelectCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<SelectCommandRequest>,
+                                                                 proto_decode_length_tramp<SelectCommandRequest>,
+                                                                 proto_decode_32bit_tramp<SelectCommandRequest>};
 #endif
 #ifdef USE_SIREN
 void ListEntitiesSirenResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -1957,6 +1985,9 @@ bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns SirenCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<SirenCommandRequest>,
+                                                                proto_decode_length_tramp<SirenCommandRequest>,
+                                                                proto_decode_32bit_tramp<SirenCommandRequest>};
 #endif
 #ifdef USE_LOCK
 void ListEntitiesLockResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -2050,6 +2081,9 @@ bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns LockCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<LockCommandRequest>,
+                                                               proto_decode_length_tramp<LockCommandRequest>,
+                                                               proto_decode_32bit_tramp<LockCommandRequest>};
 #endif
 #ifdef USE_BUTTON
 void ListEntitiesButtonResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -2104,6 +2138,8 @@ bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns ButtonCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<ButtonCommandRequest>, nullptr, proto_decode_32bit_tramp<ButtonCommandRequest>};
 #endif
 #ifdef USE_MEDIA_PLAYER
 void MediaPlayerSupportedFormat::encode(ProtoWriteBuffer &buffer) const {
@@ -2236,6 +2272,9 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
   }
   return true;
 }
+const ProtoDecodeFns MediaPlayerCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<MediaPlayerCommandRequest>, proto_decode_length_tramp<MediaPlayerCommandRequest>,
+    proto_decode_32bit_tramp<MediaPlayerCommandRequest>};
 #endif
 #ifdef USE_BLUETOOTH_PROXY
 bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
@@ -2248,6 +2287,8 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
   }
   return true;
 }
+const ProtoDecodeFns SubscribeBluetoothLEAdvertisementsRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SubscribeBluetoothLEAdvertisementsRequest>, nullptr, nullptr};
 void BluetoothLERawAdvertisement::encode(ProtoWriteBuffer &buffer) const {
   buffer.write_raw_byte(8);
   buffer.encode_varint_raw_64(this->address);
@@ -2297,6 +2338,8 @@ bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, proto_varint_value
   }
   return true;
 }
+const ProtoDecodeFns BluetoothDeviceRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<BluetoothDeviceRequest>,
+                                                                   nullptr, nullptr};
 void BluetoothDeviceConnectionResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_bool(2, this->connected);
@@ -2321,6 +2364,8 @@ bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, proto_var
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTGetServicesRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTGetServicesRequest>, nullptr, nullptr};
 void BluetoothGATTDescriptor::encode(ProtoWriteBuffer &buffer) const {
   if (this->uuid[0] != 0 || this->uuid[1] != 0) {
     buffer.encode_uint64(1, this->uuid[0], true);
@@ -2430,6 +2475,8 @@ bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, proto_varint_val
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTReadRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTReadRequest>, nullptr, nullptr};
 void BluetoothGATTReadResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -2470,6 +2517,9 @@ bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDeli
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTWriteRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTWriteRequest>, proto_decode_length_tramp<BluetoothGATTWriteRequest>,
+    nullptr};
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -2483,6 +2533,8 @@ bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, proto_
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTReadDescriptorRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTReadDescriptorRequest>, nullptr, nullptr};
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -2508,6 +2560,9 @@ bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, Proto
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTWriteDescriptorRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTWriteDescriptorRequest>,
+    proto_decode_length_tramp<BluetoothGATTWriteDescriptorRequest>, nullptr};
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -2524,6 +2579,8 @@ bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, proto_varint_v
   }
   return true;
 }
+const ProtoDecodeFns BluetoothGATTNotifyRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothGATTNotifyRequest>, nullptr, nullptr};
 void BluetoothGATTNotifyDataResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_uint32(2, this->handle);
@@ -2646,6 +2703,8 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_vari
   }
   return true;
 }
+const ProtoDecodeFns BluetoothScannerSetModeRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothScannerSetModeRequest>, nullptr, nullptr};
 #endif
 #ifdef USE_VOICE_ASSISTANT
 bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
@@ -2661,6 +2720,8 @@ bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, proto_vari
   }
   return true;
 }
+const ProtoDecodeFns SubscribeVoiceAssistantRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SubscribeVoiceAssistantRequest>, nullptr, nullptr};
 void VoiceAssistantAudioSettings::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, this->noise_suppression_level);
   buffer.encode_uint32(2, this->auto_gain);
@@ -2702,6 +2763,8 @@ bool VoiceAssistantResponse::decode_varint(uint32_t field_id, proto_varint_value
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantResponse::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<VoiceAssistantResponse>,
+                                                                   nullptr, nullptr};
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
@@ -2717,6 +2780,8 @@ bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantEventData::DECODE_FNS PROGMEM = {
+    nullptr, proto_decode_length_tramp<VoiceAssistantEventData>, nullptr};
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -2738,6 +2803,9 @@ bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDe
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantEventResponse::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<VoiceAssistantEventResponse>, proto_decode_length_tramp<VoiceAssistantEventResponse>,
+    nullptr};
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 2:
@@ -2760,6 +2828,8 @@ bool VoiceAssistantAudio::decode_length(uint32_t field_id, ProtoLengthDelimited 
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantAudio::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<VoiceAssistantAudio>, proto_decode_length_tramp<VoiceAssistantAudio>, nullptr};
 void VoiceAssistantAudio::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_bytes(1, this->data, this->data_len);
   buffer.encode_bool(2, this->end);
@@ -2804,6 +2874,9 @@ bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLen
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantTimerEventResponse::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<VoiceAssistantTimerEventResponse>,
+    proto_decode_length_tramp<VoiceAssistantTimerEventResponse>, nullptr};
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 4:
@@ -2833,6 +2906,9 @@ bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLength
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantAnnounceRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<VoiceAssistantAnnounceRequest>, proto_decode_length_tramp<VoiceAssistantAnnounceRequest>,
+    nullptr};
 void VoiceAssistantAnnounceFinished::encode(ProtoWriteBuffer &buffer) const { buffer.encode_bool(1, this->success); }
 uint32_t VoiceAssistantAnnounceFinished::calculate_size() const {
   uint32_t size = 0;
@@ -2897,6 +2973,9 @@ bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengt
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantExternalWakeWord::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<VoiceAssistantExternalWakeWord>,
+    proto_decode_length_tramp<VoiceAssistantExternalWakeWord>, nullptr};
 bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1:
@@ -2908,6 +2987,8 @@ bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoL
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantConfigurationRequest::DECODE_FNS PROGMEM = {
+    nullptr, proto_decode_length_tramp<VoiceAssistantConfigurationRequest>, nullptr};
 void VoiceAssistantConfigurationResponse::encode(ProtoWriteBuffer &buffer) const {
   for (auto &it : this->available_wake_words) {
     buffer.encode_sub_message(1, it);
@@ -2942,6 +3023,8 @@ bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengt
   }
   return true;
 }
+const ProtoDecodeFns VoiceAssistantSetConfiguration::DECODE_FNS PROGMEM = {
+    nullptr, proto_decode_length_tramp<VoiceAssistantSetConfiguration>, nullptr};
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
 void ListEntitiesAlarmControlPanelResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3030,6 +3113,10 @@ bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit
   }
   return true;
 }
+const ProtoDecodeFns AlarmControlPanelCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<AlarmControlPanelCommandRequest>,
+    proto_decode_length_tramp<AlarmControlPanelCommandRequest>,
+    proto_decode_32bit_tramp<AlarmControlPanelCommandRequest>};
 #endif
 #ifdef USE_TEXT
 void ListEntitiesTextResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3119,6 +3206,9 @@ bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns TextCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<TextCommandRequest>,
+                                                               proto_decode_length_tramp<TextCommandRequest>,
+                                                               proto_decode_32bit_tramp<TextCommandRequest>};
 #endif
 #ifdef USE_DATETIME_DATE
 void ListEntitiesDateResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3202,6 +3292,8 @@ bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns DateCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<DateCommandRequest>, nullptr,
+                                                               proto_decode_32bit_tramp<DateCommandRequest>};
 #endif
 #ifdef USE_DATETIME_TIME
 void ListEntitiesTimeResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3285,6 +3377,8 @@ bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns TimeCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<TimeCommandRequest>, nullptr,
+                                                               proto_decode_32bit_tramp<TimeCommandRequest>};
 #endif
 #ifdef USE_EVENT
 void ListEntitiesEventResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3428,6 +3522,8 @@ bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns ValveCommandRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ValveCommandRequest>, nullptr,
+                                                                proto_decode_32bit_tramp<ValveCommandRequest>};
 #endif
 #ifdef USE_DATETIME_DATETIME
 void ListEntitiesDateTimeResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3501,6 +3597,8 @@ bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns DateTimeCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<DateTimeCommandRequest>, nullptr, proto_decode_32bit_tramp<DateTimeCommandRequest>};
 #endif
 #ifdef USE_UPDATE
 void ListEntitiesUpdateResponse::encode(ProtoWriteBuffer &buffer) const {
@@ -3590,6 +3688,8 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   }
   return true;
 }
+const ProtoDecodeFns UpdateCommandRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<UpdateCommandRequest>, nullptr, proto_decode_32bit_tramp<UpdateCommandRequest>};
 #endif
 #ifdef USE_ZWAVE_PROXY
 bool ZWaveProxyFrame::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
@@ -3604,6 +3704,8 @@ bool ZWaveProxyFrame::decode_length(uint32_t field_id, ProtoLengthDelimited valu
   }
   return true;
 }
+const ProtoDecodeFns ZWaveProxyFrame::DECODE_FNS PROGMEM = {nullptr, proto_decode_length_tramp<ZWaveProxyFrame>,
+                                                            nullptr};
 void ZWaveProxyFrame::encode(ProtoWriteBuffer &buffer) const { buffer.encode_bytes(1, this->data, this->data_len); }
 uint32_t ZWaveProxyFrame::calculate_size() const {
   uint32_t size = 0;
@@ -3632,6 +3734,8 @@ bool ZWaveProxyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited va
   }
   return true;
 }
+const ProtoDecodeFns ZWaveProxyRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<ZWaveProxyRequest>,
+                                                              proto_decode_length_tramp<ZWaveProxyRequest>, nullptr};
 void ZWaveProxyRequest::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, static_cast<uint32_t>(this->type));
   buffer.encode_bytes(2, this->data, this->data_len);
@@ -3719,6 +3823,10 @@ bool InfraredRFTransmitRawTimingsRequest::decode_32bit(uint32_t field_id, Proto3
   }
   return true;
 }
+const ProtoDecodeFns InfraredRFTransmitRawTimingsRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<InfraredRFTransmitRawTimingsRequest>,
+    proto_decode_length_tramp<InfraredRFTransmitRawTimingsRequest>,
+    proto_decode_32bit_tramp<InfraredRFTransmitRawTimingsRequest>};
 void InfraredRFReceiveEvent::encode(ProtoWriteBuffer &buffer) const {
 #ifdef USE_DEVICES
   buffer.encode_uint32(1, this->device_id);
@@ -3768,6 +3876,8 @@ bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, proto_varint_
   }
   return true;
 }
+const ProtoDecodeFns SerialProxyConfigureRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SerialProxyConfigureRequest>, nullptr, nullptr};
 void SerialProxyDataReceived::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, this->instance);
   buffer.encode_bytes(2, this->data_ptr_, this->data_len_);
@@ -3800,6 +3910,8 @@ bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimi
   }
   return true;
 }
+const ProtoDecodeFns SerialProxyWriteRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SerialProxyWriteRequest>, proto_decode_length_tramp<SerialProxyWriteRequest>, nullptr};
 bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -3813,6 +3925,8 @@ bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, proto_vari
   }
   return true;
 }
+const ProtoDecodeFns SerialProxySetModemPinsRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SerialProxySetModemPinsRequest>, nullptr, nullptr};
 bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
     case 1:
@@ -3823,6 +3937,8 @@ bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, proto_vari
   }
   return true;
 }
+const ProtoDecodeFns SerialProxyGetModemPinsRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<SerialProxyGetModemPinsRequest>, nullptr, nullptr};
 void SerialProxyGetModemPinsResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, this->instance);
   buffer.encode_uint32(2, this->line_states);
@@ -3846,6 +3962,8 @@ bool SerialProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t v
   }
   return true;
 }
+const ProtoDecodeFns SerialProxyRequest::DECODE_FNS PROGMEM = {proto_decode_varint_tramp<SerialProxyRequest>, nullptr,
+                                                               nullptr};
 void SerialProxyRequestResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint32(1, this->instance);
   buffer.encode_uint32(2, static_cast<uint32_t>(this->type));
@@ -3884,6 +4002,8 @@ bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, proto
   }
   return true;
 }
+const ProtoDecodeFns BluetoothSetConnectionParamsRequest::DECODE_FNS PROGMEM = {
+    proto_decode_varint_tramp<BluetoothSetConnectionParamsRequest>, nullptr, nullptr};
 void BluetoothSetConnectionParamsResponse::encode(ProtoWriteBuffer &buffer) const {
   buffer.encode_uint64(1, this->address);
   buffer.encode_int32(2, this->error);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -393,13 +393,16 @@ class HelloRequest final : public ProtoDecodableMessage {
   StringRef client_info{};
   uint32_t api_version_major{0};
   uint32_t api_version_minor{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class HelloResponse final : public ProtoMessage {
  public:
@@ -682,13 +685,16 @@ class CoverCommandRequest final : public CommandProtoMessage {
   bool has_tilt{false};
   float tilt{0.0f};
   bool stop{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_FAN
@@ -749,14 +755,17 @@ class FanCommandRequest final : public CommandProtoMessage {
   int32_t speed_level{0};
   bool has_preset_mode{false};
   StringRef preset_mode{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_LIGHT
@@ -839,14 +848,17 @@ class LightCommandRequest final : public CommandProtoMessage {
   uint32_t flash_length{0};
   bool has_effect{false};
   StringRef effect{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SENSOR
@@ -930,13 +942,16 @@ class SwitchCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("switch_command_request"); }
 #endif
   bool state{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_TEXT_SENSOR
@@ -983,12 +998,15 @@ class SubscribeLogsRequest final : public ProtoDecodableMessage {
 #endif
   enums::LogLevel level{};
   bool dump_config{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SubscribeLogsResponse final : public ProtoMessage {
  public:
@@ -1022,12 +1040,15 @@ class NoiseEncryptionSetKeyRequest final : public ProtoDecodableMessage {
 #endif
   const uint8_t *key{nullptr};
   uint16_t key_len{0};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class NoiseEncryptionSetKeyResponse final : public ProtoMessage {
  public:
@@ -1104,13 +1125,16 @@ class HomeassistantActionResponse final : public ProtoDecodableMessage {
   const uint8_t *response_data{nullptr};
   uint16_t response_data_len{0};
 #endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_API_HOMEASSISTANT_STATES
@@ -1142,12 +1166,15 @@ class HomeAssistantStateResponse final : public ProtoDecodableMessage {
   StringRef entity_id{};
   StringRef state{};
   StringRef attribute{};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 #endif
 class GetTimeRequest final : public ProtoMessage {
@@ -1171,12 +1198,15 @@ class DSTRule final : public ProtoDecodableMessage {
   uint32_t month{0};
   uint32_t week{0};
   uint32_t day_of_week{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class ParsedTimezone final : public ProtoDecodableMessage {
  public:
@@ -1184,13 +1214,16 @@ class ParsedTimezone final : public ProtoDecodableMessage {
   int32_t dst_offset_seconds{0};
   DSTRule dst_start{};
   DSTRule dst_end{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class GetTimeResponse final : public ProtoDecodableMessage {
  public:
@@ -1202,13 +1235,16 @@ class GetTimeResponse final : public ProtoDecodableMessage {
   uint32_t epoch_seconds{0};
   StringRef timezone{};
   ParsedTimezone parsed_timezone{};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 #ifdef USE_API_USER_DEFINED_ACTIONS
 class ListEntitiesServicesArgument final : public ProtoMessage {
@@ -1253,15 +1289,27 @@ class ExecuteServiceArgument final : public ProtoDecodableMessage {
   FixedVector<int32_t> int_array{};
   FixedVector<float> float_array{};
   FixedVector<std::string> string_array{};
-  void decode(const uint8_t *buffer, size_t length);
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) {
+    uint32_t count_bool_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 6);
+    this->bool_array.init(count_bool_array);
+    uint32_t count_int_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 7);
+    this->int_array.init(count_int_array);
+    uint32_t count_float_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 8);
+    this->float_array.init(count_float_array);
+    uint32_t count_string_array = ProtoDecodableMessage::count_repeated_field(buffer, length, 9);
+    this->string_array.init(count_string_array);
+    proto_decode_message(this, buffer, length, &DECODE_FNS);
+  }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class ExecuteServiceRequest final : public ProtoDecodableMessage {
  public:
@@ -1278,15 +1326,21 @@ class ExecuteServiceRequest final : public ProtoDecodableMessage {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
   bool return_response{false};
 #endif
-  void decode(const uint8_t *buffer, size_t length);
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) {
+    uint32_t count_args = ProtoDecodableMessage::count_repeated_field(buffer, length, 2);
+    this->args.init(count_args);
+    proto_decode_message(this, buffer, length, &DECODE_FNS);
+  }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
@@ -1360,12 +1414,15 @@ class CameraImageRequest final : public ProtoDecodableMessage {
 #endif
   bool single{false};
   bool stream{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_CLIMATE
@@ -1457,14 +1514,17 @@ class ClimateCommandRequest final : public CommandProtoMessage {
   StringRef custom_preset{};
   bool has_target_humidity{false};
   float target_humidity{0.0f};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_WATER_HEATER
@@ -1522,13 +1582,16 @@ class WaterHeaterCommandRequest final : public CommandProtoMessage {
   uint32_t state{0};
   float target_temperature_low{0.0f};
   float target_temperature_high{0.0f};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_NUMBER
@@ -1578,13 +1641,16 @@ class NumberCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("number_command_request"); }
 #endif
   float state{0.0f};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SELECT
@@ -1629,14 +1695,17 @@ class SelectCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("select_command_request"); }
 #endif
   StringRef state{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_SIREN
@@ -1689,14 +1758,17 @@ class SirenCommandRequest final : public CommandProtoMessage {
   uint32_t duration{0};
   bool has_volume{false};
   float volume{0.0f};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_LOCK
@@ -1745,14 +1817,17 @@ class LockCommandRequest final : public CommandProtoMessage {
   enums::LockCommand command{};
   bool has_code{false};
   StringRef code{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_BUTTON
@@ -1779,13 +1854,16 @@ class ButtonCommandRequest final : public CommandProtoMessage {
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const LogString *message_name() const override { return LOG_STR("button_command_request"); }
 #endif
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_MEDIA_PLAYER
@@ -1855,14 +1933,17 @@ class MediaPlayerCommandRequest final : public CommandProtoMessage {
   StringRef media_url{};
   bool has_announcement{false};
   bool announcement{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_BLUETOOTH_PROXY
@@ -1874,12 +1955,15 @@ class SubscribeBluetoothLEAdvertisementsRequest final : public ProtoDecodableMes
   const LogString *message_name() const override { return LOG_STR("subscribe_bluetooth_le_advertisements_request"); }
 #endif
   uint32_t flags{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothLERawAdvertisement final : public ProtoMessage {
  public:
@@ -1924,12 +2008,15 @@ class BluetoothDeviceRequest final : public ProtoDecodableMessage {
   enums::BluetoothDeviceRequestType request_type{};
   bool has_address_type{false};
   uint32_t address_type{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothDeviceConnectionResponse final : public ProtoMessage {
  public:
@@ -1958,12 +2045,15 @@ class BluetoothGATTGetServicesRequest final : public ProtoDecodableMessage {
   const LogString *message_name() const override { return LOG_STR("bluetooth_gatt_get_services_request"); }
 #endif
   uint64_t address{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTDescriptor final : public ProtoMessage {
  public:
@@ -2049,12 +2139,15 @@ class BluetoothGATTReadRequest final : public ProtoDecodableMessage {
 #endif
   uint64_t address{0};
   uint32_t handle{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTReadResponse final : public ProtoMessage {
  public:
@@ -2091,13 +2184,16 @@ class BluetoothGATTWriteRequest final : public ProtoDecodableMessage {
   bool response{false};
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2108,12 +2204,15 @@ class BluetoothGATTReadDescriptorRequest final : public ProtoDecodableMessage {
 #endif
   uint64_t address{0};
   uint32_t handle{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
  public:
@@ -2126,13 +2225,16 @@ class BluetoothGATTWriteDescriptorRequest final : public ProtoDecodableMessage {
   uint32_t handle{0};
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
  public:
@@ -2144,12 +2246,15 @@ class BluetoothGATTNotifyRequest final : public ProtoDecodableMessage {
   uint64_t address{0};
   uint32_t handle{0};
   bool enable{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothGATTNotifyDataResponse final : public ProtoMessage {
  public:
@@ -2324,12 +2429,15 @@ class BluetoothScannerSetModeRequest final : public ProtoDecodableMessage {
   const LogString *message_name() const override { return LOG_STR("bluetooth_scanner_set_mode_request"); }
 #endif
   enums::BluetoothScannerMode mode{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_VOICE_ASSISTANT
@@ -2342,12 +2450,15 @@ class SubscribeVoiceAssistantRequest final : public ProtoDecodableMessage {
 #endif
   bool subscribe{false};
   uint32_t flags{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAudioSettings final : public ProtoMessage {
  public:
@@ -2391,23 +2502,29 @@ class VoiceAssistantResponse final : public ProtoDecodableMessage {
 #endif
   uint32_t port{0};
   bool error{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantEventData final : public ProtoDecodableMessage {
  public:
   StringRef name{};
   StringRef value{};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
  public:
@@ -2418,13 +2535,16 @@ class VoiceAssistantEventResponse final : public ProtoDecodableMessage {
 #endif
   enums::VoiceAssistantEvent event_type{};
   std::vector<VoiceAssistantEventData> data{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAudio final : public ProtoDecodableMessage {
  public:
@@ -2436,6 +2556,11 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
   bool end{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
   void encode(ProtoWriteBuffer &buffer) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -2443,8 +2568,6 @@ class VoiceAssistantAudio final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
  public:
@@ -2459,13 +2582,16 @@ class VoiceAssistantTimerEventResponse final : public ProtoDecodableMessage {
   uint32_t total_seconds{0};
   uint32_t seconds_left{0};
   bool is_active{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
  public:
@@ -2478,13 +2604,16 @@ class VoiceAssistantAnnounceRequest final : public ProtoDecodableMessage {
   StringRef text{};
   StringRef preannounce_media_id{};
   bool start_conversation{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantAnnounceFinished final : public ProtoMessage {
  public:
@@ -2524,13 +2653,16 @@ class VoiceAssistantExternalWakeWord final : public ProtoDecodableMessage {
   uint32_t model_size{0};
   StringRef model_hash{};
   StringRef url{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
  public:
@@ -2540,12 +2672,15 @@ class VoiceAssistantConfigurationRequest final : public ProtoDecodableMessage {
   const LogString *message_name() const override { return LOG_STR("voice_assistant_configuration_request"); }
 #endif
   std::vector<VoiceAssistantExternalWakeWord> external_wake_words{};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class VoiceAssistantConfigurationResponse final : public ProtoMessage {
  public:
@@ -2573,12 +2708,15 @@ class VoiceAssistantSetConfiguration final : public ProtoDecodableMessage {
   const LogString *message_name() const override { return LOG_STR("voice_assistant_set_configuration"); }
 #endif
   std::vector<std::string> active_wake_words{};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 #endif
 #ifdef USE_ALARM_CONTROL_PANEL
@@ -2625,14 +2763,17 @@ class AlarmControlPanelCommandRequest final : public CommandProtoMessage {
 #endif
   enums::AlarmControlPanelStateCommand command{};
   StringRef code{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_TEXT
@@ -2680,14 +2821,17 @@ class TextCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("text_command_request"); }
 #endif
   StringRef state{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATE
@@ -2735,13 +2879,16 @@ class DateCommandRequest final : public CommandProtoMessage {
   uint32_t year{0};
   uint32_t month{0};
   uint32_t day{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_TIME
@@ -2789,13 +2936,16 @@ class TimeCommandRequest final : public CommandProtoMessage {
   uint32_t hour{0};
   uint32_t minute{0};
   uint32_t second{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_EVENT
@@ -2880,13 +3030,16 @@ class ValveCommandRequest final : public CommandProtoMessage {
   bool has_position{false};
   float position{0.0f};
   bool stop{false};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_DATETIME_DATETIME
@@ -2930,13 +3083,16 @@ class DateTimeCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("date_time_command_request"); }
 #endif
   uint32_t epoch_seconds{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_UPDATE
@@ -2988,13 +3144,16 @@ class UpdateCommandRequest final : public CommandProtoMessage {
   const LogString *message_name() const override { return LOG_STR("update_command_request"); }
 #endif
   enums::UpdateCommand command{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_ZWAVE_PROXY
@@ -3007,6 +3166,10 @@ class ZWaveProxyFrame final : public ProtoDecodableMessage {
 #endif
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
   void encode(ProtoWriteBuffer &buffer) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -3014,7 +3177,6 @@ class ZWaveProxyFrame final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
 };
 class ZWaveProxyRequest final : public ProtoDecodableMessage {
  public:
@@ -3026,6 +3188,11 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
   enums::ZWaveProxyRequestType type{};
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
   void encode(ProtoWriteBuffer &buffer) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP
@@ -3033,8 +3200,6 @@ class ZWaveProxyRequest final : public ProtoDecodableMessage {
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 #endif
 #ifdef USE_INFRARED
@@ -3073,14 +3238,17 @@ class InfraredRFTransmitRawTimingsRequest final : public ProtoDecodableMessage {
   const uint8_t *timings_data_{nullptr};
   uint16_t timings_length_{0};
   uint16_t timings_count_{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  bool decode_32bit(uint32_t field_id, Proto32Bit value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_32bit(uint32_t field_id, Proto32Bit value) override;
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class InfraredRFReceiveEvent final : public ProtoMessage {
  public:
@@ -3117,12 +3285,15 @@ class SerialProxyConfigureRequest final : public ProtoDecodableMessage {
   enums::SerialProxyParity parity{};
   uint32_t stop_bits{0};
   uint32_t data_size{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyDataReceived final : public ProtoMessage {
  public:
@@ -3156,13 +3327,16 @@ class SerialProxyWriteRequest final : public ProtoDecodableMessage {
   uint32_t instance{0};
   const uint8_t *data{nullptr};
   uint16_t data_len{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3173,12 +3347,15 @@ class SerialProxySetModemPinsRequest final : public ProtoDecodableMessage {
 #endif
   uint32_t instance{0};
   uint32_t line_states{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
  public:
@@ -3188,12 +3365,15 @@ class SerialProxyGetModemPinsRequest final : public ProtoDecodableMessage {
   const LogString *message_name() const override { return LOG_STR("serial_proxy_get_modem_pins_request"); }
 #endif
   uint32_t instance{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyGetModemPinsResponse final : public ProtoMessage {
  public:
@@ -3221,12 +3401,15 @@ class SerialProxyRequest final : public ProtoDecodableMessage {
 #endif
   uint32_t instance{0};
   enums::SerialProxyRequestType type{};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class SerialProxyRequestResponse final : public ProtoMessage {
  public:
@@ -3261,12 +3444,15 @@ class BluetoothSetConnectionParamsRequest final : public ProtoDecodableMessage {
   uint32_t max_interval{0};
   uint32_t latency{0};
   uint32_t timeout{0};
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value);
+  static const ProtoDecodeFns DECODE_FNS;
+
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, &DECODE_FNS); }
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif
 
  protected:
-  bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;
 };
 class BluetoothSetConnectionParamsResponse final : public ProtoMessage {
  public:

--- a/esphome/components/api/proto.cpp
+++ b/esphome/components/api/proto.cpp
@@ -203,9 +203,24 @@ void ProtoWriteBuffer::debug_check_encode_size_(uint32_t field_id, uint32_t expe
 }
 #endif
 
-void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
+/// Read a function pointer from a PROGMEM struct.
+/// On ESP8266, uses pgm_read_ptr for flash access; on all other platforms, direct dereference.
+template<typename T> static inline T read_fn_ptr(const T *addr) {
+#ifdef USE_ESP8266
+  return reinterpret_cast<T>(pgm_read_ptr(addr));
+#else
+  return *addr;
+#endif
+}
+
+void proto_decode_message(void *msg, const uint8_t *buffer, size_t length, const ProtoDecodeFns *fns) {
   const uint8_t *ptr = buffer;
   const uint8_t *end = buffer + length;
+
+  // Read function pointers once from PROGMEM at the start
+  auto decode_varint = read_fn_ptr(&fns->decode_varint);
+  auto decode_length = read_fn_ptr(&fns->decode_length);
+  auto decode_32bit = read_fn_ptr(&fns->decode_32bit);
 
   while (ptr < end) {
     // Parse field header - ptr < end guarantees len >= 1
@@ -227,7 +242,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Invalid VarInt at offset %ld", (long) (ptr - buffer));
           return;
         }
-        if (!this->decode_varint(field_id, res.value)) {
+        if (decode_varint && !decode_varint(msg, field_id, res.value)) {
           ESP_LOGV(TAG, "Cannot decode VarInt field %" PRIu32 " with value %" PRIu64 "!", field_id,
                    static_cast<uint64_t>(res.value));
         }
@@ -246,7 +261,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           ESP_LOGV(TAG, "Out-of-bounds Length Delimited at offset %ld", (long) (ptr - buffer));
           return;
         }
-        if (!this->decode_length(field_id, ProtoLengthDelimited(ptr, field_length))) {
+        if (decode_length && !decode_length(msg, field_id, ProtoLengthDelimited(ptr, field_length))) {
           ESP_LOGV(TAG, "Cannot decode Length Delimited field %" PRIu32 "!", field_id);
         }
         ptr += field_length;
@@ -258,7 +273,7 @@ void ProtoDecodableMessage::decode(const uint8_t *buffer, size_t length) {
           return;
         }
         uint32_t val = encode_uint32(ptr[3], ptr[2], ptr[1], ptr[0]);
-        if (!this->decode_32bit(field_id, Proto32Bit(val))) {
+        if (decode_32bit && !decode_32bit(msg, field_id, Proto32Bit(val))) {
           ESP_LOGV(TAG, "Cannot decode 32-bit field %" PRIu32 " with value %" PRIu32 "!", field_id, val);
         }
         ptr += 4;

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -544,7 +544,9 @@ class ProtoDecodableMessage : public ProtoMessage {
   // Default decode() for messages with no decode fields (all return false).
   void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, nullptr); }
 
- protected:
+ public:
+  // Public destructor needed because some messages (DSTRule, ParsedTimezone)
+  // are used as value-type members in other messages.
   ~ProtoDecodableMessage() = default;
 };
 

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -486,11 +486,44 @@ class ProtoMessage {
   ~ProtoMessage() = default;
 };
 
-// Base class for messages that support decoding
+/// Function pointer types for decode field dispatch.
+/// Used by proto_decode_message() to call concrete message decode methods
+/// without virtual dispatch, avoiding per-message vtable entries.
+using decode_varint_fn_t = bool (*)(void *msg, uint32_t field_id, proto_varint_value_t value);
+using decode_length_fn_t = bool (*)(void *msg, uint32_t field_id, ProtoLengthDelimited value);
+using decode_32bit_fn_t = bool (*)(void *msg, uint32_t field_id, Proto32Bit value);
+
+/// Decode dispatch table — packs 3 function pointers into a single struct
+/// so call sites only need to load one address instead of three.
+/// Marked PROGMEM so it lives in flash on ESP8266 (where .rodata is RAM).
+struct ProtoDecodeFns {
+  decode_varint_fn_t decode_varint;
+  decode_length_fn_t decode_length;
+  decode_32bit_fn_t decode_32bit;
+};
+
+/// Shared protobuf decode loop. Single copy in flash; field dispatch via function pointers.
+/// nullptr entries in fns are skipped (wire type not used by this message).
+void proto_decode_message(void *msg, const uint8_t *buffer, size_t length, const ProtoDecodeFns *fns);
+
+/// Template trampolines for decode dispatch. Each instantiation is a tiny
+/// function that casts void* to the concrete type and calls the method.
+/// Defined in the header so the linker can fold identical instantiations (ICF).
+template<typename T> bool proto_decode_varint_tramp(void *m, uint32_t fid, proto_varint_value_t v) {
+  return static_cast<T *>(m)->decode_varint(fid, v);
+}
+template<typename T> bool proto_decode_length_tramp(void *m, uint32_t fid, ProtoLengthDelimited v) {
+  return static_cast<T *>(m)->decode_length(fid, v);
+}
+template<typename T> bool proto_decode_32bit_tramp(void *m, uint32_t fid, Proto32Bit v) {
+  return static_cast<T *>(m)->decode_32bit(fid, v);
+}
+
+// Base class for messages that support decoding.
+// decode_varint/decode_length/decode_32bit are non-virtual; the concrete type's
+// methods are resolved statically via function-pointer trampolines in decode().
 class ProtoDecodableMessage : public ProtoMessage {
  public:
-  void decode(const uint8_t *buffer, size_t length);
-
   /**
    * Count occurrences of a repeated field in a protobuf buffer.
    * This is a lightweight scan that only parses tags and skips field data.
@@ -502,12 +535,17 @@ class ProtoDecodableMessage : public ProtoMessage {
    */
   static uint32_t count_repeated_field(const uint8_t *buffer, size_t length, uint32_t target_field_id);
 
+  // Non-virtual defaults for messages with no fields to decode.
+  // Concrete message classes hide these with their own implementations.
+  bool decode_varint(uint32_t field_id, proto_varint_value_t value) { return false; }
+  bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
+  bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
+
+  // Default decode() for messages with no decode fields (all return false).
+  void decode(const uint8_t *buffer, size_t length) { proto_decode_message(this, buffer, length, nullptr); }
+
  protected:
   ~ProtoDecodableMessage() = default;
-  virtual bool decode_varint(uint32_t field_id, proto_varint_value_t value) { return false; }
-  virtual bool decode_length(uint32_t field_id, ProtoLengthDelimited value) { return false; }
-  virtual bool decode_32bit(uint32_t field_id, Proto32Bit value) { return false; }
-  // NOTE: decode_64bit removed - wire type 1 not supported
 };
 
 class ProtoSize {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2292,6 +2292,7 @@ def build_message_type(
             dump.extend(wrap_with_ifdef(ti.dump_content, field_ifdef))
 
     cpp = ""
+    has_decode_fields = False
     if decode_varint:
         o = f"bool {desc.name}::decode_varint(uint32_t field_id, proto_varint_value_t value) {{\n"
         o += "  switch (field_id) {\n"
@@ -2301,8 +2302,9 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_varint(uint32_t field_id, proto_varint_value_t value) override;"
-        protected_content.insert(0, prot)
+        prot = "bool decode_varint(uint32_t field_id, proto_varint_value_t value);"
+        public_content.append(prot)
+        has_decode_fields = True
     if decode_length:
         o = f"bool {desc.name}::decode_length(uint32_t field_id, ProtoLengthDelimited value) {{\n"
         o += "  switch (field_id) {\n"
@@ -2312,8 +2314,9 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_length(uint32_t field_id, ProtoLengthDelimited value) override;"
-        protected_content.insert(0, prot)
+        prot = "bool decode_length(uint32_t field_id, ProtoLengthDelimited value);"
+        public_content.append(prot)
+        has_decode_fields = True
     if decode_32bit:
         o = f"bool {desc.name}::decode_32bit(uint32_t field_id, Proto32Bit value) {{\n"
         o += "  switch (field_id) {\n"
@@ -2323,8 +2326,9 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_32bit(uint32_t field_id, Proto32Bit value) override;"
-        protected_content.insert(0, prot)
+        prot = "bool decode_32bit(uint32_t field_id, Proto32Bit value);"
+        public_content.append(prot)
+        has_decode_fields = True
     if decode_64bit:
         o = f"bool {desc.name}::decode_64bit(uint32_t field_id, Proto64Bit value) {{\n"
         o += "  switch (field_id) {\n"
@@ -2334,23 +2338,46 @@ def build_message_type(
         o += "  return true;\n"
         o += "}\n"
         cpp += o
-        prot = "bool decode_64bit(uint32_t field_id, Proto64Bit value) override;"
-        protected_content.insert(0, prot)
+        prot = "bool decode_64bit(uint32_t field_id, Proto64Bit value);"
+        public_content.append(prot)
+        has_decode_fields = True
 
-    # Generate custom decode() override for messages with FixedVector fields
-    if fixed_vector_fields:
-        # Generate the decode() implementation in cpp
-        o = f"void {desc.name}::decode(const uint8_t *buffer, size_t length) {{\n"
-        # Count and init each FixedVector field
-        for field_name, field_number in fixed_vector_fields:
-            o += f"  uint32_t count_{field_name} = ProtoDecodableMessage::count_repeated_field(buffer, length, {field_number});\n"
-            o += f"  this->{field_name}.init(count_{field_name});\n"
-        # Call parent decode to populate the fields
-        o += "  ProtoDecodableMessage::decode(buffer, length);\n"
-        o += "}\n"
-        cpp += o
-        # Generate the decode() declaration in header (public method)
-        prot = "void decode(const uint8_t *buffer, size_t length);"
+    # Generate decode() inline in the header with a static ProtoDecodeFns table.
+    # Packing 3 function pointers into a single struct means each call site only
+    # loads one address instead of three, reducing call-site overhead.
+    # Trampolines are defined in proto.h so the linker can fold identical ones (ICF).
+    # decode_varint/decode_length/decode_32bit are public (non-virtual, no override risk).
+    # Messages with FixedVector fields need pre-processing before the decode loop.
+    if has_decode_fields:
+        # Build trampoline arguments — pass nullptr for wire types not used
+        varint_tramp = (
+            f"proto_decode_varint_tramp<{desc.name}>" if decode_varint else "nullptr"
+        )
+        length_tramp = (
+            f"proto_decode_length_tramp<{desc.name}>" if decode_length else "nullptr"
+        )
+        bit32_tramp = (
+            f"proto_decode_32bit_tramp<{desc.name}>" if decode_32bit else "nullptr"
+        )
+
+        # Static decode function table — one per message type
+        # PROGMEM puts it in flash on ESP8266 (where .rodata is RAM)
+        prot = "static const ProtoDecodeFns DECODE_FNS;\n"
+        public_content.append(prot)
+        # Generate the static definition in cpp with PROGMEM
+        cpp += f"const ProtoDecodeFns {desc.name}::DECODE_FNS PROGMEM = {{{varint_tramp}, {length_tramp}, {bit32_tramp}}};\n"
+
+        decode_body = ""
+        if fixed_vector_fields:
+            # Count and init each FixedVector field before decoding
+            for field_name, field_number in fixed_vector_fields:
+                decode_body += f"  uint32_t count_{field_name} = ProtoDecodableMessage::count_repeated_field(buffer, length, {field_number});\n"
+                decode_body += f"  this->{field_name}.init(count_{field_name});\n"
+        decode_body += "  proto_decode_message(this, buffer, length, &DECODE_FNS);\n"
+
+        prot = "void decode(const uint8_t *buffer, size_t length) {\n"
+        prot += decode_body
+        prot += "}"
         public_content.append(prot)
 
     # Only generate encode method if this message needs encoding and has fields


### PR DESCRIPTION
# What does this implement/fix?

Replace virtual `decode_varint`/`decode_length`/`decode_32bit` methods on `ProtoDecodableMessage` with non-virtual methods and static function-pointer dispatch tables (`ProtoDecodeFns`).

Each decodable message gets a `static const PROGMEM` dispatch table containing trampolines to its concrete decode methods. The shared decode loop (`proto_decode_message`) reads function pointers from this table instead of using virtual dispatch through the vtable.

This eliminates vtables for all `ProtoDecodableMessage` subclasses in non-debug builds (where `dump_to`/`message_name` virtuals are compiled out), removing the vptr from each message instance on the stack.

The `DECODE_FNS` tables are marked `PROGMEM` so they live in flash on ESP8266 (where `.rodata` is RAM), matching the behavior of compiler-generated vtables. On all other platforms `PROGMEM` is a no-op. Function pointers are read via `pgm_read_ptr` on ESP8266 and direct dereference elsewhere.

Rebased on top of #15293 (decode benchmark fix) so CodSpeed can accurately measure the decode performance impact with benchmarks that actually execute the decode loop.

Also fixes a build error where `ProtoDecodableMessage`'s protected destructor prevented `DSTRule` and `ParsedTimezone` from being used as value-type members.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #15293
- Replaces #15287

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no user-facing config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).