### PR TITLE
[ci] Add lint check for test package key matching bus directory

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -1031,7 +1031,7 @@ def lint_test_package_key_matches_bus(fname, content):
                     1,
                     f"Package key {highlight(pkg_key)} does not match bus directory "
                     f"{highlight(bus_dir)}. The package key must match the directory "
-                    f"name under test_build_components/common/. "
+                    f"name under tests/test_build_components/common/. "
                     f"Change {highlight(pkg_key)} to {highlight(bus_dir)}.",
                 )
             )

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -1006,6 +1006,38 @@ def lint_log_in_header(fname, line, col, content):
     )
 
 
+PACKAGE_BUS_RE = re.compile(
+    r"^\s+(\w+):\s*!include\s+\S*test_build_components/common/(\w+)/",
+    re.MULTILINE,
+)
+
+
+@lint_content_check(include=["tests/components/*/test.*.yaml"])
+def lint_test_package_key_matches_bus(fname, content):
+    """Ensure package keys match the common bus directory name.
+
+    For example, a package using uart_115200 includes must use
+    'uart_115200' as the key, not 'uart'.
+    """
+    errs: list[tuple[int, int, str]] = []
+    for match in PACKAGE_BUS_RE.finditer(content):
+        pkg_key = match.group(1)
+        bus_dir = match.group(2)
+        if pkg_key != bus_dir:
+            lineno = content.count("\n", 0, match.start()) + 1
+            errs.append(
+                (
+                    lineno,
+                    1,
+                    f"Package key {highlight(pkg_key)} does not match bus directory "
+                    f"{highlight(bus_dir)}. The package key must match the directory "
+                    f"name under test_build_components/common/. "
+                    f"Change {highlight(pkg_key)} to {highlight(bus_dir)}.",
+                )
+            )
+    return errs
+
+
 @lint_content_find_check(
     "FINAL_VALIDATE_SCHEMA",
     include=["esphome/core/*.py"],


### PR DESCRIPTION
# What does this implement/fix?

Adds a ci-custom.py lint check that validates package keys in component test YAML files match the directory name in the common bus include path. For example, if a test file includes `../../test_build_components/common/uart_115200/esp32-idf.yaml`, the package key must be `uart_115200`, not `uart`.

This mismatch causes the test grouping script to incorrectly group components with incompatible bus configurations, leading to merge failures during CI. This has happened multiple times with new components (most recently emontx in #9027, fixed in #15546).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Prevents recurring issues like #15546

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - CI tooling only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).