### PR TITLE
[multiple] Add missing cv.COMPONENT_SCHEMA to CONFIG_SCHEMA

### DIFF
--- a/esphome/components/ads1118/__init__.py
+++ b/esphome/components/ads1118/__init__.py
@@ -12,11 +12,15 @@ CONF_ADS1118_ID = "ads1118_id"
 ads1118_ns = cg.esphome_ns.namespace("ads1118")
 ADS1118 = ads1118_ns.class_("ADS1118", cg.Component, spi.SPIDevice)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(ADS1118),
-    }
-).extend(spi.spi_device_schema(cs_pin_required=True))
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(ADS1118),
+        }
+    )
+    .extend(spi.spi_device_schema(cs_pin_required=True))
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/esphome/components/as3935/sensor.py
+++ b/esphome/components/as3935/sensor.py
@@ -26,7 +26,7 @@ CONFIG_SCHEMA = cv.Schema(
             accuracy_decimals=1,
         ),
     }
-).extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/esphome/components/cse7766/sensor.py
+++ b/esphome/components/cse7766/sensor.py
@@ -32,52 +32,56 @@ DEPENDENCIES = ["uart"]
 cse7766_ns = cg.esphome_ns.namespace("cse7766")
 CSE7766Component = cse7766_ns.class_("CSE7766Component", cg.Component, uart.UARTDevice)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(CSE7766Component),
-        cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_ENERGY): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT_HOURS,
-            accuracy_decimals=3,
-            device_class=DEVICE_CLASS_ENERGY,
-            state_class=STATE_CLASS_TOTAL_INCREASING,
-        ),
-        cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT_AMPS,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_APPARENT_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_REACTIVE_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_REACTIVE_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER_FACTOR,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(CSE7766Component),
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ENERGY): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOURS,
+                accuracy_decimals=3,
+                device_class=DEVICE_CLASS_ENERGY,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
+            ),
+            cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT_AMPS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_APPARENT_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_REACTIVE_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT_AMPS_REACTIVE,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_REACTIVE_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_POWER_FACTOR,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "cse7766", baud_rate=4800, parity="EVEN", require_rx=True
 )

--- a/esphome/components/cst226/binary_sensor/__init__.py
+++ b/esphome/components/cst226/binary_sensor/__init__.py
@@ -15,10 +15,14 @@ CST226Button = cst226_ns.class_(
     cg.Parented.template(CST226Touchscreen),
 )
 
-CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(CST226Button).extend(
-    {
-        cv.GenerateID(CONF_CST226_ID): cv.use_id(CST226Touchscreen),
-    }
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(CST226Button)
+    .extend(
+        {
+            cv.GenerateID(CONF_CST226_ID): cv.use_id(CST226Touchscreen),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
 )
 
 

--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -44,7 +44,9 @@ CONFIG_SCHEMA = cv.All(
                 CONF_RECEIVE_TIMEOUT, default="200ms"
             ): cv.positive_time_period_milliseconds,
         }
-    ).extend(uart.UART_DEVICE_SCHEMA),
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA),
 )
 
 

--- a/esphome/components/e131/__init__.py
+++ b/esphome/components/e131/__init__.py
@@ -29,7 +29,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.GenerateID(): cv.declare_id(E131Component),
         cv.Optional(CONF_METHOD, default="MULTICAST"): cv.one_of(*METHODS, upper=True),
     }
-)
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):

--- a/esphome/components/gcja5/sensor.py
+++ b/esphome/components/gcja5/sensor.py
@@ -29,68 +29,72 @@ GCJA5Component = gcja5_ns.class_("GCJA5Component", cg.PollingComponent, uart.UAR
 CONF_PMC_0_3 = "pmc_0_3"
 CONF_PMC_5_0 = "pmc_5_0"
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(GCJA5Component),
-        cv.Optional(CONF_PM_1_0): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_CHEMICAL_WEAPON,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_PM1,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PM_2_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_CHEMICAL_WEAPON,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_PM25,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PM_10_0): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_CHEMICAL_WEAPON,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_PM10,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_0_3): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_0_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_1_0): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_2_5): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_5_0): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_PMC_10_0): sensor.sensor_schema(
-            unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
-            icon=ICON_COUNTER,
-            accuracy_decimals=0,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(GCJA5Component),
+            cv.Optional(CONF_PM_1_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_PM1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_2_5): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_PM25,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_10_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_PM10,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_0_3): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_0_5): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_1_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_2_5): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_5_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PMC_10_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
+                icon=ICON_COUNTER,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "gcja5", baud_rate=9600, require_rx=True, parity="EVEN"
 )

