### PR TITLE
[at581x] Fix non-templated frequency/power_consumption constants for TemplatableFn

### DIFF
--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -173,10 +173,9 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_hw_frontend_reset(template_))
 
     if freq := config.get(CONF_FREQUENCY):
-        if cg.is_template(freq):
-            template_ = await cg.templatable(freq, args, cg.int32)
-        else:
-            template_ = int(freq / 1000000)
+        if not cg.is_template(freq):
+            freq = int(freq / 1000000)
+        template_ = await cg.templatable(freq, args, cg.int_)
         cg.add(var.set_frequency(template_))
 
     if (sens_dist := config.get(CONF_SENSING_DISTANCE)) is not None:
@@ -204,10 +203,9 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_stage_gain(template_))
 
     if power := config.get(CONF_POWER_CONSUMPTION):
-        if cg.is_template(power):
-            template_ = await cg.templatable(power, args, cg.int32)
-        else:
-            template_ = int(power * 1000000)
+        if not cg.is_template(power):
+            power = int(power * 1000000)
+        template_ = await cg.templatable(power, args, cg.int_)
         cg.add(var.set_power_consumption(template_))
 
     return var


### PR DESCRIPTION
# What does this implement/fix?

Fix build failure in `at581x` component where non-templated `frequency` and `power_consumption` values were passed as raw Python `int` to `TEMPLATABLE_VALUE` setters, which expect a lambda or `TemplatableFn`-compatible type.

The `frequency` and `power_consumption` config options have unit conversions in the non-template path (`int(freq / 1000000)`, `int(power * 1000000)`). These raw ints can't be assigned to `TemplatableFn`. The fix passes them through `cg.templatable()` which wraps constants in stateless lambdas.

Also fixes the output type from `cg.int32` to `cg.int_` to match the C++ `TEMPLATABLE_VALUE(int, ...)` declarations.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
  sda: GPIO4
  scl: GPIO5

at581x:
  id: my_at581x

button:
  - platform: template
    name: "Configure Radar"
    on_press:
      - at581x.settings:
          id: my_at581x
          frequency: "5800MHz"
          power_consumption: "70uA"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).