### PR TITLE
[zephyr] Fix user overlay only emitting first property

### DIFF
--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -199,11 +199,14 @@ def zephyr_add_user(key, value):
 def copy_files():
     user = zephyr_data()[KEY_USER]
     if user:
+        entries = "\n".join(
+            f"{key} = {', '.join(value)};" for key, value in user.items()
+        )
         zephyr_add_overlay(
             f"""
                 / {{
                     zephyr,user {{
-                        {chr(10).join(f"{key} = {', '.join(value)};" for key, value in user.items())}
+                        {entries}
                     }};
                 }};
             """

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -199,7 +199,7 @@ def zephyr_add_user(key, value):
 def copy_files():
     user = zephyr_data()[KEY_USER]
     if user:
-        entries = "\n".join(
+        entries = " ".join(
             f"{key} = {', '.join(value)};" for key, value in user.items()
         )
         zephyr_add_overlay(

--- a/esphome/components/zephyr/__init__.py
+++ b/esphome/components/zephyr/__init__.py
@@ -203,7 +203,7 @@ def copy_files():
             f"""
                 / {{
                     zephyr,user {{
-                        {[f"{key} = {', '.join(value)};" for key, value in user.items()][0]}
+                        {chr(10).join(f"{key} = {', '.join(value)};" for key, value in user.items())}
                     }};
                 }};
             """


### PR DESCRIPTION
# What does this implement/fix?

The `copy_files()` function in the zephyr component generates a devicetree overlay for the `zephyr,user` node. The list comprehension that formats the key-value pairs used `[0]` to index the result, so only the first property was emitted and any additional properties were silently discarded.

Currently only `adc` uses `zephyr_add_user()` with a single key (`io-channels`), so this hasn't caused issues in practice, but it would break as soon as a second key is added.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal fix, no config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).