### PR TITLE
[rpi_dpi_rgb][qspi_dbi] Add deprecation warnings

### DIFF
--- a/esphome/components/qspi_dbi/__init__.py
+++ b/esphome/components/qspi_dbi/__init__.py
@@ -1,3 +1,8 @@
 CODEOWNERS = ["@clydebarrow"]
 
 CONF_DRAW_FROM_ORIGIN = "draw_from_origin"
+
+DEPRECATED_COMPONENT = """
+The 'qspi_dbi' component is deprecated and no new models will be added to it.
+New model PRs should target the newer and more performant 'mipi_spi' component.
+"""

--- a/esphome/components/qspi_dbi/display.py
+++ b/esphome/components/qspi_dbi/display.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import display, spi
@@ -29,6 +31,7 @@ from . import CONF_DRAW_FROM_ORIGIN
 from .models import DriverChip
 
 DEPENDENCIES = ["spi"]
+LOGGER = logging.getLogger(__name__)
 
 qspi_dbi_ns = cg.esphome_ns.namespace("qspi_dbi")
 QSPI_DBI = qspi_dbi_ns.class_(
@@ -160,6 +163,9 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    LOGGER.warning(
+        "The 'qspi_dbi' component is deprecated, it is recommended to use 'mipi_spi' instead."
+    )
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
     await spi.register_spi_device(var, config, write_only=True)

--- a/esphome/components/rpi_dpi_rgb/__init__.py
+++ b/esphome/components/rpi_dpi_rgb/__init__.py
@@ -1,1 +1,6 @@
 CODEOWNERS = ["@clydebarrow"]
+
+DEPRECATED_COMPONENT = """
+The 'rpi_dpi_rgb' component is deprecated and no new models will be added to it.
+New model PRs should target the newer and more performant 'mipi_rgb' component.
+"""

--- a/esphome/components/rpi_dpi_rgb/display.py
+++ b/esphome/components/rpi_dpi_rgb/display.py
@@ -1,3 +1,5 @@
+import logging
+
 from esphome import pins
 import esphome.codegen as cg
 from esphome.components import display
@@ -38,6 +40,7 @@ from esphome.const import (
 )
 
 DEPENDENCIES = ["esp32"]
+LOGGER = logging.getLogger(__name__)
 
 rpi_dpi_rgb_ns = cg.esphome_ns.namespace("rpi_dpi_rgb")
 RPI_DPI_RGB = rpi_dpi_rgb_ns.class_("RpiDpiRgb", display.Display, cg.Component)
@@ -126,6 +129,9 @@ CONFIG_SCHEMA = cv.All(
 
 
 async def to_code(config):
+    LOGGER.warning(
+        "The 'rpi_dpi_rgb' component is deprecated, it is recommended to use 'mipi_rgb' instead."
+    )
     var = cg.new_Pvariable(config[CONF_ID])
     await display.register_display(var, config)
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add deprecation warnings for `rpi_dpi_rgb` and `qspi_dbi` displays which have been superseded by `mipi_rgb` and `mipi_spi`.

* Use of these components will issue a build-time warning;
* Any PR raised against these components will be flagged by CI
* No functionality is changed.
* The docs already note these components as having been deprecated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
