### PR TITLE
[codegen] Fix templatable float type to use cg.float_

### DIFF
--- a/esphome/components/analog_threshold/binary_sensor.py
+++ b/esphome/components/analog_threshold/binary_sensor.py
@@ -40,10 +40,10 @@ async def to_code(config):
     cg.add(var.set_sensor(sens))
 
     if isinstance(config[CONF_THRESHOLD], dict):
-        lower = await cg.templatable(config[CONF_THRESHOLD][CONF_LOWER], [], float)
-        upper = await cg.templatable(config[CONF_THRESHOLD][CONF_UPPER], [], float)
+        lower = await cg.templatable(config[CONF_THRESHOLD][CONF_LOWER], [], cg.float_)
+        upper = await cg.templatable(config[CONF_THRESHOLD][CONF_UPPER], [], cg.float_)
     else:
-        lower = await cg.templatable(config[CONF_THRESHOLD], [], float)
+        lower = await cg.templatable(config[CONF_THRESHOLD], [], cg.float_)
         upper = lower
     cg.add(var.set_upper_threshold(upper))
     cg.add(var.set_lower_threshold(lower))

--- a/esphome/components/audio_adc/__init__.py
+++ b/esphome/components/audio_adc/__init__.py
@@ -32,7 +32,7 @@ async def audio_adc_set_mic_gain_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config.get(CONF_MIC_GAIN), args, float)
+    template_ = await cg.templatable(config.get(CONF_MIC_GAIN), args, cg.float_)
     cg.add(var.set_mic_gain(template_))
 
     return var

--- a/esphome/components/audio_dac/__init__.py
+++ b/esphome/components/audio_dac/__init__.py
@@ -52,7 +52,7 @@ async def audio_dac_set_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config.get(CONF_VOLUME), args, float)
+    template_ = await cg.templatable(config.get(CONF_VOLUME), args, cg.float_)
     cg.add(var.set_volume(template_))
 
     return var

--- a/esphome/components/climate/__init__.py
+++ b/esphome/components/climate/__init__.py
@@ -488,16 +488,16 @@ async def climate_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(mode, args, ClimateMode)
         cg.add(var.set_mode(template_))
     if (target_temp := config.get(CONF_TARGET_TEMPERATURE)) is not None:
-        template_ = await cg.templatable(target_temp, args, float)
+        template_ = await cg.templatable(target_temp, args, cg.float_)
         cg.add(var.set_target_temperature(template_))
     if (target_temp_low := config.get(CONF_TARGET_TEMPERATURE_LOW)) is not None:
-        template_ = await cg.templatable(target_temp_low, args, float)
+        template_ = await cg.templatable(target_temp_low, args, cg.float_)
         cg.add(var.set_target_temperature_low(template_))
     if (target_temp_high := config.get(CONF_TARGET_TEMPERATURE_HIGH)) is not None:
-        template_ = await cg.templatable(target_temp_high, args, float)
+        template_ = await cg.templatable(target_temp_high, args, cg.float_)
         cg.add(var.set_target_temperature_high(template_))
     if (target_humidity := config.get(CONF_TARGET_HUMIDITY)) is not None:
-        template_ = await cg.templatable(target_humidity, args, float)
+        template_ = await cg.templatable(target_humidity, args, cg.float_)
         cg.add(var.set_target_humidity(template_))
     if (fan_mode := config.get(CONF_FAN_MODE)) is not None:
         template_ = await cg.templatable(fan_mode, args, ClimateFanMode)

--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -303,13 +303,13 @@ async def cover_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(stop, args, bool)
         cg.add(var.set_stop(template_))
     if (state := config.get(CONF_STATE)) is not None:
-        template_ = await cg.templatable(state, args, float)
+        template_ = await cg.templatable(state, args, cg.float_)
         cg.add(var.set_position(template_))
     if (position := config.get(CONF_POSITION)) is not None:
-        template_ = await cg.templatable(position, args, float)
+        template_ = await cg.templatable(position, args, cg.float_)
         cg.add(var.set_position(template_))
     if (tilt := config.get(CONF_TILT)) is not None:
