### PR TITLE
[esp32_ble_tracker] Restart BLE scan after OTA failure

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -95,13 +95,11 @@ void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, u
       client->disconnect();
     }
 #endif
-  } else if (state == ota::OTA_ERROR || state == ota::OTA_ABORT) {
-    if (this->scan_continuous_before_ota_) {
-      this->scan_continuous_before_ota_ = false;
-      this->scan_continuous_ = true;
-      // Do not restart scanning immediately here; allow loop() to
-      // safely restart scanning once the scanner and all clients are idle.
-    }
+  } else if ((state == ota::OTA_ERROR || state == ota::OTA_ABORT) && this->scan_continuous_before_ota_) {
+    this->scan_continuous_before_ota_ = false;
+    this->scan_continuous_ = true;
+    // Do not restart scanning immediately here; allow loop() to
+    // safely restart scanning once the scanner and all clients are idle.
   }
 }
 #endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -88,12 +88,19 @@ void ESP32BLETracker::setup() {
 #ifdef USE_OTA_STATE_LISTENER
 void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) {
   if (state == ota::OTA_STARTED) {
+    this->scan_continuous_before_ota_ = this->scan_continuous_;
     this->stop_scan();
 #ifdef ESPHOME_ESP32_BLE_TRACKER_CLIENT_COUNT
     for (auto *client : this->clients_) {
       client->disconnect();
     }
 #endif
+  } else if (state == ota::OTA_ERROR || state == ota::OTA_ABORT) {
+    if (this->scan_continuous_before_ota_) {
+      this->scan_continuous_before_ota_ = false;
+      this->scan_continuous_ = true;
+      this->start_scan();
+    }
   }
 }
 #endif

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -99,7 +99,8 @@ void ESP32BLETracker::on_ota_global_state(ota::OTAState state, float progress, u
     if (this->scan_continuous_before_ota_) {
       this->scan_continuous_before_ota_ = false;
       this->scan_continuous_ = true;
-      this->start_scan();
+      // Do not restart scanning immediately here; allow loop() to
+      // safely restart scanning once the scanner and all clients are idle.
     }
   }
 }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -436,6 +436,7 @@ class ESP32BLETracker : public Component,
   ScannerState scanner_state_{ScannerState::IDLE};
   bool scan_continuous_;
   bool scan_active_;
+  bool scan_continuous_before_ota_{false};
   bool ble_was_disabled_{true};
   bool raw_advertisements_{false};
   bool parse_advertisements_{false};

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -436,7 +436,9 @@ class ESP32BLETracker : public Component,
   ScannerState scanner_state_{ScannerState::IDLE};
   bool scan_continuous_;
   bool scan_active_;
+#ifdef USE_OTA_STATE_LISTENER
   bool scan_continuous_before_ota_{false};
+#endif
   bool ble_was_disabled_{true};
   bool raw_advertisements_{false};
   bool parse_advertisements_{false};


### PR DESCRIPTION
# What does this implement/fix?

When OTA starts, `stop_scan()` is called which clears the `scan_continuous_` flag. If OTA fails or aborts, the scan was never restarted because `scan_continuous_` was already `false`. This left the device without BLE scanning until reboot.

This fix saves the `scan_continuous_` state before stopping the scan on `OTA_STARTED`, and restores it on `OTA_ERROR` or `OTA_ABORT` to resume scanning.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is an internal bug fix
esp32_ble_tracker:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).