### PR TITLE
[codegen] Fix templatable uint32 type to use cg.uint32

### DIFF
--- a/esphome/components/pulse_counter/sensor.py
+++ b/esphome/components/pulse_counter/sensor.py
@@ -160,6 +160,6 @@ async def to_code(config):
 async def set_total_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, int)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint32)
     cg.add(var.set_total_pulses(template_))
     return var

--- a/esphome/components/pulse_meter/sensor.py
+++ b/esphome/components/pulse_meter/sensor.py
@@ -110,6 +110,6 @@ async def to_code(config):
 async def set_total_action_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, int)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.uint32)
     cg.add(var.set_total_pulses(template_))
     return var


### PR DESCRIPTION
# What does this implement/fix?

Fix `cg.templatable()` calls that use Python `int` as the output type to use `cg.uint32` instead, for components where the C++ `TEMPLATABLE_VALUE` declares `uint32_t`.

**Components fixed:**
- `pulse_meter` — total_pulses (`uint32_t`)
- `pulse_counter` — total_pulses (`uint32_t`)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example using pulse_meter (TEMPLATABLE_VALUE(uint32_t, total_pulses))
sensor:
  - platform: pulse_meter
    name: "Pulse Meter"
    pin: GPIO4
    on_value:
      - sensor.pulse_meter.set_total_pulses:
          id: pulse_meter
          value: 1000
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).