-        template_ = await cg.templatable(tilt, args, float)
+        template_ = await cg.templatable(tilt, args, cg.float_)
         cg.add(var.set_tilt(template_))
     return var
 

--- a/esphome/components/dfrobot_sen0395/__init__.py
+++ b/esphome/components/dfrobot_sen0395/__init__.py
@@ -166,24 +166,24 @@ async def dfrobot_sen0395_settings_to_code(config, action_id, template_arg, args
         segments = config[CONF_DETECTION_SEGMENTS]
 
         if len(segments) >= 2:
-            template_ = await cg.templatable(segments[0], args, float)
+            template_ = await cg.templatable(segments[0], args, cg.float_)
             cg.add(var.set_det_min1(template_))
-            template_ = await cg.templatable(segments[1], args, float)
+            template_ = await cg.templatable(segments[1], args, cg.float_)
             cg.add(var.set_det_max1(template_))
         if len(segments) >= 4:
-            template_ = await cg.templatable(segments[2], args, float)
+            template_ = await cg.templatable(segments[2], args, cg.float_)
             cg.add(var.set_det_min2(template_))
-            template_ = await cg.templatable(segments[3], args, float)
+            template_ = await cg.templatable(segments[3], args, cg.float_)
             cg.add(var.set_det_max2(template_))
         if len(segments) >= 6:
-            template_ = await cg.templatable(segments[4], args, float)
+            template_ = await cg.templatable(segments[4], args, cg.float_)
             cg.add(var.set_det_min3(template_))
-            template_ = await cg.templatable(segments[5], args, float)
+            template_ = await cg.templatable(segments[5], args, cg.float_)
             cg.add(var.set_det_max3(template_))
         if len(segments) >= 8:
-            template_ = await cg.templatable(segments[6], args, float)
+            template_ = await cg.templatable(segments[6], args, cg.float_)
             cg.add(var.set_det_min4(template_))
-            template_ = await cg.templatable(segments[7], args, float)
+            template_ = await cg.templatable(segments[7], args, cg.float_)
             cg.add(var.set_det_max4(template_))
     if CONF_OUTPUT_LATENCY in config:
         template_ = await cg.templatable(

--- a/esphome/components/esp8266_pwm/output.py
+++ b/esphome/components/esp8266_pwm/output.py
@@ -62,6 +62,6 @@ async def to_code(config) -> None:
 async def esp8266_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_FREQUENCY], args, float)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
     cg.add(var.set_frequency(template_))
     return var

--- a/esphome/components/integration/sensor.py
+++ b/esphome/components/integration/sensor.py
@@ -133,6 +133,6 @@ async def sensor_integration_reset_to_code(config, action_id, template_arg, args
 async def sensor_integration_set_value_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)
     cg.add(var.set_value(template_))
     return var

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -82,6 +82,6 @@ async def to_code(config):
 async def ledc_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_FREQUENCY], args, float)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
     cg.add(var.set_frequency(template_))
     return var

