### PR TITLE
[graph] Fix legend config incorrectly accepting a list

### DIFF
--- a/esphome/components/graph/__init__.py
+++ b/esphome/components/graph/__init__.py
@@ -110,7 +110,7 @@ GRAPH_SCHEMA = cv.Schema(
         cv.Optional(CONF_MIN_RANGE): cv.float_range(min=0, min_included=False),
         cv.Optional(CONF_MAX_RANGE): cv.float_range(min=0, min_included=False),
         cv.Optional(CONF_TRACES): cv.ensure_list(GRAPH_TRACE_SCHEMA),
-        cv.Optional(CONF_LEGEND): cv.ensure_list(GRAPH_LEGEND_SCHEMA),
+        cv.Optional(CONF_LEGEND): GRAPH_LEGEND_SCHEMA,
     }
 )
 
@@ -192,7 +192,7 @@ async def to_code(config):
         cg.add(var.add_trace(tr))
     # Add legend
     if CONF_LEGEND in config:
-        lgd = config[CONF_LEGEND][0]
+        lgd = config[CONF_LEGEND]
         legend = cg.new_Pvariable(lgd[CONF_ID], GraphLegend())
         if CONF_NAME_FONT in lgd:
             font = await cg.get_variable(lgd[CONF_NAME_FONT])


### PR DESCRIPTION
## What does this implement/fix?

The `legend` config under `graph` was wrapped in `cv.ensure_list()` but only the first element was ever used (`config[CONF_LEGEND][0]`). Legend is a single config block, not a list. This removes the `ensure_list` wrapper so the schema matches the actual usage and the docs.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - no config change, existing single-legend configs continue to work.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).