### PR TITLE
[esp32_ble] Add bluetooth classic compatibility option

### DIFF
--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -240,6 +240,7 @@ def register_bt_logger(*loggers: BTLoggers) -> None:
 
 
 CONF_BLE_ID = "ble_id"
+CONF_BT_CLASSIC_COMPATIBILITY = "bt_classic_compatibility"
 CONF_IO_CAPABILITY = "io_capability"
 CONF_AUTH_REQ_MODE = "auth_req_mode"
 CONF_MAX_KEY_SIZE = "max_key_size"
@@ -319,6 +320,7 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ESP32BLE),
         cv.Optional(CONF_NAME): cv.All(cv.string, cv.Length(max=20)),
+        cv.Optional(CONF_BT_CLASSIC_COMPATIBILITY, default=False): cv.boolean,
         cv.Optional(CONF_IO_CAPABILITY, default="none"): cv.enum(
             IO_CAPABILITY, lower=True
         ),
@@ -603,6 +605,9 @@ async def to_code(config):
 
     add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
     add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
+
+    if config.get(CONF_BT_CLASSIC_COMPATIBILITY, False):
+        cg.add_define("USE_ESP32_BT_CLASSIC_COMPATIBILITY")
 
     # Register the core BLE loggers that are always needed
     register_bt_logger(BTLoggers.GAP, BTLoggers.BTM, BTLoggers.HCI)

--- a/esphome/components/esp32_ble/__init__.py
+++ b/esphome/components/esp32_ble/__init__.py
@@ -240,7 +240,6 @@ def register_bt_logger(*loggers: BTLoggers) -> None:
 
 
 CONF_BLE_ID = "ble_id"
-CONF_BT_CLASSIC_COMPATIBILITY = "bt_classic_compatibility"
 CONF_IO_CAPABILITY = "io_capability"
 CONF_AUTH_REQ_MODE = "auth_req_mode"
 CONF_MAX_KEY_SIZE = "max_key_size"
@@ -320,7 +319,6 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(ESP32BLE),
         cv.Optional(CONF_NAME): cv.All(cv.string, cv.Length(max=20)),
-        cv.Optional(CONF_BT_CLASSIC_COMPATIBILITY, default=False): cv.boolean,
         cv.Optional(CONF_IO_CAPABILITY, default="none"): cv.enum(
             IO_CAPABILITY, lower=True
         ),
@@ -605,9 +603,6 @@ async def to_code(config):
 
     add_idf_sdkconfig_option("CONFIG_BT_ENABLED", True)
     add_idf_sdkconfig_option("CONFIG_BT_BLE_42_FEATURES_SUPPORTED", True)
-
-    if config.get(CONF_BT_CLASSIC_COMPATIBILITY, False):
-        cg.add_define("USE_ESP32_BT_CLASSIC_COMPATIBILITY")
 
     # Register the core BLE loggers that are always needed
     register_bt_logger(BTLoggers.GAP, BTLoggers.BTM, BTLoggers.HCI)

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -233,7 +233,7 @@ bool ESP32BLE::ble_setup_() {
       ESP_LOGE(TAG, "esp_bluedroid_enable failed: %d", err);
       return false;
     }
-}
+  }
 
 #ifdef ESPHOME_ESP32_BLE_GAP_EVENT_HANDLER_COUNT
   err = esp_ble_gap_register_callback(ESP32BLE::gap_event_handler);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -178,7 +178,11 @@ bool ESP32BLE::ble_setup_() {
         ;
     }
     if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
+#ifdef USE_ESP32_BT_CLASSIC_COMPATIBILITY
+      err = esp_bt_controller_enable(ESP_BT_MODE_BTDM);
+#else
       err = esp_bt_controller_enable(ESP_BT_MODE_BLE);
+#endif
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_bt_controller_enable failed: %s", esp_err_to_name(err));
         return false;
@@ -190,7 +194,9 @@ bool ESP32BLE::ble_setup_() {
     }
   }
 
+#ifndef USE_ESP32_BT_CLASSIC_COMPATIBILITY
   esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
+#endif
 #else
   esp_hosted_connect_to_slave();  // NOLINT
 
@@ -214,16 +220,20 @@ bool ESP32BLE::ble_setup_() {
   esp_bluedroid_attach_hci_driver(&operations);
 #endif
 
-  err = esp_bluedroid_init();
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_init failed: %d", err);
-    return false;
+  if (esp_bluedroid_get_status() == ESP_BLUEDROID_STATUS_UNINITIALIZED) {
+    err = esp_bluedroid_init();
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_bluedroid_init failed: %d", err);
+      return false;
+    }
   }
-  err = esp_bluedroid_enable();
-  if (err != ESP_OK) {
-    ESP_LOGE(TAG, "esp_bluedroid_enable failed: %d", err);
-    return false;
-  }
+  if (esp_bluedroid_get_status() != ESP_BLUEDROID_STATUS_ENABLED) {
+    err = esp_bluedroid_enable();
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "esp_bluedroid_enable failed: %d", err);
+      return false;
+    }
+}
 
 #ifdef ESPHOME_ESP32_BLE_GAP_EVENT_HANDLER_COUNT
   err = esp_ble_gap_register_callback(ESP32BLE::gap_event_handler);

--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -178,6 +178,7 @@ bool ESP32BLE::ble_setup_() {
         ;
     }
     if (esp_bt_controller_get_status() == ESP_BT_CONTROLLER_STATUS_INITED) {
+// For compatibility with (external) components that need BT Classic
 #ifdef USE_ESP32_BT_CLASSIC_COMPATIBILITY
       err = esp_bt_controller_enable(ESP_BT_MODE_BTDM);
 #else
@@ -194,6 +195,7 @@ bool ESP32BLE::ble_setup_() {
     }
   }
 
+// For compatibility with (external) components that need BT Classic
 #ifndef USE_ESP32_BT_CLASSIC_COMPATIBILITY
   esp_bt_controller_mem_release(ESP_BT_MODE_CLASSIC_BT);
 #endif


### PR DESCRIPTION
# What does this implement/fix?

As it is currently implemented, the `esp32_ble` component takes full control over the Bluetooth stack, making it impossible for any (external / custom) components to use the 'Classic' Bluetooth part of the stack.

<details><summary>
Why is BT Classic needed? 
TL;DR: Its for the tinkerers and custom components.
</summary>

I've previously tinkered with properly implementing a Bluetooth classic component into ESPHome (#4736) but never managed to get it quite stable enough for my personal taste to release it to the masses. For personal use though it works great, and having to keep every component that touches the Bluetooth stack patched just to keep a custom component compatible with the latest version of ESPHome is quite a pain.

I'm also using a custom component that relies on BT Classic to communicate with some older Bluetooth devices that is purely for internal use, but cannot be maintained without also having to patch `esp32_ble` to allow both BLE and BT Classic to co-exist.
</details>

This PR provides a minimally invasive way of allowing users and fellow tinkerers to keep access to the Classical Bluetooth parts for custom components without the need to keep a patched version of the `esp32_ble` component maintained to avoid conflicts with the Bluetooth stack.

The newly added option is disabled by default and would have no impact on existing configs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

esp32_ble:
  bt_classic_compatibility: True

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
