### PR TITLE
[bmp581_spi] Add C++ unit tests

### DIFF
--- a/tests/components/bmp581_spi/bmp581_spi.cpp
+++ b/tests/components/bmp581_spi/bmp581_spi.cpp
@@ -1,0 +1,240 @@
+#include "common.h"
+
+namespace esphome::bmp581_spi::testing {
+
+// ---------------------------------------------------------------------------
+// bmp_read_byte tests
+// ---------------------------------------------------------------------------
+
+// The BMP581 SPI protocol requires setting the MSB of the register address to
+// indicate a read operation. Verify that bmp_read_byte ORs the register address
+// with SPI_READ_BIT before transmitting.
+TEST(BMP581SPIReadByteTest, ReadByteEncodesReadBitInRegister) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  uint8_t data = SPI_DUMMY_BYTE;
+  comp.bmp_read_byte(bmp581_base::BMP581_CHIP_ID, &data);
+
+  ASSERT_GE(mock.sent_bytes.size(), 1u);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_CHIP_ID) | SPI_READ_BIT);
+}
+
+// After the address byte, bmp_read_byte must clock out one byte by sending a
+// zero dummy byte. The device drives the MISO line during this transfer.
+TEST(BMP581SPIReadByteTest, ReadByteSendsDummyByteToClockResponse) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  uint8_t data = SPI_DUMMY_BYTE;
+  comp.bmp_read_byte(bmp581_base::BMP581_INT_STATUS, &data);
+
+  ASSERT_EQ(mock.sent_bytes.size(), 2u);
+  EXPECT_EQ(mock.sent_bytes[1], SPI_DUMMY_BYTE);
+}
+
+// The byte returned by the device (mocked as the transfer response) must be
+// stored in the output pointer.
+TEST(BMP581SPIReadByteTest, ReadByteCapturesResponseInOutputPointer) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  // First transfer (address byte) returns 0; second (dummy) returns the sensor value.
+  mock.push_response(SPI_DUMMY_BYTE);
+  mock.push_response(bmp581_base::BMP581_ASIC_ID);
+
+  uint8_t data = SPI_DUMMY_BYTE;
+  comp.bmp_read_byte(bmp581_base::BMP581_CHIP_ID, &data);
+
+  EXPECT_EQ(data, bmp581_base::BMP581_ASIC_ID);
+}
+
+// Each read is a single SPI transaction: CS must be asserted before the first
+// byte and de-asserted after the last byte.
+TEST(BMP581SPIReadByteTest, ReadByteIsOneSPITransaction) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  uint8_t data = SPI_DUMMY_BYTE;
+  bool result = comp.bmp_read_byte(bmp581_base::BMP581_STATUS, &data);
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// bmp_write_byte tests
+// ---------------------------------------------------------------------------
+
+// For write operations the MSB of the register address must be cleared
+// (AND with SPI_WRITE_MASK). All BMP581 register addresses already have
+// bit 7 clear, so the encoded byte equals the original address.
+TEST(BMP581SPIWriteByteTest, WriteByteEncodesWriteMaskInRegister) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  comp.bmp_write_byte(bmp581_base::BMP581_OSR, static_cast<uint8_t>(bmp581_base::OVERSAMPLING_X4));
+
+  ASSERT_GE(mock.sent_bytes.size(), 1u);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_OSR) & SPI_WRITE_MASK);
+}
+
+// The data byte must follow the register address byte on the SPI bus.
+TEST(BMP581SPIWriteByteTest, WriteByteTransmitsDataAfterRegister) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  constexpr uint8_t write_value = static_cast<uint8_t>(bmp581_base::IIR_FILTER_4);
+  comp.bmp_write_byte(bmp581_base::BMP581_DSP_IIR, write_value);
+
+  ASSERT_EQ(mock.sent_bytes.size(), 2u);
+  EXPECT_EQ(mock.sent_bytes[1], write_value);
+}
+
+// Each write is a single SPI transaction.
+TEST(BMP581SPIWriteByteTest, WriteByteIsOneSPITransaction) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  bool result = comp.bmp_write_byte(bmp581_base::BMP581_COMMAND, static_cast<uint8_t>(bmp581_base::RESET_COMMAND));
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// bmp_read_bytes tests
+// ---------------------------------------------------------------------------
+
+// bmp_read_bytes must send the register address with the read bit set, then
+// clock out len bytes by sending len dummy zeros.
+TEST(BMP581SPIReadBytesTest, ReadBytesEncodesReadBitAndClocksAllBytes) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  constexpr size_t read_len = 3;
+  uint8_t buf[read_len] = {};
+  comp.bmp_read_bytes(bmp581_base::BMP581_MEASUREMENT_DATA, buf, read_len);
+
+  // First byte: register address with read bit
+  ASSERT_EQ(mock.sent_bytes.size(), read_len + 1);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_MEASUREMENT_DATA) | SPI_READ_BIT);
+
+  // Remaining bytes: dummy zeros to clock out the responses
+  for (size_t i = 1; i <= read_len; i++) {
+    EXPECT_EQ(mock.sent_bytes[i], SPI_DUMMY_BYTE) << "dummy byte index " << i;
+  }
+}
+
+// Response bytes returned by the device must be stored into the output buffer
+// in order.
+TEST(BMP581SPIReadBytesTest, ReadBytesCapturesAllResponsesIntoBuffer) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  // Preset: address transfer returns 0, then three data bytes
+  mock.push_response(SPI_DUMMY_BYTE);
+  constexpr uint8_t byte0 = static_cast<uint8_t>(bmp581_base::OVERSAMPLING_X8);
+  constexpr uint8_t byte1 = static_cast<uint8_t>(bmp581_base::OVERSAMPLING_X16);
+  constexpr uint8_t byte2 = static_cast<uint8_t>(bmp581_base::OVERSAMPLING_X32);
+  mock.push_response(byte0);
+  mock.push_response(byte1);
+  mock.push_response(byte2);
+
+  constexpr size_t read_len = 3;
+  uint8_t buf[read_len] = {};
+  bool result = comp.bmp_read_bytes(bmp581_base::BMP581_MEASUREMENT_DATA, buf, read_len);
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(buf[0], byte0);
+  EXPECT_EQ(buf[1], byte1);
+  EXPECT_EQ(buf[2], byte2);
+}
+
+// The entire multi-byte read must be wrapped in a single CS assertion.
+TEST(BMP581SPIReadBytesTest, ReadBytesIsOneSPITransaction) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  constexpr size_t read_len = 6;
+  uint8_t buf[read_len] = {};
+  comp.bmp_read_bytes(bmp581_base::BMP581_MEASUREMENT_DATA, buf, read_len);
+
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// bmp_write_bytes tests
+// ---------------------------------------------------------------------------
+
+// bmp_write_bytes must send the register address (write-masked) followed by
+// each data byte in the array.
+TEST(BMP581SPIWriteBytesTest, WriteBytesEncodesWriteMaskAndTransmitsAllBytes) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  constexpr size_t write_len = 2;
+  uint8_t data[write_len] = {static_cast<uint8_t>(bmp581_base::IIR_FILTER_8),
+                             static_cast<uint8_t>(bmp581_base::IIR_FILTER_16)};
+  comp.bmp_write_bytes(bmp581_base::BMP581_DSP, data, write_len);
+
+  ASSERT_EQ(mock.sent_bytes.size(), write_len + 1);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_DSP) & SPI_WRITE_MASK);
+  EXPECT_EQ(mock.sent_bytes[1], data[0]);
+  EXPECT_EQ(mock.sent_bytes[2], data[1]);
+}
+
+// The entire multi-byte write must be one SPI transaction.
+TEST(BMP581SPIWriteBytesTest, WriteBytesIsOneSPITransaction) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  constexpr size_t write_len = 2;
+  uint8_t data[write_len] = {static_cast<uint8_t>(bmp581_base::IIR_FILTER_2),
+                             static_cast<uint8_t>(bmp581_base::IIR_FILTER_64)};
+  bool result = comp.bmp_write_bytes(bmp581_base::BMP581_DSP, data, write_len);
+
+  EXPECT_TRUE(result);
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
+}
+
+// ---------------------------------------------------------------------------
+// activate_interface tests
+// ---------------------------------------------------------------------------
+
+// The BMP581 reverts to I2C mode after a reset. activate_interface() must
+// perform a dummy read of the CHIP_ID register to force the device back into
+// SPI mode. Verify that the correct register address (with read bit) is sent.
+TEST(BMP581SPIActivateInterfaceTest, ActivateInterfaceReadsChipIdRegister) {
+  MockSPIDelegate mock;
+  TestBMP581SPIComponent comp;
+  comp.set_test_delegate(&mock);
+
+  comp.call_activate_interface();
+
+  // activate_interface calls bmp_read_byte(BMP581_CHIP_ID, &dummy), which sends
+  // the address byte (with read bit) followed by one dummy byte.
+  ASSERT_EQ(mock.sent_bytes.size(), 2u);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_CHIP_ID) | SPI_READ_BIT);
+  EXPECT_EQ(mock.sent_bytes[1], SPI_DUMMY_BYTE);
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
+}
+
+}  // namespace esphome::bmp581_spi::testing

