### PR TITLE
[scheduler] Fix unrealistic scheduler benchmarks missing periodic drain

### DIFF
--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -203,33 +203,6 @@ static void Scheduler_Defer_SameID(benchmark::State &state) {
 }
 BENCHMARK(Scheduler_Defer_SameID);
 
-// --- Scheduler: defer with unique IDs (no cancel path) ---
-
-static void Scheduler_Defer_UniqueID(benchmark::State &state) {
-  Scheduler scheduler;
-  Component dummy_component;
-
-  // Measures defer with unique numeric IDs — cancel_item_locked_ runs but
-  // never finds a match, measuring the scan overhead on an empty search.
-  static constexpr int kBatchSize = 3;
-  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
-  warm_pool(scheduler, &dummy_component, kBatchSize, 0);
-  for (auto _ : state) {
-    uint32_t now = millis();
-    uint32_t id = 0;
-    for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, id++, 0, []() {});
-      if ((i + 1) % kBatchSize == 0) {
-        scheduler.call(++now);
-      }
-    }
-    scheduler.call(++now);
-    benchmark::DoNotOptimize(scheduler);
-  }
-  state.SetItemsProcessed(state.iterations() * kInnerIterations);
-}
-BENCHMARK(Scheduler_Defer_UniqueID);
-
 // --- Scheduler: set_timeout with batch size exceeding pool (cliff test) ---
 
 static void Scheduler_SetTimeout_ExceedPool(benchmark::State &state) {

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -154,4 +154,29 @@ static void Scheduler_Defer(benchmark::State &state) {
 }
 BENCHMARK(Scheduler_Defer);
 
+// --- Scheduler: set_timeout with batch size exceeding pool (cliff test) ---
+
+static void Scheduler_SetTimeout_ExceedPool(benchmark::State &state) {
+  Scheduler scheduler;
+  Component dummy_component;
+
+  // Register 10 timeouts then call() — exceeds MAX_POOL_SIZE=5 to measure
+  // the performance cliff when the recycling pool is exhausted and items
+  // must be malloc'd/freed.
+  static constexpr int kBatchSize = 10;
+  for (auto _ : state) {
+    uint32_t now = millis();
+    for (int i = 0; i < kInnerIterations; i++) {
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kBatchSize), 1000, []() {});
+      if ((i + 1) % kBatchSize == 0) {
+        scheduler.call(++now);
+      }
+    }
+    scheduler.call(++now);
+    benchmark::DoNotOptimize(scheduler);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Scheduler_SetTimeout_ExceedPool);
+
 }  // namespace esphome::benchmarks

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -155,17 +155,16 @@ static void Scheduler_Defer(benchmark::State &state) {
   Component dummy_component;
 
   // defer() is Component::defer which calls set_timeout(delay=0).
-  // Call set_timeout directly since defer() is protected.
-  // Register 3 defers then call() — realistic worst case where multiple
-  // components defer in the same loop iteration. Keeps item count within
-  // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
+  // Component::defer(func) passes nullptr as the name, which skips
+  // cancel_item_locked_ entirely — matching production behavior where
+  // defers are anonymous fire-and-forget callbacks.
   static constexpr int kBatchSize = 3;
   static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 0);
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kBatchSize), 0, []() {});
+      scheduler.set_timeout(&dummy_component, static_cast<const char *>(nullptr), 0, []() {});
       if ((i + 1) % kBatchSize == 0) {
         scheduler.call(++now);
       }
@@ -176,6 +175,60 @@ static void Scheduler_Defer(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations() * kInnerIterations);
 }
 BENCHMARK(Scheduler_Defer);
