### PR TITLE
[http_request] Fix crash when esp_http_client_init fails

### DIFF
--- a/esphome/components/http_request/http_request_idf.cpp
+++ b/esphome/components/http_request/http_request_idf.cpp
@@ -17,6 +17,7 @@
 namespace esphome::http_request {
 
 static const char *const TAG = "http_request.idf";
+static constexpr uint32_t ERROR_DURATION_MS = 1000;
 
 struct UserData {
   const std::vector<std::string> &lower_case_collect_headers;
@@ -57,7 +58,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
                                                        const std::vector<Header> &request_headers,
                                                        const std::vector<std::string> &lower_case_collect_headers) {
   if (!network::is_connected()) {
-    this->status_momentary_error("failed", 1000);
+    this->status_momentary_error("failed", ERROR_DURATION_MS);
     ESP_LOGE(TAG, "HTTP Request failed; Not connected to network");
     return nullptr;
   }
@@ -74,7 +75,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   } else if (method == "PATCH") {
     method_idf = HTTP_METHOD_PATCH;
   } else {
-    this->status_momentary_error("failed", 1000);
+    this->status_momentary_error("failed", ERROR_DURATION_MS);
     ESP_LOGE(TAG, "HTTP Request failed; Unsupported method");
     return nullptr;
   }
@@ -112,6 +113,11 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   config.event_handler = http_event_handler;
 
   esp_http_client_handle_t client = esp_http_client_init(&config);
+  if (client == nullptr) {
+    this->status_momentary_error("failed", ERROR_DURATION_MS);
+    ESP_LOGE(TAG, "HTTP Request failed; client could not be initialized");
+    return nullptr;
+  }
 
   std::shared_ptr<HttpContainerIDF> container = std::make_shared<HttpContainerIDF>(client);
   container->set_parent(this);
@@ -129,7 +135,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
 
   esp_err_t err = esp_http_client_open(client, body_len);
   if (err != ESP_OK) {
-    this->status_momentary_error("failed", 1000);
+    this->status_momentary_error("failed", ERROR_DURATION_MS);
     ESP_LOGE(TAG, "HTTP Request failed: %s", esp_err_to_name(err));
     esp_http_client_cleanup(client);
     return nullptr;
@@ -151,7 +157,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   }
 
   if (err != ESP_OK) {
-    this->status_momentary_error("failed", 1000);
+    this->status_momentary_error("failed", ERROR_DURATION_MS);
     ESP_LOGE(TAG, "HTTP Request failed: %s", esp_err_to_name(err));
     esp_http_client_cleanup(client);
     return nullptr;
@@ -176,7 +182,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
       err = esp_http_client_set_redirection(client);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_http_client_set_redirection failed: %s", esp_err_to_name(err));
-        this->status_momentary_error("failed", 1000);
+        this->status_momentary_error("failed", ERROR_DURATION_MS);
         esp_http_client_cleanup(client);
         return nullptr;
       }
@@ -189,7 +195,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
       err = esp_http_client_open(client, 0);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_http_client_open failed: %s", esp_err_to_name(err));
-        this->status_momentary_error("failed", 1000);
+        this->status_momentary_error("failed", ERROR_DURATION_MS);
         esp_http_client_cleanup(client);
         return nullptr;
       }
@@ -214,7 +220,7 @@ std::shared_ptr<HttpContainer> HttpRequestIDF::perform(const std::string &url, c
   }
 
   ESP_LOGE(TAG, "HTTP Request failed; URL: %s; Code: %d", url.c_str(), container->status_code);
-  this->status_momentary_error("failed", 1000);
+  this->status_momentary_error("failed", ERROR_DURATION_MS);
   return container;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

`esp_http_client_init()` can return NULL on memory allocation failure, URL parse failure, or transport allocation failure. The return value was not checked, so the NULL handle was passed to `esp_http_client_open()`, causing a `StoreProhibited` crash.

This adds a NULL check after `esp_http_client_init()` that logs the error and returns gracefully, allowing callers (e.g. `online_image`) to handle the failure through their existing error paths instead of crashing.

Also extracts the magic `1000` error duration to a named `constexpr`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15326

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
http_request:
  timeout: 15s

button:
  - platform: template
    name: "Test HTTP Request"
    on_press:
      - http_request.get:
          url: "http://192.168.1.1/"
          on_response:
            then:
              - lambda: |-
                  ESP_LOGI("http_test", "Response status: %d", response->status_code);

  - platform: template
    name: "Test HTTP Request httpbin"
    on_press:
      - http_request.get:
          url: "https://httpbin.org/get"
          on_response:
            then:
              - lambda: |-
                  ESP_LOGI("http_test", "httpbin response status: %d", response->status_code);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).