### PR TITLE
[gpio_expander] Remove loop() from GPIO expander components

### DIFF
--- a/esphome/components/gpio_expander/cached_gpio.h
+++ b/esphome/components/gpio_expander/cached_gpio.h
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <limits>
 #include <type_traits>
+#include "esphome/core/application.h"
 #include "esphome/core/hal.h"
 
 namespace esphome::gpio_expander {
@@ -32,6 +33,15 @@ class CachedGpioExpander {
   /// @param pin Pin number to read
   /// @return Pin state
   bool digital_read(P pin) {
+    // Invalidate cache once per loop iteration so we always get a fresh
+    // hardware read on the first access each loop, while still caching
+    // within the same iteration for other pins in the same bank.
+    const uint32_t now = App.get_loop_component_start_time();
+    if (now != this->last_loop_time_) {
+      this->last_loop_time_ = now;
+      this->reset_pin_cache_();
+    }
+
     const P bank = pin / BANK_SIZE;
     const T pin_mask = (1 << (pin % BANK_SIZE));
     // Check if specific pin cache is valid
@@ -68,7 +78,7 @@ class CachedGpioExpander {
   /// @param value Pin state to write (true = HIGH, false = LOW)
   virtual void digital_write_hw(P pin, bool value) = 0;
 
-  /// @brief Invalidate cache. This function should be called in component loop().
+  /// @brief Invalidate all cached pin states, forcing the next digital_read() to read from hardware.
   void reset_pin_cache_() { memset(this->read_cache_valid_, 0x00, CACHE_SIZE_BYTES); }
 
   static constexpr uint16_t BITS_PER_BYTE = 8;
@@ -76,6 +86,7 @@ class CachedGpioExpander {
   static constexpr size_t BANKS = N / BANK_SIZE;
   static constexpr size_t CACHE_SIZE_BYTES = BANKS * sizeof(T);
 
+  uint32_t last_loop_time_{0};
   T read_cache_valid_[BANKS]{0};
 };
 

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -26,10 +26,6 @@ void MCP23016::setup() {
   this->write_reg_(MCP23016_IODIR1, 0xFFFF);
 }
 
-void MCP23016::loop() {
-  // Invalidate cache at the start of each loop
-  this->reset_pin_cache_();
-}
 bool MCP23016::digital_read_hw(uint8_t pin) { return this->read_reg_(MCP23016_GP1, &this->input_mask_); }
 
 bool MCP23016::digital_read_cache(uint8_t pin) { return this->input_mask_ & (1 << pin); }

--- a/esphome/components/mcp23016/mcp23016.h
+++ b/esphome/components/mcp23016/mcp23016.h
@@ -30,7 +30,6 @@ class MCP23016 : public Component, public i2c::I2CDevice, public gpio_expander::
   MCP23016() = default;
 
   void setup() override;
-  void loop() override;
   void pin_mode(uint8_t pin, gpio::Flags flags);
 
   float get_setup_priority() const override;

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.h
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.h
@@ -17,8 +17,6 @@ template<uint8_t N> class MCP23XXXBase : public Component, public gpio_expander:
   void set_open_drain_ints(const bool value) { this->open_drain_ints_ = value; }
   float get_setup_priority() const override { return setup_priority::IO; }
 
-  void loop() override { this->reset_pin_cache_(); }
-
  protected:
   // read a given register
   virtual bool read_reg(uint8_t reg, uint8_t *value) = 0;

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -51,11 +51,6 @@ void PCA6416AComponent::setup() {
            this->status_has_error());
 }
 
-void PCA6416AComponent::loop() {
-  // Invalidate cache at the start of each loop
-  this->reset_pin_cache_();
-}
-
 void PCA6416AComponent::dump_config() {
   if (this->has_pullup_) {
     ESP_LOGCONFIG(TAG, "PCAL6416A:");

--- a/esphome/components/pca6416a/pca6416a.h
+++ b/esphome/components/pca6416a/pca6416a.h
@@ -16,7 +16,6 @@ class PCA6416AComponent : public Component,
 
   /// Check i2c availability and setup masks
   void setup() override;
-  void loop() override;
   /// Helper function to set the pin mode of a pin.
   void pin_mode(uint8_t pin, gpio::Flags flags);
 

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -36,12 +36,6 @@ void PCA9554Component::setup() {
            this->status_has_error());
 }
 
-void PCA9554Component::loop() {
-  // Invalidate the cache at the start of each loop.
-  // The actual read will happen on demand when digital_read() is called
-  this->reset_pin_cache_();
-}
-
 void PCA9554Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "PCA9554:\n"

--- a/esphome/components/pca9554/pca9554.h
+++ b/esphome/components/pca9554/pca9554.h
@@ -16,8 +16,6 @@ class PCA9554Component : public Component,
 
   /// Check i2c availability and setup masks
   void setup() override;
-  /// Invalidate cache at start of each loop
-  void loop() override;
   /// Helper function to set the pin mode of a pin.
   void pin_mode(uint8_t pin, gpio::Flags flags);
 

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -16,10 +16,6 @@ void PCF8574Component::setup() {
   this->write_gpio_();
   this->read_gpio_();
 }
-void PCF8574Component::loop() {
-  // Invalidate the cache at the start of each loop
-  this->reset_pin_cache_();
-}
 void PCF8574Component::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "PCF8574:\n"

--- a/esphome/components/pcf8574/pcf8574.h
+++ b/esphome/components/pcf8574/pcf8574.h
@@ -20,8 +20,6 @@ class PCF8574Component : public Component,
 
   /// Check i2c availability and setup masks
   void setup() override;
-  /// Invalidate cache at start of each loop
-  void loop() override;
   /// Helper function to set the pin mode of a pin.
   void pin_mode(uint8_t pin, gpio::Flags flags);
 

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -60,8 +60,6 @@ void PI4IOE5V6408Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   this->write_gpio_modes_();
 }
 
-void PI4IOE5V6408Component::loop() { this->reset_pin_cache_(); }
-
 bool PI4IOE5V6408Component::read_gpio_outputs_() {
   if (this->is_failed())
     return false;

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.h
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.h
@@ -18,7 +18,6 @@ class PI4IOE5V6408Component : public Component,
 
   float get_setup_priority() const override;
   void dump_config() override;
-  void loop() override;
 
   /// Indicate if the component should reset the state during setup
   void set_reset(bool reset) { this->reset_ = reset; }

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -39,9 +39,6 @@ void SX1509Component::dump_config() {
 }
 
 void SX1509Component::loop() {
-  // Reset cache at the start of each loop
-  this->reset_pin_cache_();
-
   if (this->has_keypad_) {
     if (millis() - this->last_loop_timestamp_ < min_loop_period_)
       return;

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -43,8 +43,6 @@ void TCA9555Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   // Write GPIO to enable input mode
   this->write_gpio_modes_();
 }
-void TCA9555Component::loop() { this->reset_pin_cache_(); }
-
 bool TCA9555Component::read_gpio_outputs_() {
   if (this->is_failed())
     return false;

--- a/esphome/components/tca9555/tca9555.h
+++ b/esphome/components/tca9555/tca9555.h
@@ -22,8 +22,6 @@ class TCA9555Component : public Component,
 
   void dump_config() override;
 
-  void loop() override;
-
  protected:
   bool digital_read_hw(uint8_t pin) override;
   bool digital_read_cache(uint8_t pin) override;


### PR DESCRIPTION
# What does this implement/fix?

All GPIO expander components (`pcf8574`, `pca9554`, `tca9555`, `pi4ioe5v6408`, `pca6416a`, `mcp23016`, `mcp23xxx_base`) had a `loop()` override whose only purpose was calling `reset_pin_cache_()` — a 2-byte `memset` — every single main loop iteration. While the work per call is trivial, the loop dispatch overhead runs at full loop speed (~130Hz on ESP8266) for every expander instance.

This moves the cache invalidation into `CachedGpioExpander::digital_read()` itself. On each call it compares `App.get_loop_component_start_time()` against a stored timestamp; when a new loop iteration is detected, it calls `reset_pin_cache_()` before proceeding. This preserves the exact same caching semantics (first read per loop does hardware I2C, subsequent reads of same-bank pins use cache) while eliminating the dedicated `loop()` entirely.

For `sx1509`, only the `reset_pin_cache_()` call is removed from `loop()` — the method is kept because it also contains keypad scanning logic.

**Trade-off:** One extra `uint32_t` (4 bytes RAM) per expander instance and one timestamp comparison per `digital_read()` call — far cheaper than the loop dispatch overhead eliminated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).