--- a/esphome/components/libretiny_pwm/output.py
+++ b/esphome/components/libretiny_pwm/output.py
@@ -43,6 +43,6 @@ async def to_code(config):
 async def libretiny_pwm_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_FREQUENCY], args, float)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
     cg.add(var.set_frequency(template_))
     return var

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -262,7 +262,7 @@ LIGHT_DIM_RELATIVE_ACTION_SCHEMA = cv.Schema(
 async def light_dim_relative_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    templ = await cg.templatable(config[CONF_RELATIVE_BRIGHTNESS], args, float)
+    templ = await cg.templatable(config[CONF_RELATIVE_BRIGHTNESS], args, cg.float_)
     cg.add(var.set_relative_brightness(templ))
     if CONF_TRANSITION_LENGTH in config:
         templ = await cg.templatable(config[CONF_TRANSITION_LENGTH], args, cg.uint32)

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -183,18 +183,18 @@ async def light_control_to_code(config, action_id, template_arg, args):
     # (config_key, setter_name, c++ type)
     FIELDS = (
         (CONF_COLOR_MODE, "set_color_mode", ColorMode),
-        (CONF_STATE, "set_state", bool),
+        (CONF_STATE, "set_state", cg.bool_),
         (CONF_TRANSITION_LENGTH, "set_transition_length", cg.uint32),
         (CONF_FLASH_LENGTH, "set_flash_length", cg.uint32),
-        (CONF_BRIGHTNESS, "set_brightness", float),
-        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", float),
-        (CONF_RED, "set_red", float),
-        (CONF_GREEN, "set_green", float),
-        (CONF_BLUE, "set_blue", float),
-        (CONF_WHITE, "set_white", float),
-        (CONF_COLOR_TEMPERATURE, "set_color_temperature", float),
-        (CONF_COLD_WHITE, "set_cold_white", float),
-        (CONF_WARM_WHITE, "set_warm_white", float),
+        (CONF_BRIGHTNESS, "set_brightness", cg.float_),
+        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", cg.float_),
+        (CONF_RED, "set_red", cg.float_),
+        (CONF_GREEN, "set_green", cg.float_),
+        (CONF_BLUE, "set_blue", cg.float_),
+        (CONF_WHITE, "set_white", cg.float_),
+        (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_),
+        (CONF_COLD_WHITE, "set_cold_white", cg.float_),
+        (CONF_WARM_WHITE, "set_warm_white", cg.float_),
     )
     for conf_key, setter, type_ in FIELDS:
         if conf_key in config:

--- a/esphome/components/media_player/__init__.py
+++ b/esphome/components/media_player/__init__.py
@@ -305,7 +305,7 @@ _register_state_conditions()
 async def media_player_volume_set_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    volume = await cg.templatable(config[CONF_VOLUME], args, float)
+    volume = await cg.templatable(config[CONF_VOLUME], args, cg.float_)
     cg.add(var.set_volume(volume))
     return var
 

--- a/esphome/components/nextion/display.py
+++ b/esphome/components/nextion/display.py
@@ -148,7 +148,7 @@ async def nextion_set_brightness_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_BRIGHTNESS], args, float)
+    template_ = await cg.templatable(config[CONF_BRIGHTNESS], args, cg.float_)
     cg.add(var.set_brightness(template_))
 
     return var

--- a/esphome/components/nextion/sensor/__init__.py
+++ b/esphome/components/nextion/sensor/__init__.py
@@ -116,7 +116,7 @@ async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_STATE], args, float)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.float_)
     cg.add(var.set_state(template_))
 
     template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -257,10 +257,14 @@ async def _build_number_automations(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await cg.register_component(trigger, conf)
         if CONF_ABOVE in conf:
-            template_ = await cg.templatable(conf[CONF_ABOVE], [(float, "x")], float)
+            template_ = await cg.templatable(
+                conf[CONF_ABOVE], [(float, "x")], cg.float_
+            )
             cg.add(trigger.set_min(template_))
         if CONF_BELOW in conf:
-            template_ = await cg.templatable(conf[CONF_BELOW], [(float, "x")], float)
+            template_ = await cg.templatable(
+                conf[CONF_BELOW], [(float, "x")], cg.float_
+            )
             cg.add(trigger.set_max(template_))
         await automation.build_automation(trigger, [(float, "x")], conf)
 
@@ -362,7 +366,7 @@ OPERATION_BASE_SCHEMA = cv.Schema(
 async def number_set_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)
     cg.add(var.set_value(template_))
     return var
 

--- a/esphome/components/output/__init__.py
+++ b/esphome/components/output/__init__.py
@@ -104,7 +104,7 @@ async def output_turn_off_to_code(config, action_id, template_arg, args):
 async def output_set_level_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_LEVEL], args, float)
+    template_ = await cg.templatable(config[CONF_LEVEL], args, cg.float_)
     cg.add(var.set_level(template_))
     return var
 
