### PR TITLE
[ci] move import to function

### DIFF
--- a/script/helpers.py
+++ b/script/helpers.py
@@ -15,8 +15,6 @@ from typing import Any
 
 import colorama
 
-from esphome.loader import get_platform
-
 root_path = os.path.abspath(os.path.normpath(os.path.join(__file__, "..", "..")))
 basepath = os.path.join(root_path, "esphome")
 temp_folder = os.path.join(root_path, ".temp")
@@ -644,7 +642,7 @@ def get_all_dependencies(
         PLATFORM_HOST,
     )
     from esphome.core import CORE
-    from esphome.loader import get_component
+    from esphome.loader import get_component, get_platform
 
     all_components: set[str] = set(component_names)
 

--- a/tests/script/test_helpers.py
+++ b/tests/script/test_helpers.py
@@ -1037,7 +1037,7 @@ def test_get_all_dependencies_platform_component() -> None:
 
     with (
         patch("esphome.loader.get_component") as mock_get_component,
-        patch("helpers.get_platform") as mock_get_platform,
+        patch("esphome.loader.get_platform") as mock_get_platform,
     ):
         mock_get_platform.return_value = platform_comp
         mock_get_component.return_value = None
@@ -1061,7 +1061,7 @@ def test_get_all_dependencies_platform_component_with_dependencies() -> None:
 
     with (
         patch("esphome.loader.get_component") as mock_get_component,
-        patch("helpers.get_platform") as mock_get_platform,
+        patch("esphome.loader.get_platform") as mock_get_platform,
     ):
         mock_get_platform.return_value = platform_comp
         mock_get_component.side_effect = lambda name: (


### PR DESCRIPTION
# What does this implement/fix?

Move `from esphome.loader import get_platform` to `get_all_dependencies` (`create_components_graph` also uses it, but that already imports it locally)

Update tests to use `esphome.loader.get_platform` instead of `helpers.get_platform`

When running CI tests locally with `docker run --rm -v "${PWD}/":/esphome -it ghcr.io/esphome/esphome-lint script/quicklint`

```
Traceback (most recent call last):
  File "/esphome/script/ci-custom.py", line 15, in <module>
    from helpers import filter_changed, git_ls_files, print_error_for_file, styled
  File "/esphome/script/helpers.py", line 18, in <module>
    from esphome.loader import get_platform
ModuleNotFoundError: No module named 'esphome'
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
