### PR TITLE
[ci] Fix status-check-labels workflow flooding CI queue

### DIFF
--- a/.github/workflows/status-check-labels.yml
+++ b/.github/workflows/status-check-labels.yml
@@ -2,7 +2,7 @@ name: Status check labels
 
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/status-check-labels.yml
+++ b/.github/workflows/status-check-labels.yml
@@ -4,28 +4,27 @@ on:
   pull_request:
     types: [labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check:
-    name: Check ${{ matrix.label }}
+    name: Check blocking labels
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        label:
-          - needs-docs
-          - merge-after-release
-          - chained-pr
     steps:
-      - name: Check for ${{ matrix.label }} label
+      - name: Check for blocking labels
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
+            const blockingLabels = ['needs-docs', 'merge-after-release', 'chained-pr'];
             const { data: labels } = await github.rest.issues.listLabelsOnIssue({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number
             });
-            const hasLabel = labels.find(label => label.name === '${{ matrix.label }}');
-            if (hasLabel) {
-              core.setFailed('Pull request cannot be merged, it is labeled as ${{ matrix.label }}');
+            const labelNames = labels.map(l => l.name);
+            const found = blockingLabels.filter(bl => labelNames.includes(bl));
+            if (found.length > 0) {
+              core.setFailed(`Pull request cannot be merged, it has blocking label(s): ${found.join(', ')}`);
             }


### PR DESCRIPTION
# What does this implement/fix?

The `status-check-labels` workflow uses a 3-job matrix that triggers on every `labeled`/`unlabeled` event. When the auto-label workflow adds multiple labels to a PR, each label fires a new run of 3 jobs, flooding the CI queue:

<img width="444" height="754" alt="Screenshot 2026-04-08 at 12 46 06 PM" src="https://github.com/user-attachments/assets/2499aa77-0c49-4b37-951c-c4de32f49220" />


This PR fixes it by:
1. **Adding `concurrency` with `cancel-in-progress`** — rapid label events on the same PR cancel superseded runs instead of queuing
2. **Collapsing the 3-job matrix into a single job** — one API call checks all blocking labels, reducing jobs from 3 to 1 per trigger

**Note:** If any of the old matrix check names (`Check needs-docs`, `Check merge-after-release`, `Check chained-pr`) are configured as required status checks in branch protection, they need to be updated to `Check blocking labels`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

N/A — CI workflow change only.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).