### PR TITLE
[multiple] Fix channel/pin range validation and widen channel types

### DIFF
--- a/esphome/components/bp1658cj/output.py
+++ b/esphome/components/bp1658cj/output.py
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_BP1658CJ_ID): cv.use_id(BP1658CJ),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=4),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/mcp3008/sensor/__init__.py
+++ b/esphome/components/mcp3008/sensor/__init__.py
@@ -35,7 +35,7 @@ CONFIG_SCHEMA = (
     .extend(
         {
             cv.GenerateID(CONF_MCP3008_ID): cv.use_id(MCP3008),
-            cv.Required(CONF_NUMBER): cv.int_,
+            cv.Required(CONF_NUMBER): cv.int_range(min=0, max=7),
             cv.Optional(CONF_REFERENCE_VOLTAGE, default="3.3V"): cv.voltage,
         }
     )

--- a/esphome/components/my9231/my9231.cpp
+++ b/esphome/components/my9231/my9231.cpp
@@ -83,7 +83,7 @@ void MY9231OutputComponent::loop() {
 }
 void MY9231OutputComponent::set_channel_value_(uint16_t channel, uint16_t value) {
   ESP_LOGV(TAG, "set channels %u to %u", channel, value);
-  uint8_t index = this->num_channels_ - channel - 1;
+  uint16_t index = this->num_channels_ - channel - 1;
   if (this->pwm_amounts_[index] != value) {
     this->update_ = true;
   }

--- a/esphome/components/my9231/my9231.cpp
+++ b/esphome/components/my9231/my9231.cpp
@@ -81,7 +81,7 @@ void MY9231OutputComponent::loop() {
   }
   this->update_ = false;
 }
-void MY9231OutputComponent::set_channel_value_(uint8_t channel, uint16_t value) {
+void MY9231OutputComponent::set_channel_value_(uint16_t channel, uint16_t value) {
   ESP_LOGV(TAG, "set channels %u to %u", channel, value);
   uint8_t index = this->num_channels_ - channel - 1;
   if (this->pwm_amounts_[index] != value) {

--- a/esphome/components/my9231/my9231.h
+++ b/esphome/components/my9231/my9231.h
@@ -30,7 +30,7 @@ class MY9231OutputComponent : public Component {
   class Channel : public output::FloatOutput {
    public:
     void set_parent(MY9231OutputComponent *parent) { parent_ = parent; }
-    void set_channel(uint8_t channel) { channel_ = channel; }
+    void set_channel(uint16_t channel) { channel_ = channel; }
 
    protected:
     void write_state(float state) override {
@@ -39,13 +39,13 @@ class MY9231OutputComponent : public Component {
     }
 
     MY9231OutputComponent *parent_;
-    uint8_t channel_;
+    uint16_t channel_;
   };
 
  protected:
   uint16_t get_max_amount_() const { return (uint32_t(1) << this->bit_depth_) - 1; }
 
-  void set_channel_value_(uint8_t channel, uint16_t value);
+  void set_channel_value_(uint16_t channel, uint16_t value);
   void init_chips_(uint8_t command);
   void write_word_(uint16_t value, uint8_t bits);
   void send_di_pulses_(uint8_t count);

--- a/esphome/components/my9231/output.py
+++ b/esphome/components/my9231/output.py
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_MY9231_ID): cv.use_id(MY9231OutputComponent),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.uint16_t,
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/my9231/output.py
+++ b/esphome/components/my9231/output.py
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_MY9231_ID): cv.use_id(MY9231OutputComponent),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
+        cv.Required(CONF_CHANNEL): cv.uint16_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm16716/output.py
+++ b/esphome/components/sm16716/output.py
@@ -14,7 +14,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_SM16716_ID): cv.use_id(SM16716),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=254),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2135/output.py
+++ b/esphome/components/sm2135/output.py
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_SM2135_ID): cv.use_id(SM2135),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=4),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2235/output.py
+++ b/esphome/components/sm2235/output.py
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_SM2235_ID): cv.use_id(SM2235),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=4),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/sm2335/output.py
+++ b/esphome/components/sm2335/output.py
@@ -15,7 +15,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_SM2335_ID): cv.use_id(SM2335),
         cv.Required(CONF_ID): cv.declare_id(Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=4),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/tlc5947/output/__init__.py
