### PR TITLE
[core] Optimize format_hex_internal by splitting separator loop

### DIFF
--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -348,48 +348,34 @@ std::string format_mac_address_pretty(const uint8_t *mac) {
 }
 
 // Internal helper for hex formatting - base is 'a' for lowercase or 'A' for uppercase.
-// Splits into two loops to eliminate per-byte branch on separator.
+// When separator is set, it is written unconditionally after each byte and the last
+// one is overwritten with '\0', eliminating the per-byte `i < length - 1` check.
 static char *format_hex_internal(char *buffer, size_t buffer_size, const uint8_t *data, size_t length, char separator,
                                  char base) {
   if (length == 0) {
     buffer[0] = '\0';
     return buffer;
   }
-  if (separator) {
-    // With separator: "XX:XX:...:XX\0" = length * 3 bytes total
-    size_t max_bytes = buffer_size / 3;
-    if (max_bytes == 0) {
-      buffer[0] = '\0';
-      return buffer;
-    }
-    if (length > max_bytes) {
-      length = max_bytes;
-    }
-    for (size_t i = 0; i < length; i++) {
-      size_t pos = i * 3;
-      buffer[pos] = format_hex_char(data[i] >> 4, base);
-      buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
+  uint8_t stride = separator ? 3 : 2;
+  size_t max_bytes = separator ? (buffer_size / 3) : ((buffer_size - 1) / 2);
+  if (max_bytes == 0) {
+    buffer[0] = '\0';
+    return buffer;
+  }
+  if (length > max_bytes) {
+    length = max_bytes;
+  }
+  for (size_t i = 0; i < length; i++) {
+    size_t pos = i * stride;
+    buffer[pos] = format_hex_char(data[i] >> 4, base);
+    buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
+    if (separator) {
       buffer[pos + 2] = separator;
     }
-    // Overwrite last separator with null terminator
-    buffer[length * 3 - 1] = '\0';
-  } else {
-    // Without separator: "XXXX...XX\0" = length * 2 + 1 bytes total
-    size_t max_bytes = (buffer_size - 1) / 2;
-    if (max_bytes == 0) {
-      buffer[0] = '\0';
-      return buffer;
-    }
-    if (length > max_bytes) {
-      length = max_bytes;
-    }
-    for (size_t i = 0; i < length; i++) {
-      size_t pos = i * 2;
-      buffer[pos] = format_hex_char(data[i] >> 4, base);
-      buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
-    }
-    buffer[length * 2] = '\0';
   }
+  // With separator: overwrite last separator with '\0'
+  // Without: write '\0' after last hex char
+  buffer[length * stride - (separator ? 1 : 0)] = '\0';
   return buffer;
 }
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -347,33 +347,49 @@ std::string format_mac_address_pretty(const uint8_t *mac) {
   return std::string(buf);
 }
 
-// Internal helper for hex formatting - base is 'a' for lowercase or 'A' for uppercase
+// Internal helper for hex formatting - base is 'a' for lowercase or 'A' for uppercase.
+// Splits into two loops to eliminate per-byte branch on separator.
 static char *format_hex_internal(char *buffer, size_t buffer_size, const uint8_t *data, size_t length, char separator,
                                  char base) {
   if (length == 0) {
     buffer[0] = '\0';
     return buffer;
   }
-  // With separator: total length is 3*length (2*length hex chars, (length-1) separators, 1 null terminator)
-  // Without separator: total length is 2*length + 1 (2*length hex chars, 1 null terminator)
-  uint8_t stride = separator ? 3 : 2;
-  size_t max_bytes = separator ? (buffer_size / stride) : ((buffer_size - 1) / stride);
-  if (max_bytes == 0) {
-    buffer[0] = '\0';
-    return buffer;
-  }
-  if (length > max_bytes) {
-    length = max_bytes;
-  }
-  for (size_t i = 0; i < length; i++) {
-    size_t pos = i * stride;
-    buffer[pos] = format_hex_char(data[i] >> 4, base);
-    buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
-    if (separator && i < length - 1) {
+  if (separator) {
+    // With separator: "XX:XX:...:XX\0" = length * 3 bytes total
+    size_t max_bytes = buffer_size / 3;
+    if (max_bytes == 0) {
+      buffer[0] = '\0';
+      return buffer;
+    }
+    if (length > max_bytes) {
+      length = max_bytes;
+    }
+    for (size_t i = 0; i < length; i++) {
+      size_t pos = i * 3;
+      buffer[pos] = format_hex_char(data[i] >> 4, base);
+      buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
       buffer[pos + 2] = separator;
     }
+    // Overwrite last separator with null terminator
+    buffer[length * 3 - 1] = '\0';
+  } else {
+    // Without separator: "XXXX...XX\0" = length * 2 + 1 bytes total
+    size_t max_bytes = (buffer_size - 1) / 2;
+    if (max_bytes == 0) {
+      buffer[0] = '\0';
+      return buffer;
+    }
+    if (length > max_bytes) {
+      length = max_bytes;
+    }
+    for (size_t i = 0; i < length; i++) {
+      size_t pos = i * 2;
+      buffer[pos] = format_hex_char(data[i] >> 4, base);
+      buffer[pos + 1] = format_hex_char(data[i] & 0x0F, base);
+    }
+    buffer[length * 2] = '\0';
   }
-  buffer[length * stride - (separator ? 1 : 0)] = '\0';
   return buffer;
 }
 

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -352,8 +352,9 @@ std::string format_mac_address_pretty(const uint8_t *mac) {
 // one is overwritten with '\0', eliminating the per-byte `i < length - 1` check.
 static char *format_hex_internal(char *buffer, size_t buffer_size, const uint8_t *data, size_t length, char separator,
                                  char base) {
-  if (length == 0) {
-    buffer[0] = '\0';
+  if (length == 0 || buffer_size == 0) {
+    if (buffer_size > 0)
+      buffer[0] = '\0';
     return buffer;
   }
   uint8_t stride = separator ? 3 : 2;

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1263,13 +1263,15 @@ constexpr uint8_t parse_hex_char(char c) {
 }
 
 /// Convert a nibble (0-15) to hex char with specified base ('a' for lowercase, 'A' for uppercase)
-inline char format_hex_char(uint8_t v, char base) { return v >= 10 ? base + (v - 10) : '0' + v; }
+__attribute__((always_inline)) inline char format_hex_char(uint8_t v, char base) {
+  return v >= 10 ? base + (v - 10) : '0' + v;
+}
 
 /// Convert a nibble (0-15) to lowercase hex char
-inline char format_hex_char(uint8_t v) { return format_hex_char(v, 'a'); }
+__attribute__((always_inline)) inline char format_hex_char(uint8_t v) { return format_hex_char(v, 'a'); }
 
 /// Convert a nibble (0-15) to uppercase hex char (used for pretty printing)
-inline char format_hex_pretty_char(uint8_t v) { return format_hex_char(v, 'A'); }
+__attribute__((always_inline)) inline char format_hex_pretty_char(uint8_t v) { return format_hex_char(v, 'A'); }
 
 /// Write int8 value to buffer without modulo operations.
 /// Buffer must have at least 4 bytes free. Returns pointer past last char written.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1263,15 +1263,13 @@ constexpr uint8_t parse_hex_char(char c) {
 }
 
 /// Convert a nibble (0-15) to hex char with specified base ('a' for lowercase, 'A' for uppercase)
-__attribute__((always_inline)) inline char format_hex_char(uint8_t v, char base) {
-  return v >= 10 ? base + (v - 10) : '0' + v;
-}
+ESPHOME_ALWAYS_INLINE inline char format_hex_char(uint8_t v, char base) { return v >= 10 ? base + (v - 10) : '0' + v; }
 
 /// Convert a nibble (0-15) to lowercase hex char
-__attribute__((always_inline)) inline char format_hex_char(uint8_t v) { return format_hex_char(v, 'a'); }
+ESPHOME_ALWAYS_INLINE inline char format_hex_char(uint8_t v) { return format_hex_char(v, 'a'); }
 
 /// Convert a nibble (0-15) to uppercase hex char (used for pretty printing)
-__attribute__((always_inline)) inline char format_hex_pretty_char(uint8_t v) { return format_hex_char(v, 'A'); }
+ESPHOME_ALWAYS_INLINE inline char format_hex_pretty_char(uint8_t v) { return format_hex_char(v, 'A'); }
 
 /// Write int8 value to buffer without modulo operations.
 /// Buffer must have at least 4 bytes free. Returns pointer past last char written.

--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -10,7 +10,6 @@ namespace esphome::benchmarks {
 static constexpr int kInnerIterations = 2000;
 
 // --- random_float() ---
-// Ported from ol.yaml:148 "Random Float Benchmark"
 
 static void RandomFloat(benchmark::State &state) {
   for (auto _ : state) {
@@ -37,5 +36,271 @@ static void RandomUint32(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations() * kInnerIterations);
 }
 BENCHMARK(RandomUint32);
+
+// --- format_hex_to() - 6 bytes (MAC address sized) ---
+
+static void FormatHexTo_6Bytes(benchmark::State &state) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45};
+  char buffer[13];  // 6 * 2 + 1
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      format_hex_to(buffer, data, 6);
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(FormatHexTo_6Bytes);
+
+// --- format_hex_to() - 16 bytes (UUID sized) ---
+
+static void FormatHexTo_16Bytes(benchmark::State &state) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89,
+                          0xFE, 0xDC, 0xBA, 0x98, 0x76, 0x54, 0x32, 0x10};
+  char buffer[33];  // 16 * 2 + 1
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      format_hex_to(buffer, data, 16);
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(FormatHexTo_16Bytes);
+
+// --- format_hex_to() - 100 bytes (large payload) ---
+
+static void FormatHexTo_100Bytes(benchmark::State &state) {
+  uint8_t data[100];
+  for (int i = 0; i < 100; i++)
+    data[i] = static_cast<uint8_t>(i);
+  char buffer[201];  // 100 * 2 + 1
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      format_hex_to(buffer, data, 100);
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(FormatHexTo_100Bytes);
+
+// --- format_hex_pretty_to() - 6 bytes with ':' separator ---
+
+static void FormatHexPrettyTo_6Bytes(benchmark::State &state) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45};
+  char buffer[18];  // 6 * 3
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      format_hex_pretty_to(buffer, data, 6);
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(FormatHexPrettyTo_6Bytes);
+
+// --- format_mac_addr_upper() ---
+
+static void FormatMacAddrUpper(benchmark::State &state) {
+  const uint8_t mac[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      format_mac_addr_upper(mac, buffer);
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(FormatMacAddrUpper);
+
+// --- fnv1_hash() - short string ---
+
+static void Fnv1Hash_Short(benchmark::State &state) {
+  const char *str = "sensor.temperature";
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= fnv1_hash(str);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Fnv1Hash_Short);
+
+// --- fnv1_hash() - long string ---
+
+static void Fnv1Hash_Long(benchmark::State &state) {
+  const char *str = "binary_sensor.living_room_motion_sensor_occupancy_detected";
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= fnv1_hash(str);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Fnv1Hash_Long);
+
+// --- fnv1a_hash() - short string ---
+// Use DoNotOptimize on the input pointer to prevent constexpr evaluation
+
+static void Fnv1aHash_Short(benchmark::State &state) {
+  const char *str = "sensor.temperature";
+  benchmark::DoNotOptimize(str);
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= fnv1a_hash(str);
+      benchmark::ClobberMemory();
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Fnv1aHash_Short);
+
+// --- fnv1a_hash() - long string ---
+
+static void Fnv1aHash_Long(benchmark::State &state) {
+  const char *str = "binary_sensor.living_room_motion_sensor_occupancy_detected";
+  benchmark::DoNotOptimize(str);
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= fnv1a_hash(str);
+      benchmark::ClobberMemory();
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Fnv1aHash_Long);
+
+// --- fnv1_hash_object_id() - typical entity name ---
+
+static void Fnv1HashObjectId(benchmark::State &state) {
+  const char *name = "Living Room Temperature Sensor";
+  size_t len = strlen(name);
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= fnv1_hash_object_id(name, len);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Fnv1HashObjectId);
+
+// --- parse_hex() - 6 bytes from string ---
+
+static void ParseHex_6Bytes(benchmark::State &state) {
+  const char *hex_str = "ABCDEF012345";
+  uint8_t data[6];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      parse_hex(hex_str, data, 6);
+    }
+    benchmark::DoNotOptimize(data);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ParseHex_6Bytes);
+
+// --- parse_hex() - 16 bytes from string ---
+
+static void ParseHex_16Bytes(benchmark::State &state) {
+  const char *hex_str = "ABCDEF0123456789FEDCBA9876543210";
+  uint8_t data[16];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      parse_hex(hex_str, data, 16);
+    }
+    benchmark::DoNotOptimize(data);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ParseHex_16Bytes);
+
+// --- crc8() - 8 bytes ---
+
+static void CRC8_8Bytes(benchmark::State &state) {
+  const uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  for (auto _ : state) {
+    uint8_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= crc8(data, 8);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CRC8_8Bytes);
+
+// --- crc16() - 8 bytes ---
+
+static void CRC16_8Bytes(benchmark::State &state) {
+  const uint8_t data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  for (auto _ : state) {
+    uint16_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result ^= crc16(data, 8);
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CRC16_8Bytes);
+
+// --- value_accuracy_to_buf() - typical sensor value ---
+
+static void ValueAccuracyToBuf(benchmark::State &state) {
+  char raw_buf[VALUE_ACCURACY_MAX_LEN];
+  std::span<char, VALUE_ACCURACY_MAX_LEN> buf(raw_buf);
+  float value = 23.456f;
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      value_accuracy_to_buf(buf, value, 2);
+    }
+    benchmark::DoNotOptimize(raw_buf);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(ValueAccuracyToBuf);
+
+// --- int8_to_str() ---
+
+static void Int8ToStr(benchmark::State &state) {
+  char buffer[5];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      int8_to_str(buffer, static_cast<int8_t>(i & 0xFF));
+    }
+    benchmark::DoNotOptimize(buffer);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Int8ToStr);
+
+// --- base64_decode() - into pre-allocated buffer ---
+
+static void Base64Decode_32Bytes(benchmark::State &state) {
+  // 32 bytes encoded = 44 base64 chars
+  const uint8_t encoded[] = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGx0eHw==";
+  size_t encoded_len = 44;
+  uint8_t output[32];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      base64_decode(encoded, encoded_len, output, sizeof(output));
+    }
+    benchmark::DoNotOptimize(output);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Base64Decode_32Bytes);
 
 }  // namespace esphome::benchmarks

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -3,7 +3,7 @@
 
 #include "esphome/core/helpers.h"
 
-namespace esphome::testing {
+namespace esphome::core::testing {
 
 // --- format_hex_to() ---
 
@@ -81,8 +81,8 @@ TEST(FormatHexPrettyTo, ZeroBufferSize) {
 TEST(FormatHexPrettyTo, CustomSeparator) {
   const uint8_t data[] = {0xAA, 0xBB, 0xCC};
   char buffer[9];
-  format_hex_pretty_to(buffer, data, 3, ':');
-  EXPECT_STREQ(buffer, "AA:BB:CC");
+  format_hex_pretty_to(buffer, data, 3, '-');
+  EXPECT_STREQ(buffer, "AA-BB-CC");
 }
 
 // --- format_mac_addr_upper() ---
@@ -117,4 +117,4 @@ TEST(FormatHexChar, UppercaseDigits) {
   EXPECT_EQ(format_hex_pretty_char(15), 'F');
 }
 
-}  // namespace esphome::testing
+}  // namespace esphome::core::testing

--- a/tests/components/core/test_helpers.cpp
+++ b/tests/components/core/test_helpers.cpp
@@ -1,0 +1,120 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome::testing {
+
+// --- format_hex_to() ---
+
+TEST(FormatHexTo, Basic) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF};
+  char buffer[7];  // 3 * 2 + 1
+  format_hex_to(buffer, data, 3);
+  EXPECT_STREQ(buffer, "abcdef");
+}
+
+TEST(FormatHexTo, SingleByte) {
+  const uint8_t data[] = {0x0F};
+  char buffer[3];
+  format_hex_to(buffer, data, 1);
+  EXPECT_STREQ(buffer, "0f");
+}
+
+TEST(FormatHexTo, ZeroLength) {
+  char buffer[4] = "xxx";
+  format_hex_to(buffer, static_cast<size_t>(sizeof(buffer)), static_cast<const uint8_t *>(nullptr), 0);
+  EXPECT_STREQ(buffer, "");
+}
+
+TEST(FormatHexTo, ZeroBufferSize) {
+  char buffer[4] = "xxx";
+  const uint8_t data[] = {0xAB};
+  format_hex_to(buffer, static_cast<size_t>(0), data, 1);
+  // Should not crash, buffer unchanged
+  EXPECT_EQ(buffer[0], 'x');
+}
+
+TEST(FormatHexTo, BufferTooSmall) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF};
+  char buffer[5];  // only room for 2 bytes
+  format_hex_to(buffer, data, 3);
+  EXPECT_STREQ(buffer, "abcd");
+}
+
+TEST(FormatHexTo, MacAddress) {
+  const uint8_t mac[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  char buffer[13];
+  format_hex_to(buffer, mac, 6);
+  EXPECT_STREQ(buffer, "aabbccddeeff");
+}
+
+// --- format_hex_pretty_to() ---
+
+TEST(FormatHexPrettyTo, BasicColon) {
+  const uint8_t data[] = {0xAB, 0xCD, 0xEF};
+  char buffer[9];  // 3 * 3
+  format_hex_pretty_to(buffer, data, 3);
+  EXPECT_STREQ(buffer, "AB:CD:EF");
+}
+
+TEST(FormatHexPrettyTo, SingleByte) {
+  const uint8_t data[] = {0x0F};
+  char buffer[3];
+  format_hex_pretty_to(buffer, data, 1);
+  EXPECT_STREQ(buffer, "0F");
+}
+
+TEST(FormatHexPrettyTo, ZeroLength) {
+  char buffer[4] = "xxx";
+  format_hex_pretty_to(buffer, static_cast<size_t>(sizeof(buffer)), static_cast<const uint8_t *>(nullptr), 0);
+  EXPECT_STREQ(buffer, "");
+}
+
+TEST(FormatHexPrettyTo, ZeroBufferSize) {
+  char buffer[4] = "xxx";
+  const uint8_t data[] = {0xAB};
+  format_hex_pretty_to(buffer, static_cast<size_t>(0), data, 1);
+  EXPECT_EQ(buffer[0], 'x');
+}
+
+TEST(FormatHexPrettyTo, CustomSeparator) {
+  const uint8_t data[] = {0xAA, 0xBB, 0xCC};
+  char buffer[9];
+  format_hex_pretty_to(buffer, data, 3, ':');
+  EXPECT_STREQ(buffer, "AA:BB:CC");
+}
+
+// --- format_mac_addr_upper() ---
+
+TEST(FormatMacAddrUpper, Basic) {
+  const uint8_t mac[] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  format_mac_addr_upper(mac, buffer);
+  EXPECT_STREQ(buffer, "AA:BB:CC:DD:EE:FF");
+}
+
+TEST(FormatMacAddrUpper, AllZeros) {
+  const uint8_t mac[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  char buffer[MAC_ADDRESS_PRETTY_BUFFER_SIZE];
+  format_mac_addr_upper(mac, buffer);
+  EXPECT_STREQ(buffer, "00:00:00:00:00:00");
+}
+
+// --- format_hex_char() ---
+
+TEST(FormatHexChar, LowercaseDigits) {
+  EXPECT_EQ(format_hex_char(0), '0');
+  EXPECT_EQ(format_hex_char(9), '9');
+  EXPECT_EQ(format_hex_char(10), 'a');
+  EXPECT_EQ(format_hex_char(15), 'f');
+}
+
+TEST(FormatHexChar, UppercaseDigits) {
+  EXPECT_EQ(format_hex_pretty_char(0), '0');
+  EXPECT_EQ(format_hex_pretty_char(9), '9');
+  EXPECT_EQ(format_hex_pretty_char(10), 'A');
+  EXPECT_EQ(format_hex_pretty_char(15), 'F');
+}
+
+}  // namespace esphome::testing


### PR DESCRIPTION
# What does this implement/fix?

Optimizes `format_hex_internal` by removing the per-byte `&& i < length - 1` check in the separator path. Instead, the separator is written unconditionally after every byte, and the existing null terminator write overwrites the last separator.

The null terminator line is unchanged: `buffer[length * stride - (separator ? 1 : 0)] = '\0'`.

Also marks `format_hex_char` overloads `always_inline` to prevent the compiler from outlining them.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal optimization only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).