### PR TITLE
[ld2410] Fix flaky integration test race condition

### DIFF
--- a/tests/integration/test_uart_mock_ld2410.py
+++ b/tests/integration/test_uart_mock_ld2410.py
@@ -73,9 +73,16 @@ async def test_uart_mock_ld2410(
         ],
     )
 
-    # Signal when we see recovery frame values
+    # Signal when we see ALL recovery frame values to avoid race where some
+    # arrive after the waiter fires but before we index into the lists
     recovery_received = collector.add_waiter(
-        lambda: pytest.approx(50.0) in collector.sensor_states["moving_distance"]
+        lambda: (
+            pytest.approx(50.0) in collector.sensor_states["moving_distance"]
+            and pytest.approx(75.0) in collector.sensor_states["still_distance"]
+            and pytest.approx(100.0) in collector.sensor_states["moving_energy"]
+            and pytest.approx(80.0) in collector.sensor_states["still_energy"]
+            and pytest.approx(127.0) in collector.sensor_states["detection_distance"]
+        )
     )
 
     async with (


### PR DESCRIPTION
## What does this implement/fix?

Fixes a race condition in the ld2410 UART mock integration test that caused intermittent `IndexError: list index out of range` failures.

The recovery frame waiter only checked for `moving_distance == 50.0`, but then the test indexed into other sensor lists (`still_distance`, `moving_energy`, etc.) at the same position. When the waiter fired before all sensor values from the recovery frame had been delivered via the API, the other lists were shorter, causing the IndexError.

The fix waits for ALL five recovery frame sensor values before proceeding to assertions, matching the approach already used in the ld2450 test.

## Types of changes
  - [ ] New integration (new platform support)
  - [ ] New component (new device/entity support)
  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] Breaking change (fix/feature causing existing functionality to break)
  - [ ] Other

## Related issue or feature (if applicable):
N/A — flaky CI test

## Test Environment
N/A — test-only change

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (if applicable).

## Example entry for `Changelog`:
### Fixed
- ld2410: Fix flaky integration test race condition in recovery frame assertions