### PR TITLE
[multiple] Fix -Wformat and -Wextra warnings across 33 component files

### DIFF
--- a/esphome/components/adc/adc_sensor_esp32.cpp
+++ b/esphome/components/adc/adc_sensor_esp32.cpp
@@ -2,6 +2,7 @@
 
 #include "adc_sensor.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome {
 namespace adc {
@@ -346,7 +347,8 @@ float ADCSensor::sample_autorange_() {
   ESP_LOGVV(TAG, "Autorange summary:");
   ESP_LOGVV(TAG, "  Raw readings: 12db=%d, 6db=%d, 2.5db=%d, 0db=%d", raw12, raw6, raw2, raw0);
   ESP_LOGVV(TAG, "  Voltages: 12db=%.6f, 6db=%.6f, 2.5db=%.6f, 0db=%.6f", mv12, mv6, mv2, mv0);
-  ESP_LOGVV(TAG, "  Coefficients: c12=%u, c6=%u, c2=%u, c0=%u, sum=%u", c12, c6, c2, c0, csum);
+  ESP_LOGVV(TAG, "  Coefficients: c12=%" PRIu32 ", c6=%" PRIu32 ", c2=%" PRIu32 ", c0=%" PRIu32 ", sum=%" PRIu32, c12,
+            c6, c2, c0, csum);
 
   if (csum == 0) {
     ESP_LOGE(TAG, "Invalid weight sum in autorange calculation");
@@ -354,8 +356,10 @@ float ADCSensor::sample_autorange_() {
   }
 
   const float final_result = (mv12 * c12 + mv6 * c6 + mv2 * c2 + mv0 * c0) / csum;
-  ESP_LOGV(TAG, "Autorange final: (%.6f*%u + %.6f*%u + %.6f*%u + %.6f*%u)/%u = %.6fV", mv12, c12, mv6, c6, mv2, c2, mv0,
-           c0, csum, final_result);
+  ESP_LOGV(TAG,
+           "Autorange final: (%.6f*%" PRIu32 " + %.6f*%" PRIu32 " + %.6f*%" PRIu32 " + %.6f*%" PRIu32 ")/%" PRIu32
+           " = %.6fV",
+           mv12, c12, mv6, c6, mv2, c2, mv0, c0, csum, final_result);
 
   return final_result;
 }

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1465,7 +1465,7 @@ void APIConnection::send_infrared_rf_receive_event(const InfraredRFReceiveEvent 
 void APIConnection::on_serial_proxy_configure_request(const SerialProxyConfigureRequest &msg) {
   auto &proxies = App.get_serial_proxies();
   if (msg.instance >= proxies.size()) {
-    ESP_LOGW(TAG, "Serial proxy instance %u out of range (max %u)", msg.instance,
+    ESP_LOGW(TAG, "Serial proxy instance %" PRIu32 " out of range (max %" PRIu32 ")", msg.instance,
              static_cast<uint32_t>(proxies.size()));
     return;
   }
@@ -1476,7 +1476,7 @@ void APIConnection::on_serial_proxy_configure_request(const SerialProxyConfigure
 void APIConnection::on_serial_proxy_write_request(const SerialProxyWriteRequest &msg) {
   auto &proxies = App.get_serial_proxies();
   if (msg.instance >= proxies.size()) {
-    ESP_LOGW(TAG, "Serial proxy instance %u out of range", msg.instance);
+    ESP_LOGW(TAG, "Serial proxy instance %" PRIu32 " out of range", msg.instance);
     return;
   }
   proxies[msg.instance]->write_from_client(msg.data, msg.data_len);
@@ -1485,7 +1485,7 @@ void APIConnection::on_serial_proxy_write_request(const SerialProxyWriteRequest 
 void APIConnection::on_serial_proxy_set_modem_pins_request(const SerialProxySetModemPinsRequest &msg) {
   auto &proxies = App.get_serial_proxies();
   if (msg.instance >= proxies.size()) {
-    ESP_LOGW(TAG, "Serial proxy instance %u out of range", msg.instance);
+    ESP_LOGW(TAG, "Serial proxy instance %" PRIu32 " out of range", msg.instance);
     return;
   }
   proxies[msg.instance]->set_modem_pins(msg.line_states);
@@ -1494,7 +1494,7 @@ void APIConnection::on_serial_proxy_set_modem_pins_request(const SerialProxySetM
 void APIConnection::on_serial_proxy_get_modem_pins_request(const SerialProxyGetModemPinsRequest &msg) {
   auto &proxies = App.get_serial_proxies();
   if (msg.instance >= proxies.size()) {
-    ESP_LOGW(TAG, "Serial proxy instance %u out of range", msg.instance);
+    ESP_LOGW(TAG, "Serial proxy instance %" PRIu32 " out of range", msg.instance);
     return;
   }
   SerialProxyGetModemPinsResponse resp{};
@@ -1506,7 +1506,7 @@ void APIConnection::on_serial_proxy_get_modem_pins_request(const SerialProxyGetM
 void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
   auto &proxies = App.get_serial_proxies();
   if (msg.instance >= proxies.size()) {
-    ESP_LOGW(TAG, "Serial proxy instance %u out of range", msg.instance);
+    ESP_LOGW(TAG, "Serial proxy instance %" PRIu32 " out of range", msg.instance);
     return;
   }
   switch (msg.type) {
@@ -1536,7 +1536,7 @@ void APIConnection::on_serial_proxy_request(const SerialProxyRequest &msg) {
       break;
     }
     default:
-      ESP_LOGW(TAG, "Unknown serial proxy request type: %u", static_cast<uint32_t>(msg.type));
+      ESP_LOGW(TAG, "Unknown serial proxy request type: %" PRIu32, static_cast<uint32_t>(msg.type));
       break;
   }
 }

--- a/esphome/components/audio_file/media_source/audio_file_media_source.cpp
+++ b/esphome/components/audio_file/media_source/audio_file_media_source.cpp
@@ -4,6 +4,7 @@
 
 #include "esphome/components/audio/audio_decoder.h"
 
+#include <cinttypes>
 #include <cstring>
 
 namespace esphome::audio_file {
@@ -249,7 +250,7 @@ void AudioFileMediaSource::decode_task(void *params) {
 
         audio::AudioStreamInfo stream_info = decoder->get_audio_stream_info().value();
 
-        ESP_LOGD(TAG, "Bits per sample: %d, Channels: %d, Sample rate: %d", stream_info.get_bits_per_sample(),
+        ESP_LOGD(TAG, "Bits per sample: %d, Channels: %d, Sample rate: %" PRIu32, stream_info.get_bits_per_sample(),
                  stream_info.get_channels(), stream_info.get_sample_rate());
 
         if (stream_info.get_bits_per_sample() != 16 || stream_info.get_channels() > 2) {

--- a/esphome/components/bm8563/bm8563.cpp
+++ b/esphome/components/bm8563/bm8563.cpp
@@ -1,4 +1,7 @@
 #include "bm8563.h"
+
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 namespace esphome::bm8563 {
@@ -146,10 +149,10 @@ optional<uint8_t> BM8563::read_register_(uint8_t reg) {
 }
 
 void BM8563::set_timer_irq_(uint32_t duration_s) {
-  ESP_LOGI(TAG, "Timer Duration: %u s", duration_s);
+  ESP_LOGI(TAG, "Timer Duration: %" PRIu32 " s", duration_s);
 
   if (duration_s > MAX_TIMER_DURATION_S) {
-    ESP_LOGW(TAG, "Timer duration %u s exceeds maximum %u s", duration_s, MAX_TIMER_DURATION_S);
+    ESP_LOGW(TAG, "Timer duration %" PRIu32 " s exceeds maximum %" PRIu32 " s", duration_s, MAX_TIMER_DURATION_S);
     return;
   }
 

--- a/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
+++ b/esphome/components/bme68x_bsec2/bme68x_bsec2.cpp
@@ -89,7 +89,7 @@ void BME68xBSEC2Component::dump_config() {
                 "  Operating age: %s\n"
                 "  Sample rate: %s\n"
                 "  Voltage: %s\n"
-                "  State save interval: %ims\n"
+                "  State save interval: %" PRIu32 "ms\n"
                 "  Temperature offset: %.2f",
                 BME68X_BSEC2_OPERATING_AGE_LOG(this->operating_age_), BME68X_BSEC2_SAMPLE_RATE_LOG(this->sample_rate_),
                 BME68X_BSEC2_VOLTAGE_LOG(this->voltage_), this->state_save_interval_ms_, this->temperature_offset_);
@@ -283,7 +283,7 @@ void BME68xBSEC2Component::run_() {
   if (this->bsec_settings_.trigger_measurement && this->bsec_settings_.op_mode != BME68X_SLEEP_MODE) {
     bme68x_get_conf(&bme68x_conf, &this->bme68x_);
     uint32_t meas_dur = bme68x_get_meas_dur(this->op_mode_, &bme68x_conf, &this->bme68x_);
-    ESP_LOGV(TAG, "Queueing read in %uus", meas_dur);
+    ESP_LOGV(TAG, "Queueing read in %" PRIu32 "us", meas_dur);
     this->trigger_time_ns_ = curr_time_ns;
     this->set_timeout("read", meas_dur / 1000, [this]() { this->read_(this->trigger_time_ns_); });
   } else {

--- a/esphome/components/dlms_meter/dlms_meter.cpp
+++ b/esphome/components/dlms_meter/dlms_meter.cpp
@@ -1,5 +1,7 @@
 #include "dlms_meter.h"
 
+#include <cinttypes>
+
 #if defined(USE_ESP8266_FRAMEWORK_ARDUINO)
 #include <bearssl/bearssl.h>
 #elif defined(USE_ESP32)
@@ -21,7 +23,7 @@ void DlmsMeterComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "DLMS Meter:\n"
                 "  Provider: %s\n"
-                "  Read Timeout: %u ms",
+                "  Read Timeout: %" PRIu32 " ms",
                 provider_name, this->read_timeout_);
 #define DLMS_METER_LOG_SENSOR(s) LOG_SENSOR("  ", #s, this->s##_sensor_);
   DLMS_METER_SENSOR_LIST(DLMS_METER_LOG_SENSOR, )

--- a/esphome/components/esp32_touch/esp32_touch.cpp
+++ b/esphome/components/esp32_touch/esp32_touch.cpp
@@ -217,7 +217,7 @@ void ESP32TouchComponent::setup() {
   for (uint32_t i = 0; i < ONESHOT_SCAN_COUNT; i++) {
     err = touch_sensor_trigger_oneshot_scanning(this->sens_handle_, ONESHOT_SCAN_TIMEOUT_MS);
     if (err != ESP_OK) {
-      ESP_LOGW(TAG, "Oneshot scan %d failed: %s", i, esp_err_to_name(err));
+      ESP_LOGW(TAG, "Oneshot scan %" PRIu32 " failed: %s", i, esp_err_to_name(err));
     }
   }
 

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -4,6 +4,8 @@
 
 #include "espnow_err.h"
 
+#include <cinttypes>
+
 #include "esphome/core/application.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/helpers.h"
@@ -266,7 +268,7 @@ void ESPNowComponent::loop() {
   if (wifi::global_wifi_component != nullptr && wifi::global_wifi_component->is_connected()) {
     int32_t new_channel = wifi::global_wifi_component->get_wifi_channel();
     if (new_channel != this->wifi_channel_) {
-      ESP_LOGI(TAG, "Wifi Channel is changed from %d to %d.", this->wifi_channel_, new_channel);
+      ESP_LOGI(TAG, "Wifi Channel is changed from %d to %" PRId32 ".", this->wifi_channel_, new_channel);
       this->wifi_channel_ = new_channel;
     }
   }

--- a/esphome/components/http_request/http_request.cpp
+++ b/esphome/components/http_request/http_request.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "http_request";
 void HttpRequestComponent::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "HTTP Request:\n"
-                "  Timeout: %ums\n"
+                "  Timeout: %" PRIu32 "ms\n"
                 "  User-Agent: %s\n"
                 "  Follow redirects: %s\n"
                 "  Redirect limit: %d",

--- a/esphome/components/hub75/hub75.cpp
+++ b/esphome/components/hub75/hub75.cpp
@@ -1,6 +1,8 @@
 #include "hub75_component.h"
 #include "esphome/core/application.h"
 
+#include <cinttypes>
+
 #ifdef USE_ESP32
 
 namespace esphome::hub75 {
@@ -58,7 +60,7 @@ void HUB75Display::dump_config() {
                 config_.pins.oe, config_.pins.clk);
 
   ESP_LOGCONFIG(TAG,
-                "  Clock Speed: %u MHz\n"
+                "  Clock Speed: %" PRIu32 " MHz\n"
                 "  Latch Blanking: %i\n"
                 "  Clock Phase: %s\n"
                 "  Min Refresh Rate: %i Hz\n"

--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -1,4 +1,7 @@
 #include "infrared.h"
+
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 #ifdef USE_API
@@ -100,7 +103,7 @@ void Infrared::control(const InfraredCall &call) {
     // Zero-copy from packed protobuf data
     transmit_data->set_data_from_packed_sint32(call.get_packed_data(), call.get_packed_length(),
                                                call.get_packed_count());
-    ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%u", call.get_packed_count(),
+    ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%" PRIu32, call.get_packed_count(),
              call.get_repeat_count());
   } else if (call.is_base64url()) {
     // Decode base64url (URL-safe) into transmit buffer
@@ -113,16 +116,16 @@ void Infrared::control(const InfraredCall &call) {
     for (int32_t timing : transmit_data->get_data()) {
       int32_t abs_timing = timing < 0 ? -timing : timing;
       if (abs_timing > max_timing_us) {
-        ESP_LOGE(TAG, "Invalid timing value: %d µs (max %d)", timing, max_timing_us);
+        ESP_LOGE(TAG, "Invalid timing value: %" PRId32 " µs (max %" PRId32 ")", timing, max_timing_us);
         return;
       }
     }
-    ESP_LOGD(TAG, "Transmitting base64url raw timings: count=%zu, repeat=%u", transmit_data->get_data().size(),
+    ESP_LOGD(TAG, "Transmitting base64url raw timings: count=%zu, repeat=%" PRIu32, transmit_data->get_data().size(),
              call.get_repeat_count());
   } else {
     // From vector (lambdas/automations)
     transmit_data->set_data(call.get_raw_timings());
-    ESP_LOGD(TAG, "Transmitting raw timings: count=%zu, repeat=%u", call.get_raw_timings().size(),
+    ESP_LOGD(TAG, "Transmitting raw timings: count=%zu, repeat=%" PRIu32, call.get_raw_timings().size(),
              call.get_repeat_count());
   }
 

--- a/esphome/components/infrared/infrared.cpp
+++ b/esphome/components/infrared/infrared.cpp
@@ -103,7 +103,7 @@ void Infrared::control(const InfraredCall &call) {
     // Zero-copy from packed protobuf data
     transmit_data->set_data_from_packed_sint32(call.get_packed_data(), call.get_packed_length(),
                                                call.get_packed_count());
-    ESP_LOGD(TAG, "Transmitting packed raw timings: count=%u, repeat=%" PRIu32, call.get_packed_count(),
+    ESP_LOGD(TAG, "Transmitting packed raw timings: count=%" PRIu16 ", repeat=%" PRIu32, call.get_packed_count(),
              call.get_repeat_count());
   } else if (call.is_base64url()) {
     // Decode base64url (URL-safe) into transmit buffer

--- a/esphome/components/inkplate/inkplate.cpp
+++ b/esphome/components/inkplate/inkplate.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 #include <hal/gpio_hal.h>
 
 namespace esphome {
@@ -193,7 +195,7 @@ void Inkplate::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "  Greyscale: %s\n"
                 "  Partial Updating: %s\n"
-                "  Full Update Every: %d",
+                "  Full Update Every: %" PRIu32,
                 YESNO(this->greyscale_), YESNO(this->partial_updating_), this->full_update_every_);
   // Log pins
   LOG_PIN("  CKV Pin: ", this->ckv_pin_);
@@ -306,7 +308,7 @@ void Inkplate::fill(Color color) {
   // If clipping is active, fall back to base implementation
   if (this->get_clipping().is_set()) {
     Display::fill(color);
-    ESP_LOGV(TAG, "Fill finished (%ums)", millis() - start_time);
+    ESP_LOGV(TAG, "Fill finished (%" PRIu32 "ms)", millis() - start_time);
     return;
   }
 
@@ -329,12 +331,12 @@ void Inkplate::display() {
     this->display3b_();
   } else {
     if (this->partial_updating_ && this->partial_update_()) {
-      ESP_LOGV(TAG, "Display finished (partial) (%ums)", millis() - start_time);
+      ESP_LOGV(TAG, "Display finished (partial) (%" PRIu32 "ms)", millis() - start_time);
       return;
     }
     this->display1b_();
   }
-  ESP_LOGV(TAG, "Display finished (full) (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Display finished (full) (%" PRIu32 "ms)", millis() - start_time);
 }
 
 void Inkplate::display1b_() {
@@ -409,7 +411,7 @@ void Inkplate::display1b_() {
 
   uint32_t clock = (1UL << this->cl_pin_->get_pin());
   uint32_t data_mask = this->get_data_pin_mask_();
-  ESP_LOGV(TAG, "Display1b start loops (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Display1b start loops (%" PRIu32 "ms)", millis() - start_time);
 
   for (uint8_t k = 0; k < rep; k++) {
     buffer_ptr = &this->buffer_[this->get_buffer_length_() - 1];
@@ -440,7 +442,7 @@ void Inkplate::display1b_() {
     }
     delayMicroseconds(230);
   }
-  ESP_LOGV(TAG, "Display1b first loop x %d (%ums)", 4, millis() - start_time);
+  ESP_LOGV(TAG, "Display1b first loop x %d (%" PRIu32 "ms)", 4, millis() - start_time);
 
   buffer_ptr = &this->buffer_[this->get_buffer_length_() - 1];
   vscan_start_();
@@ -469,7 +471,7 @@ void Inkplate::display1b_() {
     vscan_end_();
   }
   delayMicroseconds(230);
-  ESP_LOGV(TAG, "Display1b second loop (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Display1b second loop (%" PRIu32 "ms)", millis() - start_time);
 
   if (this->model_ == INKPLATE_6_PLUS) {
     clean_fast_(2, 2);
@@ -495,13 +497,13 @@ void Inkplate::display1b_() {
       vscan_end_();
     }
     delayMicroseconds(230);
-    ESP_LOGV(TAG, "Display1b third loop (%ums)", millis() - start_time);
+    ESP_LOGV(TAG, "Display1b third loop (%" PRIu32 "ms)", millis() - start_time);
   }
   vscan_start_();
   eink_off_();
   this->block_partial_ = false;
   this->partial_updates_ = 0;
-  ESP_LOGV(TAG, "Display1b finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Display1b finished (%" PRIu32 "ms)", millis() - start_time);
 }
 
 void Inkplate::display3b_() {
@@ -614,7 +616,7 @@ void Inkplate::display3b_() {
   clean_fast_(3, 1);
   vscan_start_();
   eink_off_();
-  ESP_LOGV(TAG, "Display3b finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Display3b finished (%" PRIu32 "ms)", millis() - start_time);
 }
 
 bool Inkplate::partial_update_() {
@@ -641,7 +643,7 @@ bool Inkplate::partial_update_() {
       this->partial_buffer_2_[n--] = LUTW[diffw & 0x0F] & LUTB[diffb & 0x0F];
     }
   }
-  ESP_LOGV(TAG, "Partial update buffer built after (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Partial update buffer built after (%" PRIu32 "ms)", millis() - start_time);
 
   int rep = (this->model_ == INKPLATE_6_V2) ? 6 : 5;
 
@@ -667,7 +669,7 @@ bool Inkplate::partial_update_() {
       vscan_end_();
     }
     delayMicroseconds(230);
-    ESP_LOGV(TAG, "Partial update loop k=%d (%ums)", k, millis() - start_time);
+    ESP_LOGV(TAG, "Partial update loop k=%d (%" PRIu32 "ms)", k, millis() - start_time);
   }
   clean_fast_(2, 2);
   clean_fast_(3, 1);
@@ -675,7 +677,7 @@ bool Inkplate::partial_update_() {
   eink_off_();
 
   memcpy(this->buffer_, this->partial_buffer_, this->get_buffer_length_());
-  ESP_LOGV(TAG, "Partial update finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Partial update finished (%" PRIu32 "ms)", millis() - start_time);
   return true;
 }
 
@@ -730,7 +732,7 @@ void Inkplate::clean() {
   clean_fast_(0, 8);   // Black to Black
   clean_fast_(2, 1);   // Black to White
   clean_fast_(1, 10);  // White to White
-  ESP_LOGV(TAG, "Clean finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Clean finished (%" PRIu32 "ms)", millis() - start_time);
 }
 
 void Inkplate::clean_fast_(uint8_t c, uint8_t rep) {
@@ -773,9 +775,9 @@ void Inkplate::clean_fast_(uint8_t c, uint8_t rep) {
       vscan_end_();
     }
     delayMicroseconds(230);
-    ESP_LOGV(TAG, "Clean fast rep loop %d finished (%ums)", k, millis() - start_time);
+    ESP_LOGV(TAG, "Clean fast rep loop %d finished (%" PRIu32 "ms)", k, millis() - start_time);
   }
-  ESP_LOGV(TAG, "Clean fast finished (%ums)", millis() - start_time);
+  ESP_LOGV(TAG, "Clean fast finished (%" PRIu32 "ms)", millis() - start_time);
 }
 
 void Inkplate::pins_z_state_() {

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -10,6 +10,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#include <cinttypes>
 #include <cmath>
 #include <numbers>
 
@@ -575,7 +576,7 @@ void LD2450Component::handle_periodic_data_() {
       if (this->get_timeout_status_(this->presence_millis_)) {
         this->target_binary_sensor_->publish_state(false);
       } else {
-        ESP_LOGV(TAG, "Clear presence waiting timeout: %d", this->timeout_);
+        ESP_LOGV(TAG, "Clear presence waiting timeout: %" PRIu32, this->timeout_);
       }
     }
   }

--- a/esphome/components/max7219digit/max7219digit.cpp
+++ b/esphome/components/max7219digit/max7219digit.cpp
@@ -6,6 +6,7 @@
 #include "max7219font.h"
 
 #include <algorithm>
+#include <cinttypes>
 
 namespace esphome {
 namespace max7219digit {
@@ -92,7 +93,9 @@ void MAX7219Component::loop() {
   if (this->scroll_mode_ == ScrollMode::STOP) {
     if (static_cast<size_t>(this->stepsleft_ + get_width_internal()) == first_line_size + 1) {
       if (millis_since_last_scroll < this->scroll_dwell_) {
-        ESP_LOGVV(TAG, "Dwell time at end of string in case of stop at end. Step %d, since last scroll %d, dwell %d.",
+        ESP_LOGVV(TAG,
+                  "Dwell time at end of string in case of stop at end. Step %d, since last scroll %" PRIu32
+                  ", dwell %d.",
                   this->stepsleft_, millis_since_last_scroll, this->scroll_dwell_);
         return;
       }

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -313,7 +313,7 @@ void Modbus::send_next_frame_() {
   this->last_send_ = millis();
   this->tx_buffer_.pop_front();
   if (!this->tx_buffer_.empty()) {
-    ESP_LOGV(TAG, "Write queue contains %" PRIu32 " items.", this->tx_buffer_.size());
+    ESP_LOGV(TAG, "Write queue contains %zu items.", this->tx_buffer_.size());
   }
 }
 

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -319,14 +319,14 @@ void Nextion::filled_circle(uint16_t center_x, uint16_t center_y, uint16_t radiu
 void Nextion::qrcode(uint16_t x1, uint16_t y1, const char *content, uint16_t size, uint16_t background_color,
                      uint16_t foreground_color, int32_t logo_pic, uint8_t border_width) {
   this->add_no_result_to_queue_with_printf_(
-      "qrcode", "qrcode %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu8 ",%" PRIu8 ",\"%s\"", x1,
+      "qrcode", "qrcode %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRId32 ",%" PRIu8 ",\"%s\"", x1,
       y1, size, background_color, foreground_color, logo_pic, border_width, content);
 }
 
 void Nextion::qrcode(uint16_t x1, uint16_t y1, const char *content, uint16_t size, Color background_color,
                      Color foreground_color, int32_t logo_pic, uint8_t border_width) {
   this->add_no_result_to_queue_with_printf_(
-      "qrcode", "qrcode %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu8 ",%" PRIu8 ",\"%s\"", x1,
+      "qrcode", "qrcode %" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRIu16 ",%" PRId32 ",%" PRIu8 ",\"%s\"", x1,
       y1, size, display::ColorUtil::color_to_565(background_color), display::ColorUtil::color_to_565(foreground_color),
       logo_pic, border_width, content);
 }

--- a/esphome/components/qmp6988/qmp6988.cpp
+++ b/esphome/components/qmp6988/qmp6988.cpp
@@ -1,4 +1,6 @@
 #include "qmp6988.h"
+
+#include <cinttypes>
 #include <cmath>
 
 namespace esphome {
@@ -129,7 +131,7 @@ bool QMP6988Component::get_calibration_data_() {
 
   ESP_LOGV(TAG,
            "Calibration data:\n"
-           "  COE_a0[%d] COE_a1[%d] COE_a2[%d] COE_b00[%d]\n"
+           "  COE_a0[%" PRId32 "] COE_a1[%d] COE_a2[%d] COE_b00[%" PRId32 "]\n"
            "  COE_bt1[%d] COE_bt2[%d] COE_bp1[%d] COE_b11[%d]\n"
            "  COE_bp2[%d] COE_b12[%d] COE_b21[%d] COE_bp3[%d]",
            qmp6988_data_.qmp6988_cali.COE_a0, qmp6988_data_.qmp6988_cali.COE_a1, qmp6988_data_.qmp6988_cali.COE_a2,
@@ -153,7 +155,7 @@ bool QMP6988Component::get_calibration_data_() {
   qmp6988_data_.ik.bp3 = 2915L * (int64_t) qmp6988_data_.qmp6988_cali.COE_bp3 + 157155561L;    // 28Q65
   ESP_LOGV(TAG,
            "Int calibration data:\n"
-           "  a0[%d] a1[%d] a2[%d] b00[%d]\n"
+           "  a0[%" PRId32 "] a1[%" PRId32 "] a2[%" PRId32 "] b00[%" PRId32 "]\n"
            "  bt1[%lld] bt2[%lld] bp1[%lld] b11[%lld]\n"
            "  bp2[%lld] b12[%lld] b21[%lld] bp3[%lld]",
            qmp6988_data_.ik.a0, qmp6988_data_.ik.a1, qmp6988_data_.ik.a2, qmp6988_data_.ik.b00, qmp6988_data_.ik.bt1,

--- a/esphome/components/rd03d/rd03d.cpp
+++ b/esphome/components/rd03d/rd03d.cpp
@@ -1,6 +1,8 @@
 #include "rd03d.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+
+#include <cinttypes>
 #include <cmath>
 
 namespace esphome::rd03d {
@@ -56,7 +58,7 @@ void RD03DComponent::dump_config() {
                   *this->tracking_mode_ == TrackingMode::SINGLE_TARGET ? "single" : "multi");
   }
   if (this->throttle_ > 0) {
-    ESP_LOGCONFIG(TAG, "  Throttle: %ums", this->throttle_);
+    ESP_LOGCONFIG(TAG, "  Throttle: %" PRIu32 "ms", this->throttle_);
   }
 #ifdef USE_SENSOR
   LOG_SENSOR("  ", "Target Count", this->target_count_sensor_);

--- a/esphome/components/remote_base/symphony_protocol.cpp
+++ b/esphome/components/remote_base/symphony_protocol.cpp
@@ -28,7 +28,7 @@ static constexpr uint32_t INTER_FRAME_GAP_US = 34760;
 
 void SymphonyProtocol::encode(RemoteTransmitData *dst, const SymphonyData &data) {
   dst->set_carrier_frequency(CARRIER_FREQUENCY);
-  ESP_LOGD(TAG, "Sending Symphony: data=0x%0*" PRIX32 " nbits=%u repeats=%u", (data.nbits + 3) / 4,
+  ESP_LOGD(TAG, "Sending Symphony: data=0x%0*" PRIX32 " nbits=%" PRIu8 " repeats=%" PRIu8, (data.nbits + 3) / 4,
            (uint32_t) data.data, data.nbits, data.repeats);
   // Each bit produces a mark+space (2 entries). We fold the inter-frame/footer gap
   // into the last bit's space of each frame to avoid over-length gaps.
@@ -115,7 +115,7 @@ optional<SymphonyData> SymphonyProtocol::decode(RemoteReceiveData src) {
 
 void SymphonyProtocol::dump(const SymphonyData &data) {
   const int hex_width = (data.nbits + 3) / 4;  // pad to nibble width
-  ESP_LOGI(TAG, "Received Symphony: data=0x%0*" PRIX32 ", nbits=%d", hex_width, (uint32_t) data.data, data.nbits);
+  ESP_LOGI(TAG, "Received Symphony: data=0x%0*" PRIX32 ", nbits=%" PRIu8, hex_width, (uint32_t) data.data, data.nbits);
 }
 
 }  // namespace remote_base

--- a/esphome/components/remote_base/symphony_protocol.cpp
+++ b/esphome/components/remote_base/symphony_protocol.cpp
@@ -1,6 +1,8 @@
 #include "symphony_protocol.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace remote_base {
 
@@ -26,8 +28,8 @@ static constexpr uint32_t INTER_FRAME_GAP_US = 34760;
 
 void SymphonyProtocol::encode(RemoteTransmitData *dst, const SymphonyData &data) {
   dst->set_carrier_frequency(CARRIER_FREQUENCY);
-  ESP_LOGD(TAG, "Sending Symphony: data=0x%0*X nbits=%u repeats=%u", (data.nbits + 3) / 4, (uint32_t) data.data,
-           data.nbits, data.repeats);
+  ESP_LOGD(TAG, "Sending Symphony: data=0x%0*" PRIX32 " nbits=%u repeats=%u", (data.nbits + 3) / 4,
+           (uint32_t) data.data, data.nbits, data.repeats);
   // Each bit produces a mark+space (2 entries). We fold the inter-frame/footer gap
   // into the last bit's space of each frame to avoid over-length gaps.
   dst->reserve(data.nbits * 2u * data.repeats);
@@ -112,8 +114,8 @@ optional<SymphonyData> SymphonyProtocol::decode(RemoteReceiveData src) {
 }
 
 void SymphonyProtocol::dump(const SymphonyData &data) {
-  const int32_t hex_width = (data.nbits + 3) / 4;  // pad to nibble width
-  ESP_LOGI(TAG, "Received Symphony: data=0x%0*X, nbits=%d", hex_width, (uint32_t) data.data, data.nbits);
+  const int hex_width = (data.nbits + 3) / 4;  // pad to nibble width
+  ESP_LOGI(TAG, "Received Symphony: data=0x%0*" PRIX32 ", nbits=%d", hex_width, (uint32_t) data.data, data.nbits);
 }
 
 }  // namespace remote_base

--- a/esphome/components/runtime_image/bmp_decoder.cpp
+++ b/esphome/components/runtime_image/bmp_decoder.cpp
@@ -6,6 +6,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome::runtime_image {
 
 static const char *const TAG = "image_decoder.bmp";
@@ -107,7 +109,7 @@ int HOT BmpDecoder::decode(uint8_t *buffer, size_t size) {
     }
 
     if (this->compression_method_ != 0) {
-      ESP_LOGE(TAG, "Unsupported compression method: %d", this->compression_method_);
+      ESP_LOGE(TAG, "Unsupported compression method: %" PRIu32, this->compression_method_);
       return DECODE_ERROR_UNSUPPORTED_FORMAT;
     }
 

--- a/esphome/components/serial_proxy/serial_proxy.cpp
+++ b/esphome/components/serial_proxy/serial_proxy.cpp
@@ -91,7 +91,9 @@ void SerialProxy::dump_config() {
 
 void SerialProxy::configure(uint32_t baudrate, bool flow_control, uint8_t parity, uint8_t stop_bits,
                             uint8_t data_size) {
-  ESP_LOGD(TAG, "Configuring serial proxy [%" PRIu32 "]: baud=%" PRIu32 ", flow_ctrl=%s, parity=%u, stop=%u, data=%u",
+  ESP_LOGD(TAG,
+           "Configuring serial proxy [%" PRIu32 "]: baud=%" PRIu32 ", flow_ctrl=%s, parity=%" PRIu8 ", stop=%" PRIu8
+           ", data=%" PRIu8,
            this->instance_index_, baudrate, YESNO(flow_control), parity, stop_bits, data_size);
 
   auto *uart_comp = this->parent_;

--- a/esphome/components/serial_proxy/serial_proxy.cpp
+++ b/esphome/components/serial_proxy/serial_proxy.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_SERIAL_PROXY
 
 #include "esphome/core/log.h"
+
+#include <cinttypes>
 #include "esphome/core/util.h"
 
 #ifdef USE_API
@@ -74,7 +76,7 @@ void __attribute__((noinline)) SerialProxy::read_and_send_(size_t available) {
 
 void SerialProxy::dump_config() {
   ESP_LOGCONFIG(TAG,
-                "Serial Proxy [%u]:\n"
+                "Serial Proxy [%" PRIu32 "]:\n"
                 "  Name: %s\n"
                 "  Port Type: %s\n"
                 "  RTS Pin: %s\n"
@@ -89,7 +91,7 @@ void SerialProxy::dump_config() {
 
 void SerialProxy::configure(uint32_t baudrate, bool flow_control, uint8_t parity, uint8_t stop_bits,
                             uint8_t data_size) {
-  ESP_LOGD(TAG, "Configuring serial proxy [%u]: baud=%u, flow_ctrl=%s, parity=%u, stop=%u, data=%u",
+  ESP_LOGD(TAG, "Configuring serial proxy [%" PRIu32 "]: baud=%" PRIu32 ", flow_ctrl=%s, parity=%u, stop=%u, data=%u",
            this->instance_index_, baudrate, YESNO(flow_control), parity, stop_bits, data_size);
 
   auto *uart_comp = this->parent_;
@@ -148,7 +150,7 @@ void SerialProxy::write_from_client(const uint8_t *data, size_t len) {
 void SerialProxy::set_modem_pins(uint32_t line_states) {
   const bool rts = (line_states & SERIAL_PROXY_LINE_STATE_FLAG_RTS) != 0;
   const bool dtr = (line_states & SERIAL_PROXY_LINE_STATE_FLAG_DTR) != 0;
-  ESP_LOGV(TAG, "Setting modem pins [%u]: RTS=%s, DTR=%s", this->instance_index_, ONOFF(rts), ONOFF(dtr));
+  ESP_LOGV(TAG, "Setting modem pins [%" PRIu32 "]: RTS=%s, DTR=%s", this->instance_index_, ONOFF(rts), ONOFF(dtr));
 
   if (this->rts_pin_ != nullptr) {
     this->rts_state_ = rts;
@@ -161,12 +163,12 @@ void SerialProxy::set_modem_pins(uint32_t line_states) {
 }
 
 uint32_t SerialProxy::get_modem_pins() const {
-  return (this->rts_state_ ? SERIAL_PROXY_LINE_STATE_FLAG_RTS : 0u) |
-         (this->dtr_state_ ? SERIAL_PROXY_LINE_STATE_FLAG_DTR : 0u);
+  return (this->rts_state_ ? static_cast<uint32_t>(SERIAL_PROXY_LINE_STATE_FLAG_RTS) : 0u) |
+         (this->dtr_state_ ? static_cast<uint32_t>(SERIAL_PROXY_LINE_STATE_FLAG_DTR) : 0u);
 }
 
 uart::UARTFlushResult SerialProxy::flush_port() {
-  ESP_LOGV(TAG, "Flushing serial proxy [%u]", this->instance_index_);
+  ESP_LOGV(TAG, "Flushing serial proxy [%" PRIu32 "]", this->instance_index_);
   return this->flush();
 }
 
@@ -180,19 +182,19 @@ void SerialProxy::serial_proxy_request(api::APIConnection *api_connection, api::
       }
       this->api_connection_ = api_connection;
       this->enable_loop();
-      ESP_LOGV(TAG, "API connection subscribed to serial proxy [%u]", this->instance_index_);
+      ESP_LOGV(TAG, "API connection subscribed to serial proxy [%" PRIu32 "]", this->instance_index_);
       break;
     case api::enums::SERIAL_PROXY_REQUEST_TYPE_UNSUBSCRIBE:
       if (this->api_connection_ != api_connection) {
-        ESP_LOGV(TAG, "API connection is not subscribed to serial proxy [%u]", this->instance_index_);
+        ESP_LOGV(TAG, "API connection is not subscribed to serial proxy [%" PRIu32 "]", this->instance_index_);
         return;
       }
       this->api_connection_ = nullptr;
       this->disable_loop();
-      ESP_LOGV(TAG, "API connection unsubscribed from serial proxy [%u]", this->instance_index_);
+      ESP_LOGV(TAG, "API connection unsubscribed from serial proxy [%" PRIu32 "]", this->instance_index_);
       break;
     default:
-      ESP_LOGW(TAG, "Unknown serial proxy request type: %u", static_cast<uint32_t>(type));
+      ESP_LOGW(TAG, "Unknown serial proxy request type: %" PRIu32, static_cast<uint32_t>(type));
       break;
   }
 }

--- a/esphome/components/spa06_base/spa06_base.cpp
+++ b/esphome/components/spa06_base/spa06_base.cpp
@@ -1,5 +1,7 @@
 #include "spa06_base.h"
 
+#include <cinttypes>
+
 #include "esphome/core/helpers.h"
 
 namespace esphome::spa06_base {
@@ -195,7 +197,7 @@ bool SPA06Component::read_coefficients_() {
   ESP_LOGV(TAG,
            "Coefficients:\n"
            "  c0: %i, c1: %i,\n"
-           "  c00: %i, c10: %i, c20: %i, c30: %i, c40: %i,\n"
+           "  c00: %" PRIi32 ", c10: %" PRIi32 ", c20: %i, c30: %i, c40: %i,\n"
            "  c01: %i, c11: %i, c21: %i, c31: %i",
            this->c0_, this->c1_, this->c00_, this->c10_, this->c20_, this->c30_, this->c40_, this->c01_, this->c11_,
            this->c21_, this->c31_);

--- a/esphome/components/sps30/sps30.cpp
+++ b/esphome/components/sps30/sps30.cpp
@@ -2,6 +2,8 @@
 #include "esphome/core/log.h"
 #include "sps30.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace sps30 {
 
@@ -105,7 +107,7 @@ void SPS30Component::dump_config() {
                 "  Firmware version v%0d.%0d",
                 this->serial_number_, this->raw_firmware_version_ >> 8, this->raw_firmware_version_ & 0xFF);
   if (this->idle_interval_.has_value()) {
-    ESP_LOGCONFIG(TAG, "  Idle interval: %us", this->idle_interval_.value() / 1000);
+    ESP_LOGCONFIG(TAG, "  Idle interval: %" PRIu32 "s", this->idle_interval_.value() / 1000);
   }
   LOG_SENSOR("  ", "PM1.0 Weight Concentration", this->pm_1_0_sensor_);
   LOG_SENSOR("  ", "PM2.5 Weight Concentration", this->pm_2_5_sensor_);
@@ -142,8 +144,8 @@ void SPS30Component::update() {
   // If its not time to take an action, do nothing.
   const uint32_t update_start_ms = millis();
   if (this->next_state_ != NONE && (int32_t) (this->next_state_ms_ - update_start_ms) > 0) {
-    ESP_LOGD(TAG, "Sensor waiting for %ums before transitioning to state %d.", (this->next_state_ms_ - update_start_ms),
-             this->next_state_);
+    ESP_LOGD(TAG, "Sensor waiting for %" PRIu32 "ms before transitioning to state %d.",
+             (this->next_state_ms_ - update_start_ms), this->next_state_);
     return;
   }
 

--- a/esphome/components/thermostat/thermostat_climate.cpp
+++ b/esphome/components/thermostat/thermostat_climate.cpp
@@ -2,6 +2,7 @@
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
+#include <cinttypes>
 
 namespace esphome::thermostat {
 
@@ -1346,15 +1347,16 @@ void ThermostatClimate::set_timer_duration_in_sec_(ThermostatClimateTimerIndex t
 
     if (elapsed >= new_duration_ms) {
       // Timer should complete immediately (including when new_duration_ms is 0)
-      ESP_LOGVV(TAG, "timer %d completing immediately (elapsed %d >= new %d)", timer_index, elapsed, new_duration_ms);
+      ESP_LOGVV(TAG, "timer %d completing immediately (elapsed %" PRIu32 " >= new %" PRIu32 ")", timer_index, elapsed,
+                new_duration_ms);
       this->timer_[timer_index].active = false;
       // Trigger the timer callback immediately
       this->call_timer_callback_(timer_index);
       return;
     } else {
       // Adjust timer to run for remaining time - keep original start time
-      ESP_LOGVV(TAG, "timer %d adjusted: elapsed %d, new total %d, remaining %d", timer_index, elapsed, new_duration_ms,
-                new_duration_ms - elapsed);
+      ESP_LOGVV(TAG, "timer %d adjusted: elapsed %" PRIu32 ", new total %" PRIu32 ", remaining %" PRIu32, timer_index,
+                elapsed, new_duration_ms, new_duration_ms - elapsed);
       this->timer_[timer_index].time = new_duration_ms;
       return;
     }

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include <vector>
 
 #include "tormatic_cover.h"
@@ -120,11 +121,11 @@ void Tormatic::recalibrate_duration_(GateStatus s) {
 
   if (s == OPENED) {
     this->open_duration_ = now - this->direction_start_time_;
-    ESP_LOGI(TAG, "Recalibrated the gate's open duration to %dms", this->open_duration_);
+    ESP_LOGI(TAG, "Recalibrated the gate's open duration to %" PRIu32 "ms", this->open_duration_);
   }
   if (s == CLOSED) {
     this->close_duration_ = now - this->direction_start_time_;
-    ESP_LOGI(TAG, "Recalibrated the gate's close duration to %dms", this->close_duration_);
+    ESP_LOGI(TAG, "Recalibrated the gate's close duration to %" PRIu32 "ms", this->close_duration_);
   }
 
   this->direction_start_time_ = 0;
@@ -269,7 +270,7 @@ optional<GateStatus> Tormatic::read_gate_status_() {
   switch (hdr.type) {
     case STATUS: {
       if (hdr.payload_size() != sizeof(StatusReply)) {
-        ESP_LOGE(TAG, "Header specifies payload size %d but size of StatusReply is %d", hdr.payload_size(),
+        ESP_LOGE(TAG, "Header specifies payload size %" PRIu32 " but size of StatusReply is %zu", hdr.payload_size(),
                  sizeof(StatusReply));
       }
 
@@ -294,7 +295,7 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     default:
       // Unknown message type, drain the remaining amount of bytes specified in
       // the header.
-      ESP_LOGE(TAG, "Reading remaining %d payload bytes of unknown type 0x%x", hdr.payload_size(), hdr.type);
+      ESP_LOGE(TAG, "Reading remaining %" PRIu32 " payload bytes of unknown type 0x%x", hdr.payload_size(), hdr.type);
       break;
   }
 
@@ -339,7 +340,7 @@ template<typename T> optional<T> Tormatic::read_data_() {
   }
   obj.byteswap();
 
-  ESP_LOGV(TAG, "Read %s in %d ms", obj.print().c_str(), millis() - start);
+  ESP_LOGV(TAG, "Read %s in %" PRIu32 " ms", obj.print().c_str(), millis() - start);
   return obj;
 }
 

--- a/esphome/components/tormatic/tormatic_protocol.h
+++ b/esphome/components/tormatic/tormatic_protocol.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cinttypes>
+
 #include "esphome/components/cover/cover.h"
 
 /**
@@ -86,7 +88,7 @@ struct MessageHeader {
   std::string print() {
     // 64 bytes: "MessageHeader: seq " + uint16 + ", len " + uint32 + ", type " + type + safety margin
     char buf[64];
-    buf_append_printf(buf, sizeof(buf), 0, "MessageHeader: seq %d, len %d, type %s", this->seq, this->len,
+    buf_append_printf(buf, sizeof(buf), 0, "MessageHeader: seq %d, len %" PRIu32 ", type %s", this->seq, this->len,
                       message_type_to_str(this->type));
     return buf;
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -296,7 +296,7 @@ void IDFUARTComponent::set_rx_timeout(size_t rx_timeout) {
 void IDFUARTComponent::write_array(const uint8_t *data, size_t len) {
   int32_t write_len = uart_write_bytes(this->uart_num_, data, len);
   if (write_len != (int32_t) len) {
-    ESP_LOGW(TAG, "uart_write_bytes failed: %d != %zu", write_len, len);
+    ESP_LOGW(TAG, "uart_write_bytes failed: %" PRId32 " != %zu", write_len, len);
     this->mark_failed();
   }
 #ifdef USE_UART_DEBUGGER

--- a/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
+++ b/esphome/components/uponor_smatrix/climate/uponor_smatrix_climate.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace uponor_smatrix {
 
@@ -10,7 +12,7 @@ static const char *const TAG = "uponor_smatrix.climate";
 
 void UponorSmatrixClimate::dump_config() {
   LOG_CLIMATE("", "Uponor Smatrix Climate", this);
-  ESP_LOGCONFIG(TAG, "  Device address: 0x%08X", this->address_);
+  ESP_LOGCONFIG(TAG, "  Device address: 0x%08" PRIX32, this->address_);
 }
 
 void UponorSmatrixClimate::loop() {

--- a/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
+++ b/esphome/components/uponor_smatrix/sensor/uponor_smatrix_sensor.cpp
@@ -1,6 +1,8 @@
 #include "uponor_smatrix_sensor.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace uponor_smatrix {
 
@@ -9,7 +11,7 @@ static const char *const TAG = "uponor_smatrix.sensor";
 void UponorSmatrixSensor::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "Uponor Smatrix Sensor\n"
-                "  Device address: 0x%08X",
+                "  Device address: 0x%08" PRIX32,
                 this->address_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "External Temperature", this->external_temperature_sensor_);

--- a/esphome/components/uponor_smatrix/uponor_smatrix.cpp
+++ b/esphome/components/uponor_smatrix/uponor_smatrix.cpp
@@ -3,6 +3,8 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 namespace esphome {
 namespace uponor_smatrix {
 
@@ -24,7 +26,7 @@ void UponorSmatrixComponent::dump_config() {
 #ifdef USE_TIME
   if (this->time_id_ != nullptr) {
     ESP_LOGCONFIG(TAG, "  Time synchronization: YES");
-    ESP_LOGCONFIG(TAG, "  Time master device address: 0x%08X", this->time_device_address_);
+    ESP_LOGCONFIG(TAG, "  Time master device address: 0x%08" PRIX32 "", this->time_device_address_);
   }
 #endif
 
@@ -33,7 +35,7 @@ void UponorSmatrixComponent::dump_config() {
   if (!this->unknown_devices_.empty()) {
     ESP_LOGCONFIG(TAG, "  Detected unknown device addresses:");
     for (auto device_address : this->unknown_devices_) {
-      ESP_LOGCONFIG(TAG, "    0x%08X", device_address);
+      ESP_LOGCONFIG(TAG, "    0x%08" PRIX32 "", device_address);
     }
   }
 }
@@ -103,14 +105,14 @@ bool UponorSmatrixComponent::parse_byte_(uint8_t byte) {
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
   char hex_buf[format_hex_size(UPONOR_MAX_LOG_BYTES)];
 #endif
-  ESP_LOGV(TAG, "Received packet: addr=%08X, data=%s, crc=%04X", device_address,
+  ESP_LOGV(TAG, "Received packet: addr=%08" PRIX32 ", data=%s, crc=%04X", device_address,
            format_hex_to(hex_buf, &packet[4], packet_len - 6), crc);
 
   // Handle packet
   size_t data_len = (packet_len - 6) / 3;
   if (data_len == 0) {
     if (packet[4] == UPONOR_ID_REQUEST)
-      ESP_LOGVV(TAG, "Ignoring request packet for device 0x%08X", device_address);
+      ESP_LOGVV(TAG, "Ignoring request packet for device 0x%08" PRIX32 "", device_address);
     return true;
   }
 
@@ -135,7 +137,7 @@ bool UponorSmatrixComponent::parse_byte_(uint8_t byte) {
       if (data[i].id == UPONOR_ID_DATETIME1)
         found_time = true;
       if (found_temperature && found_time) {
-        ESP_LOGI(TAG, "Using detected time device address 0x%08X", device_address);
+        ESP_LOGI(TAG, "Using detected time device address 0x%08" PRIX32 "", device_address);
         this->time_device_address_ = device_address;
         break;
       }
@@ -154,7 +156,7 @@ bool UponorSmatrixComponent::parse_byte_(uint8_t byte) {
 
   // Log unknown device addresses
   if (!found && !this->unknown_devices_.count(device_address)) {
-    ESP_LOGI(TAG, "Received packet for unknown device address 0x%08X ", device_address);
+    ESP_LOGI(TAG, "Received packet for unknown device address 0x%08" PRIX32 " ", device_address);
     this->unknown_devices_.insert(device_address);
   }
 

--- a/esphome/components/vl53l0x/vl53l0x_sensor.cpp
+++ b/esphome/components/vl53l0x/vl53l0x_sensor.cpp
@@ -1,6 +1,8 @@
 #include "vl53l0x_sensor.h"
 #include "esphome/core/log.h"
 
+#include <cinttypes>
+
 /*
  * Most of the code in this integration is based on the VL53L0x library
  * by Pololu (Pololu Corporation), which in turn is based on the VL53L0X
@@ -28,8 +30,8 @@ void VL53L0XSensor::dump_config() {
     LOG_PIN("  Enable Pin: ", this->enable_pin_);
   }
   ESP_LOGCONFIG(TAG,
-                "  Timeout: %u%s\n"
-                "  Timing Budget %uus ",
+                "  Timeout: %" PRIu32 "%s\n"
+                "  Timing Budget %" PRIu32 "us ",
                 this->timeout_us_, this->timeout_us_ > 0 ? "us" : " (no timeout)", this->measurement_timing_budget_us_);
 }
 

--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -112,7 +112,8 @@ void WaterHeaterCall::validate_() {
   auto traits = this->parent_->get_traits();
   if (this->mode_.has_value()) {
     if (!traits.supports_mode(*this->mode_)) {
-      ESP_LOGW(TAG, "'%s' - Mode %" PRIu32 " not supported", this->parent_->get_name().c_str(), *this->mode_);
+      ESP_LOGW(TAG, "'%s' - Mode %" PRIu32 " not supported", this->parent_->get_name().c_str(),
+               static_cast<uint32_t>(*this->mode_));
       this->mode_.reset();
     }
   }

--- a/esphome/components/water_heater/water_heater.cpp
+++ b/esphome/components/water_heater/water_heater.cpp
@@ -1,5 +1,7 @@
 #include "water_heater.h"
 #include "esphome/core/log.h"
+
+#include <cinttypes>
 #include "esphome/core/application.h"
 #include "esphome/core/controller_registry.h"
 #include "esphome/core/progmem.h"
@@ -110,7 +112,7 @@ void WaterHeaterCall::validate_() {
   auto traits = this->parent_->get_traits();
   if (this->mode_.has_value()) {
     if (!traits.supports_mode(*this->mode_)) {
-      ESP_LOGW(TAG, "'%s' - Mode %d not supported", this->parent_->get_name().c_str(), *this->mode_);
+      ESP_LOGW(TAG, "'%s' - Mode %" PRIu32 " not supported", this->parent_->get_name().c_str(), *this->mode_);
       this->mode_.reset();
     }
   }

--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -3,6 +3,8 @@
 #ifdef USE_API
 
 #include "esphome/components/api/api_server.h"
+
+#include <cinttypes>
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -160,7 +162,7 @@ void ZWaveProxy::zwave_proxy_request(api::APIConnection *api_connection, api::en
       break;
 
     default:
-      ESP_LOGW(TAG, "Unknown request type: %d", type);
+      ESP_LOGW(TAG, "Unknown request type: %" PRIu32, static_cast<uint32_t>(type));
       break;
   }
 }


### PR DESCRIPTION
## What does this implement/fix?

Fixes compiler warnings (`-Wformat=` and `-Wextra`) across 33 component files. On ESP32 (Xtensa/RISC-V), `uint32_t` is `unsigned long` not `unsigned int`, causing mismatches with `%u`/`%d`/`%X`/`%i` format specifiers.

### Changes:
- Use `PRIu32`/`PRId32`/`PRIX32`/`PRIi32` from `<cinttypes>` for `uint32_t`/`int32_t` printf args
- Fix `%lu` with `size_t` → `%zu` (modbus)
- Fix `%hhu` with `int32_t` → `PRId32` (nextion)
- Fix enum/non-enum ternary warning with `static_cast` (serial_proxy)

### Components fixed:
adc, api, audio_file, bm8563, bme68x_bsec2, dlms_meter, esp32_touch, espnow, http_request, hub75, infrared, inkplate, ld2450, max7219digit, modbus, nextion, qmp6988, rd03d, remote_base, runtime_image, serial_proxy, spa06_base, sps30, thermostat, tormatic, uart, uponor_smatrix (3 files), vl53l0x, water_heater, zwave_proxy

## Types of changes
  - [x] Bug fix (non-breaking change which fixes an issue)

## Test Environment
  - ESP32 IDF build

## Checklist:
  - [x] The code change is tested and works locally.