### PR TITLE
[at581x] Fix codegen crash when using lambdas for frequency/time/power

### DIFF
--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -183,15 +183,21 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(sens_dist, args, int)
         cg.add(var.set_sensing_distance(template_))
 
-    for key, setter in (
-        (CONF_POWERON_SELFCHECK_TIME, var.set_poweron_selfcheck_time),
-        (CONF_PROTECT_TIME, var.set_protect_time),
-        (CONF_TRIGGER_BASE, var.set_trigger_base),
-        (CONF_TRIGGER_KEEP, var.set_trigger_keep),
-    ):
-        if (value := config.get(key)) is not None:
-            template_ = await cg.templatable(value, args, cg.int32)
-            cg.add(setter(template_))
+    if selfcheck := config.get(CONF_POWERON_SELFCHECK_TIME):
+        template_ = await cg.templatable(selfcheck, args, cg.int32)
+        cg.add(var.set_poweron_selfcheck_time(template_))
+
+    if protect := config.get(CONF_PROTECT_TIME):
+        template_ = await cg.templatable(protect, args, cg.int32)
+        cg.add(var.set_protect_time(template_))
+
+    if trig_base := config.get(CONF_TRIGGER_BASE):
+        template_ = await cg.templatable(trig_base, args, cg.int32)
+        cg.add(var.set_trigger_base(template_))
+
+    if trig_keep := config.get(CONF_TRIGGER_KEEP):
+        template_ = await cg.templatable(trig_keep, args, cg.int32)
+        cg.add(var.set_trigger_keep(template_))
 
     if stage_gain := config.get(CONF_STAGE_GAIN):
         template_ = await cg.templatable(stage_gain, args, int)

--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -173,49 +173,35 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_hw_frontend_reset(template_))
 
     if freq := config.get(CONF_FREQUENCY):
-        template_ = await cg.templatable(freq, args, float)
-        template_ = int(template_ / 1000000)
+        if cg.is_template(freq):
+            template_ = await cg.templatable(freq, args, cg.int32)
+        else:
+            template_ = int(freq / 1000000)
         cg.add(var.set_frequency(template_))
 
     if sens_dist := config.get(CONF_SENSING_DISTANCE):
         template_ = await cg.templatable(sens_dist, args, int)
         cg.add(var.set_sensing_distance(template_))
 
-    if selfcheck := config.get(CONF_POWERON_SELFCHECK_TIME):
-        template_ = await cg.templatable(selfcheck, args, float)
-        if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds
-        template_ = int(template_)
-        cg.add(var.set_poweron_selfcheck_time(template_))
-
-    if protect := config.get(CONF_PROTECT_TIME):
-        template_ = await cg.templatable(protect, args, float)
-        if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds
-        template_ = int(template_)
-        cg.add(var.set_protect_time(template_))
-
-    if trig_base := config.get(CONF_TRIGGER_BASE):
-        template_ = await cg.templatable(trig_base, args, float)
-        if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds
-        template_ = int(template_)
-        cg.add(var.set_trigger_base(template_))
-
-    if trig_keep := config.get(CONF_TRIGGER_KEEP):
-        template_ = await cg.templatable(trig_keep, args, float)
-        if isinstance(template_, cv.TimePeriod):
-            template_ = template_.total_milliseconds
-        template_ = int(template_)
-        cg.add(var.set_trigger_keep(template_))
+    for key, setter in (
+        (CONF_POWERON_SELFCHECK_TIME, var.set_poweron_selfcheck_time),
+        (CONF_PROTECT_TIME, var.set_protect_time),
+        (CONF_TRIGGER_BASE, var.set_trigger_base),
+        (CONF_TRIGGER_KEEP, var.set_trigger_keep),
+    ):
+        if (value := config.get(key)) is not None:
+            template_ = await cg.templatable(value, args, cg.int32)
+            cg.add(setter(template_))
 
     if stage_gain := config.get(CONF_STAGE_GAIN):
         template_ = await cg.templatable(stage_gain, args, int)
         cg.add(var.set_stage_gain(template_))
 
     if power := config.get(CONF_POWER_CONSUMPTION):
-        template_ = await cg.templatable(power, args, float)
-        template_ = int(template_ * 1000000)
+        if cg.is_template(power):
+            template_ = await cg.templatable(power, args, cg.int32)
+        else:
+            template_ = int(power * 1000000)
         cg.add(var.set_power_consumption(template_))
 
     return var

--- a/tests/components/at581x/common.yaml
+++ b/tests/components/at581x/common.yaml
@@ -12,6 +12,11 @@ esphome:
           trigger_keep: 10s
           stage_gain: 3
           power_consumption: 70uA
+      - at581x.settings:
+          id: waveradar
+          frequency: !lambda "return 5800;"
+          poweron_selfcheck_time: !lambda "return 2000;"
+          power_consumption: !lambda "return 70;"
       - at581x.reset:
           id: waveradar
 


### PR DESCRIPTION
# What does this implement/fix?

Fix `TypeError` crash during code generation when using lambda expressions for `frequency`, `poweron_selfcheck_time`, `protect_time`, `trigger_base`, `trigger_keep`, or `power_consumption` in the `at581x.settings` action.

The issue was that `int()` and arithmetic operations (`/ 1000000`, `* 1000000`) were applied to the result of `cg.templatable()`, which returns a `LambdaExpression` object for lambda values. Python can't do `int(LambdaExpression)` or `LambdaExpression / 1000000`.

**Frequency/power_consumption fix:** Check `cg.is_template()` before the arithmetic. For lambdas, pass through directly (the user's lambda returns the already-converted value). For static values, do the unit conversion in Python as before.

**Time period fields fix:** Replace `float` type + manual `TimePeriod` extraction + `int()` cast with `cg.int32`. This works because `safe_exp` already handles `TimePeriodMilliseconds` → `IntLiteral` conversion, and for lambdas the `int32_t` return type is correct.

**Reproducing the crash:**
```yaml
# This crashes without the fix:
# TypeError: unsupported operand type(s) for /: 'LambdaExpression' and 'int'
on_boot:
  - at581x.settings:
      id: waveradar
      frequency: !lambda "return 5800;"
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
at581x:
  i2c_id: i2c_bus
  id: waveradar

esphome:
  on_boot:
    then:
      - at581x.settings:
          id: waveradar
          frequency: 5800MHz
          sensing_distance: 200
          poweron_selfcheck_time: 2s
      - at581x.settings:
          id: waveradar
          frequency: !lambda "return 5800;"
          poweron_selfcheck_time: !lambda "return 2000;"
          power_consumption: !lambda "return 70;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).