### PR TITLE
[ld2420] Fix select options wrapped in extra list

### DIFF
--- a/esphome/components/ld2420/select/__init__.py
+++ b/esphome/components/ld2420/select/__init__.py
@@ -28,7 +28,7 @@ async def to_code(config):
     if operating_mode_config := config.get(CONF_OPERATING_MODE):
         sel = await select.new_select(
             operating_mode_config,
-            options=[CONF_SELECTS],
+            options=CONF_SELECTS,
         )
         await cg.register_parented(sel, config[CONF_LD2420_ID])
         cg.add(LD2420_component.set_operating_mode_select(sel))


### PR DESCRIPTION
## What does this implement/fix?

`options=[CONF_SELECTS]` wraps the already-a-list in another list, producing `[["Normal","Calibrate","Simple"]]` instead of the expected `["Normal","Calibrate","Simple"]`.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).