### PR TITLE
[spi] Fix IndexError on invalid RP2040 CLK pin

### DIFF
--- a/esphome/components/spi/__init__.py
+++ b/esphome/components/spi/__init__.py
@@ -246,11 +246,15 @@ def validate_hw_pins(spi, index=-1):
         return clk_pin_no >= 0
 
     if target_platform == PLATFORM_RP2040:
-        pin_set = (
-            list(filter(lambda s: clk_pin_no in s[CONF_CLK_PIN], RP_SPI_PINSETS))[0]
-            if index == -1
-            else RP_SPI_PINSETS[index]
-        )
+        if index == -1:
+            matches = list(
+                filter(lambda s: clk_pin_no in s[CONF_CLK_PIN], RP_SPI_PINSETS)
+            )
+            if not matches:
+                return False
+            pin_set = matches[0]
+        else:
+            pin_set = RP_SPI_PINSETS[index]
         if pin_set is None:
             return False
         if sdo_pin_no not in pin_set[CONF_MOSI_PIN]:


### PR DESCRIPTION
# What does this implement/fix?

When an invalid CLK pin is used on RP2040 without specifying a SPI bus index, `validate_hw_pins` filters `RP_SPI_PINSETS` to find a matching pin set and indexes `[0]` on the result. If no pin set matches (invalid CLK pin), the filter returns an empty list and `[0]` throws an `IndexError` instead of a clear validation error.

Fix: check for empty matches and return `False` so the caller produces a proper error message.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - validation fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).