### PR TITLE
[epaper_spi] Fix deep sleep command

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi.h
+++ b/esphome/components/epaper_spi/epaper_spi.h
@@ -110,12 +110,14 @@ class EPaperBase : public Display,
     this->fill(COLOR_ON);
   }
 
- protected:
-  int get_height_internal() override { return this->height_; };
-  int get_width_internal() override { return this->width_; };
   int get_width() override { return this->effective_transform_ & SWAP_XY ? this->height_ : this->width_; }
   int get_height() override { return this->effective_transform_ & SWAP_XY ? this->width_ : this->height_; }
   void draw_pixel_at(int x, int y, Color color) override;
+
+ protected:
+  int get_height_internal() override { return this->height_; };
+  int get_width_internal() override { return this->width_; };
+  bool is_using_partial_update_() const { return this->full_update_every_ > 1; }
   void process_state_();
 
   const char *epaper_state_to_string_();

--- a/esphome/components/epaper_spi/epaper_spi_mono.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_mono.cpp
@@ -20,7 +20,7 @@ void EPaperMono::deep_sleep() {
 
 bool EPaperMono::reset() {
   if (EPaperBase::reset()) {
-    this->command(0x12);
+    this->cmd_data(0x12, {0x03});
     return true;
   }
   return false;

--- a/esphome/components/epaper_spi/epaper_spi_mono.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_mono.cpp
@@ -15,7 +15,11 @@ void EPaperMono::refresh_screen(bool partial) {
 
 void EPaperMono::deep_sleep() {
   ESP_LOGV(TAG, "Deep sleep");
-  this->cmd_data(0x10, {0x03});
+  if (this->is_using_partial_update_()) {
+    this->cmd_data(0x10, {0x00});  // sleep in power on mode
+  } else {
+    this->cmd_data(0x10, {0x03});  // deep sleep
+  }
 }
 
 bool EPaperMono::reset() {
@@ -27,6 +31,14 @@ bool EPaperMono::reset() {
 }
 
 void EPaperMono::set_window() {
+  // if not using partial update, the display will go into deep sleep, so must rewrite entire
+  // buffer since the display RAM will not retain contents
+  if (!this->is_using_partial_update_()) {
+    this->x_low_ = 0;
+    this->x_high_ = this->width_;
+    this->y_low_ = 0;
+    this->y_high_ = this->height_;
+  }
   // round x-coordinates to byte boundaries
   this->x_low_ &= ~7;
   this->x_high_ += 7;

--- a/esphome/components/epaper_spi/epaper_spi_mono.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_mono.cpp
@@ -15,12 +15,12 @@ void EPaperMono::refresh_screen(bool partial) {
 
 void EPaperMono::deep_sleep() {
   ESP_LOGV(TAG, "Deep sleep");
-  this->command(0x10);
+  this->cmd_data(0x10, {0x03});
 }
 
 bool EPaperMono::reset() {
   if (EPaperBase::reset()) {
-    this->cmd_data(0x12, {0x03});
+    this->command(0x12);
     return true;
   }
   return false;

--- a/tests/components/epaper_spi/test.esp32-s3-idf.yaml
+++ b/tests/components/epaper_spi/test.esp32-s3-idf.yaml
@@ -78,6 +78,7 @@ display:
     model: seeed-reterminal-e1002
   - platform: epaper_spi
     model: seeed-ee04-mono-4.26
+    full_update_every: 10
     # Override pins to avoid conflict with other display configs
     busy_pin: 43
     dc_pin: 42


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The deep sleep command lacked an argument, probably meaning it never entered deep sleep.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
