### PR TITLE
[api] Use integer comparison for float zero checks in protobuf encoding

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -25,6 +25,19 @@ constexpr uint8_t WIRE_TYPE_LENGTH_DELIMITED = 2;  // string, bytes, embedded me
 constexpr uint8_t WIRE_TYPE_FIXED32 = 5;           // fixed32, sfixed32, float
 constexpr uint8_t WIRE_TYPE_MASK = 0b111;          // Mask to extract wire type from tag
 
+// Reinterpret float bits as uint32_t without floating-point comparison.
+// Used by both encode_float() and calc_float() to ensure identical zero checks.
+// Uses union type-punning which is a GCC/Clang extension (not standard C++),
+// but bit_cast/memcpy don't optimize to a no-op on xtensa-gcc (ESP8266).
+inline uint32_t float_to_raw(float value) {
+  union {
+    float f;
+    uint32_t u;
+  } v;
+  v.f = value;
+  return v.u;
+}
+
 // Helper functions for ZigZag encoding/decoding
 inline constexpr uint32_t encode_zigzag32(int32_t value) {
   return (static_cast<uint32_t>(value) << 1) ^ (static_cast<uint32_t>(value >> 31));
@@ -432,14 +445,10 @@ class ProtoEncode {
   // is needed in the future, the necessary encoding/decoding functions must be added.
   static inline void encode_float(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, uint32_t field_id, float value,
                                   bool force = false) {
-    if (value == 0.0f && !force)
+    uint32_t raw = float_to_raw(value);
+    if (raw == 0 && !force)
       return;
-    union {
-      float value;
-      uint32_t raw;
-    } val{};
-    val.value = value;
-    encode_fixed32(pos PROTO_ENCODE_DEBUG_ARG, field_id, val.raw);
+    encode_fixed32(pos PROTO_ENCODE_DEBUG_ARG, field_id, raw);
   }
   static inline void encode_int32(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, uint32_t field_id, int32_t value,
                                   bool force = false) {
@@ -751,8 +760,8 @@ class ProtoSize {
   }
   static constexpr uint32_t calc_bool(uint32_t field_id_size, bool value) { return value ? field_id_size + 1 : 0; }
   static constexpr uint32_t calc_bool_force(uint32_t field_id_size) { return field_id_size + 1; }
-  static constexpr uint32_t calc_float(uint32_t field_id_size, float value) {
-    return value != 0.0f ? field_id_size + 4 : 0;
+  static uint32_t calc_float(uint32_t field_id_size, float value) {
+    return float_to_raw(value) != 0 ? field_id_size + 4 : 0;
   }
   static constexpr uint32_t calc_fixed32(uint32_t field_id_size, uint32_t value) {
     return value ? field_id_size + 4 : 0;


### PR DESCRIPTION
# What does this implement/fix?

`encode_float()` already used union type-punning to convert a float to its raw uint32_t bits for encoding. However, its zero check still used a floating-point comparison (`value == 0.0f`), and `calc_float()` used `value != 0.0f` with no type-punning at all.

This extracts the existing union type-punning into a shared `float_to_raw()` helper and uses it in both places, so the zero check is a simple integer comparison (`raw == 0`) in both `encode_float()` and `calc_float()`. This ensures size calculation always matches encoding and eliminates the floating-point comparison entirely.

On platforms without hardware FPU (ESP8266, some LibreTiny chips), `value != 0.0f` compiles to a software float library call (`__nesf2` or similar). The new code does a single integer comparison instead.

### Flash size (ESP8266, real device config — neargaragedoor.yaml)

| | Flash | RAM |
|---|---|---|
| dev (before) | 481,473 bytes | 32,052 bytes |
| PR (after) | 481,169 bytes | 32,052 bytes |
| **Delta** | **-304 bytes** | **0** |

### CodSpeed benchmark results

| Benchmark | Before | After | Improvement |
|---|---|---|---|
| CalculateSize_LightStateResponse | 61.5 µs | 53.1 µs | **+15.87%** |
| CalculateSize_SensorStateResponse | 19.6 µs | 18 µs | **+9.28%** |
| Encode_LightStateResponse | 239.7 µs | 223.5 µs | **+7.26%** |

**Note:** The CI memory impact analysis uses a representative test configuration that does not include sensors, lights, or climate components with float fields, so it will not show a flash size delta. The 304-byte savings above was measured on a real ESP8266 device config (ratgdo) that includes sensors, lights, covers, and locks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).