### PR TITLE
[total_daily_energy] Replace loop() with timeout-based midnight reset

### DIFF
--- a/esphome/components/total_daily_energy/total_daily_energy.cpp
+++ b/esphome/components/total_daily_energy/total_daily_energy.cpp
@@ -1,10 +1,21 @@
 #include "total_daily_energy.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace total_daily_energy {
+namespace esphome::total_daily_energy {
 
 static const char *const TAG = "total_daily_energy";
+static constexpr uint32_t TIMEOUT_ID_MIDNIGHT = 1;
+static constexpr uint8_t SECONDS_PER_MINUTE = 60;
+static constexpr uint8_t MINUTES_PER_HOUR = 60;
+static constexpr uint8_t HOURS_PER_DAY = 24;
+static constexpr uint32_t SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+static constexpr uint16_t MILLIS_PER_SECOND = 1000;
+// Wake up 90 minutes before midnight to recalculate, ensuring DST transitions
+// (which shift wall clock by 1 hour but don't change millis()) don't cause
+// the midnight reset to fire late. DST transitions don't trigger the time sync
+// callback since they change local time interpretation, not the epoch.
+static constexpr uint32_t PRE_MIDNIGHT_SECONDS = 90 * SECONDS_PER_MINUTE;
 
 void TotalDailyEnergy::setup() {
   float initial_value = 0;
@@ -15,28 +26,55 @@ void TotalDailyEnergy::setup() {
   }
   this->publish_state_and_save(initial_value);
 
-  this->last_update_ = millis();
+  this->last_update_ = App.get_loop_component_start_time();
 
   this->parent_->add_on_state_callback([this](float state) { this->process_new_state_(state); });
+
+  // Schedule initial midnight reset if time is already valid, otherwise
+  // the time sync callback will handle it once time becomes available.
+  this->schedule_midnight_reset_();
+  // Re-schedule on every NTP sync in case the clock jumped across midnight.
+  this->time_->add_on_time_sync_callback([this]() { this->schedule_midnight_reset_(); });
 }
 
 void TotalDailyEnergy::dump_config() { LOG_SENSOR("", "Total Daily Energy", this); }
 
-void TotalDailyEnergy::loop() {
+void TotalDailyEnergy::schedule_midnight_reset_() {
   auto t = this->time_->now();
   if (!t.is_valid())
     return;
 
-  if (this->last_day_of_year_ == 0) {
+  // Check if the day changed (time sync moved us past midnight, or first call)
+  if (this->last_day_of_year_ != t.day_of_year) {
+    if (this->last_day_of_year_ != 0) {
+      // Day actually changed — reset energy
+      this->total_energy_ = 0;
+      this->publish_state_and_save(0);
+    }
     this->last_day_of_year_ = t.day_of_year;
-    return;
   }
 
-  if (t.day_of_year != this->last_day_of_year_) {
-    this->last_day_of_year_ = t.day_of_year;
-    this->total_energy_ = 0;
-    this->publish_state_and_save(0);
+  // Calculate seconds until next midnight.
+  // Uses the same TIMEOUT_ID_MIDNIGHT ID so re-scheduling (e.g. from time sync) cancels
+  // any previously pending timeout.
+  uint32_t seconds_until_midnight =
+      ((HOURS_PER_DAY - 1 - t.hour) * MINUTES_PER_HOUR + (MINUTES_PER_HOUR - 1 - t.minute)) * SECONDS_PER_MINUTE +
+      (SECONDS_PER_MINUTE - t.second);
+
+  // set_timeout counts real elapsed millis, but DST shifts wall clock by up to 1 hour
+  // without changing millis. To avoid firing up to 1 hour late/early, we use two stages:
+  // 1) Wake up 90 minutes before midnight to recalculate with current wall clock
+  // 2) From there, schedule the precise midnight reset
+  uint32_t timeout_seconds;
+  if (seconds_until_midnight > PRE_MIDNIGHT_SECONDS) {
+    timeout_seconds = seconds_until_midnight - PRE_MIDNIGHT_SECONDS;
+  } else {
+    timeout_seconds = seconds_until_midnight + 1;
   }
+
+  ESP_LOGD(TAG, "Scheduling midnight check in %us", timeout_seconds);
+  this->set_timeout(TIMEOUT_ID_MIDNIGHT, timeout_seconds * MILLIS_PER_SECOND,
+                    [this]() { this->schedule_midnight_reset_(); });
 }
 
 void TotalDailyEnergy::publish_state_and_save(float state) {
@@ -50,14 +88,14 @@ void TotalDailyEnergy::publish_state_and_save(float state) {
 void TotalDailyEnergy::process_new_state_(float state) {
   if (std::isnan(state))
     return;
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   const float old_state = this->last_power_state_;
   const float new_state = state;
-  float delta_hours = (now - this->last_update_) / 1000.0f / 60.0f / 60.0f;
+  float delta_hours = (now - this->last_update_) / static_cast<float>(MILLIS_PER_SECOND) / SECONDS_PER_HOUR;
   float delta_energy = 0.0f;
   switch (this->method_) {
     case TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID:
-      delta_energy = delta_hours * (old_state + new_state) / 2.0;
+      delta_energy = delta_hours * (old_state + new_state) / 2.0f;
       break;
     case TOTAL_DAILY_ENERGY_METHOD_LEFT:
       delta_energy = delta_hours * old_state;
@@ -71,5 +109,4 @@ void TotalDailyEnergy::process_new_state_(float state) {
   this->publish_state_and_save(this->total_energy_ + delta_energy);
 }
 
-}  // namespace total_daily_energy
-}  // namespace esphome
+}  // namespace esphome::total_daily_energy

--- a/esphome/components/total_daily_energy/total_daily_energy.h
+++ b/esphome/components/total_daily_energy/total_daily_energy.h
@@ -6,8 +6,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/time/real_time_clock.h"
 
-namespace esphome {
-namespace total_daily_energy {
+namespace esphome::total_daily_energy {
 
 enum TotalDailyEnergyMethod {
   TOTAL_DAILY_ENERGY_METHOD_TRAPEZOID = 0,
@@ -23,12 +22,12 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   void set_method(TotalDailyEnergyMethod method) { method_ = method; }
   void setup() override;
   void dump_config() override;
-  void loop() override;
 
   void publish_state_and_save(float state);
 
  protected:
   void process_new_state_(float state);
+  void schedule_midnight_reset_();
 
   ESPPreferenceObject pref_;
   time::RealTimeClock *time_;
@@ -41,5 +40,4 @@ class TotalDailyEnergy : public sensor::Sensor, public Component {
   float last_power_state_{0.0f};
 };
 
-}  // namespace total_daily_energy
-}  // namespace esphome
+}  // namespace esphome::total_daily_energy


### PR DESCRIPTION
# What does this implement/fix?

The `total_daily_energy` component previously ran its `loop()` every main loop iteration (~130Hz) just to check if midnight had passed. This called `time_->now()` on every iteration to construct a full `ESPTime` struct, making it the most expensive component by call count (7804 calls/60s and 423.8ms total CPU time per minute).

This replaces the `loop()` with a `set_timeout` that schedules the midnight reset at the exact right time. The timeout is (re)scheduled:
- At `setup()` if time is already valid
- On every NTP sync callback (in case the clock jumped across midnight)
- After each midnight reset fires (self-rescheduling)

### Runtime stats (ESP8266)

**Before (with `loop()`)** — `total_daily_energy` was the #1 most expensive component:
```
total_daily_energy.sensor: count=7804, avg=0.054ms, max=0.24ms, total=423.8ms
api:                       count=7804, avg=0.007ms, max=1.55ms, total=51.1ms
mdns:                      count=1121, avg=0.037ms, max=0.09ms, total=41.5ms
```

**After (timeout-based)** — `total_daily_energy` no longer appears (zero loop calls):
```
mdns:                      count=1090, avg=0.060ms, max=2.50ms, total=65.5ms
api:                       count=7580, avg=0.008ms, max=2.75ms, total=60.0ms
wifi:                      count=7580, avg=0.007ms, max=4.66ms, total=51.6ms
```

~424ms of CPU time per minute eliminated (ESP8266 is single-core, so wall clock ≈ CPU time). For context, a bluetooth proxy actively processing BLE advertisements uses ~208ms/min — a no-op midnight check was **2x more expensive** than real BLE proxy work.

### DST handling

`set_timeout` counts real elapsed milliseconds (`millis()`), not wall clock time. DST transitions shift wall clock by 1 hour without changing `millis()`, which would cause a single timeout to fire up to 1 hour late (spring-forward) or early (fall-back).

To handle this, `schedule_midnight_reset_()` uses a two-stage approach:
- **>90 minutes from midnight:** schedules a pre-check at midnight minus 90 minutes
- **≤90 minutes from midnight:** schedules the actual reset with a +1s buffer

The pre-check recalculates with fresh wall clock time, so even after a 1-hour DST shift the final timeout is accurate. DST transitions typically occur at 2 AM, well outside the 90-minute window.

NTP sync also triggers rescheduling via `add_on_time_sync_callback`, but DST transitions do not fire this callback (DST changes local time interpretation, not the epoch).

A standalone DST simulation test (`dst_test.cpp`) is attached to this PR, verifying correctness for spring-forward, fall-back, edge cases (90-min boundary, exactly midnight, late night), and self-correcting behavior when DST causes early/late pre-check firing.

## Flash impact

+576 bytes on ESP8266. Breakdown:

- **One-time template costs (shared with other components):** ~234 bytes
  - `Callback<void()>` `_M_realloc_insert` (198 bytes) — first ESP8266 user of `add_on_time_sync_callback` that triggers this instantiation. Will be eliminated entirely by #15272.
  - `Scheduler::set_timeout(uint32_t)` (36 bytes) — first user of this overload.
- **Per-component logic:** ~342 bytes
  - `schedule_midnight_reset_()` (292 bytes), lambda wrappers (~50 bytes)
- **Removed:** `loop()` (160 bytes)

After #15272 merges, the net cost drops to ~378 bytes — a reasonable tradeoff for eliminating ~7800 unnecessary `time_->now()` calls per minute.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).