### PR TITLE
[esp32_camera] Bump esp32-camera to v2.1.6

### DIFF
--- a/esphome/components/camera_encoder/__init__.py
+++ b/esphome/components/camera_encoder/__init__.py
@@ -50,7 +50,7 @@ async def to_code(config: ConfigType) -> None:
     buffer = cg.new_Pvariable(config[CONF_ENCODER_BUFFER_ID])
     cg.add(buffer.set_buffer_size(config[CONF_BUFFER_SIZE]))
     if config[CONF_TYPE] == ESP32_CAMERA_ENCODER:
-        add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
+        add_idf_component(name="espressif/esp32-camera", ref="2.1.6")
         cg.add_define("USE_ESP32_CAMERA_JPEG_ENCODER")
         var = cg.new_Pvariable(
             config[CONF_ID],

--- a/esphome/components/esp32_camera/__init__.py
+++ b/esphome/components/esp32_camera/__init__.py
@@ -400,7 +400,7 @@ async def to_code(config):
     if config[CONF_JPEG_QUALITY] != 0 and config[CONF_PIXEL_FORMAT] != "JPEG":
         cg.add_define("USE_ESP32_CAMERA_JPEG_CONVERSION")
 
-    add_idf_component(name="espressif/esp32-camera", ref="2.1.5")
+    add_idf_component(name="espressif/esp32-camera", ref="2.1.6")
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW", True)
     add_idf_sdkconfig_option("CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY", False)
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
   espressif/esp-tflite-micro:
     version: 1.3.3~1
   espressif/esp32-camera:
-    version: 2.1.5
+    version: 2.1.6
   espressif/mdns:
     version: 1.10.0
   espressif/esp_wifi_remote:


### PR DESCRIPTION
## What does this implement/fix?

Bumps the `espressif/esp32-camera` component from v2.1.5 to [v2.1.6](https://github.com/espressif/esp32-camera/releases/tag/v2.1.6). This is needed for ESP-IDF 6 support.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - version bump only.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).