### PR TITLE
[esp32] Fix ESP32-C6 pin validator rejecting GPIO 24-30 with wrong error

### DIFF
--- a/esphome/components/esp32/gpio_esp32_c6.py
+++ b/esphome/components/esp32/gpio_esp32_c6.py
@@ -26,8 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def esp32_c6_validate_gpio_pin(value: int) -> int:
-    if value < 0 or value > 23:
-        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-23)")
+    if value < 0 or value > 30:
+        raise cv.Invalid(f"Invalid pin number: {value} (must be 0-30)")
     if value in _ESP32C6_SPI_PSRAM_PINS:
         raise cv.Invalid(
             f"This pin cannot be used on ESP32-C6s and is already used by the SPI/PSRAM interface (function: {_ESP32C6_SPI_PSRAM_PINS[value]})"
@@ -47,8 +47,8 @@ def esp32_c6_validate_supports(value: dict[str, Any]) -> dict[str, Any]:
     mode = value[CONF_MODE]
     is_input = mode[CONF_INPUT]
 
-    if num < 0 or num > 23:
-        raise cv.Invalid(f"Invalid pin number: {num} (must be 0-23)")
+    if num < 0 or num > 30:
+        raise cv.Invalid(f"Invalid pin number: {num} (must be 0-30)")
     if is_input:
         # All ESP32 pins support input mode
         pass


### PR DESCRIPTION
# What does this implement/fix?

Fix the ESP32-C6 GPIO pin validator rejecting pins 24-30 with "must be 0-23" instead of the correct "used by SPI/PSRAM interface" error.

The ESP32-C6 has GPIOs 0-30. Pins 24-30 are reserved for SPI/PSRAM and the code has a dedicated check with informative error messages (listing the SPI function name). But the range check on line 29 rejected anything >23 first, making the SPI check unreachable for these pins.

**Before:** `GPIO25 → "Invalid pin number: 25 (must be 0-23)"`
**After:** `GPIO25 → "This pin cannot be used on ESP32-C6s and is already used by the SPI/PSRAM interface (function: SPIQ)"`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-c6-devkitc-1
  variant: esp32c6
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).