### PR TITLE
[lightwaverf] Fix write pin using input schema instead of output

### DIFF
--- a/esphome/components/lightwaverf/__init__.py
+++ b/esphome/components/lightwaverf/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(LIGHTWAVERFComponent),
         cv.Optional(CONF_READ_PIN, default=13): pins.internal_gpio_input_pin_schema,
-        cv.Optional(CONF_WRITE_PIN, default=14): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_WRITE_PIN, default=14): pins.internal_gpio_output_pin_schema,
     }
 ).extend(cv.polling_component_schema("1s"))
 


### PR DESCRIPTION
## What does this implement/fix?

The TX (write) pin incorrectly uses `internal_gpio_input_pin_schema`. It should be `internal_gpio_output_pin_schema` since it is a transmit pin.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).