### PR TITLE
[thermostat] Fix on_boot_restore_from DEFAULT_PRESET validation bypass

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -503,7 +503,7 @@ def validate_thermostat(config):
     # If restoring default preset on boot is true then ensure we have a default preset
     if (
         CONF_ON_BOOT_RESTORE_FROM in config
-        and config[CONF_ON_BOOT_RESTORE_FROM] is OnBootRestoreFrom.DEFAULT_PRESET
+        and config[CONF_ON_BOOT_RESTORE_FROM] == "DEFAULT_PRESET"
         and CONF_DEFAULT_PRESET not in config
     ):
         raise cv.Invalid(


### PR DESCRIPTION
# What does this implement/fix?

Fix validation for `on_boot_restore_from: DEFAULT_PRESET` that was supposed to require `default_preset` but never fired.

The check on line 506 used Python `is` (identity comparison):
```python
config[CONF_ON_BOOT_RESTORE_FROM] is OnBootRestoreFrom.DEFAULT_PRESET
```

- Left side: an `EnumValue`-enhanced string `"DEFAULT_PRESET"` (returned by `cv.enum`)
- Right side: a `MockObj` codegen expression (`thermostat::OnBootRestoreFrom::DEFAULT_PRESET`)

These are always different objects, so `is` was always `False` and the validation never rejected invalid configs. A user could set `on_boot_restore_from: DEFAULT_PRESET` without defining `default_preset`, and at runtime the thermostat would try to restore a non-existent preset.

The fix changes `is` to `==` with the string key `"DEFAULT_PRESET"`, which correctly matches the validated config value.

**Tested:**
- `on_boot_restore_from: DEFAULT_PRESET` without `default_preset` → now correctly rejected
- `on_boot_restore_from: DEFAULT_PRESET` with `default_preset: Home` → passes
- `on_boot_restore_from: MEMORY` without `default_preset` → passes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config was incorrectly accepted before this fix.
# Now correctly rejects with:
#   "default_preset must be defined to use on_boot_restore_from in DEFAULT_PRESET mode"
climate:
  - platform: thermostat
    name: "Thermostat"
    sensor: temp_sensor
    on_boot_restore_from: DEFAULT_PRESET
    # default_preset is missing!
    preset:
      - name: Home
        default_target_temperature_low: 18
        default_target_temperature_high: 24
    heat_action:
      - logger.log: "Heating"
    idle_action:
      - logger.log: "Idle"
    min_idle_time: 30s
    min_heating_off_time: 30s
    min_heating_run_time: 30s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).