### PR TITLE
[gcja5][cd74hc4067][openthread_info] Fix PollingComponent mismatches

### DIFF
--- a/esphome/components/cd74hc4067/__init__.py
+++ b/esphome/components/cd74hc4067/__init__.py
@@ -9,9 +9,7 @@ MULTI_CONF = True
 
 cd74hc4067_ns = cg.esphome_ns.namespace("cd74hc4067")
 
-CD74HC4067Component = cd74hc4067_ns.class_(
-    "CD74HC4067Component", cg.Component, cg.PollingComponent
-)
+CD74HC4067Component = cd74hc4067_ns.class_("CD74HC4067Component", cg.Component)
 
 CONF_PIN_S0 = "pin_s0"
 CONF_PIN_S1 = "pin_s1"

--- a/esphome/components/gcja5/sensor.py
+++ b/esphome/components/gcja5/sensor.py
@@ -24,7 +24,7 @@ DEPENDENCIES = ["uart"]
 
 gcja5_ns = cg.esphome_ns.namespace("gcja5")
 
-GCJA5Component = gcja5_ns.class_("GCJA5Component", cg.PollingComponent, uart.UARTDevice)
+GCJA5Component = gcja5_ns.class_("GCJA5Component", cg.Component, uart.UARTDevice)
 
 CONF_PMC_0_3 = "pmc_0_3"
 CONF_PMC_5_0 = "pmc_5_0"

--- a/esphome/components/openthread_info/text_sensor.py
+++ b/esphome/components/openthread_info/text_sensor.py
@@ -54,7 +54,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_IP_ADDRESS): text_sensor.text_sensor_schema(
             IPAddressOpenThreadInfo, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
-        ),
+        ).extend(cv.polling_component_schema("1s")),
         cv.Optional(CONF_ROLE): text_sensor.text_sensor_schema(
             RoleOpenThreadInfo, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ).extend(cv.polling_component_schema("1s")),


### PR DESCRIPTION
# What does this implement/fix?

Fix three PollingComponent declaration mismatches found by scanning for inconsistencies between Python class declarations, C++ class hierarchies, and schema definitions.

**gcja5**: Python declared `GCJA5Component` as `cg.PollingComponent` but the C++ class (`gcja5.h`) inherits from `Component`, not `PollingComponent`. The component uses `loop()` not `update()`. Fix: change Python to `cg.Component`.

**cd74hc4067**: Python declared `CD74HC4067Component` with both `cg.Component` and `cg.PollingComponent` but C++ only inherits `Component`. The `PollingComponent` parent belongs to `CD74HC4067Sensor`, not the mux component itself. Fix: remove `cg.PollingComponent` from Python.

**openthread_info**: `IPAddressOpenThreadInfo` is declared as `PollingComponent` (like all other sensors in this file) but its schema entry was the only one missing `.extend(cv.polling_component_schema(...))`. Without `update_interval`, the component defaults to 0ms and polls as fast as possible, wasting CPU. Fix: add `polling_component_schema("1s")` to match the other sensors.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# openthread_info ip_address now correctly accepts update_interval
text_sensor:
  - platform: openthread_info
    ip_address:
      name: "OT IP Address"
      # update_interval now defaults to 1s instead of polling as fast as possible
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).