@@ -123,7 +123,7 @@ async def output_set_level_to_code(config, action_id, template_arg, args):
 async def output_set_min_power_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_MIN_POWER], args, float)
+    template_ = await cg.templatable(config[CONF_MIN_POWER], args, cg.float_)
     cg.add(var.set_min_power(template_))
     return var
 
@@ -142,7 +142,7 @@ async def output_set_min_power_to_code(config, action_id, template_arg, args):
 async def output_set_max_power_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_MAX_POWER], args, float)
+    template_ = await cg.templatable(config[CONF_MAX_POWER], args, cg.float_)
     cg.add(var.set_max_power(template_))
     return var
 

--- a/esphome/components/pid/climate.py
+++ b/esphome/components/pid/climate.py
@@ -189,13 +189,13 @@ async def set_control_parameters(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    kp_template_ = await cg.templatable(config[CONF_KP], args, float)
+    kp_template_ = await cg.templatable(config[CONF_KP], args, cg.float_)
     cg.add(var.set_kp(kp_template_))
 
-    ki_template_ = await cg.templatable(config[CONF_KI], args, float)
+    ki_template_ = await cg.templatable(config[CONF_KI], args, cg.float_)
     cg.add(var.set_ki(ki_template_))
 
-    kd_template_ = await cg.templatable(config[CONF_KD], args, float)
+    kd_template_ = await cg.templatable(config[CONF_KD], args, cg.float_)
     cg.add(var.set_kd(kd_template_))
 
     return var

--- a/esphome/components/pipsolar/output/__init__.py
+++ b/esphome/components/pipsolar/output/__init__.py
@@ -103,6 +103,6 @@ async def to_code(config):
 async def output_pipsolar_set_level_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, float)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.float_)
     cg.add(var.set_level(template_))
     return var

--- a/esphome/components/rp2040_pwm/output.py
+++ b/esphome/components/rp2040_pwm/output.py
@@ -47,6 +47,6 @@ async def to_code(config):
 async def rp2040_set_frequency_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_FREQUENCY], args, float)
+    template_ = await cg.templatable(config[CONF_FREQUENCY], args, cg.float_)
     cg.add(var.set_frequency(template_))
     return var

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -371,13 +371,13 @@ def sensor_schema(
 
 @FILTER_REGISTRY.register("offset", OffsetFilter, cv.templatable(cv.float_))
 async def offset_filter_to_code(config, filter_id):
-    template_ = await cg.templatable(config, [], float)
+    template_ = await cg.templatable(config, [], cg.float_)
     return cg.new_Pvariable(filter_id, template_)
 
 
 @FILTER_REGISTRY.register("multiply", MultiplyFilter, cv.templatable(cv.float_))
 async def multiply_filter_to_code(config, filter_id):
-    template_ = await cg.templatable(config, [], float)
+    template_ = await cg.templatable(config, [], cg.float_)
     return cg.new_Pvariable(filter_id, template_)
 
 
@@ -389,7 +389,7 @@ async def multiply_filter_to_code(config, filter_id):
 async def filter_out_filter_to_code(config, filter_id):
     if not isinstance(config, list):
         config = [config]
-    template_ = [await cg.templatable(x, [], float) for x in config]
+    template_ = [await cg.templatable(x, [], cg.float_) for x in config]
     return cg.new_Pvariable(filter_id, cg.TemplateArguments(len(template_)), template_)
 
 
@@ -658,7 +658,7 @@ THROTTLE_WITH_PRIORITY_SCHEMA = cv.maybe_simple_value(
 async def throttle_with_priority_filter_to_code(config, filter_id):
     if not isinstance(config[CONF_VALUE], list):
         config[CONF_VALUE] = [config[CONF_VALUE]]
-    template_ = [await cg.templatable(x, [], float) for x in config[CONF_VALUE]]
+    template_ = [await cg.templatable(x, [], cg.float_) for x in config[CONF_VALUE]]
     return cg.new_Pvariable(
         filter_id, cg.TemplateArguments(len(template_)), config[CONF_TIMEOUT], template_
     )
@@ -713,7 +713,7 @@ async def timeout_filter_to_code(config, filter_id):
     else:
         # Use TimeoutFilterConfigured for configured value mode
         filter_id.type = TimeoutFilterConfigured
-        template_ = await cg.templatable(config[CONF_VALUE], [], float)
+        template_ = await cg.templatable(config[CONF_VALUE], [], cg.float_)
         var = cg.new_Pvariable(filter_id, config[CONF_TIMEOUT], template_)
     await cg.register_component(var, {})
     return var
@@ -909,10 +909,10 @@ async def _build_sensor_automations(var, config):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await cg.register_component(trigger, conf)
         if (above := conf.get(CONF_ABOVE)) is not None:
-            template_ = await cg.templatable(above, [(float, "x")], float)
+            template_ = await cg.templatable(above, [(float, "x")], cg.float_)
             cg.add(trigger.set_min(template_))
         if (below := conf.get(CONF_BELOW)) is not None:
-            template_ = await cg.templatable(below, [(float, "x")], float)
+            template_ = await cg.templatable(below, [(float, "x")], cg.float_)
             cg.add(trigger.set_max(template_))
         await automation.build_automation(trigger, [(float, "x")], conf)
 

--- a/esphome/components/servo/__init__.py
+++ b/esphome/components/servo/__init__.py
@@ -67,7 +67,7 @@ async def to_code(config):
 async def servo_write_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_LEVEL], args, float)
