### PR TITLE
[api] Auto-derive max_value for enum fields in protobuf codegen

### DIFF
--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -87,7 +87,7 @@ uint8_t *SerialProxyInfo::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PAR
 uint32_t SerialProxyInfo::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->name.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->port_type));
+  size += this->port_type ? 2 : 0;
   return size;
 }
 #endif
@@ -244,7 +244,7 @@ uint32_t ListEntitiesBinarySensorResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -305,7 +305,7 @@ uint32_t ListEntitiesCoverResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_bool(1, this->supports_stop);
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -328,7 +328,7 @@ uint32_t CoverStateResponse::calculate_size() const {
   size += 5;
   size += ProtoSize::calc_float(1, this->position);
   size += ProtoSize::calc_float(1, this->tilt);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->current_operation));
+  size += this->current_operation ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -408,7 +408,7 @@ uint32_t ListEntitiesFanResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   if (!this->supported_preset_modes->empty()) {
     for (const char *it : *this->supported_preset_modes) {
       size += ProtoSize::calc_length_force(1, strlen(it));
@@ -437,7 +437,7 @@ uint32_t FanStateResponse::calculate_size() const {
   size += 5;
   size += ProtoSize::calc_bool(1, this->state);
   size += ProtoSize::calc_bool(1, this->oscillating);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->direction));
+  size += this->direction ? 2 : 0;
   size += ProtoSize::calc_int32(1, this->speed_level);
   size += ProtoSize::calc_length(1, this->preset_mode.size());
 #ifdef USE_DEVICES
@@ -536,9 +536,7 @@ uint32_t ListEntitiesLightResponse::calculate_size() const {
   size += 5;
   size += ProtoSize::calc_length(1, this->name.size());
   if (!this->supported_color_modes->empty()) {
-    for (const auto &it : *this->supported_color_modes) {
-      size += ProtoSize::calc_uint32_force(1, static_cast<uint32_t>(it));
-    }
+    size += this->supported_color_modes->size() * 2;
   }
   size += ProtoSize::calc_float(1, this->min_mireds);
   size += ProtoSize::calc_float(1, this->max_mireds);
@@ -551,7 +549,7 @@ uint32_t ListEntitiesLightResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(2, this->device_id);
 #endif
@@ -582,7 +580,7 @@ uint32_t LightStateResponse::calculate_size() const {
   size += 5;
   size += ProtoSize::calc_bool(1, this->state);
   size += ProtoSize::calc_float(1, this->brightness);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->color_mode));
+  size += this->color_mode ? 2 : 0;
   size += ProtoSize::calc_float(1, this->color_brightness);
   size += ProtoSize::calc_float(1, this->red);
   size += ProtoSize::calc_float(1, this->green);
@@ -739,9 +737,9 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
   size += ProtoSize::calc_int32(1, this->accuracy_decimals);
   size += ProtoSize::calc_bool(1, this->force_update);
   size += ProtoSize::calc_length(1, this->device_class.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state_class));
+  size += this->state_class ? 2 : 0;
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -796,7 +794,7 @@ uint32_t ListEntitiesSwitchResponse::calculate_size() const {
 #endif
   size += ProtoSize::calc_bool(1, this->assumed_state);
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -873,7 +871,7 @@ uint32_t ListEntitiesTextSensorResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -922,7 +920,7 @@ uint8_t *SubscribeLogsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEB
 }
 uint32_t SubscribeLogsResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->level));
+  size += this->level ? 2 : 0;
   size += ProtoSize::calc_length(1, this->message_len_);
   return size;
 }
@@ -1171,7 +1169,7 @@ uint8_t *ListEntitiesServicesArgument::encode(ProtoWriteBuffer &buffer PROTO_ENC
 uint32_t ListEntitiesServicesArgument::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->name.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->type));
+  size += this->type ? 2 : 0;
   return size;
 }
 uint8_t *ListEntitiesServicesResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
