### PR TITLE
[binary_sensor] Add on_multi_click integration test

### DIFF
--- a/tests/integration/fixtures/multi_click_trigger.yaml
+++ b/tests/integration/fixtures/multi_click_trigger.yaml
@@ -1,6 +1,5 @@
 esphome:
   name: test-multi-click
-  platformio_options: {}
 
 host:
 api:

--- a/tests/integration/fixtures/multi_click_trigger.yaml
+++ b/tests/integration/fixtures/multi_click_trigger.yaml
@@ -1,0 +1,106 @@
+esphome:
+  name: test-multi-click
+  platformio_options: {}
+
+host:
+api:
+  batch_delay: 0ms
+  services:
+    - service: run_all_tests
+      then:
+        # Prime the binary sensor with an initial OFF state.
+        # trigger_on_initial_state defaults to false, so the first
+        # state change from unknown won't fire callbacks.
+        - binary_sensor.template.publish:
+            id: test_button
+            state: false
+        - delay: 50ms
+
+        # Test 1: Single click (ON < 50ms, OFF >= 30ms)
+        - binary_sensor.template.publish:
+            id: test_button
+            state: true
+        - delay: 20ms
+        - binary_sensor.template.publish:
+            id: test_button
+            state: false
+        # Wait for single click trigger (30ms) + cooldown (100ms) + margin
+        - delay: 200ms
+
+        # Test 2: Double click (ON < 50ms, OFF < 25ms, ON < 50ms, OFF >= 25ms)
+        - binary_sensor.template.publish:
+            id: test_button
+            state: true
+        - delay: 20ms
+        - binary_sensor.template.publish:
+            id: test_button
+            state: false
+        - delay: 15ms
+        - binary_sensor.template.publish:
+            id: test_button
+            state: true
+        - delay: 20ms
+        - binary_sensor.template.publish:
+            id: test_button
+            state: false
+        # Wait for double click trigger (25ms) + cooldown (100ms) + margin
+        - delay: 200ms
+
+        # Test 3: Long press (ON >= 80ms)
+        - binary_sensor.template.publish:
+            id: test_button
+            state: true
+        - delay: 100ms
+        - binary_sensor.template.publish:
+            id: test_button
+            state: false
+
+logger:
+  level: VERBOSE
+
+globals:
+  - id: single_click_count
+    type: int
+    initial_value: "0"
+  - id: double_click_count
+    type: int
+    initial_value: "0"
+  - id: long_press_count
+    type: int
+    initial_value: "0"
+
+binary_sensor:
+  - platform: template
+    name: "Test Button"
+    id: test_button
+    on_multi_click:
+      # Single press
+      - timing:
+          - ON for at most 50ms
+          - OFF for at least 30ms
+        invalid_cooldown: 100ms
+        then:
+          - lambda: |-
+              id(single_click_count) += 1;
+              ESP_LOGI("multi_click_test", "SINGLE_CLICK count=%d", id(single_click_count));
+
+      # Double press
+      - timing:
+          - ON for at most 50ms
+          - OFF for at most 25ms
+          - ON for at most 50ms
+          - OFF for at least 25ms
+        invalid_cooldown: 100ms
+        then:
+          - lambda: |-
+              id(double_click_count) += 1;
+              ESP_LOGI("multi_click_test", "DOUBLE_CLICK count=%d", id(double_click_count));
+
+      # Long press
+      - timing:
+          - ON for at least 80ms
+        invalid_cooldown: 100ms
+        then:
+          - lambda: |-
+              id(long_press_count) += 1;
+              ESP_LOGI("multi_click_test", "LONG_PRESS count=%d", id(long_press_count));

--- a/tests/integration/test_multi_click_trigger.py
+++ b/tests/integration/test_multi_click_trigger.py
@@ -4,7 +4,6 @@ Tests that on_multi_click correctly triggers for single click, double click,
 and long press patterns using a template binary sensor with timing
 orchestrated entirely in YAML.
 
