### PR TITLE
[core] Reduce runtime_stats measurement overhead

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -519,13 +519,6 @@ WarnIfComponentBlockingGuard::warn_blocking(Component *component, uint32_t block
   }
 }
 
-#ifdef USE_RUNTIME_STATS
-void WarnIfComponentBlockingGuard::record_runtime_stats_() {
-  uint32_t duration_us = micros() - this->started_us_;
-  this->component_->runtime_stats_.record_time(duration_us);
-}
-#endif
-
 #ifdef USE_SETUP_PRIORITY_OVERRIDE
 void clear_setup_priority_overrides() {
   // Free the setup priority map completely

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -628,23 +628,22 @@ class WarnIfComponentBlockingGuard {
         started_us_(micros())
 #endif
   {
+#ifdef USE_RUNTIME_STATS
+    // Use micros()-derived ms for both stats and blocking detection so clocks match
+    this->started_ = this->started_us_ / 1000U;
+#endif
   }
 
   // Finish the timing operation and return the current time
-  // Inlined: the fast path is just millis() + subtract + compare
   inline uint32_t HOT finish() {
-    uint32_t curr_time = millis();
-    uint32_t blocking_time = curr_time - this->started_;
 #ifdef USE_RUNTIME_STATS
-    this->record_runtime_stats_();
+    // Single micros() call serves both runtime stats and blocking detection.
+    // Converting to millis avoids the separate millis() call.
+    uint32_t curr_time = this->record_runtime_stats_();
+#else
+    uint32_t curr_time = millis();
 #endif
-#ifndef USE_BENCHMARK
-    // Fast path: compare against constant threshold in ms (computed at compile time from centiseconds)
-    static constexpr uint32_t WARN_IF_BLOCKING_OVER_MS = static_cast<uint32_t>(WARN_IF_BLOCKING_OVER_CS) * 10U;
-    if (blocking_time > WARN_IF_BLOCKING_OVER_MS) [[unlikely]] {
-      warn_blocking(this->component_, blocking_time);
-    }
-#endif
+    this->check_blocking_(curr_time);
     return curr_time;
   }
 
@@ -655,8 +654,23 @@ class WarnIfComponentBlockingGuard {
   Component *component_;
 #ifdef USE_RUNTIME_STATS
   uint32_t started_us_;
-  void record_runtime_stats_();
+  // Record runtime stats and return current time in ms (derived from micros())
+  inline uint32_t record_runtime_stats_() {
+    uint32_t end_us = micros();
+    this->component_->runtime_stats_.record_time(end_us - this->started_us_);
+    return end_us / 1000U;
+  }
 #endif
+  // Fast path: compare against constant threshold in ms (computed at compile time from centiseconds)
+  inline void check_blocking_(uint32_t curr_time) {
+#ifndef USE_BENCHMARK
+    static constexpr uint32_t WARN_IF_BLOCKING_OVER_MS = static_cast<uint32_t>(WARN_IF_BLOCKING_OVER_CS) * 10U;
+    uint32_t blocking_time = curr_time - this->started_;
+    if (blocking_time > WARN_IF_BLOCKING_OVER_MS) [[unlikely]] {
+      warn_blocking(this->component_, blocking_time);
+    }
+#endif
+  }
 
  private:
   // Cold path for blocking warning - defined in component.cpp

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -628,22 +628,15 @@ class WarnIfComponentBlockingGuard {
         started_us_(micros())
 #endif
   {
-#ifdef USE_RUNTIME_STATS
-    // Use micros()-derived ms for both stats and blocking detection so clocks match
-    this->started_ = this->started_us_ / 1000U;
-#endif
   }
 
-  // Finish the timing operation and return the current time
+  // Finish the timing operation and return the current time (millis)
   inline uint32_t HOT finish() {
 #ifdef USE_RUNTIME_STATS
-    // Single micros() call serves both runtime stats and blocking detection.
-    // Converting to millis avoids the separate millis() call.
-    uint32_t curr_time = this->record_runtime_stats_();
-#else
-    uint32_t curr_time = millis();
+    this->record_runtime_stats_();
 #endif
-    this->check_blocking_(curr_time);
+    uint32_t curr_time = millis();
+    this->check_blocking_(curr_time - this->started_);
     return curr_time;
   }
 
@@ -654,18 +647,12 @@ class WarnIfComponentBlockingGuard {
   Component *component_;
 #ifdef USE_RUNTIME_STATS
   uint32_t started_us_;
-  // Record runtime stats and return current time in ms (derived from micros())
-  inline uint32_t record_runtime_stats_() {
-    uint32_t end_us = micros();
-    this->component_->runtime_stats_.record_time(end_us - this->started_us_);
-    return end_us / 1000U;
-  }
+  inline void record_runtime_stats_() { this->component_->runtime_stats_.record_time(micros() - this->started_us_); }
 #endif
   // Fast path: compare against constant threshold in ms (computed at compile time from centiseconds)
-  inline void check_blocking_(uint32_t curr_time) {
+  inline void check_blocking_(uint32_t blocking_time) {
 #ifndef USE_BENCHMARK
     static constexpr uint32_t WARN_IF_BLOCKING_OVER_MS = static_cast<uint32_t>(WARN_IF_BLOCKING_OVER_CS) * 10U;
-    uint32_t blocking_time = curr_time - this->started_;
     if (blocking_time > WARN_IF_BLOCKING_OVER_MS) [[unlikely]] {
       warn_blocking(this->component_, blocking_time);
     }

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -631,12 +631,20 @@ class WarnIfComponentBlockingGuard {
   }
 
   // Finish the timing operation and return the current time (millis)
+  // Inlined: the fast path is just millis() + subtract + compare
   inline uint32_t HOT finish() {
 #ifdef USE_RUNTIME_STATS
-    this->record_runtime_stats_();
+    this->component_->runtime_stats_.record_time(micros() - this->started_us_);
 #endif
     uint32_t curr_time = millis();
-    this->check_blocking_(curr_time - this->started_);
+#ifndef USE_BENCHMARK
+    // Fast path: compare against constant threshold in ms (computed at compile time from centiseconds)
+    static constexpr uint32_t WARN_IF_BLOCKING_OVER_MS = static_cast<uint32_t>(WARN_IF_BLOCKING_OVER_CS) * 10U;
+    uint32_t blocking_time = curr_time - this->started_;
+    if (blocking_time > WARN_IF_BLOCKING_OVER_MS) [[unlikely]] {
+      warn_blocking(this->component_, blocking_time);
+    }
+#endif
     return curr_time;
   }
 
@@ -647,17 +655,7 @@ class WarnIfComponentBlockingGuard {
   Component *component_;
 #ifdef USE_RUNTIME_STATS
   uint32_t started_us_;
-  inline void record_runtime_stats_() { this->component_->runtime_stats_.record_time(micros() - this->started_us_); }
 #endif
-  // Fast path: compare against constant threshold in ms (computed at compile time from centiseconds)
-  inline void check_blocking_(uint32_t blocking_time) {
-#ifndef USE_BENCHMARK
-    static constexpr uint32_t WARN_IF_BLOCKING_OVER_MS = static_cast<uint32_t>(WARN_IF_BLOCKING_OVER_CS) * 10U;
-    if (blocking_time > WARN_IF_BLOCKING_OVER_MS) [[unlikely]] {
-      warn_blocking(this->component_, blocking_time);
-    }
-#endif
-  }
 
  private:
   // Cold path for blocking warning - defined in component.cpp


### PR DESCRIPTION
# What does this implement/fix?

On devices where component loop() hot paths have been optimized, the `runtime_stats` measurement overhead had become the dominant cost for fast components — we were measuring measurement overhead, not actual work. On devices with real bottlenecks, the problematic component was still immediately obvious, but on optimized devices it was impossible to confirm they were truly at optimal.

A benchmark button revealed that wifi's actual loop cost is **0.5 μs**, but `runtime_stats` reported **11 μs** — the extra 10.5 μs was pure instrumentation overhead from `WarnIfComponentBlockingGuard`.

### What was being measured

The old `record_runtime_stats_()` was a **non-inlined function** that called `micros()`, and it ran **after** `millis()` had already been called in `finish()`. So the stats for each component included:

1. The `millis()` call itself
2. The out-of-line function call overhead (entry/retw on Xtensa)
3. A second timer read (`micros()` inside `record_runtime_stats_()`)

None of that is the component's actual work — it's all instrumentation.

### Fix

Inline `record_runtime_stats_()` and move it **before** `millis()` so the `micros()` snapshot captures only the component's work, not the measurement machinery. The `millis()` return value stays in the caller's clock domain unchanged.

### Results

**ESP32 (IDF) — system with api + web_server + ota:**

Before, fast components like OTA reported ~3 μs avg — mostly measurement overhead. After:
```
api:            count=7488, avg=0.004ms, max=2.15ms, total=29.5ms
web_server:     count=7494, avg=0.001ms, max=0.27ms, total=7.6ms
esphome.ota:    count=7488, avg=0.000ms, max=0.01ms, total=1.6ms
```

OTA now reports 0.000 ms avg — the actual work is below the measurement threshold, which is what you'd expect for a component that just checks a bool.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).