### PR TITLE
[api] Fix batch messages stuck in Nagle buffer

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -315,6 +315,8 @@ void APIConnection::process_active_iterator_() {
       this->destroy_active_iterator_();
       if (this->flags_.state_subscription) {
         this->begin_iterator_(ActiveIterator::INITIAL_STATE);
+      } else {
+        this->finalize_iterator_sync_();
       }
     } else {
       this->process_iterator_batch_(this->iterator_storage_.list_entities);
@@ -322,19 +324,25 @@ void APIConnection::process_active_iterator_() {
   } else {  // INITIAL_STATE
     if (this->iterator_storage_.initial_state.completed()) {
       this->destroy_active_iterator_();
-      // Process any remaining batched messages immediately
-      if (!this->deferred_batch_.empty()) {
-        this->process_batch_();
-      }
-      // Now that everything is sent, enable immediate sending for future state changes
-      this->flags_.should_try_send_immediately = true;
-      // Release excess memory from buffers that grew during initial sync
-      this->deferred_batch_.release_buffer();
-      this->helper_->release_buffers();
+      this->finalize_iterator_sync_();
     } else {
       this->process_iterator_batch_(this->iterator_storage_.initial_state);
     }
   }
+}
+
+void APIConnection::finalize_iterator_sync_() {
+  // Flush any remaining batched messages immediately so clients
+  // receive completion responses (e.g. ListEntitiesDoneResponse)
+  // without waiting for the batch timer.
+  if (!this->deferred_batch_.empty()) {
+    this->process_batch_();
+  }
+  // Enable immediate sending for future state changes
+  this->flags_.should_try_send_immediately = true;
+  // Release excess memory from buffers that grew during initial sync
+  this->deferred_batch_.release_buffer();
+  this->helper_->release_buffers();
 }
 
 void APIConnection::process_iterator_batch_(ComponentIterator &iterator) {
@@ -2221,6 +2229,13 @@ void APIConnection::process_batch_multi_(APIBuffer &shared_buf, size_t num_items
     if (footer_size > 0) {
       shared_buf.resize(shared_buf.size() + footer_size);
     }
+
+    // Ensure TCP_NODELAY is on before writing batch data.
+    // Log messages enable Nagle (NODELAY off) to coalesce small packets.
+    // Without this, batch data written to the socket sits in LWIP's Nagle
+    // buffer — the remote won't ACK until it sends its own data (e.g. a
+    // ping), which can take 20+ seconds.
+    this->helper_->set_nodelay_for_message(false);
 
     // Send all collected messages
     APIError err = this->helper_->write_protobuf_messages(ProtoWriteBuffer{&shared_buf},

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -618,6 +618,7 @@ class APIConnection final : public APIServerConnectionBase {
   // Helper methods for iterator lifecycle management
   void destroy_active_iterator_();
   void begin_iterator_(ActiveIterator type);
+  void finalize_iterator_sync_();
 #ifdef USE_CAMERA
   std::unique_ptr<camera::CameraImageReader> image_reader_;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes batch messages (entity listing, initial state) getting stuck in LWIP's TCP Nagle buffer, causing delayed or failed delivery to API clients.

## Background

The multi-message batch write path (`process_batch_multi_`) was introduced in #9012 (2025-06-10) when TCP_NODELAY was always on, so it wrote directly via `write_protobuf_messages()` without managing NODELAY state.

In #13026 (2026-01-07), Nagle toggling was added to coalesce log packets and reduce LWIP buffer pressure. This disables NODELAY during log bursts so small log messages are batched by the TCP stack. #13439 later refined this into the counter-based `set_nodelay_for_message()`. However, the multi-message batch path was never updated to restore NODELAY before writing. The single-message fast path was not affected because it uses `send_buffer()` which already calls `set_nodelay_for_message(false)`.

When log messages leave Nagle enabled (NODELAY off) and the batch path writes entity listing or state responses, the data sits in LWIP's Nagle buffer. LWIP won't flush until the remote ACKs previous data, but the remote is waiting for the batch response and has nothing to send — creating a deadlock that only breaks when some other event (keepalive ping, log message) happens to trigger a write with NODELAY on.

This has been **causing slow reconnects in Home Assistant for months** — the stall during initial entity listing or state sync would silently resolve when any other message happened to flush the TCP buffer (e.g. a keepalive ping or a log message being sent to another client), masking the root cause and making it difficult to reproduce.

The bug became consistently reproducible after aioesphomeapi v44.8.0 added `subscribe_states` to `esphome logs` (aioesphomeapi#1547). The log runner now calls `device_info_and_list_entities()` with a 60-second timeout after subscribing to logs. When the entity listing gets stuck in the Nagle buffer, this timeout expires, the client sends a `DisconnectRequest`, reconnects, and repeats the cycle indefinitely — providing a reliable reproduction case that led to identifying the root cause.

## Fix

1. **Call `set_nodelay_for_message(false)` before `write_protobuf_messages` in `process_batch_multi_`** to ensure TCP_NODELAY is on, matching what the single-message path already does via `send_buffer()`.

2. **Flush batch immediately when LIST_ENTITIES completes without state subscription** (log-only clients). Previously only the INITIAL_STATE completion path flushed. Extracted shared `finalize_iterator_sync_()` helper to deduplicate.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Regression from #13026

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config changes needed — this is an internal API server fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).