### PR TITLE
[wifi] Replace FreeRTOS queue with LockFreeQueue on ESP-IDF

### DIFF
--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -6,6 +6,9 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
+#ifdef USE_ESP32
+#include "esphome/core/lock_free_queue.h"
+#endif
 #include "esphome/core/string_ref.h"
 
 #include <span>
@@ -724,6 +727,7 @@ class WiFiComponent final : public Component {
 
 #ifdef USE_ESP32
   void wifi_process_event_(IDFWiFiEvent *data);
+  friend void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
 #endif
 
 #ifdef USE_RP2040
@@ -860,6 +864,13 @@ class WiFiComponent final : public Component {
   bool post_connect_roaming_{true};  // Enabled by default
 #if defined(USE_ESP32) && defined(USE_WIFI_RUNTIME_POWER_SAVE)
   bool is_high_performance_mode_{false};
+#endif
+
+#ifdef USE_ESP32
+  // Lock-free SPSC queue for WiFi events from ESP-IDF event handler.
+  // 17 slots = 16 usable (ring buffer reserves one slot). WiFi events are rare.
+  // Placed at end of class to avoid padding between smaller fields.
+  LockFreeQueue<IDFWiFiEvent, 17> event_queue_;
 #endif
 
  private:

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -47,7 +47,6 @@ namespace esphome::wifi {
 static const char *const TAG = "wifi_esp32";
 
 static EventGroupHandle_t s_wifi_event_group;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-static QueueHandle_t s_event_queue;            // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 static esp_netif_t *s_sta_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 #ifdef USE_WIFI_AP
 static esp_netif_t *s_ap_netif = nullptr;     // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -132,11 +131,10 @@ void event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, voi
     return;
   }
 
-  // copy to heap to keep queue object small
+  // copy to heap — WiFi events are rare so heap alloc is fine
   auto *to_send = new IDFWiFiEvent;  // NOLINT(cppcoreguidelines-owning-memory)
   memcpy(to_send, &event, sizeof(IDFWiFiEvent));
-  // don't block, we may miss events but the core can handle that
-  if (xQueueSend(s_event_queue, &to_send, 0L) != pdPASS) {
+  if (!global_wifi_component->event_queue_.push(to_send)) {
     delete to_send;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }
@@ -155,12 +153,6 @@ void WiFiComponent::wifi_pre_setup_() {
   s_wifi_event_group = xEventGroupCreate();
   if (s_wifi_event_group == nullptr) {
     ESP_LOGE(TAG, "xEventGroupCreate failed");
-    return;
-  }
-  // NOLINTNEXTLINE(bugprone-sizeof-expression)
-  s_event_queue = xQueueCreate(64, sizeof(IDFWiFiEvent *));
-  if (s_event_queue == nullptr) {
-    ESP_LOGE(TAG, "xQueueCreate failed");
     return;
   }
   err = esp_event_loop_create_default();
@@ -724,16 +716,14 @@ const char *get_disconnect_reason_str(uint8_t reason) {
 }
 
 void WiFiComponent::wifi_loop_() {
-  while (true) {
-    IDFWiFiEvent *data;
-    if (xQueueReceive(s_event_queue, &data, 0L) != pdTRUE) {
-      // no event ready
-      break;
-    }
+  uint16_t dropped = this->event_queue_.get_and_reset_dropped_count();
+  if (dropped > 0) {
+    ESP_LOGW(TAG, "Dropped %u WiFi events due to buffer overflow", dropped);
+  }
 
-    // process event
+  IDFWiFiEvent *data;
+  while ((data = this->event_queue_.pop()) != nullptr) {
     wifi_process_event_(data);
-
     delete data;  // NOLINT(cppcoreguidelines-owning-memory)
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Replaces the FreeRTOS `xQueue` used for WiFi event passing on ESP-IDF with the existing `LockFreeQueue` SPSC ring buffer. This avoids the FreeRTOS kernel spinlock overhead on every loop iteration when checking for events.

The `LockFreeQueue::pop()` fast path when the queue is empty is just two atomic loads and a comparison. `xQueueReceive` takes a spinlock, checks the queue, and releases the spinlock — even when empty. This happens every loop iteration and the queue is almost always empty (WiFi events are rare: connect, disconnect, scan).

WiFi events are rare so heap allocation for event data is retained — no `EventPool` needed unlike the BLE path which processes hundreds of events per second. Dropped events are now logged (the old code silently discarded them).

This matches the lock-free pattern already used by `esp32_ble`.

**Queue sizing:** The old queue had 64 slots (picked as a round number in #2303, never revisited). WiFi events are serialized through the ESP-IDF event loop task, and the realistic worst-case burst is ~6 events (scan done + connect + disconnect + reconnect + got IP + got IPv6). The new queue uses 16 usable slots (17 ring buffer slots, one reserved), which is 2.5x headroom over worst case. Tested on multiple devices (ESP32, ESP32-S3, ESP32-C3) with no queue overflow logged.

**RAM:** The queue is now a member variable on `WiFiComponent` instead of a heap-allocated FreeRTOS queue. Measured **+248 bytes free heap** on ESP32-S3 — the old `xQueueCreate(64, ...)` heap allocation is eliminated. The CI static RAM analysis will show a small increase from the `LockFreeQueue` embedded in the class, but this is offset by the larger heap savings (not visible to static analysis).

**Measured on ESP32-S3 (BLE proxy, steady state, no WiFi events):**
- Before: wifi: count=7493, avg=0.011ms, total=83.1ms
- After: wifi: count=7496, avg=0.008ms, total=61.6ms (26% reduction)
- Free heap: +248 bytes

**Measured on ESP32-C3 (BLE proxy + SCD4x):**
- Before: wifi: count=7340, avg=0.037ms, total=268.3ms
- After: wifi: count=7342, avg=0.036ms, total=260.7ms (3% — C3 bottleneck is elsewhere)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — internal optimization
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).