### PR TITLE
[nextion] Collapse nested namespace to esphome::nextion

### DIFF
--- a/esphome/components/nextion/automation.h
+++ b/esphome/components/nextion/automation.h
@@ -2,8 +2,7 @@
 #include "esphome/core/automation.h"
 #include "nextion.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 template<typename... Ts> class NextionSetBrightnessAction : public Action<Ts...> {
  public:
@@ -91,5 +90,4 @@ template<typename... Ts> class NextionPublishBoolAction : public Action<Ts...> {
   NextionComponent *component_;
 };
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/util.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 static const char *const TAG = "nextion_binarysensor";
 
@@ -64,5 +63,4 @@ void NextionBinarySensor::set_state(bool state, bool publish, bool send_to_nexti
   ESP_LOGN(TAG, "Write: %s=%s", this->variable_name_.c_str(), ONOFF(this->state));
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/binary_sensor/nextion_binarysensor.h
+++ b/esphome/components/nextion/binary_sensor/nextion_binarysensor.h
@@ -4,8 +4,8 @@
 #include "../nextion_component.h"
 #include "../nextion_base.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 class NextionBinarySensor;
 
 class NextionBinarySensor : public NextionComponent,
@@ -38,5 +38,4 @@ class NextionBinarySensor : public NextionComponent,
  protected:
   uint8_t page_id_;
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -5,8 +5,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 static const char *const TAG = "nextion";
 
@@ -1290,5 +1289,4 @@ void Nextion::set_writer(const nextion_writer_t &writer) { this->writer_ = write
 
 bool Nextion::is_updating() { return this->connection_state_.is_updating_; }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion.h
+++ b/esphome/components/nextion/nextion.h
@@ -21,8 +21,7 @@
 #endif  // USE_ESP32 vs USE_ESP8266
 #endif  // USE_NEXTION_TFT_UPLOAD
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 class Nextion;
 class NextionComponentBase;
@@ -1547,5 +1546,4 @@ class Nextion : public NextionBase, public PollingComponent, public uart::UARTDe
   uint16_t max_q_age_ms_ = 8000;         ///< Maximum age for queue items in ms
 };
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_base.h
+++ b/esphome/components/nextion/nextion_base.h
@@ -2,8 +2,8 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/color.h"
 #include "nextion_component_base.h"
-namespace esphome {
-namespace nextion {
+
+namespace esphome::nextion {
 
 #ifdef ESPHOME_LOG_HAS_VERY_VERBOSE
 #define NEXTION_PROTOCOL_LOG
@@ -61,5 +61,4 @@ class NextionBase {
   bool is_detected_ = false;
 };
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_commands.cpp
+++ b/esphome/components/nextion/nextion_commands.cpp
@@ -3,8 +3,8 @@
 #include "esphome/core/log.h"
 #include <cinttypes>
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 static const char *const TAG = "nextion";
 
 // Sleep safe commands
@@ -340,5 +340,4 @@ void Nextion::set_nextion_rtc_time(ESPTime time) {
   this->add_no_result_to_queue_with_printf_("rtc5", "rtc5=%u", time.second);
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_component.cpp
+++ b/esphome/components/nextion/nextion_component.cpp
@@ -1,7 +1,6 @@
 #include "nextion_component.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 void NextionComponent::set_background_color(Color bco) {
   if (this->variable_name_ == this->variable_name_to_send_) {
@@ -110,5 +109,4 @@ void NextionComponent::update_component_settings(bool force_update) {
     this->component_flags_.font_id_needs_update = false;
   }
 }
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_component.h
+++ b/esphome/components/nextion/nextion_component.h
@@ -3,8 +3,8 @@
 #include "esphome/core/color.h"
 #include "nextion_base.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 class NextionComponent;
 
 class NextionComponent : public NextionComponentBase {
@@ -80,5 +80,4 @@ class NextionComponent : public NextionComponentBase {
     uint16_t reserved : 3;
   } component_flags_;
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_component_base.h
+++ b/esphome/components/nextion/nextion_component_base.h
@@ -5,8 +5,7 @@
 #include <vector>
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 enum NextionQueueType {
   NO_RESULT = 0,
@@ -102,5 +101,4 @@ class NextionComponentBase {
 
   bool needs_to_send_update_;
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/nextion_upload.cpp
+++ b/esphome/components/nextion/nextion_upload.cpp
@@ -4,8 +4,8 @@
 
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 static const char *const TAG = "nextion.upload";
 
 bool Nextion::upload_end_(bool successful) {
@@ -33,7 +33,6 @@ bool Nextion::upload_end_(bool successful) {
   return successful;
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion
 
 #endif  // USE_NEXTION_TFT_UPLOAD

--- a/esphome/components/nextion/nextion_upload_arduino.cpp
+++ b/esphome/components/nextion/nextion_upload_arduino.cpp
@@ -11,8 +11,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 static const char *const TAG = "nextion.upload.arduino";
 static constexpr size_t NEXTION_MAX_RESPONSE_LOG_BYTES = 16;
 
@@ -342,8 +342,7 @@ WiFiClient *Nextion::get_wifi_client_() {
 }
 #endif  // USE_ESP8266
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion
 
 #endif  // NOT USE_ESP32
 #endif  // USE_NEXTION_TFT_UPLOAD

--- a/esphome/components/nextion/nextion_upload_esp32.cpp
+++ b/esphome/components/nextion/nextion_upload_esp32.cpp
@@ -14,8 +14,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 static const char *const TAG = "nextion.upload.esp32";
 static constexpr size_t NEXTION_MAX_RESPONSE_LOG_BYTES = 16;
 
@@ -344,8 +344,7 @@ bool Nextion::upload_tft(uint32_t baud_rate, bool exit_reparse) {
   return this->upload_end_(true);
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion
 
 #endif  // USE_ESP32
 #endif  // USE_NEXTION_TFT_UPLOAD

--- a/esphome/components/nextion/sensor/nextion_sensor.cpp
+++ b/esphome/components/nextion/sensor/nextion_sensor.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/util.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 static const char *const TAG = "nextion_sensor";
 
@@ -108,5 +107,4 @@ void NextionSensor::wave_update_() {
   this->nextion_->add_addt_command_to_queue(this);
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/sensor/nextion_sensor.h
+++ b/esphome/components/nextion/sensor/nextion_sensor.h
@@ -4,8 +4,8 @@
 #include "../nextion_component.h"
 #include "../nextion_base.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 class NextionSensor;
 
 class NextionSensor : public NextionComponent, public sensor::Sensor, public PollingComponent {
@@ -44,5 +44,4 @@ class NextionSensor : public NextionComponent, public sensor::Sensor, public Pol
   bool send_last_value_ = true;
   void wave_update_();
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/switch/nextion_switch.cpp
+++ b/esphome/components/nextion/switch/nextion_switch.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/util.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
 
 static const char *const TAG = "nextion_switch";
 
@@ -48,5 +47,4 @@ void NextionSwitch::set_state(bool state, bool publish, bool send_to_nextion) {
 
 void NextionSwitch::write_state(bool state) { this->set_state(state); }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/switch/nextion_switch.h
+++ b/esphome/components/nextion/switch/nextion_switch.h
@@ -4,8 +4,8 @@
 #include "../nextion_component.h"
 #include "../nextion_base.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 class NextionSwitch;
 
 class NextionSwitch : public NextionComponent, public switch_::Switch, public PollingComponent {
@@ -30,5 +30,4 @@ class NextionSwitch : public NextionComponent, public switch_::Switch, public Po
  protected:
   void write_state(bool state) override;
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.cpp
@@ -2,8 +2,8 @@
 #include "esphome/core/util.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 static const char *const TAG = "nextion_textsensor";
 
 void NextionTextSensor::process_text(const std::string &variable_name, const std::string &text_value) {
@@ -45,5 +45,4 @@ void NextionTextSensor::set_state(const std::string &state, bool publish, bool s
   ESP_LOGN(TAG, "Write: %s='%s'", this->variable_name_.c_str(), state.c_str());
 }
 
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion

--- a/esphome/components/nextion/text_sensor/nextion_textsensor.h
+++ b/esphome/components/nextion/text_sensor/nextion_textsensor.h
@@ -4,8 +4,8 @@
 #include "../nextion_component.h"
 #include "../nextion_base.h"
 
-namespace esphome {
-namespace nextion {
+namespace esphome::nextion {
+
 class NextionTextSensor;
 
 class NextionTextSensor : public NextionComponent, public text_sensor::TextSensor, public PollingComponent {
@@ -28,5 +28,4 @@ class NextionTextSensor : public NextionComponent, public text_sensor::TextSenso
     this->set_state(state_value, publish, send_to_nextion);
   }
 };
-}  // namespace nextion
-}  // namespace esphome
+}  // namespace esphome::nextion


### PR DESCRIPTION
# What does this implement/fix?

Collapses the nested namespace declarations across all Nextion component files from:
```cpp
namespace esphome {
namespace nextion {
// ...
}  // namespace nextion
}  // namespace esphome
```

to the C++17 nested namespace syntax:
```cpp
namespace esphome::nextion {
// ...
}  // namespace esphome::nextion
```

Pure style/consistency change. No logic change, no API change.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`: N/A

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
