### PR TITLE
[internal_temperature] Move code into platform specific files

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature.h
+++ b/esphome/components/internal_temperature/internal_temperature.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/core/component.h"
 
 namespace esphome {
 namespace internal_temperature {
 
 class InternalTemperatureSensor : public sensor::Sensor, public PollingComponent {
  public:
+#if defined(USE_ESP32) || (defined(USE_ZEPHYR) && defined(USE_NRF52))
   void setup() override;
+#endif  // USE_ESP32 || (USE_ZEPHYR && USE_NRF52)
   void dump_config() override;
 
   void update() override;

--- a/esphome/components/internal_temperature/internal_temperature.h
+++ b/esphome/components/internal_temperature/internal_temperature.h
@@ -3,8 +3,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 class InternalTemperatureSensor : public sensor::Sensor, public PollingComponent {
  public:
@@ -16,5 +15,4 @@ class InternalTemperatureSensor : public sensor::Sensor, public PollingComponent
   void update() override;
 };
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature

--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -1,0 +1,43 @@
+#ifdef USE_BK72XX
+
+#include "esphome/core/log.h"
+#include "internal_temperature.h"
+
+extern "C" {
+uint32_t temp_single_get_current_temperature(uint32_t *temp_value);
+}
+
+namespace esphome {
+namespace internal_temperature {
+
+static const char *const TAG = "internal_temperature.bk72xx";
+
+void InternalTemperatureSensor::update() {
+  float temperature = NAN;
+  bool success = false;
+
+  uint32_t raw, result;
+  result = temp_single_get_current_temperature(&raw);
+  success = (result == 0);
+#if defined(USE_LIBRETINY_VARIANT_BK7231N)
+  temperature = raw * -0.38f + 156.0f;
+#elif defined(USE_LIBRETINY_VARIANT_BK7231T)
+  temperature = raw * 0.04f;
+#else   // USE_LIBRETINY_VARIANT
+  temperature = raw * 0.128f;
+#endif  // USE_LIBRETINY_VARIANT
+
+  if (success && std::isfinite(temperature)) {
+    this->publish_state(temperature);
+  } else {
+    ESP_LOGD(TAG, "Ignoring invalid temperature (success=%d, value=%.1f)", success, temperature);
+    if (!this->has_state()) {
+      this->publish_state(NAN);
+    }
+  }
+}
+
+}  // namespace internal_temperature
+}  // namespace esphome
+
+#endif  // USE_BK72XX

--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -7,8 +7,7 @@ extern "C" {
 uint32_t temp_single_get_current_temperature(uint32_t *temp_value);
 }
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.bk72xx";
 
@@ -37,7 +36,6 @@ void InternalTemperatureSensor::update() {
   }
 }
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature
 
 #endif  // USE_BK72XX

--- a/esphome/components/internal_temperature/internal_temperature_common.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_common.cpp
@@ -1,0 +1,12 @@
+#include "esphome/core/log.h"
+#include "internal_temperature.h"
+
+namespace esphome {
+namespace internal_temperature {
+
+static const char *const TAG = "internal_temperature";
+
+void InternalTemperatureSensor::dump_config() { LOG_SENSOR("", "Internal Temperature Sensor", this); }
+
+}  // namespace internal_temperature
+}  // namespace esphome

--- a/esphome/components/internal_temperature/internal_temperature_common.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_common.cpp
@@ -1,12 +1,10 @@
 #include "esphome/core/log.h"
 #include "internal_temperature.h"
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature";
 
 void InternalTemperatureSensor::dump_config() { LOG_SENSOR("", "Internal Temperature Sensor", this); }
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -15,8 +15,7 @@ uint8_t temprature_sens_read();
 #include "driver/temperature_sensor.h"
 #endif  // USE_ESP32_VARIANT
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.esp32";
 
@@ -77,7 +76,6 @@ void InternalTemperatureSensor::setup() {
 #endif  // USE_ESP32_VARIANT
 }
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature
 
 #endif  // USE_ESP32

--- a/esphome/components/internal_temperature/internal_temperature_esp32.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_esp32.cpp
@@ -1,7 +1,8 @@
-#include "internal_temperature.h"
-#include "esphome/core/log.h"
-
 #ifdef USE_ESP32
+
+#include "esphome/core/log.h"
+#include "internal_temperature.h"
+
 #if defined(USE_ESP32_VARIANT_ESP32)
 // there is no official API available on the original ESP32
 extern "C" {
@@ -13,70 +14,21 @@ uint8_t temprature_sens_read();
     defined(USE_ESP32_VARIANT_ESP32S3)
 #include "driver/temperature_sensor.h"
 #endif  // USE_ESP32_VARIANT
-#endif  // USE_ESP32
-#ifdef USE_RP2040
-#include "Arduino.h"
-#endif  // USE_RP2040
-#ifdef USE_BK72XX
-extern "C" {
-uint32_t temp_single_get_current_temperature(uint32_t *temp_value);
-}
-#endif  // USE_BK72XX
-#if defined(USE_ZEPHYR) && defined(USE_NRF52)
-#include <zephyr/device.h>
-#include <zephyr/drivers/sensor.h>
-#endif  // USE_ZEPHYR && USE_NRF52
 
 namespace esphome {
 namespace internal_temperature {
 
-static const char *const TAG = "internal_temperature";
-#if defined(USE_ZEPHYR) && defined(USE_NRF52)
-static const struct device *const DIE_TEMPERATURE_SENSOR = DEVICE_DT_GET_ONE(nordic_nrf_temp);
-#endif  // USE_ZEPHYR && USE_NRF52
-#ifdef USE_ESP32
+static const char *const TAG = "internal_temperature.esp32";
+
 #if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
     defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || defined(USE_ESP32_VARIANT_ESP32H2) || \
     defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
 static temperature_sensor_handle_t tsensNew = NULL;
 #endif  // USE_ESP32_VARIANT
-#endif  // USE_ESP32
 
 void InternalTemperatureSensor::update() {
-#if defined(USE_ZEPHYR) && defined(USE_NRF52)
-  struct sensor_value value;
-  int result = sensor_sample_fetch(DIE_TEMPERATURE_SENSOR);
-  if (result != 0) {
-    ESP_LOGE(TAG, "Failed to fetch nRF52 die temperature sample (%d)", result);
-    if (!this->has_state()) {
-      this->publish_state(NAN);
-    }
-    return;
-  }
-
-  result = sensor_channel_get(DIE_TEMPERATURE_SENSOR, SENSOR_CHAN_DIE_TEMP, &value);
-  if (result != 0) {
-    ESP_LOGE(TAG, "Failed to get nRF52 die temperature (%d)", result);
-    if (!this->has_state()) {
-      this->publish_state(NAN);
-    }
-    return;
-  }
-
-  const float temperature = value.val1 + (value.val2 / 1000000.0f);
-  if (std::isfinite(temperature)) {
-    this->publish_state(temperature);
-  } else {
-    ESP_LOGD(TAG, "Ignoring invalid nRF52 temperature (value=%.1f)", temperature);
-    if (!this->has_state()) {
-      this->publish_state(NAN);
-    }
-  }
-#else
-
   float temperature = NAN;
   bool success = false;
-#ifdef USE_ESP32
 #if defined(USE_ESP32_VARIANT_ESP32)
   uint8_t raw = temprature_sens_read();
   ESP_LOGV(TAG, "Raw temperature value: %d", raw);
@@ -92,23 +44,7 @@ void InternalTemperatureSensor::update() {
     ESP_LOGE(TAG, "Reading failed (%d)", result);
   }
 #endif  // USE_ESP32_VARIANT
-#endif  // USE_ESP32
-#ifdef USE_RP2040
-  temperature = analogReadTemp();
-  success = (temperature != 0.0f);
-#endif  // USE_RP2040
-#ifdef USE_BK72XX
-  uint32_t raw, result;
-  result = temp_single_get_current_temperature(&raw);
-  success = (result == 0);
-#if defined(USE_LIBRETINY_VARIANT_BK7231N)
-  temperature = raw * -0.38f + 156.0f;
-#elif defined(USE_LIBRETINY_VARIANT_BK7231T)
-  temperature = raw * 0.04f;
-#else   // USE_LIBRETINY_VARIANT
-  temperature = raw * 0.128f;
-#endif  // USE_LIBRETINY_VARIANT
-#endif  // USE_BK72XX
+
   if (success && std::isfinite(temperature)) {
     this->publish_state(temperature);
   } else {
@@ -117,18 +53,9 @@ void InternalTemperatureSensor::update() {
       this->publish_state(NAN);
     }
   }
-#endif  // USE_ZEPHYR && USE_NRF52
 }
 
 void InternalTemperatureSensor::setup() {
-#if defined(USE_ZEPHYR) && defined(USE_NRF52)
-  if (!device_is_ready(DIE_TEMPERATURE_SENSOR)) {
-    ESP_LOGE(TAG, "nRF52 die temperature sensor device %s not ready", DIE_TEMPERATURE_SENSOR->name);
-    this->mark_failed();
-    return;
-  }
-#endif  // USE_ZEPHYR && USE_NRF52
-#ifdef USE_ESP32
 #if defined(USE_ESP32_VARIANT_ESP32C2) || defined(USE_ESP32_VARIANT_ESP32C3) || defined(USE_ESP32_VARIANT_ESP32C5) || \
     defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32C61) || defined(USE_ESP32_VARIANT_ESP32H2) || \
     defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
@@ -148,10 +75,9 @@ void InternalTemperatureSensor::setup() {
     return;
   }
 #endif  // USE_ESP32_VARIANT
-#endif  // USE_ESP32
 }
-
-void InternalTemperatureSensor::dump_config() { LOG_SENSOR("", "Internal Temperature Sensor", this); }
 
 }  // namespace internal_temperature
 }  // namespace esphome
+
+#endif  // USE_ESP32

--- a/esphome/components/internal_temperature/internal_temperature_rp2040.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2040.cpp
@@ -5,8 +5,7 @@
 
 #include "Arduino.h"
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.rp2040";
 
@@ -27,7 +26,6 @@ void InternalTemperatureSensor::update() {
   }
 }
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature
 
 #endif  // USE_RP2040

--- a/esphome/components/internal_temperature/internal_temperature_rp2040.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_rp2040.cpp
@@ -1,0 +1,33 @@
+#ifdef USE_RP2040
+
+#include "esphome/core/log.h"
+#include "internal_temperature.h"
+
+#include "Arduino.h"
+
+namespace esphome {
+namespace internal_temperature {
+
+static const char *const TAG = "internal_temperature.rp2040";
+
+void InternalTemperatureSensor::update() {
+  float temperature = NAN;
+  bool success = false;
+
+  temperature = analogReadTemp();
+  success = (temperature != 0.0f);
+
+  if (success && std::isfinite(temperature)) {
+    this->publish_state(temperature);
+  } else {
+    ESP_LOGD(TAG, "Ignoring invalid temperature (success=%d, value=%.1f)", success, temperature);
+    if (!this->has_state()) {
+      this->publish_state(NAN);
+    }
+  }
+}
+
+}  // namespace internal_temperature
+}  // namespace esphome
+
+#endif  // USE_RP2040

--- a/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
@@ -1,0 +1,58 @@
+#if defined(USE_ZEPHYR) && defined(USE_NRF52)
+
+#include "esphome/core/log.h"
+#include "internal_temperature.h"
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+
+namespace esphome {
+namespace internal_temperature {
+
+static const char *const TAG = "internal_temperature.zephyr";
+
+static const struct device *const DIE_TEMPERATURE_SENSOR = DEVICE_DT_GET_ONE(nordic_nrf_temp);
+
+void InternalTemperatureSensor::update() {
+  struct sensor_value value;
+  int result = sensor_sample_fetch(DIE_TEMPERATURE_SENSOR);
+  if (result != 0) {
+    ESP_LOGE(TAG, "Failed to fetch nRF52 die temperature sample (%d)", result);
+    if (!this->has_state()) {
+      this->publish_state(NAN);
+    }
+    return;
+  }
+
+  result = sensor_channel_get(DIE_TEMPERATURE_SENSOR, SENSOR_CHAN_DIE_TEMP, &value);
+  if (result != 0) {
+    ESP_LOGE(TAG, "Failed to get nRF52 die temperature (%d)", result);
+    if (!this->has_state()) {
+      this->publish_state(NAN);
+    }
+    return;
+  }
+
+  const float temperature = value.val1 + (value.val2 / 1000000.0f);
+  if (std::isfinite(temperature)) {
+    this->publish_state(temperature);
+  } else {
+    ESP_LOGD(TAG, "Ignoring invalid nRF52 temperature (value=%.1f)", temperature);
+    if (!this->has_state()) {
+      this->publish_state(NAN);
+    }
+  }
+}
+
+void InternalTemperatureSensor::setup() {
+  if (!device_is_ready(DIE_TEMPERATURE_SENSOR)) {
+    ESP_LOGE(TAG, "nRF52 die temperature sensor device %s not ready", DIE_TEMPERATURE_SENSOR->name);
+    this->mark_failed();
+    return;
+  }
+}
+
+}  // namespace internal_temperature
+}  // namespace esphome
+
+#endif  // USE_ZEPHYR && USE_NRF52

--- a/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_zephyr.cpp
@@ -6,8 +6,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 
-namespace esphome {
-namespace internal_temperature {
+namespace esphome::internal_temperature {
 
 static const char *const TAG = "internal_temperature.zephyr";
 
@@ -52,7 +51,6 @@ void InternalTemperatureSensor::setup() {
   }
 }
 
-}  // namespace internal_temperature
-}  // namespace esphome
+}  // namespace esphome::internal_temperature
 
 #endif  // USE_ZEPHYR && USE_NRF52

