### PR TITLE
[ags10] Fix wrong type passed to cg.templatable for set_zero_point mode

### DIFF
--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -112,7 +112,9 @@ AGS10_SET_ZERO_POINT_ACTION_MODE = {
 AGS10_SET_ZERO_POINT_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.use_id(AGS10Component),
-        cv.Required(CONF_MODE): cv.enum(AGS10_SET_ZERO_POINT_ACTION_MODE, upper=True),
+        cv.Required(CONF_MODE): cv.templatable(
+            cv.enum(AGS10_SET_ZERO_POINT_ACTION_MODE, upper=True)
+        ),
         cv.Optional(CONF_VALUE, default=0xFFFF): cv.templatable(cv.uint16_t),
     },
 )

--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -131,6 +131,6 @@ async def ags10setzeropoint_to_code(config, action_id, template_arg, args):
         config.get(CONF_MODE), args, AGS10SetZeroPointActionMode
     )
     cg.add(var.set_mode(mode))
-    value = await cg.templatable(config[CONF_VALUE], args, int)
+    value = await cg.templatable(config[CONF_VALUE], args, cg.uint16)
     cg.add(var.set_value(value))
     return var

--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -127,7 +127,9 @@ AGS10_SET_ZERO_POINT_SCHEMA = cv.Schema(
 async def ags10setzeropoint_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    mode = await cg.templatable(config.get(CONF_MODE), args, enumerate)
+    mode = await cg.templatable(
+        config.get(CONF_MODE), args, AGS10SetZeroPointActionMode
+    )
     cg.add(var.set_mode(mode))
     value = await cg.templatable(config[CONF_VALUE], args, int)
     cg.add(var.set_value(value))

--- a/tests/components/ags10/common.yaml
+++ b/tests/components/ags10/common.yaml
@@ -4,3 +4,14 @@ sensor:
     tvoc:
       name: AGS10 TVOC
     update_interval: 60s
+
+button:
+  - platform: template
+    name: "Test AGS10 Actions"
+    on_press:
+      - ags10.set_zero_point:
+          id: ags10_1
+          mode: CURRENT_VALUE
+      - ags10.new_i2c_address:
+          id: ags10_1
+          address: 0x1A


### PR DESCRIPTION
# What does this implement/fix?

Fix several issues in the AGS10 `set_zero_point` action codegen:

1. **`enumerate` passed as C++ type**: Python's builtin `enumerate` function was passed as the output type to `cg.templatable()` instead of `AGS10SetZeroPointActionMode`. With lambdas this would generate invalid C++.

2. **`int` instead of `cg.uint16` for value**: The C++ `TEMPLATABLE_VALUE(uint16_t, value)` expects `uint16_t` but Python passed `int`, forcing `TemplatableValue` to fall back to heap-allocating a `std::function` instead of a direct function pointer for lambdas.

3. **`mode` not templatable in schema**: The `to_code` already used `cg.templatable()` for mode (indicating the intent was to support lambdas), but the schema used plain `cv.enum()` without `cv.templatable()` wrapping, so lambdas were rejected at validation time. Now `mode: !lambda "return ags10::CURRENT_VALUE;"` works.

Also adds test coverage for the `ags10.set_zero_point` and `ags10.new_i2c_address` actions which were previously untested.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6392

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ags10
    id: ags10_1
    tvoc:
      name: AGS10 TVOC

button:
  - platform: template
    name: "Calibrate AGS10"
    on_press:
      - ags10.set_zero_point:
          id: ags10_1
          mode: CURRENT_VALUE
      - ags10.new_i2c_address:
          id: ags10_1
          address: 0x1A
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).