### PR TITLE
[rotary_encoder] Fix set_value action accepting any sensor ID

### DIFF
--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -119,7 +119,7 @@ async def to_code(config):
     RotaryEncoderSetValueAction,
     cv.Schema(
         {
-            cv.Required(CONF_ID): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_ID): cv.use_id(RotaryEncoderSensor),
             cv.Required(CONF_VALUE): cv.templatable(cv.int_),
         }
     ),


### PR DESCRIPTION
# What does this implement/fix?

The `sensor.rotary_encoder.set_value` action used `cv.use_id(sensor.Sensor)` which allowed referencing any sensor by ID, not just rotary encoders. The C++ `RotaryEncoderSetValueAction` constructor expects a `RotaryEncoderSensor *`, so passing a different sensor type would generate incorrect code.

Changed to `cv.use_id(RotaryEncoderSensor)` to restrict the action to only accept rotary encoder sensor IDs.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: rotary_encoder
    id: my_encoder
    name: Rotary Encoder
    pin_a: GPIO12
    pin_b: GPIO13

# This action now correctly requires a rotary_encoder sensor ID
button:
  - platform: template
    name: Reset Encoder
    on_press:
      - sensor.rotary_encoder.set_value:
          id: my_encoder
          value: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).