--- a/tests/components/bmp581_spi/common.h
+++ b/tests/components/bmp581_spi/common.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "esphome/components/bmp581_base/bmp581_base.h"
+#include "esphome/components/bmp581_spi/bmp581_spi.h"
+#include "esphome/components/spi/spi.h"
+
+namespace esphome::bmp581_spi::testing {
+
+// SPI protocol constants for BMP581 (from datasheet section 6.3)
+// In SPI mode, the MSB of the register address selects read (1) or write (0).
+inline constexpr uint8_t SPI_READ_BIT = 0x80;    // OR with register address for read access
+inline constexpr uint8_t SPI_WRITE_MASK = 0x7F;  // AND with register address for write access
+
+// A dummy zero byte sent during reads to clock out the response from the device
+inline constexpr uint8_t SPI_DUMMY_BYTE = 0x00;
+
+// Mock SPIDelegate that records the sequence of transfers and returns preset response bytes.
+// This allows tests to verify the SPI wire protocol without real hardware.
+class MockSPIDelegate : public spi::SPIDelegate {
+ public:
+  MockSPIDelegate() = default;
+
+  // Preset bytes to return from successive transfer() calls (in order).
+  // NOTE: std::vector is used here for test convenience.
+  std::vector<uint8_t> response_bytes;
+  size_t response_index{0};
+
+  // All bytes passed to transfer(), in order.
+  std::vector<uint8_t> sent_bytes;
+
+  // Number of times begin_transaction() / end_transaction() were called.
+  int begin_count{0};
+  int end_count{0};
+
+  void push_response(uint8_t byte) { response_bytes.push_back(byte); }
+
+  uint8_t transfer(uint8_t data) override {
+    sent_bytes.push_back(data);
+    if (response_index < response_bytes.size()) {
+      return response_bytes[response_index++];
+    }
+    return SPI_DUMMY_BYTE;
+  }
+
+  void begin_transaction() override { begin_count++; }
+  void end_transaction() override { end_count++; }
+
+  void reset() {
+    response_bytes.clear();
+    response_index = 0;
+    sent_bytes.clear();
+    begin_count = 0;
+    end_count = 0;
+  }
+};
+
+// Subclass of BMP581SPIComponent that exposes protected members for injection in tests.
+// delegate_ is protected in SPIClient, so a derived class can set it directly.
+// activate_interface() is protected in BMP581SPIComponent; call_activate_interface() is a
+// public wrapper so tests can invoke it directly without friend declarations.
+class TestBMP581SPIComponent : public BMP581SPIComponent {
+ public:
+  void set_test_delegate(spi::SPIDelegate *delegate) { this->delegate_ = delegate; }
+  void call_activate_interface() { esphome::bmp581_spi::BMP581SPIComponent::activate_interface(); }
+};
+
+}  // namespace esphome::bmp581_spi::testing

