### PR TITLE
[mitsubishi_cn105] Fix test grouping conflict with uart package

### DIFF
--- a/tests/components/mitsubishi_cn105/test.esp32-idf.yaml
+++ b/tests/components/mitsubishi_cn105/test.esp32-idf.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_9600_even/esp32-idf.yaml
+  uart_9600_even: !include ../../test_build_components/common/uart_9600_even/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/mitsubishi_cn105/test.esp8266-ard.yaml
+++ b/tests/components/mitsubishi_cn105/test.esp8266-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_9600_even/esp8266-ard.yaml
+  uart_9600_even: !include ../../test_build_components/common/uart_9600_even/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/mitsubishi_cn105/test.rp2040-ard.yaml
+++ b/tests/components/mitsubishi_cn105/test.rp2040-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_9600_even/rp2040-ard.yaml
+  uart_9600_even: !include ../../test_build_components/common/uart_9600_even/rp2040-ard.yaml
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fix CI test grouping failure caused by `mitsubishi_cn105` test files using `uart` as the package key while including the `uart_9600_even` bus config. The test grouping system uses the package key name to determine compatibility, so it incorrectly grouped `mitsubishi_cn105` (which needs 9600 baud with EVEN parity) with components using the standard `uart` package (9600 baud, no parity). At merge time, the conflicting UART configs caused the entire batch to fail.

The fix renames the package key from `uart` to `uart_9600_even` to match the actual bus config directory, allowing the grouping system to correctly identify the incompatibility.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes regression from #15315

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).