### PR TITLE
[pylontech] Remove unnecessary Component inheritance from sensor/text_sensor

### DIFF
--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -18,7 +18,7 @@ from esphome.const import (
 
 from .. import CONF_BATTERY, CONF_PYLONTECH_ID, PYLONTECH_COMPONENT_SCHEMA, pylontech_ns
 
-PylontechSensor = pylontech_ns.class_("PylontechSensor", cg.Component)
+PylontechSensor = pylontech_ns.class_("PylontechSensor")
 
 CONF_COULOMB = "coulomb"
 CONF_TEMPERATURE_LOW = "temperature_low"

--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -75,9 +75,11 @@ TYPES: dict[str, cv.Schema] = {
     ),
 }
 
-CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
-    {cv.GenerateID(): cv.declare_id(PylontechSensor)}
-).extend({cv.Optional(marker): schema for marker, schema in TYPES.items()})
+CONFIG_SCHEMA = (
+    PYLONTECH_COMPONENT_SCHEMA.extend({cv.GenerateID(): cv.declare_id(PylontechSensor)})
+    .extend({cv.Optional(marker): schema for marker, schema in TYPES.items()})
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):
@@ -89,4 +91,5 @@ async def to_code(config):
             sens = await sensor.new_sensor(marker_config)
             cg.add(getattr(bat, f"set_{marker}_sensor")(sens))
 
+    await cg.register_component(bat, config)
     cg.add(paren.register_listener(bat))

--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -89,5 +89,4 @@ async def to_code(config):
             sens = await sensor.new_sensor(marker_config)
             cg.add(getattr(bat, f"set_{marker}_sensor")(sens))
 
-    await cg.register_component(bat, config)
     cg.add(paren.register_listener(bat))

--- a/esphome/components/pylontech/sensor/__init__.py
+++ b/esphome/components/pylontech/sensor/__init__.py
@@ -75,11 +75,9 @@ TYPES: dict[str, cv.Schema] = {
     ),
 }
 
-CONFIG_SCHEMA = (
-    PYLONTECH_COMPONENT_SCHEMA.extend({cv.GenerateID(): cv.declare_id(PylontechSensor)})
-    .extend({cv.Optional(marker): schema for marker, schema in TYPES.items()})
-    .extend(cv.COMPONENT_SCHEMA)
-)
+CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
+    {cv.GenerateID(): cv.declare_id(PylontechSensor)}
+).extend({cv.Optional(marker): schema for marker, schema in TYPES.items()})
 
 
 async def to_code(config):

--- a/esphome/components/pylontech/sensor/pylontech_sensor.h
+++ b/esphome/components/pylontech/sensor/pylontech_sensor.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace pylontech {
 
-class PylontechSensor : public PylontechListener, public Component {
+class PylontechSensor : public PylontechListener {
  public:
   PylontechSensor(int8_t bat_num);
   void dump_config() override;

--- a/esphome/components/pylontech/text_sensor/__init__.py
+++ b/esphome/components/pylontech/text_sensor/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID
 
 from .. import CONF_BATTERY, CONF_PYLONTECH_ID, PYLONTECH_COMPONENT_SCHEMA, pylontech_ns
 
-PylontechTextSensor = pylontech_ns.class_("PylontechTextSensor", cg.Component)
+PylontechTextSensor = pylontech_ns.class_("PylontechTextSensor")
 
 CONF_BASE_STATE = "base_state"
 CONF_VOLTAGE_STATE = "voltage_state"

--- a/esphome/components/pylontech/text_sensor/__init__.py
+++ b/esphome/components/pylontech/text_sensor/__init__.py
@@ -19,15 +19,9 @@ MARKERS: list[str] = [
     CONF_TEMPERATURE_STATE,
 ]
 
-CONFIG_SCHEMA = (
-    PYLONTECH_COMPONENT_SCHEMA.extend(
-        {cv.GenerateID(): cv.declare_id(PylontechTextSensor)}
-    )
-    .extend(
-        {cv.Optional(marker): text_sensor.text_sensor_schema() for marker in MARKERS}
-    )
-    .extend(cv.COMPONENT_SCHEMA)
-)
+CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
+    {cv.GenerateID(): cv.declare_id(PylontechTextSensor)}
+).extend({cv.Optional(marker): text_sensor.text_sensor_schema() for marker in MARKERS})
 
 
 async def to_code(config):

--- a/esphome/components/pylontech/text_sensor/__init__.py
+++ b/esphome/components/pylontech/text_sensor/__init__.py
@@ -19,9 +19,15 @@ MARKERS: list[str] = [
     CONF_TEMPERATURE_STATE,
 ]
 
-CONFIG_SCHEMA = PYLONTECH_COMPONENT_SCHEMA.extend(
-    {cv.GenerateID(): cv.declare_id(PylontechTextSensor)}
-).extend({cv.Optional(marker): text_sensor.text_sensor_schema() for marker in MARKERS})
+CONFIG_SCHEMA = (
+    PYLONTECH_COMPONENT_SCHEMA.extend(
+        {cv.GenerateID(): cv.declare_id(PylontechTextSensor)}
+    )
+    .extend(
+        {cv.Optional(marker): text_sensor.text_sensor_schema() for marker in MARKERS}
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
 
 
 async def to_code(config):
@@ -33,4 +39,5 @@ async def to_code(config):
             var = await text_sensor.new_text_sensor(marker_config)
             cg.add(getattr(bat, f"set_{marker}_text_sensor")(var))
 
+    await cg.register_component(bat, config)
     cg.add(paren.register_listener(bat))

--- a/esphome/components/pylontech/text_sensor/__init__.py
+++ b/esphome/components/pylontech/text_sensor/__init__.py
@@ -33,5 +33,4 @@ async def to_code(config):
             var = await text_sensor.new_text_sensor(marker_config)
             cg.add(getattr(bat, f"set_{marker}_text_sensor")(var))
 
-    await cg.register_component(bat, config)
     cg.add(paren.register_listener(bat))

--- a/esphome/components/pylontech/text_sensor/pylontech_text_sensor.h
+++ b/esphome/components/pylontech/text_sensor/pylontech_text_sensor.h
@@ -6,7 +6,7 @@
 namespace esphome {
 namespace pylontech {
 
-class PylontechTextSensor : public PylontechListener, public Component {
+class PylontechTextSensor : public PylontechListener {
  public:
   PylontechTextSensor(int8_t bat_num);
   void dump_config() override;


### PR DESCRIPTION
# What does this implement/fix?

Remove unnecessary `Component` inheritance from `PylontechSensor` and `PylontechTextSensor`.

Both classes inherited `Component` but never used `setup()`, `loop()`, or any Component functionality. The `dump_config()` override works via the `PylontechListener` virtual method — the parent `PylontechComponent::dump_config()` iterates all registered listeners and calls their `dump_config()`.

**Changes:**
- C++: Remove `public Component` from class declarations in both headers
- Python: Remove `cg.Component` from both `class_()` declarations

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pylontech
    pylontech_id: my_pylontech
    battery: 1
    voltage:
      name: "Battery Voltage"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).