### PR TITLE
[ltr390] Reduce data polling delay and timeout

### DIFF
--- a/esphome/components/ltr390/ltr390.cpp
+++ b/esphome/components/ltr390/ltr390.cpp
@@ -45,6 +45,7 @@ optional<uint32_t> LTR390Component::read_sensor_data_(LTR390MODE mode) {
   uint8_t buffer[num_bytes];
 
   // Wait until data available
+  constexpr uint32_t max_wait_ms = 25;
   const uint32_t now = millis();
   while (true) {
     std::bitset<8> status = this->reg(LTR390_MAIN_STATUS).get();
@@ -52,12 +53,12 @@ optional<uint32_t> LTR390Component::read_sensor_data_(LTR390MODE mode) {
     if (available)
       break;
 
-    if (millis() - now > 100) {
+    if (millis() - now > max_wait_ms) {
       ESP_LOGW(TAG, "Sensor didn't return any data, aborting");
       return {};
     }
-    ESP_LOGD(TAG, "Waiting for data");
-    delay(2);
+    ESP_LOGV(TAG, "Waiting for data");
+    delay(1);
   }
 
   if (!this->read_bytes(MODEADDRESSES[mode], buffer, num_bytes)) {


### PR DESCRIPTION
# What does this implement/fix?

Reduces the blocking time of the LTR390 data polling loop:

- Polling delay reduced from 2ms to 1ms (verified sufficient in practice — data is ready within one retry)
- Timeout reduced from 100ms to 25ms to stay within the 30ms max blocking time guideline
- Polling "Waiting for data" log message changed from DEBUG to VERBOSE to reduce log spam during normal operation

In testing, `ltr390.sensor` average time per read dropped from ~6-8ms to ~4.2ms.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ltr390
    uv_index:
      name: "LTR390 UV Index"
    light:
      name: "LTR390 Light"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).