### PR TITLE
[udp] Fix on_receive only processing first automation

### DIFF
--- a/esphome/components/udp/__init__.py
+++ b/esphome/components/udp/__init__.py
@@ -130,12 +130,9 @@ async def to_code(config):
     if (listen_address := str(config[CONF_LISTEN_ADDRESS])) != "255.255.255.255":
         cg.add(var.set_listen_address(listen_address))
     cg.add(var.set_addresses([str(addr) for addr in config[CONF_ADDRESSES]]))
-    if on_receive := config.get(CONF_ON_RECEIVE):
-        on_receive = on_receive[0]
-        trigger_id = cg.new_Pvariable(on_receive[CONF_TRIGGER_ID])
-        trigger = await automation.build_automation(
-            trigger_id, trigger_argtype, on_receive
-        )
+    for conf in config.get(CONF_ON_RECEIVE, []):
+        trigger_id = cg.new_Pvariable(conf[CONF_TRIGGER_ID])
+        trigger = await automation.build_automation(trigger_id, trigger_argtype, conf)
         trigger_lambda = await cg.process_lambda(
             trigger.trigger(
                 cg.std_vector.template(cg.uint8)(
@@ -146,6 +143,7 @@ async def to_code(config):
             listener_argtype,
         )
         cg.add(var.add_listener(trigger_lambda))
+    if config.get(CONF_ON_RECEIVE):
         cg.add(var.set_should_listen())
 
 


### PR DESCRIPTION
# What does this implement/fix?

The `on_receive` automation in the UDP component only processed the first entry — `on_receive[0]` took just the first automation from the list and silently dropped any additional ones. Changed to iterate over all entries using the standard `for conf in config.get(CONF_ON_RECEIVE, [])` pattern.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
udp:
  port: 18511
  on_receive:
    - then:
        - logger.log: "First handler"
    - then:
        - logger.log: "Second handler - previously silently dropped"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).