### PR TITLE
[core] Add uint32_to_str helper and use in preferences

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -4,7 +4,6 @@
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include <nvs_flash.h>
-#include <cinttypes>
 #include <cstring>
 #include <vector>
 
@@ -12,8 +11,7 @@ namespace esphome::esp32 {
 
 static const char *const TAG = "preferences";
 
-// Buffer size for converting uint32_t to string: max "4294967295" (10 chars) + null terminator + 1 padding
-static constexpr size_t KEY_BUFFER_SIZE = 12;
+static constexpr size_t KEY_BUFFER_SIZE = UINT32_MAX_STR_SIZE;
 
 struct NVSData {
   uint32_t key;
@@ -52,7 +50,7 @@ bool ESP32PreferenceBackend::load(uint8_t *data, size_t len) {
   }
 
   char key_str[KEY_BUFFER_SIZE];
-  snprintf(key_str, sizeof(key_str), "%" PRIu32, this->key);
+  uint32_to_str(key_str, this->key);
   size_t actual_len;
   esp_err_t err = nvs_get_blob(this->nvs_handle, key_str, nullptr, &actual_len);
   if (err != 0) {
@@ -109,7 +107,7 @@ bool ESP32Preferences::sync() {
 
   for (const auto &save : s_pending_save) {
     char key_str[KEY_BUFFER_SIZE];
-    snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+    uint32_to_str(key_str, save.key);
     ESP_LOGVV(TAG, "Checking if NVS data %s has changed", key_str);
     if (this->is_changed_(this->nvs_handle, save, key_str)) {
       esp_err_t err = nvs_set_blob(this->nvs_handle, key_str, save.data.data(), save.data.size());

--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -11,8 +11,6 @@ namespace esphome::esp32 {
 
 static const char *const TAG = "preferences";
 
-static constexpr size_t KEY_BUFFER_SIZE = UINT32_MAX_STR_SIZE;
-
 struct NVSData {
   uint32_t key;
   SmallInlineBuffer<8> data;  // Most prefs fit in 8 bytes (covers fan, cover, select, etc.)
@@ -49,7 +47,7 @@ bool ESP32PreferenceBackend::load(uint8_t *data, size_t len) {
     }
   }
 
-  char key_str[KEY_BUFFER_SIZE];
+  char key_str[UINT32_MAX_STR_SIZE];
   uint32_to_str(key_str, this->key);
   size_t actual_len;
   esp_err_t err = nvs_get_blob(this->nvs_handle, key_str, nullptr, &actual_len);
@@ -106,7 +104,7 @@ bool ESP32Preferences::sync() {
   uint32_t last_key = 0;
 
   for (const auto &save : s_pending_save) {
-    char key_str[KEY_BUFFER_SIZE];
+    char key_str[UINT32_MAX_STR_SIZE];
     uint32_to_str(key_str, save.key);
     ESP_LOGVV(TAG, "Checking if NVS data %s has changed", key_str);
     if (this->is_changed_(this->nvs_handle, save, key_str)) {

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -3,7 +3,6 @@
 #include "preferences.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
-#include <cinttypes>
 #include <cstring>
 #include <vector>
 
@@ -11,8 +10,7 @@ namespace esphome::libretiny {
 
 static const char *const TAG = "preferences";
 
-// Buffer size for converting uint32_t to string: max "4294967295" (10 chars) + null terminator + 1 padding
-static constexpr size_t KEY_BUFFER_SIZE = 12;
+static constexpr size_t KEY_BUFFER_SIZE = UINT32_MAX_STR_SIZE;
 
 struct NVSData {
   uint32_t key;
@@ -51,7 +49,7 @@ bool LibreTinyPreferenceBackend::load(uint8_t *data, size_t len) {
   }
 
   char key_str[KEY_BUFFER_SIZE];
-  snprintf(key_str, sizeof(key_str), "%" PRIu32, this->key);
+  uint32_to_str(key_str, this->key);
   fdb_blob_make(this->blob, data, len);
   size_t actual_len = fdb_kv_get_blob(this->db, key_str, this->blob);
   if (actual_len != len) {
@@ -93,7 +91,7 @@ bool LibreTinyPreferences::sync() {
 
   for (const auto &save : s_pending_save) {
     char key_str[KEY_BUFFER_SIZE];
-    snprintf(key_str, sizeof(key_str), "%" PRIu32, save.key);
+    uint32_to_str(key_str, save.key);
     ESP_LOGVV(TAG, "Checking if FDB data %s has changed", key_str);
     if (this->is_changed_(&this->db, save, key_str)) {
       ESP_LOGV(TAG, "sync: key: %s, len: %zu", key_str, save.data.size());

--- a/esphome/components/libretiny/preferences.cpp
+++ b/esphome/components/libretiny/preferences.cpp
@@ -10,8 +10,6 @@ namespace esphome::libretiny {
 
 static const char *const TAG = "preferences";
 
-static constexpr size_t KEY_BUFFER_SIZE = UINT32_MAX_STR_SIZE;
-
 struct NVSData {
   uint32_t key;
   SmallInlineBuffer<8> data;  // Most prefs fit in 8 bytes (covers fan, cover, select, etc.)
@@ -48,7 +46,7 @@ bool LibreTinyPreferenceBackend::load(uint8_t *data, size_t len) {
     }
   }
 
-  char key_str[KEY_BUFFER_SIZE];
+  char key_str[UINT32_MAX_STR_SIZE];
   uint32_to_str(key_str, this->key);
   fdb_blob_make(this->blob, data, len);
   size_t actual_len = fdb_kv_get_blob(this->db, key_str, this->blob);
@@ -90,7 +88,7 @@ bool LibreTinyPreferences::sync() {
   uint32_t last_key = 0;
 
   for (const auto &save : s_pending_save) {
-    char key_str[KEY_BUFFER_SIZE];
+    char key_str[UINT32_MAX_STR_SIZE];
     uint32_to_str(key_str, save.key);
     ESP_LOGVV(TAG, "Checking if FDB data %s has changed", key_str);
     if (this->is_changed_(&this->db, save, key_str)) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -382,17 +382,13 @@ char *uint32_to_str_unchecked(char *buf, uint32_t val) {
     *buf++ = '0';
     return buf;
   }
-  // Write digits backwards into stack buffer, then copy forward.
-  // Avoids std::reverse (saves ~24 bytes on Xtensa).
-  char tmp[10];
-  char *p = tmp + sizeof(tmp);
+  char *start = buf;
   while (val > 0) {
-    *--p = '0' + (val % 10);
+    *buf++ = '0' + (val % 10);
     val /= 10;
   }
-  size_t len = tmp + sizeof(tmp) - p;
-  memcpy(buf, p, len);
-  return buf + len;
+  std::reverse(start, buf);
+  return buf;
 }
 
 char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -377,7 +377,7 @@ static char *format_hex_internal(char *buffer, size_t buffer_size, const uint8_t
   return buffer;
 }
 
-char *uint32_to_str_(char *buf, uint32_t val) {
+char *uint32_to_str_unchecked(char *buf, uint32_t val) {
   if (val == 0) {
     *buf++ = '0';
     return buf;

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -382,13 +382,17 @@ char *uint32_to_str_(char *buf, uint32_t val) {
     *buf++ = '0';
     return buf;
   }
-  char *start = buf;
+  // Write digits backwards into stack buffer, then copy forward.
+  // Avoids std::reverse (saves ~24 bytes on Xtensa).
+  char tmp[10];
+  char *p = tmp + sizeof(tmp);
   while (val > 0) {
-    *buf++ = '0' + (val % 10);
+    *--p = '0' + (val % 10);
     val /= 10;
   }
-  std::reverse(start, buf);
-  return buf;
+  size_t len = tmp + sizeof(tmp) - p;
+  memcpy(buf, p, len);
+  return buf + len;
 }
 
 char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length) {

--- a/esphome/core/helpers.cpp
+++ b/esphome/core/helpers.cpp
@@ -377,6 +377,20 @@ static char *format_hex_internal(char *buffer, size_t buffer_size, const uint8_t
   return buffer;
 }
 
+char *uint32_to_str_(char *buf, uint32_t val) {
+  if (val == 0) {
+    *buf++ = '0';
+    return buf;
+  }
+  char *start = buf;
+  while (val > 0) {
+    *buf++ = '0' + (val % 10);
+    val /= 10;
+  }
+  std::reverse(start, buf);
+  return buf;
+}
+
 char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length) {
   return format_hex_internal(buffer, buffer_size, data, length, 0, 'a');
 }

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1300,19 +1300,7 @@ static constexpr size_t UINT32_MAX_STR_SIZE = 11;
 
 /// Write unsigned 32-bit integer to buffer (internal, no size check).
 /// Buffer must have at least 10 bytes free. Returns pointer past last char written.
-inline char *uint32_to_str_(char *buf, uint32_t val) {
-  if (val == 0) {
-    *buf++ = '0';
-    return buf;
-  }
-  char *start = buf;
-  while (val > 0) {
-    *buf++ = '0' + (val % 10);
-    val /= 10;
-  }
-  std::reverse(start, buf);
-  return buf;
-}
+char *uint32_to_str_(char *buf, uint32_t val);
 
 /// Write unsigned 32-bit integer to buffer with compile-time size check.
 /// Null-terminates the output. Returns number of chars written (excluding null).

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1295,6 +1295,33 @@ inline char *int8_to_str(char *buf, int8_t val) {
   return buf;
 }
 
+/// Minimum buffer size for uint32_to_str: 10 digits + null terminator.
+static constexpr size_t UINT32_MAX_STR_SIZE = 11;
+
+/// Write unsigned 32-bit integer to buffer (internal, no size check).
+/// Buffer must have at least 10 bytes free. Returns pointer past last char written.
+inline char *uint32_to_str_(char *buf, uint32_t val) {
+  if (val == 0) {
+    *buf++ = '0';
+    return buf;
+  }
+  char *start = buf;
+  while (val > 0) {
+    *buf++ = '0' + (val % 10);
+    val /= 10;
+  }
+  std::reverse(start, buf);
+  return buf;
+}
+
+/// Write unsigned 32-bit integer to buffer with compile-time size check.
+/// Null-terminates the output. Returns number of chars written (excluding null).
+inline size_t uint32_to_str(std::span<char, UINT32_MAX_STR_SIZE> buf, uint32_t val) {
+  char *end = uint32_to_str_(buf.data(), val);
+  *end = '\0';
+  return static_cast<size_t>(end - buf.data());
+}
+
 /// Format byte array as lowercase hex to buffer (base implementation).
 char *format_hex_to(char *buffer, size_t buffer_size, const uint8_t *data, size_t length);
 

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1300,12 +1300,12 @@ static constexpr size_t UINT32_MAX_STR_SIZE = 11;
 
 /// Write unsigned 32-bit integer to buffer (internal, no size check).
 /// Buffer must have at least 10 bytes free. Returns pointer past last char written.
-char *uint32_to_str_(char *buf, uint32_t val);
+char *uint32_to_str_unchecked(char *buf, uint32_t val);
 
 /// Write unsigned 32-bit integer to buffer with compile-time size check.
 /// Null-terminates the output. Returns number of chars written (excluding null).
 inline size_t uint32_to_str(std::span<char, UINT32_MAX_STR_SIZE> buf, uint32_t val) {
-  char *end = uint32_to_str_(buf.data(), val);
+  char *end = uint32_to_str_unchecked(buf.data(), val);
   *end = '\0';
   return static_cast<size_t>(end - buf.data());
 }

--- a/tests/benchmarks/core/bench_helpers.cpp
+++ b/tests/benchmarks/core/bench_helpers.cpp
@@ -1,4 +1,6 @@
 #include <benchmark/benchmark.h>
+#include <cinttypes>
+#include <cstdio>
 
 #include "esphome/core/helpers.h"
 
@@ -37,5 +39,59 @@ static void RandomUint32(benchmark::State &state) {
   state.SetItemsProcessed(state.iterations() * kInnerIterations);
 }
 BENCHMARK(RandomUint32);
+
+// --- uint32_to_str() vs snprintf ---
+
+static void Uint32ToStr_Small(benchmark::State &state) {
+  char buf[UINT32_MAX_STR_SIZE];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      uint32_to_str(buf, 12345);
+      benchmark::DoNotOptimize(buf);
+      benchmark::ClobberMemory();
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Uint32ToStr_Small);
+
+static void Snprintf_Uint32_Small(benchmark::State &state) {
+  char buf[UINT32_MAX_STR_SIZE];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      snprintf(buf, sizeof(buf), "%" PRIu32, static_cast<uint32_t>(12345));
+      benchmark::DoNotOptimize(buf);
+      benchmark::ClobberMemory();
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Snprintf_Uint32_Small);
+
+static void Uint32ToStr_Large(benchmark::State &state) {
+  char buf[UINT32_MAX_STR_SIZE];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      uint32_to_str(buf, 4294967295u);
+      benchmark::DoNotOptimize(buf);
+      benchmark::ClobberMemory();
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Uint32ToStr_Large);
+
+static void Snprintf_Uint32_Large(benchmark::State &state) {
+  char buf[UINT32_MAX_STR_SIZE];
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      snprintf(buf, sizeof(buf), "%" PRIu32, static_cast<uint32_t>(4294967295u));
+      benchmark::DoNotOptimize(buf);
+      benchmark::ClobberMemory();
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Snprintf_Uint32_Large);
 
 }  // namespace esphome::benchmarks

--- a/tests/components/core/test_uint32_to_str.cpp
+++ b/tests/components/core/test_uint32_to_str.cpp
@@ -1,14 +1,13 @@
 #include <gtest/gtest.h>
-#include <cstring>
 
 #include "esphome/core/helpers.h"
 
-namespace esphome::testing {
+namespace esphome::core::testing {
 
 // --- uint32_to_str_() (internal, raw pointer) ---
 
 TEST(Uint32ToStr, InternalZero) {
-  char buf[12];
+  char buf[UINT32_MAX_STR_SIZE];
   char *end = uint32_to_str_(buf, 0);
   *end = '\0';
   EXPECT_STREQ(buf, "0");
@@ -16,14 +15,14 @@ TEST(Uint32ToStr, InternalZero) {
 }
 
 TEST(Uint32ToStr, InternalSingleDigit) {
-  char buf[12];
+  char buf[UINT32_MAX_STR_SIZE];
   char *end = uint32_to_str_(buf, 7);
   *end = '\0';
   EXPECT_STREQ(buf, "7");
 }
 
 TEST(Uint32ToStr, InternalMultiDigit) {
-  char buf[12];
+  char buf[UINT32_MAX_STR_SIZE];
   char *end = uint32_to_str_(buf, 12345);
   *end = '\0';
   EXPECT_STREQ(buf, "12345");
@@ -31,7 +30,7 @@ TEST(Uint32ToStr, InternalMultiDigit) {
 }
 
 TEST(Uint32ToStr, InternalMaxValue) {
-  char buf[12];
+  char buf[UINT32_MAX_STR_SIZE];
   char *end = uint32_to_str_(buf, 4294967295u);
   *end = '\0';
   EXPECT_STREQ(buf, "4294967295");
@@ -39,7 +38,7 @@ TEST(Uint32ToStr, InternalMaxValue) {
 }
 
 TEST(Uint32ToStr, InternalPowersOfTen) {
-  char buf[12];
+  char buf[UINT32_MAX_STR_SIZE];
   char *end;
 
   end = uint32_to_str_(buf, 10);
@@ -75,4 +74,4 @@ TEST(Uint32ToStr, SpanMaxValue) {
   EXPECT_STREQ(buf, "4294967295");
 }
 
-}  // namespace esphome::testing
+}  // namespace esphome::core::testing

--- a/tests/components/core/test_uint32_to_str.cpp
+++ b/tests/components/core/test_uint32_to_str.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <cstring>
+
+#include "esphome/core/helpers.h"
+
+namespace esphome::testing {
+
+// --- uint32_to_str_() (internal, raw pointer) ---
+
+TEST(Uint32ToStr, InternalZero) {
+  char buf[12];
+  char *end = uint32_to_str_(buf, 0);
+  *end = '\0';
+  EXPECT_STREQ(buf, "0");
+  EXPECT_EQ(end - buf, 1);
+}
+
+TEST(Uint32ToStr, InternalSingleDigit) {
+  char buf[12];
+  char *end = uint32_to_str_(buf, 7);
+  *end = '\0';
+  EXPECT_STREQ(buf, "7");
+}
+
+TEST(Uint32ToStr, InternalMultiDigit) {
+  char buf[12];
+  char *end = uint32_to_str_(buf, 12345);
+  *end = '\0';
+  EXPECT_STREQ(buf, "12345");
+  EXPECT_EQ(end - buf, 5);
+}
+
+TEST(Uint32ToStr, InternalMaxValue) {
+  char buf[12];
+  char *end = uint32_to_str_(buf, 4294967295u);
+  *end = '\0';
+  EXPECT_STREQ(buf, "4294967295");
+  EXPECT_EQ(end - buf, 10);
+}
+
+TEST(Uint32ToStr, InternalPowersOfTen) {
+  char buf[12];
+  char *end;
+
+  end = uint32_to_str_(buf, 10);
+  *end = '\0';
+  EXPECT_STREQ(buf, "10");
+
+  end = uint32_to_str_(buf, 100);
+  *end = '\0';
+  EXPECT_STREQ(buf, "100");
+
+  end = uint32_to_str_(buf, 1000000);
+  *end = '\0';
+  EXPECT_STREQ(buf, "1000000");
+}
+
+// --- uint32_to_str() (public, span API) ---
+
+TEST(Uint32ToStr, SpanZero) {
+  char buf[UINT32_MAX_STR_SIZE];
+  EXPECT_EQ(uint32_to_str(buf, 0), 1u);
+  EXPECT_STREQ(buf, "0");
+}
+
+TEST(Uint32ToStr, SpanMultiDigit) {
+  char buf[UINT32_MAX_STR_SIZE];
+  EXPECT_EQ(uint32_to_str(buf, 12345), 5u);
+  EXPECT_STREQ(buf, "12345");
+}
+
+TEST(Uint32ToStr, SpanMaxValue) {
+  char buf[UINT32_MAX_STR_SIZE];
+  EXPECT_EQ(uint32_to_str(buf, 4294967295u), 10u);
+  EXPECT_STREQ(buf, "4294967295");
+}
+
+}  // namespace esphome::testing

--- a/tests/components/core/test_uint32_to_str.cpp
+++ b/tests/components/core/test_uint32_to_str.cpp
@@ -4,11 +4,11 @@
 
 namespace esphome::core::testing {
 
-// --- uint32_to_str_() (internal, raw pointer) ---
+// --- uint32_to_str_unchecked() (internal, raw pointer) ---
 
 TEST(Uint32ToStr, InternalZero) {
   char buf[UINT32_MAX_STR_SIZE];
-  char *end = uint32_to_str_(buf, 0);
+  char *end = uint32_to_str_unchecked(buf, 0);
   *end = '\0';
   EXPECT_STREQ(buf, "0");
   EXPECT_EQ(end - buf, 1);
@@ -16,14 +16,14 @@ TEST(Uint32ToStr, InternalZero) {
 
 TEST(Uint32ToStr, InternalSingleDigit) {
   char buf[UINT32_MAX_STR_SIZE];
-  char *end = uint32_to_str_(buf, 7);
+  char *end = uint32_to_str_unchecked(buf, 7);
   *end = '\0';
   EXPECT_STREQ(buf, "7");
 }
 
 TEST(Uint32ToStr, InternalMultiDigit) {
   char buf[UINT32_MAX_STR_SIZE];
-  char *end = uint32_to_str_(buf, 12345);
+  char *end = uint32_to_str_unchecked(buf, 12345);
   *end = '\0';
   EXPECT_STREQ(buf, "12345");
   EXPECT_EQ(end - buf, 5);
@@ -31,7 +31,7 @@ TEST(Uint32ToStr, InternalMultiDigit) {
 
 TEST(Uint32ToStr, InternalMaxValue) {
   char buf[UINT32_MAX_STR_SIZE];
-  char *end = uint32_to_str_(buf, 4294967295u);
+  char *end = uint32_to_str_unchecked(buf, 4294967295u);
   *end = '\0';
   EXPECT_STREQ(buf, "4294967295");
   EXPECT_EQ(end - buf, 10);
@@ -41,15 +41,15 @@ TEST(Uint32ToStr, InternalPowersOfTen) {
   char buf[UINT32_MAX_STR_SIZE];
   char *end;
 
-  end = uint32_to_str_(buf, 10);
+  end = uint32_to_str_unchecked(buf, 10);
   *end = '\0';
   EXPECT_STREQ(buf, "10");
 
-  end = uint32_to_str_(buf, 100);
+  end = uint32_to_str_unchecked(buf, 100);
   *end = '\0';
   EXPECT_STREQ(buf, "100");
 
-  end = uint32_to_str_(buf, 1000000);
+  end = uint32_to_str_unchecked(buf, 1000000);
   *end = '\0';
   EXPECT_STREQ(buf, "1000000");
 }


### PR DESCRIPTION
# What does this implement/fix?

Adds `uint32_to_str_unchecked` (in helpers.cpp, not inlined — 78 bytes) and `uint32_to_str` (`std::span<char, 11>` public API with compile-time size enforcement) for converting `uint32_t` to decimal strings without `snprintf`.

Replaces `snprintf(buf, sizeof(buf), "%" PRIu32, key)` with `uint32_to_str(buf, key)` in esp32 and libretiny preferences, where keys are formatted as decimal strings on every preference read/write.

The compiler already optimizes the `val / 10` and `val % 10` to multiply-by-reciprocal (`muluh` + shift) on all targets including ESP8266 (no hardware divider), so no manual optimization is needed.

**Note:** The memory impact CI numbers are inflated due to #15598 (variant test configs produce mismatched build groupings between branches). The actual cost is just the 78-byte function body minus saved `snprintf` call setup at each site.

This helper is also reused by #15596 (`value_accuracy_to_buf` optimization), so the function cost is amortized across multiple consumers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - internal helper
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).