+
+// --- Scheduler: defer with same ID (cancel-and-replace pattern) ---
+
+static void Scheduler_Defer_SameID(benchmark::State &state) {
+  Scheduler scheduler;
+  Component dummy_component;
+
+  // Measures defer with a fixed numeric ID — each call cancels the previous
+  // pending defer before adding the new one. This is the pattern used by
+  // components that defer work but want to coalesce rapid updates.
+  static constexpr int kBatchSize = 3;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
+  warm_pool(scheduler, &dummy_component, kBatchSize, 0);
+  for (auto _ : state) {
+    uint32_t now = millis();
+    for (int i = 0; i < kInnerIterations; i++) {
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(0), 0, []() {});
+      if ((i + 1) % kBatchSize == 0) {
+        scheduler.call(++now);
+      }
+    }
+    scheduler.call(++now);
+    benchmark::DoNotOptimize(scheduler);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Scheduler_Defer_SameID);
+
+// --- Scheduler: defer with unique IDs (no cancel path) ---
+
+static void Scheduler_Defer_UniqueID(benchmark::State &state) {
+  Scheduler scheduler;
+  Component dummy_component;
+
+  // Measures defer with unique numeric IDs — cancel_item_locked_ runs but
+  // never finds a match, measuring the scan overhead on an empty search.
+  static constexpr int kBatchSize = 3;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
+  warm_pool(scheduler, &dummy_component, kBatchSize, 0);
+  for (auto _ : state) {
+    uint32_t now = millis();
+    uint32_t id = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      scheduler.set_timeout(&dummy_component, id++, 0, []() {});
+      if ((i + 1) % kBatchSize == 0) {
+        scheduler.call(++now);
+      }
+    }
+    scheduler.call(++now);
+    benchmark::DoNotOptimize(scheduler);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Scheduler_Defer_UniqueID);
 
 // --- Scheduler: set_timeout with batch size exceeding pool (cliff test) ---
 

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -82,23 +82,19 @@ BENCHMARK(Scheduler_Call_5IntervalsFiring);
 static void Scheduler_SetTimeout(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
-  // Number of distinct timeout keys; controls how many unique timers exist
-  // simultaneously and the drain cadence for process_to_add().
-  static constexpr int kKeyCount = 5;
 
+  // Register 3 timeouts then call() — realistic worst case where multiple
+  // components schedule in the same loop iteration. Keeps item count within
+  // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
+  static constexpr int kBatchSize = 3;
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 1000, []() {});
-      // Drain periodically to reflect production behavior where call() runs
-      // each main loop iteration. call() moves to_add_ into items_ and cleans
-      // up cancelled items. Without this, cancelled items accumulate causing
-      // O(n²) scan cost in cancel_item_locked_.
-      if ((i + 1) % kKeyCount == 0) {
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kBatchSize), 1000, []() {});
+      if ((i + 1) % kBatchSize == 0) {
         scheduler.call(++now);
       }
     }
-    // Final drain in case kInnerIterations is not a multiple of kKeyCount
     scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }
@@ -111,23 +107,19 @@ BENCHMARK(Scheduler_SetTimeout);
 static void Scheduler_SetInterval(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
-  // Number of distinct interval keys; controls how many unique timers exist
-  // simultaneously and the drain cadence for process_to_add().
-  static constexpr int kKeyCount = 5;
 
+  // Register 3 intervals then call() — realistic worst case where multiple
+  // components schedule in the same loop iteration. Keeps item count within
+  // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
+  static constexpr int kBatchSize = 3;
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_interval(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 1000, []() {});
-      // Drain periodically to reflect production behavior where call() runs
-      // each main loop iteration. call() moves to_add_ into items_ and cleans
-      // up cancelled items. Without this, cancelled items accumulate causing
-      // O(n²) scan cost in cancel_item_locked_.
-      if ((i + 1) % kKeyCount == 0) {
+      scheduler.set_interval(&dummy_component, static_cast<uint32_t>(i % kBatchSize), 1000, []() {});
+      if ((i + 1) % kBatchSize == 0) {
         scheduler.call(++now);
       }
     }
-    // Final drain in case kInnerIterations is not a multiple of kKeyCount
     scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }
@@ -140,23 +132,21 @@ BENCHMARK(Scheduler_SetInterval);
 static void Scheduler_Defer(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
-  // Number of distinct defer keys; controls how many unique defers exist
-  // simultaneously and the drain cadence for call().
-  static constexpr int kKeyCount = 5;
 
   // defer() is Component::defer which calls set_timeout(delay=0).
   // Call set_timeout directly since defer() is protected.
-  // Drain with call() periodically to reflect production behavior where
-  // call() runs each main loop iteration, keeping the defer queue small.
+  // Register 3 defers then call() — realistic worst case where multiple
+  // components defer in the same loop iteration. Keeps item count within
+  // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
+  static constexpr int kBatchSize = 3;
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 0, []() {});
-      if ((i + 1) % kKeyCount == 0) {
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kBatchSize), 0, []() {});
+      if ((i + 1) % kBatchSize == 0) {
         scheduler.call(++now);
       }
     }
