### PR TITLE
[codegen] Fix templatable bool type to use cg.bool_

### DIFF
--- a/esphome/components/cover/__init__.py
+++ b/esphome/components/cover/__init__.py
@@ -300,7 +300,7 @@ async def cover_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     if (stop := config.get(CONF_STOP)) is not None:
-        template_ = await cg.templatable(stop, args, bool)
+        template_ = await cg.templatable(stop, args, cg.bool_)
         cg.add(var.set_stop(template_))
     if (state := config.get(CONF_STATE)) is not None:
         template_ = await cg.templatable(state, args, float)

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -345,7 +345,7 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     if (oscillating := config.get(CONF_OSCILLATING)) is not None:
-        template_ = await cg.templatable(oscillating, args, bool)
+        template_ = await cg.templatable(oscillating, args, cg.bool_)
         cg.add(var.set_oscillating(template_))
     if (speed := config.get(CONF_SPEED)) is not None:
         template_ = await cg.templatable(speed, args, int)
@@ -370,7 +370,7 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
 async def fan_cycle_speed_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_OFF_SPEED_CYCLE], args, bool)
+    template_ = await cg.templatable(config[CONF_OFF_SPEED_CYCLE], args, cg.bool_)
     cg.add(var.set_no_off_cycle(template_))
     return var
 

--- a/esphome/components/htu21d/sensor.py
+++ b/esphome/components/htu21d/sensor.py
@@ -118,6 +118,6 @@ async def set_heater_level_to_code(config, action_id, template_arg, args):
 async def set_heater_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    status_ = await cg.templatable(config[CONF_STATUS], args, bool)
+    status_ = await cg.templatable(config[CONF_STATUS], args, cg.bool_)
     cg.add(var.set_status(status_))
     return var

--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -504,7 +504,7 @@ async def mqtt_publish_action_to_code(config, action_id, template_arg, args):
     cg.add(var.set_payload(template_))
     template_ = await cg.templatable(config[CONF_QOS], args, cg.uint8)
     cg.add(var.set_qos(template_))
-    template_ = await cg.templatable(config[CONF_RETAIN], args, bool)
+    template_ = await cg.templatable(config[CONF_RETAIN], args, cg.bool_)
     cg.add(var.set_retain(template_))
     return var
 
@@ -537,7 +537,7 @@ async def mqtt_publish_json_action_to_code(config, action_id, template_arg, args
     cg.add(var.set_payload(lambda_))
     template_ = await cg.templatable(config[CONF_QOS], args, cg.uint8)
     cg.add(var.set_qos(template_))
-    template_ = await cg.templatable(config[CONF_RETAIN], args, bool)
+    template_ = await cg.templatable(config[CONF_RETAIN], args, cg.bool_)
     cg.add(var.set_retain(template_))
     return var
 

--- a/esphome/components/nextion/binary_sensor/__init__.py
+++ b/esphome/components/nextion/binary_sensor/__init__.py
@@ -76,13 +76,13 @@ async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
 
-    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, cg.bool_)
     cg.add(var.set_publish_state(template_))
 
-    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, cg.bool_)
     cg.add(var.set_send_to_nextion(template_))
 
     return var

--- a/esphome/components/nextion/sensor/__init__.py
+++ b/esphome/components/nextion/sensor/__init__.py
@@ -119,10 +119,10 @@ async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     template_ = await cg.templatable(config[CONF_STATE], args, float)
     cg.add(var.set_state(template_))
 
-    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, cg.bool_)
     cg.add(var.set_publish_state(template_))
 
-    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, cg.bool_)
     cg.add(var.set_send_to_nextion(template_))
 
     return var

--- a/esphome/components/nextion/switch/__init__.py
+++ b/esphome/components/nextion/switch/__init__.py
@@ -58,13 +58,13 @@ async def sensor_nextion_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
 
-    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_PUBLISH_STATE], args, cg.bool_)
     cg.add(var.set_publish_state(template_))
 
