### PR TITLE
[multiple] Fix validation ranges and error messages

### DIFF
--- a/esphome/components/bmp581_spi/sensor.py
+++ b/esphome/components/bmp581_spi/sensor.py
@@ -31,7 +31,7 @@ BMP581SPIComponent = bmp581_ns.class_(
 def check_spi_mode(config):
     spi_mode = config.get(CONF_SPI_MODE)
     if spi_mode not in VALID_SPI_MODES:
-        raise cv.Invalid("BMP581 only supports SPI mode 3")
+        raise cv.Invalid("BMP581 only supports SPI mode 0 or mode 3")
     return config
 
 

--- a/esphome/components/mcp23s08/__init__.py
+++ b/esphome/components/mcp23s08/__init__.py
@@ -18,7 +18,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.declare_id(mcp23S08),
-            cv.Optional(CONF_DEVICEADDRESS, default=0): cv.uint8_t,
+            cv.Optional(CONF_DEVICEADDRESS, default=0): cv.int_range(min=0, max=3),
         }
     )
     .extend(mcp23xxx_base.MCP23XXX_CONFIG_SCHEMA)

--- a/esphome/components/mcp23s17/__init__.py
+++ b/esphome/components/mcp23s17/__init__.py
@@ -18,7 +18,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.declare_id(mcp23S17),
-            cv.Optional(CONF_DEVICEADDRESS, default=0): cv.uint8_t,
+            cv.Optional(CONF_DEVICEADDRESS, default=0): cv.int_range(min=0, max=7),
         }
     )
     .extend(mcp23xxx_base.MCP23XXX_CONFIG_SCHEMA)

--- a/esphome/components/pcd8544/display.py
+++ b/esphome/components/pcd8544/display.py
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
             cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,  # CE
-            cv.Optional(CONF_CONTRAST, default=0x7F): cv.int_,
+            cv.Optional(CONF_CONTRAST, default=0x7F): cv.int_range(min=0, max=127),
         }
     )
     .extend(cv.polling_component_schema("1s"))


### PR DESCRIPTION
# What does this implement/fix?

Four validation fixes:

**bmp581_spi** — Error message said "only supports SPI mode 3" but both mode 0 and mode 3 are valid (per `VALID_SPI_MODES` dict and datasheet). Fixed message to "mode 0 or mode 3".

**mcp23s08** — `deviceaddress` validated as `cv.uint8_t` (0-255) but the MCP23S08 only has 2 hardware address pins (A0, A1). The C++ masks with `& 0x03` (line 16 of mcp23s08.cpp), so values >3 silently wrap. Changed to `cv.int_range(min=0, max=3)`.

**mcp23s17** — Same issue, but MCP23S17 has 3 address pins (A0, A1, A2). C++ masks with `& 0b111` (line 17 of mcp23s17.cpp). Changed to `cv.int_range(min=0, max=7)`.

**pcd8544** — `contrast` validated as `cv.int_` (any integer) but the PCD8544 VOP command uses 7 bits (`0x80 | contrast_`). Values above 127 produce incorrect display commands. Changed to `cv.int_range(min=0, max=127)`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# mcp23s08: address now validated to 0-3
mcp23s08:
  id: mcp1
  deviceaddress: 2  # max 3

# mcp23s17: address now validated to 0-7
mcp23s17:
  id: mcp2
  deviceaddress: 5  # max 7
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).