-    // Final drain in case kInnerIterations is not a multiple of kKeyCount
     scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -82,12 +82,24 @@ BENCHMARK(Scheduler_Call_5IntervalsFiring);
 static void Scheduler_SetTimeout(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
+  // Number of distinct timeout keys; controls how many unique timers exist
+  // simultaneously and the drain cadence for process_to_add().
+  static constexpr int kKeyCount = 5;
 
   for (auto _ : state) {
+    uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % 5), 1000, []() {});
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 1000, []() {});
+      // Drain periodically to reflect production behavior where call() runs
+      // each main loop iteration. call() moves to_add_ into items_ and cleans
+      // up cancelled items. Without this, cancelled items accumulate causing
+      // O(n²) scan cost in cancel_item_locked_.
+      if ((i + 1) % kKeyCount == 0) {
+        scheduler.call(++now);
+      }
     }
-    scheduler.process_to_add();
+    // Final drain in case kInnerIterations is not a multiple of kKeyCount
+    scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }
   state.SetItemsProcessed(state.iterations() * kInnerIterations);
@@ -104,17 +116,19 @@ static void Scheduler_SetInterval(benchmark::State &state) {
   static constexpr int kKeyCount = 5;
 
   for (auto _ : state) {
+    uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
       scheduler.set_interval(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 1000, []() {});
-      // Drain to_add_ periodically to reflect production behavior where
-      // process_to_add() runs each main loop iteration. Without this,
-      // cancelled items accumulate in to_add_ causing O(n²) scan cost.
+      // Drain periodically to reflect production behavior where call() runs
+      // each main loop iteration. call() moves to_add_ into items_ and cleans
+      // up cancelled items. Without this, cancelled items accumulate causing
+      // O(n²) scan cost in cancel_item_locked_.
       if ((i + 1) % kKeyCount == 0) {
-        scheduler.process_to_add();
+        scheduler.call(++now);
       }
     }
-    // Final drain in case kInnerIterations is not a multiple of 5
-    scheduler.process_to_add();
+    // Final drain in case kInnerIterations is not a multiple of kKeyCount
+    scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }
   state.SetItemsProcessed(state.iterations() * kInnerIterations);
@@ -126,14 +140,24 @@ BENCHMARK(Scheduler_SetInterval);
 static void Scheduler_Defer(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
+  // Number of distinct defer keys; controls how many unique defers exist
+  // simultaneously and the drain cadence for call().
+  static constexpr int kKeyCount = 5;
 
   // defer() is Component::defer which calls set_timeout(delay=0).
   // Call set_timeout directly since defer() is protected.
+  // Drain with call() periodically to reflect production behavior where
+  // call() runs each main loop iteration, keeping the defer queue small.
   for (auto _ : state) {
+    uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
-      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % 5), 0, []() {});
+      scheduler.set_timeout(&dummy_component, static_cast<uint32_t>(i % kKeyCount), 0, []() {});
+      if ((i + 1) % kKeyCount == 0) {
+        scheduler.call(++now);
+      }
     }
