### PR TITLE
[core] Replace deprecated datetime.utcfromtimestamp()

### DIFF
--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 import logging
 from pathlib import Path
 
@@ -27,8 +27,8 @@ def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
         _LOGGER.debug("has_remote_file_changed: File exists at %s", local_file_path)
         try:
             local_modification_time = local_file_path.stat().st_mtime
-            local_modification_time_str = datetime.utcfromtimestamp(
-                local_modification_time
+            local_modification_time_str = datetime.fromtimestamp(
+                local_modification_time, tz=UTC
             ).strftime("%a, %d %b %Y %H:%M:%S GMT")
 
             headers = {


### PR DESCRIPTION
# What does this implement/fix?

Replace `datetime.utcfromtimestamp()` with `datetime.fromtimestamp(ts, tz=UTC)`.

`utcfromtimestamp()` has been deprecated since Python 3.12 and is scheduled for removal in a future version. It returns a naive datetime which can cause subtle timezone bugs. The replacement returns a timezone-aware UTC datetime.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal Python change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).