### PR TITLE
[bl0940] Fix restore_value reading from wrong config dict

### DIFF
--- a/esphome/components/bl0940/number/__init__.py
+++ b/esphome/components/bl0940/number/__init__.py
@@ -89,6 +89,6 @@ async def to_code(config):
             )
             await cg.register_component(var, conf)
 
-            if restore_value := config.get(CONF_RESTORE_VALUE):
+            if restore_value := conf.get(CONF_RESTORE_VALUE):
                 cg.add(var.set_restore_value(restore_value))
             cg.add(getattr(bl0940, setter_method)(var))


### PR DESCRIPTION
# What does this implement/fix?

Fix `restore_value` being silently ignored for BL0940 calibration numbers.

Line 92 read `config.get(CONF_RESTORE_VALUE)` from the parent config dict (which contains `current_calibration`, `voltage_calibration`, etc.), but `CONF_RESTORE_VALUE` is defined in the per-calibration `CALIBRATION_SCHEMA` and lives in the `conf` sub-dict.

Since `config` never has a `restore_value` key, `config.get(CONF_RESTORE_VALUE)` always returned `None` and `set_restore_value()` was never called, even when the user explicitly set `restore_value: true` on a calibration number.

**Fix:** Change `config.get(...)` to `conf.get(...)`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
number:
  - platform: bl0940
    current_calibration:
      name: "Current Cal"
      restore_value: true  # was silently ignored before this fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).