### PR TITLE
[wifi] Avoid redundant SDK calls in WiFi loop on ESP8266

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -2130,11 +2130,6 @@ void WiFiComponent::retry_connect() {
 }
 
 void WiFiComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
-bool WiFiComponent::is_connected_() const {
-  return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
-         this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
-}
-void WiFiComponent::update_connected_state_() { this->connected_ = this->is_connected_(); }
 void WiFiComponent::set_power_save_mode(WiFiPowerSaveMode power_save) {
   this->power_save_ = power_save;
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -784,7 +784,8 @@ void WiFiComponent::loop() {
       }
 
       case WIFI_COMPONENT_STATE_STA_CONNECTED: {
-        if (!this->is_connected_()) {
+        // Use cached connected_ set unconditionally at the top of loop()
+        if (!this->connected_) {
           ESP_LOGW(TAG, "Connection lost; reconnecting");
           this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTING;
           this->retry_connect();

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -398,6 +398,17 @@ class WiFiPowerSaveListener {
   virtual void on_wifi_power_save(WiFiPowerSaveMode mode) = 0;
 };
 
+#ifdef USE_ESP8266
+enum class ESP8266WiFiSTAState : uint8_t {
+  IDLE,             // Not connecting
+  CONNECTING,       // Connection in progress
+  ASSOCIATED,       // Associated to AP, waiting for IP
+  CONNECTED,        // Successfully connected with IP
+  ERROR_NOT_FOUND,  // AP not found (probe failed)
+  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
+};
+#endif
+
 /// This component is responsible for managing the ESP WiFi interface.
 class WiFiComponent final : public Component {
  public:
@@ -811,6 +822,9 @@ class WiFiComponent final : public Component {
   uint8_t num_ipv6_addresses_{0};
 #endif /* USE_NETWORK_IPV6 */
   bool error_from_callback_{false};
+#ifdef USE_ESP8266
+  ESP8266WiFiSTAState sta_state_{ESP8266WiFiSTAState::IDLE};
+#endif
   RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
   RoamingState roaming_state_{RoamingState::IDLE};
   bssid_t roaming_target_bssid_{};  // BSSID of the AP we're trying to roam to

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -681,8 +681,11 @@ class WiFiComponent final : public Component {
   bool wifi_sta_connect_(const WiFiAP &ap);
   void wifi_pre_setup_();
   WiFiSTAConnectStatus wifi_sta_connect_status_() const;
-  bool is_connected_() const;
-  void update_connected_state_();
+  bool is_connected_() const {
+    return this->state_ == WIFI_COMPONENT_STATE_STA_CONNECTED &&
+           this->wifi_sta_connect_status_() == WiFiSTAConnectStatus::CONNECTED && !this->error_from_callback_;
+  }
+  void update_connected_state_() { this->connected_ = this->is_connected_(); }
   bool wifi_scan_start_(bool passive);
 
 #ifdef USE_WIFI_AP

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -815,7 +815,10 @@ class WiFiComponent final : public Component {
 #endif /* USE_NETWORK_IPV6 */
   bool error_from_callback_{false};
 #ifdef USE_ESP8266
-  uint8_t sta_state_{0};  // ESP8266WiFiSTAState, defined in wifi_component_esp8266.cpp
+  // ESP8266WiFiSTAState enum, defined in wifi_component_esp8266.cpp.
+  // Written from SDK system context (wifi_event_callback) — uint8_t writes
+  // are atomic on Xtensa LX106 so no synchronization is needed.
+  uint8_t sta_state_{0};
 #endif
   RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
   RoamingState roaming_state_{RoamingState::IDLE};

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -398,17 +398,6 @@ class WiFiPowerSaveListener {
   virtual void on_wifi_power_save(WiFiPowerSaveMode mode) = 0;
 };
 
-#ifdef USE_ESP8266
-enum class ESP8266WiFiSTAState : uint8_t {
-  IDLE,             // Not connecting
-  CONNECTING,       // Connection in progress
-  ASSOCIATED,       // Associated to AP, waiting for IP
-  CONNECTED,        // Successfully connected with IP
-  ERROR_NOT_FOUND,  // AP not found (probe failed)
-  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
-};
-#endif
-
 /// This component is responsible for managing the ESP WiFi interface.
 class WiFiComponent final : public Component {
  public:
@@ -826,7 +815,7 @@ class WiFiComponent final : public Component {
 #endif /* USE_NETWORK_IPV6 */
   bool error_from_callback_{false};
 #ifdef USE_ESP8266
-  ESP8266WiFiSTAState sta_state_{ESP8266WiFiSTAState::IDLE};
+  uint8_t sta_state_{0};  // ESP8266WiFiSTAState, defined in wifi_component_esp8266.cpp
 #endif
   RetryHiddenMode retry_hidden_mode_{RetryHiddenMode::BLIND_RETRY};
   RoamingState roaming_state_{RoamingState::IDLE};

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -53,8 +53,8 @@ enum class ESP8266WiFiSTAState : uint8_t {
   ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
 };
 
-static ESP8266WiFiSTAState s_sta_state =
-    ESP8266WiFiSTAState::IDLE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static ESP8266WiFiSTAState s_sta_state = ESP8266WiFiSTAState::IDLE;
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -44,18 +44,6 @@ namespace esphome::wifi {
 
 static const char *const TAG = "wifi_esp8266";
 
-enum class ESP8266WiFiSTAState : uint8_t {
-  IDLE,             // Not connecting
-  CONNECTING,       // Connection in progress
-  ASSOCIATED,       // Associated to AP, waiting for IP
-  CONNECTED,        // Successfully connected with IP
-  ERROR_NOT_FOUND,  // AP not found (probe failed)
-  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
-};
-
-// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
-static ESP8266WiFiSTAState s_sta_state = ESP8266WiFiSTAState::IDLE;
-
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
   bool current_sta = current_mode & 0b01;
@@ -365,7 +353,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // Reset flags, do this _before_ wifi_station_connect as the callback method
   // may be called from wifi_station_connect
-  s_sta_state = ESP8266WiFiSTAState::CONNECTING;
+  this->sta_state_ = ESP8266WiFiSTAState::CONNECTING;
 
   ETS_UART_INTR_DISABLE();
   ret = wifi_station_connect();
@@ -495,7 +483,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       ESP_LOGV(TAG, "Connected ssid='%.*s' bssid=%s channel=%u", it.ssid_len, (const char *) it.ssid, bssid_buf,
                it.channel);
 #endif
-      s_sta_state = ESP8266WiFiSTAState::ASSOCIATED;
+      global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ASSOCIATED;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       // Defer listener notification until state machine reaches STA_CONNECTED
       // This ensures wifi.connected condition returns true in listener automations
@@ -508,13 +496,13 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       if (it.reason == REASON_NO_AP_FOUND) {
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
                  (const char *) it.ssid);
-        s_sta_state = ESP8266WiFiSTAState::ERROR_NOT_FOUND;
+        global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ERROR_NOT_FOUND;
       } else {
         char bssid_s[18];
         format_mac_addr_upper(it.bssid, bssid_s);
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
                  (const char *) it.ssid, bssid_s, LOG_STR_ARG(get_disconnect_reason_str(it.reason)));
-        s_sta_state = ESP8266WiFiSTAState::ERROR_FAILED;
+        global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ERROR_FAILED;
       }
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
@@ -541,7 +529,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
           mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
       ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", network::IPAddress(&it.ip).str_to(ip_buf),
                network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
-      s_sta_state = ESP8266WiFiSTAState::CONNECTED;
+      global_wifi_component->sta_state_ = ESP8266WiFiSTAState::CONNECTED;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
       // Defer listener callbacks to main loop - system context has limited stack
       global_wifi_component->pending_.got_ip = true;
@@ -640,7 +628,7 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // wifi_station_get_connect_status() which queries the SDK every time.
   // Use if-else instead of switch to avoid GCC generating a CSWTCH
   // lookup table in .rodata (flash) on ESP8266.
-  auto state = s_sta_state;
+  auto state = this->sta_state_;
   if (state == ESP8266WiFiSTAState::CONNECTED)
     return WiFiSTAConnectStatus::CONNECTED;
   if (state == ESP8266WiFiSTAState::ERROR_NOT_FOUND)

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -44,11 +44,17 @@ namespace esphome::wifi {
 
 static const char *const TAG = "wifi_esp8266";
 
-static bool s_sta_connected = false;          // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_got_ip = false;             // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connect_not_found = false;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connect_error = false;      // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static bool s_sta_connecting = false;         // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+enum class ESP8266WiFiSTAState : uint8_t {
+  IDLE,             // Not connecting
+  CONNECTING,       // Connection in progress
+  ASSOCIATED,       // Associated to AP, waiting for IP
+  CONNECTED,        // Successfully connected with IP
+  ERROR_NOT_FOUND,  // AP not found (probe failed)
+  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
+};
+
+static ESP8266WiFiSTAState s_sta_state =
+    ESP8266WiFiSTAState::IDLE;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
@@ -359,11 +365,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // Reset flags, do this _before_ wifi_station_connect as the callback method
   // may be called from wifi_station_connect
-  s_sta_connecting = true;
-  s_sta_connected = false;
-  s_sta_got_ip = false;
-  s_sta_connect_error = false;
-  s_sta_connect_not_found = false;
+  s_sta_state = ESP8266WiFiSTAState::CONNECTING;
 
   ETS_UART_INTR_DISABLE();
   ret = wifi_station_connect();
@@ -493,7 +495,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       ESP_LOGV(TAG, "Connected ssid='%.*s' bssid=%s channel=%u", it.ssid_len, (const char *) it.ssid, bssid_buf,
                it.channel);
 #endif
-      s_sta_connected = true;
+      s_sta_state = ESP8266WiFiSTAState::ASSOCIATED;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       // Defer listener notification until state machine reaches STA_CONNECTED
       // This ensures wifi.connected condition returns true in listener automations
@@ -506,16 +508,14 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       if (it.reason == REASON_NO_AP_FOUND) {
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
                  (const char *) it.ssid);
-        s_sta_connect_not_found = true;
+        s_sta_state = ESP8266WiFiSTAState::ERROR_NOT_FOUND;
       } else {
         char bssid_s[18];
         format_mac_addr_upper(it.bssid, bssid_s);
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
                  (const char *) it.ssid, bssid_s, LOG_STR_ARG(get_disconnect_reason_str(it.reason)));
-        s_sta_connect_error = true;
+        s_sta_state = ESP8266WiFiSTAState::ERROR_FAILED;
       }
-      s_sta_connected = false;
-      s_sta_connecting = false;
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       global_wifi_component->pending_.disconnect = true;
@@ -541,7 +541,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
           mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
       ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", network::IPAddress(&it.ip).str_to(ip_buf),
                network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
-      s_sta_got_ip = true;
+      s_sta_state = ESP8266WiFiSTAState::CONNECTED;
 #ifdef USE_WIFI_IP_STATE_LISTENERS
       // Defer listener callbacks to main loop - system context has limited stack
       global_wifi_component->pending_.got_ip = true;
@@ -636,16 +636,22 @@ void WiFiComponent::wifi_pre_setup_() {
 }
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
-  station_status_t status = wifi_station_get_connect_status();
-  if (status == STATION_GOT_IP)
-    return WiFiSTAConnectStatus::CONNECTED;
-  if (status == STATION_NO_AP_FOUND)
-    return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
-  if (status == STATION_CONNECT_FAIL || status == STATION_WRONG_PASSWORD)
-    return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
-  if (status == STATION_CONNECTING)
-    return WiFiSTAConnectStatus::CONNECTING;
-  return WiFiSTAConnectStatus::IDLE;
+  // Use cached state from wifi_event_callback() instead of calling
+  // wifi_station_get_connect_status() which queries the SDK every time
+  switch (s_sta_state) {
+    case ESP8266WiFiSTAState::CONNECTED:
+      return WiFiSTAConnectStatus::CONNECTED;
+    case ESP8266WiFiSTAState::ERROR_NOT_FOUND:
+      return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
+    case ESP8266WiFiSTAState::ERROR_FAILED:
+      return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
+    case ESP8266WiFiSTAState::CONNECTING:
+    case ESP8266WiFiSTAState::ASSOCIATED:
+      return WiFiSTAConnectStatus::CONNECTING;
+    case ESP8266WiFiSTAState::IDLE:
+    default:
+      return WiFiSTAConnectStatus::IDLE;
+  }
 }
 bool WiFiComponent::wifi_scan_start_(bool passive) {
   // enable STA

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -637,21 +637,19 @@ void WiFiComponent::wifi_pre_setup_() {
 
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // Use cached state from wifi_event_callback() instead of calling
-  // wifi_station_get_connect_status() which queries the SDK every time
-  switch (s_sta_state) {
-    case ESP8266WiFiSTAState::CONNECTED:
-      return WiFiSTAConnectStatus::CONNECTED;
-    case ESP8266WiFiSTAState::ERROR_NOT_FOUND:
-      return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
-    case ESP8266WiFiSTAState::ERROR_FAILED:
-      return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
-    case ESP8266WiFiSTAState::CONNECTING:
-    case ESP8266WiFiSTAState::ASSOCIATED:
-      return WiFiSTAConnectStatus::CONNECTING;
-    case ESP8266WiFiSTAState::IDLE:
-    default:
-      return WiFiSTAConnectStatus::IDLE;
-  }
+  // wifi_station_get_connect_status() which queries the SDK every time.
+  // Use if-else instead of switch to avoid GCC generating a CSWTCH
+  // lookup table in .rodata (flash) on ESP8266.
+  auto state = s_sta_state;
+  if (state == ESP8266WiFiSTAState::CONNECTED)
+    return WiFiSTAConnectStatus::CONNECTED;
+  if (state == ESP8266WiFiSTAState::ERROR_NOT_FOUND)
+    return WiFiSTAConnectStatus::ERROR_NETWORK_NOT_FOUND;
+  if (state == ESP8266WiFiSTAState::ERROR_FAILED)
+    return WiFiSTAConnectStatus::ERROR_CONNECT_FAILED;
+  if (state == ESP8266WiFiSTAState::CONNECTING || state == ESP8266WiFiSTAState::ASSOCIATED)
+    return WiFiSTAConnectStatus::CONNECTING;
+  return WiFiSTAConnectStatus::IDLE;
 }
 bool WiFiComponent::wifi_scan_start_(bool passive) {
   // enable STA

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -639,6 +639,7 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
     return WiFiSTAConnectStatus::CONNECTING;
   return WiFiSTAConnectStatus::IDLE;
 }
+
 bool WiFiComponent::wifi_scan_start_(bool passive) {
   // enable STA
   if (!this->wifi_mode_(true, {}))

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -626,8 +626,8 @@ void WiFiComponent::wifi_pre_setup_() {
 WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // Use cached state from wifi_event_callback() instead of calling
   // wifi_station_get_connect_status() which queries the SDK every time.
-  // Use if-else instead of switch to avoid GCC generating a CSWTCH
-  // lookup table in .rodata (flash) on ESP8266.
+  // Use if statements with early returns instead of switch to avoid GCC
+  // generating a CSWTCH lookup table in .rodata (flash) on ESP8266.
   auto state = this->sta_state_;
   if (state == ESP8266WiFiSTAState::CONNECTED)
     return WiFiSTAConnectStatus::CONNECTED;

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -44,6 +44,15 @@ namespace esphome::wifi {
 
 static const char *const TAG = "wifi_esp8266";
 
+enum class ESP8266WiFiSTAState : uint8_t {
+  IDLE,             // Not connecting
+  CONNECTING,       // Connection in progress
+  ASSOCIATED,       // Associated to AP, waiting for IP
+  CONNECTED,        // Successfully connected with IP
+  ERROR_NOT_FOUND,  // AP not found (probe failed)
+  ERROR_FAILED,     // Connection failed (auth, timeout, etc.)
+};
+
 bool WiFiComponent::wifi_mode_(optional<bool> sta, optional<bool> ap) {
   uint8_t current_mode = wifi_get_opmode();
   bool current_sta = current_mode & 0b01;
@@ -353,7 +362,7 @@ bool WiFiComponent::wifi_sta_connect_(const WiFiAP &ap) {
 
   // Reset flags, do this _before_ wifi_station_connect as the callback method
   // may be called from wifi_station_connect
-  this->sta_state_ = ESP8266WiFiSTAState::CONNECTING;
+  this->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::CONNECTING);
 
   ETS_UART_INTR_DISABLE();
   ret = wifi_station_connect();
@@ -483,7 +492,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       ESP_LOGV(TAG, "Connected ssid='%.*s' bssid=%s channel=%u", it.ssid_len, (const char *) it.ssid, bssid_buf,
                it.channel);
 #endif
-      global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ASSOCIATED;
+      global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ASSOCIATED);
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       // Defer listener notification until state machine reaches STA_CONNECTED
       // This ensures wifi.connected condition returns true in listener automations
@@ -496,13 +505,13 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
       if (it.reason == REASON_NO_AP_FOUND) {
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' reason='Probe Request Unsuccessful'", it.ssid_len,
                  (const char *) it.ssid);
-        global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ERROR_NOT_FOUND;
+        global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ERROR_NOT_FOUND);
       } else {
         char bssid_s[18];
         format_mac_addr_upper(it.bssid, bssid_s);
         ESP_LOGW(TAG, "Disconnected ssid='%.*s' bssid=" LOG_SECRET("%s") " reason='%s'", it.ssid_len,
                  (const char *) it.ssid, bssid_s, LOG_STR_ARG(get_disconnect_reason_str(it.reason)));
-        global_wifi_component->sta_state_ = ESP8266WiFiSTAState::ERROR_FAILED;
+        global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::ERROR_FAILED);
       }
       global_wifi_component->error_from_callback_ = true;
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
@@ -529,7 +538,7 @@ void WiFiComponent::wifi_event_callback(System_Event_t *event) {
           mask_buf[network::IP_ADDRESS_BUFFER_SIZE];
       ESP_LOGV(TAG, "static_ip=%s gateway=%s netmask=%s", network::IPAddress(&it.ip).str_to(ip_buf),
                network::IPAddress(&it.gw).str_to(gw_buf), network::IPAddress(&it.mask).str_to(mask_buf));
-      global_wifi_component->sta_state_ = ESP8266WiFiSTAState::CONNECTED;
+      global_wifi_component->sta_state_ = static_cast<uint8_t>(ESP8266WiFiSTAState::CONNECTED);
 #ifdef USE_WIFI_IP_STATE_LISTENERS
       // Defer listener callbacks to main loop - system context has limited stack
       global_wifi_component->pending_.got_ip = true;
@@ -628,7 +637,7 @@ WiFiSTAConnectStatus WiFiComponent::wifi_sta_connect_status_() const {
   // wifi_station_get_connect_status() which queries the SDK every time.
   // Use if statements with early returns instead of switch to avoid GCC
   // generating a CSWTCH lookup table in .rodata (flash) on ESP8266.
-  auto state = this->sta_state_;
+  auto state = static_cast<ESP8266WiFiSTAState>(this->sta_state_);
   if (state == ESP8266WiFiSTAState::CONNECTED)
     return WiFiSTAConnectStatus::CONNECTED;
   if (state == ESP8266WiFiSTAState::ERROR_NOT_FOUND)


### PR DESCRIPTION
# What does this implement/fix?

Reduces WiFi component loop overhead on ESP8266 by ~49% (98ms → 49.7ms per 60s period).

**Three changes:**

1. **ESP8266: Replace boolean flags with enum state machine** — The five separate `static bool` variables tracking WiFi STA state are replaced with a single `uint8_t` member variable on `WiFiComponent`, backed by an `ESP8266WiFiSTAState` enum defined privately in the ESP8266 cpp file. This matches the pattern already used by LibreTiny. The `wifi_sta_connect_status_()` method now reads the cached enum instead of calling `wifi_station_get_connect_status()` on every invocation, eliminating a per-loop SDK call.

2. **All platforms: Use cached `connected_` in STA_CONNECTED branch** — The `WIFI_COMPONENT_STATE_STA_CONNECTED` case in `loop()` called `is_connected_()` (which queries platform-specific status), but `update_connected_state_()` already cached this result in `connected_` unconditionally at the top of `loop()`. The branch now reads the cached value instead.

3. **All platforms: Inline `is_connected_()` and `update_connected_state_()`** — Moved these small methods to the header so the compiler can inline them into `loop()`, eliminating two function call/return round trips per loop iteration. On ESP8266's 80MHz CPU, function call overhead (prologue, stack frame, epilogue) is significant.

**Measured results (ESP8266, runtime_stats, 60s period):**
- Before: `wifi: count=7813, avg=0.013ms, max=0.10ms, total=98.0ms`
- After: `wifi: count=7822, avg=0.006ms, max=0.04ms, total=49.7ms`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — internal optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).