-    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, bool)
+    template_ = await cg.templatable(config[CONF_SEND_TO_NEXTION], args, cg.bool_)
     cg.add(var.set_send_to_nextion(template_))
 
     return var

--- a/esphome/components/number/__init__.py
+++ b/esphome/components/number/__init__.py
@@ -445,7 +445,7 @@ async def number_to_to_code(config, action_id, template_arg, args):
         to_ = await cg.templatable(operation, args, NumberOperation)
         cg.add(var.set_operation(to_))
         if (cycle := config.get(CONF_CYCLE)) is not None:
-            template_ = await cg.templatable(cycle, args, bool)
+            template_ = await cg.templatable(cycle, args, cg.bool_)
             cg.add(var.set_cycle(template_))
     if (mode := config.get(CONF_MODE)) is not None:
         template_ = await cg.templatable(

--- a/esphome/components/online_image/__init__.py
+++ b/esphome/components/online_image/__init__.py
@@ -100,7 +100,7 @@ async def online_image_action_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(config[CONF_URL], args, cg.std_string)
         cg.add(var.set_url(template_))
     if CONF_UPDATE in config:
-        template_ = await cg.templatable(config[CONF_UPDATE], args, bool)
+        template_ = await cg.templatable(config[CONF_UPDATE], args, cg.bool_)
         cg.add(var.set_update(template_))
     return var
 

--- a/esphome/components/remote_base/__init__.py
+++ b/esphome/components/remote_base/__init__.py
@@ -868,7 +868,7 @@ async def keeloq_action(var, config, args):
     cg.add(var.set_encrypted(template_))
     template_ = await cg.templatable(config[CONF_COMMAND], args, cg.uint8)
     cg.add(var.set_command(template_))
-    template_ = await cg.templatable(config[CONF_LEVEL], args, bool)
+    template_ = await cg.templatable(config[CONF_LEVEL], args, cg.bool_)
     cg.add(var.set_vlow(template_))
 
 
@@ -1580,7 +1580,7 @@ async def rc_switch_type_a_action(var, config, args):
     cg.add(
         var.set_device(await cg.templatable(config[CONF_DEVICE], args, cg.std_string))
     )
-    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, bool)))
+    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, cg.bool_)))
 
 
 @register_binary_sensor(
@@ -1605,7 +1605,7 @@ async def rc_switch_type_b_action(var, config, args):
     cg.add(var.set_protocol(proto))
     cg.add(var.set_address(await cg.templatable(config[CONF_ADDRESS], args, cg.uint8)))
     cg.add(var.set_channel(await cg.templatable(config[CONF_CHANNEL], args, cg.uint8)))
-    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, bool)))
+    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, cg.bool_)))
 
 
 @register_binary_sensor(
@@ -1638,7 +1638,7 @@ async def rc_switch_type_c_action(var, config, args):
     )
     cg.add(var.set_group(await cg.templatable(config[CONF_GROUP], args, cg.uint8)))
     cg.add(var.set_device(await cg.templatable(config[CONF_DEVICE], args, cg.uint8)))
-    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, bool)))
+    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, cg.bool_)))
 
 
 @register_binary_sensor(
@@ -1663,7 +1663,7 @@ async def rc_switch_type_d_action(var, config, args):
     cg.add(var.set_protocol(proto))
     cg.add(var.set_group(await cg.templatable(config[CONF_GROUP], args, cg.std_string)))
     cg.add(var.set_device(await cg.templatable(config[CONF_DEVICE], args, cg.uint8)))
-    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, bool)))
+    cg.add(var.set_state(await cg.templatable(config[CONF_STATE], args, cg.bool_)))
 
 
 @register_trigger("rc_switch", RCSwitchTrigger, RCSwitchData)

--- a/esphome/components/remote_transmitter/__init__.py
+++ b/esphome/components/remote_transmitter/__init__.py
@@ -128,7 +128,7 @@ DIGITAL_WRITE_ACTION_SCHEMA = cv.maybe_simple_value(
 async def digital_write_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_TRANSMITTER_ID])
