### PR TITLE
[epaper_spi] Add Waveshare 3.97" SSD1677 models

### DIFF
--- a/esphome/components/epaper_spi/display.py
+++ b/esphome/components/epaper_spi/display.py
@@ -47,7 +47,17 @@ epaper_spi_ns = cg.esphome_ns.namespace("epaper_spi")
 EPaperBase = epaper_spi_ns.class_(
     "EPaperBase", cg.PollingComponent, spi.SPIDevice, display.Display
 )
-Transform = epaper_spi_ns.enum("Transform")
+
+NONE = RawExpression("esphome::epaper_spi::NONE")
+MIRROR_X = RawExpression("esphome::epaper_spi::MIRROR_X")
+MIRROR_Y = RawExpression("esphome::epaper_spi::MIRROR_Y")
+SWAP_XY = RawExpression("esphome::epaper_spi::SWAP_XY")
+
+Transform = {
+    CONF_MIRROR_X: MIRROR_X,
+    CONF_MIRROR_Y: MIRROR_Y,
+    CONF_SWAP_XY: SWAP_XY,
+}
 
 # Import all models dynamically from the models package
 for module_info in pkgutil.iter_modules(models.__path__):
@@ -87,8 +97,9 @@ def model_schema(config):
             ),
             cv.Optional(CONF_TRANSFORM): cv.Schema(
                 {
-                    cv.Required(CONF_MIRROR_X): cv.boolean,
-                    cv.Required(CONF_MIRROR_Y): cv.boolean,
+                    cv.Optional(CONF_MIRROR_X): cv.boolean,
+                    cv.Optional(CONF_MIRROR_Y): cv.boolean,
+                    cv.Optional(CONF_SWAP_XY): cv.boolean,
                 }
             ),
             cv.Optional(CONF_FULL_UPDATE_EVERY, default=1): cv.int_range(1, 255),
@@ -194,13 +205,16 @@ async def to_code(config):
     if busy_pin := config.get(CONF_BUSY_PIN):
         busy = await cg.gpio_pin_expression(busy_pin)
         cg.add(var.set_busy_pin(busy))
+    if enable_pins := config.get(CONF_ENABLE_PIN):
+        for pin in enable_pins:
+            p = await cg.gpio_pin_expression(pin)
+            cg.add(var.add_enable_pin(p))
     cg.add(var.set_full_update_every(config[CONF_FULL_UPDATE_EVERY]))
     if CONF_RESET_DURATION in config:
         cg.add(var.set_reset_duration(config[CONF_RESET_DURATION]))
-    if transform := config.get(CONF_TRANSFORM):
-        transform[CONF_SWAP_XY] = False
-    else:
-        transform = {x: model.get_default(x, False) for x in TRANSFORM_OPTIONS}
+    transform = {x: model.get_default(x, False) for x in TRANSFORM_OPTIONS}
+    if user_transform := config.get(CONF_TRANSFORM):
+        transform.update(user_transform)
     rotation = config[CONF_ROTATION]
     if rotation == 180:
         transform[CONF_MIRROR_X] = not transform[CONF_MIRROR_X]
@@ -212,11 +226,7 @@ async def to_code(config):
         transform[CONF_SWAP_XY] = not transform[CONF_SWAP_XY]
         transform[CONF_MIRROR_Y] = not transform[CONF_MIRROR_Y]
     transform_str = "|".join(
-        {
-            str(getattr(Transform, x.upper()))
-            for x in TRANSFORM_OPTIONS
-            if transform.get(x)
-        }
+        sorted({str(Transform[x]) for x in TRANSFORM_OPTIONS if transform.get(x)})
     )
     if transform_str:
         cg.add(var.set_transform(RawExpression(transform_str)))

--- a/esphome/components/epaper_spi/epaper_spi.cpp
+++ b/esphome/components/epaper_spi/epaper_spi.cpp
@@ -1,5 +1,4 @@
 #include "epaper_spi.h"
-#include <cinttypes>
 #include "esphome/core/application.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -48,6 +47,10 @@ void EPaperBase::setup_pins_() const {
 
   if (this->busy_pin_ != nullptr) {
     this->busy_pin_->setup();  // INPUT
+  }
+  for (auto *pin : this->enable_pins_) {
+    pin->setup();
+    pin->digital_write(true);
   }
 }
 
