### PR TITLE
[multiple] Add missing state_class to sensor schemas

### DIFF
--- a/esphome/components/dsmr/sensor.py
+++ b/esphome/components/dsmr/sensor.py
@@ -122,42 +122,52 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional("total_imported_energy"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_delivered_tariff1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_delivered_tariff2"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_delivered_tariff3"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_delivered_tariff4"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("total_exported_energy"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_returned_tariff1"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_returned_tariff2"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_returned_tariff3"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("reactive_energy_returned_tariff4"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOVOLT_AMPS_REACTIVE_HOURS,
             accuracy_decimals=3,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
         ),
         cv.Optional("power_delivered"): sensor.sensor_schema(
             unit_of_measurement=UNIT_KILOWATT,

--- a/esphome/components/ltr390/sensor.py
+++ b/esphome/components/ltr390/sensor.py
@@ -10,6 +10,7 @@ from esphome.const import (
     DEVICE_CLASS_EMPTY,
     DEVICE_CLASS_ILLUMINANCE,
     ICON_BRIGHTNESS_5,
+    STATE_CLASS_MEASUREMENT,
     UNIT_LUX,
 )
 
@@ -57,24 +58,28 @@ CONFIG_SCHEMA = cv.All(
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_ILLUMINANCE,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_AMBIENT_LIGHT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_COUNTS,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_EMPTY,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_UV_INDEX): sensor.sensor_schema(
                 unit_of_measurement=UNIT_UVI,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=5,
                 device_class=DEVICE_CLASS_EMPTY,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_UV): sensor.sensor_schema(
                 unit_of_measurement=UNIT_COUNTS,
                 icon=ICON_BRIGHTNESS_5,
                 accuracy_decimals=1,
                 device_class=DEVICE_CLASS_EMPTY,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_GAIN, default="X18"): cv.Any(
                 cv.enum(GAIN_OPTIONS),

--- a/esphome/components/mopeka_pro_check/sensor.py
+++ b/esphome/components/mopeka_pro_check/sensor.py
@@ -115,6 +115,7 @@ CONFIG_SCHEMA = (
                 icon=ICON_COUNTER,
                 accuracy_decimals=0,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_MINIMUM_SIGNAL_QUALITY, default="MEDIUM"): cv.enum(
                 SIGNAL_QUALITIES, upper=True

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     CONF_RESTORE_MODE,
     CONF_VALUE,
     ICON_ROTATE_RIGHT,
+    STATE_CLASS_MEASUREMENT,
     UNIT_STEPS,
 )
 
@@ -60,6 +61,7 @@ CONFIG_SCHEMA = cv.All(
         unit_of_measurement=UNIT_STEPS,
         icon=ICON_ROTATE_RIGHT,
         accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
     )
     .extend(
         {

--- a/esphome/components/seeed_mr24hpc1/sensor.py
+++ b/esphome/components/seeed_mr24hpc1/sensor.py
@@ -5,6 +5,7 @@ from esphome.const import (
     DEVICE_CLASS_DISTANCE,
     DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_SPEED,
+    STATE_CLASS_MEASUREMENT,
     UNIT_METER,
 )
 
@@ -26,6 +27,7 @@ CONFIG_SCHEMA = cv.Schema(
             unit_of_measurement=UNIT_METER,
             accuracy_decimals=2,  # Specify the number of decimal places
             icon="mdi:signal-distance-variant",
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_MOVEMENT_SIGNS): sensor.sensor_schema(
             icon="mdi:human-greeting-variant",
@@ -34,6 +36,7 @@ CONFIG_SCHEMA = cv.Schema(
             unit_of_measurement=UNIT_METER,
             accuracy_decimals=2,
             icon="mdi:signal-distance-variant",
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_CUSTOM_SPATIAL_STATIC_VALUE): sensor.sensor_schema(
             device_class=DEVICE_CLASS_ENERGY,
@@ -48,6 +51,7 @@ CONFIG_SCHEMA = cv.Schema(
             device_class=DEVICE_CLASS_SPEED,
             accuracy_decimals=2,
             icon="mdi:run-fast",
+            state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_CUSTOM_MODE_NUM): sensor.sensor_schema(
             icon="mdi:counter",

--- a/esphome/components/xiaomi_cgpr1/binary_sensor.py
+++ b/esphome/components/xiaomi_cgpr1/binary_sensor.py
@@ -12,6 +12,7 @@ from esphome.const import (
     DEVICE_CLASS_MOTION,
     ENTITY_CATEGORY_DIAGNOSTIC,
     ICON_TIMELAPSE,
+    STATE_CLASS_MEASUREMENT,
     UNIT_LUX,
     UNIT_MINUTE,
     UNIT_PERCENT,
@@ -45,6 +46,7 @@ CONFIG_SCHEMA = cv.All(
                 icon=ICON_TIMELAPSE,
                 accuracy_decimals=0,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_ILLUMINANCE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_LUX,

--- a/esphome/components/xiaomi_cgpr1/binary_sensor.py
+++ b/esphome/components/xiaomi_cgpr1/binary_sensor.py
@@ -39,6 +39,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_BATTERY,
+                state_class=STATE_CLASS_MEASUREMENT,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_IDLE_TIME): sensor.sensor_schema(
@@ -52,6 +53,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_LUX,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_ILLUMINANCE,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
         }
     )

--- a/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
+++ b/esphome/components/xiaomi_mjyd02yla/binary_sensor.py
@@ -43,6 +43,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_MINUTE,
                 icon=ICON_TIMELAPSE,
                 accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_BATTERY_LEVEL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,


### PR DESCRIPTION
# What does this implement/fix?

Add missing `state_class` to 18 sensors across 8 components, enabling Home Assistant long-term statistics tracking.

Without `state_class`, Home Assistant won't record long-term statistics for these sensors. These are the remaining sensors in the codebase that have `unit_of_measurement` but no `state_class`.

**`STATE_CLASS_TOTAL_INCREASING`** (energy meters):
| Component | Sensors | Unit |
|-----------|---------|------|
| dsmr | 10 reactive energy sensors | kvarh |
| teleinfo | energy sensor | Wh |

**`STATE_CLASS_MEASUREMENT`** (instantaneous values):
| Component | Sensors | Unit |
|-----------|---------|------|
| ltr390 | light, ambient_light, uv_index, uv | lux, counts, UVI |
| mopeka_pro_check | ignored_reads | (diagnostic counter) |
| rotary_encoder | position | steps |
| seeed_mr24hpc1 | presence distance, motion distance, motion speed | m, m/s |
| xiaomi_cgpr1 | idle_time | min |
| xiaomi_mjyd02yla | idle_time | min |

Partial fix for https://github.com/esphome/backlog/issues/79

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Partial fix for https://github.com/esphome/backlog/issues/79

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — state_class is added automatically
# via the sensor schema defaults
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).