### PR TITLE
[uart] fix baud rate not applied on `load_settings()` for ESP32 (IDF)

### DIFF
--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -390,5 +390,15 @@ void IRAM_ATTR IDFUARTComponent::uart_rx_isr_callback(uart_port_t uart_num, uart
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
+uint32_t IDFUARTComponent::get_hw_baud_rate() const {
+  uint32_t baud_rate = 0;
+  esp_err_t err = uart_get_baudrate(this->uart_num_, &baud_rate);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_get_baudrate failed: %s", esp_err_to_name(err));
+    return 0;
+  }
+  return baud_rate;
+}
+
 }  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -125,8 +125,6 @@ void IDFUARTComponent::setup() {
 void IDFUARTComponent::load_settings(bool dump_config) {
   esp_err_t err;
 
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
-
   if (uart_is_driver_installed(this->uart_num_)) {
     err = uart_driver_delete(this->uart_num_);
     if (err != ESP_OK) {
@@ -148,7 +146,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "01 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   // uart_param_config must be called before uart_driver_install: it resets the
   // UART peripheral registers, which would undo baud rate and framing settings
@@ -160,8 +157,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "02 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
-
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
@@ -190,7 +185,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
-  ESP_LOGD(TAG, "03 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {
@@ -209,7 +203,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "04 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_pin(this->uart_num_, tx, rx, flow_control, UART_PIN_NO_CHANGE);
   if (err != ESP_OK) {
@@ -217,7 +210,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "05 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_full_threshold(this->uart_num_, this->rx_full_threshold_);
   if (err != ESP_OK) {
@@ -225,7 +217,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "06 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_timeout(this->uart_num_, this->rx_timeout_);
   if (err != ESP_OK) {
@@ -233,7 +224,6 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "07 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
   auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
@@ -243,14 +233,12 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "08 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
   // Register ISR callback to wake the main loop when UART data arrives.
   // The callback runs in ISR context and uses vTaskNotifyGiveFromISR() to
   // wake the main loop task directly — no queue or FreeRTOS task needed.
   uart_set_select_notif_callback(this->uart_num_, IDFUARTComponent::uart_rx_isr_callback);
-  ESP_LOGD(TAG, "09 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
   if (dump_config) {
@@ -401,16 +389,6 @@ void IRAM_ATTR IDFUARTComponent::uart_rx_isr_callback(uart_port_t uart_num, uart
   }
 }
 #endif  // USE_UART_WAKE_LOOP_ON_RX
-
-uint32_t IDFUARTComponent::get_hw_baud_rate() const {
-  uint32_t baud_rate = 0;
-  esp_err_t err = uart_get_baudrate(this->uart_num_, &baud_rate);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_get_baudrate failed: %s", esp_err_to_name(err));
-    return 0;
-  }
-  return baud_rate;
-}
 
 }  // namespace esphome::uart
 #endif  // USE_ESP32

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -125,16 +125,6 @@ void IDFUARTComponent::setup() {
 void IDFUARTComponent::load_settings(bool dump_config) {
   esp_err_t err;
 
-  // uart_param_config must be called before uart_driver_install: it resets the
-  // UART peripheral registers, which would undo baud rate and framing settings
-  // applied after driver installation.
-  uart_config_t uart_config = this->get_config_();
-  err = uart_param_config(this->uart_num_, &uart_config);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
   ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   if (uart_is_driver_installed(this->uart_num_)) {
@@ -158,6 +148,20 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+
+  // uart_param_config must be called before uart_driver_install: it resets the
+  // UART peripheral registers, which would undo baud rate and framing settings
+  // applied after driver installation.
+  uart_config_t uart_config = this->get_config_();
+  err = uart_param_config(this->uart_num_, &uart_config);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
   int8_t rx = this->rx_pin_ != nullptr ? this->rx_pin_->get_pin() : -1;
@@ -186,6 +190,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {
@@ -204,6 +209,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_pin(this->uart_num_, tx, rx, flow_control, UART_PIN_NO_CHANGE);
   if (err != ESP_OK) {
@@ -211,6 +217,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_full_threshold(this->uart_num_, this->rx_full_threshold_);
   if (err != ESP_OK) {
@@ -218,6 +225,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_timeout(this->uart_num_, this->rx_timeout_);
   if (err != ESP_OK) {
@@ -225,6 +233,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
   auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
@@ -234,12 +243,14 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
   // Register ISR callback to wake the main loop when UART data arrives.
   // The callback runs in ISR context and uses vTaskNotifyGiveFromISR() to
   // wake the main loop task directly — no queue or FreeRTOS task needed.
   uart_set_select_notif_callback(this->uart_num_, IDFUARTComponent::uart_rx_isr_callback);
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
   if (dump_config) {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -148,7 +148,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "01 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   // uart_param_config must be called before uart_driver_install: it resets the
   // UART peripheral registers, which would undo baud rate and framing settings
@@ -160,7 +160,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "02 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
 
   int8_t tx = this->tx_pin_ != nullptr ? this->tx_pin_->get_pin() : -1;
@@ -190,7 +190,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
   if (this->rx_pin_ != this->tx_pin_) {
     setup_pin_if_needed(this->tx_pin_);
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "03 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   uint32_t invert = 0;
   if (this->tx_pin_ != nullptr && this->tx_pin_->is_inverted()) {
@@ -209,7 +209,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "04 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_pin(this->uart_num_, tx, rx, flow_control, UART_PIN_NO_CHANGE);
   if (err != ESP_OK) {
@@ -217,7 +217,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "05 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_full_threshold(this->uart_num_, this->rx_full_threshold_);
   if (err != ESP_OK) {
@@ -225,7 +225,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "06 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   err = uart_set_rx_timeout(this->uart_num_, this->rx_timeout_);
   if (err != ESP_OK) {
@@ -233,7 +233,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "07 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
   auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
@@ -243,14 +243,14 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "08 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
 #ifdef USE_UART_WAKE_LOOP_ON_RX
   // Register ISR callback to wake the main loop when UART data arrives.
   // The callback runs in ISR context and uses vTaskNotifyGiveFromISR() to
   // wake the main loop task directly — no queue or FreeRTOS task needed.
   uart_set_select_notif_callback(this->uart_num_, IDFUARTComponent::uart_rx_isr_callback);
-  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
+  ESP_LOGD(TAG, "09 hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 #endif  // USE_UART_WAKE_LOOP_ON_RX
 
   if (dump_config) {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -125,6 +125,17 @@ void IDFUARTComponent::setup() {
 void IDFUARTComponent::load_settings(bool dump_config) {
   esp_err_t err;
 
+  // uart_param_config must be called before uart_driver_install: it resets the
+  // UART peripheral registers, which would undo baud rate and framing settings
+  // applied after driver installation.
+  uart_config_t uart_config = this->get_config_();
+  err = uart_param_config(this->uart_num_, &uart_config);
+  if (err != ESP_OK) {
+    ESP_LOGW(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
+  }
+
   if (uart_is_driver_installed(this->uart_num_)) {
     err = uart_driver_delete(this->uart_num_);
     if (err != ESP_OK) {
@@ -214,18 +225,11 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
+  // Per ESP-IDF docs, uart_set_mode() must be called only after uart_driver_install().
   auto mode = this->flow_control_pin_ != nullptr ? UART_MODE_RS485_HALF_DUPLEX : UART_MODE_UART;
-  err = uart_set_mode(this->uart_num_, mode);  // per docs, must be called only after uart_driver_install()
+  err = uart_set_mode(this->uart_num_, mode);
   if (err != ESP_OK) {
     ESP_LOGW(TAG, "uart_set_mode failed: %s", esp_err_to_name(err));
-    this->mark_failed();
-    return;
-  }
-
-  uart_config_t uart_config = this->get_config_();
-  err = uart_param_config(this->uart_num_, &uart_config);
-  if (err != ESP_OK) {
-    ESP_LOGW(TAG, "uart_param_config failed: %s", esp_err_to_name(err));
     this->mark_failed();
     return;
   }

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -147,9 +147,12 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     return;
   }
 
-  // uart_param_config must be called before uart_driver_install: it resets the
-  // UART peripheral registers, which would undo baud rate and framing settings
-  // applied after driver installation.
+  // uart_param_config must be called after uart_driver_install and before any
+  // other uart_set_*() calls. The driver installation resets the UART peripheral
+  // registers to their default state, overwriting any previously configured baud
+  // rate or framing settings. Calling uart_param_config here ensures the requested
+  // settings are applied after the reset and before pin routing, inversion, and
+  // threshold configuration.
   uart_config_t uart_config = this->get_config_();
   err = uart_param_config(this->uart_num_, &uart_config);
   if (err != ESP_OK) {

--- a/esphome/components/uart/uart_component_esp_idf.cpp
+++ b/esphome/components/uart/uart_component_esp_idf.cpp
@@ -135,6 +135,7 @@ void IDFUARTComponent::load_settings(bool dump_config) {
     this->mark_failed();
     return;
   }
+  ESP_LOGD(TAG, "hardware baud_rate: %" PRIu32, this->get_hw_baud_rate());
 
   if (uart_is_driver_installed(this->uart_num_)) {
     err = uart_driver_delete(this->uart_num_);

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -52,6 +52,10 @@ class IDFUARTComponent : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   void load_settings() override { this->load_settings(true); }
 
+  /// Returns the baud rate currently configured in the UART hardware registers.
+  /// Useful for debugging to verify the hardware matches the requested baud rate.
+  uint32_t get_hw_baud_rate() const;
+
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;

--- a/esphome/components/uart/uart_component_esp_idf.h
+++ b/esphome/components/uart/uart_component_esp_idf.h
@@ -52,10 +52,6 @@ class IDFUARTComponent : public UARTComponent, public Component {
   void load_settings(bool dump_config) override;
   void load_settings() override { this->load_settings(true); }
 
-  /// Returns the baud rate currently configured in the UART hardware registers.
-  /// Useful for debugging to verify the hardware matches the requested baud rate.
-  uint32_t get_hw_baud_rate() const;
-
  protected:
   void check_logger_conflict() override;
   uart_port_t uart_num_;


### PR DESCRIPTION
# What does this implement/fix?

### Problem

On ESP32 (ESP-IDF), calling `set_baud_rate()` followed by `load_settings()` does not change the baud rate on the wire. The hardware continues operating at the previously configured rate.

The root cause is the position of `uart_param_config()` in `load_settings()`. It was called last, after `uart_set_pin()`, `uart_set_line_inverse()`, and the threshold/timeout functions. `uart_driver_install()` resets the UART peripheral registers to their default state, and one or more of the subsequent `uart_set_*()` calls was restoring the old baud rate before `uart_param_config()` could apply the new one.

### Fix

Move `uart_param_config()` to immediately after `uart_driver_install()`, before any other `uart_set_*()` calls. This ensures the requested baud rate and framing settings are applied after the driver reset and are not overwritten.

### Testing

Verified on ESP32 (IDF) using `uart_get_baudrate()` to confirm the hardware baud rate matches the requested value after `load_settings()` returns.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
