### PR TITLE
[deep_sleep] Fix wakeup_pin_mode rejecting lowercase on ESP32/BK72XX

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -266,8 +266,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_WAKEUP_PIN): validate_wakeup_pin,
             cv.Optional(CONF_WAKEUP_PIN_MODE): cv.All(
                 cv.only_on([PLATFORM_ESP32, PLATFORM_BK72XX]),
-                cv.enum(WAKEUP_PIN_MODES),
-                upper=True,
+                cv.enum(WAKEUP_PIN_MODES, upper=True),
             ),
             cv.Optional(CONF_ESP32_EXT1_WAKEUP): cv.All(
                 cv.only_on_esp32,


### PR DESCRIPTION
# What does this implement/fix?

Fix `wakeup_pin_mode` rejecting lowercase values like `ignore` on ESP32 and BK72XX platforms.

The `upper=True` keyword argument was passed to `cv.All()` instead of `cv.enum()`:

```python
# Before (broken) — upper=True silently swallowed by cv.All's **kwargs
cv.Optional(CONF_WAKEUP_PIN_MODE): cv.All(
    cv.only_on([PLATFORM_ESP32, PLATFORM_BK72XX]),
    cv.enum(WAKEUP_PIN_MODES),
    upper=True,
),

# After (fixed) — upper=True passed to cv.enum where it belongs
cv.Optional(CONF_WAKEUP_PIN_MODE): cv.All(
    cv.only_on([PLATFORM_ESP32, PLATFORM_BK72XX]),
    cv.enum(WAKEUP_PIN_MODES, upper=True),
),
```

The ESP8266 schema at line 250 already had the correct form: `cv.enum(WAKEUP_PIN_MODES, upper=True)`.

**Before fix:** `wakeup_pin_mode: ignore` → `Unknown value 'ignore', valid options are 'IGNORE', 'KEEP_AWAKE', 'INVERT_WAKEUP'`
**After fix:** `wakeup_pin_mode: ignore` → Configuration is valid

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
deep_sleep:
  wakeup_pin:
    number: GPIO4
  wakeup_pin_mode: ignore  # this was rejected before the fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).