### PR TITLE
[api] Fix ListEntitiesRequest not read due to LWIP rcvevent tracking

### DIFF
--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -56,7 +56,7 @@ namespace esphome::api {
 // This is a balance between API responsiveness and allowing other components to run.
 // Since each message could contain multiple protobuf messages when using packet batching,
 // this limits the number of messages processed, not the number of TCP packets.
-static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 5;
+static constexpr uint8_t MAX_MESSAGES_PER_LOOP = 10;
 static constexpr uint8_t MAX_PING_RETRIES = 60;
 static constexpr uint16_t PING_RETRY_INTERVAL = 1000;
 static constexpr uint32_t KEEPALIVE_DISCONNECT_TIMEOUT = (KEEPALIVE_TIMEOUT_MS * 5) / 2;
@@ -220,10 +220,17 @@ void APIConnection::loop() {
   }
 
   const uint32_t now = App.get_loop_component_start_time();
-  // Check if socket has data ready before attempting to read
-  if (this->helper_->is_socket_ready()) {
+  // Check if socket has data ready before attempting to read.
+  // Also try reading if we hit the message limit last time — LWIP's rcvevent
+  // (used by is_socket_ready) tracks pbuf dequeues, not bytes. When multiple
+  // messages share a TCP segment, the last message's data stays in LWIP's
+  // lastdata cache after rcvevent hits 0, making is_socket_ready() return false
+  // even though data remains.
+  if (this->helper_->is_socket_ready() || this->flags_.may_have_remaining_data) {
+    this->flags_.may_have_remaining_data = false;
     // Read up to MAX_MESSAGES_PER_LOOP messages per loop to improve throughput
-    for (uint8_t message_count = 0; message_count < MAX_MESSAGES_PER_LOOP; message_count++) {
+    uint8_t message_count = 0;
+    for (; message_count < MAX_MESSAGES_PER_LOOP; message_count++) {
       ReadPacketBuffer buffer;
       err = this->helper_->read_packet(&buffer);
       if (err == APIError::WOULD_BLOCK) {
@@ -244,6 +251,11 @@ void APIConnection::loop() {
         if (this->flags_.remove)
           return;
       }
+    }
+    // If we hit the limit, there may be more data remaining in LWIP's
+    // lastdata cache that rcvevent doesn't account for.
+    if (message_count == MAX_MESSAGES_PER_LOOP) {
+      this->flags_.may_have_remaining_data = true;
     }
   }
 
@@ -2086,6 +2098,13 @@ void APIConnection::process_batch_() {
     return;
   }
 
+  // Ensure TCP_NODELAY is on before draining overflow and writing batch data.
+  // Log messages enable Nagle (NODELAY off) to coalesce small packets.
+  // If Nagle is still on when we try to drain, LWIP holds data in the
+  // Nagle buffer, the TCP send buffer stays full, and the overflow
+  // buffer can never drain — blocking the batch write indefinitely.
+  this->helper_->set_nodelay_for_message(false);
+
   // Try to clear buffer first
   if (!this->try_to_clear_buffer(true)) {
     // Can't write now, we'll try again later
@@ -2192,13 +2211,6 @@ void APIConnection::process_batch_multi_(APIBuffer &shared_buf, size_t num_items
     if (footer_size > 0) {
       shared_buf.resize(shared_buf.size() + footer_size);
     }
-
-    // Ensure TCP_NODELAY is on before writing batch data.
-    // Log messages enable Nagle (NODELAY off) to coalesce small packets.
-    // Without this, batch data written to the socket sits in LWIP's Nagle
-    // buffer — the remote won't ACK until it sends its own data (e.g. a
-    // ping), which can take 20+ seconds.
-    this->helper_->set_nodelay_for_message(false);
 
     // Send all collected messages
     APIError err = this->helper_->write_protobuf_messages(ProtoWriteBuffer{&shared_buf},

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -52,7 +52,7 @@
 
 namespace esphome::api {
 
-// Read a maximum of 5 messages per loop iteration to prevent starving other components.
+// Maximum messages to read per loop iteration to prevent starving other components.
 // This is a balance between API responsiveness and allowing other components to run.
 // Since each message could contain multiple protobuf messages when using packet batching,
 // this limits the number of messages processed, not the number of TCP packets.

--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -771,6 +771,7 @@ class APIConnection final : public APIServerConnectionBase {
     uint8_t batch_scheduled : 1;
     uint8_t batch_first_message : 1;          // For batch buffer allocation
     uint8_t should_try_send_immediately : 1;  // True after initial states are sent
+    uint8_t may_have_remaining_data : 1;      // Read loop hit limit, retry without ready check
 #ifdef HAS_PROTO_MESSAGE_DUMP
     uint8_t log_only_mode : 1;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes `ListEntitiesRequest` silently sitting unread in the socket buffer, causing entity listing to stall until a keepalive ping or reconnection triggers new socket activity. This has been **causing slow reconnects in Home Assistant** — the stall during initial entity listing would silently resolve when any other message happened to flush the TCP buffer (e.g. a keepalive ping), masking the root cause.

#15581 attempted to fix this by ensuring TCP_NODELAY was set before batch writes. While that correctly addressed a secondary issue (batch data sitting in LWIP's Nagle buffer during the 100ms batch delay), it wasn't the root cause — the `ListEntitiesRequest` was never being read from the socket in the first place.

## Root Cause

The `is_socket_ready()` fast-path optimization uses LWIP's `rcvevent` counter to avoid taking the LWIP core lock when there's no data. This was designed with the assumption that the read loop would always drain the socket completely (until `EWOULDBLOCK`), which keeps `rcvevent` in sync — when the socket is empty, `rcvevent == 0`, and `is_socket_ready()` correctly returns false.

However, `MAX_MESSAGES_PER_LOOP` (set to 5) can cause the read loop to exit **before** the socket is fully drained. When this happens, `rcvevent` may already be 0 even though data remains in LWIP's internal `lastdata` cache. This is because `rcvevent` tracks **pbuf dequeues**, not remaining bytes — when multiple ESPHome messages share a single TCP segment (same pbuf), reading all but the last message exhausts `rcvevent` while the last message's data stays cached.

The client sends 6 messages during handshake (`HelloReq`, `AuthReq`, `GetTimeResp`, `SubscribeLogsReq`, `DeviceInfoReq`, `ListEntitiesReq`). With the limit at 5, `ListEntitiesReq` is left unread. `is_socket_ready()` returns false on every subsequent loop iteration, and the entity listing silently stalls until something else (like a keepalive ping) triggers new socket activity that increments `rcvevent`.

This is also partly a victim of our own success — recent work has drastically sped up encode/decode on both the client (aioesphomeapi) and server sides. When both sides were slower, messages were naturally spread across separate TCP segments, each getting its own pbuf and incrementing `rcvevent` independently. Now that both sides are fast, the client encodes and sends multiple messages before the kernel batches them into a single TCP segment (single pbuf). The `rcvevent`-based readiness check worked fine when 1 message ≈ 1 pbuf, but breaks down when multiple messages share a pbuf and the read loop doesn't drain completely.

This explains why the bug was **only reproducible on Ethernet devices** and was timing-dependent — it required all 6 handshake messages to arrive and be buffered in the kernel socket before the first `loop()` call reads them. On Ethernet with low latency this happened ~40% of the time, increasing to ~80% as recent protobuf encode/decode improvements made both sides faster and more likely to coalesce messages into shared TCP segments. WiFi devices have enough latency that messages trickle in across multiple loop iterations, never reaching the limit in a single pass.

See #15590 for the `ready()` contract documentation that prevents this class of bug in the future.

## Fix

1. **Track when the read loop hits `MAX_MESSAGES_PER_LOOP`** and set a `may_have_remaining_data` flag. On the next loop iteration, bypass the `is_socket_ready()` check and attempt to read directly — the read will either succeed (remaining data) or return `WOULD_BLOCK` (no data).

2. **Increase `MAX_MESSAGES_PER_LOOP` from 5 to 10** — decode cost is now 3x cheaper than when the limit was set, and we already batch 24–34 messages per write. This provides headroom so the handshake burst is processed in one pass.

3. **Move `set_nodelay_for_message(false)` before `try_to_clear_buffer`** in `process_batch_()` — ensures TCP_NODELAY is on before draining the overflow buffer, not just before the batch write.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Became consistently reproducible after aioesphomeapi v44.8.0 added `subscribe_states` to `esphome logs` (aioesphomeapi#1547), which sends `DeviceInfoRequest` + `ListEntitiesRequest` together during the handshake

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes needed — this is an internal API server fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