--- a/esphome/components/hlw8032/sensor.py
+++ b/esphome/components/hlw8032/sensor.py
@@ -27,42 +27,46 @@ DEPENDENCIES = ["uart"]
 hlw8032_ns = cg.esphome_ns.namespace("hlw8032")
 HLW8032Component = hlw8032_ns.class_("HLW8032Component", cg.Component, uart.UARTDevice)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(HLW8032Component),
-        cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_VOLTAGE,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT): sensor.sensor_schema(
-            unit_of_measurement=UNIT_AMPERE,
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_CURRENT,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_WATT,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
-            unit_of_measurement=UNIT_VOLT_AMPS,
-            accuracy_decimals=1,
-            device_class=DEVICE_CLASS_APPARENT_POWER,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
-            accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER_FACTOR,
-            state_class=STATE_CLASS_MEASUREMENT,
-        ),
-        cv.Optional(CONF_CURRENT_RESISTOR, default=0.001): cv.resistance,
-        cv.Optional(CONF_VOLTAGE_DIVIDER, default=1.720): cv.positive_float,
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(HLW8032Component),
+            cv.Optional(CONF_VOLTAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_APPARENT_POWER): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT_AMPS,
+                accuracy_decimals=1,
+                device_class=DEVICE_CLASS_APPARENT_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_POWER_FACTOR): sensor.sensor_schema(
+                accuracy_decimals=2,
+                device_class=DEVICE_CLASS_POWER_FACTOR,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_RESISTOR, default=0.001): cv.resistance,
+            cv.Optional(CONF_VOLTAGE_DIVIDER, default=1.720): cv.positive_float,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "hlw8032", baud_rate=4800, require_rx=True, data_bits=8, parity="EVEN"

--- a/esphome/components/sml/__init__.py
+++ b/esphome/components/sml/__init__.py
@@ -19,12 +19,16 @@ CONF_OBIS_CODE = "obis_code"
 CONF_SERVER_ID = "server_id"
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(Sml),
-        cv.Optional(CONF_ON_DATA): automation.validate_automation({}),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(Sml),
+            cv.Optional(CONF_ON_DATA): automation.validate_automation({}),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/esphome/components/sml/sensor/__init__.py
+++ b/esphome/components/sml/sensor/__init__.py
@@ -10,13 +10,17 @@ AUTO_LOAD = ["sml"]
 SmlSensor = sml_ns.class_("SmlSensor", sensor.Sensor, cg.Component)
 
 
-CONFIG_SCHEMA = sensor.sensor_schema().extend(
-    {
-        cv.GenerateID(): cv.declare_id(SmlSensor),
-        cv.GenerateID(CONF_SML_ID): cv.use_id(Sml),
-        cv.Required(CONF_OBIS_CODE): obis_code,
-        cv.Optional(CONF_SERVER_ID, default=""): cv.string,
-    }
+CONFIG_SCHEMA = (
+    sensor.sensor_schema()
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(SmlSensor),
+            cv.GenerateID(CONF_SML_ID): cv.use_id(Sml),
+            cv.Required(CONF_OBIS_CODE): obis_code,
+            cv.Optional(CONF_SERVER_ID, default=""): cv.string,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
 )
 
 

--- a/esphome/components/sml/text_sensor/__init__.py
+++ b/esphome/components/sml/text_sensor/__init__.py
@@ -19,13 +19,17 @@ SML_TYPES = {
 
 SmlTextSensor = sml_ns.class_("SmlTextSensor", text_sensor.TextSensor, cg.Component)
 
-CONFIG_SCHEMA = text_sensor.text_sensor_schema(SmlTextSensor).extend(
-    {
-        cv.GenerateID(CONF_SML_ID): cv.use_id(Sml),
-        cv.Required(CONF_OBIS_CODE): obis_code,
-        cv.Optional(CONF_SERVER_ID, default=""): cv.string,
-        cv.Optional(CONF_FORMAT, default=""): cv.enum(SML_TYPES, lower=True),
-    }
+CONFIG_SCHEMA = (
+    text_sensor.text_sensor_schema(SmlTextSensor)
+    .extend(
+        {
+            cv.GenerateID(CONF_SML_ID): cv.use_id(Sml),
+            cv.Required(CONF_OBIS_CODE): obis_code,
+            cv.Optional(CONF_SERVER_ID, default=""): cv.string,
+            cv.Optional(CONF_FORMAT, default=""): cv.enum(SML_TYPES, lower=True),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
 )
 
 

--- a/esphome/components/sun_gtil2/__init__.py
+++ b/esphome/components/sun_gtil2/__init__.py
@@ -13,11 +13,15 @@ sun_gtil2_ns = cg.esphome_ns.namespace("sun_gtil2")
 
 SunGTIL2Component = sun_gtil2_ns.class_("SunGTIL2", cg.Component, uart.UARTDevice)
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(SunGTIL2Component),
-    }
-).extend(uart.UART_DEVICE_SCHEMA)
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(SunGTIL2Component),
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):

--- a/esphome/components/tm1651/__init__.py
+++ b/esphome/components/tm1651/__init__.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_CLK_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_DIO_PIN): pins.internal_gpio_output_pin_schema,
         }
