### PR TITLE
[time] Use set_interval for CronTrigger instead of loop()

### DIFF
--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -20,7 +20,12 @@ bool CronTrigger::matches(const ESPTime &time) {
   return time.is_valid() && this->seconds_[time.second] && this->minutes_[time.minute] && this->hours_[time.hour] &&
          this->days_of_month_[time.day_of_month] && this->months_[time.month] && this->days_of_week_[time.day_of_week];
 }
-void CronTrigger::loop() {
+void CronTrigger::setup() {
+  // Cron resolution is 1 second — check once per second instead of every loop iteration
+  this->set_interval(1000, [this]() { this->check_time_(); });
+}
+
+void CronTrigger::check_time_() {
   ESPTime time = this->rtc_->now();
   if (!time.is_valid())
     return;

--- a/esphome/components/time/automation.h
+++ b/esphome/components/time/automation.h
@@ -26,10 +26,11 @@ class CronTrigger : public Trigger<>, public Component {
   void add_day_of_week(uint8_t day_of_week);
   void add_days_of_week(const std::vector<uint8_t> &days_of_week);
   bool matches(const ESPTime &time);
-  void loop() override;
+  void setup() override;
   float get_setup_priority() const override;
 
  protected:
+  void check_time_();
   std::bitset<61> seconds_;
   std::bitset<60> minutes_;
   std::bitset<24> hours_;

--- a/tests/components/time/common.yaml
+++ b/tests/components/time/common.yaml
@@ -6,5 +6,12 @@ api:
 
 time:
   - platform: homeassistant
+    on_time:
+      - at: "16:00:00"
+        then:
+          - logger.log: It's 16:00
+      - cron: "0 30 * * * *"
+        then:
+          - logger.log: Every hour at 30 minutes
   - platform: sntp
     id: sntp_time

--- a/tests/components/time/common.yaml
+++ b/tests/components/time/common.yaml
@@ -6,5 +6,9 @@ api:
 
 time:
   - platform: homeassistant
+    on_time:
+      - cron: "*/10 * * * * *"
+        then:
+          - logger.log: "CronTrigger fired (every 10 seconds)"
   - platform: sntp
     id: sntp_time


### PR DESCRIPTION
# What does this implement/fix?

`CronTrigger::loop()` called `rtc_->now()` on every main loop iteration (~130Hz) to check if the current time matches a cron pattern. Since cron resolution is 1 second, this means ~7100 `now()` calls per minute when 60 would suffice. The `last_check_ >= time` early return caught most duplicates but still constructed the full `ESPTime` struct every iteration.

`now()` is not a cheap call — it constructs a full `ESPTime` struct from the current epoch. This was identified as the same class of problem fixed in #15432 for `total_daily_energy`, where `now()` in `loop()` made it the most expensive component by call count.

This replaces `loop()` with a `set_interval(1000)` call in `setup()`, moving the time-checking logic to a private `check_time_()` method. The catch-up loop for missed seconds is preserved unchanged, so no cron triggers are missed even if the interval drifts.

### Runtime stats (ESP32 with ethernet)

**Before** — `time` was the #1 most expensive component at 506ms/min:
```
time:                      count=7116, avg=0.071ms, max=2.32ms, total=506.2ms
api:                       count=7116, avg=0.030ms, max=60.78ms, total=210.5ms
template.water_heater:     count=7116, avg=0.013ms, max=0.35ms, total=91.1ms
```

**After** — `time` drops from 7116 to 60 calls, 506ms to 26ms:
```
api:                       count=7475, avg=0.006ms, max=3.53ms, total=41.3ms
time:                      count=60,   avg=0.429ms, max=2.31ms, total=25.8ms
template.water_heater:     count=7475, avg=0.003ms, max=0.09ms, total=23.2ms
```

For context, a bluetooth proxy actively processing BLE advertisements uses ~208ms/min. A no-op `CronTrigger` time check was **2.4x more expensive** than real BLE proxy work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #15432 (same `now()` in `loop()` pattern)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).