@@ -1193,7 +1191,7 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
       size += ProtoSize::calc_message_force(1, it.calculate_size());
     }
   }
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->supports_response));
+  size += this->supports_response ? 2 : 0;
   return size;
 }
 bool ExecuteServiceArgument::decode_varint(uint32_t field_id, proto_varint_value_t value) {
@@ -1347,7 +1345,7 @@ uint32_t ListEntitiesCameraResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -1441,23 +1439,17 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
   size += ProtoSize::calc_bool(1, this->supports_current_temperature);
   size += ProtoSize::calc_bool(1, this->supports_two_point_target_temperature);
   if (!this->supported_modes->empty()) {
-    for (const auto &it : *this->supported_modes) {
-      size += ProtoSize::calc_uint32_force(1, static_cast<uint32_t>(it));
-    }
+    size += this->supported_modes->size() * 2;
   }
   size += ProtoSize::calc_float(1, this->visual_min_temperature);
   size += ProtoSize::calc_float(1, this->visual_max_temperature);
   size += ProtoSize::calc_float(1, this->visual_target_temperature_step);
   size += ProtoSize::calc_bool(1, this->supports_action);
   if (!this->supported_fan_modes->empty()) {
-    for (const auto &it : *this->supported_fan_modes) {
-      size += ProtoSize::calc_uint32_force(1, static_cast<uint32_t>(it));
-    }
+    size += this->supported_fan_modes->size() * 2;
   }
   if (!this->supported_swing_modes->empty()) {
-    for (const auto &it : *this->supported_swing_modes) {
-      size += ProtoSize::calc_uint32_force(1, static_cast<uint32_t>(it));
-    }
+    size += this->supported_swing_modes->size() * 2;
   }
   if (!this->supported_custom_fan_modes->empty()) {
     for (const char *it : *this->supported_custom_fan_modes) {
@@ -1465,9 +1457,7 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
     }
   }
   if (!this->supported_presets->empty()) {
-    for (const auto &it : *this->supported_presets) {
-      size += ProtoSize::calc_uint32_force(2, static_cast<uint32_t>(it));
-    }
+    size += this->supported_presets->size() * 3;
   }
   if (!this->supported_custom_presets->empty()) {
     for (const char *it : *this->supported_custom_presets) {
@@ -1478,7 +1468,7 @@ uint32_t ListEntitiesClimateResponse::calculate_size() const {
 #ifdef USE_ENTITY_ICON
   size += ProtoSize::calc_length(2, this->icon.size());
 #endif
-  size += ProtoSize::calc_uint32(2, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 3 : 0;
   size += ProtoSize::calc_float(2, this->visual_current_temperature_step);
   size += ProtoSize::calc_bool(2, this->supports_current_humidity);
   size += ProtoSize::calc_bool(2, this->supports_target_humidity);
@@ -1514,16 +1504,16 @@ uint8_t *ClimateStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBU
 uint32_t ClimateStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
+  size += this->mode ? 2 : 0;
   size += ProtoSize::calc_float(1, this->current_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature_low);
   size += ProtoSize::calc_float(1, this->target_temperature_high);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->action));
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->fan_mode));
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->swing_mode));
+  size += this->action ? 2 : 0;
+  size += this->fan_mode ? 2 : 0;
+  size += this->swing_mode ? 2 : 0;
   size += ProtoSize::calc_length(1, this->custom_fan_mode.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->preset));
+  size += this->preset ? 2 : 0;
   size += ProtoSize::calc_length(1, this->custom_preset.size());
   size += ProtoSize::calc_float(1, this->current_humidity);
   size += ProtoSize::calc_float(1, this->target_humidity);
