### PR TITLE
[mcp4461] Fix terminal disable passing string where C++ expects char

### DIFF
--- a/esphome/components/mcp4461/output/__init__.py
+++ b/esphome/components/mcp4461/output/__init__.py
@@ -48,11 +48,11 @@ async def to_code(config):
         config[CONF_CHANNEL],
     )
     if not config[CONF_TERMINAL_A]:
-        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], "a"))
+        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], ord("a")))
     if not config[CONF_TERMINAL_B]:
-        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], "b"))
+        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], ord("b")))
     if not config[CONF_TERMINAL_W]:
-        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], "w"))
+        cg.add(parent.initialize_terminal_disabled(config[CONF_CHANNEL], ord("w")))
     if CONF_INITIAL_VALUE in config:
         cg.add(
             parent.set_initial_value(config[CONF_CHANNEL], config[CONF_INITIAL_VALUE])

--- a/tests/components/mcp4461/common.yaml
+++ b/tests/components/mcp4461/common.yaml
@@ -22,3 +22,11 @@ output:
     id: digipot_wiper_4
     mcp4461_id: mcp4461_digipot_01
     channel: D
+
+  - platform: mcp4461
+    id: digipot_wiper_5
+    mcp4461_id: mcp4461_digipot_01
+    channel: A
+    terminal_a: false
+    terminal_b: false
+    terminal_w: false


### PR DESCRIPTION
# What does this implement/fix?

Fix compile error when disabling MCP4461 terminals (`terminal_a: false`, `terminal_b: false`, or `terminal_w: false`).

The Python codegen passed string literals `"a"`, `"b"`, `"w"` to `initialize_terminal_disabled()` which expects a `char` parameter. ESPHome's codegen converts Python strings to C++ string literals (`"a"` = `const char*`), but the C++ function signature is `void initialize_terminal_disabled(Mcp4461WiperIdx wiper, char terminal)`.

**Generated C++ before (broken):**
```cpp
parent->initialize_terminal_disabled(wiper, "a");  // const char* → char: compile error
```

**Generated C++ after (fixed):**
```cpp
parent->initialize_terminal_disabled(wiper, 97);  // int → char: implicit conversion
```

Fix uses `ord("a")` to pass the ASCII value as an integer, which C++ implicitly converts to `char`.

This bug was never caught in CI because no test set any terminal to `false` — the defaults are all `true`, so the code path was never exercised. Added test coverage for all three terminals disabled.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
output:
  - platform: mcp4461
    id: my_digipot
    mcp4461_id: mcp4461_1
    channel: A
    terminal_a: false  # this caused a compile error before the fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).