### PR TITLE
[codegen] Fix templatable int type to use cg.int32

### DIFF
--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -129,6 +129,6 @@ async def to_code(config):
 async def sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, int)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.int32)
     cg.add(var.set_value(template_))
     return var


### PR DESCRIPTION
# What does this implement/fix?

Fix deprecation warning in `RotaryEncoderSetValueAction` by using `cg.int32` instead of Python `int` for the templatable value type.

When `cg.templatable()` is called with Python `int`, the generated lambda lacks a proper C++ return type annotation. If the automation's trigger args are `bool`, the compiler infers the lambda returns `bool` instead of `int`, triggering the `TemplatableFn` deprecation warning:

```
warning: 'esphome::TemplatableFn<T, X>::TemplatableFn(F) ...' is deprecated:
Lambda return type does not match TemplatableFn<T> — use the correct type in codegen
```

Using `cg.int32` ensures the lambda gets `-> int32_t` in its signature, matching the `TEMPLATABLE_VALUE(int, value)` declaration in the C++ header.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
sensor:
  - platform: rotary_encoder
    name: "Rotary Encoder"
    pin_a: GPIO1
    pin_b: GPIO2
    on_clockwise:
      - sensor.rotary_encoder.set_value:
          id: rotary_encoder
          value: 10
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).