### PR TITLE
[time] Fix strftime %Z and %z returning wrong timezone

### DIFF
--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -4,6 +4,7 @@
 
 #include "posix_tz.h"
 #include <cctype>
+#include <cstdio>
 
 namespace esphome::time {
 
@@ -440,6 +441,18 @@ bool parse_posix_tz(const char *tz_string, ParsedTimezone &result) {
   p++;
   // has_dst() now returns true since dst_start.type was set by parse_dst_rule
   return internal::parse_dst_rule(p, result.dst_end);
+}
+
+// Format a POSIX offset (positive = west) as "+HHMM" / "-HHMM" for display.
+// Convention: negate POSIX sign so east-of-UTC is positive (ISO 8601 / RFC 2822).
+void format_designation(int32_t posix_offset, char *buf, size_t buf_size) {
+  int32_t display = -posix_offset;
+  char sign = display >= 0 ? '+' : '-';
+  if (display < 0)
+    display = -display;
+  int h = display / 3600;
+  int m = (display % 3600) / 60;
+  snprintf(buf, buf_size, "%c%02d%02d", sign, h, m);
 }
 
 bool epoch_to_local_tm(time_t utc_epoch, const ParsedTimezone &tz, struct tm *out_tm) {

--- a/esphome/components/time/posix_tz.h
+++ b/esphome/components/time/posix_tz.h
@@ -36,6 +36,9 @@ struct ParsedTimezone {
   bool has_dst() const { return this->dst_start.type != DSTRuleType::NONE; }
 };
 
+/// Format a POSIX offset as "+HHMM"/"-HHMM" into buf (must be >= 6 bytes).
+void format_designation(int32_t posix_offset, char *buf, size_t buf_size);
+
 /// Parse a POSIX TZ string into a ParsedTimezone struct.
 ///
 /// @deprecated Remove before 2026.9.0 (bridge code for backward compatibility).

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -2,6 +2,9 @@
 #include "helpers.h"
 
 #include <algorithm>
+#ifdef USE_TIME_TIMEZONE
+#include "esphome/components/time/posix_tz.h"
+#endif
 
 namespace esphome {
 
@@ -14,12 +17,45 @@ uint8_t days_in_month(uint8_t month, uint16_t year) {
 
 size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   struct tm c_tm = this->to_c_tm();
+#ifdef USE_TIME_TIMEZONE
+  // ::strftime uses libc's internal timezone state for %Z and %z, but we
+  // eliminated setenv("TZ")/tzset() on embedded platforms to save flash.
+  // Substitute %Z and %z with correct values from our parsed timezone.
+  // Quick scan: does format contain %Z or %z?
+  bool needs_subst = false;
+  for (const char *p = format; *p; p++) {
+    if (*p == '%' && (*(p + 1) == 'Z' || *(p + 1) == 'z')) {
+      needs_subst = true;
+      break;
+    }
+  }
+  if (needs_subst) {
+    const auto &tz = time::get_global_tz();
+    char designation[6];  // "+HHMM" + null
+    int32_t offset = c_tm.tm_isdst > 0 ? tz.dst_offset_seconds : tz.std_offset_seconds;
+    time::format_designation(offset, designation, sizeof(designation));
+
+    char modified[STRFTIME_BUFFER_SIZE];
+    char *out = modified;
+    char *out_end = modified + sizeof(modified) - 1;
+    for (const char *p = format; *p && out < out_end; p++) {
+      if (*p == '%' && (*(p + 1) == 'Z' || *(p + 1) == 'z')) {
+        p++;  // skip the Z/z
+        for (const char *d = designation; *d && out < out_end; d++)
+          *out++ = *d;
+      } else {
+        *out++ = *p;
+      }
+    }
+    *out = '\0';
+    return ::strftime(buffer, buffer_len, modified, &c_tm);
+  }
+#endif
   return ::strftime(buffer, buffer_len, format, &c_tm);
 }
 
 size_t ESPTime::strftime_to(std::span<char, STRFTIME_BUFFER_SIZE> buffer, const char *format) {
-  struct tm c_tm = this->to_c_tm();
-  size_t len = ::strftime(buffer.data(), buffer.size(), format, &c_tm);
+  size_t len = this->strftime(buffer.data(), buffer.size(), format);
   if (len > 0) {
     return len;
   }

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -24,7 +24,7 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   // Quick scan: does format contain %Z or %z (but not %%Z/%%z)?
   bool needs_subst = false;
   for (const char *p = format; *p; p++) {
-    if (*p == '%') {
+    if (*p == '%' && *(p + 1)) {
       p++;
       if (*p == '%')
         continue;  // %% is a literal %, skip

--- a/esphome/core/time.cpp
+++ b/esphome/core/time.cpp
@@ -21,12 +21,17 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
   // ::strftime uses libc's internal timezone state for %Z and %z, but we
   // eliminated setenv("TZ")/tzset() on embedded platforms to save flash.
   // Substitute %Z and %z with correct values from our parsed timezone.
-  // Quick scan: does format contain %Z or %z?
+  // Quick scan: does format contain %Z or %z (but not %%Z/%%z)?
   bool needs_subst = false;
   for (const char *p = format; *p; p++) {
-    if (*p == '%' && (*(p + 1) == 'Z' || *(p + 1) == 'z')) {
-      needs_subst = true;
-      break;
+    if (*p == '%') {
+      p++;
+      if (*p == '%')
+        continue;  // %% is a literal %, skip
+      if (*p == 'Z' || *p == 'z') {
+        needs_subst = true;
+        break;
+      }
     }
   }
   if (needs_subst) {
@@ -39,10 +44,19 @@ size_t ESPTime::strftime(char *buffer, size_t buffer_len, const char *format) {
     char *out = modified;
     char *out_end = modified + sizeof(modified) - 1;
     for (const char *p = format; *p && out < out_end; p++) {
-      if (*p == '%' && (*(p + 1) == 'Z' || *(p + 1) == 'z')) {
-        p++;  // skip the Z/z
-        for (const char *d = designation; *d && out < out_end; d++)
-          *out++ = *d;
+      if (*p == '%') {
+        if (*(p + 1) == '%') {
+          // %% → copy both percent signs (literal %)
+          *out++ = *p++;
+          if (out < out_end)
+            *out++ = *p;
+        } else if (*(p + 1) == 'Z' || *(p + 1) == 'z') {
+          p++;  // skip the Z/z
+          for (const char *d = designation; *d && out < out_end; d++)
+            *out++ = *d;
+        } else {
+          *out++ = *p;
+        }
       } else {
         *out++ = *p;
       }


### PR DESCRIPTION
# What does this implement/fix?

While investigating #15314, I tested `strftime` and found it works correctly for all standard format specifiers (`%A`, `%B`, `%d`, `%H`, etc.). However, I discovered that `%Z` and `%z` return `GMT`/`+0000` instead of the actual timezone.

This was caused by #13635 which removed `setenv("TZ",...)/tzset()` on embedded platforms to save ~9.5KB flash. The time **values** are correct (they come from our custom timezone parser via `struct tm` fields), but `%Z` and `%z` read from libc's internal `_tzname`/`_timezone` state which is stuck at `GMT`/`+0000`.

Ideally we would just set `tm_gmtoff` and `tm_zone` in the `struct tm` and let `::strftime` use them, but ESP-IDF's newlib [does not define `__TM_GMTOFF`/`__TM_ZONE`](https://github.com/espressif/newlib-esp32) — they are compiled out (only enabled for Cygwin). So `::strftime` falls through to `__gettzinfo()`/`_tzname[]` which are stuck at GMT.

Instead, this substitutes `%Z` and `%z` in the format string with the correct `+HHMM`/`-HHMM` designation computed from our parsed timezone offset before passing to `::strftime`. The substitution only runs when `%Z` or `%z` are present in the format string, so there is zero overhead for the common case.

**Before:** `%Z` → `GMT`, `%z` → `+0000`
**After:** `%Z` → `-0600`, `%z` → `-0600` (example: America/Denver during DST)

Also refactors `strftime_to()` to delegate to `strftime()` instead of duplicating the `::strftime` call, ensuring both code paths get the fix.

Not tagged for backport since this is an edge case that nobody has reported.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #15314 (investigation led to discovery, but user's issue is likely resource exhaustion not this bug)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: sntp
    id: sntp_time
    timezone: America/Denver

button:
  - platform: template
    name: "Test strftime"
    on_press:
      - lambda: |-
          auto now = id(sntp_time).now();
          if (!now.is_valid()) return;
          char buf[64];
          now.strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S %Z (%z)");
          ESP_LOGI("test", "Time: %s", buf);
          // Expected: 2026-03-31 01:17:07 -0600 (-0600)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).