### PR TITLE
[opentherm] Fix step=0 default overriding entity step

### DIFF
--- a/esphome/components/opentherm/input.py
+++ b/esphome/components/opentherm/input.py
@@ -2,51 +2,48 @@ from typing import Any
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE
 
 from . import generate, schema
 
-CONF_min_value = "min_value"
-CONF_max_value = "max_value"
-CONF_auto_min_value = "auto_min_value"
-CONF_auto_max_value = "auto_max_value"
-CONF_step = "step"
+CONF_AUTO_MIN_VALUE = "auto_min_value"
+CONF_AUTO_MAX_VALUE = "auto_max_value"
 
 OpenthermInput = generate.opentherm_ns.class_("OpenthermInput")
 
 
 def validate_min_value_less_than_max_value(conf):
     if (
-        CONF_min_value in conf
-        and CONF_max_value in conf
-        and conf[CONF_min_value] > conf[CONF_max_value]
+        CONF_MIN_VALUE in conf
+        and CONF_MAX_VALUE in conf
+        and conf[CONF_MIN_VALUE] > conf[CONF_MAX_VALUE]
     ):
-        raise cv.Invalid(f"{CONF_min_value} must be less than {CONF_max_value}")
+        raise cv.Invalid(f"{CONF_MIN_VALUE} must be less than {CONF_MAX_VALUE}")
     return conf
 
 
 def input_schema(entity: schema.InputSchema) -> cv.Schema:
     result = cv.Schema(
         {
-            cv.Optional(CONF_min_value, entity.range[0]): cv.float_range(
+            cv.Optional(CONF_MIN_VALUE, entity.range[0]): cv.float_range(
                 entity.range[0], entity.range[1]
             ),
-            cv.Optional(CONF_max_value, entity.range[1]): cv.float_range(
+            cv.Optional(CONF_MAX_VALUE, entity.range[1]): cv.float_range(
                 entity.range[0], entity.range[1]
             ),
         }
     )
     result = result.add_extra(validate_min_value_less_than_max_value)
-    result = result.extend({cv.Optional(CONF_step, False): cv.float_})
     if entity.auto_min_value is not None:
-        result = result.extend({cv.Optional(CONF_auto_min_value, False): cv.boolean})
+        result = result.extend({cv.Optional(CONF_AUTO_MIN_VALUE, False): cv.boolean})
     if entity.auto_max_value is not None:
-        result = result.extend({cv.Optional(CONF_auto_max_value, False): cv.boolean})
+        result = result.extend({cv.Optional(CONF_AUTO_MAX_VALUE, False): cv.boolean})
 
     return result
 
 
 def generate_setters(entity: cg.MockObj, conf: dict[str, Any]) -> None:
-    generate.add_property_set(entity, CONF_min_value, conf)
-    generate.add_property_set(entity, CONF_max_value, conf)
-    generate.add_property_set(entity, CONF_auto_min_value, conf)
-    generate.add_property_set(entity, CONF_auto_max_value, conf)
+    generate.add_property_set(entity, CONF_MIN_VALUE, conf)
+    generate.add_property_set(entity, CONF_MAX_VALUE, conf)
+    generate.add_property_set(entity, CONF_AUTO_MIN_VALUE, conf)
+    generate.add_property_set(entity, CONF_AUTO_MAX_VALUE, conf)

--- a/esphome/components/opentherm/number/__init__.py
+++ b/esphome/components/opentherm/number/__init__.py
@@ -3,7 +3,13 @@ from typing import Any
 import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
-from esphome.const import CONF_INITIAL_VALUE, CONF_RESTORE_VALUE, CONF_STEP
+from esphome.const import (
+    CONF_INITIAL_VALUE,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_RESTORE_VALUE,
+    CONF_STEP,
+)
 
 from .. import const, generate, input, schema, validate
 
@@ -18,9 +24,9 @@ OpenthermNumber = generate.opentherm_ns.class_(
 async def new_openthermnumber(config: dict[str, Any]) -> cg.Pvariable:
     var = await number.new_number(
         config,
-        min_value=config[input.CONF_min_value],
-        max_value=config[input.CONF_max_value],
-        step=config[input.CONF_step],
+        min_value=config[CONF_MIN_VALUE],
+        max_value=config[CONF_MAX_VALUE],
+        step=config[CONF_STEP],
     )
     await cg.register_component(var, config)
     input.generate_setters(var, config)


### PR DESCRIPTION
# What does this implement/fix?

Fix opentherm number entities getting `step=0` instead of the correct entity-defined step value.

The number schema correctly sets `cv.Optional(CONF_STEP, entity.step)` (e.g. `step=0.1`), but then `input_schema()` extended it with `cv.Optional(CONF_step, False)` — same key `"step"` but with `False` as the default. Since the last `.extend()` wins and `False == 0` numerically, the correct step was overwritten with 0.

This caused:
- HA sliders with no granularity (step of 0)
- Potential division-by-zero in HA UI calculations

**Fix:** Remove the redundant `CONF_step` entry from `input_schema()` since the number schema already handles it correctly.

**Also:** Clean up local lowercase `CONF_` constants (`CONF_min_value`, `CONF_max_value`, `CONF_step`) replacing them with standard `CONF_MIN_VALUE`, `CONF_MAX_VALUE`, `CONF_STEP` from `esphome.const`, and rename opentherm-specific ones (`CONF_auto_min_value`, `CONF_auto_max_value`) to `UPPER_CASE`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
opentherm:
  # ...

number:
  - platform: opentherm
    t_set:
      name: "Boiler Setpoint"
      # step now correctly defaults to 0.1 instead of 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).