### PR TITLE
[grove_tb6612fng] Move direction logic from Python to C++ to fix lambda crash

### DIFF
--- a/esphome/components/grove_tb6612fng/__init__.py
+++ b/esphome/components/grove_tb6612fng/__init__.py
@@ -80,11 +80,9 @@ async def grove_tb6612fng_run_to_code(config, action_id, template_arg, args):
 
     template_channel = await cg.templatable(config[CONF_CHANNEL], args, int)
     template_speed = await cg.templatable(config[CONF_SPEED], args, cg.uint16)
-    template_speed = (
-        template_speed if config[CONF_DIRECTION] == "FORWARD" else -template_speed
-    )
     cg.add(var.set_channel(template_channel))
     cg.add(var.set_speed(template_speed))
+    cg.add(var.set_direction(config[CONF_DIRECTION] == "FORWARD"))
     return var
 
 

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.h
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.h
@@ -168,11 +168,19 @@ class GROVETB6612FNGMotorRunAction : public Action<Ts...>, public Parented<Grove
   TEMPLATABLE_VALUE(uint8_t, channel)
   TEMPLATABLE_VALUE(uint16_t, speed)
 
+  void set_direction(bool forward) { this->forward_ = forward; }
+
   void play(const Ts &...x) override {
     auto channel = this->channel_.value(x...);
-    auto speed = this->speed_.value(x...);
+    int16_t speed = this->speed_.value(x...);
+    if (!this->forward_) {
+      speed = -speed;
+    }
     this->parent_->dc_motor_run(channel, speed);
   }
+
+ protected:
+  bool forward_{true};
 };
 
 template<typename... Ts>

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.h
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.h
@@ -172,11 +172,15 @@ class GROVETB6612FNGMotorRunAction : public Action<Ts...>, public Parented<Grove
 
   void play(const Ts &...x) override {
     auto channel = this->channel_.value(x...);
-    int16_t speed = this->speed_.value(x...);
-    if (!this->forward_) {
-      speed = -speed;
+    int32_t speed = this->speed_.value(x...);
+    if (speed > 255) {
+      speed = 255;
     }
-    this->parent_->dc_motor_run(channel, speed);
+    int16_t signed_speed = static_cast<int16_t>(speed);
+    if (!this->forward_) {
+      signed_speed = -signed_speed;
+    }
+    this->parent_->dc_motor_run(channel, signed_speed);
   }
 
  protected:

--- a/esphome/components/grove_tb6612fng/grove_tb6612fng.h
+++ b/esphome/components/grove_tb6612fng/grove_tb6612fng.h
@@ -172,15 +172,11 @@ class GROVETB6612FNGMotorRunAction : public Action<Ts...>, public Parented<Grove
 
   void play(const Ts &...x) override {
     auto channel = this->channel_.value(x...);
-    int32_t speed = this->speed_.value(x...);
-    if (speed > 255) {
-      speed = 255;
-    }
-    int16_t signed_speed = static_cast<int16_t>(speed);
+    int16_t speed = this->speed_.value(x...);
     if (!this->forward_) {
-      signed_speed = -signed_speed;
+      speed = -speed;
     }
-    this->parent_->dc_motor_run(channel, signed_speed);
+    this->parent_->dc_motor_run(channel, speed);
   }
 
  protected:

--- a/tests/components/grove_tb6612fng/common.yaml
+++ b/tests/components/grove_tb6612fng/common.yaml
@@ -6,6 +6,11 @@ esphome:
           speed: 255
           direction: BACKWARD
           id: test_motor
+      - grove_tb6612fng.run:
+          channel: 0
+          speed: !lambda "return 200;"
+          direction: BACKWARD
+          id: test_motor
       - grove_tb6612fng.stop:
           channel: 1
           id: test_motor


### PR DESCRIPTION
# What does this implement/fix?

Fix `TypeError` crash when using a lambda for `speed` with `direction: BACKWARD` in the `grove_tb6612fng.run` action.

The Python codegen negated the speed with `-template_speed` to implement backward direction. When speed is a lambda, `cg.templatable()` returns a `LambdaExpression` object which has no `__neg__` operator, crashing codegen.

**Fix:** Move the direction logic into the C++ `GROVETB6612FNGMotorRunAction::play()` method:
- Add `set_direction(bool)` setter and `forward_` field
- Negate speed in `play()` when direction is backward  
- Python passes direction as a bool instead of negating speed

This also fixes a type mismatch: speed was stored as `uint16_t` but `dc_motor_run()` takes `int16_t`. The cast now happens explicitly in `play()` where the negation is applied.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# This now works — previously crashed codegen
on_press:
  - grove_tb6612fng.run:
      channel: 0
      speed: !lambda "return 200;"
      direction: BACKWARD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).