### PR TITLE
[cse7766] prevent NaN/null power factor in edge cases

### DIFF
--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -206,7 +206,8 @@ void CSE7766Component::parse_data_() {
       if (apparent_power > 0) {
         pf = power / apparent_power;
         if (pf < 0 || pf > 1) {
-          ESP_LOGD(TAG, "Out-of-range power factor %.4f clamped to [0, 1] (measurement noise near chip resolution limit)",
+          ESP_LOGD(TAG,
+                   "Out-of-range power factor %.4f clamped to [0, 1] (measurement noise near chip resolution limit)",
                    pf);
           pf = pf < 0.0f ? 0.0f : 1.0f;
         }

--- a/esphome/components/cse7766/cse7766.cpp
+++ b/esphome/components/cse7766/cse7766.cpp
@@ -206,17 +206,20 @@ void CSE7766Component::parse_data_() {
       if (apparent_power > 0) {
         pf = power / apparent_power;
         if (pf < 0 || pf > 1) {
-          ESP_LOGD(TAG, "Impossible power factor: %.4f not in interval [0, 1]", pf);
-          pf = NAN;
+          ESP_LOGD(TAG, "Out-of-range power factor %.4f clamped to [0, 1] (measurement noise near chip resolution limit)",
+                   pf);
+          pf = pf < 0.0f ? 0.0f : 1.0f;
         }
       } else if (apparent_power == 0 && power == 0) {
         // No load, report ideal power factor
         pf = 1.0f;
       } else if (current == 0 && calculated_current <= 0.05f) {
-        // Datasheet: minimum measured current is 50mA
-        ESP_LOGV(TAG, "Can't calculate power factor (current below minimum for CSE7766)");
+        // Datasheet: minimum measured current is 50mA; no current means no phase shift, unity PF by convention
+        ESP_LOGV(TAG, "Current below 50mA minimum for CSE7766, reporting unity power factor");
+        pf = 1.0f;
       } else {
-        ESP_LOGW(TAG, "Can't calculate power factor from P = %.4f W, S = %.4f VA", power, apparent_power);
+        ESP_LOGW(TAG, "Can't calculate power factor from P = %.4f W, S = %.4f VA; reporting 0", power, apparent_power);
+        pf = 0.0f;
       }
       this->power_factor_sensor_->publish_state(pf);
     }


### PR DESCRIPTION
# What does this implement/fix?

The power factor sensor currently publishes a NaN in two situations:

1. When the calculated PF is outside [0, 1] (e.g. during inrush transients where chip ADC noise may cause invalid values)
2. Implicitly, when current is below the chip's 50mA minimum threshold, where messages are logged but the NaN propagates through.

In Home Assistant, or any other downstream consumer, this NaN is stored as unknown/null, which breaks statistics, averaging filters, and history graphs, producing gaps and poisoning averages. I have experienced this myself frequently when monitoring an air conditioner that frequently cycles, as well as monitoring power factor across other devices with strong inrush currents, e.g. an air conditioner as follows:

<img width="1417" height="840" alt="image" src="https://github.com/user-attachments/assets/8e76fa5c-79d0-4e6d-a71f-edc26565f7ac" />

While NaN may be technically mathematically correct, I believe the benefits of a consistent, numerical output outweigh a desire for true correctness here, and thus propose ensuring that this sensor always outputs a numeric value as follows:

1. Out-of-range PF: clamp to 0 or 1 instead of NaN. These are likely ADC noise artifacts rather than true physical impossibilities. The nearest valid boundary is a more reasonable interpretation with the goal of always outputting a numerical value, and this is consistent with how the other impossible reactive power values are already handled here.
2. Below-threshold current: explicitly publish 1.0f. When current is below 50mA the load is effectively absent; unity PF is the typical convention here, found on many other devices. This also matches the existing apparent_power == 0 && power == 0 case which returns 1.0.
3. Unexpected fallback: publish 0.0f rather than NaN so downstream consumers always receive a numeric value, though this one is less likely to happen and I'm open to leaving it NaN for the exceptional error case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A, though happy to create one if desired.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A, the current behaviour is not explicitly (or implicitly) documented, so I don't believe a documentation change is warranted.

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A, same as existing sensor configuration.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder). **No tests currently exist for this code, so none added.**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). **N/A**
