### PR TITLE
[codegen] Fix templatable int type to use cg.int_

### DIFF
--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -180,7 +180,7 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_frequency(template_))
 
     if (sens_dist := config.get(CONF_SENSING_DISTANCE)) is not None:
-        template_ = await cg.templatable(sens_dist, args, int)
+        template_ = await cg.templatable(sens_dist, args, cg.int_)
         cg.add(var.set_sensing_distance(template_))
 
     if selfcheck := config.get(CONF_POWERON_SELFCHECK_TIME):
@@ -200,7 +200,7 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_trigger_keep(template_))
 
     if (stage_gain := config.get(CONF_STAGE_GAIN)) is not None:
-        template_ = await cg.templatable(stage_gain, args, int)
+        template_ = await cg.templatable(stage_gain, args, cg.int_)
         cg.add(var.set_stage_gain(template_))
 
     if power := config.get(CONF_POWER_CONSUMPTION):

--- a/esphome/components/ezo_pmp/__init__.py
+++ b/esphome/components/ezo_pmp/__init__.py
@@ -202,7 +202,7 @@ async def ezo_pmp_dose_volume_over_time_to_code(config, action_id, template_arg,
     template_ = await cg.templatable(config[CONF_VOLUME], args, cg.double)
     cg.add(var.set_volume(template_))
 
-    template_ = await cg.templatable(config[CONF_DURATION], args, int)
+    template_ = await cg.templatable(config[CONF_DURATION], args, cg.int_)
     cg.add(var.set_duration(template_))
 
     return var
@@ -236,7 +236,7 @@ async def ezo_pmp_dose_with_constant_flow_rate_to_code(
     template_ = await cg.templatable(config[CONF_VOLUME_PER_MINUTE], args, cg.double)
     cg.add(var.set_volume(template_))
 
-    template_ = await cg.templatable(config[CONF_DURATION], args, int)
+    template_ = await cg.templatable(config[CONF_DURATION], args, cg.int_)
     cg.add(var.set_duration(template_))
 
     return var

--- a/esphome/components/fan/__init__.py
+++ b/esphome/components/fan/__init__.py
@@ -348,7 +348,7 @@ async def fan_turn_on_to_code(config, action_id, template_arg, args):
         template_ = await cg.templatable(oscillating, args, bool)
         cg.add(var.set_oscillating(template_))
     if (speed := config.get(CONF_SPEED)) is not None:
-        template_ = await cg.templatable(speed, args, int)
+        template_ = await cg.templatable(speed, args, cg.int_)
         cg.add(var.set_speed(template_))
     if (direction := config.get(CONF_DIRECTION)) is not None:
         template_ = await cg.templatable(direction, args, FanDirection)

--- a/esphome/components/pmwcs3/sensor.py
+++ b/esphome/components/pmwcs3/sensor.py
@@ -137,6 +137,6 @@ PMWCS3_NEW_I2C_ADDRESS_SCHEMA = cv.maybe_simple_value(
 async def pmwcs3newi2caddress_to_code(config, action_id, template_arg, args):
     parent = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, parent)
-    address = await cg.templatable(config[CONF_ADDRESS], args, int)
+    address = await cg.templatable(config[CONF_ADDRESS], args, cg.int_)
     cg.add(var.set_new_address(address))
     return var


### PR DESCRIPTION
# What does this implement/fix?

Fix `cg.templatable()` calls that use Python `int` as the output type to use `cg.int_` instead, for components where the C++ `TEMPLATABLE_VALUE` declares `int`.

When `cg.templatable()` is called with Python `int`, `safe_exp()` converts it to an `IntLiteral` (a numeric value like `0`) instead of a type name. This means the generated lambda lacks a proper `-> int` return type annotation, which can trigger the `TemplatableFn` deprecation warning when the automation's trigger args don't match.

**Components fixed:**
- `at581x` — sensing_distance, stage_gain
- `fan` — speed
- `pmwcs3` — address
- `ezo_pmp` — duration (2 occurrences)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example using fan speed (TEMPLATABLE_VALUE(int, speed))
fan:
  - platform: speed
    name: "My Fan"
    output: fan_output
    on_turn_on:
      - fan.turn_on:
          id: my_fan
          speed: 50
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).