### PR TITLE
[time] Support */N syntax in cron expressions

### DIFF
--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -123,8 +123,8 @@ def _parse_cron_part(part, min_value, max_value, special_mapping):
                 f"Can't have more than two '/' in one time expression, got {part}"
             )
         offset, repeat = data
-        offset_n = 0
-        if offset:
+        offset_n = min_value
+        if offset and offset not in ("*", "?"):
             offset_n = _parse_cron_int(
                 offset,
                 special_mapping,

--- a/tests/unit_tests/components/test_time.py
+++ b/tests/unit_tests/components/test_time.py
@@ -1,0 +1,80 @@
+"""Tests for time component cron expression parsing."""
+
+from esphome.components.time import _parse_cron_part
+
+
+def test_star_slash_seconds() -> None:
+    assert _parse_cron_part("*/10", 0, 60, {}) == {0, 10, 20, 30, 40, 50, 60}
+
+
+def test_star_slash_minutes() -> None:
+    assert _parse_cron_part("*/5", 0, 59, {}) == {
+        0,
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        55,
+    }
+
+
+def test_star_slash_hours() -> None:
+    assert _parse_cron_part("*/2", 0, 23, {}) == {
+        0,
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+    }
+
+
+def test_star_slash_days_of_month() -> None:
+    """days_of_month starts at 1, not 0."""
+    assert _parse_cron_part("*/5", 1, 31, {}) == {1, 6, 11, 16, 21, 26, 31}
+
+
+def test_question_slash() -> None:
+    assert _parse_cron_part("?/10", 0, 60, {}) == {0, 10, 20, 30, 40, 50, 60}
+
+
+def test_empty_offset_slash() -> None:
+    """Empty offset defaults to min_value."""
+    assert _parse_cron_part("/10", 0, 60, {}) == {0, 10, 20, 30, 40, 50, 60}
+
+
+def test_empty_offset_slash_nonzero_min() -> None:
+    """Empty offset defaults to min_value, not 0."""
+    assert _parse_cron_part("/5", 1, 31, {}) == {1, 6, 11, 16, 21, 26, 31}
+
+
+def test_numeric_offset_slash() -> None:
+    assert _parse_cron_part("5/10", 0, 60, {}) == {5, 15, 25, 35, 45, 55}
+
+
+def test_star() -> None:
+    assert _parse_cron_part("*", 0, 59, {}) == set(range(0, 60))
+
+
+def test_question() -> None:
+    assert _parse_cron_part("?", 0, 59, {}) == set(range(0, 60))
+
+
+def test_range() -> None:
+    assert _parse_cron_part("1-5", 0, 59, {}) == {1, 2, 3, 4, 5}
+
+
+def test_single_value() -> None:
+    assert _parse_cron_part("30", 0, 59, {}) == {30}


### PR DESCRIPTION
# What does this implement/fix?

The standard cron `*/N` syntax (e.g., `*/10 * * * * *` for every 10 seconds) was not supported. Using `*/N` produced the error:

```
Offset for '/' time expression must be an integer, got *
```

This was because the parser treated `*` before `/` as a literal value to parse as an integer, rather than recognizing it as a wildcard meaning "start from the minimum value".

The fix treats `*` and `?` before `/` the same as an empty offset — starting from `min_value`. Also fixes the empty offset default from `0` to `min_value`, which is correct for fields like `days_of_month` where the range starts at 1.

Examples now supported:
- `*/10 * * * * *` → every 10 seconds (0, 10, 20, 30, 40, 50)
- `* */5 * * * *` → every 5 minutes (0, 5, 10, ..., 55)
- `* * */2 * * *` → every 2 hours (0, 2, 4, ..., 22)

Existing syntax like `5/10` (start at 5, repeat every 10) continues to work unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: sntp
    on_time:
      - cron: "*/10 * * * * *"
        then:
          - logger.log: "Every 10 seconds"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).