### PR TITLE
[template] Fix cover position_action overridden by has_position default

### DIFF
--- a/esphome/components/template/cover/__init__.py
+++ b/esphome/components/template/cover/__init__.py
@@ -108,7 +108,6 @@ async def to_code(config):
     cg.add(var.set_optimistic(config[CONF_OPTIMISTIC]))
     cg.add(var.set_assumed_state(config[CONF_ASSUMED_STATE]))
     cg.add(var.set_restore_mode(config[CONF_RESTORE_MODE]))
-    cg.add(var.set_has_position(config[CONF_HAS_POSITION]))
 
 
 @automation.register_action(


### PR DESCRIPTION
# What does this implement/fix?

Fix template cover `position_action` being silently broken by a duplicate `set_has_position` call.

Lines 101-107 correctly handle `has_position`:
- If `position_action` is configured → `set_has_position(True)` (line 105)
- Otherwise → `set_has_position(config[CONF_HAS_POSITION])` (line 107, default `False`)

But line 111 unconditionally called `set_has_position(config[CONF_HAS_POSITION])` again, overwriting the `True` from line 105 back to `False`. This made the position action unreachable at runtime — the cover would not report position support despite having a position action configured.

The fix removes the duplicate line 111 since the if/else on lines 101-107 already covers both cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: template
    name: "My Cover"
    position_action:
      - logger.log: "Setting position"
    open_action:
      - logger.log: "Opening"
    close_action:
      - logger.log: "Closing"
    stop_action:
      - logger.log: "Stopping"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).