@@ -1656,7 +1646,7 @@ uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -1664,9 +1654,7 @@ uint32_t ListEntitiesWaterHeaterResponse::calculate_size() const {
   size += ProtoSize::calc_float(1, this->max_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature_step);
   if (!this->supported_modes->empty()) {
-    for (const auto &it : *this->supported_modes) {
-      size += ProtoSize::calc_uint32_force(1, static_cast<uint32_t>(it));
-    }
+    size += this->supported_modes->size() * 2;
   }
   size += ProtoSize::calc_uint32(1, this->supported_features);
   return size;
@@ -1690,7 +1678,7 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
   size += 5;
   size += ProtoSize::calc_float(1, this->current_temperature);
   size += ProtoSize::calc_float(1, this->target_temperature);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
+  size += this->mode ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -1774,9 +1762,9 @@ uint32_t ListEntitiesNumberResponse::calculate_size() const {
   size += ProtoSize::calc_float(1, this->max_value);
   size += ProtoSize::calc_float(1, this->step);
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->unit_of_measurement.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
+  size += this->mode ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -1862,7 +1850,7 @@ uint32_t ListEntitiesSelectResponse::calculate_size() const {
     }
   }
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -1959,7 +1947,7 @@ uint32_t ListEntitiesSirenResponse::calculate_size() const {
   }
   size += ProtoSize::calc_bool(1, this->supports_duration);
   size += ProtoSize::calc_bool(1, this->supports_volume);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -2067,7 +2055,7 @@ uint32_t ListEntitiesLockResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_bool(1, this->assumed_state);
   size += ProtoSize::calc_bool(1, this->supports_open);
   size += ProtoSize::calc_bool(1, this->requires_code);
@@ -2089,7 +2077,7 @@ uint8_t *LockStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_P
 uint32_t LockStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
+  size += this->state ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -2161,7 +2149,7 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -2206,7 +2194,7 @@ uint32_t MediaPlayerSupportedFormat::calculate_size() const {
   size += ProtoSize::calc_length(1, this->format.size());
   size += ProtoSize::calc_uint32(1, this->sample_rate);
   size += ProtoSize::calc_uint32(1, this->num_channels);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->purpose));
+  size += this->purpose ? 2 : 0;
   size += ProtoSize::calc_uint32(1, this->sample_bytes);
   return size;
 }
@@ -2239,7 +2227,7 @@ uint32_t ListEntitiesMediaPlayerResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_bool(1, this->supports_pause);
   if (!this->supported_formats.empty()) {
     for (const auto &it : this->supported_formats) {
@@ -2266,7 +2254,7 @@ uint8_t *MediaPlayerStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_
 uint32_t MediaPlayerStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
+  size += this->state ? 2 : 0;
   size += ProtoSize::calc_float(1, this->volume);
   size += ProtoSize::calc_bool(1, this->muted);
 #ifdef USE_DEVICES
@@ -2348,7 +2336,7 @@ uint8_t *BluetoothLERawAdvertisement::encode(ProtoWriteBuffer &buffer PROTO_ENCO
   ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(this->rssi));
   if (this->address_type) {
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(this->address_type));
+    ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, this->address_type);
   }
   ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
   ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(this->data_len));
@@ -2762,9 +2750,9 @@ uint8_t *BluetoothScannerStateResponse::encode(ProtoWriteBuffer &buffer PROTO_EN
 }
 uint32_t BluetoothScannerStateResponse::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->configured_mode));
+  size += this->state ? 2 : 0;
+  size += this->mode ? 2 : 0;
+  size += this->configured_mode ? 2 : 0;
   return size;
 }
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
@@ -3116,7 +3104,7 @@ uint32_t ListEntitiesAlarmControlPanelResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_uint32(1, this->supported_features);
   size += ProtoSize::calc_bool(1, this->requires_code);
   size += ProtoSize::calc_bool(1, this->requires_code_to_arm);
@@ -3137,7 +3125,7 @@ uint8_t *AlarmControlPanelStateResponse::encode(ProtoWriteBuffer &buffer PROTO_E
 uint32_t AlarmControlPanelStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->state));
+  size += this->state ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3209,11 +3197,11 @@ uint32_t ListEntitiesTextResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_uint32(1, this->min_length);
   size += ProtoSize::calc_uint32(1, this->max_length);
   size += ProtoSize::calc_length(1, this->pattern.size());
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->mode));
+  size += this->mode ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3298,7 +3286,7 @@ uint32_t ListEntitiesDateResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3385,7 +3373,7 @@ uint32_t ListEntitiesTimeResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3476,7 +3464,7 @@ uint32_t ListEntitiesEventResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
   if (!this->event_types->empty()) {
     for (const char *it : *this->event_types) {
@@ -3536,7 +3524,7 @@ uint32_t ListEntitiesValveResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
   size += ProtoSize::calc_bool(1, this->assumed_state);
   size += ProtoSize::calc_bool(1, this->supports_position);
@@ -3560,7 +3548,7 @@ uint32_t ValveStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
   size += ProtoSize::calc_float(1, this->position);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->current_operation));
