### PR TITLE
[uptime] Pass known length to publish_state to avoid redundant strlen

### DIFF
--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -70,7 +70,7 @@ void UptimeTextSensor::update() {
   if (show_seconds)
     append_unit(buf, sizeof(buf), pos, this->separator_, seconds, this->seconds_text_);
 
-  this->publish_state(buf);
+  this->publish_state(buf, pos);
 }
 
 float UptimeTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -70,7 +70,8 @@ void UptimeTextSensor::update() {
   if (show_seconds)
     append_unit(buf, sizeof(buf), pos, this->separator_, seconds, this->seconds_text_);
 
-  this->publish_state(buf, pos);
+  // pos is capped at sizeof(buf) on overflow, clamp to valid string length
+  this->publish_state(buf, std::min(pos, sizeof(buf) - 1));
 }
 
 float UptimeTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }

--- a/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
+++ b/esphome/components/uptime/text_sensor/uptime_text_sensor.cpp
@@ -70,8 +70,7 @@ void UptimeTextSensor::update() {
   if (show_seconds)
     append_unit(buf, sizeof(buf), pos, this->separator_, seconds, this->seconds_text_);
 
-  // pos is capped at sizeof(buf) on overflow, clamp to valid string length
-  this->publish_state(buf, std::min(pos, sizeof(buf) - 1));
+  this->publish_state(buf, pos);
 }
 
 float UptimeTextSensor::get_setup_priority() const { return setup_priority::HARDWARE; }


### PR DESCRIPTION
# What does this implement/fix?

The uptime text sensor already computes the output string length in `pos` via `buf_append_printf`, but then calls `publish_state(buf)` which uses the `const char*` overload that calls `strlen`. This passes `pos` directly to avoid the redundant `strlen`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

n/a - no config changes

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).