### PR TITLE
[libretiny] Fix board pin alias resolution TypeError

### DIFF
--- a/esphome/components/libretiny/gpio.py
+++ b/esphome/components/libretiny/gpio.py
@@ -41,7 +41,7 @@ def _lookup_board_pins(board):
     board_pins = component.board_pins.get(board, {})
     # Resolve aliased board pins (shorthand when two boards have the same pin configuration)
     while isinstance(board_pins, str):
-        board_pins = board_pins[board_pins]
+        board_pins = component.board_pins[board_pins]
     return board_pins
 
 


### PR DESCRIPTION
# What does this implement/fix?

Fix `_lookup_board_pins()` crashing with `TypeError` when resolving aliased board pin configurations.

When a board's pin config is a string (an alias pointing to another board's pin config), the code did `board_pins = board_pins[board_pins]` — indexing a string with itself. Python raises `TypeError: string indices must be integers, not 'str'`.

The fix looks up the alias name in the component's `board_pins` dict instead: `board_pins = component.board_pins[board_pins]`.

No current LibreTiny boards use aliases (all entries are dicts), so this is a latent bug that would crash if aliased board pin configs were ever added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — fixes internal pin lookup logic for aliased boards
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).