### PR TITLE
[multiple] Fix missing entity base classes in Python class declarations

### DIFF
--- a/esphome/components/bh1900nux/sensor.py
+++ b/esphome/components/bh1900nux/sensor.py
@@ -12,7 +12,7 @@ CODEOWNERS = ["@B48D81EFCC"]
 
 sensor_ns = cg.esphome_ns.namespace("bh1900nux")
 BH1900NUXSensor = sensor_ns.class_(
-    "BH1900NUXSensor", cg.PollingComponent, i2c.I2CDevice
+    "BH1900NUXSensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
 CONFIG_SCHEMA = (

--- a/esphome/components/gl_r01_i2c/sensor.py
+++ b/esphome/components/gl_r01_i2c/sensor.py
@@ -13,7 +13,7 @@ DEPENDENCIES = ["i2c"]
 
 gl_r01_i2c_ns = cg.esphome_ns.namespace("gl_r01_i2c")
 GLR01I2CComponent = gl_r01_i2c_ns.class_(
-    "GLR01I2CComponent", i2c.I2CDevice, cg.PollingComponent
+    "GLR01I2CComponent", sensor.Sensor, i2c.I2CDevice, cg.PollingComponent
 )
 
 CONFIG_SCHEMA = (

--- a/esphome/components/ld2420/select/__init__.py
+++ b/esphome/components/ld2420/select/__init__.py
@@ -12,7 +12,7 @@ CONF_SELECTS = [
     "Simple",
 ]
 
-LD2420Select = ld2420_ns.class_("LD2420Select", cg.Component)
+LD2420Select = ld2420_ns.class_("LD2420Select", select.Select, cg.Component)
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_LD2420_ID): cv.use_id(LD2420Component),

--- a/esphome/components/sdp3x/sensor.py
+++ b/esphome/components/sdp3x/sensor.py
@@ -14,7 +14,10 @@ CODEOWNERS = ["@Azimath"]
 
 sdp3x_ns = cg.esphome_ns.namespace("sdp3x")
 SDP3XComponent = sdp3x_ns.class_(
-    "SDP3XComponent", cg.PollingComponent, sensirion_common.SensirionI2CDevice
+    "SDP3XComponent",
+    sensor.Sensor,
+    cg.PollingComponent,
+    sensirion_common.SensirionI2CDevice,
 )
 
 

--- a/esphome/components/sen0321/sensor.py
+++ b/esphome/components/sen0321/sensor.py
@@ -12,7 +12,7 @@ DEPENDENCIES = ["i2c"]
 
 sen0321_sensor_ns = cg.esphome_ns.namespace("sen0321_sensor")
 Sen0321Sensor = sen0321_sensor_ns.class_(
-    "Sen0321Sensor", cg.PollingComponent, i2c.I2CDevice
+    "Sen0321Sensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
 CONFIG_SCHEMA = (

--- a/esphome/components/sen21231/sensor.py
+++ b/esphome/components/sen21231/sensor.py
@@ -8,7 +8,7 @@ DEPENDENCIES = ["i2c"]
 
 sen21231_sensor_ns = cg.esphome_ns.namespace("sen21231_sensor")
 Sen21231Sensor = sen21231_sensor_ns.class_(
-    "Sen21231Sensor", cg.PollingComponent, i2c.I2CDevice
+    "Sen21231Sensor", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
 )
 
 CONFIG_SCHEMA = (

--- a/esphome/components/tc74/sensor.py
+++ b/esphome/components/tc74/sensor.py
@@ -11,7 +11,9 @@ CODEOWNERS = ["@sethgirvan"]
 DEPENDENCIES = ["i2c"]
 
 tc74_ns = cg.esphome_ns.namespace("tc74")
-TC74Component = tc74_ns.class_("TC74Component", cg.PollingComponent, i2c.I2CDevice)
+TC74Component = tc74_ns.class_(
+    "TC74Component", sensor.Sensor, cg.PollingComponent, i2c.I2CDevice
+)
 
 CONFIG_SCHEMA = (
     sensor.sensor_schema(


### PR DESCRIPTION
# What does this implement/fix?

Several components declare their Python `class_()` without including the entity base class (`sensor.Sensor` or `select.Select`) in the parent list, even though the C++ classes correctly inherit from them. This causes `cv.use_id(sensor.Sensor)` / `cv.use_id(select.Select)` cross-references from other components (e.g. `copy` sensor, `template` sensors) to fail validation.

**Sensors missing `sensor.Sensor`:**
- `bh1900nux`
- `gl_r01_i2c`
- `sdp3x`
- `sen0321`
- `sen21231`
- `tc74`

**Select missing `select.Select`:**
- `ld2420`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A
- 
**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# A copy sensor referencing a bh1900nux sensor would previously fail validation:
sensor:
  - platform: bh1900nux
    id: my_temp
    name: Temperature

  - platform: copy
    source_id: my_temp
    name: Temperature Copy
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).