### PR TITLE
[mcp23xxx][pi4ioe5v6408] Disable loop when all pins are outputs

### DIFF
--- a/esphome/components/mcp23x08_base/mcp23x08_base.cpp
+++ b/esphome/components/mcp23x08_base/mcp23x08_base.cpp
@@ -37,6 +37,11 @@ void MCP23X08Base::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (this->interrupt_pin_ != nullptr && (flags & gpio::FLAG_INPUT)) {
     this->pin_interrupt_mode(pin, mcp23xxx_base::MCP23XXX_CHANGE);
   }
+  // Enable polling loop for input pins (not needed for interrupt-driven mode
+  // where the ISR handles re-enabling loop)
+  if (this->interrupt_pin_ == nullptr && (flags & gpio::FLAG_INPUT)) {
+    this->enable_loop();
+  }
 }
 
 void MCP23X08Base::pin_interrupt_mode(uint8_t pin, mcp23xxx_base::MCP23XXXInterruptMode interrupt_mode) {

--- a/esphome/components/mcp23x17_base/mcp23x17_base.cpp
+++ b/esphome/components/mcp23x17_base/mcp23x17_base.cpp
@@ -49,6 +49,11 @@ void MCP23X17Base::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (this->interrupt_pin_ != nullptr && (flags & gpio::FLAG_INPUT)) {
     this->pin_interrupt_mode(pin, mcp23xxx_base::MCP23XXX_CHANGE);
   }
+  // Enable polling loop for input pins (not needed for interrupt-driven mode
+  // where the ISR handles re-enabling loop)
+  if (this->interrupt_pin_ == nullptr && (flags & gpio::FLAG_INPUT)) {
+    this->enable_loop();
+  }
 }
 
 void MCP23X17Base::pin_interrupt_mode(uint8_t pin, mcp23xxx_base::MCP23XXXInterruptMode interrupt_mode) {

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.h
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.h
@@ -35,8 +35,11 @@ template<uint8_t N> class MCP23XXXBase : public Component, public gpio_expander:
       this->interrupt_pin_->setup();
       this->interrupt_pin_->attach_interrupt(&MCP23XXXBase::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
       this->set_invalidate_on_read_(false);
-      this->disable_loop();
     }
+    // Disable loop until an input pin is configured via pin_mode()
+    // For interrupt-driven mode, loop is re-enabled by the ISR
+    // For polling mode, loop is re-enabled when pin_mode() registers an input pin
+    this->disable_loop();
   }
   static void IRAM_ATTR gpio_intr(MCP23XXXBase *arg) { arg->enable_loop_soon_any_context(); }
 

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -41,8 +41,11 @@ void PI4IOE5V6408Component::setup() {
     this->interrupt_pin_->setup();
     this->interrupt_pin_->attach_interrupt(&PI4IOE5V6408Component::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
     this->set_invalidate_on_read_(false);
-    this->disable_loop();
   }
+  // Disable loop until an input pin is configured via pin_mode()
+  // For interrupt-driven mode, loop is re-enabled by the ISR
+  // For polling mode, loop is re-enabled when pin_mode() registers an input pin
+  this->disable_loop();
 }
 void IRAM_ATTR PI4IOE5V6408Component::gpio_intr(PI4IOE5V6408Component *arg) { arg->enable_loop_soon_any_context(); }
 void PI4IOE5V6408Component::dump_config() {
@@ -66,6 +69,11 @@ void PI4IOE5V6408Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     } else if (flags & gpio::FLAG_PULLDOWN) {
       this->pull_up_down_mask_ &= ~(1 << pin);
       this->pull_enable_mask_ |= 1 << pin;
+    }
+    // Enable polling loop for input pins (not needed for interrupt-driven mode
+    // where the ISR handles re-enabling loop)
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
     }
   }
   // Write GPIO to enable input mode


### PR DESCRIPTION
# What does this implement/fix?

Applies the same optimization from #15455 (PCF8574/PCA9554) to the MCP23xxx family (MCP23008, MCP23017, MCP23S08, MCP23S17) and PI4IOE5V6408 GPIO expander components.

When an expander has only output pins configured, `loop()` was still running every iteration to invalidate the read cache via `reset_pin_cache_()`. Since no `digital_read()` calls will ever be made on an output-only expander, this work is wasted.

Now `disable_loop()` is called unconditionally in `setup()`. For polling mode, loop is re-enabled only when `pin_mode()` registers an input pin. For interrupt-driven mode, behavior is unchanged as the ISR already manages loop enablement.

I don't have these chips to test on real hardware but the change is straightforward and follows the same proven pattern as #15455 which was tested on real hardware.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15455

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — optimization is automatic
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).