### PR TITLE
[spi] Add spi0 and spi1 to reserved IDs for RP2040 compatibility

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -244,6 +244,8 @@ RESERVED_IDS = [
     "open",
     "setup",
     "loop",
+    "spi0",
+    "spi1",
     "uart0",
     "uart1",
     "uart2",


### PR DESCRIPTION
# What does this implement/fix?

Add `spi0` and `spi1` to the `RESERVED_IDS` list in `config_validation.py`.

On RP2040, the Pico SDK defines `spi0` and `spi1` as preprocessor macros:
```c
#define spi0 ((spi_inst_t *)spi0_hw)
#define spi1 ((spi_inst_t *)spi1_hw)
```

When a user sets `id: spi0` on their SPI component, ESPHome generates `static spi::SPIComponent *spi0;` in C++, which the preprocessor expands into nonsense, causing cryptic compile errors. This is the same class of issue that led to `uart0`/`uart1`/`uart2` already being reserved.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15373

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This config previously failed to compile on RP2040.
# Now it produces a clear validation error telling the user
# to pick a different ID.
esphome:
  name: test

rp2040:
  board: rpipico

spi:
  - id: spi0  # Will now error: "ID 'spi0' is reserved internally"
    clk_pin: GPIO2
    mosi_pin: GPIO3
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).