@@ -213,7 +216,9 @@ void EPaperBase::process_state_() {
     case EPaperState::DEEP_SLEEP:
       this->deep_sleep();
       this->set_state_(EPaperState::IDLE);
-      ESP_LOGD(TAG, "Display update took %" PRIu32 " ms", millis() - this->update_start_time_);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG
+      ESP_LOGD(TAG, "Display update took %u ms", (unsigned) (millis() - this->update_start_time_));
+#endif
       break;
   }
 }

--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -47,6 +47,7 @@ class EPaperBase : public Display,
     this->row_width_ = (this->width_ + 7) / 8;  // width of a row in bytes
   }
   void set_dc_pin(GPIOPin *dc_pin) { dc_pin_ = dc_pin; }
+  void add_enable_pin(GPIOPin *pin) { this->enable_pins_.push_back(pin); }
   float get_setup_priority() const override;
   void set_reset_pin(GPIOPin *reset) { this->reset_pin_ = reset; }
   void set_busy_pin(GPIOPin *busy) { this->busy_pin_ = busy; }
@@ -167,6 +168,7 @@ class EPaperBase : public Display,
   GPIOPin *dc_pin_{};
   GPIOPin *busy_pin_{};
   GPIOPin *reset_pin_{};
+  std::vector<GPIOPin *> enable_pins_;
   bool waiting_for_idle_{};
   uint32_t delay_until_{};  // timestamp until which to delay processing
   uint16_t next_delay_{};   // milliseconds to delay before next state

--- a/esphome/components/epaper_spi/models/__init__.py
+++ b/esphome/components/epaper_spi/models/__init__.py
@@ -1,11 +1,13 @@
-from typing import Any, Self
+from typing import Any, TypeVar
 
 import esphome.config_validation as cv
 from esphome.const import CONF_DIMENSIONS, CONF_HEIGHT, CONF_WIDTH
 
+T = TypeVar("T", bound="EpaperModel")
+
 
 class EpaperModel:
