### PR TITLE
[prometheus] Fix relabel validation not checking for required keys

### DIFF
--- a/esphome/components/prometheus/__init__.py
+++ b/esphome/components/prometheus/__init__.py
@@ -10,12 +10,14 @@ AUTO_LOAD = ["web_server_base"]
 prometheus_ns = cg.esphome_ns.namespace("prometheus")
 PrometheusHandler = prometheus_ns.class_("PrometheusHandler", cg.Component)
 
-CUSTOMIZED_ENTITY = cv.Schema(
-    {
-        cv.Optional(CONF_ID): cv.string_strict,
-        cv.Optional(CONF_NAME): cv.string_strict,
-    },
-    cv.has_at_least_one_key,
+CUSTOMIZED_ENTITY = cv.All(
+    cv.Schema(
+        {
+            cv.Optional(CONF_ID): cv.string_strict,
+            cv.Optional(CONF_NAME): cv.string_strict,
+        },
+    ),
+    cv.has_at_least_one_key(CONF_ID, CONF_NAME),
 )
 
 CONFIG_SCHEMA = cv.Schema(


### PR DESCRIPTION
# What does this implement/fix?

Fix the prometheus relabel entity schema not validating that at least one of `id` or `name` is provided.

`cv.has_at_least_one_key` was passed as the second positional argument to `cv.Schema()`, which is the `required` flag — not a validator. The function object is truthy so it set `required=True`, but never actually ran as a validator. It was also missing the key name arguments (`CONF_ID`, `CONF_NAME`).

**Before:**
```python
# cv.has_at_least_one_key treated as required=True, not as a validator
CUSTOMIZED_ENTITY = cv.Schema({...}, cv.has_at_least_one_key)
```

**After:**
```python
# Properly validates that at least one key is present
CUSTOMIZED_ENTITY = cv.All(
    cv.Schema({...}),
    cv.has_at_least_one_key(CONF_ID, CONF_NAME),
)
```

Without the fix, an empty relabel entry `{}` passes validation and silently does nothing in code generation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
prometheus:
  relabel:
    my_sensor:
      name: "Custom Name"  # at least one of id/name now required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).