### PR TITLE
[epaper_spi] Remove noop deep sleep command

### DIFF
--- a/esphome/components/epaper_spi/epaper_spi_mono.cpp
+++ b/esphome/components/epaper_spi/epaper_spi_mono.cpp
@@ -14,10 +14,9 @@ void EPaperMono::refresh_screen(bool partial) {
 }
 
 void EPaperMono::deep_sleep() {
-  ESP_LOGV(TAG, "Deep sleep");
-  if (this->is_using_partial_update_()) {
-    this->cmd_data(0x10, {0x00});  // sleep in power on mode
-  } else {
+  // Deep sleep loses RAM so cannot be used with partial update
+  if (!this->is_using_partial_update_()) {
+    ESP_LOGV(TAG, "Deep sleep");
     this->cmd_data(0x10, {0x03});  // deep sleep
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

The SSD1677 controller logic currently issues a 0x10 command with data 0x00. This command is simply telling the controller to continue in normal mode, so for sleep purposes it does nothing. Remove the command entirely and only trigger deep sleep when partial update is not used.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- not applicable

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
