### PR TITLE
[htu21d] Fix set_heater action reading wrong config key

### DIFF
--- a/esphome/components/htu21d/sensor.py
+++ b/esphome/components/htu21d/sensor.py
@@ -118,6 +118,6 @@ async def set_heater_level_to_code(config, action_id, template_arg, args):
 async def set_heater_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    status_ = await cg.templatable(config[CONF_LEVEL], args, bool)
+    status_ = await cg.templatable(config[CONF_STATUS], args, bool)
     cg.add(var.set_status(status_))
     return var

--- a/tests/components/htu21d/common.yaml
+++ b/tests/components/htu21d/common.yaml
@@ -1,5 +1,6 @@
 sensor:
   - platform: htu21d
+    id: htu21d_sensor
     i2c_id: i2c_bus
     model: htu21d
     temperature:
@@ -9,3 +10,14 @@ sensor:
     heater:
       name: Heater
     update_interval: 15s
+
+button:
+  - platform: template
+    name: "Test HTU21D Actions"
+    on_press:
+      - htu21d.set_heater:
+          id: htu21d_sensor
+          status: true
+      - htu21d.set_heater_level:
+          id: htu21d_sensor
+          level: 5


### PR DESCRIPTION
# What does this implement/fix?

Fix the `htu21d.set_heater` action which was completely non-functional due to reading the wrong config key.

The action schema defines `CONF_STATUS` (`"status"`) as the required key, but `set_heater_to_code` read `CONF_LEVEL` (`"level"`) — copy-pasted from the adjacent `set_heater_level` action. This caused a `KeyError: 'level'` at code generation time whenever anyone used the action.

Also adds test coverage for both `htu21d.set_heater` and `htu21d.set_heater_level` actions, which were previously untested.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: htu21d
    id: htu21d_sensor
    temperature:
      name: Temperature
    humidity:
      name: Humidity

button:
  - platform: template
    name: "Toggle Heater"
    on_press:
      - htu21d.set_heater:
          id: htu21d_sensor
          status: true
      - htu21d.set_heater_level:
          id: htu21d_sensor
          level: 5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).