### PR TITLE
[multiple] Fix misc low-priority bugs (batch 3)

### DIFF
--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -119,7 +119,7 @@ DisplayMenuOnPrevTrigger = display_menu_base_ns.class_(
 
 
 def validate_format(format):
-    if re.search(r"^%([+-])*(\d+)*(\.\d+)*[fg]$", format) is None:
+    if re.search(r"^%([+-])*(\d+)*(\.\d+)?[fg]$", format) is None:
         raise cv.Invalid(
             f"{CONF_FORMAT}: has to specify a printf-like format string specifying exactly one f or g type conversion, '{format}' provided"
         )

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -119,7 +119,7 @@ DisplayMenuOnPrevTrigger = display_menu_base_ns.class_(
 
 
 def validate_format(format):
-    if re.search(r"^%([+-])*(\d+)*(\.\d+)?[fg]$", format) is None:
+    if re.search(r"^%[+-]*(\d+)?(\.\d+)?[fg]$", format) is None:
         raise cv.Invalid(
             f"{CONF_FORMAT}: has to specify a printf-like format string specifying exactly one f or g type conversion, '{format}' provided"
         )

--- a/esphome/components/ens160_base/__init__.py
+++ b/esphome/components/ens160_base/__init__.py
@@ -24,7 +24,6 @@ CODEOWNERS = ["@vincentscode", "@latonita"]
 ens160_ns = cg.esphome_ns.namespace("ens160_base")
 
 CONF_AQI = "aqi"
-UNIT_INDEX = "index"
 
 CONFIG_SCHEMA_BASE = cv.Schema(
     {

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -238,7 +238,7 @@ def validate_font_config(config):
     return config
 
 
-FONT_EXTENSIONS = (".ttf", ".woff", ".otf", "bdf", ".pcf")
+FONT_EXTENSIONS = (".ttf", ".woff", ".otf", ".bdf", ".pcf")
 
 
 def validate_truetype_file(value):

--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -66,7 +66,7 @@ KNOWN_FIRMWARE = {
 
 
 def parse_firmware_version(value):
-    match = re.match(r"(\d+).(\d+)", value)
+    match = re.match(r"(\d+)\.(\d+)", value)
     if match is None:
         raise ValueError(f"Not a valid version number {value}")
     major = int(match[1])
@@ -128,7 +128,7 @@ def validate_firmware(value):
 
 def validate_sha256(value):
     value = cv.string(value)
-    if not value.isalnum() or not len(value) == 64:
+    if len(value) != 64 or not re.fullmatch(r"[0-9a-fA-F]{64}", value):
         raise ValueError(f"Not a valid SHA256 hex string: {value}")
     return value
 

--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -66,7 +66,7 @@ KNOWN_FIRMWARE = {
 
 
 def parse_firmware_version(value):
-    match = re.match(r"(\d+)\.(\d+)", value)
+    match = re.fullmatch(r"(\d+)\.(\d+)", value)
     if match is None:
         raise ValueError(f"Not a valid version number {value}")
     major = int(match[1])

--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -128,7 +128,7 @@ def validate_firmware(value):
 
 def validate_sha256(value):
     value = cv.string(value)
-    if len(value) != 64 or not re.fullmatch(r"[0-9a-fA-F]{64}", value):
+    if not re.fullmatch(r"[0-9a-fA-F]{64}", value):
         raise ValueError(f"Not a valid SHA256 hex string: {value}")
     return value
 


### PR DESCRIPTION
# What does this implement/fix?

Five small fixes found during a codebase-wide Python scan:

| Component | Fix |
|-----------|-----|
| **shelly_dimmer** | Escape dot in firmware version regex (`(\d+).(\d+)` → `(\d+)\.(\d+)`). Unescaped `.` matched any character, so `"51x5"` would pass as version `51.5`. |
| **shelly_dimmer** | Replace `isalnum()` with hex-only regex for SHA256 validation. `isalnum()` accepted non-hex characters (g-z), so a 64-char string of all z's would pass. |
| **font** | Add missing dot to `"bdf"` → `".bdf"` in `FONT_EXTENSIONS`. Other entries (`.ttf`, `.woff`, etc.) all have the dot. Without it, any filename ending in `bdf` (e.g. `mybdf`) would incorrectly match. |
| **ens160_base** | Remove unused `UNIT_INDEX = "index"` constant. Never referenced anywhere. |
| **display_menu_base** | Fix `validate_format` regex allowing multiple precision specifiers (e.g. `%.3.2f`). Changed `(\.\d+)*` to `(\.\d+)?` so at most one precision is accepted. |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — these fix validation logic, regex patterns, and dead code
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).