### PR TITLE
[at581x][canbus] Fix walrus operator skipping falsy config values

### DIFF
--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -177,7 +177,7 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         template_ = int(template_ / 1000000)
         cg.add(var.set_frequency(template_))
 
-    if sens_dist := config.get(CONF_SENSING_DISTANCE):
+    if (sens_dist := config.get(CONF_SENSING_DISTANCE)) is not None:
         template_ = await cg.templatable(sens_dist, args, int)
         cg.add(var.set_sensing_distance(template_))
 
@@ -209,7 +209,7 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         template_ = int(template_)
         cg.add(var.set_trigger_keep(template_))
 
-    if stage_gain := config.get(CONF_STAGE_GAIN):
+    if (stage_gain := config.get(CONF_STAGE_GAIN)) is not None:
         template_ = await cg.templatable(stage_gain, args, int)
         cg.add(var.set_stage_gain(template_))
 

--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -161,7 +161,7 @@ async def canbus_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_CANBUS_ID])
 
-    if can_id := config.get(CONF_CAN_ID):
+    if (can_id := config.get(CONF_CAN_ID)) is not None:
         can_id = await cg.templatable(can_id, args, cg.uint32)
         cg.add(var.set_can_id(can_id))
         cg.add(var.set_use_extended_id(config[CONF_USE_EXTENDED_ID]))


### PR DESCRIPTION
# What does this implement/fix?

Fix `if val := config.get(KEY)` pattern silently ignoring valid falsy values (0, False) in action code generation.

Python's walrus operator assigns the value and then evaluates its truthiness. When the value is `0` or `False`, the condition is falsy and the setter call is skipped, even though 0 is a valid config value.

**at581x** (`settings` action):
- `sensing_distance: 0` — valid per schema (`min=0, max=1023`), silently ignored
- `stage_gain: 0` — valid per schema (`min=0, max=12`), silently ignored

**canbus** (`send` action):
- `can_id: 0` — valid per schema (`min=0`), silently ignored. CAN ID 0 is the highest-priority identifier on the bus. When skipped, the action falls back to the parent bus's CAN ID instead.

The fix changes `if val := config.get(KEY):` to `if (val := config.get(KEY)) is not None:` which correctly distinguishes "not provided" (None) from "provided as 0".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# canbus: can_id 0 is now correctly applied instead of falling back to bus default
canbus:
  - platform: esp32_can
    id: my_can
    can_id: 0x100
    tx_pin: GPIO5
    rx_pin: GPIO4
    bit_rate: 500kbps
    on_frame:
      - can_id: 0x200
        then:
          - canbus.send:
              can_id: 0  # was silently ignored before this fix
              data: [0x01, 0x02]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).