-Regression test for: https://github.com/esphome/esphome/issues/15323
 """
 
 from __future__ import annotations
@@ -63,7 +62,7 @@ async def test_multi_click_trigger(
         except TimeoutError:
             pytest.fail(
                 "Timeout waiting for SINGLE_CLICK - on_multi_click did not trigger. "
-                "See issue #15323."
+                "on_multi_click did not trigger."
             )
         assert count == 1, f"Expected single click count=1, got {count}"
 
@@ -72,7 +71,7 @@ async def test_multi_click_trigger(
         except TimeoutError:
             pytest.fail(
                 "Timeout waiting for DOUBLE_CLICK - on_multi_click did not trigger. "
-                "See issue #15323."
+                "on_multi_click did not trigger."
             )
         assert count == 1, f"Expected double click count=1, got {count}"
 
@@ -81,6 +80,6 @@ async def test_multi_click_trigger(
         except TimeoutError:
             pytest.fail(
                 "Timeout waiting for LONG_PRESS - on_multi_click did not trigger. "
-                "See issue #15323."
+                "on_multi_click did not trigger."
             )
         assert count == 1, f"Expected long press count=1, got {count}"

--- a/tests/integration/test_multi_click_trigger.py
+++ b/tests/integration/test_multi_click_trigger.py
@@ -1,0 +1,86 @@
+"""Integration test for on_multi_click binary sensor automation.
+
+Tests that on_multi_click correctly triggers for single click, double click,
+and long press patterns using a template binary sensor with timing
+orchestrated entirely in YAML.
+
+Regression test for: https://github.com/esphome/esphome/issues/15323
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_multi_click_trigger(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test that on_multi_click triggers for single, double, and long press patterns."""
+    loop = asyncio.get_running_loop()
+
+    single_click_pattern = re.compile(r"SINGLE_CLICK count=(\d+)")
+    double_click_pattern = re.compile(r"DOUBLE_CLICK count=(\d+)")
+    long_press_pattern = re.compile(r"LONG_PRESS count=(\d+)")
+
+    single_click_future: asyncio.Future[int] = loop.create_future()
+    double_click_future: asyncio.Future[int] = loop.create_future()
+    long_press_future: asyncio.Future[int] = loop.create_future()
+
+    def check_output(line: str) -> None:
+        """Check log output for multi-click trigger messages."""
+        if m := single_click_pattern.search(line):
+            if not single_click_future.done():
+                single_click_future.set_result(int(m.group(1)))
+        elif m := double_click_pattern.search(line):
+            if not double_click_future.done():
+                double_click_future.set_result(int(m.group(1)))
+        elif (m := long_press_pattern.search(line)) and not long_press_future.done():
+            long_press_future.set_result(int(m.group(1)))
+
+    async with (
+        run_compiled(yaml_config, line_callback=check_output),
+        api_client_connected() as client,
+    ):
+        entities, services = await client.list_entities_services()
+
+        test_service = next((s for s in services if s.name == "run_all_tests"), None)
+        assert test_service is not None, "run_all_tests service not found"
+
+        # Kick off the entire test sequence (runs in YAML with delays)
+        await client.execute_service(test_service, {})
+
+        # Wait for all three triggers (total YAML sequence is ~4.5s)
+        try:
+            count = await asyncio.wait_for(single_click_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(
+                "Timeout waiting for SINGLE_CLICK - on_multi_click did not trigger. "
+                "See issue #15323."
+            )
+        assert count == 1, f"Expected single click count=1, got {count}"
+
+        try:
+            count = await asyncio.wait_for(double_click_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(
+                "Timeout waiting for DOUBLE_CLICK - on_multi_click did not trigger. "
+                "See issue #15323."
+            )
+        assert count == 1, f"Expected double click count=1, got {count}"
+
+        try:
+            count = await asyncio.wait_for(long_press_future, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(
+                "Timeout waiting for LONG_PRESS - on_multi_click did not trigger. "
+                "See issue #15323."
+            )
+        assert count == 1, f"Expected long press count=1, got {count}"

--- a/tests/integration/test_multi_click_trigger.py
+++ b/tests/integration/test_multi_click_trigger.py
@@ -48,7 +48,7 @@ async def test_multi_click_trigger(
         run_compiled(yaml_config, line_callback=check_output),
         api_client_connected() as client,
     ):
-        entities, services = await client.list_entities_services()
+        _entities, services = await client.list_entities_services()
 
         test_service = next((s for s in services if s.name == "run_all_tests"), None)
         assert test_service is not None, "run_all_tests service not found"
@@ -56,13 +56,12 @@ async def test_multi_click_trigger(
         # Kick off the entire test sequence (runs in YAML with delays)
         await client.execute_service(test_service, {})
 
-        # Wait for all three triggers (total YAML sequence is ~4.5s)
+        # Wait for all three triggers
         try:
             count = await asyncio.wait_for(single_click_future, timeout=5.0)
         except TimeoutError:
             pytest.fail(
-                "Timeout waiting for SINGLE_CLICK - on_multi_click did not trigger. "
-                "on_multi_click did not trigger."
+                "Timeout waiting for SINGLE_CLICK - on_multi_click did not trigger."
             )
         assert count == 1, f"Expected single click count=1, got {count}"
 
@@ -70,8 +69,7 @@ async def test_multi_click_trigger(
             count = await asyncio.wait_for(double_click_future, timeout=5.0)
         except TimeoutError:
             pytest.fail(
-                "Timeout waiting for DOUBLE_CLICK - on_multi_click did not trigger. "
-                "on_multi_click did not trigger."
+                "Timeout waiting for DOUBLE_CLICK - on_multi_click did not trigger."
             )
         assert count == 1, f"Expected double click count=1, got {count}"
 
@@ -79,7 +77,6 @@ async def test_multi_click_trigger(
             count = await asyncio.wait_for(long_press_future, timeout=5.0)
         except TimeoutError:
             pytest.fail(
-                "Timeout waiting for LONG_PRESS - on_multi_click did not trigger. "
-                "on_multi_click did not trigger."
+                "Timeout waiting for LONG_PRESS - on_multi_click did not trigger."
             )
         assert count == 1, f"Expected long press count=1, got {count}"


### PR DESCRIPTION
# What does this implement/fix?

While investigating #15323, `on_multi_click` was found to be working as expected — single click, double click, and long press patterns all trigger correctly. This integration test was developed during that investigation and has value as ongoing regression coverage, so a PR was made.

The entire timing sequence is orchestrated in YAML using a single service call with delays, keeping the test simple and deterministic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).