### PR TITLE
2026.3.3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = ESPHome
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2026.3.2
+PROJECT_NUMBER         = 2026.3.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -47,7 +47,7 @@ from esphome.coroutine import CoroPriority, coroutine_with_priority
 import esphome.final_validate as fv
 from esphome.helpers import copy_file_if_changed, rmtree, write_file_if_changed
 from esphome.types import ConfigType
-from esphome.writer import clean_cmake_cache
+from esphome.writer import clean_build, clean_cmake_cache
 
 from .boards import BOARDS, STANDARD_BOARDS
 from .const import (  # noqa
@@ -1911,6 +1911,7 @@ def _write_sdkconfig():
     if write_file_if_changed(internal_path, contents):
         # internal changed, update real one
         write_file_if_changed(sdk_path, contents)
+        clean_build(clear_pio_cache=False)
 
 
 def _write_idf_component_yml():

--- a/esphome/components/nextion/nextion.cpp
+++ b/esphome/components/nextion/nextion.cpp
@@ -1064,7 +1064,7 @@ void Nextion::add_no_result_to_queue_(const std::string &variable_name) {
   nextion_queue->component = new nextion::NextionComponentBase;
   nextion_queue->component->set_variable_name(variable_name);
 
-  nextion_queue->queue_time = millis();
+  nextion_queue->queue_time = App.get_loop_component_start_time();
 
   this->nextion_queue_.push_back(nextion_queue);
 

--- a/esphome/components/runtime_image/runtime_image.cpp
+++ b/esphome/components/runtime_image/runtime_image.cpp
@@ -247,6 +247,9 @@ void RuntimeImage::release_buffer_() {
     this->height_ = 0;
     this->buffer_width_ = 0;
     this->buffer_height_ = 0;
+#ifdef USE_LVGL
+    memset(&this->dsc_, 0, sizeof(this->dsc_));
+#endif
   }
 }
 

--- a/esphome/const.py
+++ b/esphome/const.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from esphome.enum import StrEnum
 
-__version__ = "2026.3.2"
+__version__ = "2026.3.3"
 
 ALLOWED_NAME_CHARS = "abcdefghijklmnopqrstuvwxyz0123456789-_"
 VALID_SUBSTITUTIONS_CHARACTERS = (


### PR DESCRIPTION
**Do not merge, release script will automatically merge**
- [nextion] Fix queue age check using inconsistent time sources [esphome#15317](https://github.com/esphome/esphome/pull/15317)
- [online_image] Clear LVGL dsc when image size changes. [esphome#15360](https://github.com/esphome/esphome/pull/15360)
- [esp32] Clean build when sdkconfig options change [esphome#15439](https://github.com/esphome/esphome/pull/15439)

<details>
<summary>Metadata</summary>

@coderabbitai ignore
</details>
