### PR TITLE
[core] Suppress component source overflow warnings in testing mode

### DIFF
--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -71,11 +71,13 @@ def register_component_source(name: str) -> int:
         return pool.sources[name]
     idx = len(pool.sources) + 1
     if idx > _MAX_COMPONENT_SOURCES:
-        _LOGGER.warning(
-            "Too many unique component source names (max %d), '%s' will show as '<unknown>'",
-            _MAX_COMPONENT_SOURCES,
-            name,
-        )
+        if not CORE.testing_mode:
+            _LOGGER.warning(
+                "Too many unique component source names (max %d), "
+                "'%s' will show as '<unknown>'",
+                _MAX_COMPONENT_SOURCES,
+                name,
+            )
         return 0
     pool.sources[name] = idx
     _ensure_source_table_registered()

--- a/tests/unit_tests/test_cpp_helpers.py
+++ b/tests/unit_tests/test_cpp_helpers.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -131,14 +132,36 @@ async def test_generate_component_source_table_empty_pool(
     add_global_mock.assert_not_called()
 
 
-def test_register_component_source_overflow_returns_zero(
-    monkeypatch: pytest.MonkeyPatch,
+def test_register_component_source_overflow_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     # Pre-fill pool to max
     pool = ComponentSourcePool(
         sources={f"comp_{i}": i + 1 for i in range(0xFF)},
         table_registered=True,
     )
-    monkeypatch.setattr(ch, "CORE", Mock(data={ch._COMPONENT_SOURCE_DOMAIN: pool}))
-    idx = register_component_source("overflow_component")
+    monkeypatch.setattr(
+        ch, "CORE", Mock(data={ch._COMPONENT_SOURCE_DOMAIN: pool}, testing_mode=False)
+    )
+    with caplog.at_level(logging.WARNING):
+        idx = register_component_source("overflow_component")
     assert idx == 0
+    assert "Too many unique component source names" in caplog.text
+    assert "overflow_component" in caplog.text
+
+
+def test_register_component_source_overflow_suppressed_in_testing_mode(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Pre-fill pool to max
+    pool = ComponentSourcePool(
+        sources={f"comp_{i}": i + 1 for i in range(0xFF)},
+        table_registered=True,
+    )
+    monkeypatch.setattr(
+        ch, "CORE", Mock(data={ch._COMPONENT_SOURCE_DOMAIN: pool}, testing_mode=True)
+    )
+    with caplog.at_level(logging.WARNING):
+        idx = register_component_source("overflow_component")
+    assert idx == 0
+    assert "Too many unique component source names" not in caplog.text

--- a/tests/unit_tests/test_cpp_helpers.py
+++ b/tests/unit_tests/test_cpp_helpers.py
@@ -1,4 +1,3 @@
-import logging
 from unittest.mock import Mock
 
 import pytest
@@ -132,8 +131,8 @@ async def test_generate_component_source_table_empty_pool(
     add_global_mock.assert_not_called()
 
 
-def test_register_component_source_overflow_warns(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def test_register_component_source_overflow_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Pre-fill pool to max
     pool = ComponentSourcePool(
@@ -141,8 +140,5 @@ def test_register_component_source_overflow_warns(
         table_registered=True,
     )
     monkeypatch.setattr(ch, "CORE", Mock(data={ch._COMPONENT_SOURCE_DOMAIN: pool}))
-    with caplog.at_level(logging.WARNING):
-        idx = register_component_source("overflow_component")
+    idx = register_component_source("overflow_component")
     assert idx == 0
-    assert "Too many unique component source names" in caplog.text
-    assert "overflow_component" in caplog.text


### PR DESCRIPTION
# What does this implement/fix?

Suppress the "Too many unique component source names" warning when `CORE.testing_mode` is set. This limit (255) is only hit in CI when many components are compiled together in test builds — production configs won't realistically reach it. The warning is still emitted for non-testing builds.

We considered expanding the index from 8 to 9 bits (bitfielding `component_source_index_` and `warn_if_blocking_over_`) in #15319, but that added +232 bytes of flash for code nobody would use on a real device.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal change, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).