--- a/tests/components/bmp581_spi/sensor/bmp581_spi.cpp
+++ b/tests/components/bmp581_spi/sensor/bmp581_spi.cpp
@@ -8,8 +8,8 @@ namespace esphome::bmp581_spi::testing {
 
 // The BMP581 SPI protocol requires setting the MSB of the register address to
 // indicate a read operation. Verify that bmp_read_byte ORs the register address
-// with SPI_READ_BIT before transmitting.
-TEST(BMP581SPIReadByteTest, ReadByteEncodesReadBitInRegister) {
+// with SPI_READ_BIT, then clocks out one dummy byte to capture the response.
+TEST(BMP581SPIReadByteTest, ReadByteEncodesReadBitAndClocksDummyByte) {
   MockSPIDelegate mock;
   TestBMP581SPIComponent comp;
   comp.set_test_delegate(&mock);
@@ -17,22 +17,11 @@ TEST(BMP581SPIReadByteTest, ReadByteEncodesReadBitInRegister) {
   uint8_t data = SPI_DUMMY_BYTE;
   comp.bmp_read_byte(bmp581_base::BMP581_CHIP_ID, &data);
 
-  ASSERT_GE(mock.sent_bytes.size(), 1u);
-  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_CHIP_ID) | SPI_READ_BIT);
-}
-
-// After the address byte, bmp_read_byte must clock out one byte by sending a
-// zero dummy byte. The device drives the MISO line during this transfer.
-TEST(BMP581SPIReadByteTest, ReadByteSendsDummyByteToClockResponse) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  uint8_t data = SPI_DUMMY_BYTE;
-  comp.bmp_read_byte(bmp581_base::BMP581_INT_STATUS, &data);
-
   ASSERT_EQ(mock.sent_bytes.size(), 2u);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_CHIP_ID) | SPI_READ_BIT);
   EXPECT_EQ(mock.sent_bytes[1], SPI_DUMMY_BYTE);
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
 }
 
 // The byte returned by the device (mocked as the transfer response) must be
