### PR TITLE
[template] Inline template binary sensor lambda via constexpr NTTP

### DIFF
--- a/esphome/components/template/binary_sensor/__init__.py
+++ b/esphome/components/template/binary_sensor/__init__.py
@@ -68,7 +68,7 @@ async def to_code(config):
         func_expr = None
 
     if func_expr is not None:
-        # TemplateBinarySensor<func> — compiler inlines the call
+        # TemplateBinarySensorLambda<func> — compiler inlines the call
         id_ = config[CONF_ID]
         id_ = id_.copy()
         id_.type = TemplateBinarySensorLambda.template(func_expr)

--- a/esphome/components/template/binary_sensor/__init__.py
+++ b/esphome/components/template/binary_sensor/__init__.py
@@ -3,12 +3,16 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_CONDITION, CONF_ID, CONF_LAMBDA, CONF_STATE
-from esphome.cpp_generator import LambdaExpression
+from esphome.cpp_generator import LambdaExpression, RawExpression, UnaryOpExpression
+from esphome.types import ConfigType
 
 from .. import template_ns
 
 TemplateBinarySensor = template_ns.class_(
-    "TemplateBinarySensor", binary_sensor.BinarySensor, cg.Component
+    "TemplateBinarySensor", cg.Component, binary_sensor.BinarySensor
+)
+TemplateBinarySensorLambda = template_ns.class_(
+    "TemplateBinarySensorLambda", TemplateBinarySensor
 )
 
 CONFIG_SCHEMA = (
@@ -25,29 +29,55 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
-    var = await binary_sensor.new_binary_sensor(config)
-    await cg.register_component(var, config)
+def _declare_constexpr_lambda(
+    config: ConfigType, template_: LambdaExpression
+) -> RawExpression:
+    """Declare a constexpr function pointer from a captureless lambda.
 
+    Generates: static constexpr auto name = +[]() -> optional<bool> { body };
+    The unary + converts the captureless lambda to a function pointer,
+    making it usable as a non-type template parameter for inlining.
+    """
+    func_name = f"template_binary_sensor_{config[CONF_ID]}_f"
+    # UnaryOpExpression handles the +lambda → function pointer conversion
+    func_ptr = UnaryOpExpression("+", template_)
+    cg.add_global(
+        cg.RawStatement(f"static constexpr auto {func_name} = {func_ptr};"),
+    )
+    return RawExpression(func_name)
+
+
+async def to_code(config):
     if lamb := config.get(CONF_LAMBDA):
         template_ = await cg.process_lambda(
-            lamb, [], return_type=cg.optional.template(bool)
+            lamb, [], return_type=cg.optional.template(bool), capture=""
         )
-        cg.add(var.set_template(template_))
-    if condition := config.get(CONF_CONDITION):
+        func_expr = _declare_constexpr_lambda(config, template_)
+    elif condition := config.get(CONF_CONDITION):
         condition = await automation.build_condition(
             condition, cg.TemplateArguments(), []
         )
-        # Generate a stateless lambda that calls condition.check()
-        # capture="" is safe because condition is a global variable in generated C++ code
-        # and doesn't need to be captured. This allows implicit conversion to function pointer.
         template_ = LambdaExpression(
             f"return {condition.check()};",
             [],
             return_type=cg.optional.template(bool),
             capture="",
         )
-        cg.add(var.set_template(template_))
+        func_expr = _declare_constexpr_lambda(config, template_)
+    else:
+        func_expr = None
+
+    if func_expr is not None:
+        # TemplateBinarySensor<func> — compiler inlines the call
+        id_ = config[CONF_ID]
+        id_ = id_.copy()
+        id_.type = TemplateBinarySensorLambda.template(func_expr)
+        var = cg.new_Pvariable(id_)
+    else:
+        var = cg.new_Pvariable(config[CONF_ID])
+
+    await binary_sensor.register_binary_sensor(var, config)
+    await cg.register_component(var, config)
 
 
 @automation.register_action(

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -5,8 +5,6 @@ namespace esphome::template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void TemplateBinarySensor::setup() { this->loop(); }
-
 void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }
 
 }  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -5,21 +5,8 @@ namespace esphome::template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void TemplateBinarySensor::setup() {
-  if (!this->f_.has_value()) {
-    this->disable_loop();
-  } else {
-    this->loop();
-  }
+void log_template_binary_sensor(binary_sensor::BinarySensor *obj) {
+  LOG_BINARY_SENSOR("", "Template Binary Sensor", obj);
 }
-
-void TemplateBinarySensor::loop() {
-  auto s = this->f_();
-  if (s.has_value()) {
-    this->publish_state(*s);
-  }
-}
-
-void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }
 
 }  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.cpp
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.cpp
@@ -5,8 +5,8 @@ namespace esphome::template_ {
 
 static const char *const TAG = "template.binary_sensor";
 
-void log_template_binary_sensor(binary_sensor::BinarySensor *obj) {
-  LOG_BINARY_SENSOR("", "Template Binary Sensor", obj);
-}
+void TemplateBinarySensor::setup() { this->loop(); }
+
+void TemplateBinarySensor::dump_config() { LOG_BINARY_SENSOR("", "Template Binary Sensor", this); }
 
 }  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -16,13 +16,13 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
 };
 
 /// Template binary sensor with compile-time lambda for zero-overhead inlined evaluation.
