### PR TITLE
[esp32] Preserve crash data across OTA rollback reboots

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -276,6 +276,7 @@ class APIConnection final : public APIServerConnectionBase {
       App.schedule_dump_config();
 #ifdef USE_ESP32_CRASH_HANDLER
     esp32::crash_handler_log();
+    esp32::crash_handler_clear();
 #endif
 #ifdef USE_RP2040_CRASH_HANDLER
     rp2040::crash_handler_log();

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -108,8 +108,10 @@ void crash_handler_read_and_clear() {
 bool crash_handler_has_data() { return s_crash_data_valid; }
 
 void crash_handler_clear() {
+  // Only clear the magic so data doesn't survive the next reboot.
+  // Keep s_crash_data_valid so crash_handler_log() still works for
+  // additional API clients connecting during this boot session.
   s_raw_crash_data.magic = 0;
-  s_crash_data_valid = false;
 }
 
 // Look up the exception cause as a human-readable string.

--- a/esphome/components/esp32/crash_handler.cpp
+++ b/esphome/components/esp32/crash_handler.cpp
@@ -101,11 +101,16 @@ void crash_handler_read_and_clear() {
     if (s_raw_crash_data.pseudo_excause > 1)
       s_raw_crash_data.pseudo_excause = 0;
   }
-  // Clear magic regardless so we don't re-report on next normal reboot
-  s_raw_crash_data.magic = 0;
+  // Don't clear magic here — crash data must survive OTA rollback reboots.
+  // Magic is cleared by crash_handler_clear() after an API client receives the data.
 }
 
 bool crash_handler_has_data() { return s_crash_data_valid; }
+
+void crash_handler_clear() {
+  s_raw_crash_data.magic = 0;
+  s_crash_data_valid = false;
+}
 
 // Look up the exception cause as a human-readable string.
 // Tables mirror ESP-IDF's panic_arch_fill_info() which uses local static arrays

--- a/esphome/components/esp32/crash_handler.h
+++ b/esphome/components/esp32/crash_handler.h
@@ -4,11 +4,17 @@
 
 namespace esphome::esp32 {
 
-/// Read crash data from NOINIT memory and clear the magic marker.
+/// Read and validate crash data from NOINIT memory.
+/// Does not clear the magic marker — call crash_handler_clear() after
+/// the data has been delivered to an API client so it survives OTA rollback reboots.
 void crash_handler_read_and_clear();
 
 /// Log crash data if a crash was detected on previous boot.
 void crash_handler_log();
+
+/// Clear the magic marker and mark crash data as consumed.
+/// Call after the data has been delivered to an API client.
+void crash_handler_clear();
 
 /// Returns true if crash data was found this boot.
 bool crash_handler_has_data();


### PR DESCRIPTION
# What does this implement/fix?

Previously, `crash_handler_read_and_clear()` cleared the `.noinit` magic marker immediately at boot. If OTA rollback triggered a reboot before an API client connected, the crash trace was permanently lost — the user would never see what caused the crash.

Now the magic marker is only cleared after `crash_handler_log()` delivers the data to an API client (via a new `crash_handler_clear()` function). This means:

- Crash data survives OTA rollback reboots (and any other reboots before API connection)
- Serial output still logs the crash on every boot while the data is present
- Once an API client connects and receives the crash log, the magic is cleared so it won't persist to the next reboot
- `s_crash_data_valid` is kept true after clearing, so additional API clients connecting in the same boot session still receive the crash report

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No configuration changes needed - crash handler is built-in
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).