### PR TITLE
[modbus_controller] Fix output missing address validation and text_sensor division

### DIFF
--- a/esphome/components/modbus_controller/output/__init__.py
+++ b/esphome/components/modbus_controller/output/__init__.py
@@ -11,6 +11,7 @@ from .. import (
     modbus_controller_ns,
 )
 from ..const import (
+    CONF_CUSTOM_COMMAND,
     CONF_MODBUS_CONTROLLER_ID,
     CONF_REGISTER_TYPE,
     CONF_USE_WRITE_MULTIPLE,
@@ -36,6 +37,9 @@ CONFIG_SCHEMA = cv.typed_schema(
             {
                 cv.GenerateID(): cv.declare_id(ModbusBinaryOutput),
                 cv.Required(CONF_ADDRESS): cv.positive_int,
+                cv.Optional(CONF_CUSTOM_COMMAND): cv.invalid(
+                    "custom_command is not supported for outputs"
+                ),
                 cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
                 cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
             }
@@ -44,6 +48,9 @@ CONFIG_SCHEMA = cv.typed_schema(
             {
                 cv.GenerateID(): cv.declare_id(ModbusFloatOutput),
                 cv.Required(CONF_ADDRESS): cv.positive_int,
+                cv.Optional(CONF_CUSTOM_COMMAND): cv.invalid(
+                    "custom_command is not supported for outputs"
+                ),
                 cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(
                     SENSOR_VALUE_TYPE
                 ),

--- a/esphome/components/modbus_controller/output/__init__.py
+++ b/esphome/components/modbus_controller/output/__init__.py
@@ -35,6 +35,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         "coil": output.BINARY_OUTPUT_SCHEMA.extend(ModbusItemBaseSchema).extend(
             {
                 cv.GenerateID(): cv.declare_id(ModbusBinaryOutput),
+                cv.Required(CONF_ADDRESS): cv.positive_int,
                 cv.Optional(CONF_WRITE_LAMBDA): cv.returning_lambda,
                 cv.Optional(CONF_USE_WRITE_MULTIPLE, default=False): cv.boolean,
             }
@@ -42,6 +43,7 @@ CONFIG_SCHEMA = cv.typed_schema(
         "holding": output.FLOAT_OUTPUT_SCHEMA.extend(ModbusItemBaseSchema).extend(
             {
                 cv.GenerateID(): cv.declare_id(ModbusFloatOutput),
+                cv.Required(CONF_ADDRESS): cv.positive_int,
                 cv.Optional(CONF_VALUE_TYPE, default="U_WORD"): cv.enum(
                     SENSOR_VALUE_TYPE
                 ),

--- a/esphome/components/modbus_controller/text_sensor/__init__.py
+++ b/esphome/components/modbus_controller/text_sensor/__init__.py
@@ -61,7 +61,7 @@ async def to_code(config):
     response_size = config[CONF_RESPONSE_SIZE]
     reg_count = config[CONF_REGISTER_COUNT]
     if reg_count == 0:
-        reg_count = response_size / 2
+        reg_count = response_size // 2
     var = cg.new_Pvariable(
         config[CONF_ID],
         config[CONF_REGISTER_TYPE],


### PR DESCRIPTION
# What does this implement/fix?

Two minor fixes in the modbus_controller component:

1. **output**: `CONF_ADDRESS` is declared as optional in `ModbusItemBaseSchema` but always accessed directly in `to_code()`. Unlike other modbus_controller sub-components (sensor, binary_sensor, switch, text_sensor), the output doesn't call `validate_modbus_register` and doesn't support `custom_command`, so omitting `address` passes validation but crashes with a `KeyError`. Fix: override `address` as required in both the coil and holding schemas.

2. **text_sensor**: `response_size / 2` produces a float instead of `response_size // 2` which produces an int. The value is passed to a C++ constructor that takes an integer, so it works in practice, but integer division is correct here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - validation fix, no config change needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).