### PR TITLE
[pmsx003] Connect model-specific sensor validation to schema

### DIFF
--- a/esphome/components/pmsx003/sensor.py
+++ b/esphome/components/pmsx003/sensor.py
@@ -185,7 +185,7 @@ def validate_update_interval(value):
     return value
 
 
-CONFIG_SCHEMA = (
+CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(PMSX003Component),
@@ -290,7 +290,8 @@ CONFIG_SCHEMA = (
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
-    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(uart.UART_DEVICE_SCHEMA),
+    validate_pmsx003_sensors,
 )
 
 


### PR DESCRIPTION
# What does this implement/fix?

Wire up the existing `validate_pmsx003_sensors` validator that was defined but never connected to `CONFIG_SCHEMA`.

The validator checks that configured sensors are supported by the selected PMS model. For example, `temperature` and `humidity` are only available on PMS5003T and PMS5003ST — configuring them on a PMSX003 would silently create sensors that never publish data.

The validator was already written (line 170) with the correct model-to-sensor mapping, just never added to the schema chain. This adds it via `cv.All()`.

**Before:** `type: PMSX003` with `temperature:` → accepted, sensor never publishes
**After:** `type: PMSX003` with `temperature:` → "PMSX003 does not have temperature sensor!"

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: pmsx003
    type: PMSX003
    pm_2_5:
      name: "PM 2.5"
    # temperature:  ← would now correctly be rejected for PMSX003
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).