### PR TITLE
[nextion] Fix queue age check using inconsistent time sources

### DIFF
--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1034,7 +1034,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
   nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->component->set_variable_name(variable_name);
 
-  nextion_queue->queue_time = millis();
+  nextion_queue->queue_time = App.get_loop_component_start_time();
 
   this->nextion_queue_.push_back(nextion_queue);
 


### PR DESCRIPTION
# What does this implement/fix?

`add_no_result_to_queue_()` was setting `queue_time` using `millis()`, while the queue age timeout check in `process_nextion_commands_()` uses `App.get_loop_component_start_time()` as the reference clock.

These two values are not guaranteed to be equal. If `App.get_loop_component_start_time()` lags behind `millis()` by more than `max_q_age_ms_`, the subtraction `ms - queue_time` underflows (both are `uint32_t`) and produces a large positive number, causing freshly-queued `NO_RESULT` items to be immediately purged as if they had timed out.

This was confirmed by UART tracing: items queued only milliseconds earlier were being removed by the timeout loop, followed immediately by the Nextion sending the expected `0x01` ACKs against an already-empty queue, producing spurious `[E][nextion] Queue empty` errors.

`add_to_get_queue()` was already using `App.get_loop_component_start_time()`  correctly. This change aligns `add_no_result_to_queue_()` with the same time source, making the age calculation consistent across all queue insertion paths.

`App.get_loop_component_start_time()` is also cheaper than `millis()` since it returns a cached value set once per loop iteration, avoiding a hardware register read.

### Notes

- No behaviour change under normal conditions where the two clocks are close
- Fixes spurious `[E][nextion] Queue empty` errors after page changes
- Fixes spurious `[D][nextion] Remove old queue` purges of live items
- One-line change with no API impact


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
