### PR TITLE
[yaml] Add IncludeFile representer to ESPHomeDumper

### DIFF
--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -754,6 +754,9 @@ class ESPHomeDumper(yaml.SafeDumper):
     def represent_remove(self, value):
         return self.represent_scalar(tag="!remove", value=value.value)
 
+    def represent_include_file(self, value):
+        return self.represent_scalar(tag="!include", value=value.file.as_posix())
+
     def represent_id(self, value):
         if is_secret(value.id):
             return self.represent_secret(value.id)
@@ -785,3 +788,4 @@ ESPHomeDumper.add_multi_representer(Remove, ESPHomeDumper.represent_remove)
 ESPHomeDumper.add_multi_representer(core.ID, ESPHomeDumper.represent_id)
 ESPHomeDumper.add_multi_representer(uuid.UUID, ESPHomeDumper.represent_stringify)
 ESPHomeDumper.add_multi_representer(Path, ESPHomeDumper.represent_stringify)
+ESPHomeDumper.add_multi_representer(IncludeFile, ESPHomeDumper.represent_include_file)

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -755,6 +755,11 @@ class ESPHomeDumper(yaml.SafeDumper):
         return self.represent_scalar(tag="!remove", value=value.value)
 
     def represent_include_file(self, value):
+        if value.vars:
+            mapping = {"file": value.file.as_posix(), "vars": value.vars}
+            return self.represent_mapping(
+                tag="!include", mapping=mapping, flow_style=False
+            )
         return self.represent_scalar(tag="!include", value=value.file.as_posix())
 
     def represent_id(self, value):

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -508,6 +508,28 @@ def test_represent_remove() -> None:
     assert yaml_util.dump({"key": Remove("my_id")}) == "key: !remove 'my_id'\n"
 
 
+def test_represent_include_file() -> None:
+    """Test that IncludeFile objects are dumped as !include scalars."""
+    include = yaml_util.IncludeFile(
+        Path("/fake/main.yaml"), "path/to/file.yaml", None, lambda _: {}
+    )
+    assert yaml_util.dump({"key": include}) == "key: !include 'path/to/file.yaml'\n"
+
+
+def test_represent_include_file_with_data_base_mixin() -> None:
+    """Test that IncludeFile wrapped with ESPHomeDataBase mixin is also dumped correctly.
+
+    The YAML loader wraps IncludeFile via add_class_to_obj, creating a dynamic
+    subclass. add_multi_representer must match this subclass through the MRO.
+    """
+    include = yaml_util.IncludeFile(
+        Path("/fake/main.yaml"), "common/spi.yaml", None, lambda _: {}
+    )
+    wrapped = yaml_util.make_data_base(include)
+    assert isinstance(wrapped, yaml_util.ESPHomeDataBase)
+    assert yaml_util.dump({"pkg": wrapped}) == "pkg: !include 'common/spi.yaml'\n"
+
+
 # ── IncludeFile unit tests ──────────────────────────────────────────────────
 
 

--- a/tests/unit_tests/test_yaml_util.py
+++ b/tests/unit_tests/test_yaml_util.py
@@ -516,6 +516,20 @@ def test_represent_include_file() -> None:
     assert yaml_util.dump({"key": include}) == "key: !include 'path/to/file.yaml'\n"
 
 
+def test_represent_include_file_with_vars() -> None:
+    """Test that IncludeFile with vars is dumped as !include mapping form."""
+    include = yaml_util.IncludeFile(
+        Path("/fake/main.yaml"),
+        "path/to/file.yaml",
+        {"key": "value"},
+        lambda _: {},
+    )
+    result = yaml_util.dump({"key": include})
+    assert "!include" in result
+    assert "file: path/to/file.yaml" in result
+    assert "key: value" in result
+
+
 def test_represent_include_file_with_data_base_mixin() -> None:
     """Test that IncludeFile wrapped with ESPHomeDataBase mixin is also dumped correctly.
 


### PR DESCRIPTION
# What does this implement/fix?

The deferred `IncludeFile` objects introduced in #12213 cannot be serialized by the YAML dumper, causing `test_build_components` to fail with `RepresenterError: ('cannot represent an object', IncludeFile(...))` when merging configs that contain `!include` package references.

Adds a `represent_include_file` method to `ESPHomeDumper` that serializes `IncludeFile` back to `!include <path>`. Uses `add_multi_representer` to also match the dynamically-created `ESPHomeDataBase` subclass produced by `add_class_to_obj`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes regression from https://github.com/esphome/esphome/pull/12213

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal tooling fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).