-    scheduler.process_to_add();
+    // Final drain in case kInnerIterations is not a multiple of kKeyCount
+    scheduler.call(++now);
     benchmark::DoNotOptimize(scheduler);
   }
   state.SetItemsProcessed(state.iterations() * kInnerIterations);

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -8,7 +8,9 @@ namespace esphome::benchmarks {
 // Inner iteration count to amortize CodSpeed instrumentation overhead.
 // Without this, the ~60ns per-iteration valgrind start/stop cost dominates
 // sub-microsecond benchmarks.
-static constexpr int kInnerIterations = 2000;
+// Must be divisible by all batch sizes used below (3, 10) to avoid
+// pool imbalance at iteration boundaries that causes spurious malloc.
+static constexpr int kInnerIterations = 2100;
 
 // Warm the scheduler pool by registering and replacing items twice.
 // The first batch allocates fresh items; the second batch cancels them and
@@ -102,6 +104,7 @@ static void Scheduler_SetTimeout(benchmark::State &state) {
   // components schedule in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();
@@ -128,6 +131,7 @@ static void Scheduler_SetInterval(benchmark::State &state) {
   // components schedule in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();
@@ -156,6 +160,7 @@ static void Scheduler_Defer(benchmark::State &state) {
   // components defer in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 0);
   for (auto _ : state) {
     uint32_t now = millis();
@@ -182,6 +187,7 @@ static void Scheduler_SetTimeout_ExceedPool(benchmark::State &state) {
   // the performance cliff when the recycling pool is exhausted and items
   // must be malloc'd/freed.
   static constexpr int kBatchSize = 10;
+  static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -10,6 +10,21 @@ namespace esphome::benchmarks {
 // sub-microsecond benchmarks.
 static constexpr int kInnerIterations = 2000;
 
+// Warm the scheduler pool by registering and replacing items twice.
+// The first batch allocates fresh items; the second batch cancels them and
+// populates the recycling pool with the cancelled items from the first batch.
+static void warm_pool(Scheduler &scheduler, Component *component, int batch_size, uint32_t delay) {
+  uint32_t now = millis();
+  for (int i = 0; i < batch_size; i++) {
+    scheduler.set_timeout(component, static_cast<uint32_t>(i), delay, []() {});
+  }
+  scheduler.call(++now);
+  for (int i = 0; i < batch_size; i++) {
+    scheduler.set_timeout(component, static_cast<uint32_t>(i), delay, []() {});
+  }
+  scheduler.call(++now);
+}
+
 // --- Scheduler fast path: no work to do ---
 
 static void Scheduler_Call_NoWork(benchmark::State &state) {
@@ -87,6 +102,7 @@ static void Scheduler_SetTimeout(benchmark::State &state) {
   // components schedule in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
@@ -112,6 +128,7 @@ static void Scheduler_SetInterval(benchmark::State &state) {
   // components schedule in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
@@ -139,6 +156,7 @@ static void Scheduler_Defer(benchmark::State &state) {
   // components defer in the same loop iteration. Keeps item count within
   // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
   static constexpr int kBatchSize = 3;
+  warm_pool(scheduler, &dummy_component, kBatchSize, 0);
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {
@@ -164,6 +182,7 @@ static void Scheduler_SetTimeout_ExceedPool(benchmark::State &state) {
   // the performance cliff when the recycling pool is exhausted and items
   // must be malloc'd/freed.
   static constexpr int kBatchSize = 10;
+  warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
   for (auto _ : state) {
     uint32_t now = millis();
     for (int i = 0; i < kInnerIterations; i++) {


### PR DESCRIPTION
# What does this implement/fix?

Fix scheduler registration benchmarks (`SetTimeout`, `SetInterval`, `Defer`) that were unrealistic due to missing periodic drains and pool management issues:

- **Missing `call()` drains**: Benchmarks were not calling `scheduler.call()` to drain and clean up cancelled items. In production, `call()` runs every loop iteration. Without draining, cancelled items accumulated causing O(n²) scan cost in `cancel_item_locked_` that doesn't reflect real-world behavior.
- **Pool imbalance**: `kInnerIterations` (2000) was not divisible by batch sizes, causing pool misses at iteration boundaries that triggered spurious `malloc`/`free`.
- **Unrealistic defer pattern**: `Scheduler_Defer` used numeric IDs which triggered `cancel_item_locked_` scans. Production defers are typically anonymous (`Component::defer(func)` passes `nullptr`, skipping cancel entirely).

Changes:
- All registration benchmarks now call `scheduler.call(++now)` every `kBatchSize` iterations matching production loop behavior
- `kInnerIterations` changed to 2100 (divisible by batch sizes 3 and 10) with `static_assert` guards
- `Scheduler_Defer` uses anonymous `nullptr` name matching `Component::defer(func)`
- Added `Scheduler_Defer_SameID` for the cancel-and-replace coalescing pattern
- Added `Scheduler_SetTimeout_ExceedPool` (batch=10) to measure the performance cliff when exceeding `MAX_POOL_SIZE=5`
- Extracted `warm_pool()` helper to populate the recycling pool before benchmark loops
- Time advances (`++now`) on each drain to match production behavior

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - benchmark-only change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).