### PR TITLE
[neopixelbus] Fix SPI pin validation accepting one wrong pin on ESP8266

### DIFF
--- a/esphome/components/neopixelbus/_methods.py
+++ b/esphome/components/neopixelbus/_methods.py
@@ -344,7 +344,7 @@ def _spi_extra_validate(config):
     if CORE.is_esp32:
         return
 
-    if config[CONF_DATA_PIN] != 13 and config[CONF_CLOCK_PIN] != 14:
+    if config[CONF_DATA_PIN] != 13 or config[CONF_CLOCK_PIN] != 14:
         raise cv.Invalid(
             "SPI only supports pins GPIO13 for data and GPIO14 for clock on ESP8266"
         )


### PR DESCRIPTION
# What does this implement/fix?

Fix SPI pin validation for NeoPixelBus on ESP8266 only raising an error when **both** pins are wrong.

The condition `config[CONF_DATA_PIN] != 13 and config[CONF_CLOCK_PIN] != 14` uses `and`, which means it only triggers when both pins are invalid. If only one is wrong (e.g. `data_pin: 5` with `clock_pin: 14`), the config is silently accepted and fails at runtime.

**Fix:** Change `and` to `or` so either wrong pin triggers the error.

**Before:** `data_pin: 5, clock_pin: 14` → accepted (wrong)
**After:** `data_pin: 5, clock_pin: 14` → "SPI only supports pins GPIO13 for data and GPIO14 for clock on ESP8266"

Note: This only affects ESP8266. ESP32 skips this check (line 344-345).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
light:
  - platform: neopixelbus
    type: APA102
    variant: APA102
    method: SPI
    num_leds: 10
    data_pin: 13
    clock_pin: 14
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).