### PR TITLE
[preferences] Reduce log verbosity for unchanged NVS/FDB writes

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -129,11 +129,15 @@ bool ESP32Preferences::sync() {
   }
   s_pending_save.clear();
 
-  ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
-           failed);
   if (failed > 0) {
-    ESP_LOGE(TAG, "Writing %d items failed. Last error=%s for key=%" PRIu32, failed, esp_err_to_name(last_err),
-             last_key);
+    ESP_LOGW(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%s for key=%" PRIu32,
+             cached + written + failed, cached, written, failed, esp_err_to_name(last_err), last_key);
+  } else if (written > 0) {
+    ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
+             failed);
+  } else {
+    ESP_LOGV(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
+             failed);
   }
 
   // note: commit on esp-idf currently is a no-op, nvs_set_blob always writes

--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -130,7 +130,7 @@ bool ESP32Preferences::sync() {
   s_pending_save.clear();
 
   if (failed > 0) {
-    ESP_LOGW(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%s for key=%" PRIu32,
+    ESP_LOGE(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%s for key=%" PRIu32,
              cached + written + failed, cached, written, failed, esp_err_to_name(last_err), last_key);
   } else if (written > 0) {
     ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -108,16 +108,21 @@ bool LibreTinyPreferences::sync() {
       }
       written++;
     } else {
-      ESP_LOGD(TAG, "FDB data not changed; skipping %" PRIu32 "  len=%zu", save.key, save.data.size());
+      ESP_LOGV(TAG, "FDB data not changed; skipping %" PRIu32 "  len=%zu", save.key, save.data.size());
       cached++;
     }
   }
   s_pending_save.clear();
 
-  ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
-           failed);
   if (failed > 0) {
-    ESP_LOGE(TAG, "Writing %d items failed. Last error=%d for key=%" PRIu32, failed, last_err, last_key);
+    ESP_LOGW(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%d for key=%" PRIu32,
+             cached + written + failed, cached, written, failed, last_err, last_key);
+  } else if (written > 0) {
+    ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
+             failed);
+  } else {
+    ESP_LOGV(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,
+             failed);
   }
 
   return failed == 0;

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -115,7 +115,7 @@ bool LibreTinyPreferences::sync() {
   s_pending_save.clear();
 
   if (failed > 0) {
-    ESP_LOGW(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%d for key=%" PRIu32,
+    ESP_LOGE(TAG, "Writing %d items: %d cached, %d written, %d failed. Last error=%d for key=%" PRIu32,
              cached + written + failed, cached, written, failed, last_err, last_key);
   } else if (written > 0) {
     ESP_LOGD(TAG, "Writing %d items: %d cached, %d written, %d failed", cached + written + failed, cached, written,


### PR DESCRIPTION
# What does this implement/fix?

Reduces log spam from preferences sync when nothing has actually changed. Previously, every sync cycle logged at DEBUG level even when all items were cached (unchanged), producing repeated noise like:

```
[22:32:58.834][D][preferences:132]: Writing 1 items: 1 cached, 0 written, 0 failed
[22:33:58.834][D][preferences:132]: Writing 1 items: 1 cached, 0 written, 0 failed
```

Now the log level reflects what actually happened:
- **ERROR** when writes failed (merged the separate error log into one line)
- **DEBUG** when data was actually written
- **VERBOSE** when everything was cached (no-op)

Also downgraded the per-item "FDB data not changed" log in LibreTiny from DEBUG to VERBOSE.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this is a logging-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).