### PR TITLE
[multiple] Fix misc cosmetic bugs (error messages, types, defaults)

### DIFF
--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -390,7 +390,7 @@ def validate_multi_click_timing(value):
         new_state = v_.get(CONF_STATE, not state)
         if new_state == state:
             raise cv.Invalid(
-                f"Timings must have alternating state. Indices {i} and {i + 1} have the same state {state}"
+                f"Timings must have alternating state. Indices {i - 1} and {i} have the same state {state}"
             )
         if max_length is not None and max_length < min_length:
             raise cv.Invalid(

--- a/esphome/components/lc709203f/sensor.py
+++ b/esphome/components/lc709203f/sensor.py
@@ -36,7 +36,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(lc709203f),
-            cv.Optional(CONF_SIZE, default="500"): cv.int_range(100, 3000),
+            cv.Optional(CONF_SIZE, default=500): cv.int_range(100, 3000),
             cv.Optional(CONF_VOLTAGE, default="3.7"): cv.enum(
                 BATTERY_VOLTAGE_OPTIONS, upper=True
             ),

--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -405,7 +405,7 @@ def _model_config_to_manifest_data(model_config):
         file = _compute_local_file_path(model_config) / "manifest.json"
 
     else:
-        raise ValueError("Unsupported config type: {model_config[CONF_TYPE]}")
+        raise ValueError(f"Unsupported config type: {model_config[CONF_TYPE]}")
 
     return _load_model_data(file)
 

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -50,7 +50,7 @@ def validate_min_max_value(config):
         max_val = config[CONF_MAX_VALUE]
         if min_val >= max_val:
             raise cv.Invalid(
-                f"Max value {max_val} must be smaller than min value {min_val}"
+                f"Max value {max_val} must be greater than min value {min_val}"
             )
     return config
 

--- a/esphome/components/sprinkler/__init__.py
+++ b/esphome/components/sprinkler/__init__.py
@@ -272,7 +272,7 @@ SPRINKLER_VALVE_SCHEMA = cv.Schema(
                     ),
                     cv.Optional(
                         CONF_UNIT_OF_MEASUREMENT, default=UNIT_SECOND
-                    ): cv.one_of(UNIT_MINUTE, UNIT_SECOND, lower="True"),
+                    ): cv.one_of(UNIT_MINUTE, UNIT_SECOND, lower=True),
                 }
             )
             .extend(cv.COMPONENT_SCHEMA),

--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -127,7 +127,7 @@ def validate_st7789v(config):
 
     if model_data[REQUIRE_PS] and CONF_POWER_SUPPLY not in config:
         raise cv.Invalid(
-            f'{CONF_POWER_SUPPLY} must be specified when {CONF_MODEL} is {config[CONF_MODEL]}"'
+            f"{CONF_POWER_SUPPLY} must be specified when {CONF_MODEL} is {config[CONF_MODEL]}"
         )
 
     if (


### PR DESCRIPTION
# What does this implement/fix?

Six small fixes for cosmetic bugs found during a codebase-wide Python scan:

| Component | Fix |
|-----------|-----|
| **sprinkler** | `lower="True"` (string) → `lower=True` (bool). Works by accident since non-empty strings are truthy, but wrong type. |
| **lc709203f** | `default="500"` (string) → `default=500` (int). The `cv.int_range` validator coerces it, but the default type should match. |
| **st7789v** | Remove stray trailing `"` in validation error message f-string. |
| **rotary_encoder** | Error says "Max value must be smaller than min value" — inverted. Fixed to "must be greater than". |
| **micro_wake_word** | Missing `f` prefix on error string with `{model_config[CONF_TYPE]}` placeholder — showed literal braces. |
| **binary_sensor** | Multi-click timing error reports indices `{i} and {i+1}` but conflict is between `{i-1} and {i}`. |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — these fix error messages, default types, and argument types
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).