### PR TITLE
[ota] Fix check_error skipping validation for RESPONSE_OK

### DIFF
--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -130,7 +130,7 @@ def check_error(data: list[int] | bytes, expect: int | list[int] | None) -> None
     :param expect: Expected response code(s), None to skip validation.
     :raises OTAError: If an error code is detected or response doesn't match expected.
     """
-    if not expect:
+    if expect is None:
         return
     if not data:
         raise OTAError(

--- a/esphome/espota2.py
+++ b/esphome/espota2.py
@@ -278,7 +278,7 @@ def perform_ota(
             raise OTAError("ESP requests password, but no password given!")
 
         nonce_bytes = receive_exactly(
-            sock, nonce_size, f"{hash_name} authentication nonce", [], decode=False
+            sock, nonce_size, f"{hash_name} authentication nonce", None, decode=False
         )
         assert isinstance(nonce_bytes, bytes)
         nonce = nonce_bytes.decode()


### PR DESCRIPTION
# What does this implement/fix?

Fix OTA error checking being silently skipped when validating for `RESPONSE_OK` (0x00).

`check_error()` used `if not expect: return` to skip validation when `expect=None`. But `RESPONSE_OK` is `0x00`, which is also falsy in Python. So `check_error(data, RESPONSE_OK)` skipped all validation — error codes from the device were silently ignored.

This affects line 245 where the OTA handshake validates the version response:
```python
_, version = receive_exactly(sock, 2, "version", RESPONSE_OK)
```

If the device responded with an error code instead of OK, the error would be silently swallowed and the OTA would continue with bad data.

**Fix:** `if not expect` → `if expect is None`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — this fixes the OTA upload protocol error handling
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).