### PR TITLE
[ili9xxx] Fix SPI MOSI pin validation never executing

### DIFF
--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -212,7 +212,7 @@ def final_validate(config):
 
     return spi.final_validate_device_schema(
         "ili9xxx", require_miso=False, require_mosi=True
-    )
+    )(config)
 
 
 FINAL_VALIDATE_SCHEMA = final_validate

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -210,9 +210,9 @@ def final_validate(config):
     ):
         LOGGER.info("Consider enabling PSRAM if available for the display buffer")
 
-    return spi.final_validate_device_schema(
-        "ili9xxx", require_miso=False, require_mosi=True
-    )(config)
+    spi.final_validate_device_schema("ili9xxx", require_miso=False, require_mosi=True)(
+        config
+    )
 
 
 FINAL_VALIDATE_SCHEMA = final_validate


### PR DESCRIPTION
# What does this implement/fix?

Fix `final_validate` returning the SPI validator callable without invoking it.

`spi.final_validate_device_schema(...)` returns a validator function. The code returned it from `final_validate`, but the framework (`config.py:956`) calls `FINAL_VALIDATE_SCHEMA(conf)` and **discards the return value**. So the SPI validator was created but never called — MOSI pin validation was silently skipped.

The fix adds `(config)` to call the validator immediately:
```python
# Before — returns callable, framework discards it
return spi.final_validate_device_schema("ili9xxx", require_miso=False, require_mosi=True)

# After — calls validator, SPI pin check actually runs
return spi.final_validate_device_schema("ili9xxx", require_miso=False, require_mosi=True)(config)
```

Without this fix, a user could configure an SPI bus without a MOSI pin and ili9xxx would only fail at runtime.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
spi:
  clk_pin: GPIO18
  mosi_pin: GPIO23

display:
  - platform: ili9xxx
    model: ili9341
    dc_pin: GPIO27
    cs_pin: GPIO5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).