### PR TITLE
[gdk101] Increase reset retries for slow-booting sensor MCU

### DIFF
--- a/esphome/components/gdk101/gdk101.cpp
+++ b/esphome/components/gdk101/gdk101.cpp
@@ -7,7 +7,7 @@ namespace gdk101 {
 
 static const char *const TAG = "gdk101";
 static constexpr uint8_t NUMBER_OF_READ_RETRIES = 5;
-static constexpr uint8_t NUMBER_OF_RESET_RETRIES = 10;
+static constexpr uint8_t NUMBER_OF_RESET_RETRIES = 30;
 static constexpr uint32_t RESET_INTERVAL_ID = 0;
 static constexpr uint32_t RESET_INTERVAL_MS = 1000;
 


### PR DESCRIPTION
# What does this implement/fix?

#11750 added retry logic for the GDK101 reset. An earlier design retried in `update()` which gave the sensor MCU much more time to boot (60s polling interval × 10 retries = ~10 minutes), but wasn't a great design. The final version used `set_interval` with a 1-second interval and 10 retries, which only gives 10 seconds — not enough for some sensors.

Increase `NUMBER_OF_RESET_RETRIES` from 10 to 30, giving the sensor MCU up to 30 seconds to boot after a power cycle.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to https://github.com/esphome/esphome/pull/11750

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).