### PR TITLE
[bl0940] Fix reference_voltage config ignored in non-legacy mode

### DIFF
--- a/esphome/components/bl0940/sensor.py
+++ b/esphome/components/bl0940/sensor.py
@@ -126,7 +126,7 @@ def set_reference_values(config):
         config.setdefault(CONF_POWER_REFERENCE, DEFAULT_BL0940_LEGACY_PREF)
         config.setdefault(CONF_ENERGY_REFERENCE, DEFAULT_BL0940_LEGACY_EREF)
     else:
-        vref = config.get(CONF_VOLTAGE_REFERENCE, DEFAULT_BL0940_VREF)
+        vref = config.get(CONF_REFERENCE_VOLTAGE, DEFAULT_BL0940_VREF)
         r_one = config.get(CONF_RESISTOR_ONE, DEFAULT_BL0940_R1)
         r_two = config.get(CONF_RESISTOR_TWO, DEFAULT_BL0940_R2)
         r_shunt = config.get(CONF_RESISTOR_SHUNT, DEFAULT_BL0940_RL)


### PR DESCRIPTION
# What does this implement/fix?

Fix `reference_voltage` config option being silently ignored in non-legacy mode.

The BL0940 component has two confusingly named config keys:
- `CONF_REFERENCE_VOLTAGE` (`"reference_voltage"`) — the chip's internal Vref (~1.218V), imported from `esphome.const`
- `CONF_VOLTAGE_REFERENCE` (`"voltage_reference"`) — the computed calibration reference (~33000 in legacy), defined locally

In `set_reference_values()`, the non-legacy path at line 129 read `CONF_VOLTAGE_REFERENCE` instead of `CONF_REFERENCE_VOLTAGE` when getting the chip Vref for the reference calculations. This meant a user setting `reference_voltage: 1.25` to compensate for chip-to-chip Vref variation had their value silently ignored — the calculations always used the default 1.218V.

The fix changes line 129 from:
```python
vref = config.get(CONF_VOLTAGE_REFERENCE, DEFAULT_BL0940_VREF)
```
to:
```python
vref = config.get(CONF_REFERENCE_VOLTAGE, DEFAULT_BL0940_VREF)
```

This works by accident in the default case (neither key set → falls back to 1.218), which is why the bug wasn't noticed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: bl0940
    uart_id: my_uart
    legacy_mode: false
    reference_voltage: 1.25
    voltage:
      name: "BL0940 Voltage"
    current:
      name: "BL0940 Current"
    power:
      name: "BL0940 Power"
    energy:
      name: "BL0940 Energy"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).