### PR TITLE
tca9555: add software-emulated open-drain output mode

### DIFF
--- a/esphome/components/tca9555/__init__.py
+++ b/esphome/components/tca9555/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
+    CONF_OPEN_DRAIN,
     CONF_OUTPUT,
 )
 
@@ -41,6 +42,10 @@ async def to_code(config):
 
 
 def validate_mode(value):
+    if value.get(CONF_OPEN_DRAIN) and not value.get(CONF_OUTPUT):
+        raise cv.Invalid("Open-drain only works with output mode")
+    if value.get(CONF_OPEN_DRAIN) and value.get(CONF_INPUT):
+        raise cv.Invalid("Open-drain is not available in input mode")
     if not (value[CONF_INPUT] or value[CONF_OUTPUT]):
         raise cv.Invalid("Mode must be either input or output")
     if value[CONF_INPUT] and value[CONF_OUTPUT]:
@@ -51,7 +56,7 @@ def validate_mode(value):
 TCA9555_PIN_SCHEMA = pins.gpio_base_schema(
     TCA9555GPIOPin,
     cv.int_range(min=0, max=15),
-    modes=[CONF_INPUT, CONF_OUTPUT],
+    modes=[CONF_INPUT, CONF_OUTPUT, CONF_OPEN_DRAIN],
     mode_validator=validate_mode,
     invertible=True,
 ).extend(

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -119,9 +119,9 @@ void TCA9555Component::digital_write_hw(uint8_t pin, bool value) {
     //   LOW  = driven LOW (output mode)
     // With inverted: true in YAML, the switch logic is flipped by the pin layer.
     if (value) {
-      this->mode_mask_ |= pin_mask;       // input = high-Z (released)
+      this->mode_mask_ |= pin_mask;  // input = high-Z (released)
     } else {
-      this->mode_mask_ &= ~pin_mask;      // output = drive (LOW by default)
+      this->mode_mask_ &= ~pin_mask;  // output = drive (LOW by default)
     }
     this->write_gpio_modes_();
   } else {

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -33,14 +33,25 @@ void TCA9555Component::dump_config() {
   }
 }
 void TCA9555Component::pin_mode(uint8_t pin, gpio::Flags flags) {
-  if (flags == gpio::FLAG_INPUT) {
-    // Set mode mask bit
-    this->mode_mask_ |= 1 << pin;
-  } else if (flags == gpio::FLAG_OUTPUT) {
-    // Clear mode mask bit
-    this->mode_mask_ &= ~(1 << pin);
+  uint16_t pin_mask = 1 << pin;
+  if (flags & gpio::FLAG_INPUT) {
+    // Set mode mask bit (1 = input)
+    this->mode_mask_ |= pin_mask;
+    this->open_drain_mask_ &= ~pin_mask;
+  } else if (flags & gpio::FLAG_OUTPUT) {
+    if (flags & gpio::FLAG_OPEN_DRAIN) {
+      // Open-drain emulation: start in high-Z (input) state.
+      // digital_write will toggle between input (high-Z) and output (driven LOW).
+      this->mode_mask_ |= pin_mask;
+      this->open_drain_mask_ |= pin_mask;
+      // Ensure output register is LOW for when we switch to output mode
+      this->output_mask_ &= ~pin_mask;
+    } else {
+      // Regular output: clear mode mask bit (0 = output)
+      this->mode_mask_ &= ~pin_mask;
+      this->open_drain_mask_ &= ~pin_mask;
+    }
   }
-  // Write GPIO to enable input mode
   this->write_gpio_modes_();
 }
 void TCA9555Component::loop() { this->reset_pin_cache_(); }
@@ -98,10 +109,28 @@ void TCA9555Component::digital_write_hw(uint8_t pin, bool value) {
   if (this->is_failed())
     return;
 
-  if (value) {
-    this->output_mask_ |= (1 << pin);
+  uint16_t pin_mask = 1 << pin;
+
+  if (this->open_drain_mask_ & pin_mask) {
+    // Open-drain emulation: toggle between high-Z (input) and driven output.
+    // The output register value is set during pin_mode() and determines the
+    // driven level. By default it's LOW (standard open-drain behavior):
+    //   HIGH = high-Z (input mode)
+    //   LOW  = driven LOW (output mode)
+    // With inverted: true in YAML, the switch logic is flipped by the pin layer.
+    if (value) {
+      this->mode_mask_ |= pin_mask;       // input = high-Z (released)
+    } else {
+      this->mode_mask_ &= ~pin_mask;      // output = drive (LOW by default)
+    }
+    this->write_gpio_modes_();
   } else {
-    this->output_mask_ &= ~(1 << pin);
+    // Normal output mode
+    if (value) {
+      this->output_mask_ |= pin_mask;
+    } else {
+      this->output_mask_ &= ~pin_mask;
+    }
   }
 
   uint8_t data[2];

--- a/esphome/components/tca9555/tca9555.h
+++ b/esphome/components/tca9555/tca9555.h
@@ -29,12 +29,14 @@ class TCA9555Component : public Component,
   bool digital_read_cache(uint8_t pin) override;
   void digital_write_hw(uint8_t pin, bool value) override;
 
-  /// Mask for the pin mode - 1 means output, 0 means input
+  /// Mask for the pin mode - 1 means input, 0 means output
   uint16_t mode_mask_{0x00};
   /// The mask to write as output state - 1 means HIGH, 0 means LOW
   uint16_t output_mask_{0x00};
   /// The state read in digital_read_hw - 1 means HIGH, 0 means LOW
   uint16_t input_mask_{0x00};
+  /// Mask for open-drain pins - 1 means open-drain emulation enabled
+  uint16_t open_drain_mask_{0x00};
 
   bool read_gpio_modes_();
   bool write_gpio_modes_();

--- a/tests/components/tca9555/common.yaml
+++ b/tests/components/tca9555/common.yaml
@@ -21,3 +21,12 @@ output:
       number: 0
       mode: OUTPUT
       inverted: false
+  - platform: gpio
+    id: tca9555_open_drain_output
+    pin:
+      tca9555: tca9555_hub
+      number: 2
+      mode:
+        output: true
+        open_drain: true
+      inverted: false


### PR DESCRIPTION
# What does this implement/fix?

Add software-emulated open-drain output mode for TCA9555 GPIO expander.

The TCA9555 has no hardware open-drain register, but open-drain can be emulated by toggling the pin between INPUT (high-Z) and OUTPUT driving LOW via the configuration register. This is the same approach already used by the SX1509 and CH422G components in ESPHome.

**Behavior:**
- `digital_write(HIGH)` -> pin set to INPUT mode (high-Z, released)
- `digital_write(LOW)` -> pin set to OUTPUT mode driving LOW

This is useful for circuits with shared signal lines (e.g. wired-AND buses, interrupt lines, diode-OR failsafe paths) where actively driving LOW would block other signal sources.


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- No existing issue. Feature request based on real-world use in a house automation PCB with diode-OR failsafe relay drivers.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

Will add after code PR is reviewed.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
tca9555:
  - id: tca9555_hub
    address: 0x21

output:
  - platform: gpio
    id: relay_output
    pin:
      tca9555: tca9555_hub
      number: 0
      mode:
        output: true
        open_drain: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
