### PR TITLE
[core] Shrink scheduler vectors after startup to reclaim excess capacity

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -108,6 +108,12 @@ void Application::setup() {
   }
 
   ESP_LOGI(TAG, "setup() finished successfully!");
+  // Shrink scheduler vectors after startup transients settle (one-shot timeouts
+  // from setup cause temporary vector growth).
+  if (!this->components_.empty()) {
+    this->scheduler.set_timeout(this->components_[0], InternalSchedulerID::SCHEDULER_SHRINK, 5000,
+                                [this]() { this->scheduler.shrink_to_fit(); });
+  }
 
 #ifdef USE_SETUP_PRIORITY_OVERRIDE
   // Clear setup priority overrides to free memory

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -63,8 +63,9 @@ inline constexpr uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
 /// Uses a separate NameType (NUMERIC_ID_INTERNAL) so IDs can never collide
 /// with component-level NUMERIC_ID values, even if the uint32_t values overlap.
 enum class InternalSchedulerID : uint32_t {
-  POLLING_UPDATE = 0,  // PollingComponent interval
-  DELAY_ACTION = 1,    // DelayAction timeout
+  POLLING_UPDATE = 0,    // PollingComponent interval
+  DELAY_ACTION = 1,      // DelayAction timeout
+  SCHEDULER_SHRINK = 2,  // Post-startup scheduler vector shrink
 };
 
 // Forward declaration

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -822,6 +822,19 @@ bool HOT Scheduler::SchedulerItem::cmp(SchedulerItem *a, SchedulerItem *b) {
                                                               : (a->next_execution_high_ > b->next_execution_high_);
 }
 
+void Scheduler::shrink_to_fit() {
+  LockGuard guard{this->lock_};
+  // Swap with right-sized copies to release excess capacity.
+  // shrink_to_fit() is non-binding on most embedded allocators, so we
+  // must copy-and-swap to guarantee memory is actually freed.
+  if (this->items_.capacity() > this->items_.size()) {
+    std::vector<SchedulerItem *>(this->items_).swap(this->items_);
+  }
+  if (this->to_add_.capacity() > 0) {
+    std::vector<SchedulerItem *>().swap(this->to_add_);
+  }
+}
+
 // Recycle a SchedulerItem back to the pool for reuse.
 // IMPORTANT: Caller must hold the scheduler lock before calling this function.
 // This protects scheduler_item_pool_ from concurrent access by other threads

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -144,6 +144,8 @@ class Scheduler {
     this->process_to_add_slow_path_();
   }
 
+  void shrink_to_fit();
+
   // Name storage type discriminator for SchedulerItem
   // Used to distinguish between static strings, hashed strings, numeric IDs, and internal numeric IDs
   enum class NameType : uint8_t {


### PR DESCRIPTION
# What does this implement/fix?

During setup, the scheduler's `items_` and `to_add_` vectors grow to accommodate startup timeouts and intervals. As one-shot timeouts fire and complete, the item count drops but the vector capacity stays at its high-water mark, wasting ~100-200 bytes of heap permanently.

This schedules a one-shot timeout 5 seconds after `setup()` completes to shrink both vectors to their actual size via copy-and-swap. `std::vector::shrink_to_fit()` is non-binding on most embedded allocators, so copy-and-swap is needed to guarantee memory is actually freed.

Tested on two devices:
- **neargarageratgdo**: `items` cap 32 → 7 (5 active), `to_add` cap 16 → 0
- **apollo-r-pro-1-eth**: `items` cap 32 → 13 (10 active), `to_add` cap 8 → 0

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — internal scheduler optimization, no config changes.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).