### PR TITLE
[core] Use __builtin_ctz for FiniteSetMask bit scanning

### DIFF
--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -160,10 +160,11 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
     if (mask == 0)
       return BitPolicy::MAX_BITS;
 #if defined(__GNUC__) || defined(__clang__)
-    if constexpr (sizeof(bitmask_t) <= sizeof(unsigned int))
+    if constexpr (sizeof(bitmask_t) <= sizeof(unsigned int)) {
       return __builtin_ctz(static_cast<unsigned int>(mask));
-    else
-      return __builtin_ctzl(static_cast<unsigned long>(mask));
+    } else {
+      return __builtin_ctzl(static_cast<uint32_t>(mask));
+    }
 #else
     int bit = 0;
     while (bit < BitPolicy::MAX_BITS && !(mask & (static_cast<bitmask_t>(1) << bit))) {

--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -157,14 +157,19 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
   /// Find the lowest set bit in a bitmask
   /// Returns the bit position, or MAX_BITS if no bits are set
   static constexpr int find_lowest_set_bit(bitmask_t mask) {
-    if (mask == 0)
+    if (mask == 0) {
       return BitPolicy::MAX_BITS;
-#if defined(__GNUC__) || defined(__clang__)
-    if constexpr (sizeof(bitmask_t) <= sizeof(unsigned int)) {
-      return __builtin_ctz(static_cast<unsigned int>(mask));
-    } else {
-      return __builtin_ctzl(static_cast<uint32_t>(mask));
     }
+#if defined(__GNUC__) || defined(__clang__)
+    int bit;
+    if constexpr (sizeof(bitmask_t) <= sizeof(unsigned int)) {
+      bit = __builtin_ctz(static_cast<unsigned int>(mask));
+    } else if constexpr (sizeof(bitmask_t) <= sizeof(uint32_t)) {
+      bit = __builtin_ctzl(static_cast<uint32_t>(mask));
+    } else {
+      bit = __builtin_ctzll(static_cast<unsigned long long>(mask));
+    }
+    return bit < BitPolicy::MAX_BITS ? bit : BitPolicy::MAX_BITS;
 #else
     int bit = 0;
     while (bit < BitPolicy::MAX_BITS && !(mask & (static_cast<bitmask_t>(1) << bit))) {

--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -119,7 +119,7 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
 
     constexpr ValueType operator*() const {
       // Return value for the first set bit
-      return BitPolicy::from_bit(find_next_set_bit(mask_, 0));
+      return BitPolicy::from_bit(find_lowest_set_bit(mask_));
     }
 
     constexpr Iterator &operator++() {
@@ -151,17 +151,26 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
   /// Get the first value from a raw bitmask
   /// Used for optimizing intersection logic (e.g., "pick first suitable mode")
   static constexpr ValueType first_value_from_mask(bitmask_t mask) {
-    return BitPolicy::from_bit(find_next_set_bit(mask, 0));
+    return BitPolicy::from_bit(find_lowest_set_bit(mask));
   }
 
-  /// Find the next set bit in a bitmask starting from a given position
-  /// Returns the bit position, or MAX_BITS if no more bits are set
-  static constexpr int find_next_set_bit(bitmask_t mask, int start_bit) {
-    int bit = start_bit;
+  /// Find the lowest set bit in a bitmask
+  /// Returns the bit position, or MAX_BITS if no bits are set
+  static constexpr int find_lowest_set_bit(bitmask_t mask) {
+    if (mask == 0)
+      return BitPolicy::MAX_BITS;
+#if defined(__GNUC__) || defined(__clang__)
+    if constexpr (sizeof(bitmask_t) <= sizeof(unsigned int))
+      return __builtin_ctz(static_cast<unsigned int>(mask));
+    else
+      return __builtin_ctzl(static_cast<unsigned long>(mask));
+#else
+    int bit = 0;
     while (bit < BitPolicy::MAX_BITS && !(mask & (static_cast<bitmask_t>(1) << bit))) {
       ++bit;
     }
     return bit;
+#endif
   }
 
  protected:

--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -167,7 +167,7 @@ template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16
     } else if constexpr (sizeof(bitmask_t) <= sizeof(uint32_t)) {
       bit = __builtin_ctzl(static_cast<uint32_t>(mask));
     } else {
-      bit = __builtin_ctzll(static_cast<unsigned long long>(mask));
+      bit = __builtin_ctzll(static_cast<uint64_t>(mask));
     }
     return bit < BitPolicy::MAX_BITS ? bit : BitPolicy::MAX_BITS;
 #else


### PR DESCRIPTION
# What does this implement/fix?

Replace the linear bit-scanning loop in `FiniteSetMask::find_next_set_bit` with `__builtin_ctz`, which compiles to a single-cycle `NSAU` instruction on Xtensa (ESP32/ESP32-S3). Also rename to `find_lowest_set_bit` and drop the unused `start_bit` parameter since all call sites pass 0.

This eliminates the standalone `find_next_set_bit` function and replaces 3 function calls + loops in `LightCall::compute_color_mode_()` with inline `NSAU` instructions. The fallback loop is retained for non-GCC/Clang compilers.

**Disassembly before** (3 `call8` to `find_next_set_bit` with loop):
```
call8  find_next_set_bit  ; loop up to 10 iterations
call8  find_next_set_bit
call8  find_next_set_bit
```

**Disassembly after** (3 inline `nsau` instructions):
```
nsau  a8, a8   ; single cycle
nsau  a8, a8
nsau  a8, a8
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).