### PR TITLE
[api] Split Noise handshake state_action_ to reduce stack pressure

### DIFF
--- a/esphome/components/api/api_frame_helper_noise.cpp
+++ b/esphome/components/api/api_frame_helper_noise.cpp
@@ -244,131 +244,143 @@ APIError APINoiseFrameHelper::try_read_frame_() {
  * If an error occurred, returns that error. Only returns OK if the transport is ready for data
  * traffic.
  */
+// Split into per-state methods so the compiler doesn't allocate stack space
+// for all branches simultaneously. On RP2040 the core0 stack lives in a 4KB
+// scratch RAM bank; the Noise crypto path (curve25519) needs ~2KB+ of stack,
+// so every byte saved in the caller matters.
 APIError APINoiseFrameHelper::state_action_() {
-  int err;
-  APIError aerr;
-  if (state_ == State::INITIALIZE) {
-    HELPER_LOG("Bad state for method: %d", (int) state_);
-    return APIError::BAD_STATE;
+  switch (this->state_) {
+    case State::INITIALIZE:
+      HELPER_LOG("Bad state for method: %d", (int) this->state_);
+      return APIError::BAD_STATE;
+    case State::CLIENT_HELLO:
+      return this->state_action_client_hello_();
+    case State::SERVER_HELLO:
+      return this->state_action_server_hello_();
+    case State::HANDSHAKE:
+      return this->state_action_handshake_();
+    case State::CLOSED:
+    case State::FAILED:
+      return APIError::BAD_STATE;
+    default:
+      return APIError::OK;
   }
-  if (state_ == State::CLIENT_HELLO) {
-    // waiting for client hello
-    aerr = this->try_read_frame_();
-    if (aerr != APIError::OK) {
-      return handle_handshake_frame_error_(aerr);
-    }
-    // ignore contents, may be used in future for flags
-    // Resize for: existing prologue + 2 size bytes + frame data
-    size_t old_size = this->prologue_.size();
-    size_t rx_size = this->rx_buf_.size();
-    this->prologue_.resize(old_size + 2 + rx_size);
-    this->prologue_[old_size] = (uint8_t) (rx_size >> 8);
-    this->prologue_[old_size + 1] = (uint8_t) rx_size;
-    if (rx_size > 0) {
-      std::memcpy(this->prologue_.data() + old_size + 2, this->rx_buf_.data(), rx_size);
-    }
-
-    state_ = State::SERVER_HELLO;
+}
+APIError APINoiseFrameHelper::state_action_client_hello_() {
+  // waiting for client hello
+  APIError aerr = this->try_read_frame_();
+  if (aerr != APIError::OK) {
+    return handle_handshake_frame_error_(aerr);
   }
-  if (state_ == State::SERVER_HELLO) {
-    // send server hello
-    const auto &name = App.get_name();
-    char mac[MAC_ADDRESS_BUFFER_SIZE];
-    get_mac_address_into_buffer(mac);
-
-    // Calculate positions and sizes
-    size_t name_len = name.size() + 1;  // including null terminator
-    size_t name_offset = 1;
-    size_t mac_offset = name_offset + name_len;
-    size_t total_size = 1 + name_len + MAC_ADDRESS_BUFFER_SIZE;
-
-    // 1 (proto) + name (max ESPHOME_DEVICE_NAME_MAX_LEN) + 1 (name null)
-    // + mac (MAC_ADDRESS_BUFFER_SIZE - 1) + 1 (mac null)
-    constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + MAC_ADDRESS_BUFFER_SIZE;
-    uint8_t msg[max_msg_size];
-
-    // chosen proto
-    msg[0] = 0x01;
-
-    // node name, terminated by null byte
-    std::memcpy(msg + name_offset, name.c_str(), name_len);
-    // node mac, terminated by null byte
-    std::memcpy(msg + mac_offset, mac, MAC_ADDRESS_BUFFER_SIZE);
-
-    aerr = write_frame_(msg, total_size);
-    if (aerr != APIError::OK)
-      return aerr;
-
-    // start handshake
-    aerr = init_handshake_();
-    if (aerr != APIError::OK)
-      return aerr;
-
-    state_ = State::HANDSHAKE;
+  // ignore contents, may be used in future for flags
+  // Resize for: existing prologue + 2 size bytes + frame data
+  size_t old_size = this->prologue_.size();
+  size_t rx_size = this->rx_buf_.size();
+  this->prologue_.resize(old_size + 2 + rx_size);
+  this->prologue_[old_size] = (uint8_t) (rx_size >> 8);
+  this->prologue_[old_size + 1] = (uint8_t) rx_size;
+  if (rx_size > 0) {
+    std::memcpy(this->prologue_.data() + old_size + 2, this->rx_buf_.data(), rx_size);
   }
-  if (state_ == State::HANDSHAKE) {
-    int action = noise_handshakestate_get_action(handshake_);
-    if (action == NOISE_ACTION_READ_MESSAGE) {
-      // waiting for handshake msg
-      aerr = this->try_read_frame_();
-      if (aerr != APIError::OK) {
-        return handle_handshake_frame_error_(aerr);
-      }
 
-      if (this->rx_buf_.empty()) {
-        send_explicit_handshake_reject_(LOG_STR("Empty handshake message"));
-        return APIError::BAD_HANDSHAKE_ERROR_BYTE;
-      } else if (this->rx_buf_[0] != 0x00) {
-        HELPER_LOG("Bad handshake error byte: %u", this->rx_buf_[0]);
-        send_explicit_handshake_reject_(LOG_STR("Bad handshake error byte"));
-        return APIError::BAD_HANDSHAKE_ERROR_BYTE;
-      }
-
-      NoiseBuffer mbuf;
-      noise_buffer_init(mbuf);
-      noise_buffer_set_input(mbuf, this->rx_buf_.data() + 1, this->rx_buf_.size() - 1);
-      err = noise_handshakestate_read_message(handshake_, &mbuf, nullptr);
-      if (err != 0) {
-        // Special handling for MAC failure
-        send_explicit_handshake_reject_(err == NOISE_ERROR_MAC_FAILURE ? LOG_STR("Handshake MAC failure")
-                                                                       : LOG_STR("Handshake error"));
-        return handle_noise_error_(err, LOG_STR("noise_handshakestate_read_message"),
-                                   APIError::HANDSHAKESTATE_READ_FAILED);
-      }
-
-      aerr = check_handshake_finished_();
-      if (aerr != APIError::OK)
-        return aerr;
-    } else if (action == NOISE_ACTION_WRITE_MESSAGE) {
-      uint8_t buffer[65];
-      NoiseBuffer mbuf;
-      noise_buffer_init(mbuf);
-      noise_buffer_set_output(mbuf, buffer + 1, sizeof(buffer) - 1);
-
-      err = noise_handshakestate_write_message(handshake_, &mbuf, nullptr);
-      APIError aerr_write = handle_noise_error_(err, LOG_STR("noise_handshakestate_write_message"),
-                                                APIError::HANDSHAKESTATE_WRITE_FAILED);
-      if (aerr_write != APIError::OK)
-        return aerr_write;
-      buffer[0] = 0x00;  // success
-
-      aerr = write_frame_(buffer, mbuf.size + 1);
-      if (aerr != APIError::OK)
-        return aerr;
-      aerr = check_handshake_finished_();
-      if (aerr != APIError::OK)
-        return aerr;
-    } else {
-      // bad state for action
-      state_ = State::FAILED;
-      HELPER_LOG("Bad action for handshake: %d", action);
-      return APIError::HANDSHAKESTATE_BAD_STATE;
-    }
-  }
-  if (state_ == State::CLOSED || state_ == State::FAILED) {
-    return APIError::BAD_STATE;
-  }
+  state_ = State::SERVER_HELLO;
   return APIError::OK;
+}
+APIError APINoiseFrameHelper::state_action_server_hello_() {
+  // send server hello
+  const auto &name = App.get_name();
+  char mac[MAC_ADDRESS_BUFFER_SIZE];
+  get_mac_address_into_buffer(mac);
+
+  // Calculate positions and sizes
+  size_t name_len = name.size() + 1;  // including null terminator
+  size_t name_offset = 1;
+  size_t mac_offset = name_offset + name_len;
+  size_t total_size = 1 + name_len + MAC_ADDRESS_BUFFER_SIZE;
+
+  // 1 (proto) + name (max ESPHOME_DEVICE_NAME_MAX_LEN) + 1 (name null)
+  // + mac (MAC_ADDRESS_BUFFER_SIZE - 1) + 1 (mac null)
+  constexpr size_t max_msg_size = 1 + ESPHOME_DEVICE_NAME_MAX_LEN + 1 + MAC_ADDRESS_BUFFER_SIZE;
+  uint8_t msg[max_msg_size];
+
+  // chosen proto
+  msg[0] = 0x01;
+
+  // node name, terminated by null byte
+  std::memcpy(msg + name_offset, name.c_str(), name_len);
+  // node mac, terminated by null byte
+  std::memcpy(msg + mac_offset, mac, MAC_ADDRESS_BUFFER_SIZE);
+
+  APIError aerr = write_frame_(msg, total_size);
+  if (aerr != APIError::OK)
+    return aerr;
+
+  // start handshake
+  aerr = init_handshake_();
+  if (aerr != APIError::OK)
+    return aerr;
+
+  state_ = State::HANDSHAKE;
+  return APIError::OK;
+}
+APIError APINoiseFrameHelper::state_action_handshake_() {
+  int action = noise_handshakestate_get_action(this->handshake_);
+  if (action == NOISE_ACTION_READ_MESSAGE) {
+    return this->state_action_handshake_read_();
+  } else if (action == NOISE_ACTION_WRITE_MESSAGE) {
+    return this->state_action_handshake_write_();
+  }
+  // bad state for action
+  this->state_ = State::FAILED;
+  HELPER_LOG("Bad action for handshake: %d", action);
+  return APIError::HANDSHAKESTATE_BAD_STATE;
+}
+APIError APINoiseFrameHelper::state_action_handshake_read_() {
+  APIError aerr = this->try_read_frame_();
+  if (aerr != APIError::OK) {
+    return this->handle_handshake_frame_error_(aerr);
+  }
+
+  if (this->rx_buf_.empty()) {
+    this->send_explicit_handshake_reject_(LOG_STR("Empty handshake message"));
+    return APIError::BAD_HANDSHAKE_ERROR_BYTE;
+  } else if (this->rx_buf_[0] != 0x00) {
+    HELPER_LOG("Bad handshake error byte: %u", this->rx_buf_[0]);
+    this->send_explicit_handshake_reject_(LOG_STR("Bad handshake error byte"));
+    return APIError::BAD_HANDSHAKE_ERROR_BYTE;
+  }
+
+  NoiseBuffer mbuf;
+  noise_buffer_init(mbuf);
+  noise_buffer_set_input(mbuf, this->rx_buf_.data() + 1, this->rx_buf_.size() - 1);
+  int err = noise_handshakestate_read_message(this->handshake_, &mbuf, nullptr);
+  if (err != 0) {
+    // Special handling for MAC failure
+    this->send_explicit_handshake_reject_(err == NOISE_ERROR_MAC_FAILURE ? LOG_STR("Handshake MAC failure")
+                                                                         : LOG_STR("Handshake error"));
+    return this->handle_noise_error_(err, LOG_STR("noise_handshakestate_read_message"),
+                                     APIError::HANDSHAKESTATE_READ_FAILED);
+  }
+
+  return this->check_handshake_finished_();
+}
+APIError APINoiseFrameHelper::state_action_handshake_write_() {
+  uint8_t buffer[65];
+  NoiseBuffer mbuf;
+  noise_buffer_init(mbuf);
+  noise_buffer_set_output(mbuf, buffer + 1, sizeof(buffer) - 1);
+
+  int err = noise_handshakestate_write_message(this->handshake_, &mbuf, nullptr);
+  APIError aerr = this->handle_noise_error_(err, LOG_STR("noise_handshakestate_write_message"),
+                                            APIError::HANDSHAKESTATE_WRITE_FAILED);
+  if (aerr != APIError::OK)
+    return aerr;
+  buffer[0] = 0x00;  // success
+
+  aerr = this->write_frame_(buffer, mbuf.size + 1);
+  if (aerr != APIError::OK)
+    return aerr;
+  return this->check_handshake_finished_();
 }
 void APINoiseFrameHelper::send_explicit_handshake_reject_(const LogString *reason) {
   // Max reject message: "Bad handshake packet len" (24) + 1 (failure byte) = 25 bytes

--- a/esphome/components/api/api_frame_helper_noise.h
+++ b/esphome/components/api/api_frame_helper_noise.h
@@ -26,6 +26,11 @@ class APINoiseFrameHelper final : public APIFrameHelper {
 
  protected:
   APIError state_action_();
+  APIError state_action_client_hello_();
+  APIError state_action_server_hello_();
+  APIError state_action_handshake_();
+  APIError state_action_handshake_read_();
+  APIError state_action_handshake_write_();
   APIError try_read_frame_();
   APIError write_frame_(const uint8_t *data, uint16_t len);
   APIError init_handshake_();


### PR DESCRIPTION
# What does this implement/fix?

On RP2040, the core0 stack lives in a 4KB SCRATCH_Y RAM bank. The Noise protocol handshake calls into curve25519 scalar multiplication (`ge25519_scalarmult_base`) which needs ~2KB+ of stack for field element arithmetic. When all handshake state branches lived in a single `state_action_()` function, the compiler allocated stack space for all branches simultaneously — SERVER_HELLO's `msg[46]` + `mac[13]`, HANDSHAKE's `buffer[65]` + `NoiseBuffer`, etc. — leaving insufficient headroom for the crypto path.

This was observed as a crash on a WIZnet W5500-EVB-Pico (RP2040 + Ethernet) during API client connection:

```
[E][rp2040.crash:103]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[E][rp2040.crash:104]:   PC:  0x100369FA  (fault location)
  0x100369FA => ge25519_scalarmult_base at ??:?
[E][rp2040.crash:105]:   LR:  0x1001DB9B  (return address)
  0x1001DB9B => lwip_standard_chksum at ??:?
[E][rp2040.crash:106]:   SP:  0x20041D38
[E][rp2040.crash:108]:   BT0: 0x10037B34  (stack backtrace)
[E][rp2040.crash:108]:   BT1: 0x100182BD
  0x100182BD => pbuf_clen at ??:?
[E][rp2040.crash:108]:   BT2: 0x10037B34
[E][rp2040.crash:108]:   BT3: 0x1001C79F
  0x1001C79F => __wrap_pbuf_get_at at ??:?
```

SP at `0x20041D38` is only 712 bytes from the top of SCRATCH_Y (`0x20042000`), confirming the stack overflow during the Noise crypto path. The LWIP symbols in LR/backtrace are stale stack entries from network operations preceding the handshake.

Split `state_action_()` into per-state methods so each state's locals occupy separate stack frames. Also split the handshake READ/WRITE paths so the write path (which calls into the heavy crypto) doesn't carry the read path's locals. The crypto path now only carries its own ~85 bytes of locals instead of ~200+ bytes from all branches combined.

Verified fix on hardware — crash is no longer reproducible after this change.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal refactor, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).