### PR TITLE
[pcf8563] Fix default I2C address from 8-bit (0xA3) to 7-bit (0x51)

### DIFF
--- a/esphome/components/pcf8563/time.py
+++ b/esphome/components/pcf8563/time.py
@@ -21,7 +21,7 @@ CONFIG_SCHEMA = time.TIME_SCHEMA.extend(
     {
         cv.GenerateID(): cv.declare_id(pcf8563Component),
     }
-).extend(i2c.i2c_device_schema(0xA3))
+).extend(i2c.i2c_device_schema(0x51))
 
 
 @automation.register_action(


### PR DESCRIPTION
# What does this implement/fix?

Fix the PCF8563 RTC default I2C address from `0xA3` to `0x51`.

The PCF8563 datasheet lists the address as "read A3h and write A2h" using 8-bit notation where the LSB is the R/W bit. ESPHome's I2C layer uses 7-bit addresses and handles the R/W bit internally. The correct 7-bit address is `0xA2 >> 1 = 0x51`.

With `0xA3` as the default, the component could not communicate with the RTC chip. Every user of this component must have been manually overriding the address to `0x51` in their config.

The sibling PCF85063 component already uses `0x51` correctly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6407

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
time:
  - platform: pcf8563
    # address now correctly defaults to 0x51
    # previously defaulted to 0xA3 which didn't work
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).