-    ),
+    ).extend(cv.COMPONENT_SCHEMA),
 )
 
 

--- a/esphome/components/tt21100/binary_sensor/__init__.py
+++ b/esphome/components/tt21100/binary_sensor/__init__.py
@@ -16,11 +16,15 @@ TT21100Button = tt21100_ns.class_(
     cg.Parented.template(TT21100Touchscreen),
 )
 
-CONFIG_SCHEMA = binary_sensor.binary_sensor_schema(TT21100Button).extend(
-    {
-        cv.GenerateID(CONF_TT21100_ID): cv.use_id(TT21100Touchscreen),
-        cv.Required(CONF_INDEX): cv.int_range(min=0, max=3),
-    }
+CONFIG_SCHEMA = (
+    binary_sensor.binary_sensor_schema(TT21100Button)
+    .extend(
+        {
+            cv.GenerateID(CONF_TT21100_ID): cv.use_id(TT21100Touchscreen),
+            cv.Required(CONF_INDEX): cv.int_range(min=0, max=3),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
 )
 
 

--- a/esphome/components/wiegand/__init__.py
+++ b/esphome/components/wiegand/__init__.py
@@ -48,7 +48,7 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
     }
-)
+).extend(cv.COMPONENT_SCHEMA)
 
 
 async def to_code(config):


### PR DESCRIPTION
# What does this implement/fix?

Fix `cv.COMPONENT_SCHEMA` mismatches across 15 components:

**Added missing `cv.COMPONENT_SCHEMA`** (14 components): These call `cg.register_component()` but their `CONFIG_SCHEMA` doesn't extend `cv.COMPONENT_SCHEMA`, preventing users from setting `setup_priority`.

| Component | Schema extended |
|-----------|----------------|
| ads1118 | `spi_device_schema` only |
| cse7766 | `UART_DEVICE_SCHEMA` only |
| cst226/binary_sensor | `binary_sensor_schema` only |
| dsmr | `UART_DEVICE_SCHEMA` only |
| e131 | plain `cv.Schema` |
| gcja5 | `UART_DEVICE_SCHEMA` only |
| hlw8032 | `UART_DEVICE_SCHEMA` only |
| sml | `UART_DEVICE_SCHEMA` only |
| sml/sensor | `sensor_schema` only |
| sml/text_sensor | `text_sensor_schema` only |
| sun_gtil2 | `UART_DEVICE_SCHEMA` only |
| tm1651 | plain `cv.Schema` |
| tt21100/binary_sensor | `binary_sensor_schema` only |
| wiegand | plain `cv.Schema` |

**Removed unnecessary `cv.COMPONENT_SCHEMA`** (1 component):

| Component | Reason |
|-----------|--------|
| as3935/sensor | Sensor platform that registers sensors on parent hub, never calls `register_component`. `setup_priority` was silently ignored. |

Found by scanning the codebase for `register_component` calls without `COMPONENT_SCHEMA` in the schema chain, and vice versa.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Users can now set setup_priority on these components, e.g.:
e131:
  setup_priority: 500
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).