### PR TITLE
[light] Pass LightTraits to avoid redundant virtual get_traits() calls

### DIFF
--- a/esphome/components/light/light_call.cpp
+++ b/esphome/components/light/light_call.cpp
@@ -198,13 +198,13 @@ LightColorValues LightCall::validate_() {
 
   // Ensure there is always a color mode set
   if (!this->has_color_mode()) {
-    this->color_mode_ = this->compute_color_mode_();
+    this->color_mode_ = this->compute_color_mode_(traits);
     this->set_flag_(FLAG_HAS_COLOR_MODE);
   }
   auto color_mode = this->color_mode_;
 
   // Transform calls that use non-native parameters for the current mode.
-  this->transform_parameters_();
+  this->transform_parameters_(traits);
 
   // Business logic adjustments before validation
   // Flag whether an explicit turn off was requested, in which case we'll also stop the effect.
@@ -366,9 +366,7 @@ LightColorValues LightCall::validate_() {
 
   return v;
 }
-void LightCall::transform_parameters_() {
-  auto traits = this->parent_->get_traits();
-
+void LightCall::transform_parameters_(const LightTraits &traits) {
   // Allow CWWW modes to be set with a white value and/or color temperature.
   // This is used in three cases in HA:
   // - CW/WW lights, which set the "brightness" and "color_temperature"
@@ -407,8 +405,8 @@ void LightCall::transform_parameters_() {
     }
   }
 }
-ColorMode LightCall::compute_color_mode_() {
-  auto supported_modes = this->parent_->get_traits().get_supported_color_modes();
+ColorMode LightCall::compute_color_mode_(const LightTraits &traits) {
+  auto supported_modes = traits.get_supported_color_modes();
   int supported_count = supported_modes.size();
 
   // Some lights don't support any color modes (e.g. monochromatic light), leave it at unknown.

--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -10,6 +10,7 @@ struct LogString;
 namespace light {
 
 class LightState;
+class LightTraits;
 
 /** This class represents a requested change in a light state.
  *
@@ -188,11 +189,11 @@ class LightCall {
   LightColorValues validate_();
 
   //// Compute the color mode that should be used for this call.
-  ColorMode compute_color_mode_();
+  ColorMode compute_color_mode_(const LightTraits &traits);
   /// Get potential color modes bitmask for this light call.
   color_mode_bitmask_t get_suitable_color_modes_mask_();
   /// Some color modes also can be set using non-native parameters, transform those calls.
-  void transform_parameters_();
+  void transform_parameters_(const LightTraits &traits);
 
   // Bitfield flags - each flag indicates whether a corresponding value has been set.
   enum FieldFlags : uint16_t {


### PR DESCRIPTION
# What does this implement/fix?

Pass the already-fetched `LightTraits` from `validate_()` to `compute_color_mode_()` and `transform_parameters_()` instead of each calling `get_traits()` independently. This eliminates 2 redundant virtual calls through `output_->get_traits()`.

`get_traits()` is a virtual dispatch (`LightState::get_traits()` → `output_->get_traits()`), so each call involves a vtable lookup + indirect call. Since `validate_()` already fetches traits at the top, passing it down removes unnecessary work.

**CodSpeed benchmark results: +5.33% faster**

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| `LightCall_ToggleOnOff_MQTT` | 398.7 µs | 378.5 µs | **+5.33%** |
| `LightCall_ColorTemperature_MQTT` | 582.5 µs | 562.3 µs | **+3.58%** |

**ESP8266 flash impact: -16 bytes**

On ESP32-S3 (Xtensa), the compiler inlines both sub-functions into `validate_()`, shrinking the hot path by 451 bytes. On ESP8266, functions are not fully inlined but still shrink from eliminating redundant `get_traits()` calls:

| Function | ESP8266 Before | ESP8266 After | Delta |
|---|---|---|---|
| `compute_color_mode_()` | 277 B | 269 B | -8 B |
| `transform_parameters_()` | 297 B | 293 B | -4 B |
| `validate_()` | 1369 B | 1373 B | +4 B |
| **Light component total** | 21,938 B | 21,930 B | **-8 B** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).