### PR TITLE
[core] Inline fast path for enable_loop

### DIFF
--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -287,19 +287,15 @@ void Component::mark_failed() {
   // Also remove from loop since failed components shouldn't loop
   App.disable_component_loop_(this);
 }
-void Component::disable_loop() {
-  if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
-    ESP_LOGVV(TAG, "%s loop disabled", LOG_STR_ARG(this->get_component_log_str()));
-    this->set_component_state_(COMPONENT_STATE_LOOP_DONE);
-    App.disable_component_loop_(this);
-  }
+void Component::disable_loop_slow_path_() {
+  ESP_LOGVV(TAG, "%s loop disabled", LOG_STR_ARG(this->get_component_log_str()));
+  this->set_component_state_(COMPONENT_STATE_LOOP_DONE);
+  App.disable_component_loop_(this);
 }
-void Component::enable_loop() {
-  if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE) {
-    ESP_LOGVV(TAG, "%s loop enabled", LOG_STR_ARG(this->get_component_log_str()));
-    this->set_component_state_(COMPONENT_STATE_LOOP);
-    App.enable_component_loop_(this);
-  }
+void Component::enable_loop_slow_path_() {
+  ESP_LOGVV(TAG, "%s loop enabled", LOG_STR_ARG(this->get_component_log_str()));
+  this->set_component_state_(COMPONENT_STATE_LOOP);
+  App.enable_component_loop_(this);
 }
 void IRAM_ATTR HOT Component::enable_loop_soon_any_context() {
   // This method is thread and ISR-safe because:

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -287,10 +287,12 @@ void Component::mark_failed() {
   // Also remove from loop since failed components shouldn't loop
   App.disable_component_loop_(this);
 }
-void Component::disable_loop_slow_path_() {
-  ESP_LOGVV(TAG, "%s loop disabled", LOG_STR_ARG(this->get_component_log_str()));
-  this->set_component_state_(COMPONENT_STATE_LOOP_DONE);
-  App.disable_component_loop_(this);
+void Component::disable_loop() {
+  if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE) {
+    ESP_LOGVV(TAG, "%s loop disabled", LOG_STR_ARG(this->get_component_log_str()));
+    this->set_component_state_(COMPONENT_STATE_LOOP_DONE);
+    App.disable_component_loop_(this);
+  }
 }
 void Component::enable_loop_slow_path_() {
   ESP_LOGVV(TAG, "%s loop enabled", LOG_STR_ARG(this->get_component_log_str()));

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -232,10 +232,7 @@ class Component {
    * @note Components should call this->disable_loop() on themselves, not on other components.
    *       This ensures the component's state is properly updated along with the loop partition.
    */
-  void disable_loop() {
-    if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE)
-      this->disable_loop_slow_path_();
-  }
+  void disable_loop();
 
   /** Enable this component's loop. The loop() method will be called normally.
    *
@@ -350,7 +347,6 @@ class Component {
   virtual void call_setup();
   void call_dump_config_();
 
-  void disable_loop_slow_path_();
   void enable_loop_slow_path_();
 
   /// Helper to set component state (clears state bits and sets new state)

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -232,7 +232,10 @@ class Component {
    * @note Components should call this->disable_loop() on themselves, not on other components.
    *       This ensures the component's state is properly updated along with the loop partition.
    */
-  void disable_loop();
+  void disable_loop() {
+    if ((this->component_state_ & COMPONENT_STATE_MASK) != COMPONENT_STATE_LOOP_DONE)
+      this->disable_loop_slow_path_();
+  }
 
   /** Enable this component's loop. The loop() method will be called normally.
    *
@@ -242,7 +245,10 @@ class Component {
    * @note Components should call this->enable_loop() on themselves, not on other components.
    *       This ensures the component's state is properly updated along with the loop partition.
    */
-  void enable_loop();
+  void enable_loop() {
+    if ((this->component_state_ & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE)
+      this->enable_loop_slow_path_();
+  }
 
   /** Thread and ISR-safe version of enable_loop() that can be called from any context.
    *
@@ -343,6 +349,9 @@ class Component {
 
   virtual void call_setup();
   void call_dump_config_();
+
+  void disable_loop_slow_path_();
+  void enable_loop_slow_path_();
 
   /// Helper to set component state (clears state bits and sets new state)
   inline void set_component_state_(uint8_t state) {


### PR DESCRIPTION
# What does this implement/fix?

Components like `light` call `enable_loop()` frequently without knowing whether the loop is already enabled. Previously, every call went through a full function call into `component.cpp` even when there was nothing to do.

This moves the state check inline into the header so the common no-op case (already enabled) is a single branch with no function call overhead. The actual state transition work (logging, state update, partition management) is moved to an `enable_loop_slow_path_()` helper in the `.cpp` file.

`disable_loop()` is left as-is since it's called intentionally during state transitions, not speculatively.

Flash impact: +16 bytes on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).