### PR TITLE
[CI] Add org fork detection warning to auto-label PR workflow

### DIFF
--- a/.github/scripts/auto-label-pr/constants.js
+++ b/.github/scripts/auto-label-pr/constants.js
@@ -4,6 +4,7 @@ module.exports = {
   CODEOWNERS_MARKER: '<!-- codeowners-request -->',
   TOO_BIG_MARKER: '<!-- too-big-request -->',
   DEPRECATED_COMPONENT_MARKER: '<!-- deprecated-component-request -->',
+  ORG_FORK_MARKER: '<!-- org-fork-warning -->',
 
   MANAGED_LABELS: [
     'new-component',

--- a/.github/scripts/auto-label-pr/constants.js
+++ b/.github/scripts/auto-label-pr/constants.js
@@ -4,7 +4,7 @@ module.exports = {
   CODEOWNERS_MARKER: '<!-- codeowners-request -->',
   TOO_BIG_MARKER: '<!-- too-big-request -->',
   DEPRECATED_COMPONENT_MARKER: '<!-- deprecated-component-request -->',
-  ORG_FORK_MARKER: '<!-- org-fork-warning -->',
+  ORG_FORK_MARKER: '<!-- maintainer-access-warning -->',
 
   MANAGED_LABELS: [
     'new-component',

--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -282,7 +282,7 @@ async function detectDeprecatedComponents(github, context, changedFiles) {
 }
 
 // Strategy: Org fork detection
-async function detectOrgFork(context) {
+function detectOrgFork(context) {
   const pr = context.payload.pull_request;
 
   // Only relevant for cross-repo PRs (forks)

--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -281,6 +281,24 @@ async function detectDeprecatedComponents(github, context, changedFiles) {
   return { labels, deprecatedInfo };
 }
 
+// Strategy: Org fork detection
+async function detectOrgFork(context) {
+  const pr = context.payload.pull_request;
+
+  // Only relevant for cross-repo PRs (forks)
+  if (!pr.head.repo || pr.head.repo.full_name === pr.base.repo.full_name) {
+    return false;
+  }
+
+  const ownerType = pr.head.repo.owner.type;
+  if (ownerType === 'Organization') {
+    console.log(`PR branch is owned by organization: ${pr.head.repo.owner.login}`);
+    return true;
+  }
+
+  return false;
+}
+
 // Strategy: Requirements detection
 async function detectRequirements(allLabels, prFiles, context) {
   const labels = new Set();
@@ -329,5 +347,6 @@ module.exports = {
   detectTests,
   detectPRTemplateCheckboxes,
   detectDeprecatedComponents,
+  detectOrgFork,
   detectRequirements
 };

--- a/.github/scripts/auto-label-pr/detectors.js
+++ b/.github/scripts/auto-label-pr/detectors.js
@@ -281,22 +281,22 @@ async function detectDeprecatedComponents(github, context, changedFiles) {
   return { labels, deprecatedInfo };
 }
 
-// Strategy: Org fork detection
-function detectOrgFork(context) {
+// Strategy: Detect when maintainers cannot modify the PR branch
+function detectMaintainerAccess(context) {
   const pr = context.payload.pull_request;
 
   // Only relevant for cross-repo PRs (forks)
   if (!pr.head.repo || pr.head.repo.full_name === pr.base.repo.full_name) {
-    return false;
+    return null;
   }
 
-  const ownerType = pr.head.repo.owner.type;
-  if (ownerType === 'Organization') {
-    console.log(`PR branch is owned by organization: ${pr.head.repo.owner.login}`);
-    return true;
+  if (pr.maintainer_can_modify) {
+    return null;
   }
 
-  return false;
+  const isOrgFork = pr.head.repo.owner.type === 'Organization';
+  console.log(`Maintainer cannot modify PR branch (${isOrgFork ? 'org fork: ' + pr.head.repo.owner.login : 'user disabled'})`);
+  return { isOrgFork, orgName: pr.head.repo.owner.login };
 }
 
 // Strategy: Requirements detection
@@ -347,6 +347,6 @@ module.exports = {
   detectTests,
   detectPRTemplateCheckboxes,
   detectDeprecatedComponents,
-  detectOrgFork,
+  detectMaintainerAccess,
   detectRequirements
 };

--- a/.github/scripts/auto-label-pr/index.js
+++ b/.github/scripts/auto-label-pr/index.js
@@ -12,10 +12,10 @@ const {
   detectTests,
   detectPRTemplateCheckboxes,
   detectDeprecatedComponents,
-  detectOrgFork,
+  detectMaintainerAccess,
   detectRequirements
 } = require('./detectors');
-const { handleReviews, handleOrgForkComment } = require('./reviews');
+const { handleReviews, handleMaintainerAccessComment } = require('./reviews');
 const { applyLabels, removeOldLabels } = require('./labels');
 
 // Fetch API data
@@ -116,7 +116,7 @@ module.exports = async ({ github, context }) => {
     testLabels,
     checkboxLabels,
     deprecatedResult,
-    isOrgFork
+    maintainerAccess
   ] = await Promise.all([
     detectMergeBranch(context),
     detectComponentPlatforms(changedFiles, apiData),
@@ -130,7 +130,7 @@ module.exports = async ({ github, context }) => {
     detectTests(changedFiles),
     detectPRTemplateCheckboxes(context),
     detectDeprecatedComponents(github, context, changedFiles),
-    detectOrgFork(context)
+    detectMaintainerAccess(context)
   ]);
 
   // Extract deprecated component info
@@ -183,7 +183,7 @@ module.exports = async ({ github, context }) => {
   // Handle reviews and org fork comment
   await Promise.all([
     handleReviews(github, context, finalLabels, originalLabelCount, deprecatedInfo, prFiles, totalAdditions, totalDeletions, MAX_LABELS, TOO_BIG_THRESHOLD),
-    handleOrgForkComment(github, context, isOrgFork)
+    handleMaintainerAccessComment(github, context, maintainerAccess)
   ]);
 
   // Apply labels

--- a/.github/scripts/auto-label-pr/index.js
+++ b/.github/scripts/auto-label-pr/index.js
@@ -12,9 +12,10 @@ const {
   detectTests,
   detectPRTemplateCheckboxes,
   detectDeprecatedComponents,
+  detectOrgFork,
   detectRequirements
 } = require('./detectors');
-const { handleReviews } = require('./reviews');
+const { handleReviews, handleOrgForkComment } = require('./reviews');
 const { applyLabels, removeOldLabels } = require('./labels');
 
 // Fetch API data
@@ -114,7 +115,8 @@ module.exports = async ({ github, context }) => {
     codeOwnerLabels,
     testLabels,
     checkboxLabels,
-    deprecatedResult
+    deprecatedResult,
+    isOrgFork
   ] = await Promise.all([
     detectMergeBranch(context),
     detectComponentPlatforms(changedFiles, apiData),
@@ -127,7 +129,8 @@ module.exports = async ({ github, context }) => {
     detectCodeOwner(github, context, changedFiles),
     detectTests(changedFiles),
     detectPRTemplateCheckboxes(context),
-    detectDeprecatedComponents(github, context, changedFiles)
+    detectDeprecatedComponents(github, context, changedFiles),
+    detectOrgFork(context)
   ]);
 
   // Extract deprecated component info
@@ -177,8 +180,11 @@ module.exports = async ({ github, context }) => {
 
   console.log('Computed labels:', finalLabels.join(', '));
 
-  // Handle reviews
-  await handleReviews(github, context, finalLabels, originalLabelCount, deprecatedInfo, prFiles, totalAdditions, totalDeletions, MAX_LABELS, TOO_BIG_THRESHOLD);
+  // Handle reviews and org fork comment
+  await Promise.all([
+    handleReviews(github, context, finalLabels, originalLabelCount, deprecatedInfo, prFiles, totalAdditions, totalDeletions, MAX_LABELS, TOO_BIG_THRESHOLD),
+    handleOrgForkComment(github, context, isOrgFork)
+  ]);
 
   // Apply labels
   await applyLabels(github, context, finalLabels);

--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -148,15 +148,20 @@ async function handleOrgForkComment(github, context, isOrgFork) {
   const prAuthor = context.payload.pull_request.user.login;
   const orgName = context.payload.pull_request.head.repo.owner.login;
 
-  // Check if we already posted the warning
-  const comments = await github.paginate(
+  // Check if we already posted the warning (iterate pages to exit early)
+  let existingComment;
+  for await (const { data: comments } of github.paginate.iterator(
     github.rest.issues.listComments,
     { owner, repo, issue_number: pr_number }
-  );
-  const existingComment = comments.find(comment =>
-    comment.user.type === 'Bot' &&
-    comment.body && comment.body.includes(ORG_FORK_MARKER)
-  );
+  )) {
+    existingComment = comments.find(comment =>
+      comment.user.type === 'Bot' &&
+      comment.body && comment.body.includes(ORG_FORK_MARKER)
+    );
+    if (existingComment) {
+      break;
+    }
+  }
 
   if (existingComment) {
     console.log('Org fork warning comment already exists, skipping');

--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -2,7 +2,8 @@ const {
   BOT_COMMENT_MARKER,
   CODEOWNERS_MARKER,
   TOO_BIG_MARKER,
-  DEPRECATED_COMPONENT_MARKER
+  DEPRECATED_COMPONENT_MARKER,
+  ORG_FORK_MARKER
 } = require('./constants');
 
 // Generate review messages
@@ -136,6 +137,61 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
   }
 }
 
+// Handle org fork warning comment
+async function handleOrgForkComment(github, context, isOrgFork) {
+  const { owner, repo } = context.repo;
+  const pr_number = context.issue.number;
+  const prAuthor = context.payload.pull_request.user.login;
+  const orgName = context.payload.pull_request.head.repo?.owner?.login;
+
+  // Find existing org fork comment
+  const comments = await github.paginate(
+    github.rest.issues.listComments,
+    { owner, repo, issue_number: pr_number }
+  );
+  const existingComment = comments.find(comment =>
+    comment.user.type === 'Bot' &&
+    comment.body && comment.body.includes(ORG_FORK_MARKER)
+  );
+
+  if (isOrgFork) {
+    const body = `${ORG_FORK_MARKER}\n### ⚠️ Organization Fork Detected\n\n` +
+      `Hey there @${prAuthor},\n` +
+      `It looks like this PR was submitted from a fork owned by the **${orgName}** organization. ` +
+      `GitHub does not allow maintainers to push changes to pull request branches when the fork is owned by an organization. ` +
+      `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
+      `To allow maintainer collaboration, please re-submit this PR from a personal fork instead.\n\n` +
+      `See: [Setting up the local repository](https://developers.esphome.io/contributing/development-environment/?h=org#set-up-the-local-repository) for more details.`;
+
+    if (existingComment) {
+      await github.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: existingComment.id,
+        body
+      });
+      console.log('Updated existing org fork warning comment');
+    } else {
+      await github.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: pr_number,
+        body
+      });
+      console.log('Created org fork warning comment');
+    }
+  } else if (existingComment) {
+    // Remove the comment if the condition is no longer met (e.g., PR was re-submitted)
+    await github.rest.issues.deleteComment({
+      owner,
+      repo,
+      comment_id: existingComment.id
+    });
+    console.log('Deleted org fork warning comment (no longer applicable)');
+  }
+}
+
 module.exports = {
-  handleReviews
+  handleReviews,
+  handleOrgForkComment
 };

--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -139,12 +139,16 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
 
 // Handle org fork warning comment
 async function handleOrgForkComment(github, context, isOrgFork) {
+  if (!isOrgFork) {
+    return;
+  }
+
   const { owner, repo } = context.repo;
   const pr_number = context.issue.number;
   const prAuthor = context.payload.pull_request.user.login;
-  const orgName = context.payload.pull_request.head.repo?.owner?.login;
+  const orgName = context.payload.pull_request.head.repo.owner.login;
 
-  // Find existing org fork comment
+  // Check if we already posted the warning
   const comments = await github.paginate(
     github.rest.issues.listComments,
     { owner, repo, issue_number: pr_number }
@@ -154,41 +158,26 @@ async function handleOrgForkComment(github, context, isOrgFork) {
     comment.body && comment.body.includes(ORG_FORK_MARKER)
   );
 
-  if (isOrgFork) {
-    const body = `${ORG_FORK_MARKER}\n### ⚠️ Organization Fork Detected\n\n` +
-      `Hey there @${prAuthor},\n` +
-      `It looks like this PR was submitted from a fork owned by the **${orgName}** organization. ` +
-      `GitHub does not allow maintainers to push changes to pull request branches when the fork is owned by an organization. ` +
-      `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
-      `To allow maintainer collaboration, please re-submit this PR from a personal fork instead.\n\n` +
-      `See: [Setting up the local repository](https://developers.esphome.io/contributing/development-environment/?h=org#set-up-the-local-repository) for more details.`;
-
-    if (existingComment) {
-      await github.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existingComment.id,
-        body
-      });
-      console.log('Updated existing org fork warning comment');
-    } else {
-      await github.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: pr_number,
-        body
-      });
-      console.log('Created org fork warning comment');
-    }
-  } else if (existingComment) {
-    // Remove the comment if the condition is no longer met (e.g., PR was re-submitted)
-    await github.rest.issues.deleteComment({
-      owner,
-      repo,
-      comment_id: existingComment.id
-    });
-    console.log('Deleted org fork warning comment (no longer applicable)');
+  if (existingComment) {
+    console.log('Org fork warning comment already exists, skipping');
+    return;
   }
+
+  const body = `${ORG_FORK_MARKER}\n### ⚠️ Organization Fork Detected\n\n` +
+    `Hey there @${prAuthor},\n` +
+    `It looks like this PR was submitted from a fork owned by the **${orgName}** organization. ` +
+    `GitHub does not allow maintainers to push changes to pull request branches when the fork is owned by an organization. ` +
+    `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
+    `To allow maintainer collaboration, please re-submit this PR from a personal fork instead.\n\n` +
+    `See: [Setting up the local repository](https://developers.esphome.io/contributing/development-environment/?h=org#set-up-the-local-repository) for more details.`;
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pr_number,
+    body
+  });
+  console.log('Created org fork warning comment');
 }
 
 module.exports = {

--- a/.github/scripts/auto-label-pr/reviews.js
+++ b/.github/scripts/auto-label-pr/reviews.js
@@ -137,16 +137,15 @@ async function handleReviews(github, context, finalLabels, originalLabelCount, d
   }
 }
 
-// Handle org fork warning comment
-async function handleOrgForkComment(github, context, isOrgFork) {
-  if (!isOrgFork) {
+// Handle maintainer access warning comment
+async function handleMaintainerAccessComment(github, context, maintainerAccess) {
+  if (!maintainerAccess) {
     return;
   }
 
   const { owner, repo } = context.repo;
   const pr_number = context.issue.number;
   const prAuthor = context.payload.pull_request.user.login;
-  const orgName = context.payload.pull_request.head.repo.owner.login;
 
   // Check if we already posted the warning (iterate pages to exit early)
   let existingComment;
@@ -164,17 +163,26 @@ async function handleOrgForkComment(github, context, isOrgFork) {
   }
 
   if (existingComment) {
-    console.log('Org fork warning comment already exists, skipping');
+    console.log('Maintainer access warning comment already exists, skipping');
     return;
   }
 
-  const body = `${ORG_FORK_MARKER}\n### ⚠️ Organization Fork Detected\n\n` +
-    `Hey there @${prAuthor},\n` +
-    `It looks like this PR was submitted from a fork owned by the **${orgName}** organization. ` +
-    `GitHub does not allow maintainers to push changes to pull request branches when the fork is owned by an organization. ` +
-    `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
-    `To allow maintainer collaboration, please re-submit this PR from a personal fork instead.\n\n` +
-    `See: [Setting up the local repository](https://developers.esphome.io/contributing/development-environment/?h=org#set-up-the-local-repository) for more details.`;
+  let body;
+  if (maintainerAccess.isOrgFork) {
+    body = `${ORG_FORK_MARKER}\n### ⚠️ Organization Fork Detected\n\n` +
+      `Hey there @${prAuthor},\n` +
+      `It looks like this PR was submitted from a fork owned by the **${maintainerAccess.orgName}** organization. ` +
+      `GitHub does not allow maintainers to push changes to pull request branches when the fork is owned by an organization. ` +
+      `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
+      `To allow maintainer collaboration, please re-submit this PR from a personal fork instead.\n\n` +
+      `See: [Setting up the local repository](https://developers.esphome.io/contributing/development-environment/?h=org#set-up-the-local-repository) for more details.`;
+  } else {
+    body = `${ORG_FORK_MARKER}\n### ⚠️ Maintainer Access Disabled\n\n` +
+      `Hey there @${prAuthor},\n` +
+      `It looks like this PR does not have the "Allow edits from maintainers" option enabled. ` +
+      `This means we won't be able to make small adjustments or fixups to your PR directly.\n\n` +
+      `Please enable this option in the PR sidebar to allow maintainer collaboration.`;
+  }
 
   await github.rest.issues.createComment({
     owner,
@@ -182,10 +190,10 @@ async function handleOrgForkComment(github, context, isOrgFork) {
     issue_number: pr_number,
     body
   });
-  console.log('Created org fork warning comment');
+  console.log('Created maintainer access warning comment');
 }
 
 module.exports = {
   handleReviews,
-  handleOrgForkComment
+  handleMaintainerAccessComment
 };


### PR DESCRIPTION
# What does this implement/fix?

Adds org fork detection to the auto-label PR workflow. When a PR is submitted from a fork owned by a GitHub organization (rather than a personal user account), the bot posts a comment warning the author that maintainers cannot push to org-owned fork branches. The comment links to the developer docs page explaining how to set up a personal fork.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - GitHub Actions workflow change only
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).