### PR TITLE
[web_server] Truncate update entity summary to 256 characters

### DIFF
--- a/esphome/components/web_server/web_server.cpp
+++ b/esphome/components/web_server/web_server.cpp
@@ -2207,7 +2207,11 @@ json::SerializationBuffer<> WebServer::update_json_(update::UpdateEntity *obj, J
   if (start_config == DETAIL_ALL) {
     root[ESPHOME_F("current_version")] = obj->update_info.current_version;
     root[ESPHOME_F("title")] = obj->update_info.title;
-    root[ESPHOME_F("summary")] = obj->update_info.summary;
+    // Truncate long changelogs — full text available via release_url
+    constexpr size_t max_summary_len = 256;
+    root[ESPHOME_F("summary")] = obj->update_info.summary.size() <= max_summary_len
+                                     ? obj->update_info.summary
+                                     : obj->update_info.summary.substr(0, max_summary_len);
     root[ESPHOME_F("release_url")] = obj->update_info.release_url;
     this->add_sorting_info_(root, obj);
   }


### PR DESCRIPTION
# What does this implement/fix?

Truncates the update entity `summary` field to 256 characters in the web server JSON serialization.

When #14711 switched `update_all_json_generator` from `DETAIL_STATE` to `DETAIL_ALL`, the full release changelog started being included in SSE event payloads. On devices with long changelogs (e.g., Doorman S3), this pushes the JSON payload past the 5120-byte serialization safety cap, triggering the heap buffer overflow fixed in #15566.

The full changelog is available via the `release_url` field (and Home Assistant fetches changelogs directly from that URL), so truncating the summary for the embedded web UI is reasonable.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related to #15566

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal truncation of update entity summary in web server JSON
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).