### PR TITLE
[rpi_dpi_rgb][st7701s][ags10] Fix Optional config keys accessed unconditionally

### DIFF
--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(AGS10Component),
-            cv.Optional(CONF_TVOC): sensor.sensor_schema(
+            cv.Required(CONF_TVOC): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PARTS_PER_BILLION,
                 icon=ICON_RADIATOR,
                 accuracy_decimals=0,

--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -102,7 +102,7 @@ CONFIG_SCHEMA = cv.All(
                         }
                     ),
                 ),
-                cv.Optional(CONF_COLOR_ORDER): cv.one_of(
+                cv.Optional(CONF_COLOR_ORDER, default="BGR"): cv.one_of(
                     *COLOR_ORDERS.keys(), upper=True
                 ),
                 cv.Optional(CONF_INVERT_COLORS, default=False): cv.boolean,

--- a/esphome/components/st7701s/display.py
+++ b/esphome/components/st7701s/display.py
@@ -138,7 +138,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.Optional(CONF_INIT_SEQUENCE, default=1): cv.ensure_list(
                     map_sequence
                 ),
-                cv.Optional(CONF_COLOR_ORDER): cv.one_of(
+                cv.Optional(CONF_COLOR_ORDER, default="BGR"): cv.one_of(
                     *COLOR_ORDERS.keys(), upper=True
                 ),
                 cv.Optional(CONF_PCLK_FREQUENCY, default="16MHz"): cv.All(


### PR DESCRIPTION
# What does this implement/fix?

Fix three components where Optional config keys were accessed unconditionally in `to_code`, causing `KeyError` when omitted.

**rpi_dpi_rgb / st7701s**: `CONF_COLOR_ORDER` was `cv.Optional` with no default but accessed via `config[CONF_COLOR_ORDER]` in `to_code`. Add `default="BGR"` to match the C++ default (`COLOR_ORDER_BGR`) and the docs (which already say "default: bgr").

**ags10**: `CONF_TVOC` was `cv.Optional` but accessed unconditionally via `config[CONF_TVOC]` — no `.get()` or guard check. Change to `cv.Required` since an AGS10 sensor component without TVOC has no purpose.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6395 (ags10 tvoc: Optional → Required)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# rpi_dpi_rgb / st7701s: color_order now defaults to BGR if omitted
display:
  - platform: rpi_dpi_rgb
    # color_order: BGR  # no longer required, defaults to BGR

# ags10: tvoc is now required
sensor:
  - platform: ags10
    tvoc:
      name: "TVOC"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).