### PR TITLE
[usb_host] Fix vid/pid=0 treated as unset in usb_device_schema

### DIFF
--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -27,7 +27,9 @@ CONF_ENABLE_HUBS = "enable_hubs"
 CONF_MAX_TRANSFER_REQUESTS = "max_transfer_requests"
 
 
-def usb_device_schema(cls=USBClient, vid: int | None = None, pid: int | None = None) -> cv.Schema:
+def usb_device_schema(
+    cls=USBClient, vid: int | None = None, pid: int | None = None
+) -> cv.Schema:
     schema = cv.COMPONENT_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(cls),

--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -33,11 +33,11 @@ def usb_device_schema(cls=USBClient, vid: int = None, pid: [int] = None) -> cv.S
             cv.GenerateID(): cv.declare_id(cls),
         }
     )
-    if vid:
+    if vid is not None:
         schema = schema.extend({cv.Optional(CONF_VID, default=vid): cv.hex_uint16_t})
     else:
         schema = schema.extend({cv.Required(CONF_VID): cv.hex_uint16_t})
-    if pid:
+    if pid is not None:
         schema = schema.extend({cv.Optional(CONF_PID, default=pid): cv.hex_uint16_t})
     else:
         schema = schema.extend({cv.Required(CONF_PID): cv.hex_uint16_t})

--- a/esphome/components/usb_host/__init__.py
+++ b/esphome/components/usb_host/__init__.py
@@ -27,7 +27,7 @@ CONF_ENABLE_HUBS = "enable_hubs"
 CONF_MAX_TRANSFER_REQUESTS = "max_transfer_requests"
 
 
-def usb_device_schema(cls=USBClient, vid: int = None, pid: [int] = None) -> cv.Schema:
+def usb_device_schema(cls=USBClient, vid: int | None = None, pid: int | None = None) -> cv.Schema:
     schema = cv.COMPONENT_SCHEMA.extend(
         {
             cv.GenerateID(): cv.declare_id(cls),


### PR DESCRIPTION
# What does this implement/fix?

Fix `usb_device_schema()` treating `vid=0` / `pid=0` as "no default provided" due to Python truthiness checks.

The `CDC_ACM` device type is defined with `vid=0, pid=0` (matching any CDC ACM class device). When `usb_device_schema(cls, 0, 0)` was called, `if vid:` evaluated `if 0:` → `False`, falling through to the `else` branch which made VID/PID required fields. Users configuring a `CDC_ACM` device had to manually specify `vid: 0x0000` and `pid: 0x0000` even though the intent was for those to be defaults.

The fix changes `if vid:` / `if pid:` to `if vid is not None:` / `if pid is not None:`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [ ] ESP32
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Before fix: CDC_ACM required explicit vid/pid even though defaults are 0
# After fix: vid/pid default to 0 as intended
uart:
  - platform: usb_uart
    type: CDC_ACM
    # vid and pid now correctly default to 0x0000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).