### PR TITLE
[tormatic] Fix UART stream desync on ESP32

### DIFF
--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -281,6 +281,12 @@ optional<GateStatus> Tormatic::read_gate_status_() {
       }
       auto status = o_status.value();
 
+      // Drain any extra payload bytes beyond the StatusReply struct to prevent
+      // them from being misinterpreted as the next message header.
+      if (hdr.payload_size() > sizeof(StatusReply)) {
+        this->drain_rx_(hdr.payload_size() - sizeof(StatusReply));
+      }
+
       return status.state;
     }
 
@@ -344,17 +350,18 @@ template<typename T> optional<T> Tormatic::read_data_() {
   return obj;
 }
 
-// Drain up to n amount of bytes from the uart rx buffer.
-void Tormatic::drain_rx_(uint16_t n) {
-  uint8_t data;
-  uint16_t count = 0;
-  while (this->available()) {
-    this->read_byte(&data);
-    count++;
-
-    if (n > 0 && count >= n) {
+// Drain n bytes from the uart rx buffer using blocking reads.
+// Unlike available()/read_byte() loops, this waits for bytes that are still
+// in transit over the wire, preventing stream desync at low baud rates.
+void Tormatic::drain_rx_(uint32_t n) {
+  uint8_t buf[64];
+  while (n > 0) {
+    uint32_t to_read = std::min(n, static_cast<uint32_t>(sizeof(buf)));
+    if (!this->read_array(buf, to_read)) {
+      ESP_LOGW(TAG, "Timeout draining %" PRIu32 " remaining payload bytes", n);
       return;
     }
+    n -= to_read;
   }
 }
 

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -259,8 +259,11 @@ optional<GateStatus> Tormatic::read_gate_status_() {
   MessageHeader hdr;
 
   if (this->pending_hdr_) {
-    // Resume processing a header whose payload hadn't fully arrived yet.
-    hdr = this->pending_hdr_.value();
+    // Already have a header from a previous loop, wait for its payload.
+    if (this->available() < this->pending_hdr_->payload_size()) {
+      return {};
+    }
+    hdr = *this->pending_hdr_;
     this->pending_hdr_.reset();
   } else {
     if (this->available() < sizeof(MessageHeader)) {
@@ -272,14 +275,13 @@ optional<GateStatus> Tormatic::read_gate_status_() {
       ESP_LOGE(TAG, "Timeout reading message header");
       return {};
     }
-    hdr = o_hdr.value();
-  }
+    hdr = *o_hdr;
 
-  // Wait for all payload bytes to arrive before processing. Save the header
-  // so we can resume on the next loop() iteration without losing the message.
-  if (this->available() < hdr.payload_size()) {
-    this->pending_hdr_ = hdr;
-    return {};
+    // Payload not ready yet — save header and resume on next loop().
+    if (this->available() < hdr.payload_size()) {
+      this->pending_hdr_ = hdr;
+      return {};
+    }
   }
 
   switch (hdr.type) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -256,6 +256,16 @@ void Tormatic::stop_at_target_() {
 // Read a GateStatus from the unit. The unit only sends messages in response to
 // status requests or commands, so a message needs to be sent first.
 optional<GateStatus> Tormatic::read_gate_status_() {
+  // Drain any pending payload bytes from a previously-read message whose
+  // payload hadn't fully arrived when the header was processed.
+  if (this->pending_drain_ > 0) {
+    if (this->available() < this->pending_drain_) {
+      return {};
+    }
+    this->drain_rx_(this->pending_drain_);
+    this->pending_drain_ = 0;
+  }
+
   if (this->available() < sizeof(MessageHeader)) {
     return {};
   }
@@ -266,6 +276,13 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     return {};
   }
   auto hdr = o_hdr.value();
+
+  // Wait for all payload bytes to arrive before processing. If not ready,
+  // save the remaining byte count and drain on the next loop iteration.
+  if (this->available() < hdr.payload_size()) {
+    this->pending_drain_ = hdr.payload_size();
+    return {};
+  }
 
   switch (hdr.type) {
     case STATUS: {
@@ -350,18 +367,14 @@ template<typename T> optional<T> Tormatic::read_data_() {
   return obj;
 }
 
-// Drain n bytes from the uart rx buffer using blocking reads.
-// Unlike available()/read_byte() loops, this waits for bytes that are still
-// in transit over the wire, preventing stream desync at low baud rates.
+// Drain n bytes from the uart rx buffer. Caller must ensure at least n bytes
+// are available before calling.
 void Tormatic::drain_rx_(uint32_t n) {
-  uint8_t buf[64];
-  while (n > 0) {
-    uint32_t to_read = std::min(n, static_cast<uint32_t>(sizeof(buf)));
-    if (!this->read_array(buf, to_read)) {
-      ESP_LOGW(TAG, "Timeout draining %" PRIu32 " remaining payload bytes", n);
+  uint8_t data;
+  for (uint32_t i = 0; i < n; i++) {
+    if (!this->read_byte(&data)) {
       return;
     }
-    n -= to_read;
   }
 }
 

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -256,33 +256,25 @@ void Tormatic::stop_at_target_() {
 // Read a GateStatus from the unit. The unit only sends messages in response to
 // status requests or commands, so a message needs to be sent first.
 optional<GateStatus> Tormatic::read_gate_status_() {
-  MessageHeader hdr;
-
-  if (this->pending_hdr_) {
-    // Already have a header from a previous loop, wait for its payload.
-    if (this->available() < this->pending_hdr_->payload_size()) {
-      return {};
-    }
-    hdr = *this->pending_hdr_;
-    this->pending_hdr_.reset();
-  } else {
+  if (!this->pending_hdr_) {
     if (this->available() < sizeof(MessageHeader)) {
       return {};
     }
 
-    auto o_hdr = this->read_data_<MessageHeader>();
-    if (!o_hdr) {
+    this->pending_hdr_ = this->read_data_<MessageHeader>();
+    if (!this->pending_hdr_) {
       ESP_LOGE(TAG, "Timeout reading message header");
       return {};
     }
-    hdr = *o_hdr;
-
-    // Payload not ready yet — save header and resume on next loop().
-    if (this->available() < hdr.payload_size()) {
-      this->pending_hdr_ = hdr;
-      return {};
-    }
   }
+
+  // Wait for all payload bytes to arrive before processing.
+  if (this->available() < this->pending_hdr_->payload_size()) {
+    return {};
+  }
+
+  auto hdr = *this->pending_hdr_;
+  this->pending_hdr_.reset();
 
   switch (hdr.type) {
     case STATUS: {
@@ -296,7 +288,6 @@ optional<GateStatus> Tormatic::read_gate_status_() {
       if (!o_status) {
         return {};
       }
-      auto status = o_status.value();
 
       // Drain any extra payload bytes beyond the StatusReply struct to prevent
       // them from being misinterpreted as the next message header.
@@ -304,7 +295,7 @@ optional<GateStatus> Tormatic::read_gate_status_() {
         this->drain_rx_(hdr.payload_size() - sizeof(StatusReply));
       }
 
-      return status.state;
+      return o_status->state;
     }
 
     case COMMAND:

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -291,18 +291,13 @@ optional<GateStatus> Tormatic::read_gate_status_() {
       if (hdr.payload_size() != sizeof(StatusReply)) {
         ESP_LOGE(TAG, "Header specifies payload size %" PRIu32 " but size of StatusReply is %zu", hdr.payload_size(),
                  sizeof(StatusReply));
-      }
-
-      // Read a StatusReply requested by update().
-      auto o_status = this->read_data_<StatusReply>();
-      if (!o_status) {
+        this->drain_rx_(hdr.payload_size());
         return {};
       }
 
-      // Drain any extra payload bytes beyond the StatusReply struct to prevent
-      // them from being misinterpreted as the next message header.
-      if (hdr.payload_size() > sizeof(StatusReply)) {
-        this->drain_rx_(hdr.payload_size() - sizeof(StatusReply));
+      auto o_status = this->read_data_<StatusReply>();
+      if (!o_status) {
+        return {};
       }
 
       return o_status->state;

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -262,6 +262,9 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     }
 
     this->pending_hdr_ = this->read_data_<MessageHeader>();
+    if (!this->pending_hdr_) {
+      return {};
+    }
 
     // Sanity check: valid messages have small payloads (3-4 bytes). A large
     // or impossible payload_size means the stream is out of sync (corrupted

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -371,7 +371,7 @@ template<typename T> optional<T> Tormatic::read_data_() {
 
 // Drain n bytes from the uart rx buffer. Caller must ensure at least n bytes
 // are available before calling.
-void Tormatic::drain_rx_(uint32_t n) {
+void Tormatic::drain_rx_(uint16_t n) {
   uint8_t data;
   for (uint32_t i = 0; i < n; i++) {
     if (!this->read_byte(&data)) {

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -266,6 +266,17 @@ optional<GateStatus> Tormatic::read_gate_status_() {
       ESP_LOGE(TAG, "Timeout reading message header");
       return {};
     }
+
+    // Sanity check: valid messages have small payloads (3-4 bytes). A large
+    // or impossible payload_size means the stream is out of sync (corrupted
+    // byte, dropped data, etc.). Flush the buffer so we can resync on the
+    // next request/response cycle.
+    if (this->pending_hdr_->payload_size() > sizeof(CommandRequestReply)) {
+      ESP_LOGW(TAG, "Unexpected payload size %" PRIu32 ", flushing rx buffer", this->pending_hdr_->payload_size());
+      this->pending_hdr_.reset();
+      this->drain_rx_(this->available());
+      return {};
+    }
   }
 
   // Wait for all payload bytes to arrive before processing.

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -10,6 +10,10 @@ namespace tormatic {
 
 static const char *const TAG = "tormatic.cover";
 
+// Time to poll the UART when flushing after desync. At 9600 baud, a full
+// 12-byte message takes ~12.5ms, so 15ms guarantees all bytes have arrived.
+static constexpr uint32_t DRAIN_TIMEOUT_MS = 15;
+
 using namespace esphome::cover;
 
 void Tormatic::setup() {
@@ -273,7 +277,7 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     if (this->pending_hdr_->payload_size() > sizeof(CommandRequestReply)) {
       ESP_LOGW(TAG, "Unexpected payload size %" PRIu32 ", flushing rx buffer", this->pending_hdr_->payload_size());
       this->pending_hdr_.reset();
-      this->drain_rx_(this->available());
+      this->drain_rx_();
       return {};
     }
   }
@@ -363,13 +367,24 @@ template<typename T> optional<T> Tormatic::read_data_() {
   return obj;
 }
 
-// Drain n bytes from the uart rx buffer. Caller must ensure at least n bytes
-// are available before calling.
+// Drain bytes from the uart rx buffer. When n > 0, drain exactly n bytes
+// (caller must ensure they are available). When n == 0, poll for 15ms to
+// guarantee a full packet time at 9600 baud has elapsed, consuming any
+// bytes still in transit.
 void Tormatic::drain_rx_(uint16_t n) {
   uint8_t data;
-  for (uint32_t i = 0; i < n; i++) {
-    if (!this->read_byte(&data)) {
-      return;
+  if (n > 0) {
+    for (uint16_t i = 0; i < n; i++) {
+      if (!this->read_byte(&data)) {
+        return;
+      }
+    }
+  } else {
+    uint32_t start = millis();
+    while (millis() - start < DRAIN_TIMEOUT_MS) {
+      if (this->available()) {
+        this->read_byte(&data);
+      }
     }
   }
 }

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -256,31 +256,29 @@ void Tormatic::stop_at_target_() {
 // Read a GateStatus from the unit. The unit only sends messages in response to
 // status requests or commands, so a message needs to be sent first.
 optional<GateStatus> Tormatic::read_gate_status_() {
-  // Drain any pending payload bytes from a previously-read message whose
-  // payload hadn't fully arrived when the header was processed.
-  if (this->pending_drain_ > 0) {
-    if (this->available() < this->pending_drain_) {
+  MessageHeader hdr;
+
+  if (this->pending_hdr_) {
+    // Resume processing a header whose payload hadn't fully arrived yet.
+    hdr = this->pending_hdr_.value();
+    this->pending_hdr_.reset();
+  } else {
+    if (this->available() < sizeof(MessageHeader)) {
       return {};
     }
-    this->drain_rx_(this->pending_drain_);
-    this->pending_drain_ = 0;
+
+    auto o_hdr = this->read_data_<MessageHeader>();
+    if (!o_hdr) {
+      ESP_LOGE(TAG, "Timeout reading message header");
+      return {};
+    }
+    hdr = o_hdr.value();
   }
 
-  if (this->available() < sizeof(MessageHeader)) {
-    return {};
-  }
-
-  auto o_hdr = this->read_data_<MessageHeader>();
-  if (!o_hdr) {
-    ESP_LOGE(TAG, "Timeout reading message header");
-    return {};
-  }
-  auto hdr = o_hdr.value();
-
-  // Wait for all payload bytes to arrive before processing. If not ready,
-  // save the remaining byte count and drain on the next loop iteration.
+  // Wait for all payload bytes to arrive before processing. Save the header
+  // so we can resume on the next loop() iteration without losing the message.
   if (this->available() < hdr.payload_size()) {
-    this->pending_drain_ = hdr.payload_size();
+    this->pending_hdr_ = hdr;
     return {};
   }
 

--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -262,10 +262,6 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     }
 
     this->pending_hdr_ = this->read_data_<MessageHeader>();
-    if (!this->pending_hdr_) {
-      ESP_LOGE(TAG, "Timeout reading message header");
-      return {};
-    }
 
     // Sanity check: valid messages have small payloads (3-4 bytes). A large
     // or impossible payload_size means the stream is out of sync (corrupted

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -43,6 +43,7 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
   void handle_gate_status_(GateStatus s);
 
   uint32_t seq_tx_{0};
+  uint32_t pending_drain_{0};
 
   GateStatus current_status_{PAUSED};
 

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -43,7 +43,7 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
   void handle_gate_status_(GateStatus s);
 
   uint32_t seq_tx_{0};
-  uint32_t pending_drain_{0};
+  optional<MessageHeader> pending_hdr_{};
 
   GateStatus current_status_{PAUSED};
 

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -34,7 +34,7 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
 
   template<typename T> void send_message_(MessageType t, T r);
   template<typename T> optional<T> read_data_();
-  void drain_rx_(uint16_t n);
+  void drain_rx_(uint16_t n = 0);
 
   void request_gate_status_();
   optional<GateStatus> read_gate_status_();

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -34,7 +34,7 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
 
   template<typename T> void send_message_(MessageType t, T r);
   template<typename T> optional<T> read_data_();
-  void drain_rx_(uint32_t n);
+  void drain_rx_(uint16_t n);
 
   void request_gate_status_();
   optional<GateStatus> read_gate_status_();

--- a/esphome/components/tormatic/tormatic_cover.h
+++ b/esphome/components/tormatic/tormatic_cover.h
@@ -34,7 +34,7 @@ class Tormatic : public cover::Cover, public uart::UARTDevice, public PollingCom
 
   template<typename T> void send_message_(MessageType t, T r);
   template<typename T> optional<T> read_data_();
-  void drain_rx_(uint16_t n = 0);
+  void drain_rx_(uint32_t n);
 
   void request_gate_status_();
   optional<GateStatus> read_gate_status_();


### PR DESCRIPTION
# What does this implement/fix?

Fix UART stream desync in the tormatic cover component that causes cascading parse errors (`Reading remaining 196867 payload bytes of unknown type 0x0`).

Since #14391 enabled wake-on-RX by default for ESP32, the main loop wakes via ISR as soon as the first UART byte arrives. At 9600 baud, the 8-byte message header is read before the payload finishes transmitting. The old `drain_rx_()` was non-blocking (used `available()`/`read_byte()`), so it would exit with 0 bytes drained. The orphan payload bytes then shift all subsequent reads, producing garbage headers that cascade indefinitely.

**Fix:** Add a `pending_hdr_` state so `read_gate_status_()` checks `available()` before reading both the header and the payload. If the payload hasn't arrived yet, the header is saved and processing resumes on the next `loop()` iteration — no messages are dropped and `loop()` never blocks.

Also adds:
- Sanity check on `payload_size()` after reading a header — if it exceeds the largest known message type, the rx buffer is flushed with a 15ms time-based drain (`DRAIN_TIMEOUT_MS`) to guarantee all in-flight bytes at 9600 baud are consumed before resuming. This prevents cascading parse errors from bytes still in transit.
- Early drain-and-return in the STATUS case when `payload_size` doesn't match `sizeof(StatusReply)`, instead of reading a potentially wrong struct.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15335

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — existing tormatic configs work as before
uart:
  - id: uart_1
    tx_pin: GPIO02
    rx_pin: GPIO03
    baud_rate: 9600

cover:
  - platform: tormatic
    device_class: garage
    name: Garage Auto
    uart_id: uart_1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).