### PR TITLE
[json] Fix heap buffer overflow in SerializationBuffer truncation path

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -140,8 +140,11 @@ SerializationBuffer<> JsonBuilder::serialize() {
     heap_size *= 2;
   }
   // Payload exceeds 5120 bytes - return truncated result
-  ESP_LOGW(TAG, "JSON payload too large, truncated to %zu bytes", size);
-  result.set_size_(size);
+  // heap_size was doubled after the last iteration, so the actual allocated
+  // buffer capacity is heap_size/2. Clamp to avoid writing past the buffer.
+  size_t max_content = heap_size / 2 - 1;
+  ESP_LOGW(TAG, "JSON payload too large, truncated to %zu bytes", max_content);
+  result.set_size_(max_content);
   return result;
 }
 


### PR DESCRIPTION
## needs https://github.com/esphome/esphome/pull/15575

# What does this implement/fix?

Fixes a heap buffer overflow in `JsonBuilder::serialize()` that causes crashes on devices with large JSON payloads.

This is a combination of two factors:

1. **Latent bug in `SerializationBuffer` (since #13625):** When the JSON payload exceeds the 5120-byte safety cap, `set_size_()` was called with the unbounded serialization size returned by `serializeJson()`. This writes a null terminator past the end of the allocated heap buffer (`buffer_[size] = '\0'` where `size >= buffer capacity`), corrupting TLSF heap metadata.

2. **Trigger: `DETAIL_ALL` for update entities (#14711):** Switching `update_all_json_generator` from `DETAIL_STATE` to `DETAIL_ALL` added the `summary` field (which contains the full release changelog) to the JSON. Devices with long changelogs (e.g., Doorman S3) easily push a single update entity past the 5120-byte cap, triggering the overflow for the first time.

The heap corruption manifests as crashes in unrelated code that happens to call `malloc()` or walk the heap afterward (e.g., `AsyncEventSourceResponse::try_send_nodefer()` building SSE strings, or `DebugComponent::update_platform_()` calling `heap_caps_get_largest_free_block()`).

**Fix:** Clamp the truncated size to the actual allocated buffer capacity (`heap_size / 2 - 1`) to prevent writing past the buffer.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #15570

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — fixes internal buffer overflow in JSON serialization safety cap
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).