### PR TITLE
[sen5x] Remove dead voc_baseline config option

### DIFF
--- a/esphome/components/sen5x/sensor.py
+++ b/esphome/components/sen5x/sensor.py
@@ -25,7 +25,6 @@ from esphome.const import (
     CONF_TEMPERATURE_COMPENSATION,
     CONF_TIME_CONSTANT,
     CONF_VOC,
-    CONF_VOC_BASELINE,
     DEVICE_CLASS_AQI,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PM1,
@@ -165,7 +164,6 @@ CONFIG_SCHEMA = (
                 gain_factor=230,
             ),
             cv.Optional(CONF_STORE_BASELINE, default=True): cv.boolean,
-            cv.Optional(CONF_VOC_BASELINE): cv.hex_uint16_t,
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,


### PR DESCRIPTION
# What does this implement/fix?

Remove the `voc_baseline` config option from the SEN5x sensor which was dead code — accepted in the schema but never passed to C++.

There is no `set_voc_baseline()` setter in the C++ class. The SEN5x manages VOC algorithm state internally via the `store_baseline` option, which saves/restores the full algorithm state (4x uint16) to flash automatically. There is no mechanism to manually inject a single baseline value.

The option was not documented on esphome.io and no tests reference it. It appears to have been copied from the SGP30 sensor component (which does have a working `voc_baseline`), but was never wired up for the SEN5x.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (option was never documented)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: sen5x
    id: sen55
    pm_2_5:
      name: "PM 2.5"
    voc:
      name: "VOC"
      algorithm_tuning:
        index_offset: 100
    store_baseline: true  # this is the correct way to manage baselines
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).