### PR TITLE
[api] Combine reserve_and_resize + resize in encode_to_buffer

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -2023,19 +2023,21 @@ uint16_t APIConnection::encode_to_buffer(uint32_t calculated_size, MessageEncode
 
   auto &shared_buf = conn->parent_->get_shared_buffer_ref();
 
+  size_t write_start;
   if (conn->flags_.batch_first_message) {
     // First message - buffer already prepared by caller, just clear flag
     conn->flags_.batch_first_message = false;
+    write_start = shared_buf.size();
+    shared_buf.resize(write_start + calculated_size);
   } else {
     // Batch message second or later
-    // Add padding for previous message footer + this message header
+    // Reserve for full message, resize to include footer gap + header padding + payload
     size_t current_size = shared_buf.size();
-    shared_buf.reserve_and_resize(current_size + total_calculated_size, current_size + footer_size + header_padding);
+    shared_buf.reserve_and_resize(current_size + total_calculated_size,
+                                  current_size + footer_size + header_padding + calculated_size);
+    write_start = shared_buf.size() - calculated_size;
   }
 
-  // Pre-resize buffer to include payload, then encode through raw pointer
-  size_t write_start = shared_buf.size();
-  shared_buf.resize(write_start + calculated_size);
   ProtoWriteBuffer buffer{&shared_buf, write_start};
   encode_fn(msg, buffer);
 


### PR DESCRIPTION
# What does this implement/fix?

For non-first batch messages in `encode_to_buffer`, the payload `resize` is folded into the existing `reserve_and_resize` call. This eliminates a redundant `size()` read, a redundant capacity check, and an extra jump on the hot path.

Disassembly comparison (ESP32 IDF, xtensa):
- `encode_to_buffer`: 130 → 113 bytes (−17 bytes)
- Flash Code total: 584,648 → 584,632 (−16 bytes)
- ~5 fewer instructions on the second-message path

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).