### PR TITLE
[script] Resolve IncludeFile objects in component config merge

### DIFF
--- a/script/merge_component_configs.py
+++ b/script/merge_component_configs.py
@@ -288,6 +288,9 @@ def merge_component_configs(
                 for pkg_name, pkg_value in list(packages_value.items()):
                     if pkg_name in common_bus_packages:
                         continue
+                    # Resolve deferred !include files before checking type
+                    if isinstance(pkg_value, yaml_util.IncludeFile):
+                        pkg_value = pkg_value.load()
                     if not isinstance(pkg_value, dict):
                         continue
                     # Component-specific package - expand its content into top level
@@ -295,6 +298,9 @@ def merge_component_configs(
             elif isinstance(packages_value, list):
                 # List format - expand all package includes
                 for pkg_value in packages_value:
+                    # Resolve deferred !include files before checking type
+                    if isinstance(pkg_value, yaml_util.IncludeFile):
+                        pkg_value = pkg_value.load()
                     if not isinstance(pkg_value, dict):
                         continue
                     comp_data = merge_config(comp_data, pkg_value)


### PR DESCRIPTION
# What does this implement/fix?

Fixes the component test merge script to handle deferred `IncludeFile` objects introduced by #12213.

When a component's test file uses a non-bus package with `!include` (e.g., `packages: device_base: !include common.yaml`), the YAML loader now returns an `IncludeFile` object instead of a resolved dict. The merge script's `isinstance(pkg_value, dict)` check silently skipped these, causing the package content (e.g., `wifi:` config) to be dropped from the merged config.

This caused grouped component tests to fail with:
```
Component web_server_base requires component network
```

The fix resolves `IncludeFile` objects via `.load()` before the type check, in both dict and list format package expansion paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #12213 (deferred `!include` resolution)
- Exposed by #9027 (emontx component) being grouped with web_server on esp8266-ard

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — fixes internal test infrastructure
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).