### PR TITLE
[modbus_controller] Fix off-by-one bounds check in byte_from_hex_str

### DIFF
--- a/esphome/components/modbus_controller/modbus_controller.h
+++ b/esphome/components/modbus_controller/modbus_controller.h
@@ -81,15 +81,15 @@ inline ModbusFunctionCode modbus_register_write_function(ModbusRegisterType reg_
 inline uint8_t c_to_hex(char c) { return (c >= 'A') ? (c >= 'a') ? (c - 'a' + 10) : (c - 'A' + 10) : (c - '0'); }
 
 /** Get a byte from a hex string
- *  hex_byte_from_str("1122",1) returns uint_8 value 0x22 == 34
- *  hex_byte_from_str("1122",0) returns 0x11
+ *  byte_from_hex_str("1122", 1) returns uint_8 value 0x22 == 34
+ *  byte_from_hex_str("1122", 0) returns 0x11
  * @param value string containing hex encoding
  * @param position  offset in bytes. Because each byte is encoded in 2 hex digits the position of the original byte in
  * the hex string is byte_pos * 2
  * @return byte value
  */
 inline uint8_t byte_from_hex_str(const std::string &value, uint8_t pos) {
-  if (value.length() < pos * 2 + 1)
+  if (value.length() < pos * 2 + 2)
     return 0;
   return (c_to_hex(value[pos * 2]) << 4) | c_to_hex(value[pos * 2 + 1]);
 }


### PR DESCRIPTION
# What does this implement/fix?

Fix an off-by-one error in `byte_from_hex_str()` bounds check. The guard `value.length() < pos * 2 + 1` allows `value[pos * 2 + 1]` to be accessed when `length == pos * 2 + 1`, which is one past the valid range. Changed to `< pos * 2 + 2` to require both hex digit characters to be present.

Also fixes incorrect function name in the doc comment (`hex_byte_from_str` → `byte_from_hex_str`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered during review of #15291

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal bugfix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).