### PR TITLE
[multiple] Fix misc cosmetic bugs (batch 2)

### DIFF
--- a/esphome/components/atm90e32/sensor.py
+++ b/esphome/components/atm90e32/sensor.py
@@ -132,7 +132,6 @@ ATM90E32_PHASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_PHASE_ANGLE): sensor.sensor_schema(
             unit_of_measurement=UNIT_DEGREES,
             accuracy_decimals=2,
-            device_class=DEVICE_CLASS_POWER,
             state_class=STATE_CLASS_MEASUREMENT,
         ),
         cv.Optional(CONF_HARMONIC_POWER): sensor.sensor_schema(

--- a/esphome/components/esp8266/gpio.py
+++ b/esphome/components/esp8266/gpio.py
@@ -155,7 +155,7 @@ ESP8266_PIN_SCHEMA = cv.All(
 
 @dataclass
 class PinInitialState:
-    mode = 255
+    mode: int = 255
     level: int = 255
 
 

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -158,7 +158,7 @@ def validate_peer(value):
 
 def _validate_raw_data(value):
     if isinstance(value, str):
-        if len(value) >= MAX_ESPNOW_PACKET_SIZE:
+        if len(value) > MAX_ESPNOW_PACKET_SIZE:
             raise cv.Invalid(
                 f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
             )

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -160,13 +160,13 @@ def _validate_raw_data(value):
     if isinstance(value, str):
         if len(value) > MAX_ESPNOW_PACKET_SIZE:
             raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
+                f"'{CONF_DATA}' must be at most {MAX_ESPNOW_PACKET_SIZE} characters long, got {len(value)}"
             )
         return value
     if isinstance(value, list):
         if len(value) > MAX_ESPNOW_PACKET_SIZE:
             raise cv.Invalid(
-                f"'{CONF_DATA}' must be less than {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
+                f"'{CONF_DATA}' must be at most {MAX_ESPNOW_PACKET_SIZE} bytes long, got {len(value)}"
             )
         return cv.Schema([cv.hex_uint8_t])(value)
     raise cv.Invalid(

--- a/esphome/components/kamstrup_kmp/sensor.py
+++ b/esphome/components/kamstrup_kmp/sensor.py
@@ -13,6 +13,7 @@ from esphome.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLUME,
+    DEVICE_CLASS_VOLUME_FLOW_RATE,
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_CELSIUS,
@@ -75,7 +76,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_FLOW): sensor.sensor_schema(
                 accuracy_decimals=1,
-                device_class=DEVICE_CLASS_VOLUME,
+                device_class=DEVICE_CLASS_VOLUME_FLOW_RATE,
                 state_class=STATE_CLASS_MEASUREMENT,
                 unit_of_measurement=UNIT_LITRE_PER_HOUR,
             ),

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -46,7 +46,7 @@ def validate_acceleration(value):
 
 def validate_speed(value):
     value = cv.string(value)
-    for suffix in ("steps/s", "steps/s"):
+    for suffix in ("steps/s",):
         value = value.removesuffix(suffix)
 
     if value == "inf":

--- a/esphome/zeroconf.py
+++ b/esphome/zeroconf.py
@@ -25,7 +25,7 @@ _BACKGROUND_TASKS: set[asyncio.Task] = set()
 
 
 class DashboardStatus:
-    def __init__(self, on_update: Callable[[dict[str, bool | None], []]]) -> None:
+    def __init__(self, on_update: Callable[[dict[str, bool | None]], None]) -> None:
         """Initialize the dashboard status."""
         self.on_update = on_update
 


### PR DESCRIPTION
# What does this implement/fix?

Six small fixes found during a codebase-wide Python scan:

| Component | Fix |
|-----------|-----|
| **zeroconf** | Fix malformed type hint `Callable[[dict[...], []]]` → `Callable[[dict[...]], None]`. The `[]` was an invalid type. |
| **stepper** | Remove duplicate `"steps/s"` suffix in `validate_speed` tuple. |
| **espnow** | Fix string data length check using `>=` while list check uses `>`. Both should use `>` since `MAX_ESPNOW_PACKET_SIZE` (250) is the max valid length. |
| **esp8266** | Add missing `: int` type annotation to `PinInitialState.mode` dataclass field. Without it, `mode` is a class variable not a dataclass field. |
| **kamstrup_kmp** | Flow sensor used `DEVICE_CLASS_VOLUME` but unit is `l/h` (flow rate). Changed to `DEVICE_CLASS_VOLUME_FLOW_RATE`. |
| **atm90e32** | Phase angle sensor used `DEVICE_CLASS_POWER` but measures degrees. Removed the incorrect device_class since there's no HA device class for phase angle. |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — these fix type hints, error messages, device classes, and validation
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).