+  size += this->current_operation ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3623,7 +3611,7 @@ uint32_t ListEntitiesDateTimeResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -3701,7 +3689,7 @@ uint32_t ListEntitiesUpdateResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
   size += ProtoSize::calc_length(1, this->device_class.size());
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
@@ -3821,7 +3809,7 @@ uint8_t *ZWaveProxyRequest::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_P
 }
 uint32_t ZWaveProxyRequest::calculate_size() const {
   uint32_t size = 0;
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->type));
+  size += this->type ? 2 : 0;
   size += ProtoSize::calc_length(1, this->data_len);
   return size;
 }
@@ -3853,7 +3841,7 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
   size += ProtoSize::calc_length(1, this->icon.size());
 #endif
   size += ProtoSize::calc_bool(1, this->disabled_by_default);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->entity_category));
+  size += this->entity_category ? 2 : 0;
 #ifdef USE_DEVICES
   size += ProtoSize::calc_uint32(1, this->device_id);
 #endif
@@ -4048,8 +4036,8 @@ uint8_t *SerialProxyRequestResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCOD
 uint32_t SerialProxyRequestResponse::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_uint32(1, this->instance);
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->type));
-  size += ProtoSize::calc_uint32(1, static_cast<uint32_t>(this->status));
+  size += this->type ? 2 : 0;
+  size += this->status ? 2 : 0;
   size += ProtoSize::calc_length(1, this->error_message.size());
   return size;
 }

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -56,6 +56,10 @@ FILE_HEADER = """// This file was automatically generated with a tool.
 // See script/api_protobuf/api_protobuf.py
 """
 
+# Populated by main() before any TypeInfo creation.
+# Maps enum type name (e.g. ".BluetoothDeviceRequestType") to max enum value.
+_enum_max_values: dict[str, int] = {}
+
 
 def indent_list(text: str, padding: str = "  ") -> list[str]:
     """Indent each line of the given text with the specified padding."""
@@ -240,12 +244,6 @@ class TypeInfo(ABC):
         "encode_bool": "ProtoEncode::write_raw_byte(pos, {value} ? 0x01 : 0x00);",
     }
 
-    # When max_value < 128, the varint is always 1 byte — use a direct byte write
-    RAW_ENCODE_SMALL_MAP: dict[str, str] = {
-        "encode_uint32": "ProtoEncode::write_raw_byte(pos, static_cast<uint8_t>({value}));",
-        "encode_uint64": "ProtoEncode::write_raw_byte(pos, static_cast<uint8_t>({value}));",
-    }
-
     def _encode_with_precomputed_tag(self, value_expr: str) -> str | None:
         """Try to emit a precomputed-tag encode for a field.
 
@@ -255,19 +253,14 @@ class TypeInfo(ABC):
 
         Returns the raw encode string if the tag is a single byte and the
         encode_func has a known raw equivalent, or None otherwise.
-        When max_value < 128, uses direct byte write instead of varint encoding.
         """
         tag = self.calculate_tag()
         if tag >= 128:
             return None
         max_val = self.max_value
+        # Only use RAW_ENCODE_MAP for forced fields or fields with max_value
         raw_expr = None
-        if max_val is not None and max_val < 128:
-            raw_expr = self.RAW_ENCODE_SMALL_MAP.get(self.encode_func)
-        if raw_expr is None:
-            # Only use RAW_ENCODE_MAP for forced fields or fields with max_value
-            if not self.force and max_val is None:
-                return None
+        if self.force or max_val is not None:
             raw_expr = self.RAW_ENCODE_MAP.get(self.encode_func)
         if raw_expr is None:
             return None
@@ -1322,18 +1315,23 @@ class EnumType(TypeInfo):
     wire_type = WireType.VARINT  # Uses wire type 0
 
     @property
+    def max_value(self) -> int | None:
+        """Get max_value from explicit annotation or auto-derive from enum definition."""
+        explicit = super().max_value
+        if explicit is not None:
+            return explicit
+        return _enum_max_values.get(self._field.type_name)
+
+    @property
     def encode_func(self) -> str:
         return "encode_uint32"
 
     @property
     def encode_content(self) -> str:
