### PR TITLE
[sprinkler][dfplayer][max6956][rf_bridge] Fix cg.templatable type mismatches

### DIFF
--- a/esphome/components/dfplayer/__init__.py
+++ b/esphome/components/dfplayer/__init__.py
@@ -122,7 +122,7 @@ async def dfplayer_previous_to_code(config, action_id, template_arg, args):
 async def dfplayer_play_mp3_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_FILE], args, float)
+    template_ = await cg.templatable(config[CONF_FILE], args, cg.uint16)
     cg.add(var.set_file(template_))
     return var
 
@@ -143,10 +143,10 @@ async def dfplayer_play_mp3_to_code(config, action_id, template_arg, args):
 async def dfplayer_play_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_FILE], args, float)
+    template_ = await cg.templatable(config[CONF_FILE], args, cg.uint16)
     cg.add(var.set_file(template_))
     if CONF_LOOP in config:
-        template_ = await cg.templatable(config[CONF_LOOP], args, float)
+        template_ = await cg.templatable(config[CONF_LOOP], args, cg.bool_)
         cg.add(var.set_loop(template_))
     return var
 
@@ -167,13 +167,13 @@ async def dfplayer_play_to_code(config, action_id, template_arg, args):
 async def dfplayer_play_folder_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_FOLDER], args, float)
+    template_ = await cg.templatable(config[CONF_FOLDER], args, cg.uint16)
     cg.add(var.set_folder(template_))
     if CONF_FILE in config:
-        template_ = await cg.templatable(config[CONF_FILE], args, float)
+        template_ = await cg.templatable(config[CONF_FILE], args, cg.uint16)
         cg.add(var.set_file(template_))
     if CONF_LOOP in config:
-        template_ = await cg.templatable(config[CONF_LOOP], args, float)
+        template_ = await cg.templatable(config[CONF_LOOP], args, cg.bool_)
         cg.add(var.set_loop(template_))
     return var
 
@@ -213,7 +213,7 @@ async def dfplayer_set_device_to_code(config, action_id, template_arg, args):
 async def dfplayer_set_volume_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_VOLUME], args, float)
+    template_ = await cg.templatable(config[CONF_VOLUME], args, cg.uint8)
     cg.add(var.set_volume(template_))
     return var
 

--- a/esphome/components/max6956/__init__.py
+++ b/esphome/components/max6956/__init__.py
@@ -117,7 +117,7 @@ async def max6956_pin_to_code(config):
 async def max6956_set_brightness_global_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_BRIGHTNESS_GLOBAL], args, float)
+    template_ = await cg.templatable(config[CONF_BRIGHTNESS_GLOBAL], args, cg.uint8)
     cg.add(var.set_brightness_global(template_))
     return var
 
@@ -139,6 +139,8 @@ async def max6956_set_brightness_global_to_code(config, action_id, template_arg,
 async def max6956_set_brightness_mode_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_BRIGHTNESS_MODE], args, float)
+    template_ = await cg.templatable(
+        config[CONF_BRIGHTNESS_MODE], args, MAX6956_CURRENTMODE
+    )
     cg.add(var.set_brightness_mode(template_))
     return var

--- a/esphome/components/rf_bridge/__init__.py
+++ b/esphome/components/rf_bridge/__init__.py
@@ -185,9 +185,9 @@ RFBRIDGE_SEND_ADVANCED_CODE_SCHEMA = cv.Schema(
 async def rf_bridge_send_advanced_code_to_code(config, action_id, template_args, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_args, paren)
-    template_ = await cg.templatable(config[CONF_LENGTH], args, cg.uint16)
+    template_ = await cg.templatable(config[CONF_LENGTH], args, cg.uint8)
     cg.add(var.set_length(template_))
-    template_ = await cg.templatable(config[CONF_PROTOCOL], args, cg.uint16)
+    template_ = await cg.templatable(config[CONF_PROTOCOL], args, cg.uint8)
     cg.add(var.set_protocol(template_))
     template_ = await cg.templatable(config[CONF_CODE], args, cg.std_string)
     cg.add(var.set_code(template_))

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -427,7 +427,7 @@ CONFIG_SCHEMA = cv.All(
 async def sprinkler_set_divider_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_DIVIDER], args, cg.float_)
+    template_ = await cg.templatable(config[CONF_DIVIDER], args, cg.uint32)
     cg.add(var.set_divider(template_))
     return var
 
@@ -471,7 +471,7 @@ async def sprinkler_set_queued_valve_to_code(config, action_id, template_arg, ar
 async def sprinkler_set_repeat_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_REPEAT], args, cg.float_)
+    template_ = await cg.templatable(config[CONF_REPEAT], args, cg.uint32)
     cg.add(var.set_repeat(template_))
     return var
 


### PR DESCRIPTION
# What does this implement/fix?

Fix the type argument passed to `cg.templatable()` in several components to match the C++ `TEMPLATABLE_VALUE` type. When a lambda is used, this type becomes the generated lambda's return type — a mismatch produces incorrect C++ that may cause compiler warnings or implicit truncation.

For literal (non-lambda) values, the type argument is unused, so these bugs only manifest when users write lambda expressions for these parameters.

**sprinkler** (2 fixes):
- `set_divider`: `cg.float_` → `cg.uint32` (C++: `TEMPLATABLE_VALUE(uint32_t, divider)`)
- `set_repeat`: `cg.float_` → `cg.uint32` (C++: `TEMPLATABLE_VALUE(uint32_t, repeat)`)

**dfplayer** (7 fixes):
- `PlayMp3Action` file, `PlayFileAction` file, `PlayFolderAction` folder/file: `float` → `cg.uint16` (C++: `uint16_t`)
- `PlayFileAction` loop, `PlayFolderAction` loop: `float` → `cg.bool_` (C++: `bool`)
- `SetVolumeAction` volume: `float` → `cg.uint8` (C++: `uint8_t`)

**max6956** (2 fixes):
- `brightness_global`: `float` → `cg.uint8` (C++: `uint8_t`)
- `brightness_mode`: `float` → `MAX6956CURRENTMODE` enum (C++: `MAX6956CURRENTMODE`)

**rf_bridge** (2 fixes):
- `length`: `cg.uint16` → `cg.uint8` (C++: `uint8_t`)
- `protocol`: `cg.uint16` → `cg.uint8` (C++: `uint8_t`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# These fixes only affect the lambda code path, e.g.:
dfplayer:
  on_press:
    - dfplayer.play:
        file: !lambda "return 1;"  # now correctly generates uint16_t lambda
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).