### PR TITLE
[api] Add (inline_encode) proto option for sub-message inlining

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -1625,6 +1625,7 @@ message BluetoothLEAdvertisementResponse {
 }
 
 message BluetoothLERawAdvertisement {
+  option (inline_encode) = true;
   uint64 address = 1 [(force) = true];
   sint32 rssi = 2 [(force) = true];
   uint32 address_type = 3 [(max_value) = 4];

--- a/esphome/components/api/api_options.proto
+++ b/esphome/components/api/api_options.proto
@@ -22,6 +22,7 @@ extend google.protobuf.MessageOptions {
     optional bool log = 1039 [default=true];
     optional bool no_delay = 1040 [default=false];
     optional string base_class = 1041;
+    optional bool inline_encode = 1042 [default=false];
 }
 
 extend google.protobuf.FieldOptions {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2331,39 +2331,35 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
 uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
-    {
-      auto &sub_msg = this->advertisements[i];
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
-      uint8_t *len_pos = pos++;
-      uint8_t *body_start = pos;
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
-      ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
-      ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
-      if (sub_msg.address_type) {
-        ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
-        ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
-      }
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
-      ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
-      *len_pos = static_cast<uint8_t>(pos - body_start);
+    auto &sub_msg = this->advertisements[i];
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
+    uint8_t *len_pos = pos++;
+    uint8_t *body_start = pos;
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
+    ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
+    ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
+    if (sub_msg.address_type) {
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
+      ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
     }
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
+    ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
+    *len_pos = static_cast<uint8_t>(pos - body_start);
   }
   return pos;
 }
 uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
-    {
-      auto &sub_msg = this->advertisements[i];
-      uint32_t sub_size = 0;
-      sub_size += ProtoSize::calc_uint64_force(1, sub_msg.address);
-      sub_size += ProtoSize::calc_sint32_force(1, sub_msg.rssi);
-      sub_size += sub_msg.address_type ? 2 : 0;
-      sub_size += 2 + sub_msg.data_len;
-      size += 2 + sub_size;
-    }
+    auto &sub_msg = this->advertisements[i];
+    uint32_t sub_size = 0;
+    sub_size += ProtoSize::calc_uint64_force(1, sub_msg.address);
+    sub_size += ProtoSize::calc_sint32_force(1, sub_msg.rssi);
+    sub_size += sub_msg.address_type ? 2 : 0;
+    sub_size += 2 + sub_msg.data_len;
+    size += 2 + sub_size;
   }
   return size;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2334,7 +2334,6 @@ uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer P
     auto &sub_msg = this->advertisements[i];
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
     uint8_t *len_pos = pos++;
-    uint8_t *body_start = pos;
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
     ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
@@ -2346,7 +2345,7 @@ uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer P
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
     ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
-    *len_pos = static_cast<uint8_t>(pos - body_start);
+    *len_pos = static_cast<uint8_t>(pos - len_pos - 1);
   }
   return pos;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2328,40 +2328,42 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
   }
   return true;
 }
-uint8_t *BluetoothLERawAdvertisement::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
-  uint8_t *__restrict__ pos = buffer.get_pos();
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
-  ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, this->address);
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
-  ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(this->rssi));
-  if (this->address_type) {
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
-    ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, this->address_type);
-  }
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(this->data_len));
-  ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, this->data, this->data_len);
-  return pos;
-}
-uint32_t BluetoothLERawAdvertisement::calculate_size() const {
-  uint32_t size = 0;
-  size += ProtoSize::calc_uint64_force(1, this->address);
-  size += ProtoSize::calc_sint32_force(1, this->rssi);
-  size += this->address_type ? 2 : 0;
-  size += 2 + this->data_len;
-  return size;
-}
 uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
-    ProtoEncode::encode_sub_message(pos PROTO_ENCODE_DEBUG_ARG, buffer, 1, this->advertisements[i]);
+    {
+      auto &sub_msg = this->advertisements[i];
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
+      uint8_t *len_pos = pos++;
+      uint8_t *body_start = pos;
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
+      ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
+      ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
+      if (sub_msg.address_type) {
+        ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
+        ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
+      }
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
+      ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
+      *len_pos = static_cast<uint8_t>(pos - body_start);
+    }
   }
   return pos;
 }
 uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
-    size += ProtoSize::calc_message_force(1, this->advertisements[i].calculate_size());
+    {
+      auto &sub_msg = this->advertisements[i];
+      uint32_t sub_size = 0;
+      sub_size += ProtoSize::calc_uint64_force(1, sub_msg.address);
+      sub_size += ProtoSize::calc_sint32_force(1, sub_msg.rssi);
+      sub_size += sub_msg.address_type ? 2 : 0;
+      sub_size += 2 + sub_msg.data_len;
+      size += 2 + sub_size;
+    }
   }
   return size;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2353,12 +2353,11 @@ uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
