### PR TITLE
[pipsolar] Fix set_level action passing string to cv.use_id

### DIFF
--- a/esphome/components/pipsolar/output/__init__.py
+++ b/esphome/components/pipsolar/output/__init__.py
@@ -94,7 +94,7 @@ async def to_code(config):
     SetOutputAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(CONF_ID),
+            cv.Required(CONF_ID): cv.use_id(PipsolarOutput),
             cv.Required(CONF_VALUE): cv.templatable(cv.positive_float),
         }
     ),


### PR DESCRIPTION
# What does this implement/fix?

Fix `output.pipsolar.set_level` action schema passing the string `"id"` to `cv.use_id()` instead of the `PipsolarOutput` class.

`cv.use_id()` expects a C++ class type (MockObj) so it can validate that the referenced ID is of the correct type. Passing `CONF_ID` (the string `"id"`) meant any entity ID would be accepted regardless of type, and the resolved variable would lack type information.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
pipsolar:
  id: pipsolar1

output:
  - platform: pipsolar
    pipsolar_id: pipsolar1
    battery_recharge_voltage:
      id: pipsolar_output_1

button:
  - platform: template
    name: "Set Level"
    on_press:
      - output.pipsolar.set_level:
          id: pipsolar_output_1
          value: 48.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).