+    template_ = await cg.templatable(config[CONF_LEVEL], args, cg.float_)
     cg.add(var.set_value(template_))
     return var
 

--- a/esphome/components/speaker/__init__.py
+++ b/esphome/components/speaker/__init__.py
@@ -127,7 +127,7 @@ automation.register_condition(
 async def speaker_volume_set_action(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    volume = await cg.templatable(config[CONF_VOLUME], args, float)
+    volume = await cg.templatable(config[CONF_VOLUME], args, cg.float_)
     cg.add(var.set_volume(volume))
     return var
 

--- a/esphome/components/template/cover/__init__.py
+++ b/esphome/components/template/cover/__init__.py
@@ -130,13 +130,13 @@ async def cover_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     if CONF_STATE in config:
-        template_ = await cg.templatable(config[CONF_STATE], args, float)
+        template_ = await cg.templatable(config[CONF_STATE], args, cg.float_)
         cg.add(var.set_position(template_))
     if CONF_POSITION in config:
-        template_ = await cg.templatable(config[CONF_POSITION], args, float)
+        template_ = await cg.templatable(config[CONF_POSITION], args, cg.float_)
         cg.add(var.set_position(template_))
     if CONF_TILT in config:
-        template_ = await cg.templatable(config[CONF_TILT], args, float)
+        template_ = await cg.templatable(config[CONF_TILT], args, cg.float_)
         cg.add(var.set_tilt(template_))
     if CONF_CURRENT_OPERATION in config:
         template_ = await cg.templatable(

--- a/esphome/components/template/sensor/__init__.py
+++ b/esphome/components/template/sensor/__init__.py
@@ -49,6 +49,6 @@ async def to_code(config):
 async def sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_STATE], args, float)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.float_)
     cg.add(var.set_state(template_))
     return var

--- a/esphome/components/template/valve/__init__.py
+++ b/esphome/components/template/valve/__init__.py
@@ -118,10 +118,10 @@ async def valve_template_publish_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     if state_config := config.get(CONF_STATE):
-        template_ = await cg.templatable(state_config, args, float)
+        template_ = await cg.templatable(state_config, args, cg.float_)
         cg.add(var.set_position(template_))
     if (position_config := config.get(CONF_POSITION)) is not None:
