### PR TITLE
[emontx] Fix uart package name in tests

### DIFF
--- a/tests/components/emontx/test.esp32-idf.yaml
+++ b/tests/components/emontx/test.esp32-idf.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp32-idf.yaml
 
 <<: !include common.yaml

--- a/tests/components/emontx/test.esp8266-ard.yaml
+++ b/tests/components/emontx/test.esp8266-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/esp8266-ard.yaml
 
 <<: !include common.yaml

--- a/tests/components/emontx/test.rp2040-ard.yaml
+++ b/tests/components/emontx/test.rp2040-ard.yaml
@@ -1,4 +1,4 @@
 packages:
-  uart: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
+  uart_115200: !include ../../test_build_components/common/uart_115200/rp2040-ard.yaml
 
 <<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Fixes the UART package key name in emontx test files. The package key was `uart` but the include pointed to `uart_115200`, causing merge conflicts during grouped CI builds. Missed in review of https://github.com/esphome/esphome/pull/9027.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes package name missed in review of https://github.com/esphome/esphome/pull/9027

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] ESP32
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - test infrastructure fix only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).