### PR TITLE
[i2s_audio] Add keep_alive option to speaker to prevent pop/click on audio start

### DIFF
--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -42,6 +42,7 @@ I2SAudioSpeaker = i2s_audio_ns.class_("I2SAudioSpeaker", I2SAudioSpeakerBase)
 
 CONF_DAC_TYPE = "dac_type"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
+CONF_KEEP_ALIVE = "keep_alive"
 CONF_SPDIF_MODE = "spdif_mode"
 
 I2SAudioSpeakerBase = i2s_audio_ns.class_(
@@ -161,6 +162,7 @@ BASE_SCHEMA = (
                 cv.positive_time_period_milliseconds,
                 cv.one_of(CONF_NEVER, lower=True),
             ),
+            cv.Optional(CONF_KEEP_ALIVE, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -250,3 +252,4 @@ async def to_code(config):
     if config[CONF_TIMEOUT] != CONF_NEVER:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))
     cg.add(var.set_buffer_duration(config[CONF_BUFFER_DURATION]))
+    cg.add(var.set_keep_alive(config[CONF_KEEP_ALIVE]))

--- a/esphome/components/i2s_audio/speaker/__init__.py
+++ b/esphome/components/i2s_audio/speaker/__init__.py
@@ -39,6 +39,7 @@ I2SAudioSpeaker = i2s_audio_ns.class_(
 
 CONF_DAC_TYPE = "dac_type"
 CONF_I2S_COMM_FMT = "i2s_comm_fmt"
+CONF_KEEP_ALIVE = "keep_alive"
 
 i2s_dac_mode_t = cg.global_ns.enum("i2s_dac_mode_t")
 INTERNAL_DAC_OPTIONS = {
@@ -130,6 +131,7 @@ BASE_SCHEMA = (
                 cv.positive_time_period_milliseconds,
                 cv.one_of(CONF_NEVER, lower=True),
             ),
+            cv.Optional(CONF_KEEP_ALIVE, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -192,3 +194,4 @@ async def to_code(config):
     if config[CONF_TIMEOUT] != CONF_NEVER:
         cg.add(var.set_timeout(config[CONF_TIMEOUT]))
     cg.add(var.set_buffer_duration(config[CONF_BUFFER_DURATION]))
+    cg.add(var.set_keep_alive(config[CONF_KEEP_ALIVE]))

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -48,6 +48,7 @@ void I2SAudioSpeakerBase::dump_config() {
   if (this->timeout_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 " ms", this->timeout_.value());
   }
+  ESP_LOGCONFIG(TAG, "  Keep alive: %s", YESNO(this->keep_alive_));
 }
 
 void I2SAudioSpeakerBase::loop() {
@@ -298,19 +299,39 @@ esp_err_t I2SAudioSpeakerBase::init_i2s_channel_(const i2s_chan_config_t &chan_c
 void I2SAudioSpeakerBase::stop_i2s_driver_() {
   if (this->tx_handle_ != nullptr) {
     i2s_channel_disable(this->tx_handle_);
-    i2s_del_channel(this->tx_handle_);
-    this->tx_handle_ = nullptr;
-
-    // i2s_del_channel() leaves dout wired to this port's data-out signal in the GPIO matrix: it only
-    // clears an internal reservation mask, never the esp_rom_gpio_connect_out_signal() routing that
-    // setup installed. If another speaker reuses this port (shared bus), its audio still reaches our
-    // dout. Detach the pin and drive it low so a stale output stops driving downstream hardware: a
-    // SPDIF optical transmitter would otherwise stay lit, and an analog DAC would emit noise.
-    gpio_reset_pin(this->dout_pin_);
-    gpio_set_direction(this->dout_pin_, GPIO_MODE_OUTPUT);
-    gpio_set_level(this->dout_pin_, 0);
+    if (this->keep_alive_) {
+      // Keep-alive mode: leave the channel allocated and configured so the next start cycle can
+      // reuse it without re-running i2s_new_channel / i2s_channel_init_std_mode, which trigger the
+      // GPIO routing and DAC PLL re-lock transients that cause the audible pop. Reset the on_sent
+      // callback (must be done while channel is disabled per ESP-IDF) and drain both queues so the
+      // next task setup's preload pushes begin from a known-empty state.
+      const i2s_event_callbacks_t callbacks = {.on_sent = nullptr};
+      i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+      if (this->i2s_event_queue_ != nullptr) {
+        xQueueReset(this->i2s_event_queue_);
+      }
+      if (this->write_records_queue_ != nullptr) {
+        xQueueReset(this->write_records_queue_);
+      }
+    } else {
+      this->delete_channel_();
+    }
   }
   this->parent_->unlock();
+}
+
+void I2SAudioSpeakerBase::delete_channel_() {
+  i2s_del_channel(this->tx_handle_);
+  this->tx_handle_ = nullptr;
+
+  // i2s_del_channel() leaves dout wired to this port's data-out signal in the GPIO matrix: it only
+  // clears an internal reservation mask, never the esp_rom_gpio_connect_out_signal() routing that
+  // setup installed. If another speaker reuses this port (shared bus), its audio still reaches our
+  // dout. Detach the pin and drive it low so a stale output stops driving downstream hardware: a
+  // SPDIF optical transmitter would otherwise stay lit, and an analog DAC would emit noise.
+  gpio_reset_pin(this->dout_pin_);
+  gpio_set_direction(this->dout_pin_, GPIO_MODE_OUTPUT);
+  gpio_set_level(this->dout_pin_, 0);
 }
 
 bool IRAM_ATTR I2SAudioSpeakerBase::i2s_on_sent_cb(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.cpp
@@ -64,6 +64,29 @@ void I2SAudioSpeaker::setup() {
     this->mark_failed();
     return;
   }
+
+  if (this->keep_alive_) {
+    // Pre-warm the I2S channel at boot time so the initial pop/click happens during startup
+    // instead of on the first audio event. The channel is initialized, briefly enabled (causing
+    // the transient), then disabled and left allocated for the keep-alive reuse path.
+    esp_err_t err = this->start_i2s_driver_(this->audio_stream_info_);
+    if (err == ESP_OK) {
+      // Channel is now enabled from start_i2s_driver_. Disable it and remove callback,
+      // leaving it allocated and configured for keep-alive reuse.
+      i2s_channel_disable(this->tx_handle_);
+      const i2s_event_callbacks_t callbacks = {
+          .on_sent = nullptr,
+      };
+      i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+      if (this->i2s_event_queue_ != nullptr) {
+        xQueueReset(this->i2s_event_queue_);
+      }
+      this->parent_->unlock();
+      ESP_LOGI(TAG, "Keep-alive: I2S channel pre-warmed at boot");
+    } else {
+      ESP_LOGW(TAG, "Keep-alive: failed to pre-warm I2S channel, will init on first use");
+    }
+  }
 }
 
 void I2SAudioSpeaker::dump_config() {
@@ -75,6 +98,7 @@ void I2SAudioSpeaker::dump_config() {
   if (this->timeout_.has_value()) {
     ESP_LOGCONFIG(TAG, "  Timeout: %" PRIu32 " ms", this->timeout_.value());
   }
+  ESP_LOGCONFIG(TAG, "  Keep alive: %s", this->keep_alive_ ? "YES" : "NO");
   ESP_LOGCONFIG(TAG, "  Communication format: %s", this->i2s_comm_fmt_.c_str());
 }
 
@@ -107,7 +131,34 @@ void I2SAudioSpeaker::loop() {
     vTaskDelete(this->speaker_task_handle_);
     this->speaker_task_handle_ = nullptr;
 
-    this->stop_i2s_driver_();
+    if (this->keep_alive_) {
+      // Keep-alive mode: disable the I2S channel but don't delete it.
+      // This stops the DMA and clocks cleanly, but the channel remains allocated
+      // and configured. On next start, we just re-enable it — no full teardown/rebuild
+      // of the I2S peripheral, which avoids the pop/click caused by GPIO reconfiguration.
+
+      // Must disable channel BEFORE modifying callbacks (ESP-IDF requirement)
+      i2s_channel_disable(this->tx_handle_);
+
+      // Disable the on_sent callback to prevent stale events
+      const i2s_event_callbacks_t callbacks = {
+          .on_sent = nullptr,
+      };
+      i2s_channel_register_event_callback(this->tx_handle_, &callbacks, this);
+
+      // Drain stale events
+      if (this->i2s_event_queue_ != nullptr) {
+        xQueueReset(this->i2s_event_queue_);
+      }
+
+      // Unlock the parent I2S bus so the next start cycle can re-acquire it
+      this->parent_->unlock();
+
+      // Don't delete channel — it stays allocated with all config intact
+      ESP_LOGD(TAG, "Keep-alive: I2S channel disabled but kept allocated");
+    } else {
+      this->stop_i2s_driver_();
+    }
     xEventGroupClearBits(this->event_group_, SpeakerEventGroupBits::ALL_BITS);
     this->status_clear_error();
 
@@ -133,10 +184,32 @@ void I2SAudioSpeaker::loop() {
         break;
       }
 
-      if (this->start_i2s_driver_(this->audio_stream_info_) != ESP_OK) {
-        ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
-        this->status_momentary_error("driver-faiure", 1000);
-        break;
+      if (this->keep_alive_ && this->tx_handle_ != nullptr && this->audio_stream_info_ == this->current_stream_info_) {
+        // Keep-alive mode: I2S channel is already allocated and configured from previous session
+        // and the stream settings are unchanged. Re-acquire the bus lock, clear stale events,
+        // and re-enable the channel.
+        if (!this->parent_->try_lock()) {
+          ESP_LOGE(TAG, "Keep-alive: parent I2S bus not free");
+          this->status_momentary_error("driver-failure", 1000);
+          break;
+        }
+        if (this->i2s_event_queue_ != nullptr) {
+          xQueueReset(this->i2s_event_queue_);
+        }
+        i2s_channel_enable(this->tx_handle_);
+        ESP_LOGD(TAG, "Keep-alive: re-enabled existing I2S channel");
+      } else {
+        // Full init path: either keep_alive is false, no channel is allocated yet, or the
+        // stream settings changed and we need to reconfigure the driver.
+        if (this->keep_alive_ && this->tx_handle_ != nullptr) {
+          // Stream info changed — tear down the existing channel before reinitialising.
+          this->stop_i2s_driver_();
+        }
+        if (this->start_i2s_driver_(this->audio_stream_info_) != ESP_OK) {
+          ESP_LOGE(TAG, "Driver failed to start; retrying in 1 second");
+          this->status_momentary_error("driver-failure", 1000);
+          break;
+        }
       }
 
       if (this->speaker_task_handle_ == nullptr) {
@@ -146,7 +219,16 @@ void I2SAudioSpeaker::loop() {
         if (this->speaker_task_handle_ == nullptr) {
           ESP_LOGE(TAG, "Task failed to start, retrying in 1 second");
           this->status_momentary_error("task-failure", 1000);
-          this->stop_i2s_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
+          if (this->keep_alive_) {
+            // Keep-alive path: bus was locked via try_lock() or start_i2s_driver_(), but no
+            // task was created to release it via TASK_STOPPED. Release the lock manually.
+            if (this->tx_handle_ != nullptr) {
+              i2s_channel_disable(this->tx_handle_);
+            }
+            this->parent_->unlock();
+          } else {
+            this->stop_i2s_driver_();  // Stops the driver to return the lock; will be reloaded in next attempt
+          }
         }
       }
       break;
@@ -272,6 +354,9 @@ void I2SAudioSpeaker::speaker_task(void *params) {
 
     xEventGroupSetBits(this_speaker->event_group_, SpeakerEventGroupBits::TASK_RUNNING);
 
+    // Original unmodified task loop — let it run and stop normally.
+    // The keep-alive magic happens in loop() where we skip stop_i2s_driver_()
+    // and in STATE_STARTING where we reuse the existing I2S driver.
     while (this_speaker->pause_state_ || !this_speaker->timeout_.has_value() ||
            (millis() - last_data_received_time) <= this_speaker->timeout_.value()) {
       uint32_t event_group_bits = xEventGroupGetBits(this_speaker->event_group_);

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -54,6 +54,7 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
 
   void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }
   void set_timeout(uint32_t ms) { this->timeout_ = ms; }
+  void set_keep_alive(bool keep_alive) { this->keep_alive_ = keep_alive; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = (gpio_num_t) pin; }
 
   /// @brief Get the I2S TX channel handle
@@ -125,6 +126,11 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   /// @brief Stops the I2S driver and unlocks the I2S port
   void stop_i2s_driver_();
 
+  /// @brief Tears down the I2S channel: disables it, deletes the channel, clears tx_handle_, and
+  /// detaches the dout pin from the GPIO matrix while driving it low. Used by both the normal stop
+  /// path and the keep-alive stream-info-changed path. Caller is responsible for the bus lock.
+  void delete_channel_();
+
   /// @brief Called in loop() when the task has stopped. Override for mode-specific cleanup.
   virtual void on_task_stopped() {}
 
@@ -153,6 +159,7 @@ class I2SAudioSpeakerBase : public I2SAudioOut, public speaker::Speaker, public 
   optional<uint32_t> timeout_;
 
   bool pause_state_{false};
+  bool keep_alive_{false};
 
   int32_t q31_volume_factor_{INT32_MAX};
 

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker.h
@@ -29,6 +29,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   void set_buffer_duration(uint32_t buffer_duration_ms) { this->buffer_duration_ms_ = buffer_duration_ms; }
   void set_timeout(uint32_t ms) { this->timeout_ = ms; }
+  void set_keep_alive(bool keep_alive) { this->keep_alive_ = keep_alive; }
   void set_dout_pin(uint8_t pin) { this->dout_pin_ = (gpio_num_t) pin; }
   void set_i2s_comm_fmt(std::string mode) { this->i2s_comm_fmt_ = std::move(mode); }
 
@@ -108,6 +109,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   optional<uint32_t> timeout_;
 
+  bool keep_alive_{false};
   bool pause_state_{false};
 
   int16_t q15_volume_factor_{INT16_MAX};
@@ -116,7 +118,7 @@ class I2SAudioSpeaker : public I2SAudioOut, public speaker::Speaker, public Comp
 
   gpio_num_t dout_pin_;
   std::string i2s_comm_fmt_;
-  i2s_chan_handle_t tx_handle_;
+  i2s_chan_handle_t tx_handle_{nullptr};
 };
 
 }  // namespace i2s_audio

--- a/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
+++ b/esphome/components/i2s_audio/speaker/i2s_audio_speaker_standard.cpp
@@ -293,8 +293,6 @@ void I2SAudioSpeaker::run_speaker_task() {
 }
 
 esp_err_t I2SAudioSpeaker::start_i2s_driver(audio::AudioStreamInfo &audio_stream_info) {
-  this->current_stream_info_ = audio_stream_info;
-
   if ((this->i2s_role_ & I2S_ROLE_SLAVE) && (this->sample_rate_ != audio_stream_info.get_sample_rate())) {  // NOLINT
     // Can't reconfigure I2S bus, so the sample rate must match the configured value
     ESP_LOGE(TAG, "Incompatible stream settings");
@@ -312,6 +310,22 @@ esp_err_t I2SAudioSpeaker::start_i2s_driver(audio::AudioStreamInfo &audio_stream
     ESP_LOGE(TAG, "Parent bus is busy");
     return ESP_ERR_INVALID_STATE;
   }
+
+  // Keep-alive fast path: if the channel survived the previous session and the stream info hasn't
+  // changed, reuse it as-is. The channel is in READY state (left there by stop_i2s_driver_'s
+  // disable), with queues and callbacks reset, ready for the task to preload and enable.
+  if (this->tx_handle_ != nullptr) {
+    if (this->current_stream_info_ == audio_stream_info) {
+      return ESP_OK;
+    }
+    // Stream info changed since the channel was allocated. Tear it down so we can rebuild with the
+    // new config; the bus lock acquired above is held across the teardown into the fresh init. The
+    // channel is in READY state here (left there by stop_i2s_driver_'s disable, or never enabled
+    // after pre-warm), so no disable call is needed before delete_channel_().
+    this->delete_channel_();
+  }
+
+  this->current_stream_info_ = audio_stream_info;
 
   uint32_t dma_buffer_length = audio_stream_info.ms_to_frames(DMA_BUFFER_DURATION_MS);
 

--- a/tests/components/i2s_audio/test.esp32-p4-idf.yaml
+++ b/tests/components/i2s_audio/test.esp32-p4-idf.yaml
@@ -1,0 +1,15 @@
+substitutions:
+  i2s_bclk_pin: GPIO12
+  i2s_lrclk_pin: GPIO10
+  i2s_mclk_pin: GPIO13
+
+<<: !include common.yaml
+
+speaker:
+  - platform: i2s_audio
+    dac_type: external
+    i2s_dout_pin: GPIO9
+    sample_rate: 16000
+    bits_per_sample: 16bit
+    channel: left
+    keep_alive: true


### PR DESCRIPTION
# What does this implement/fix?

Adds a `keep_alive` option to the `i2s_audio` speaker component. When enabled, the I2S channel is kept allocated between audio events rather than being fully torn down and recreated on each play/stop cycle.

On codec and Class D amplifier combinations (such as ES8311 + NS4150B), the full I2S peripheral teardown and reinitialisation that occurs between audio events causes an audible pop/click transient. This is because `i2s_new_channel`, `i2s_channel_init_std_mode`, and `i2s_channel_enable` reconfigure the GPIO clocks and DAC power state, producing a transient on every audio start.

The implementation is intentionally scoped to channel allocation only. `setup()`, `loop()`, the state machine, and the speaker task are unchanged from upstream — the option only changes what `start_i2s_driver()` and `stop_i2s_driver_()` do with the underlying `i2s_chan_handle_t`. No new state is introduced and no existing code path is reordered.

With `keep_alive: true`:
- On start, if a previously-allocated channel exists and the incoming stream info matches the one it was configured with, the existing channel is reused as-is — `i2s_new_channel` and `i2s_channel_init_std_mode` are both skipped, no GPIO reconfiguration occurs, and no transient is produced. The speaker task then preloads and enables the channel exactly as it does on a cold start.
- On stop, after the speaker task has exited and the channel has been disabled, the channel is kept allocated instead of being deleted. The `on_sent` callback is nulled and both the event and write-records queues are drained so the next session starts from a clean state. The parent I2S bus lock is released normally.
- The first audio event after boot performs a normal cold init (one-time transient per power cycle). Every subsequent audio event reuses the channel and is silent. If the stream info changes between sessions (e.g. a new audio source with a different sample rate), the channel is torn down and rebuilt with the new configuration — this is the only steady-state path that produces a transient.

The channel state invariants are: `RUNNING` after the task enables it, `READY` after `stop_i2s_driver_()` disables it, and `nullptr` only on cold boot or after a non-keep-alive stop.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- fixes [i2s_audio speaker: Add idle_mode: silence to keep I2S bus active and prevent pop/click on audio start](https://github.com/orgs/esphome/discussions/3604)

**Pull request in [[esphome-docs](https://github.com/esphome/esphome-docs)](https://github.com/esphome/esphome-docs) with documentation (if applicable):**
- esphome/esphome-docs#6480

## Test Environment
- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

**Tested on:** ESP32-P4 (Waveshare ESP32-P4-ETH) with ES8311 codec + NS4150B Class D amplifier

## Example entry for `config.yaml`:
```yaml
speaker:
  - platform: i2s_audio
    id: my_speaker
    dac_type: external
    i2s_audio_id: i2s_out
    i2s_dout_pin: GPIO9
    audio_dac: my_dac
    keep_alive: true  # Keeps I2S channel allocated between audio events.
                      # Eliminates pop/click on codec + Class D amp combinations
                      # (e.g. ES8311 + NS4150B) by skipping i2s_new_channel +
                      # i2s_channel_init_std_mode on reuse. First audio after
                      # boot performs a normal cold init; subsequent events
                      # are silent.
```

## Checklist:
- [x] The code change is tested and works locally.
- [X] Tests have been added to verify that the new code works (under `tests/` folder).