### PR TITLE
[socket] Document ready() contract: callers must drain or track

### DIFF
--- a/esphome/components/api/api_frame_helper.h
+++ b/esphome/components/api/api_frame_helper.h
@@ -195,7 +195,10 @@ class APIFrameHelper {
   }
   // Get the frame footer size required by this protocol
   uint8_t frame_footer_size() const { return frame_footer_size_; }
-  // Check if socket has data ready to read
+  // Check if socket has buffered data ready to read.
+  // Contract: callers must read until it would block (EAGAIN/EWOULDBLOCK)
+  // or track that they stopped early and retry without this check.
+  // See Socket::ready() for details.
   bool is_socket_ready() const { return socket_ != nullptr && socket_->ready(); }
   // Release excess memory from internal buffers after initial sync
   void release_buffers() {

--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -112,6 +112,8 @@ class BSDSocketImpl {
   int setblocking(bool blocking);
   int loop() { return 0; }
 
+  /// Check if the socket has buffered data ready to read.
+  /// See the ready() contract in socket.h — callers must drain or track remaining data.
   bool ready() const;
 
   int get_fd() const { return this->fd_; }

--- a/esphome/components/socket/lwip_raw_tcp_impl.h
+++ b/esphome/components/socket/lwip_raw_tcp_impl.h
@@ -96,6 +96,8 @@ class LWIPRawImpl : public LWIPRawCommon {
     errno = ENOSYS;
     return -1;
   }
+  // Check if the socket has buffered data ready to read.
+  // See the ready() contract in socket.h — callers must drain or track remaining data.
   // Intentionally unlocked — this is a polling check called every loop iteration.
   // A stale read at worst delays processing by one loop tick; the actual I/O in
   // read() holds the lwip lock and re-checks properly. See esphome#10681.

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -78,6 +78,8 @@ class LwIPSocketImpl {
   int setblocking(bool blocking);
   int loop() { return 0; }
 
+  /// Check if the socket has buffered data ready to read.
+  /// See the ready() contract in socket.h — callers must drain or track remaining data.
   bool ready() const;
 
   int get_fd() const { return this->fd_; }

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -53,6 +53,19 @@ bool socket_ready_fd(int fd, bool loop_monitored);
 
 // Inline ready() — defined here because it depends on socket_ready/socket_ready_fd
 // declared above, while the impl headers are included before those declarations.
+//
+// Contract (applies to ALL socket implementations — each platform implements
+// ready() differently, but this contract holds regardless of the mechanism):
+// ready() checks if the socket has buffered data ready to read. When it returns
+// true, the caller MUST read until it would block (EAGAIN/EWOULDBLOCK), or until
+// read() returns 0 to indicate EOF / connection closed, or track that it stopped
+// early and retry without calling ready(). The next call to ready() will only
+// report new data correctly if all callers fulfill this contract. Failing to
+// drain the socket may cause ready() to return false while data remains readable.
+//
+// In practice each socket is owned by a single component, so this contract is
+// straightforward to fulfill — but the owning component must be aware of it,
+// especially if it limits how many messages it processes per loop iteration.
 #if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
 inline bool Socket::ready() const {
 #ifdef USE_LWIP_FAST_SELECT


### PR DESCRIPTION
# What does this implement/fix?

Documents the contract for `Socket::ready()` across all socket implementations. The contract is:

> When `ready()` returns true, the caller **must** read until `EWOULDBLOCK` or track that it stopped early and retry without calling `ready()`. The next call to `ready()` will only report new data correctly if all callers fulfill this contract.

Each platform implements `ready()` differently (select/poll, LWIP rcvevent, raw TCP rx_buf, etc.), but this contract holds regardless of the mechanism. In practice each socket is owned by a single component, so the contract is straightforward to fulfill — but the owning component must be aware of it, especially if it limits how many messages it processes per loop iteration.

This was discovered while debugging #15589 — the API connection's read loop had a `MAX_MESSAGES_PER_LOOP` limit that could exit before draining the socket, violating this contract and causing `ready()` to return false while data remained readable. The bug was only reproducible on Ethernet devices and was timing-dependent — it required all 6 handshake messages to arrive before the first `loop()` call reads them. On Ethernet with low latency this happened ~40% of the time, increasing to ~80% as recent protobuf encode/decode improvements made both sides faster and more likely to coalesce messages into shared TCP segments. WiFi devices have enough latency that messages arrive across multiple loop iterations and never trigger the issue.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15589

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Documentation-only change, no config needed
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
