### PR TITLE
[ble_client] Fix descriptor_uuid ignored for text sensors

### DIFF
--- a/esphome/components/ble_client/text_sensor/__init__.py
+++ b/esphome/components/ble_client/text_sensor/__init__.py
@@ -88,7 +88,7 @@ async def to_code(config):
         )
         cg.add(var.set_char_uuid128(uuid128))
 
-    if descriptor_uuid := config:
+    if descriptor_uuid := config.get(CONF_DESCRIPTOR_UUID):
         if len(descriptor_uuid) == len(esp32_ble_tracker.bt_uuid16_format):
             cg.add(var.set_descr_uuid16(esp32_ble_tracker.as_hex(descriptor_uuid)))
         elif len(descriptor_uuid) == len(esp32_ble_tracker.bt_uuid32_format):


### PR DESCRIPTION
# What does this implement/fix?

Fix `descriptor_uuid` being silently ignored for BLE client text sensors.

Line 91 of `ble_client/text_sensor/__init__.py` had:
```python
if descriptor_uuid := config:
```
which assigns the entire config dict to `descriptor_uuid` (always truthy). The correct code, matching the sensor platform at `ble_client/sensor/__init__.py:133`, is:
```python
if descriptor_uuid := config.get(CONF_DESCRIPTOR_UUID):
```

Without this fix, configuring `descriptor_uuid` on a BLE text sensor has no effect — the descriptor UUID is never passed to C++, so the text sensor reads the characteristic value instead of the descriptor value.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
text_sensor:
  - platform: ble_client
    ble_client_id: my_ble_client
    name: "BLE Descriptor Value"
    service_uuid: "0000180a-0000-1000-8000-00805f9b34fb"
    characteristic_uuid: "00002a29-0000-1000-8000-00805f9b34fb"
    descriptor_uuid: "0x2902"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).