### PR TITLE
[esp32_ble][esp32_ble_server][esp32_ble_beacon] Fix UUID regex, IndexError, and unused inheritance

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -373,14 +373,14 @@ def bt_uuid(value):
     value = in_value.upper()
 
     if len(value) == len(bt_uuid16_format):
-        pattern = re.compile("^[A-F|0-9]{4,}$")
+        pattern = re.compile("^[A-F0-9]{4,}$")
         if not pattern.match(value):
             raise cv.Invalid(
                 f"Invalid hexadecimal value for 16 bit UUID format: '{in_value}'"
             )
         return value
     if len(value) == len(bt_uuid32_format):
-        pattern = re.compile("^[A-F|0-9]{8,}$")
+        pattern = re.compile("^[A-F0-9]{8,}$")
         if not pattern.match(value):
             raise cv.Invalid(
                 f"Invalid hexadecimal value for 32 bit UUID format: '{in_value}'"
@@ -388,7 +388,7 @@ def bt_uuid(value):
         return value
     if len(value) == len(bt_uuid128_format):
         pattern = re.compile(
-            "^[A-F|0-9]{8,}-[A-F|0-9]{4,}-[A-F|0-9]{4,}-[A-F|0-9]{4,}-[A-F|0-9]{12,}$"
+            "^[A-F0-9]{8,}-[A-F0-9]{4,}-[A-F0-9]{4,}-[A-F0-9]{4,}-[A-F0-9]{12,}$"
         )
         if not pattern.match(value):
             raise cv.Invalid(

--- a/esphome/components/esp32_ble_beacon/__init__.py
+++ b/esphome/components/esp32_ble_beacon/__init__.py
@@ -10,11 +10,7 @@ AUTO_LOAD = ["esp32_ble"]
 DEPENDENCIES = ["esp32"]
 
 esp32_ble_beacon_ns = cg.esphome_ns.namespace("esp32_ble_beacon")
-ESP32BLEBeacon = esp32_ble_beacon_ns.class_(
-    "ESP32BLEBeacon",
-    cg.Component,
-    cg.Parented.template(esp32_ble.ESP32BLE),
-)
+ESP32BLEBeacon = esp32_ble_beacon_ns.class_("ESP32BLEBeacon", cg.Component)
 CONF_MAJOR = "major"
 CONF_MINOR = "minor"
 CONF_MIN_INTERVAL = "min_interval"

--- a/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
+++ b/esphome/components/esp32_ble_beacon/esp32_ble_beacon.h
@@ -35,7 +35,7 @@ using esp_ble_ibeacon_t = struct {
 
 using namespace esp32_ble;
 
-class ESP32BLEBeacon : public Component, public Parented<ESP32BLE> {
+class ESP32BLEBeacon : public Component {
  public:
   explicit ESP32BLEBeacon(const std::array<uint8_t, 16> &uuid) : uuid_(uuid) {}
 

--- a/esphome/components/esp32_ble_server/__init__.py
+++ b/esphome/components/esp32_ble_server/__init__.py
@@ -307,24 +307,30 @@ def final_validate_config(config):
     # Check if all characteristics that require notifications have the notify property set
     for char_id in CORE.data.get(DOMAIN, {}).get(KEY_NOTIFY_REQUIRED, set()):
         # Look for the characteristic in the configuration
-        char_config = [
+        matches = [
             char_conf
             for service_conf in config[CONF_SERVICES]
             for char_conf in service_conf[CONF_CHARACTERISTICS]
             if char_conf[CONF_ID] == char_id
-        ][0]
+        ]
+        if not matches:
+            continue
+        char_config = matches[0]
         if not char_config[CONF_NOTIFY]:
             raise cv.Invalid(
                 f"Characteristic {char_config[CONF_UUID]} has notify actions and the {CONF_NOTIFY} property is not set"
             )
     for char_id in CORE.data.get(DOMAIN, {}).get(KEY_SET_VALUE, set()):
         # Look for the characteristic in the configuration
-        char_config = [
+        matches = [
             char_conf
             for service_conf in config[CONF_SERVICES]
             for char_conf in service_conf[CONF_CHARACTERISTICS]
             if char_conf[CONF_ID] == char_id
-        ][0]
+        ]
+        if not matches:
+            continue
+        char_config = matches[0]
         if isinstance(char_config.get(CONF_VALUE, {}).get(CONF_DATA), cv.Lambda):
             raise cv.Invalid(
                 f"Characteristic {char_config[CONF_UUID]} has both a set_value action and a templated value"


### PR DESCRIPTION
# What does this implement/fix?

Three small fixes in the ESP32 BLE components:

**esp32_ble — UUID regex matches pipe character**

The regex character class `[A-F|0-9]` included the literal `|` character. Inside `[]`, `|` is not alternation — it's a literal match. A UUID containing a pipe would incorrectly pass validation. Fixed to `[A-F0-9]` in all three UUID format patterns (16-bit, 32-bit, 128-bit).

**esp32_ble_server — IndexError on missing characteristic ID**

`final_validate_config` used `[0]` directly on a list comprehension to look up characteristic IDs registered by notify/set_value actions. If the ID didn't match any characteristic in the config, the empty list caused `IndexError`. Changed to check for empty results and `continue`.

**esp32_ble_beacon — remove unused `Parented<ESP32BLE>` inheritance**

`ESP32BLEBeacon` inherited `Parented<ESP32BLE>` but `parent_` was never set (no `register_parented` in `to_code`) and never accessed in the C++ implementation. The beacon communicates with the BLE stack via the gap event callback, not a parent pointer. Removed from both C++ header and Python class declaration.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal validation and class hierarchy fixes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).