### PR TITLE
[safe_mode] Combine related OTA rollback log messages

### DIFF
--- a/esphome/components/safe_mode/safe_mode.cpp
+++ b/esphome/components/safe_mode/safe_mode.cpp
@@ -55,11 +55,13 @@ void SafeModeComponent::dump_config() {
 #if defined(USE_ESP32) && defined(USE_OTA_ROLLBACK)
   const esp_partition_t *last_invalid = esp_ota_get_last_invalid_partition();
   if (last_invalid != nullptr) {
-    ESP_LOGW(TAG, "OTA rollback detected! Rolled back from partition '%s'", last_invalid->label);
-    ESP_LOGW(TAG, "The device reset before the boot was marked successful");
+    ESP_LOGW(TAG,
+             "OTA rollback detected! Rolled back from partition '%s'\n"
+             " The device reset before the boot was marked successful",
+             last_invalid->label);
     if (esp_reset_reason() == ESP_RST_BROWNOUT) {
-      ESP_LOGW(TAG, "Last reset was due to brownout - check your power supply!");
-      ESP_LOGW(TAG, "See https://esphome.io/guides/faq.html#brownout-detector-was-triggered");
+      ESP_LOGW(TAG, "Last reset was due to brownout - check your power supply!\n"
+                    " See https://esphome.io/guides/faq.html#brownout-detector-was-triggered");
     }
   }
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Combine consecutive `ESP_LOGW` calls for OTA rollback detection into single log calls using `\n` continuation lines. This reduces the number of network packets sent during logging from 4 to 2 (or 1 in the non-brownout case).

Follows the logging best practice documented at https://developers.esphome.io/architecture/logging/#the-solution-combine-related-log-messages

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).