+++ b/esphome/components/tlc5947/output/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_TLC5947_ID): cv.use_id(TLC5947),
         cv.Required(CONF_ID): cv.declare_id(TLC5947Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
+        cv.Required(CONF_CHANNEL): cv.uint16_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/tlc5947/output/__init__.py
+++ b/esphome/components/tlc5947/output/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_TLC5947_ID): cv.use_id(TLC5947),
         cv.Required(CONF_ID): cv.declare_id(TLC5947Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/tlc5947/output/tlc5947_output.h
+++ b/esphome/components/tlc5947/output/tlc5947_output.h
@@ -11,11 +11,11 @@ namespace tlc5947 {
 
 class TLC5947Channel : public output::FloatOutput, public Parented<TLC5947> {
  public:
-  void set_channel(uint8_t channel) { this->channel_ = channel; }
+  void set_channel(uint16_t channel) { this->channel_ = channel; }
 
  protected:
   void write_state(float state) override;
-  uint8_t channel_;
+  uint16_t channel_;
 };
 
 }  // namespace tlc5947

--- a/esphome/components/tlc5971/output/__init__.py
+++ b/esphome/components/tlc5971/output/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_TLC5971_ID): cv.use_id(TLC5971),
         cv.Required(CONF_ID): cv.declare_id(TLC5971Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
+        cv.Required(CONF_CHANNEL): cv.uint16_t,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/tlc5971/output/__init__.py
+++ b/esphome/components/tlc5971/output/__init__.py
@@ -16,7 +16,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
     {
         cv.GenerateID(CONF_TLC5971_ID): cv.use_id(TLC5971),
         cv.Required(CONF_ID): cv.declare_id(TLC5971Channel),
-        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=65535),
+        cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=255),
     }
 ).extend(cv.COMPONENT_SCHEMA)
 

--- a/esphome/components/tlc5971/output/tlc5971_output.h
+++ b/esphome/components/tlc5971/output/tlc5971_output.h
@@ -11,11 +11,11 @@ namespace tlc5971 {
 
 class TLC5971Channel : public output::FloatOutput, public Parented<TLC5971> {
  public:
-  void set_channel(uint8_t channel) { this->channel_ = channel; }
+  void set_channel(uint16_t channel) { this->channel_ = channel; }
 
  protected:
   void write_state(float state) override;
-  uint8_t channel_;
+  uint16_t channel_;
 };
 
 }  // namespace tlc5971


### PR DESCRIPTION
# What does this implement/fix?

Fix channel/pin number validation in 9 components and widen C++ channel types where needed.

**Tighten validation ranges** (6 components):

| Component | Before | After | Reason |
|-----------|--------|-------|--------|
| bp1658cj | 0-65535 | 0-4 | 5-channel chip, `pwm_amounts_` vector sized 5, OOB on >= 5 |
| sm2135 | 0-65535 | 0-4 | Same |
| sm2235 | 0-65535 | 0-4 | Same |
| sm2335 | 0-65535 | 0-4 | Same |
| sm16716 | 0-65535 | 0-254 | `num_channels` is `uint8_t`, channel is zero-indexed |
| mcp3008 | `cv.int_` (any) | 0-7 | 8-channel ADC, C++ masks with `& 0x07` |

**Widen C++ channel type and restore full range** (3 components):

| Component | C++ change | Python change |
|-----------|-----------|---------------|
| tlc5947 | `uint8_t channel_` → `uint16_t` | `max=255` → `cv.uint16_t` |
| tlc5971 | `uint8_t channel_` → `uint16_t` | `max=255` → `cv.uint16_t` |
| my9231 | `uint8_t channel_` → `uint16_t`, also `set_channel_value_` param | `max=255` → `cv.uint16_t` |

TLC5947/TLC5971/MY9231 support chaining multiple chips (up to 85) with 24/12/variable channels each, allowing total channels well above 255. The `uint8_t` channel type silently truncated higher values. Widening to `uint16_t` allows the full chain to be addressed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# bp1658cj: channel 5 now correctly rejected
output:
  - platform: bp1658cj
    id: my_output
    channel: 4  # max is now 4

# tlc5947: channels > 255 now work with chained chips
output:
  - platform: tlc5947
    id: my_output
    channel: 300  # now valid with uint16_t
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).