### PR TITLE
[time] Use O(1) closed-form leap year math for epoch-to-year conversion

### DIFF
--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -35,11 +35,10 @@ bool is_leap_year(int year) { return (year % 4 == 0 && year % 100 != 0) || (year
 static inline int days_in_year(int year) { return is_leap_year(year) ? 366 : 365; }
 
 // Count leap years in [1, year] (i.e. up to and including year)
-static inline int count_leap_years_up_to(int year) { return year / 4 - year / 100 + year / 400; }
+static constexpr int count_leap_years_up_to(int year) { return year / 4 - year / 100 + year / 400; }
 
-// Leap years before the Unix epoch: 1969/4 - 1969/100 + 1969/400
-constexpr int LEAP_YEARS_BEFORE_EPOCH = 477;
 constexpr int EPOCH_YEAR = 1970;
+constexpr int LEAP_YEARS_BEFORE_EPOCH = count_leap_years_up_to(EPOCH_YEAR - 1);
 constexpr int DAYS_PER_YEAR = 365;
 constexpr int SECONDS_PER_DAY = 86400;
 

--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -34,22 +34,35 @@ bool is_leap_year(int year) { return (year % 4 == 0 && year % 100 != 0) || (year
 // Get days in year (avoids duplicate is_leap_year calls)
 static inline int days_in_year(int year) { return is_leap_year(year) ? 366 : 365; }
 
-// Convert days since epoch to year, updating days to remainder
-static int __attribute__((noinline)) days_to_year(int64_t &days) {
-  int year = 1970;
-  int diy;
-  while (days >= (diy = days_in_year(year)) && year < 2200) {
-    days -= diy;
+// Count leap years in [1, year] (i.e. up to and including year)
+static inline int count_leap_years_up_to(int year) { return year / 4 - year / 100 + year / 400; }
+
+// Days from epoch (Jan 1 1970) to Jan 1 of given year — O(1)
+static inline int64_t days_to_year_start_fast(int year) {
+  // 365 * (year - 1970) + (leap days in [1970, year))
+  // Leap days in [1970, year) = leaps up to (year-1) - leaps up to 1969
+  constexpr int leaps_before_1970 = 477;  // 1969/4 - 1969/100 + 1969/400
+  return 365LL * (year - 1970) + (count_leap_years_up_to(year - 1) - leaps_before_1970);
+}
+
+// Convert days since epoch to year, updating days to day-of-year remainder — O(1)
+static int days_to_year(int64_t &days) {
+  // Estimate year from days using 365.2425 average
+  int year = static_cast<int>(1970 + days / 365);
+  // Adjust: check if estimate is correct
+  int64_t year_start = days_to_year_start_fast(year);
+  if (days < year_start) {
+    year--;
+    year_start = days_to_year_start_fast(year);
+  } else if (days >= year_start + days_in_year(year)) {
+    year_start += days_in_year(year);
     year++;
   }
-  while (days < 0 && year > 1900) {
-    year--;
-    days += days_in_year(year);
-  }
+  days -= year_start;
   return year;
 }
 
-// Extract just the year from a UTC epoch
+// Extract just the year from a UTC epoch — O(1)
 static int epoch_to_year(time_t epoch) {
   int64_t days = epoch / 86400;
   if (epoch < 0 && epoch % 86400 != 0)
@@ -281,15 +294,7 @@ static int __attribute__((noinline)) days_from_year_start(int year, int month, i
 }
 
 // Calculate days from epoch to Jan 1 of given year (for DST transition calculations)
-// Only supports years >= 1970. Timezone is either compiled in from YAML or set by
-// Home Assistant, so pre-1970 dates are not a concern.
-static int64_t __attribute__((noinline)) days_to_year_start(int year) {
-  int64_t days = 0;
-  for (int y = 1970; y < year; y++) {
-    days += days_in_year(y);
-  }
-  return days;
-}
+static int64_t days_to_year_start(int year) { return days_to_year_start_fast(year); }
 
 time_t __attribute__((noinline)) calculate_dst_transition(int year, const DSTRule &rule, int32_t base_offset_seconds) {
   int month, day;

--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -49,14 +49,18 @@ static inline int64_t days_to_year_start(int year) {
          (count_leap_years_up_to(year - 1) - LEAP_YEARS_BEFORE_EPOCH);
 }
 
-// Convert days since epoch to year, updating days to day-of-year remainder — O(1)
+// Convert days since epoch to year, updating days to day-of-year remainder.
+// The initial estimate from days/365 can overshoot by multiple years for
+// far-future dates (e.g., year 5000+) due to accumulated leap days,
+// so we use loops rather than single-step correction.
 static int days_to_year(int64_t &days) {
   int year = static_cast<int>(EPOCH_YEAR + days / DAYS_PER_YEAR);
   int64_t year_start = days_to_year_start(year);
-  if (days < year_start) {
+  while (days < year_start) {
     year--;
     year_start = days_to_year_start(year);
-  } else if (days >= year_start + days_in_year(year)) {
+  }
+  while (days >= year_start + days_in_year(year)) {
     year_start += days_in_year(year);
     year++;
   }

--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -37,19 +37,21 @@ static inline int days_in_year(int year) { return is_leap_year(year) ? 366 : 365
 // Count leap years in [1, year] (i.e. up to and including year)
 static inline int count_leap_years_up_to(int year) { return year / 4 - year / 100 + year / 400; }
 
+// Leap years before the Unix epoch: 1969/4 - 1969/100 + 1969/400
+constexpr int LEAP_YEARS_BEFORE_EPOCH = 477;
+constexpr int EPOCH_YEAR = 1970;
+constexpr int DAYS_PER_YEAR = 365;
+constexpr int SECONDS_PER_DAY = 86400;
+
 // Days from epoch (Jan 1 1970) to Jan 1 of given year — O(1)
 static inline int64_t days_to_year_start_fast(int year) {
-  // 365 * (year - 1970) + (leap days in [1970, year))
-  // Leap days in [1970, year) = leaps up to (year-1) - leaps up to 1969
-  constexpr int leaps_before_1970 = 477;  // 1969/4 - 1969/100 + 1969/400
-  return 365LL * (year - 1970) + (count_leap_years_up_to(year - 1) - leaps_before_1970);
+  return static_cast<int64_t>(DAYS_PER_YEAR) * (year - EPOCH_YEAR) +
+         (count_leap_years_up_to(year - 1) - LEAP_YEARS_BEFORE_EPOCH);
 }
 
 // Convert days since epoch to year, updating days to day-of-year remainder — O(1)
 static int days_to_year(int64_t &days) {
-  // Estimate year from days using 365.2425 average
-  int year = static_cast<int>(1970 + days / 365);
-  // Adjust: check if estimate is correct
+  int year = static_cast<int>(EPOCH_YEAR + days / DAYS_PER_YEAR);
   int64_t year_start = days_to_year_start_fast(year);
   if (days < year_start) {
     year--;
@@ -64,8 +66,8 @@ static int days_to_year(int64_t &days) {
 
 // Extract just the year from a UTC epoch — O(1)
 static int epoch_to_year(time_t epoch) {
-  int64_t days = epoch / 86400;
-  if (epoch < 0 && epoch % 86400 != 0)
+  int64_t days = epoch / SECONDS_PER_DAY;
+  if (epoch < 0 && epoch % SECONDS_PER_DAY != 0)
     days--;
   return days_to_year(days);
 }
@@ -100,11 +102,11 @@ int __attribute__((noinline)) day_of_week(int year, int month, int day) {
 
 void __attribute__((noinline)) epoch_to_tm_utc(time_t epoch, struct tm *out_tm) {
   // Days since epoch
-  int64_t days = epoch / 86400;
-  int32_t remaining_secs = epoch % 86400;
+  int64_t days = epoch / SECONDS_PER_DAY;
+  int32_t remaining_secs = epoch % SECONDS_PER_DAY;
   if (remaining_secs < 0) {
     days--;
-    remaining_secs += 86400;
+    remaining_secs += SECONDS_PER_DAY;
   }
 
   out_tm->tm_sec = remaining_secs % 60;
@@ -344,7 +346,7 @@ time_t __attribute__((noinline)) calculate_dst_transition(int year, const DSTRul
   int64_t days = days_to_year_start(year) + days_from_year_start(year, month, day);
 
   // Convert to epoch and add transition time and base offset
-  return days * 86400 + rule.time_seconds + base_offset_seconds;
+  return days * SECONDS_PER_DAY + rule.time_seconds + base_offset_seconds;
 }
 
 }  // namespace internal

--- a/esphome/components/time/posix_tz.cpp
+++ b/esphome/components/time/posix_tz.cpp
@@ -44,7 +44,7 @@ constexpr int DAYS_PER_YEAR = 365;
 constexpr int SECONDS_PER_DAY = 86400;
 
 // Days from epoch (Jan 1 1970) to Jan 1 of given year — O(1)
-static inline int64_t days_to_year_start_fast(int year) {
+static inline int64_t days_to_year_start(int year) {
   return static_cast<int64_t>(DAYS_PER_YEAR) * (year - EPOCH_YEAR) +
          (count_leap_years_up_to(year - 1) - LEAP_YEARS_BEFORE_EPOCH);
 }
@@ -52,10 +52,10 @@ static inline int64_t days_to_year_start_fast(int year) {
 // Convert days since epoch to year, updating days to day-of-year remainder — O(1)
 static int days_to_year(int64_t &days) {
   int year = static_cast<int>(EPOCH_YEAR + days / DAYS_PER_YEAR);
-  int64_t year_start = days_to_year_start_fast(year);
+  int64_t year_start = days_to_year_start(year);
   if (days < year_start) {
     year--;
-    year_start = days_to_year_start_fast(year);
+    year_start = days_to_year_start(year);
   } else if (days >= year_start + days_in_year(year)) {
     year_start += days_in_year(year);
     year++;
@@ -294,9 +294,6 @@ static int __attribute__((noinline)) days_from_year_start(int year, int month, i
   }
   return days;
 }
-
-// Calculate days from epoch to Jan 1 of given year (for DST transition calculations)
-static int64_t days_to_year_start(int year) { return days_to_year_start_fast(year); }
 
 time_t __attribute__((noinline)) calculate_dst_transition(int year, const DSTRule &rule, int32_t base_offset_seconds) {
   int month, day;

--- a/tests/components/time/posix_tz_parser.cpp
+++ b/tests/components/time/posix_tz_parser.cpp
@@ -765,7 +765,7 @@ TEST(PosixTzParser, EpochToLocalDstTransition) {
 TEST(PosixTzParser, EpochToLocalLeapYear2000) {
   // 2000 is a leap year (divisible by 400)
   ParsedTimezone tz;
-  parse_posix_tz("UTC0", tz);
+  ASSERT_TRUE(parse_posix_tz("UTC0", tz));
 
   // Feb 29, 2000 12:00:00 UTC
   time_t epoch = make_utc(2000, 2, 29, 12);
@@ -780,7 +780,7 @@ TEST(PosixTzParser, EpochToLocalLeapYear2000) {
 TEST(PosixTzParser, EpochToLocalNonLeapYear2100) {
   // 2100 is NOT a leap year (divisible by 100 but not 400)
   ParsedTimezone tz;
-  parse_posix_tz("UTC0", tz);
+  ASSERT_TRUE(parse_posix_tz("UTC0", tz));
 
   // Mar 1, 2100 00:00:00 UTC — the day after what would be Feb 29
   time_t epoch = make_utc(2100, 3, 1);
@@ -801,7 +801,7 @@ TEST(PosixTzParser, EpochToLocalNonLeapYear2100) {
 TEST(PosixTzParser, EpochToLocalLeapYear2400) {
   // 2400 is a leap year (divisible by 400)
   ParsedTimezone tz;
-  parse_posix_tz("UTC0", tz);
+  ASSERT_TRUE(parse_posix_tz("UTC0", tz));
 
   time_t epoch = make_utc(2400, 2, 29, 6);
   struct tm local;
@@ -815,7 +815,7 @@ TEST(PosixTzParser, EpochToLocalLeapYear2400) {
 TEST(PosixTzParser, EpochToLocalNewYearBoundaries) {
   // Test year boundary — last second of 2099 and first second of 2100
   ParsedTimezone tz;
-  parse_posix_tz("UTC0", tz);
+  ASSERT_TRUE(parse_posix_tz("UTC0", tz));
   struct tm local;
 
   // Dec 31, 2099 23:59:59 UTC
@@ -836,7 +836,7 @@ TEST(PosixTzParser, EpochToLocalNewYearBoundaries) {
 TEST(PosixTzParser, EpochToLocalDstAcrossCenturyBoundary) {
   // DST transition in year 2100 (non-leap) with US Eastern rules
   ParsedTimezone tz;
-  parse_posix_tz("EST5EDT,M3.2.0/2,M11.1.0/2", tz);
+  ASSERT_TRUE(parse_posix_tz("EST5EDT,M3.2.0/2,M11.1.0/2", tz));
 
   // July 4, 2100 16:00 UTC = 12:00 EDT
   time_t epoch = make_utc(2100, 7, 4, 16);
@@ -856,7 +856,7 @@ TEST(PosixTzParser, EpochToLocalFarFutureYear5000) {
   // Year 5000 — days/365 estimate overshoots by ~2 years due to leap days,
   // requiring multiple correction steps in days_to_year.
   ParsedTimezone tz;
-  parse_posix_tz("UTC0", tz);
+  ASSERT_TRUE(parse_posix_tz("UTC0", tz));
 
   time_t epoch = make_utc(5000, 6, 15, 12);
   struct tm local;

--- a/tests/components/time/posix_tz_parser.cpp
+++ b/tests/components/time/posix_tz_parser.cpp
@@ -759,6 +759,100 @@ TEST(PosixTzParser, EpochToLocalDstTransition) {
 }
 
 // ============================================================================
+// Leap year edge cases for closed-form year arithmetic
+// ============================================================================
+
+TEST(PosixTzParser, EpochToLocalLeapYear2000) {
+  // 2000 is a leap year (divisible by 400)
+  ParsedTimezone tz;
+  parse_posix_tz("UTC0", tz);
+
+  // Feb 29, 2000 12:00:00 UTC
+  time_t epoch = make_utc(2000, 2, 29, 12);
+  struct tm local;
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 100);  // 2000
+  EXPECT_EQ(local.tm_mon, 1);     // February
+  EXPECT_EQ(local.tm_mday, 29);
+  EXPECT_EQ(local.tm_hour, 12);
+}
+
+TEST(PosixTzParser, EpochToLocalNonLeapYear2100) {
+  // 2100 is NOT a leap year (divisible by 100 but not 400)
+  ParsedTimezone tz;
+  parse_posix_tz("UTC0", tz);
+
+  // Mar 1, 2100 00:00:00 UTC — the day after what would be Feb 29
+  time_t epoch = make_utc(2100, 3, 1);
+  struct tm local;
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 200);  // 2100
+  EXPECT_EQ(local.tm_mon, 2);     // March
+  EXPECT_EQ(local.tm_mday, 1);
+
+  // Feb 28, 2100 23:59:59 UTC — last second of February (no Feb 29)
+  epoch = make_utc(2100, 2, 28, 23, 59, 59);
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 200);
+  EXPECT_EQ(local.tm_mon, 1);  // February
+  EXPECT_EQ(local.tm_mday, 28);
+}
+
+TEST(PosixTzParser, EpochToLocalLeapYear2400) {
+  // 2400 is a leap year (divisible by 400)
+  ParsedTimezone tz;
+  parse_posix_tz("UTC0", tz);
+
+  time_t epoch = make_utc(2400, 2, 29, 6);
+  struct tm local;
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 500);  // 2400
+  EXPECT_EQ(local.tm_mon, 1);     // February
+  EXPECT_EQ(local.tm_mday, 29);
+  EXPECT_EQ(local.tm_hour, 6);
+}
+
+TEST(PosixTzParser, EpochToLocalNewYearBoundaries) {
+  // Test year boundary — last second of 2099 and first second of 2100
+  ParsedTimezone tz;
+  parse_posix_tz("UTC0", tz);
+  struct tm local;
+
+  // Dec 31, 2099 23:59:59 UTC
+  time_t epoch = make_utc(2099, 12, 31, 23, 59, 59);
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 199);  // 2099
+  EXPECT_EQ(local.tm_mon, 11);    // December
+  EXPECT_EQ(local.tm_mday, 31);
+
+  // Jan 1, 2100 00:00:00 UTC
+  epoch = make_utc(2100, 1, 1);
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 200);  // 2100
+  EXPECT_EQ(local.tm_mon, 0);     // January
+  EXPECT_EQ(local.tm_mday, 1);
+}
+
+TEST(PosixTzParser, EpochToLocalDstAcrossCenturyBoundary) {
+  // DST transition in year 2100 (non-leap) with US Eastern rules
+  ParsedTimezone tz;
+  parse_posix_tz("EST5EDT,M3.2.0/2,M11.1.0/2", tz);
+
+  // July 4, 2100 16:00 UTC = 12:00 EDT
+  time_t epoch = make_utc(2100, 7, 4, 16);
+  struct tm local;
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_hour, 12);
+  EXPECT_EQ(local.tm_isdst, 1);
+
+  // Jan 15, 2100 10:00 UTC = 05:00 EST
+  epoch = make_utc(2100, 1, 15, 10);
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_hour, 5);
+  EXPECT_EQ(local.tm_isdst, 0);
+}
+
+// ============================================================================
 // Verification against libc
 // ============================================================================
 

--- a/tests/components/time/posix_tz_parser.cpp
+++ b/tests/components/time/posix_tz_parser.cpp
@@ -852,6 +852,21 @@ TEST(PosixTzParser, EpochToLocalDstAcrossCenturyBoundary) {
   EXPECT_EQ(local.tm_isdst, 0);
 }
 
+TEST(PosixTzParser, EpochToLocalFarFutureYear5000) {
+  // Year 5000 — days/365 estimate overshoots by ~2 years due to leap days,
+  // requiring multiple correction steps in days_to_year.
+  ParsedTimezone tz;
+  parse_posix_tz("UTC0", tz);
+
+  time_t epoch = make_utc(5000, 6, 15, 12);
+  struct tm local;
+  ASSERT_TRUE(epoch_to_local_tm(epoch, tz, &local));
+  EXPECT_EQ(local.tm_year, 3100);  // 5000
+  EXPECT_EQ(local.tm_mon, 5);      // June
+  EXPECT_EQ(local.tm_mday, 15);
+  EXPECT_EQ(local.tm_hour, 12);
+}
+
 // ============================================================================
 // Verification against libc
 // ============================================================================


### PR DESCRIPTION
# What does this implement/fix?

Replace iterative O(year-1970) loops in `days_to_year`, `epoch_to_year`, and `days_to_year_start` with closed-form arithmetic using the standard leap year counting formula.

Previously these functions iterated from 1970 to the current year (56 iterations for 2026), and were called ~4 times per `now()` invocation (via `is_in_dst` → `calculate_dst_transition` ×2, plus `epoch_to_tm_utc`).

Benchmarked on ESP32 (240MHz):

| Operation | 2026.2.4 (libc TZ) | dev before (O(n)) | This PR |
|---|---|---|---|
| `now()` | 52.9 µs | 32.0 µs | 20.7 µs |
| `now()` + `strftime %A` | 91.5 µs | 81.7 µs | 22.1 µs |
| `strftime %A` (no `now()`) | 2.6 µs | 2.0 µs | 1.8 µs |
| `strftime %d %B %Y` | 31.1 µs | 25.1 µs | 13.3 µs |
| `strftime %H:%M` | 15.6 µs | 10.7 µs | 9.8 µs |

The custom TZ parser (#13635) was already faster than libc's `localtime_r`/`tzset()` path even with the O(n) loops. This change widens that gap further — `now()` is now 2.5× faster than the old libc path.

Also replaces bare `86400` literals with a `constexpr SECONDS_PER_DAY`.

Note: This is unlikely to solve #15314 — the most expensive combined `now()` + `strftime` call was only 91.5 µs on 2026.2.4 (before the TZ changes) and 81.7 µs on current dev, far too little to account for a 5-second task watchdog timeout. The benchmarks also show `now()` actually got *cheaper* in 2026.3.0 (52.9 → 32.0 µs), so the TZ parser change is not a regression. That issue is likely caused by the overall display rendering cost (large fonts on a 800×480 e-paper) rather than the time functions.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- relates to https://github.com/esphome/esphome/issues/15314

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).