### PR TITLE
[climate] Fix MQTT target_temperature_low_state_topic calling wrong setter

### DIFF
--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -400,7 +400,7 @@ async def setup_climate_core_(var, config):
             )
         ) is not None:
             cg.add(
-                mqtt_.set_custom_target_temperature_state_topic(
+                mqtt_.set_custom_target_temperature_low_state_topic(
                     target_temperature_low_state_topic
                 )
             )


### PR DESCRIPTION
# What does this implement/fix?

Fix copy-paste bug where configuring `target_temperature_low_state_topic` in a climate's MQTT config called `set_custom_target_temperature_state_topic()` (without `_low_`) instead of `set_custom_target_temperature_low_state_topic()`.

This caused two problems:
1. The low temperature state topic customization was silently ignored
2. It overwrote any previously-set normal target temperature state topic (set at lines 362-366)

The correct C++ method is generated by the `MQTT_COMPONENT_CUSTOM_TOPIC(target_temperature_low, state)` macro in `mqtt_climate.h:27`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: thermostat
    name: "My Thermostat"
    target_temperature_low_state_topic: "my/custom/low_temp/state"
    target_temperature_high_state_topic: "my/custom/high_temp/state"
    # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).