-        template_ = await cg.templatable(position_config, args, float)
+        template_ = await cg.templatable(position_config, args, cg.float_)
         cg.add(var.set_position(template_))
     if current_operation_config := config.get(CONF_CURRENT_OPERATION):
         template_ = await cg.templatable(

--- a/esphome/components/template/water_heater/__init__.py
+++ b/esphome/components/template/water_heater/__init__.py
@@ -146,11 +146,11 @@ async def water_heater_template_publish_to_code(
     await cg.register_parented(var, config[CONF_ID])
 
     if current_temp := config.get(CONF_CURRENT_TEMPERATURE):
-        template_ = await cg.templatable(current_temp, args, float)
+        template_ = await cg.templatable(current_temp, args, cg.float_)
         cg.add(var.set_current_temperature(template_))
 
     if target_temp := config.get(CONF_TARGET_TEMPERATURE):
-        template_ = await cg.templatable(target_temp, args, float)
+        template_ = await cg.templatable(target_temp, args, cg.float_)
         cg.add(var.set_target_temperature(template_))
 
     if mode := config.get(CONF_MODE):

--- a/esphome/components/ufire_ec/sensor.py
+++ b/esphome/components/ufire_ec/sensor.py
@@ -102,8 +102,8 @@ UFIRE_EC_CALIBRATE_PROBE_SCHEMA = cv.Schema(
 async def ufire_ec_calibrate_probe_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    solution_ = await cg.templatable(config[CONF_SOLUTION], args, float)
-    temperature_ = await cg.templatable(config[CONF_TEMPERATURE], args, float)
+    solution_ = await cg.templatable(config[CONF_SOLUTION], args, cg.float_)
+    temperature_ = await cg.templatable(config[CONF_TEMPERATURE], args, cg.float_)
     cg.add(var.set_solution(solution_))
     cg.add(var.set_temperature(temperature_))
     return var

--- a/esphome/components/ufire_ise/sensor.py
+++ b/esphome/components/ufire_ise/sensor.py
@@ -96,7 +96,7 @@ UFIRE_ISE_CALIBRATE_PROBE_SCHEMA = cv.Schema(
 async def ufire_ise_calibrate_probe_low_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_SOLUTION], args, float)
+    template_ = await cg.templatable(config[CONF_SOLUTION], args, cg.float_)
     cg.add(var.set_solution(template_))
     return var
 
@@ -110,7 +110,7 @@ async def ufire_ise_calibrate_probe_low_to_code(config, action_id, template_arg,
 async def ufire_ise_calibrate_probe_high_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_SOLUTION], args, float)
+    template_ = await cg.templatable(config[CONF_SOLUTION], args, cg.float_)
     cg.add(var.set_solution(template_))
     return var
 

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -232,10 +232,10 @@ async def valve_control_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(stop_config, args, bool)
         cg.add(var.set_stop(template_))
     if state_config := config.get(CONF_STATE):
-        template_ = await cg.templatable(state_config, args, float)
+        template_ = await cg.templatable(state_config, args, cg.float_)
         cg.add(var.set_position(template_))
     if (position_config := config.get(CONF_POSITION)) is not None:
-        template_ = await cg.templatable(position_config, args, float)
+        template_ = await cg.templatable(position_config, args, cg.float_)
         cg.add(var.set_position(template_))
     return var
 


### PR DESCRIPTION
# What does this implement/fix?

Fix all `cg.templatable()` calls that use Python `float` as the output type to use `cg.float_` instead.

When `cg.templatable()` is called with Python `float`, `safe_exp()` converts it to a `FloatLiteral` (a float value like `0.0`) instead of a type name. This means the generated lambda lacks a proper `-> float` return type annotation. If the automation's trigger args differ from the return type, the compiler infers the wrong return type, triggering the `TemplatableFn` deprecation warning.

Using `cg.float_` ensures the lambda gets `-> float` in its signature, matching the `TEMPLATABLE_VALUE(float, ...)` declaration in the C++ headers.

29 files fixed across cover, audio_dac, ledc, output, speaker, number, sensor, climate, servo, pid, light, media_player, nextion, dfrobot_sen0395, rp2040_pwm, esp8266_pwm, libretiny_pwm, analog_threshold, and more.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any component using templatable float values, e.g.:
sensor:
  - platform: template
    name: "Template Sensor"
    lambda: return 42.0;
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).