### PR TITLE
[core] Force inline Component::get_component_log_str()

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -267,9 +267,6 @@ void Component::call() {
       break;
   }
 }
-const LogString *Component::get_component_log_str() const {
-  return component_source_lookup(this->component_source_index_);
-}
 bool Component::should_warn_of_blocking(uint32_t blocking_time) {
   // Convert centisecond threshold to milliseconds for comparison
   uint32_t threshold_ms = static_cast<uint32_t>(this->warn_if_blocking_over_) * 10U;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -323,7 +323,9 @@ class Component {
    *
    * Returns LOG_STR("<unknown>") if source not set
    */
-  const LogString *get_component_log_str() const;
+  inline const LogString *get_component_log_str() const ESPHOME_ALWAYS_INLINE {
+    return component_source_lookup(this->component_source_index_);
+  }
 
   bool should_warn_of_blocking(uint32_t blocking_time);
 


### PR DESCRIPTION
# What does this implement/fix?

Move `get_component_log_str()` from `component.cpp` into the header as an `ESPHOME_ALWAYS_INLINE` method. This is a trivial one-liner that calls `component_source_lookup()`, but the compiler was keeping it out-of-line across 8 call sites (13 bytes).

Saves 8 bytes on ESP32.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).