--- a/esphome/components/internal_temperature/sensor.py
+++ b/esphome/components/internal_temperature/sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 from esphome.components.zephyr import zephyr_add_prj_conf
+from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
 from esphome.const import (
     DEVICE_CLASS_TEMPERATURE,
@@ -11,6 +12,7 @@ from esphome.const import (
     PLATFORM_RP2040,
     STATE_CLASS_MEASUREMENT,
     UNIT_CELSIUS,
+    PlatformFramework,
 )
 from esphome.core import CORE
 
@@ -39,3 +41,18 @@ async def to_code(config):
     if CORE.using_zephyr and CORE.is_nrf52:
         zephyr_add_prj_conf("SENSOR", True)
         zephyr_add_prj_conf("TEMP_NRF5", True)
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "internal_temperature_esp32.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP32_IDF,
+        },
+        "internal_temperature_rp2040.cpp": {PlatformFramework.RP2040_ARDUINO},
+        "internal_temperature_bk72xx.cpp": {
+            PlatformFramework.BK72XX_ARDUINO,
+        },
+        "internal_temperature_zephyr.cpp": {PlatformFramework.NRF52_ZEPHYR},
+    }
+)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Moves the internal_temperature cpp code into platform specific files, similar to adc.

As the component gains support for more platforms, the file gets more messy with ifdefs etc. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