@@ -52,41 +41,13 @@ TEST(BMP581SPIReadByteTest, ReadByteCapturesResponseInOutputPointer) {
   EXPECT_EQ(data, bmp581_base::BMP581_ASIC_ID);
 }
 
-// Each read is a single SPI transaction: CS must be asserted before the first
-// byte and de-asserted after the last byte.
-TEST(BMP581SPIReadByteTest, ReadByteIsOneSPITransaction) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  uint8_t data = SPI_DUMMY_BYTE;
-  bool result = comp.bmp_read_byte(bmp581_base::BMP581_STATUS, &data);
-
-  EXPECT_TRUE(result);
-  EXPECT_EQ(mock.begin_count, 1);
-  EXPECT_EQ(mock.end_count, 1);
-}
-
 // ---------------------------------------------------------------------------
 // bmp_write_byte tests
 // ---------------------------------------------------------------------------
 
 // For write operations the MSB of the register address must be cleared
-// (AND with SPI_WRITE_MASK). All BMP581 register addresses already have
-// bit 7 clear, so the encoded byte equals the original address.
-TEST(BMP581SPIWriteByteTest, WriteByteEncodesWriteMaskInRegister) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  comp.bmp_write_byte(bmp581_base::BMP581_OSR, static_cast<uint8_t>(bmp581_base::OVERSAMPLING_X4));
-
-  ASSERT_GE(mock.sent_bytes.size(), 1u);
-  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_OSR) & SPI_WRITE_MASK);
-}
-
-// The data byte must follow the register address byte on the SPI bus.
-TEST(BMP581SPIWriteByteTest, WriteByteTransmitsDataAfterRegister) {
+// (AND with SPI_WRITE_MASK), followed by the data byte.
+TEST(BMP581SPIWriteByteTest, WriteByteEncodesWriteMaskAndTransmitsData) {
   MockSPIDelegate mock;
   TestBMP581SPIComponent comp;
   comp.set_test_delegate(&mock);
@@ -95,18 +56,8 @@ TEST(BMP581SPIWriteByteTest, WriteByteTransmitsDataAfterRegister) {
   comp.bmp_write_byte(bmp581_base::BMP581_DSP_IIR, write_value);
 
   ASSERT_EQ(mock.sent_bytes.size(), 2u);
+  EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_DSP_IIR) & SPI_WRITE_MASK);
   EXPECT_EQ(mock.sent_bytes[1], write_value);
-}
-
-// Each write is a single SPI transaction.
-TEST(BMP581SPIWriteByteTest, WriteByteIsOneSPITransaction) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  bool result = comp.bmp_write_byte(bmp581_base::BMP581_COMMAND, static_cast<uint8_t>(bmp581_base::RESET_COMMAND));
-
-  EXPECT_TRUE(result);
   EXPECT_EQ(mock.begin_count, 1);
   EXPECT_EQ(mock.end_count, 1);
 }
@@ -134,6 +85,9 @@ TEST(BMP581SPIReadBytesTest, ReadBytesEncodesReadBitAndClocksAllBytes) {
   for (size_t i = 1; i <= read_len; i++) {
     EXPECT_EQ(mock.sent_bytes[i], SPI_DUMMY_BYTE) << "dummy byte index " << i;
   }
+
+  EXPECT_EQ(mock.begin_count, 1);
+  EXPECT_EQ(mock.end_count, 1);
 }
 
 // Response bytes returned by the device must be stored into the output buffer
