### PR TITLE
[lvgl] Fix args for lambda in set_rotation action

### DIFF
--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -216,7 +216,6 @@ def _validate_rotation(value):
 async def lvgl_set_rotation(config, action_id, template_arg, args):
     lv_comp = await cg.get_variable(config[CONF_LVGL_ID])
     async with LambdaContext(args, where=action_id) as context:
-        add_line_marks(where=action_id)
         lv_add(lv_comp.set_rotation(config[CONF_ROTATION]))
     return cg.new_Pvariable(action_id, template_arg, await context.get_lambda())
 

--- a/esphome/components/lvgl/automation.py
+++ b/esphome/components/lvgl/automation.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 from esphome import automation
+from esphome.automation import StatelessLambdaAction
 import esphome.codegen as cg
 from esphome.components.display import validate_rotation
 import esphome.config_validation as cv
@@ -201,7 +202,7 @@ def _validate_rotation(value):
 
 @automation.register_action(
     "lvgl.display.set_rotation",
-    ObjUpdateAction,
+    StatelessLambdaAction,
     cv.maybe_simple_value(
         LVGL_SCHEMA.extend(
             {
@@ -214,7 +215,7 @@ def _validate_rotation(value):
 )
 async def lvgl_set_rotation(config, action_id, template_arg, args):
     lv_comp = await cg.get_variable(config[CONF_LVGL_ID])
-    async with LambdaContext() as context:
+    async with LambdaContext(args, where=action_id) as context:
         add_line_marks(where=action_id)
         lv_add(lv_comp.set_rotation(config[CONF_ROTATION]))
     return cg.new_Pvariable(action_id, template_arg, await context.get_lambda())

--- a/esphome/components/lvgl/widgets/tabview.py
+++ b/esphome/components/lvgl/widgets/tabview.py
@@ -2,6 +2,7 @@ from esphome import automation
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_BUTTON,
     CONF_ID,
     CONF_INDEX,
     CONF_ITEMS,
@@ -73,7 +74,7 @@ class TabviewType(WidgetType):
         )
 
     def get_uses(self):
-        return CONF_BUTTONMATRIX, TYPE_FLEX
+        return CONF_BUTTONMATRIX, TYPE_FLEX, CONF_BUTTON
 
     async def to_code(self, w: Widget, config: dict):
         await w.set_property(

--- a/tests/components/lvgl/lvgl-package.yaml
+++ b/tests/components/lvgl/lvgl-package.yaml
@@ -194,6 +194,7 @@ lvgl:
           text: "Close"
           on_click:
             then:
+              - lvgl.display.set_rotation: 0
               - lvgl.widget.hide: message_box
               - lvgl.style.update:
                   id: style_test


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The newly added `lvgl.display.set_rotation` processing did not pass the args to the
lambda context, resulting in compilation errors, only in contexts where there were args.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
