### PR TITLE
[codegen] Fix templatable uint8 type to use cg.uint8

### DIFF
--- a/esphome/components/ags10/sensor.py
+++ b/esphome/components/ags10/sensor.py
@@ -97,7 +97,7 @@ AGS10_NEW_I2C_ADDRESS_SCHEMA = cv.maybe_simple_value(
 async def ags10newi2caddress_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    address = await cg.templatable(config[CONF_ADDRESS], args, int)
+    address = await cg.templatable(config[CONF_ADDRESS], args, cg.uint8)
     cg.add(var.set_new_address(address))
     return var
 

--- a/esphome/components/aic3204/audio_dac.py
+++ b/esphome/components/aic3204/audio_dac.py
@@ -43,7 +43,7 @@ async def aic3204_set_volume_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    template_ = await cg.templatable(config.get(CONF_MODE), args, int)
+    template_ = await cg.templatable(config.get(CONF_MODE), args, cg.uint8)
     cg.add(var.set_auto_mute_mode(template_))
 
     return var

--- a/esphome/components/grove_tb6612fng/__init__.py
+++ b/esphome/components/grove_tb6612fng/__init__.py
@@ -78,7 +78,7 @@ async def grove_tb6612fng_run_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
-    template_channel = await cg.templatable(config[CONF_CHANNEL], args, int)
+    template_channel = await cg.templatable(config[CONF_CHANNEL], args, cg.uint8)
     template_speed = await cg.templatable(config[CONF_SPEED], args, cg.uint16)
     cg.add(var.set_channel(template_channel))
     cg.add(var.set_speed(template_speed))
@@ -101,7 +101,7 @@ async def grove_tb6612fng_break_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
-    template_channel = await cg.templatable(config[CONF_CHANNEL], args, int)
+    template_channel = await cg.templatable(config[CONF_CHANNEL], args, cg.uint8)
     cg.add(var.set_channel(template_channel))
     return var
 
@@ -121,7 +121,7 @@ async def grove_tb6612fng_stop_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
-    template_channel = await cg.templatable(config[CONF_CHANNEL], args, int)
+    template_channel = await cg.templatable(config[CONF_CHANNEL], args, cg.uint8)
     cg.add(var.set_channel(template_channel))
     return var
 
@@ -175,6 +175,6 @@ async def grove_tb6612fng_change_address_to_code(config, action_id, template_arg
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
 
-    template_channel = await cg.templatable(config[CONF_ADDRESS], args, int)
+    template_channel = await cg.templatable(config[CONF_ADDRESS], args, cg.uint8)
     cg.add(var.set_address(template_channel))
     return var

--- a/esphome/components/htu21d/sensor.py
+++ b/esphome/components/htu21d/sensor.py
@@ -98,7 +98,7 @@ async def to_code(config):
 async def set_heater_level_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
-    level_ = await cg.templatable(config[CONF_LEVEL], args, int)
+    level_ = await cg.templatable(config[CONF_LEVEL], args, cg.uint8)
     cg.add(var.set_level(level_))
     return var
 


### PR DESCRIPTION
# What does this implement/fix?

Fix `cg.templatable()` calls that use Python `int` as the output type to use `cg.uint8` instead, for components where the C++ `TEMPLATABLE_VALUE` declares `uint8_t`.

When `cg.templatable()` is called with Python `int`, `safe_exp()` converts it to an `IntLiteral` instead of a type name. This means the generated lambda lacks a proper return type annotation.

**Components fixed:**
- `ags10` — address (`uint8_t`)
- `aic3204` — auto_mute_mode (`uint8_t`)
- `grove_tb6612fng` — channel (`uint8_t`, 3 occurrences), address (`uint8_t`)
- `htu21d` — level (`uint8_t`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example using grove_tb6612fng channel (TEMPLATABLE_VALUE(uint8_t, channel))
grove_tb6612fng:
  id: motor_driver
  address: 0x14

button:
  - platform: template
    name: "Run Motor"
    on_press:
      - grove_tb6612fng.run:
          id: motor_driver
          channel: 0
          speed: 255
          direction: FORWARD
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).