### PR TITLE
[haier] Fix control_method schema incorrectly using ensure_list

### DIFF
--- a/esphome/components/haier/climate.py
+++ b/esphome/components/haier/climate.py
@@ -215,9 +215,7 @@ CONFIG_SCHEMA = cv.All(
                 {
                     cv.Optional(
                         CONF_CONTROL_METHOD, default="SET_GROUP_PARAMETERS"
-                    ): cv.ensure_list(
-                        cv.enum(SUPPORTED_HON_CONTROL_METHODS, upper=True)
-                    ),
+                    ): cv.enum(SUPPORTED_HON_CONTROL_METHODS, upper=True),
                     cv.Optional(CONF_BEEPER): cv.invalid(
                         f"The {CONF_BEEPER} option is deprecated, use beeper_on/beeper_off actions or beeper switch for a haier platform instead"
                     ),


### PR DESCRIPTION
## What does this implement/fix?

The `control_method` option for the HON protocol was wrapped in `cv.ensure_list()` but the C++ setter `set_control_method()` takes a single `HonControlMethod` enum value, not a list. This only worked by accident via C++ brace initialization. Remove the `ensure_list` wrapper so the schema matches the actual usage.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [x] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A - existing configs with a single value continue to work.

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).