-    models: dict[str, Self] = {}
+    models: dict[str, "EpaperModel"] = {}
 
     def __init__(
         self,

--- a/esphome/components/epaper_spi/models/ssd1677.py
+++ b/esphome/components/epaper_spi/models/ssd1677.py
@@ -10,11 +10,12 @@ class SSD1677(EpaperModel):
 
     # fmt: off
     def get_init_sequence(self, config: dict):
-        width, _height = self.get_dimensions(config)
+        width, height = self.get_dimensions(config)
+        gate_count = max(width, height)
         return (
             (0x18, 0x80),    # Select internal Temp sensor
             (0x0C, 0xAE, 0xC7, 0xC3, 0xC0, 0x80),  # inrush current level 2
-            (0x01, (width - 1) % 256, (width - 1) // 256, 0x02),    # Set column gate limit
+            (0x01, (gate_count - 1) % 256, (gate_count - 1) // 256, 0x02),    # Set column gate limit
             (0x3C, 0x01),    # Set border waveform
             (0x11, 3),      # Set transform
         )
@@ -42,4 +43,44 @@ wave_4_26.extend(
             "pulldown": True,
         },
     },
+)
+
+wave_4_26.extend(
+    "waveshare-4.26in-hat-plus",
+    cs_pin=15,
+    dc_pin=27,
+    reset_pin=26,
+    busy_pin=25,
+    enable_pin=18,
+)
+
+ssd1677.extend(
+    "waveshare-3.97in",
+    width=800,
+    height=480,
+    mirror_x=True,
+)
+
+ssd1677.extend(
+    "waveshare-3.97in-hat-plus",
+    width=800,
+    height=480,
+    mirror_x=True,
+    cs_pin=15,
+    dc_pin=27,
+    reset_pin=26,
+    busy_pin=25,
+    enable_pin=33,
+)
+
+# ESP32-S3-ePaper-3.97 integrated development board
+ssd1677.extend(
+    "waveshare-3.97in-esp32-s3",
+    width=800,
+    height=480,
+    mirror_x=True,
+    cs_pin=7,
+    dc_pin=4,
+    reset_pin=5,
+    busy_pin=6,
 )

--- a/esphome/components/mipi/__init__.py
+++ b/esphome/components/mipi/__init__.py
@@ -2,7 +2,7 @@
 # Various configuration constants for MIPI displays
 # Various utility functions for MIPI DBI configuration
 
-from typing import Any, Self
+from typing import Any
 
 from esphome.components.const import CONF_COLOR_DEPTH
 from esphome.components.display import CONF_SHOW_TEST_CARD, display_ns
@@ -246,7 +246,7 @@ class DriverChip:
     Setting swap_xy to cv.UNDEFINED will indicate that the model does not support swapping X and Y axes.
     """
 
-    models: dict[str, Self] = {}
+    models: dict[str, "DriverChip"] = {}
 
     def __init__(
         self,

--- a/esphome/enum.py
+++ b/esphome/enum.py
@@ -10,4 +10,5 @@ except ImportError:
     class _StrEnum(str, Enum):
         pass
 
+
 StrEnum = _StrEnum

--- a/esphome/enum.py
+++ b/esphome/enum.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from enum import StrEnum as _StrEnum
+try:
+    from enum import StrEnum as _StrEnum
+except ImportError:
+    from enum import Enum
 
-# Re-export StrEnum from standard library for backwards compatibility
+    class _StrEnum(str, Enum):
+        pass
+
 StrEnum = _StrEnum

--- a/tests/component_tests/epaper_spi/test_init.py
+++ b/tests/component_tests/epaper_spi/test_init.py
@@ -95,8 +95,12 @@ def test_all_predefined_models(
 
     # Test all models, providing default values where necessary
     for name, model in MODELS.items():
-        # SEEED models are designed for ESP32-S3 hardware
-        if name in ("SEEED-EE04-MONO-4.26", "SEEED-RETERMINAL-E1002"):
+        # SEEED and Waveshare S3 models are designed for ESP32-S3 hardware
+        if name in (
+            "SEEED-EE04-MONO-4.26",
+            "SEEED-RETERMINAL-E1002",
+            "WAVESHARE-3.97IN-ESP32-S3",
+        ):
             set_core_config(
                 PlatformFramework.ESP32_IDF,
                 platform_data={
@@ -154,8 +158,12 @@ def test_individual_models(
     set_component_config: Callable[[str, Any], None],
 ) -> None:
     """Test each epaper model individually to ensure it validates correctly."""
-    # SEEED models are designed for ESP32-S3 hardware
-    if model_name in ("SEEED-EE04-MONO-4.26", "SEEED-RETERMINAL-E1002"):
+    # SEEED and Waveshare S3 models are designed for ESP32-S3 hardware
+    if model_name in (
+        "SEEED-EE04-MONO-4.26",
+        "SEEED-RETERMINAL-E1002",
+        "WAVESHARE-3.97IN-ESP32-S3",
+    ):
         set_core_config(
             PlatformFramework.ESP32_IDF,
             platform_data={

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -144,3 +144,29 @@ display:
       it.filled_rectangle(0, 0, it.get_width(), it.get_height(), Color::WHITE);
       it.circle(it.get_width() / 2, it.get_height() / 2, 30, Color::BLACK);
       it.circle(it.get_width() / 2, it.get_height() / 2, 20, Color(255, 0, 0));
+
+  # Waveshare 4.26" E-Paper HAT+
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-4.26in-hat-plus
+    lambda: |-
+      it.print(0, 0, id(my_font), "Hello 4.26!");
+
+  # Waveshare 3.97" E-Paper HAT+
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-3.97in-hat-plus
+    lambda: |-
+      it.print(0, 0, id(my_font), "Hello 3.97!");
+
+  # ESP32-S3-ePaper-3.97 integrated board
+  - platform: epaper_spi
+    spi_id: spi_bus
+    model: waveshare-3.97in-esp32-s3
+    lambda: |-
+      it.print(0, 0, id(my_font), "Hello S3!");
+
+font:
+  - file: "gapps:Roboto"
+    id: my_font
+    size: 20


### PR DESCRIPTION
Updates the SSD1677 initialization sequence to use the maximum dimension for the gate limit calculation and adds model definitions for Waveshare 3.97-inch display variants, including integrated ESP32-S3 and Hat Plus versions.

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
