### PR TITLE
[seeed_mr24hpc1] Move baud rate validation to FINAL_VALIDATE_SCHEMA

### DIFF
--- a/esphome/components/seeed_mr24hpc1/__init__.py
+++ b/esphome/components/seeed_mr24hpc1/__init__.py
@@ -33,6 +33,7 @@ CONFIG_SCHEMA = (
 # This authentication mode requires that the device must have transmit and receive functionality, a parity mode of "NONE", and a stop bit of one.
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
     "seeed_mr24hpc1",
+    baud_rate=115200,
     require_tx=True,
     require_rx=True,
     parity="NONE",

--- a/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
+++ b/esphome/components/seeed_mr24hpc1/seeed_mr24hpc1.cpp
@@ -62,8 +62,6 @@ void MR24HPC1Component::dump_config() {
 
 // Initialisation functions
 void MR24HPC1Component::setup() {
-  this->check_uart_settings(115200);
-
 #ifdef USE_NUMBER
   if (this->custom_mode_number_ != nullptr) {
     this->custom_mode_number_->publish_state(0);  // Zero out the custom mode


### PR DESCRIPTION
# What does this implement/fix?

The seeed_mr24hpc1 component requires 115200 baud but only checked this at runtime via `check_uart_settings()`, which logs a warning but doesn't prevent flashing. Added `baud_rate=115200` to `FINAL_VALIDATE_SCHEMA` so the wrong baud rate is caught at config validation time, and removed the redundant runtime check.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIO1
  rx_pin: GPIO3
  baud_rate: 115200  # now validated at config time

seeed_mr24hpc1:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).