### PR TITLE
[mlx90393] Remove call to non-existent set_drdy_pin method

### DIFF
--- a/esphome/components/mlx90393/sensor.py
+++ b/esphome/components/mlx90393/sensor.py
@@ -130,9 +130,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
 
-    if CONF_DRDY_PIN in config:
-        pin = await cg.gpio_pin_expression(config[CONF_DRDY_PIN])
-        cg.add(var.set_drdy_pin(pin))
     cg.add(var.set_gain(GAIN[config[CONF_GAIN]]))
     cg.add(var.set_oversampling(config[CONF_OVERSAMPLING]))
     cg.add(var.set_filter(config[CONF_FILTER]))


### PR DESCRIPTION
# What does this implement/fix?

Fix compile error when `drdy_pin` is configured on the MLX90393 sensor.

The `to_code` function processed `drdy_pin` twice:
1. Lines 133-135: created pin and called `set_drdy_pin()` — **method does not exist** in C++
2. Lines 158-160: created the same pin again and called `set_drdy_gpio()` — correct method

The C++ class only has `set_drdy_gpio()` (`sensor_mlx90393.h:30`). The first block was a typo that caused a compile error whenever `drdy_pin` was configured. The second block was the correct fix that was added later but the first was never removed.

This removes the incorrect first block; the correct `set_drdy_gpio()` call remains.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: mlx90393
    drdy_pin: GPIO4
    gain: 1X
    x_axis:
      name: "X Axis"
    y_axis:
      name: "Y Axis"
    z_axis:
      name: "Z Axis"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).