-        if result := self._encode_with_precomputed_tag(
-            f"static_cast<uint32_t>(this->{self.field_name})"
-        ):
-            return result
+        value_expr = f"static_cast<uint32_t>(this->{self.field_name})"
         if self.force:
-            return f"ProtoEncode::{self.encode_func}(pos, {self.number}, static_cast<uint32_t>(this->{self.field_name}), true);"
-        return f"ProtoEncode::{self.encode_func}(pos, {self.number}, static_cast<uint32_t>(this->{self.field_name}));"
+            return f"ProtoEncode::{self.encode_func}(pos, {self.number}, {value_expr}, true);"
+        return f"ProtoEncode::{self.encode_func}(pos, {self.number}, {value_expr});"
 
     def dump(self, name: str) -> str:
         return f"out.append_p(proto_enum_to_string<{self.cpp_type}>({name}));"
@@ -1343,6 +1341,9 @@ class EnumType(TypeInfo):
         return f"static_cast<{self.cpp_type}>({value})"
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
+        max_val = self.max_value
+        if max_val is not None and max_val < 128:
+            return self._get_single_byte_varint_size(name, force)
         return self._get_simple_size_calculation(
             name, force, "uint32", f"static_cast<uint32_t>({name})"
         )
@@ -1905,17 +1906,27 @@ class RepeatedTypeInfo(TypeInfo):
             size_expr = f"{name}->size()" if self._use_pointer else f"{name}.size()"
             o += f"  size += {size_expr} * {bytes_per_element};\n"
         else:
-            # Other types need the actual value
+            # Check if inner type produces a constant size (doesn't depend on value)
+            inner_size = self._ti.get_size_calculation("it", True)
+            if "it" not in inner_size:
+                # Constant size per element — use multiply instead of loop
+                # Extract the constant from "size += N;"
+                const_val = (
+                    inner_size.strip().removeprefix("size += ").removesuffix(";")
+                )
+                size_expr = f"{name}->size()" if self._use_pointer else f"{name}.size()"
+                o += f"  size += {size_expr} * {const_val};\n"
             # Special handling for const char* elements
-            if self._use_pointer and "const char" in self._container_no_template:
+            elif self._use_pointer and "const char" in self._container_no_template:
                 field_id_size = self.calculate_field_id_size()
                 o += f"  for (const char *it : {container_ref}) {{\n"
                 o += f"    size += ProtoSize::calc_length_force({field_id_size}, strlen(it));\n"
+                o += "  }\n"
             else:
                 auto_ref = "" if self._ti_is_bool else "&"
                 o += f"  for (const auto {auto_ref}it : {container_ref}) {{\n"
-                o += f"    {self._ti.get_size_calculation('it', True)}\n"
-            o += "  }\n"
+                o += f"    {inner_size}\n"
+                o += "  }\n"
 
         o += "}"
         return o
@@ -2787,6 +2798,11 @@ def main() -> None:
     d = descriptor.FileDescriptorSet.FromString(proto_content)
 
     file = d.file[0]
+
+    # Build enum max value map so EnumType can auto-derive max_value
+    for enum in file.enum_type:
+        if not enum.options.deprecated and enum.value:
+            _enum_max_values[f".{enum.name}"] = max(v.number for v in enum.value)
 
     # Build dynamic ifdef mappings early so we can emit USE_API_VARINT64 before includes
     enum_ifdef_map, message_ifdef_map, message_source_map, used_messages = (


### PR DESCRIPTION
# What does this implement/fix?

The protobuf code generator already parses all enum definitions and knows every enum's max value. This PR auto-derives `max_value` for enum fields at codegen time, so every enum field automatically benefits from constant-size arithmetic in `calculate_size()` — no manual `(max_value)` annotations needed.

Since every enum in `api.proto` currently has max value < 128, all enum fields get:
- **`calculate_size`**: `calc_uint32(1, static_cast<uint32_t>(field))` → `field ? 2 : 0`

For repeated enum fields with constant element size, the per-element loop is replaced with a multiply: `size += count * bytes_per_element`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — codegen-only optimization
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).