-    uint32_t sub_size = 0;
-    sub_size += ProtoSize::calc_uint64_force(1, sub_msg.address);
-    sub_size += ProtoSize::calc_sint32_force(1, sub_msg.rssi);
-    sub_size += sub_msg.address_type ? 2 : 0;
-    sub_size += 2 + sub_msg.data_len;
-    size += 2 + sub_size;
+    size += 2;
+    size += ProtoSize::calc_uint64_force(1, sub_msg.address);
+    size += ProtoSize::calc_sint32_force(1, sub_msg.rssi);
+    size += sub_msg.address_type ? 2 : 0;
+    size += 2 + sub_msg.data_len;
   }
   return size;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -2333,7 +2333,8 @@ uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer P
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
-    uint8_t *len_pos = pos++;
+    uint8_t *len_pos = pos;
+    ProtoEncode::reserve_byte(pos PROTO_ENCODE_DEBUG_ARG);
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
     ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
     ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -1888,8 +1888,6 @@ class BluetoothLERawAdvertisement final : public ProtoMessage {
   uint32_t address_type{0};
   uint8_t data[62]{};
   uint8_t data_len{0};
-  uint8_t *encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const;
-  uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP
   const char *dump_to(DumpBuffer &out) const override;
 #endif

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -352,6 +352,12 @@ class ProtoEncode {
     PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
     *pos++ = b;
   }
+  /// Reserve one byte for later backpatch (e.g., sub-message length).
+  /// Advances pos past the reserved byte without writing a value.
+  static inline void ESPHOME_ALWAYS_INLINE reserve_byte(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM) {
+    PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
+    pos++;
+  }
   /// Write raw bytes to the buffer (no tag, no length prefix).
   static inline void ESPHOME_ALWAYS_INLINE encode_raw(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
                                                       const void *data, size_t len) {

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1628,7 +1628,8 @@ def _generate_inline_size_block(
 
     lines = []
     lines.append(f"auto &sub_msg = {element};")
-    lines.append("uint32_t sub_size = 0;")
+    # 1 byte tag + 1 byte length (guaranteed < 128 by validation)
+    lines.append("size += 2;")
 
     for field in sub_desc.field:
         if field.options.deprecated:
@@ -1636,14 +1637,10 @@ def _generate_inline_size_block(
         ti = create_field_type_info(field, needs_decode=False, needs_encode=True)
         force = get_field_opt(field, pb.force, False)
         size_line = ti.get_size_calculation(f"sub_msg.{ti.field_name}", force)
-        # Replace "size +=" with "sub_size +=" for the local accumulator
-        size_line = size_line.replace("size +=", "sub_size +=")
         # Replace hardcoded this-> references (e.g., FixedArrayBytesType uses this->field_len)
         size_line = size_line.replace("this->", "sub_msg.")
         lines.extend(size_line.split("\n"))
 
-    # 1 byte tag + 1 byte length (guaranteed < 128) + body
-    lines.append("size += 2 + sub_size;")
     return "\n".join(lines)
 
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1823,21 +1823,6 @@ class FixedArrayRepeatedType(TypeInfo):
         # For fixed arrays, we always encode all elements
 
         if is_inline:
-            # Special case for single-element arrays - no loop needed
-            if self.array_size == 1:
-                return _generate_inline_size_block(
-                    self.number, self._ti.cpp_type, f"{name}[0]"
-                )
-            if self.array_size == 2:
-                return (
-                    _generate_inline_size_block(
-                        self.number, self._ti.cpp_type, f"{name}[0]"
-                    )
-                    + "\n  "
-                    + _generate_inline_size_block(
-                        self.number, self._ti.cpp_type, f"{name}[1]"
-                    )
-                )
             o = f"for (const auto &it : {name}) {{\n"
             o += indent(
                 _generate_inline_size_block(self.number, self._ti.cpp_type, "it")

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1626,13 +1626,7 @@ def _generate_inline_encode_block(
         encode_line = ti.encode_content
         # Replace this-> with sub_msg reference for the sub-message fields
         encode_line = encode_line.replace("this->", "sub_msg.")
-        # Honor per-field ifdef guards
-        field_ifdef = (
-            get_field_opt(field, pb.field_ifdef, None)
-            if field.options.HasExtension(pb.field_ifdef)
-            else None
-        )
-        lines.extend(wrap_with_ifdef(encode_line, field_ifdef))
+        lines.extend(wrap_with_ifdef(encode_line, get_field_opt(field, pb.field_ifdef)))
 
     lines.append("*len_pos = static_cast<uint8_t>(pos - len_pos - 1);")
     return "\n".join(lines)
@@ -1666,13 +1660,7 @@ def _generate_inline_size_block(
         size_line = ti.get_size_calculation(f"sub_msg.{ti.field_name}", force)
         # Replace hardcoded this-> references (e.g., FixedArrayBytesType uses this->field_len)
         size_line = size_line.replace("this->", "sub_msg.")
-        # Honor per-field ifdef guards
-        field_ifdef = (
-            get_field_opt(field, pb.field_ifdef, None)
-            if field.options.HasExtension(pb.field_ifdef)
-            else None
-        )
-        lines.extend(wrap_with_ifdef(size_line, field_ifdef))
+        lines.extend(wrap_with_ifdef(size_line, get_field_opt(field, pb.field_ifdef)))
 
     return "\n".join(lines)
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1593,11 +1593,10 @@ def _generate_inline_encode_block(
     assert tag < 128, f"inline_encode requires single-byte tag, got {tag}"
 
     lines = []
-    lines.append("{")
-    lines.append(f"  auto &sub_msg = {element};")
-    lines.append(f"  ProtoEncode::write_raw_byte(pos, {tag});")
-    lines.append("  uint8_t *len_pos = pos++;")
-    lines.append("  uint8_t *body_start = pos;")
+    lines.append(f"auto &sub_msg = {element};")
+    lines.append(f"ProtoEncode::write_raw_byte(pos, {tag});")
+    lines.append("uint8_t *len_pos = pos++;")
+    lines.append("uint8_t *body_start = pos;")
 
     # Generate inline field encoding for each sub-message field
     for field in sub_desc.field:
@@ -1607,10 +1606,9 @@ def _generate_inline_encode_block(
         encode_line = ti.encode_content
         # Replace this-> with sub_msg reference for the sub-message fields
         encode_line = encode_line.replace("this->", "sub_msg.")
-        lines.extend(f"  {line}" for line in encode_line.split("\n"))
+        lines.extend(encode_line.split("\n"))
 
-    lines.append("  *len_pos = static_cast<uint8_t>(pos - body_start);")
-    lines.append("}")
+    lines.append("*len_pos = static_cast<uint8_t>(pos - body_start);")
     return "\n".join(lines)
 
 
@@ -1630,9 +1628,8 @@ def _generate_inline_size_block(
     sub_desc = _message_desc_map[sub_msg_name]
 
     lines = []
-    lines.append("{")
-    lines.append(f"  auto &sub_msg = {element};")
-    lines.append("  uint32_t sub_size = 0;")
+    lines.append(f"auto &sub_msg = {element};")
+    lines.append("uint32_t sub_size = 0;")
 
     for field in sub_desc.field:
         if field.options.deprecated:
@@ -1644,11 +1641,10 @@ def _generate_inline_size_block(
         size_line = size_line.replace("size +=", "sub_size +=")
         # Replace hardcoded this-> references (e.g., FixedArrayBytesType uses this->field_len)
         size_line = size_line.replace("this->", "sub_msg.")
-        lines.extend(f"  {line}" for line in size_line.split("\n"))
+        lines.extend(size_line.split("\n"))
 
     # 1 byte tag + 1 byte length (guaranteed < 128) + body
-    lines.append("  size += 2 + sub_size;")
-    lines.append("}")
+    lines.append("size += 2 + sub_size;")
     return "\n".join(lines)
 
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -1596,7 +1596,6 @@ def _generate_inline_encode_block(
     lines.append(f"auto &sub_msg = {element};")
     lines.append(f"ProtoEncode::write_raw_byte(pos, {tag});")
     lines.append("uint8_t *len_pos = pos++;")
-    lines.append("uint8_t *body_start = pos;")
 
     # Generate inline field encoding for each sub-message field
     for field in sub_desc.field:
@@ -1608,7 +1607,7 @@ def _generate_inline_encode_block(
         encode_line = encode_line.replace("this->", "sub_msg.")
         lines.extend(encode_line.split("\n"))
 
-    lines.append("*len_pos = static_cast<uint8_t>(pos - body_start);")
+    lines.append("*len_pos = static_cast<uint8_t>(pos - len_pos - 1);")
     return "\n".join(lines)
 
 

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -60,6 +60,10 @@ FILE_HEADER = """// This file was automatically generated with a tool.
 # Maps enum type name (e.g. ".BluetoothDeviceRequestType") to max enum value.
 _enum_max_values: dict[str, int] = {}
 
+# Populated by main() before message generation.
+# Maps message name (e.g. "BluetoothLERawAdvertisement") to its descriptor.
+_message_desc_map: dict[str, Any] = {}
+
 
 def indent_list(text: str, padding: str = "  ") -> list[str]:
     """Indent each line of the given text with the specified padding."""
@@ -427,6 +431,23 @@ class TypeInfo(ABC):
             Estimated size in bytes including field ID and typical data
         """
 
+    def get_max_encoded_size(self) -> int | None:
+        """Get the maximum possible encoded size in bytes for this field.
+
+        Returns the worst-case encoded size including field ID and maximum
+        possible value encoding. Returns None if the size is unbounded
+        (e.g., variable-length strings without max_data_length).
+
+        Used by (inline_encode) validation to ensure sub-messages fit in a
+        single-byte length varint (< 128 bytes).
+        """
+        return None  # Unbounded by default
+
+
+def _varint_max_size(bits: int) -> int:
+    """Return the maximum varint encoding size for a value with the given number of bits."""
+    return (bits + 6) // 7  # ceil(bits / 7)
+
 
 TYPE_INFO: dict[int, TypeInfo] = {}
 
@@ -514,8 +535,30 @@ def register_type(name: int):
     return func
 
 
+class FixedSizeTypeMixin:
+    """Mixin for types with a known fixed encoded size (float, double, fixed32, fixed64)."""
+
+    def get_max_encoded_size(self) -> int:
+        return self.calculate_field_id_size() + self.get_fixed_size_bytes()
+
+
+class VarintTypeMixin:
+    """Mixin for varint types. Subclasses set _varint_max_bits."""
+
+    _varint_max_bits: int = 64  # Default to worst case
+
+    def get_max_encoded_size(self) -> int:
+        max_val = self.max_value
+        if max_val is not None:
+            return self.calculate_field_id_size() + _varint_max_size(
+                max_val.bit_length() if max_val > 0 else 1
+            )
+        return self.calculate_field_id_size() + _varint_max_size(self._varint_max_bits)
+
+
 @register_type(1)
-class DoubleType(TypeInfo):
+class DoubleType(FixedSizeTypeMixin, TypeInfo):
+    # Unsupported but defined for completeness
     cpp_type = "double"
     default_value = "0.0"
     decode_64bit = "value.as_double()"
@@ -541,7 +584,7 @@ class DoubleType(TypeInfo):
 
 
 @register_type(2)
-class FloatType(TypeInfo):
+class FloatType(FixedSizeTypeMixin, TypeInfo):
     cpp_type = "float"
     default_value = "0.0f"
     decode_32bit = "value.as_float()"
@@ -567,8 +610,9 @@ class FloatType(TypeInfo):
 
 
 @register_type(3)
-class Int64Type(TypeInfo):
+class Int64Type(VarintTypeMixin, TypeInfo):
     cpp_type = "int64_t"
+    _varint_max_bits = 64
     default_value = "0"
     decode_varint = "static_cast<int64_t>(value)"
     encode_func = "encode_int64"
@@ -587,8 +631,9 @@ class Int64Type(TypeInfo):
 
 
 @register_type(4)
-class UInt64Type(TypeInfo):
+class UInt64Type(VarintTypeMixin, TypeInfo):
     cpp_type = "uint64_t"
+    _varint_max_bits = 64
     default_value = "0"
     decode_varint = "value"
     encode_func = "encode_uint64"
@@ -607,8 +652,9 @@ class UInt64Type(TypeInfo):
 
 
 @register_type(5)
-class Int32Type(TypeInfo):
+class Int32Type(VarintTypeMixin, TypeInfo):
     cpp_type = "int32_t"
+    _varint_max_bits = 64  # int32 is sign-extended to 64 bits in protobuf
     default_value = "0"
     decode_varint = "static_cast<int32_t>(value)"
     encode_func = "encode_int32"
@@ -627,7 +673,7 @@ class Int32Type(TypeInfo):
 
 
 @register_type(6)
-class Fixed64Type(TypeInfo):
+class Fixed64Type(FixedSizeTypeMixin, TypeInfo):
     cpp_type = "uint64_t"
     default_value = "0"
     decode_64bit = "value.as_fixed64()"
@@ -653,7 +699,7 @@ class Fixed64Type(TypeInfo):
 
 
 @register_type(7)
-class Fixed32Type(TypeInfo):
+class Fixed32Type(FixedSizeTypeMixin, TypeInfo):
     cpp_type = "uint32_t"
     default_value = "0"
     decode_32bit = "value.as_fixed32()"
@@ -689,7 +735,8 @@ class Fixed32Type(TypeInfo):
 
 
 @register_type(8)
-class BoolType(TypeInfo):
+class BoolType(VarintTypeMixin, TypeInfo):
+    _varint_max_bits = 1
     cpp_type = "bool"
     default_value = "false"
     decode_varint = "value != 0"
@@ -1299,14 +1346,23 @@ class FixedArrayBytesType(TypeInfo):
             self.calculate_field_id_size() + 1 + 31
         )  # field ID + length byte + typical 31 bytes
 
+    def get_max_encoded_size(self) -> int:
+        # field_id + varint(array_size) + array_size
+        return (
+            self.calculate_field_id_size()
+            + _varint_max_size(self.array_size.bit_length())
+            + self.array_size
+        )
+
     @property
     def wire_type(self) -> WireType:
         return WireType.LENGTH_DELIMITED
 
 
 @register_type(13)
-class UInt32Type(TypeInfo):
+class UInt32Type(VarintTypeMixin, TypeInfo):
     cpp_type = "uint32_t"
+    _varint_max_bits = 32
     default_value = "0"
     decode_varint = "value"
     encode_func = "encode_uint32"
@@ -1328,7 +1384,9 @@ class UInt32Type(TypeInfo):
 
 
 @register_type(14)
-class EnumType(TypeInfo):
+class EnumType(VarintTypeMixin, TypeInfo):
+    _varint_max_bits = 32
+
     @property
     def cpp_type(self) -> str:
         return f"enums::{self._field.type_name[1:]}"
@@ -1379,7 +1437,7 @@ class EnumType(TypeInfo):
 
 
 @register_type(15)
-class SFixed32Type(TypeInfo):
+class SFixed32Type(FixedSizeTypeMixin, TypeInfo):
     cpp_type = "int32_t"
     default_value = "0"
     decode_32bit = "value.as_sfixed32()"
@@ -1405,7 +1463,7 @@ class SFixed32Type(TypeInfo):
 
 
 @register_type(16)
-class SFixed64Type(TypeInfo):
+class SFixed64Type(FixedSizeTypeMixin, TypeInfo):
     cpp_type = "int64_t"
     default_value = "0"
     decode_64bit = "value.as_sfixed64()"
@@ -1431,8 +1489,9 @@ class SFixed64Type(TypeInfo):
 
 
 @register_type(17)
-class SInt32Type(TypeInfo):
+class SInt32Type(VarintTypeMixin, TypeInfo):
     cpp_type = "int32_t"
+    _varint_max_bits = 32  # zigzag encoding keeps it 32-bit
     default_value = "0"
     decode_varint = "decode_zigzag32(static_cast<uint32_t>(value))"
     encode_func = "encode_sint32"
@@ -1451,8 +1510,9 @@ class SInt32Type(TypeInfo):
 
 
 @register_type(18)
-class SInt64Type(TypeInfo):
+class SInt64Type(VarintTypeMixin, TypeInfo):
     cpp_type = "int64_t"
+    _varint_max_bits = 64
     default_value = "0"
     decode_varint = "decode_zigzag64(value)"
     encode_func = "encode_sint64"
@@ -1500,6 +1560,98 @@ def _generate_array_dump_content(
     return o
 
 
+def _is_inline_encode(sub_msg_name: str) -> bool:
+    """Check if a sub-message type has the (inline_encode) option set."""
+    sub_desc = _message_desc_map.get(sub_msg_name)
+    if not sub_desc:
+        return False
+    inline_opt = getattr(pb, "inline_encode", None)
+    if inline_opt is None:
+        return False
+    return get_opt(sub_desc, inline_opt, False)
+
+
+def _generate_inline_encode_block(
+    field_number: int, sub_msg_name: str, element: str
+) -> str:
+    """Generate inline encode code for a sub-message with (inline_encode) = true.
+
+    Instead of calling encode_sub_message (function pointer indirection),
+    this inlines the sub-message's field encoding directly. Uses 1-byte
+    backpatch for the length (validated to be < 128 at generation time).
+
+    Uses a local reference alias 'sub_msg' to avoid issues with this-> replacement
+    on complex element expressions.
+
+    Args:
+        field_number: The parent field number for this sub-message
+        sub_msg_name: The sub-message type name
+        element: C++ expression for the element (e.g., "it" or "this->field[i]")
+    """
+    sub_desc = _message_desc_map[sub_msg_name]
+    tag = (field_number << 3) | 2  # wire type 2 = LENGTH_DELIMITED
+    assert tag < 128, f"inline_encode requires single-byte tag, got {tag}"
+
+    lines = []
+    lines.append("{")
+    lines.append(f"  auto &sub_msg = {element};")
+    lines.append(f"  ProtoEncode::write_raw_byte(pos, {tag});")
+    lines.append("  uint8_t *len_pos = pos++;")
+    lines.append("  uint8_t *body_start = pos;")
+
+    # Generate inline field encoding for each sub-message field
+    for field in sub_desc.field:
+        if field.options.deprecated:
+            continue
+        ti = create_field_type_info(field, needs_decode=False, needs_encode=True)
+        encode_line = ti.encode_content
+        # Replace this-> with sub_msg reference for the sub-message fields
+        encode_line = encode_line.replace("this->", "sub_msg.")
+        lines.extend(f"  {line}" for line in encode_line.split("\n"))
+
+    lines.append("  *len_pos = static_cast<uint8_t>(pos - body_start);")
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def _generate_inline_size_block(
+    field_number: int, sub_msg_name: str, element: str
+) -> str:
+    """Generate inline size calculation for a sub-message with (inline_encode) = true.
+
+    Uses a local reference alias 'sub_msg' to avoid issues with this-> replacement
+    on complex element expressions like 'this->advertisements[i]'.
+
+    Args:
+        field_number: The parent field number for this sub-message
+        sub_msg_name: The sub-message type name
+        element: C++ expression for the element
+    """
+    sub_desc = _message_desc_map[sub_msg_name]
+
+    lines = []
+    lines.append("{")
+    lines.append(f"  auto &sub_msg = {element};")
+    lines.append("  uint32_t sub_size = 0;")
+
+    for field in sub_desc.field:
+        if field.options.deprecated:
+            continue
+        ti = create_field_type_info(field, needs_decode=False, needs_encode=True)
+        force = get_field_opt(field, pb.force, False)
+        size_line = ti.get_size_calculation(f"sub_msg.{ti.field_name}", force)
+        # Replace "size +=" with "sub_size +=" for the local accumulator
+        size_line = size_line.replace("size +=", "sub_size +=")
+        # Replace hardcoded this-> references (e.g., FixedArrayBytesType uses this->field_len)
+        size_line = size_line.replace("this->", "sub_msg.")
+        lines.extend(f"  {line}" for line in size_line.split("\n"))
+
+    # 1 byte tag + 1 byte length (guaranteed < 128) + body
+    lines.append("  size += 2 + sub_size;")
+    lines.append("}")
+    return "\n".join(lines)
+
+
 class FixedArrayRepeatedType(TypeInfo):
     """Special type for fixed-size repeated fields using std::array.
 
@@ -1526,6 +1678,10 @@ class FixedArrayRepeatedType(TypeInfo):
             return f"ProtoEncode::{self._ti.encode_func}(pos, {self.number}, static_cast<uint32_t>({element}), true);"
         # Repeated message elements use encode_sub_message (force=true is default)
         if isinstance(self._ti, MessageType):
+            if _is_inline_encode(self._ti.cpp_type):
+                return _generate_inline_encode_block(
+                    self.number, self._ti.cpp_type, element
+                )
             return f"ProtoEncode::encode_sub_message(pos, buffer, {self.number}, {element});"
         return (
             f"ProtoEncode::{self._ti.encode_func}(pos, {self.number}, {element}, true);"
@@ -1633,14 +1789,48 @@ class FixedArrayRepeatedType(TypeInfo):
             ]
             return f"if ({non_zero_checks}) {{\n" + "\n".join(size_lines) + "\n}"
 
+        is_inline = isinstance(self._ti, MessageType) and _is_inline_encode(
+            self._ti.cpp_type
+        )
+
         # When using a define, always use loop-based approach
         if self.is_define:
+            if is_inline:
+                o = f"for (const auto &it : {name}) {{\n"
+                o += indent(
+                    _generate_inline_size_block(self.number, self._ti.cpp_type, "it")
+                )
+                o += "\n}"
+                return o
             o = f"for (const auto &it : {name}) {{\n"
             o += f"  {self._ti.get_size_calculation('it', True)}\n"
             o += "}"
             return o
 
         # For fixed arrays, we always encode all elements
+
+        if is_inline:
+            # Special case for single-element arrays - no loop needed
+            if self.array_size == 1:
+                return _generate_inline_size_block(
+                    self.number, self._ti.cpp_type, f"{name}[0]"
+                )
+            if self.array_size == 2:
+                return (
+                    _generate_inline_size_block(
+                        self.number, self._ti.cpp_type, f"{name}[0]"
+                    )
+                    + "\n  "
+                    + _generate_inline_size_block(
+                        self.number, self._ti.cpp_type, f"{name}[1]"
+                    )
+                )
+            o = f"for (const auto &it : {name}) {{\n"
+            o += indent(
+                _generate_inline_size_block(self.number, self._ti.cpp_type, "it")
+            )
+            o += "\n}"
+            return o
 
         # Special case for single-element arrays - no loop needed
         if self.array_size == 1:
@@ -1714,6 +1904,15 @@ class FixedArrayWithLengthRepeatedType(FixedArrayRepeatedType):
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
         # Calculate size only for active elements
+        if isinstance(self._ti, MessageType) and _is_inline_encode(self._ti.cpp_type):
+            o = f"for (uint16_t i = 0; i < {name}_len; i++) {{\n"
+            o += indent(
+                _generate_inline_size_block(
+                    self.number, self._ti.cpp_type, f"{name}[i]"
+                )
+            )
+            o += "\n}"
+            return o
         o = f"for (uint16_t i = 0; i < {name}_len; i++) {{\n"
         o += f"  {self._ti.get_size_calculation(f'{name}[i]', True)}\n"
         o += "}"
@@ -2222,6 +2421,28 @@ def calculate_message_estimated_size(desc: descriptor.DescriptorProto) -> int:
     return total_size
 
 
+def calculate_message_max_size(desc: descriptor.DescriptorProto) -> int | None:
+    """Calculate the maximum possible encoded size for a message.
+
+    Returns None if any field has unbounded size (e.g., variable-length strings).
+    Used to validate that (inline_encode) messages fit in a single-byte length varint.
+    """
+    total_size = 0
+
+    for field in desc.field:
+        if field.options.deprecated:
+            continue
+
+        ti = create_field_type_info(field, needs_decode=False, needs_encode=True)
+        max_size = ti.get_max_encoded_size()
+        if max_size is None:
+            return None
+
+        total_size += max_size
+
+    return total_size
+
+
 def build_message_type(
     desc: descriptor.DescriptorProto,
     base_class_fields: dict[str, list[descriptor.FieldDescriptorProto]],
@@ -2451,8 +2672,15 @@ def build_message_type(
         prot = "void decode(const uint8_t *buffer, size_t length);"
         public_content.append(prot)
 
+    # Check if this message uses inline_encode — if so, skip generating standalone
+    # encode/calculate_size methods since the encoding is inlined into the parent.
+    is_inline_only = (
+        message_id is None  # Not a service message (no id)
+        and get_opt(desc, getattr(pb, "inline_encode", None), False)
+    )
+
     # Only generate encode method if this message needs encoding and has fields
-    if needs_encode and encode:
+    if needs_encode and encode and not is_inline_only:
         # Add PROTO_ENCODE_DEBUG_ARG after pos in all proto_* calls
         encode_debug = [
             line.replace("(pos,", "(pos PROTO_ENCODE_DEBUG_ARG,") for line in encode
@@ -2470,7 +2698,7 @@ def build_message_type(
     # If no fields to encode or message doesn't need encoding, the default implementation in ProtoMessage will be used
 
     # Add calculate_size method only if this message needs encoding and has fields
-    if needs_encode and size_calc:
+    if needs_encode and size_calc and not is_inline_only:
         o = f"uint32_t {desc.name}::calculate_size() const {{\n"
         o += "  uint32_t size = 0;\n"
         o += indent("\n".join(size_calc)) + "\n"
@@ -2830,6 +3058,32 @@ def main() -> None:
         if not enum.options.deprecated and enum.value:
             _enum_max_values[f".{enum.name}"] = max(v.number for v in enum.value)
 
+    # Build message descriptor map for inline_encode lookups
+    mt = file.message_type
+    _message_desc_map.update({m.name: m for m in mt if not m.options.deprecated})
+
+    # Validate inline_encode messages fit in single-byte length varint
+    inline_encode_opt = getattr(pb, "inline_encode", None)
+    if inline_encode_opt is not None:
+        for m in mt:
+            if m.options.deprecated:
+                continue
+            if not get_opt(m, inline_encode_opt, False):
+                continue
+            max_size = calculate_message_max_size(m)
+            if max_size is None:
+                raise ValueError(
+                    f"Message '{m.name}' has (inline_encode) = true but contains "
+                    f"fields with unbounded size. Inline encoding requires all "
+                    f"fields to have bounded maximum size."
+                )
+            if max_size >= 128:
+                raise ValueError(
+                    f"Message '{m.name}' has (inline_encode) = true but max "
+                    f"encoded size is {max_size} bytes (>= 128). Inline encoding "
+                    f"requires sub-messages that fit in a single-byte length varint."
+                )
+
     # Build dynamic ifdef mappings early so we can emit USE_API_VARINT64 before includes
     enum_ifdef_map, message_ifdef_map, message_source_map, used_messages = (
         build_type_usage_map(file)
@@ -3047,8 +3301,6 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
         dump_cpp += "#endif\n"
 
     content += "\n}  // namespace enums\n\n"
-
-    mt = file.message_type
 
     # Identify empty SOURCE_CLIENT messages that don't need class generation
     for m in mt:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -446,7 +446,7 @@ class TypeInfo(ABC):
 
 def _varint_max_size(bits: int) -> int:
     """Return the maximum varint encoding size for a value with the given number of bits."""
-    return (bits + 6) // 7  # ceil(bits / 7)
+    return (max(bits, 1) + 6) // 7  # ceil(bits / 7), min 1 byte for varint(0)
 
 
 TYPE_INFO: dict[int, TypeInfo] = {}
@@ -1615,7 +1615,8 @@ def _generate_inline_encode_block(
     lines = []
     lines.append(f"auto &sub_msg = {element};")
     lines.append(f"ProtoEncode::write_raw_byte(pos, {tag});")
-    lines.append("uint8_t *len_pos = pos++;")
+    lines.append("uint8_t *len_pos = pos;")
+    lines.append("ProtoEncode::reserve_byte(pos);")
 
     # Generate inline field encoding for each sub-message field
     for field in sub_desc.field:
@@ -1625,7 +1626,13 @@ def _generate_inline_encode_block(
         encode_line = ti.encode_content
         # Replace this-> with sub_msg reference for the sub-message fields
         encode_line = encode_line.replace("this->", "sub_msg.")
-        lines.extend(encode_line.split("\n"))
+        # Honor per-field ifdef guards
+        field_ifdef = (
+            get_field_opt(field, pb.field_ifdef, None)
+            if field.options.HasExtension(pb.field_ifdef)
+            else None
+        )
+        lines.extend(wrap_with_ifdef(encode_line, field_ifdef))
 
     lines.append("*len_pos = static_cast<uint8_t>(pos - len_pos - 1);")
     return "\n".join(lines)
@@ -1659,7 +1666,13 @@ def _generate_inline_size_block(
         size_line = ti.get_size_calculation(f"sub_msg.{ti.field_name}", force)
         # Replace hardcoded this-> references (e.g., FixedArrayBytesType uses this->field_len)
         size_line = size_line.replace("this->", "sub_msg.")
-        lines.extend(size_line.split("\n"))
+        # Honor per-field ifdef guards
+        field_ifdef = (
+            get_field_opt(field, pb.field_ifdef, None)
+            if field.options.HasExtension(pb.field_ifdef)
+            else None
+        )
+        lines.extend(wrap_with_ifdef(size_line, field_ifdef))
 
     return "\n".join(lines)
 
@@ -2686,16 +2699,21 @@ def build_message_type(
 
     # Check if this message uses inline_encode — if so, skip generating standalone
     # encode/calculate_size methods since the encoding is inlined into the parent.
+    inline_opt = getattr(pb, "inline_encode", None)
     is_inline_only = (
         message_id is None  # Not a service message (no id)
-        and get_opt(desc, getattr(pb, "inline_encode", None), False)
+        and inline_opt is not None
+        and get_opt(desc, inline_opt, False)
     )
 
     # Only generate encode method if this message needs encoding and has fields
     if needs_encode and encode and not is_inline_only:
         # Add PROTO_ENCODE_DEBUG_ARG after pos in all proto_* calls
         encode_debug = [
-            line.replace("(pos,", "(pos PROTO_ENCODE_DEBUG_ARG,") for line in encode
+            line.replace("(pos,", "(pos PROTO_ENCODE_DEBUG_ARG,").replace(
+                "(pos)", "(pos PROTO_ENCODE_DEBUG_ARG)"
+            )
+            for line in encode
         ]
         o = f"uint8_t *{desc.name}::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {{\n"
         o += "  uint8_t *__restrict__ pos = buffer.get_pos();\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -854,6 +854,16 @@ class StringType(TypeInfo):
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical string
 
+    def get_max_encoded_size(self) -> int | None:
+        max_len = self.max_data_length
+        if max_len is not None:
+            return (
+                self.calculate_field_id_size()
+                + _varint_max_size(max_len.bit_length())
+                + max_len
+            )
+        return None  # Unbounded
+
 
 @register_type(11)
 class MessageType(TypeInfo):
@@ -1168,6 +1178,16 @@ class PointerToStringBufferType(PointerToBufferTypeBase):
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical string
+
+    def get_max_encoded_size(self) -> int | None:
+        max_len = self.max_data_length
+        if max_len is not None:
+            return (
+                self.calculate_field_id_size()
+                + _varint_max_size(max_len.bit_length())
+                + max_len
+            )
+        return None
 
 
 class PackedBufferTypeInfo(TypeInfo):


### PR DESCRIPTION
# What does this implement/fix?

Add a new message-level `(inline_encode)` option in `api_options.proto`. When set on a sub-message type, the protobuf code generator inlines the sub-message's field encoding directly into the parent's `encode()` and `calculate_size()` methods, eliminating the `encode_sub_message()` function pointer indirection through `proto.cpp`.

Applied to `BluetoothLERawAdvertisement` which is encoded up to 12 times per BLE advertisement batch in a hot loop. The inlined path:
- Writes the tag byte directly (precomputed)
- Reserves 1 byte for the length varint
- Encodes all sub-message fields inline (no function pointer call)
- Backpatches the length byte (guaranteed single byte since max size < 128)

The generator validates at generation time (via new `get_max_encoded_size()` on all TypeInfo subclasses) that the sub-message's maximum possible encoded size is < 128 bytes, raising `ValueError` if violated. For `BluetoothLERawAdvertisement` the max is 83 bytes.

Since the encoding is fully inlined, standalone `encode()` and `calculate_size()` methods are no longer generated for the sub-message.

### Benchmark results

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| CalcAndEncode_BLERawAdvs12 | 1.9 ms | 1.3 ms | +45.64% |
| CalcAndEncode_BLERawAdvs12_Fresh | 2.0 ms | 1.4 ms | +40.65% |
| CalculateSize_BLERawAdvs12 | 453.6 µs | 291.9 µs | +55.38% |
| Encode_BLERawAdvs12 | 1,413.5 µs | 989.4 µs | +42.86% |

Flash size: -32 bytes on ESP32.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes. This is an internal code generation optimization.
# Applied via proto option:
# message BluetoothLERawAdvertisement {
#   option (inline_encode) = true;
#   ...
# }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).