### PR TITLE
[pcf8574][pca9554] Disable loop when all pins are outputs

### DIFF
--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -40,9 +40,11 @@ void PCA9554Component::setup() {
     this->interrupt_pin_->attach_interrupt(&PCA9554Component::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
     // Don't invalidate cache on read — only invalidate when interrupt fires
     this->set_invalidate_on_read_(false);
-    // With interrupt pin, only run loop when interrupt fires
-    this->disable_loop();
   }
+  // Disable loop until an input pin is configured via pin_mode()
+  // For interrupt-driven mode, loop is re-enabled by the ISR
+  // For polling mode, loop is re-enabled when pin_mode() registers an input pin
+  this->disable_loop();
 }
 void IRAM_ATTR PCA9554Component::gpio_intr(PCA9554Component *arg) { arg->enable_loop_soon_any_context(); }
 void PCA9554Component::loop() {
@@ -89,6 +91,11 @@ void PCA9554Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
     // Clear mode mask bit
     this->config_mask_ &= ~(1 << pin);
+    // Enable polling loop for input pins (not needed for interrupt-driven mode
+    // where the ISR handles re-enabling loop)
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   } else if (flags == gpio::FLAG_OUTPUT) {
     // Set mode mask bit
     this->config_mask_ |= 1 << pin;

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -21,9 +21,11 @@ void PCF8574Component::setup() {
     this->interrupt_pin_->attach_interrupt(&PCF8574Component::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
     // Don't invalidate cache on read — only invalidate when interrupt fires
     this->set_invalidate_on_read_(false);
-    // With interrupt pin, only run loop when interrupt fires
-    this->disable_loop();
   }
+  // Disable loop until an input pin is configured via pin_mode()
+  // For interrupt-driven mode, loop is re-enabled by the ISR
+  // For polling mode, loop is re-enabled when pin_mode() registers an input pin
+  this->disable_loop();
 }
 void IRAM_ATTR PCF8574Component::gpio_intr(PCF8574Component *arg) { arg->enable_loop_soon_any_context(); }
 void PCF8574Component::loop() {
@@ -66,6 +68,11 @@ void PCF8574Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->mode_mask_ &= ~(1 << pin);
     // Write GPIO to enable input mode
     this->write_gpio_();
+    // Enable polling loop for input pins (not needed for interrupt-driven mode
+    // where the ISR handles re-enabling loop)
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   } else if (flags == gpio::FLAG_OUTPUT) {
     // Set mode mask bit
     this->mode_mask_ |= 1 << pin;


### PR DESCRIPTION
# What does this implement/fix?

When a PCF8574 or PCA9554 expander has only output pins configured, `loop()` was still running every iteration to invalidate the read cache via `reset_pin_cache_()`. Since no `digital_read()` calls will ever be made on an output-only expander, this work is wasted.

Now `disable_loop()` is called unconditionally in `setup()`. For polling mode, loop is re-enabled only when `pin_mode()` registers an input pin. For interrupt-driven mode, behavior is unchanged as the ISR already manages loop enablement.

Tested on real hardware (ESP32 with ethernet, PCF8574 output-only expander and PCF8574 interrupt-driven input expander controlling a gate via feedback cover). The output-only expander no longer appears in the active component list, and the interrupt-driven input expander correctly responds to pin changes.

<details>
<summary>Runtime stats before/after</summary>

### Before (12 active components, ~148ms total)

```
Period stats (last 60000ms): 12 active components
  gpio.binary_sensor: count=7467, avg=0.005ms, max=0.06ms, total=39.1ms
  template.binary_sensor: count=7467, avg=0.005ms, max=0.22ms, total=36.9ms
  api: count=7467, avg=0.004ms, max=2.36ms, total=27.2ms
  pcf8574: count=7467, avg=0.001ms, max=0.24ms, total=10.6ms
  preferences: count=1, avg=10.121ms, max=10.12ms, total=10.1ms
  feedback.cover: count=7467, avg=0.001ms, max=0.74ms, total=9.8ms
  gpio.binary_sensor: count=7467, avg=0.001ms, max=0.00ms, total=7.6ms
  gpio.binary_sensor: count=7467, avg=0.001ms, max=0.00ms, total=7.5ms
  template.binary_sensor: count=7467, avg=0.001ms, max=0.01ms, total=4.2ms
  esphome.ota: count=7467, avg=0.000ms, max=0.01ms, total=2.2ms
  uptime.sensor: count=1, avg=0.215ms, max=0.22ms, total=0.2ms
  template.sensor: count=1, avg=0.117ms, max=0.12ms, total=0.1ms
```

### After idle (11 active components, ~97ms total)

```
Period stats (last 60000ms): 11 active components
  api: count=7467, avg=0.004ms, max=2.26ms, total=28.3ms
  gpio.binary_sensor: count=7467, avg=0.002ms, max=0.05ms, total=16.4ms
  feedback.cover: count=7467, avg=0.002ms, max=0.02ms, total=12.4ms
  preferences: count=1, avg=8.803ms, max=8.80ms, total=8.8ms
  gpio.binary_sensor: count=7467, avg=0.001ms, max=0.00ms, total=7.6ms
  template.binary_sensor: count=7467, avg=0.001ms, max=0.02ms, total=7.6ms
  gpio.binary_sensor: count=7467, avg=0.001ms, max=0.00ms, total=7.5ms
  template.binary_sensor: count=7467, avg=0.001ms, max=0.22ms, total=7.2ms
  esphome.ota: count=7467, avg=0.000ms, max=0.01ms, total=1.3ms
  uptime.sensor: count=1, avg=0.214ms, max=0.21ms, total=0.2ms
  template.sensor: count=1, avg=0.088ms, max=0.09ms, total=0.1ms
```

### After gate operation (interrupt-driven input hub)

The interrupt-driven input hub only ran 12 loop iterations during the 60s period — triggered by actual pin change interrupts during gate open/close.

```
Period stats (last 60000ms): 18 active components
  api: count=7480, avg=0.010ms, max=5.41ms, total=71.5ms
  gpio.binary_sensor: count=7480, avg=0.004ms, max=2.11ms, total=27.2ms
  feedback.cover: count=7480, avg=0.002ms, max=0.71ms, total=15.3ms
  gpio.binary_sensor: count=7480, avg=0.002ms, max=5.12ms, total=13.6ms
  template.binary_sensor: count=7480, avg=0.001ms, max=1.77ms, total=10.1ms
  gpio.binary_sensor: count=7480, avg=0.001ms, max=0.08ms, total=7.8ms
  template.binary_sensor: count=7480, avg=0.001ms, max=0.02ms, total=7.6ms
  feedback.cover: count=2, avg=0.920ms, max=0.92ms, total=1.8ms
  feedback.cover: count=2, avg=0.910ms, max=0.97ms, total=1.8ms
  esphome.ota: count=7480, avg=0.000ms, max=0.01ms, total=1.4ms
  feedback.cover: count=1, avg=0.769ms, max=0.77ms, total=0.8ms
  pcf8574: count=12, avg=0.016ms, max=0.04ms, total=0.2ms
  binary_sensor: count=1, avg=0.185ms, max=0.19ms, total=0.2ms
  uptime.sensor: count=1, avg=0.097ms, max=0.10ms, total=0.1ms
  template.sensor: count=1, avg=0.080ms, max=0.08ms, total=0.1ms
  ethernet: count=1, avg=0.050ms, max=0.05ms, total=0.1ms
  binary_sensor: count=1, avg=0.038ms, max=0.04ms, total=0.0ms
  preferences: count=1, avg=0.029ms, max=0.03ms, total=0.0ms
```

</details>

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Output-only expander - loop() will be disabled since no input pins
pcf8574:
  - id: pcf8574_hub_out
    address: 0x24

switch:
  - platform: gpio
    pin:
      pcf8574: pcf8574_hub_out
      number: 0
      mode: OUTPUT
      inverted: true
    name: "Relay 1"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).