### PR TITLE
[thermostat] Remove non-functional cv.templatable from preset fields

### DIFF
--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -118,10 +118,8 @@ PRESET_CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MODE): validate_climate_mode,
         cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_HIGH): cv.temperature,
         cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
-        cv.Optional(CONF_FAN_MODE): cv.templatable(climate.validate_climate_fan_mode),
-        cv.Optional(CONF_SWING_MODE): cv.templatable(
-            climate.validate_climate_swing_mode
-        ),
+        cv.Optional(CONF_FAN_MODE): climate.validate_climate_fan_mode,
+        cv.Optional(CONF_SWING_MODE): climate.validate_climate_swing_mode,
     }
 )
 
@@ -451,8 +449,6 @@ def validate_thermostat(config):
                 continue
 
             fan_mode = preset_config[CONF_FAN_MODE]
-            if isinstance(fan_mode, cv.Lambda):
-                continue
 
             for req in requirements[fan_mode]:
                 if req not in config:
@@ -473,8 +469,6 @@ def validate_thermostat(config):
                 continue
 
             swing_mode = preset_config[CONF_SWING_MODE]
-            if isinstance(swing_mode, cv.Lambda):
-                continue
 
             for req in requirements[swing_mode]:
                 if req not in config:
@@ -485,24 +479,24 @@ def validate_thermostat(config):
     # If a default preset is requested then ensure that preset is defined
     if CONF_DEFAULT_PRESET in config:
         default_preset = config[CONF_DEFAULT_PRESET]
-        if not isinstance(default_preset, cv.Lambda):
-            if CONF_PRESET not in config:
-                raise cv.Invalid(
-                    f"{CONF_DEFAULT_PRESET} is specified but no presets are defined"
-                )
 
-            presets = config[CONF_PRESET]
-            found_preset = False
+        if CONF_PRESET not in config:
+            raise cv.Invalid(
+                f"{CONF_DEFAULT_PRESET} is specified but no presets are defined"
+            )
 
-            for preset in presets:
-                if preset[CONF_NAME] == default_preset:
-                    found_preset = True
-                    break
+        presets = config[CONF_PRESET]
+        found_preset = False
 
-            if found_preset is False:
-                raise cv.Invalid(
-                    f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
-                )
+        for preset in presets:
+            if preset[CONF_NAME] == default_preset:
+                found_preset = True
+                break
+
+        if found_preset is False:
+            raise cv.Invalid(
+                f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
+            )
 
     # If restoring default preset on boot is true then ensure we have a default preset
     if (
@@ -635,7 +629,7 @@ CONFIG_SCHEMA = cv.All(
             ): automation.validate_automation(single=True),
             cv.Optional(CONF_HUMIDITY_HYSTERESIS, default=1.0): cv.percentage,
             cv.Optional(CONF_DEFAULT_MODE, default=None): cv.valid,
-            cv.Optional(CONF_DEFAULT_PRESET): cv.templatable(cv.string),
+            cv.Optional(CONF_DEFAULT_PRESET): cv.string,
             cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_HIGH): cv.temperature,
             cv.Optional(CONF_DEFAULT_TARGET_TEMPERATURE_LOW): cv.temperature,
             cv.Optional(

--- a/esphome/components/thermostat/climate.py
+++ b/esphome/components/thermostat/climate.py
@@ -451,6 +451,8 @@ def validate_thermostat(config):
                 continue
 
             fan_mode = preset_config[CONF_FAN_MODE]
+            if isinstance(fan_mode, cv.Lambda):
+                continue
 
             for req in requirements[fan_mode]:
                 if req not in config:
@@ -471,6 +473,8 @@ def validate_thermostat(config):
                 continue
 
             swing_mode = preset_config[CONF_SWING_MODE]
+            if isinstance(swing_mode, cv.Lambda):
+                continue
 
             for req in requirements[swing_mode]:
                 if req not in config:
@@ -481,24 +485,24 @@ def validate_thermostat(config):
     # If a default preset is requested then ensure that preset is defined
     if CONF_DEFAULT_PRESET in config:
         default_preset = config[CONF_DEFAULT_PRESET]
+        if not isinstance(default_preset, cv.Lambda):
+            if CONF_PRESET not in config:
+                raise cv.Invalid(
+                    f"{CONF_DEFAULT_PRESET} is specified but no presets are defined"
+                )
 
-        if CONF_PRESET not in config:
-            raise cv.Invalid(
-                f"{CONF_DEFAULT_PRESET} is specified but no presets are defined"
-            )
+            presets = config[CONF_PRESET]
+            found_preset = False
 
-        presets = config[CONF_PRESET]
-        found_preset = False
+            for preset in presets:
+                if preset[CONF_NAME] == default_preset:
+                    found_preset = True
+                    break
 
-        for preset in presets:
-            if preset[CONF_NAME] == default_preset:
-                found_preset = True
-                break
-
-        if found_preset is False:
-            raise cv.Invalid(
-                f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
-            )
+            if found_preset is False:
+                raise cv.Invalid(
+                    f"{CONF_DEFAULT_PRESET} set to '{default_preset}' but no such preset has been defined. Available presets: {[preset[CONF_NAME] for preset in presets]}"
+                )
 
     # If restoring default preset on boot is true then ensure we have a default preset
     if (


### PR DESCRIPTION
# What does this implement/fix?

Remove `cv.templatable()` from `fan_mode`, `swing_mode`, and `default_preset` in the thermostat preset config schema. Lambdas were never actually supported for these fields:

1. **Validator crash**: The preset validator looks up fan_mode/swing_mode values in a requirements dict. Lambda objects aren't valid dict keys → `KeyError`.
2. **Codegen crash**: `to_code()` passes preset values directly to C++ setters without `cg.templatable()` / `cg.process_lambda()`. Lambda objects would crash codegen.
3. **C++ doesn't support it**: The preset system stores static values (`ClimateFanMode`, `ClimateSwingMode`, preset name strings), not runtime-computed ones.

Since lambdas never worked (they crashed at either validation or codegen), removing `cv.templatable()` is not a breaking change — it just replaces a crash with a clean validation error.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6400

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: thermostat
    preset:
      - name: Home
        fan_mode: LOW        # static enum, works
        swing_mode: "OFF"    # static enum, works
    default_preset: Home     # static string, works
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).