### PR TITLE
[host] Add graceful shutdown on SIGINT/SIGTERM

### DIFF
--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -5,10 +5,16 @@
 #include "esphome/core/helpers.h"
 #include "preferences.h"
 
+#include <csignal>
 #include <sched.h>
 #include <time.h>
 #include <cmath>
 #include <cstdlib>
+
+namespace {
+volatile sig_atomic_t s_signal_received = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+void signal_handler(int signal) { s_signal_received = signal; }
+}  // namespace
 
 namespace esphome {
 
@@ -72,11 +78,17 @@ uint32_t arch_get_cpu_freq_hz() { return 1000000000U; }
 void setup();
 void loop();
 int main() {
+  // Install signal handlers for graceful shutdown (flushes preferences to disk)
+  std::signal(SIGINT, signal_handler);
+  std::signal(SIGTERM, signal_handler);
+
   esphome::host::setup_preferences();
   setup();
-  while (true) {
+  while (s_signal_received == 0) {
     loop();
   }
+  esphome::App.run_safe_shutdown_hooks();
+  return 0;
 }
 
 #endif  // USE_HOST


### PR DESCRIPTION
# What does this implement/fix?

The host platform `main()` loop had no signal handling — `while(true) { loop(); }`. When SIGINT or SIGTERM was received, the default handler terminated the process immediately, skipping `on_shutdown()` hooks. This meant preferences were never flushed to disk before exit, causing data loss (e.g. `restore_value` not persisting across restarts).

This was causing the `test_template_text_save` integration test to be flaky — the test sets a text value, kills the process with SIGINT, restarts it, and checks the value was restored. Without graceful shutdown, the preferences sync that happens in `on_shutdown()` was skipped, so the value was lost between restarts depending on timing.

This adds SIGINT/SIGTERM handlers that set a flag to exit the main loop gracefully, then calls `run_safe_shutdown_hooks()` which invokes `on_shutdown()` on all components including the preferences syncer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] Host

## Example entry for `config.yaml`:

```yaml
# No config changes needed - this fixes host platform signal handling
esphome:
  name: my-host-device

host:

preferences:
  flash_write_interval: 0s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).