### PR TITLE
[api] Force inline encode_string StringRef wrapper

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -393,8 +393,8 @@ class ProtoEncode {
                                    const std::string &value, bool force = false) {
     encode_string(pos PROTO_ENCODE_DEBUG_ARG, field_id, value.data(), value.size(), force);
   }
-  static inline void encode_string(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, uint32_t field_id,
-                                   const StringRef &ref, bool force = false) {
+  static inline void ESPHOME_ALWAYS_INLINE encode_string(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
+                                                         uint32_t field_id, const StringRef &ref, bool force = false) {
     encode_string(pos PROTO_ENCODE_DEBUG_ARG, field_id, ref.c_str(), ref.size(), force);
   }
   static inline void encode_bytes(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, uint32_t field_id,


### PR DESCRIPTION
# What does this implement/fix?

Force inline the `encode_string` `StringRef` wrapper to eliminate a redundant call/return pair. Without this, every call site goes through a double call: caller → wrapper → main `encode_string`. With `ESPHOME_ALWAYS_INLINE`, the wrapper is inlined and the caller calls the main `encode_string` directly.

On ESP8266 (Xtensa, `-Os`), the compiler keeps the 13-byte wrapper as an out-of-line function because the size math favors it at 37 call sites. However, this ignores the cost of the double call/return (register window rotation on Xtensa). Forcing inline trades ~16 bytes of flash for eliminating 37 redundant call/return sequences on the protobuf encode hot path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).