-    template_ = await cg.templatable(config[CONF_VALUE], args, bool)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.bool_)
     cg.add(var.set_value(template_))
     return var
 

--- a/esphome/components/select/__init__.py
+++ b/esphome/components/select/__init__.py
@@ -279,7 +279,7 @@ async def select_operation_to_code(config, action_id, template_arg, args):
         op_ = await cg.templatable(operation, args, SelectOperation)
         cg.add(var.set_operation(op_))
         if (cycle := config.get(CONF_CYCLE)) is not None:
-            template_ = await cg.templatable(cycle, args, bool)
+            template_ = await cg.templatable(cycle, args, cg.bool_)
             cg.add(var.set_cycle(template_))
     if (mode := config.get(CONF_MODE)) is not None:
         template_ = await cg.templatable(

--- a/esphome/components/switch/__init__.py
+++ b/esphome/components/switch/__init__.py
@@ -196,7 +196,7 @@ SWITCH_CONTROL_ACTION_SCHEMA = automation.maybe_simple_id(
 async def switch_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
     return var
 

--- a/esphome/components/template/binary_sensor/__init__.py
+++ b/esphome/components/template/binary_sensor/__init__.py
@@ -64,6 +64,6 @@ async def to_code(config):
 async def binary_sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
     return var

--- a/esphome/components/template/switch/__init__.py
+++ b/esphome/components/template/switch/__init__.py
@@ -85,6 +85,6 @@ async def to_code(config):
 async def switch_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_STATE], args, bool)
+    template_ = await cg.templatable(config[CONF_STATE], args, cg.bool_)
     cg.add(var.set_state(template_))
     return var

--- a/esphome/components/template/water_heater/__init__.py
+++ b/esphome/components/template/water_heater/__init__.py
@@ -158,11 +158,11 @@ async def water_heater_template_publish_to_code(
         cg.add(var.set_mode(template_))
 
     if CONF_AWAY in config:
-        template_ = await cg.templatable(config[CONF_AWAY], args, bool)
+        template_ = await cg.templatable(config[CONF_AWAY], args, cg.bool_)
         cg.add(var.set_away(template_))
 
     if CONF_IS_ON in config:
-        template_ = await cg.templatable(config[CONF_IS_ON], args, bool)
+        template_ = await cg.templatable(config[CONF_IS_ON], args, cg.bool_)
         cg.add(var.set_is_on(template_))
 
     return var

--- a/esphome/components/valve/__init__.py
+++ b/esphome/components/valve/__init__.py
@@ -229,7 +229,7 @@ async def valve_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     if stop_config := config.get(CONF_STOP):
-        template_ = await cg.templatable(stop_config, args, bool)
+        template_ = await cg.templatable(stop_config, args, cg.bool_)
         cg.add(var.set_stop(template_))
     if state_config := config.get(CONF_STATE):
         template_ = await cg.templatable(state_config, args, float)


### PR DESCRIPTION
# What does this implement/fix?

Fix all `cg.templatable()` calls that use Python `bool` as the output type to use `cg.bool_` instead.

When `cg.templatable()` is called with Python `bool`, `safe_exp()` converts it to a `BoolLiteral` (`true`/`false`) instead of a type name. This means the generated lambda lacks a proper `-> bool` return type annotation. If the automation's trigger args differ from the return type, the compiler infers the wrong return type, triggering the `TemplatableFn` deprecation warning.

Using `cg.bool_` ensures the lambda gets `-> bool` in its signature, matching the `TEMPLATABLE_VALUE(bool, ...)` declaration in the C++ headers.

17 files fixed across cover, switch, fan, binary_sensor, template/*, nextion, remote_base, remote_transmitter, valve, select, number, htu21d, mqtt, and online_image.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any component using templatable bool values, e.g.:
switch:
  - platform: template
    name: "Template Switch"
    turn_on_action:
      - switch.turn_on: my_switch
    turn_off_action:
      - switch.turn_off: my_switch
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).