### PR TITLE
[ezo_pmp] Fix change_i2c_address action using wrong template type

### DIFF
--- a/esphome/components/ezo_pmp/__init__.py
+++ b/esphome/components/ezo_pmp/__init__.py
@@ -286,7 +286,7 @@ async def ezo_pmp_change_i2c_address_to_code(config, action_id, template_arg, ar
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_ADDRESS], args, cg.double)
+    template_ = await cg.templatable(config[CONF_ADDRESS], args, cg.int_)
     cg.add(var.set_address(template_))
 
     return var


### PR DESCRIPTION
# What does this implement/fix?

Fix `ezo_pmp.change_i2c_address` action passing `cg.double` to `cg.templatable` when the C++ `TEMPLATABLE_VALUE(int, address)` expects `int`.

For literal values this is harmless (implicit conversion), but when a lambda is used for the address, the generated C++ lambda return type would be `double` instead of `int`, causing a type mismatch.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
ezo_pmp:
  id: my_ezo_pmp

button:
  - platform: template
    name: "Change Address"
    on_press:
      - ezo_pmp.change_i2c_address:
          id: my_ezo_pmp
          address: 104
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).