### PR TITLE
[multiple] Fix validation ranges (batch 2)

### DIFF
--- a/esphome/components/dsmr/__init__.py
+++ b/esphome/components/dsmr/__init__.py
@@ -37,7 +37,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GAS_MBUS_ID, default=1): cv.int_,
             cv.Optional(CONF_WATER_MBUS_ID, default=2): cv.int_,
             cv.Optional(CONF_THERMAL_MBUS_ID, default=3): cv.int_,
-            cv.Optional(CONF_MAX_TELEGRAM_LENGTH, default=1500): cv.int_,
+            cv.Optional(CONF_MAX_TELEGRAM_LENGTH, default=1500): cv.int_range(min=1),
             cv.Optional(CONF_REQUEST_PIN): pins.gpio_output_pin_schema,
             cv.Optional(
                 CONF_REQUEST_INTERVAL, default="0ms"

--- a/esphome/components/hlk_fm22x/__init__.py
+++ b/esphome/components/hlk_fm22x/__init__.py
@@ -136,7 +136,7 @@ async def hlk_fm22x_enroll_to_code(config, action_id, template_arg, args):
     cv.maybe_simple_value(
         {
             cv.GenerateID(): cv.use_id(HlkFm22xComponent),
-            cv.Required(CONF_FACE_ID): cv.templatable(cv.uint16_t),
+            cv.Required(CONF_FACE_ID): cv.templatable(cv.int_range(min=0, max=32767)),
         },
         key=CONF_FACE_ID,
     ),

--- a/esphome/components/micronova/button/__init__.py
+++ b/esphome/components/micronova/button/__init__.py
@@ -28,7 +28,7 @@ CONFIG_SCHEMA = cv.Schema(
                 is_polling_component=False,
             )
         )
-        .extend({cv.Required(CONF_MEMORY_DATA): cv.hex_int_range()}),
+        .extend({cv.Required(CONF_MEMORY_DATA): cv.hex_int_range(min=0x00, max=0xFF)}),
     }
 )
 

--- a/esphome/components/micronova/switch/__init__.py
+++ b/esphome/components/micronova/switch/__init__.py
@@ -37,8 +37,12 @@ CONFIG_SCHEMA = cv.Schema(
         )
         .extend(
             {
-                cv.Optional(CONF_MEMORY_DATA_OFF, default=0x06): cv.hex_int_range(),
-                cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(),
+                cv.Optional(CONF_MEMORY_DATA_OFF, default=0x06): cv.hex_int_range(
+                    min=0x00, max=0xFF
+                ),
+                cv.Optional(CONF_MEMORY_DATA_ON, default=0x01): cv.hex_int_range(
+                    min=0x00, max=0xFF
+                ),
             }
         ),
     }

--- a/esphome/components/pca6416a/__init__.py
+++ b/esphome/components/pca6416a/__init__.py
@@ -51,7 +51,7 @@ PCA6416A_PIN_SCHEMA = cv.All(
     {
         cv.GenerateID(): cv.declare_id(PCA6416AGPIOPin),
         cv.Required(CONF_PCA6416A): cv.use_id(PCA6416AComponent),
-        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=16),
+        cv.Required(CONF_NUMBER): cv.int_range(min=0, max=15),
         cv.Optional(CONF_MODE, default={}): cv.All(
             {
                 cv.Optional(CONF_INPUT, default=False): cv.boolean,

--- a/esphome/components/pcf8574/__init__.py
+++ b/esphome/components/pcf8574/__init__.py
@@ -55,7 +55,7 @@ def validate_mode(value):
 
 PCF8574_PIN_SCHEMA = pins.gpio_base_schema(
     PCF8574GPIOPin,
-    cv.int_range(min=0, max=17),
+    cv.int_range(min=0, max=15),
     modes=[CONF_INPUT, CONF_OUTPUT],
     mode_validator=validate_mode,
     invertible=True,

--- a/esphome/components/xiaomi_mue4094rt/binary_sensor.py
+++ b/esphome/components/xiaomi_mue4094rt/binary_sensor.py
@@ -1,3 +1,4 @@
+from esphome import core
 import esphome.codegen as cg
 from esphome.components import binary_sensor, esp32_ble_tracker
 import esphome.config_validation as cv
@@ -21,9 +22,10 @@ CONFIG_SCHEMA = cv.All(
     .extend(
         {
             cv.Required(CONF_MAC_ADDRESS): cv.mac_address,
-            cv.Optional(
-                CONF_TIMEOUT, default="5s"
-            ): cv.positive_time_period_milliseconds,
+            cv.Optional(CONF_TIMEOUT, default="5s"): cv.All(
+                cv.positive_time_period_milliseconds,
+                cv.Range(max=core.TimePeriod(milliseconds=65535)),
+            ),
         }
     )
     .extend(esp32_ble_tracker.ESP_BLE_DEVICE_SCHEMA)


### PR DESCRIPTION
# What does this implement/fix?

Fix validation ranges in 7 components where config values exceeded what the C++ type or hardware supports.

| Component | Field | Before | After | Reason |
|-----------|-------|--------|-------|--------|
| xiaomi_mue4094rt | timeout | no upper bound | max 65535ms | C++ `uint16_t`, values >65535 silently overflow |
| micronova/button | memory_data | `cv.hex_int_range()` (any) | 0x00-0xFF | C++ `uint8_t` |
| micronova/switch | memory_data_on/off | `cv.hex_int_range()` (any) | 0x00-0xFF | C++ `uint8_t` |
| pca6416a | pin number | max=16 | max=15 | 16 pins (0-15), pin 16 maps to pin 8's hardware |
| pcf8574 | pin number | max=17 | max=15 | PCF8575 has 16 pins (0-15), 17 causes `uint16_t` overflow |
| dsmr | max_telegram_length | `cv.int_` (any) | min=1 | 0 allocates empty buffer, negative wraps to huge `size_t` |
| hlk_fm22x | face_id | `cv.uint16_t` (0-65535) | 0-32767 | C++ `TEMPLATABLE_VALUE(int16_t, face_id)`, values 32768+ overflow to negative |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# xiaomi_mue4094rt: timeout >65s now rejected
binary_sensor:
  - platform: xiaomi_mue4094rt
    timeout: 60s  # max ~65s, was unlimited
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).