### PR TITLE
[espnow] Fix string data generating invalid C++ char literals

### DIFF
--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -245,7 +245,7 @@ async def send_action(
 
     data = config.get(CONF_DATA, [])
     if isinstance(data, str):
-        data = [cg.RawExpression(f"'{c}'") for c in data]
+        data = list(data.encode())
     templ = await cg.templatable(data, args, byte_vector, byte_vector)
     cg.add(var.set_data(templ))
 

--- a/tests/components/espnow/common.yaml
+++ b/tests/components/espnow/common.yaml
@@ -30,6 +30,8 @@ espnow:
     - espnow.broadcast:
         data: "Hello, World!"
     - espnow.broadcast:
+        data: "it's a test"
+    - espnow.broadcast:
         data: [0x01, 0x02, 0x03, 0x04, 0x05]
     - espnow.broadcast:
         data: !lambda 'return {0x01, 0x02, 0x03, 0x04, 0x05};'


### PR DESCRIPTION
# What does this implement/fix?

Fix string data in `espnow.send` / `espnow.broadcast` actions generating invalid C++ when the string contains special characters.

The code converted each character to a C++ char literal using `RawExpression(f"'{c}'")`. For most characters this works, but for single quotes it generates `'''` (three quotes — invalid C++) and for backslashes it generates `'\'` (unterminated escape).

**Example:**
```yaml
- espnow.broadcast:
    data: "it's broken"
```

**Before (invalid C++):**
```cpp
std::vector<uint8_t>({'i', 't', ''', 's', ' ', 'b', 'r', 'o', 'k', 'e', 'n'});
```

**After (valid C++):**
```cpp
std::vector<uint8_t>({105, 116, 39, 115, 32, 98, 114, 111, 107, 101, 110});
```

The fix replaces `[RawExpression(f"'{c}'") for c in data]` with `list(data.encode())` which produces integer byte values that are always valid regardless of string content.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
espnow:
  on_receive:
    - espnow.broadcast:
        data: "it's a test"  # now works correctly
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).