### PR TITLE
[audio] use microFLAC library for decoding

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -210,6 +210,7 @@ async def to_code(config):
     data = _get_data()
     if data.flac_support:
         cg.add_define("USE_AUDIO_FLAC_SUPPORT")
+        add_idf_component(name="esphome/micro-flac", ref="0.1.1")
     if data.mp3_support:
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
     if data.opus_support:

--- a/esphome/components/audio/audio_decoder.cpp
+++ b/esphome/components/audio/audio_decoder.cpp
@@ -84,13 +84,10 @@ esp_err_t AudioDecoder::start(AudioFileType audio_file_type) {
   switch (this->audio_file_type_) {
 #ifdef USE_AUDIO_FLAC_SUPPORT
     case AudioFileType::FLAC:
-      this->flac_decoder_ = make_unique<esp_audio_libs::flac::FLACDecoder>();
-      // CRC check slows down decoding by 15-20% on an ESP32-S3. FLAC sources in ESPHome are either from an http source
-      // or built into the firmware, so the data integrity is already verified by the time it gets to the decoder,
-      // making the CRC check unnecessary.
-      this->flac_decoder_->set_crc_check_enabled(false);
+      this->flac_decoder_ = make_unique<micro_flac::FLACDecoder>();
       this->free_buffer_required_ =
           this->output_transfer_buffer_->capacity();  // Adjusted and reallocated after reading the header
+      this->decoder_buffers_internally_ = true;
       break;
 #endif
 #ifdef USE_AUDIO_MP3_SUPPORT
@@ -268,59 +265,45 @@ AudioDecoderState AudioDecoder::decode(bool stop_gracefully) {
 
 #ifdef USE_AUDIO_FLAC_SUPPORT
 FileDecoderState AudioDecoder::decode_flac_() {
-  if (!this->audio_stream_info_.has_value()) {
-    // Header hasn't been read
-    auto result = this->flac_decoder_->read_header(this->input_buffer_->data(), this->input_buffer_->available());
+  size_t bytes_consumed, samples_decoded;
 
-    if (result > esp_audio_libs::flac::FLAC_DECODER_HEADER_OUT_OF_DATA) {
-      // Serrious error reading FLAC header, there is no recovery
-      return FileDecoderState::FAILED;
+  micro_flac::FLACDecoderResult result = this->flac_decoder_->decode(
+      this->input_buffer_->data(), this->input_buffer_->available(), this->output_transfer_buffer_->get_buffer_end(),
+      this->output_transfer_buffer_->free(), bytes_consumed, samples_decoded);
+
+  if (result == micro_flac::FLAC_DECODER_SUCCESS) {
+    if (samples_decoded > 0 && this->audio_stream_info_.has_value()) {
+      this->output_transfer_buffer_->increase_buffer_length(
+          this->audio_stream_info_.value().samples_to_bytes(samples_decoded));
     }
-
-    size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
     this->input_buffer_->consume(bytes_consumed);
+  } else if (result == micro_flac::FLAC_DECODER_HEADER_READY) {
+    // Header just parsed, stream info now available
+    const auto &info = this->flac_decoder_->get_stream_info();
+    this->audio_stream_info_ = audio::AudioStreamInfo(info.bits_per_sample(), info.num_channels(), info.sample_rate());
 
-    if (result == esp_audio_libs::flac::FLAC_DECODER_HEADER_OUT_OF_DATA) {
-      return FileDecoderState::MORE_TO_PROCESS;
-    }
-
-    // Reallocate the output transfer buffer to the smallest necessary size
-    this->free_buffer_required_ = flac_decoder_->get_output_buffer_size_bytes();
+    // Reallocate the output transfer buffer to the required size
+    this->free_buffer_required_ = this->flac_decoder_->get_output_buffer_size_samples() * info.bytes_per_sample();
     if (!this->output_transfer_buffer_->reallocate(this->free_buffer_required_)) {
-      // Couldn't reallocate output buffer
       return FileDecoderState::FAILED;
     }
-
-    this->audio_stream_info_ =
-        audio::AudioStreamInfo(this->flac_decoder_->get_sample_depth(), this->flac_decoder_->get_num_channels(),
-                               this->flac_decoder_->get_sample_rate());
-
-    return FileDecoderState::MORE_TO_PROCESS;
-  }
-
-  uint32_t output_samples = 0;
-  auto result = this->flac_decoder_->decode_frame(this->input_buffer_->data(), this->input_buffer_->available(),
-                                                  this->output_transfer_buffer_->get_buffer_end(), &output_samples);
-
-  if (result == esp_audio_libs::flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
-    // Not an issue, just needs more data that we'll get next time.
-    return FileDecoderState::POTENTIALLY_FAILED;
-  }
-
-  size_t bytes_consumed = this->flac_decoder_->get_bytes_index();
-  this->input_buffer_->consume(bytes_consumed);
-
-  if (result > esp_audio_libs::flac::FLAC_DECODER_ERROR_OUT_OF_DATA) {
-    // Corrupted frame, don't retry with current buffer content, wait for new sync
-    return FileDecoderState::POTENTIALLY_FAILED;
-  }
-
-  // We have successfully decoded some input data and have new output data
-  this->output_transfer_buffer_->increase_buffer_length(
-      this->audio_stream_info_.value().samples_to_bytes(output_samples));
-
-  if (result == esp_audio_libs::flac::FLAC_DECODER_NO_MORE_FRAMES) {
+    this->input_buffer_->consume(bytes_consumed);
+  } else if (result == micro_flac::FLAC_DECODER_END_OF_STREAM) {
+    this->input_buffer_->consume(bytes_consumed);
     return FileDecoderState::END_OF_FILE;
+  } else if (result == micro_flac::FLAC_DECODER_NEED_MORE_DATA) {
+    this->input_buffer_->consume(bytes_consumed);
+    return FileDecoderState::MORE_TO_PROCESS;
+  } else if (result == micro_flac::FLAC_DECODER_ERROR_OUTPUT_TOO_SMALL) {
+    // Reallocate to decode the frame on the next call
+    const auto &info = this->flac_decoder_->get_stream_info();
+    this->free_buffer_required_ = this->flac_decoder_->get_output_buffer_size_samples() * info.bytes_per_sample();
+    if (!this->output_transfer_buffer_->reallocate(this->free_buffer_required_)) {
+      return FileDecoderState::FAILED;
+    }
+  } else {
+    ESP_LOGE(TAG, "FLAC decoder failed: %d", static_cast<int>(result));
+    return FileDecoderState::POTENTIALLY_FAILED;
   }
 
   return FileDecoderState::MORE_TO_PROCESS;

--- a/esphome/components/audio/audio_decoder.h
+++ b/esphome/components/audio/audio_decoder.h
@@ -16,13 +16,15 @@
 #include "esp_err.h"
 
 // esp-audio-libs
-#ifdef USE_AUDIO_FLAC_SUPPORT
-#include <flac_decoder.h>
-#endif
 #ifdef USE_AUDIO_MP3_SUPPORT
 #include <mp3_decoder.h>
 #endif
 #include <wav_decoder.h>
+
+// micro-flac
+#ifdef USE_AUDIO_FLAC_SUPPORT
+#include <micro_flac/flac_decoder.h>
+#endif
 
 // micro-opus
 #ifdef USE_AUDIO_OPUS_SUPPORT
@@ -119,7 +121,7 @@ class AudioDecoder {
   std::unique_ptr<esp_audio_libs::wav_decoder::WAVDecoder> wav_decoder_;
 #ifdef USE_AUDIO_FLAC_SUPPORT
   FileDecoderState decode_flac_();
-  std::unique_ptr<esp_audio_libs::flac::FLACDecoder> flac_decoder_;
+  std::unique_ptr<micro_flac::FLACDecoder> flac_decoder_;
 #endif
 #ifdef USE_AUDIO_MP3_SUPPORT
   FileDecoderState decode_mp3_();

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -3,6 +3,8 @@ dependencies:
     version: "7.4.2"
   esphome/esp-audio-libs:
     version: 2.0.4
+  esphome/micro-flac:
+    version: 0.1.1
   esphome/micro-opus:
     version: 0.3.6
   espressif/esp-dsp:


### PR DESCRIPTION
# What does this implement/fix?

Uses the new microFLAC library ([GitHub](https://github.com/esphome-libs/micro-flac) and [Espressif Component Registry](https://components.espressif.com/components/esphome/micro-flac/versions/0.1.1/readme)) for decoding FLAC. This library has several advantages over the currently used decoder from esp-audio-libs:

- Overall more efficient decoding and CRC computation; CRC validation is enabled by default again as the performance penalty is minimal
- True streaming support: you can pass one byte in at a time and microFLAC will still (eventually) decode the audio without internally buffering old data/recomputing previously processed data
  - ``decoder_buffers_internally_`` is now true for FLAC decoding, meaning it will never ``memmove`` the existing audio data, which slows down the overall decoding speed
  - Can use smaller transfer buffers, as the entire FLAC frame no longer needs to be available in one continuous buffer
  - Eventually, I will remove the transfer buffer entirely and read directly from the ring buffer, reducing overall memory usage and cutting down an extra memory copy (I still need to make the wav and MP3 decoder work this way as well)

The more efficient decoder and removing unnecessary ``memmove`` operations makes things more efficient. This PR is 9% faster, in terms of CPU usage, when streaming 48 kHz stereo FLAC (from an http URL with the speaker media player going through a mixer speaker) on an ESP32-S3. Plus, the previous version didn't validate CRCs but this new version does!
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_player:
  - platform: speaker
    name: None
    id: speaker_media_player
    announcement_pipeline:
      speaker: announcement_mixer_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 1
    media_pipeline:
      speaker: media_mixer_speaker
      format: FLAC
      sample_rate: 48000
      num_channels: 2

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