@@ -162,20 +116,6 @@ TEST(BMP581SPIReadBytesTest, ReadBytesCapturesAllResponsesIntoBuffer) {
   EXPECT_EQ(buf[2], byte2);
 }
 
-// The entire multi-byte read must be wrapped in a single CS assertion.
-TEST(BMP581SPIReadBytesTest, ReadBytesIsOneSPITransaction) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  constexpr size_t read_len = 6;
-  uint8_t buf[read_len] = {};
-  comp.bmp_read_bytes(bmp581_base::BMP581_MEASUREMENT_DATA, buf, read_len);
-
-  EXPECT_EQ(mock.begin_count, 1);
-  EXPECT_EQ(mock.end_count, 1);
-}
-
 // ---------------------------------------------------------------------------
 // bmp_write_bytes tests
 // ---------------------------------------------------------------------------
@@ -190,26 +130,13 @@ TEST(BMP581SPIWriteBytesTest, WriteBytesEncodesWriteMaskAndTransmitsAllBytes) {
   constexpr size_t write_len = 2;
   uint8_t data[write_len] = {static_cast<uint8_t>(bmp581_base::IIR_FILTER_8),
                              static_cast<uint8_t>(bmp581_base::IIR_FILTER_16)};
-  comp.bmp_write_bytes(bmp581_base::BMP581_DSP, data, write_len);
+  bool result = comp.bmp_write_bytes(bmp581_base::BMP581_DSP, data, write_len);
 
+  EXPECT_TRUE(result);
   ASSERT_EQ(mock.sent_bytes.size(), write_len + 1);
   EXPECT_EQ(mock.sent_bytes[0], static_cast<uint8_t>(bmp581_base::BMP581_DSP) & SPI_WRITE_MASK);
   EXPECT_EQ(mock.sent_bytes[1], data[0]);
   EXPECT_EQ(mock.sent_bytes[2], data[1]);
-}
-
-// The entire multi-byte write must be one SPI transaction.
-TEST(BMP581SPIWriteBytesTest, WriteBytesIsOneSPITransaction) {
-  MockSPIDelegate mock;
-  TestBMP581SPIComponent comp;
-  comp.set_test_delegate(&mock);
-
-  constexpr size_t write_len = 2;
-  uint8_t data[write_len] = {static_cast<uint8_t>(bmp581_base::IIR_FILTER_2),
-                             static_cast<uint8_t>(bmp581_base::IIR_FILTER_64)};
-  bool result = comp.bmp_write_bytes(bmp581_base::BMP581_DSP, data, write_len);
-
-  EXPECT_TRUE(result);
   EXPECT_EQ(mock.begin_count, 1);
   EXPECT_EQ(mock.end_count, 1);
 }

--- a/tests/components/bmp581_spi/sensor/bmp581_spi.cpp
+++ b/tests/components/bmp581_spi/sensor/bmp581_spi.cpp
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "../common.h"
 
 namespace esphome::bmp581_spi::testing {
 


### PR DESCRIPTION
# What does this implement/fix?

Adds C++ host-platform unit tests for the `bmp581_spi` component, covering the SPI wire protocol implementation. This is the first set of unit tests for a SPI device component and can serve as a reference for adding similar tests to other SPI components.

Tests cover:
- `bmp_read_byte`: verifies the read bit (MSB set) is OR'd into the register address, the dummy clock byte is sent, and the response is captured in the output pointer
- `bmp_write_byte`: verifies the write mask (MSB cleared) is AND'd into the register address, and the data byte follows
- `bmp_read_bytes`: verifies multi-byte reads send the correct address and clock all response bytes
- `bmp_write_bytes`: verifies multi-byte writes send the correct address and all data bytes
- `activate_interface`: verifies the dummy CHIP_ID read that forces the BMP581 from I2C back into SPI mode after reset

A `MockSPIDelegate` records all bytes sent on the bus and can preset response bytes, allowing tests to verify the SPI wire protocol without hardware.

## Types of changes

- [x] Code quality improvements to existing code or addition of tests
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

Tests run on host via the C++ unit test framework (no hardware required).

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — tests only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).