### PR TITLE
[hdc2080] Fix tests

### DIFF
--- a/tests/components/hdc2080/common.yaml
+++ b/tests/components/hdc2080/common.yaml
@@ -1,5 +1,6 @@
 sensor:
   - platform: hdc2080
+    i2c_id: i2c_bus
     temperature:
       name: Temperature
     humidity:


### PR DESCRIPTION
# What does this implement/fix?

Fix the following test issue since f33fd047ee5589fa7d21445ed42bb541fe06e92f with the following command:

 ./script/test_build_components -t esp32-idf -e compile

```

sensor.hdc2080: [source /home/user/esphome/tests/test_build_components/build/merged_airthings_wave_mini_airthings_wave_plus_alpha3_plus_309.esp32-idf.yaml:865]

  Too many candidates found for 'i2c_id' type 'i2c::I2CBus' Some are 'i2c_bus', 'multiplex0_chan0'.
  platform: hdc2080
  temperature:
    name: Temperature
    disabled_by_default: False
    force_update: False
    unit_of_measurement: °C
    accuracy_decimals: 1
    device_class: temperature
    state_class: measurement
  humidity:
    name: Humidity
    disabled_by_default: False
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