-/// @tparam F Constexpr function pointer returning optional<bool>.
-template<optional<bool> (*F)()> class TemplateBinarySensorLambda final : public TemplateBinarySensor {
+/// @tparam Func Constexpr function pointer returning optional<bool>.
+template<optional<bool> (*Func)()> class TemplateBinarySensorLambda final : public TemplateBinarySensor {
  public:
   void setup() override { this->loop(); }
 
   void loop() override {
-    auto s = F();
+    auto s = Func();
     if (s.has_value()) {
       this->publish_state(*s);
     }

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -8,7 +8,6 @@ namespace esphome::template_ {
 /// Action-driven template binary sensor (no lambda). State set via binary_sensor.template.publish.
 class TemplateBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
-  void setup() override;
   void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 };
@@ -17,6 +16,7 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
 /// @tparam Func Constexpr function pointer returning optional<bool>.
 template<optional<bool> (*Func)()> class TemplateBinarySensorLambda final : public TemplateBinarySensor {
  public:
+  void setup() override { this->loop(); }
   void loop() override {
     auto s = Func();
     if (s.has_value()) {

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -1,23 +1,32 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/core/template_lambda.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome::template_ {
 
-class TemplateBinarySensor final : public Component, public binary_sensor::BinarySensor {
+/// Out-of-line dump_config shared by all template binary sensor variants.
+void log_template_binary_sensor(binary_sensor::BinarySensor *obj);
+
+/// Action-driven template binary sensor (no lambda). State set via binary_sensor.template.publish.
+class TemplateBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
-  template<typename F> void set_template(F &&f) { this->f_.set(std::forward<F>(f)); }
-
-  void setup() override;
-  void loop() override;
-  void dump_config() override;
-
+  void dump_config() override { log_template_binary_sensor(this); }
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
+};
 
- protected:
-  TemplateLambda<bool> f_;
+/// Template binary sensor with compile-time lambda for zero-overhead inlined evaluation.
+/// @tparam F Constexpr function pointer returning optional<bool>.
+template<optional<bool> (*F)()> class TemplateBinarySensorLambda final : public TemplateBinarySensor {
+ public:
+  void setup() override { this->loop(); }
+
+  void loop() override {
+    auto s = F();
+    if (s.has_value()) {
+      this->publish_state(*s);
+    }
+  }
 };
 
 }  // namespace esphome::template_

--- a/esphome/components/template/binary_sensor/template_binary_sensor.h
+++ b/esphome/components/template/binary_sensor/template_binary_sensor.h
@@ -5,13 +5,11 @@
 
 namespace esphome::template_ {
 
-/// Out-of-line dump_config shared by all template binary sensor variants.
-void log_template_binary_sensor(binary_sensor::BinarySensor *obj);
-
 /// Action-driven template binary sensor (no lambda). State set via binary_sensor.template.publish.
 class TemplateBinarySensor : public Component, public binary_sensor::BinarySensor {
  public:
-  void dump_config() override { log_template_binary_sensor(this); }
+  void setup() override;
+  void dump_config() override;
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 };
 
@@ -19,8 +17,6 @@ class TemplateBinarySensor : public Component, public binary_sensor::BinarySenso
 /// @tparam Func Constexpr function pointer returning optional<bool>.
 template<optional<bool> (*Func)()> class TemplateBinarySensorLambda final : public TemplateBinarySensor {
  public:
-  void setup() override { this->loop(); }
-
   void loop() override {
     auto s = Func();
     if (s.has_value()) {


### PR DESCRIPTION
# What does this implement/fix?

Replace runtime function pointer indirection in template binary sensor with a compile-time non-type template parameter (NTTP). The lambda is now a constexpr function pointer baked into the type, allowing the compiler to fully inline the evaluation.

**Before:** every `loop()` call loaded a function pointer from the object and made an indirect call (`callx8`), preventing inlining. The `optional<bool>` wrapping/unwrapping also had runtime overhead.

```asm
l32i    a10, a2, 72       # load function pointer
beqz    a10, ...          # null check
callx8  a10               # INDIRECT CALL to lambda
s16i    a10, a1, 0        # unpack optional
extui   a10, a10, 8, 8   # check has_value
beqz.n  a10, ...          # skip if nullopt
l8ui    a11, a1, 0        # reload bool
call8   publish_state
```

**After:** the compiler inlines the lambda body directly into `loop()`, eliminating the indirect call, the null check, and the optional packing/unpacking. Only the direct call to `publish_state()` remains.

```asm
l32r    a8, ...           # load &source_sensor directly
l8ui    a11, a8, 40       # read .value() inline
beqz.n  a11, ...          # early exit
l32r    a8, ...           # load &other_sensor
l8ui    a8, a8, 28        # read .state inline
bnez.n  a8, ...           # early exit
l32r    a8, ...           # load &another_sensor
l8ui    a11, a8, 28       # read .state inline
xor/extui                 # !state → bool
call8   publish_state     # DIRECT CALL (only remaining call)
```

The class hierarchy is split into:
- `TemplateBinarySensor`: base class for action-driven sensors (no lambda, no loop override, no overhead)
- `TemplateBinarySensorLambda<F>`: template subclass with compile-time inlined `loop()`

This also removes the `TemplateLambda<bool>` member (4 bytes saved per instance) and the `template_lambda.h` dependency.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing changes

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — existing template binary sensor configs
# work unchanged. The optimization is automatic.

binary_sensor:
  - platform: template
    name: "My Sensor"
    lambda: |-
      return id(some_sensor).state;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

