### PR TITLE
[light] Use reciprocal multiply in normalize_color

### DIFF
--- a/esphome/components/light/light_color_values.h
+++ b/esphome/components/light/light_color_values.h
@@ -104,9 +104,10 @@ class LightColorValues {
         this->green_ = 1.0f;
         this->blue_ = 1.0f;
       } else {
-        this->red_ /= max_value;
-        this->green_ /= max_value;
-        this->blue_ /= max_value;
+        float inv = 1.0f / max_value;
+        this->red_ *= inv;
+        this->green_ *= inv;
+        this->blue_ *= inv;
       }
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Replace 3 software float divides (`__divsf3`) with 1 divide + 3 native `mul.s` instructions in `LightColorValues::normalize_color()`.

Xtensa has no FPU divide instruction, so each `/= max_value` compiles to a `callx8 __divsf3` (~20-30 cycle software routine). By precomputing `1.0f / max_value` once and multiplying, we get 1 software divide + 3 single-cycle hardware multiplies instead of 3 software divides.

**Disassembly before** (3 software divides):
```asm
l32r    a8, <__divsf3>
callx8  a8              ; red /= max_value
l32r    a8, <__divsf3>
callx8  a8              ; green /= max_value
l32r    a8, <__divsf3>
callx8  a8              ; blue /= max_value
```

**Disassembly after** (1 software divide + 3 hardware multiplies):
```asm
l32r    a8, <__divsf3>
callx8  a8              ; inv = 1.0f / max_value
mul.s   f1, f1, f0      ; red *= inv
mul.s   f1, f1, f0      ; green *= inv
mul.s   f0, f1, f0      ; blue *= inv
```

Saves ~40-60 cycles per `normalize_color()` call for +8 bytes of flash.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).