### PR TITLE
[web_server] Disable loop when no SSE clients are connected

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -286,10 +286,11 @@ void DeferredUpdateEventSource::try_send_nodefer(const char *message, const char
   this->send(message, event, id, reconnect);
 }
 
-void DeferredUpdateEventSourceList::loop() {
+bool DeferredUpdateEventSourceList::loop() {
   for (DeferredUpdateEventSource *dues : *this) {
     dues->loop();
   }
+  return !this->empty();
 }
 
 void DeferredUpdateEventSourceList::deferrable_send_state(void *source, const char *event_type,
@@ -318,6 +319,7 @@ void DeferredUpdateEventSourceList::add_new_client(WebServer *ws, AsyncWebServer
   es->onDisconnect([this, es](AsyncEventSourceClient *client) { this->on_client_disconnect_(es); });
 
   es->handleRequest(request);
+  ws->enable_loop_soon_any_context();
 }
 
 void DeferredUpdateEventSourceList::on_client_connect_(DeferredUpdateEventSource *source) {
@@ -419,7 +421,16 @@ void WebServer::setup() {
     this->events_.try_send_nodefer(buf, "ping", millis(), 30000);
   });
 }
-void WebServer::loop() { this->events_.loop(); }
+void WebServer::loop() {
+  // No SSE clients connected; stop looping until a new client connects via
+  // enable_loop_soon_any_context(). This is safe because:
+  // - set_interval/set_timeout/defer run via the Scheduler, independent of loop()
+  // - deferrable_send_state early-outs when no clients are connected
+  // - try_send_nodefer (log, ping) iterates sessions which are empty
+  // - REST API handlers use defer() which runs via the Scheduler
+  if (!this->events_.loop())
+    this->disable_loop();
+}
 
 #ifdef USE_LOGGER
 void WebServer::on_log(uint8_t level, const char *tag, const char *message, size_t message_len) {

--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -415,6 +415,8 @@ void WebServer::setup() {
   // doesn't need defer functionality - if the queue is full, the client JS knows it's alive because it's clearly
   // getting a lot of events
   this->set_interval(10000, [this]() {
+    if (this->events_.empty())
+      return;
     char buf[32];
     auto uptime = static_cast<uint32_t>(millis_64() / 1000);
     buf_append_printf(buf, sizeof(buf), 0, "{\"uptime\":%" PRIu32 "}", uptime);

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -169,7 +169,8 @@ class DeferredUpdateEventSourceList final : public std::list<DeferredUpdateEvent
   void on_client_disconnect_(DeferredUpdateEventSource *source);
 
  public:
-  void loop();
+  /// Returns true if there are still connected clients.
+  bool loop();
 
   void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);

--- a/esphome/components/web_server/web_server.h
+++ b/esphome/components/web_server/web_server.h
@@ -169,7 +169,7 @@ class DeferredUpdateEventSourceList final : public std::list<DeferredUpdateEvent
   void on_client_disconnect_(DeferredUpdateEventSource *source);
 
  public:
-  /// Returns true if there are still connected clients.
+  /// Returns true if there are event sources remaining (including pending cleanup).
   bool loop();
 
   void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -484,9 +484,12 @@ void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
     this->on_connect_(rsp);
   }
   this->sessions_.push_back(rsp);
+  // Wake up WebServer::loop() to drain deferred event queues for this client.
+  // Safe from httpd task context via the pending_enable_loop_ flag.
+  this->web_server_->enable_loop_soon_any_context();
 }
 
-void AsyncEventSource::loop() {
+bool AsyncEventSource::loop() {
   // Clean up dead sessions safely
   // This follows the ESP-IDF pattern where free_ctx marks resources as dead
   // and the main loop handles the actual cleanup to avoid race conditions
@@ -504,6 +507,7 @@ void AsyncEventSource::loop() {
       ++i;
     }
   }
+  return !this->sessions_.empty();
 }
 
 void AsyncEventSource::try_send_nodefer(const char *message, const char *event, uint32_t id, uint32_t reconnect) {

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -340,7 +340,7 @@ class AsyncEventSource : public AsyncWebHandler {
 
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);
   void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);
-  /// Returns true if there are still connected clients.
+  /// Returns true if there are sessions remaining (including pending cleanup).
   bool loop();
   bool empty() { return this->count() == 0; }
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -340,7 +340,8 @@ class AsyncEventSource : public AsyncWebHandler {
 
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);
   void deferrable_send_state(void *source, const char *event_type, message_generator_t *message_generator);
-  void loop();
+  /// Returns true if there are still connected clients.
+  bool loop();
   bool empty() { return this->count() == 0; }
 
   size_t count() const { return this->sessions_.size(); }


### PR DESCRIPTION
# What does this implement/fix?

The web server component's `loop()` runs every main loop iteration even when no SSE clients are connected. With runtime stats showing ~7,800 calls averaging 0.002ms per iteration, this is wasted CPU time — each call incurs a virtual dispatch, a `millis()` call for the blocking guard, and the loop body itself.

This PR uses `disable_loop()`/`enable_loop_soon_any_context()` to stop looping entirely when no SSE clients are connected. When a client connects via `/events`, the loop is re-enabled. When the last client disconnects (or the last dead session is cleaned up on ESP-IDF), the loop disables itself again.

Additionally, the 10-second ping interval now early-outs when no clients are connected, avoiding the `millis_64()` division, `buf_append_printf`, and `try_send_nodefer` iteration every 10 seconds when nobody is listening.

This is safe because all other WebServer functionality runs independently of `loop()`:
- `set_interval`/`set_timeout`/`defer` run via the Scheduler
- `deferrable_send_state` early-outs when no clients are connected
- `try_send_nodefer` (log, ping) iterates sessions which are empty
- REST API handlers use `defer()` which runs via the Scheduler

The `events_.loop()` method now returns `bool` (true if clients remain) so `WebServer::loop()` can decide without a redundant `empty()` check.

### ESP8266 (no web page open)

Before:
```
web_server: count=7788, avg=0.002ms, max=0.39ms, total=16.4ms
```

After:
```
web_server: count=7, avg=0.020ms, max=0.03ms, total=0.1ms
```

### ESP8266 (web page open)

```
web_server: count=7779, avg=0.011ms, max=1.92ms, total=88.0ms
```

### ESP32-C3 IDF (no web page open)

```
web_server: count=6, avg=0.006ms, max=0.01ms, total=0.0ms
```

### ESP32-C3 IDF (web page opened then closed mid-period)

Total stats show web_server at 4,185 calls vs 30,123 for always-on components — loop only ran while the page was open:
```
web_server: count=4185, avg=0.040ms, max=7.32ms, total=167.4ms
```

After the page was closed and the dead session was cleaned up:
```
[D][web_server_idf:500]: Removing dead event source session
```

Next period showed the loop winding down (page closed mid-period):
```
web_server: count=3823, avg=0.029ms, max=3.33ms, total=109.2ms
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
web_server:
  port: 80
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).