### PR TITLE
[packages] Fix false deprecation warning and wrong error paths in nested packages

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -482,8 +482,14 @@ class _PackageProcessor:
         # Push context from !include vars on the package root and on the packages key
         context_vars = push_context(package_config, context_vars)
         context_vars = push_context(package_config[CONF_PACKAGES], context_vars)
-        # Nested packages are always named package dicts, never the
-        # deprecated single-package form, so disable the fallback.
+        # Disable the deprecated single-package fallback for nested
+        # packages.  The fallback masks real validation errors by
+        # swallowing cv.Invalid and re-wrapping the dict as a list,
+        # which produces wrong error paths (packages->0 instead of
+        # packages-><name>).  If a nested package file happens to use
+        # the deprecated form, the user will get a direct error
+        # instead of the fallback — acceptable since the deprecated
+        # form is being removed in 2026.7.0.
         return _walk_packages(
             package_config,
             self.process_package,

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -473,6 +473,9 @@ class _PackageProcessor:
         self, package_config: dict | str, context_vars: ContextVars | None
     ) -> dict:
         """Resolve a single package and recurse into any nested packages."""
+        from_remote = isinstance(package_config, dict) and is_remote_package(
+            package_config
+        )
         package_config = self.resolve_package(package_config, context_vars)
         self.collect_substitutions(package_config)
 
@@ -482,19 +485,17 @@ class _PackageProcessor:
         # Push context from !include vars on the package root and on the packages key
         context_vars = push_context(package_config, context_vars)
         context_vars = push_context(package_config[CONF_PACKAGES], context_vars)
-        # Disable the deprecated single-package fallback for nested
-        # packages.  The fallback masks real validation errors by
-        # swallowing cv.Invalid and re-wrapping the dict as a list,
-        # which produces wrong error paths (packages->0 instead of
-        # packages-><name>).  If a nested package file happens to use
-        # the deprecated form, the user will get a direct error
-        # instead of the fallback — acceptable since the deprecated
-        # form is being removed in 2026.7.0.
+        # Disable the deprecated single-package fallback for remote
+        # packages.  _process_remote_package returns dicts with
+        # already-resolved values that is_package_definition cannot
+        # distinguish from config fragments, so the fallback would
+        # always fire and mask real errors with wrong paths
+        # (packages->0 instead of packages-><name>).
         return _walk_packages(
             package_config,
             self.process_package,
             context_vars,
-            validate_deprecated=False,
+            validate_deprecated=not from_remote,
         )
 
 

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -329,23 +329,16 @@ def _walk_packages(
     with cv.prepend_path(CONF_PACKAGES):
         if not isinstance(packages, dict):
             _walk_package_list(packages, callback, context)
-        else:
-            # Check if any values are clearly package definitions (not
-            # config fragments) before _walk_package_dict modifies the
-            # dict in-place. If so, this is a named packages dict and
-            # errors must be raised directly instead of triggering the
-            # deprecated single-package fallback.
-            is_named = any(is_package_definition(v) for v in packages.values())
-            if (result := _walk_package_dict(packages, callback, context)) is not None:
-                if not validate_deprecated or is_named:
-                    raise result
-                # Fallback: treat the dict as a single deprecated package.
-                # This block can be removed once the single-package
-                # deprecation period (2026.7.0) is over.
-                config[CONF_PACKAGES] = [packages]
-                return _walk_packages(
-                    deprecate_single_package(config), callback, context
-                )
+        elif (result := _walk_package_dict(packages, callback, context)) is not None:
+            if not validate_deprecated or any(
+                is_package_definition(v) for v in packages.values()
+            ):
+                raise result
+            # Fallback: treat the dict as a single deprecated package.
+            # This block can be removed once the single-package
+            # deprecation period (2026.7.0) is over.
+            config[CONF_PACKAGES] = [packages]
+            return _walk_packages(deprecate_single_package(config), callback, context)
 
     config[CONF_PACKAGES] = packages
     return config

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -45,6 +45,18 @@ def is_remote_package(package_config: dict) -> bool:
     return CONF_URL in package_config
 
 
+def is_package_definition(value: object) -> bool:
+    """Returns True if the value looks like a package definition rather than a config fragment.
+
+    Package definitions are IncludeFile objects, git URL shorthand strings, or
+    remote package dicts (containing a ``url:`` key).  Config fragments are
+    plain dicts that represent component configuration.
+    """
+    return isinstance(value, (yaml_util.IncludeFile, str)) or (
+        isinstance(value, dict) and is_remote_package(value)
+    )
+
+
 def valid_package_contents(package_config: dict) -> dict:
     """Validate that a package looks like a plausible ESPHome config fragment.
 
@@ -317,12 +329,20 @@ def _walk_packages(
     with cv.prepend_path(CONF_PACKAGES):
         if not isinstance(packages, dict):
             _walk_package_list(packages, callback, context)
-        elif (result := _walk_package_dict(packages, callback, context)) is not None:
-            if not validate_deprecated:
-                raise result
+        # Check if any values are clearly package definitions (not config
+        # fragments) before _walk_package_dict modifies the dict in-place.
+        # If so, this is a named packages dict and errors must be raised
+        # directly instead of triggering the deprecated single-package
+        # fallback.
+        elif (
+            is_named := any(is_package_definition(v) for v in packages.values()),
+            result := _walk_package_dict(packages, callback, context),
+        )[1] is None:
+            pass
+        elif not validate_deprecated or is_named:
+            raise result
+        else:
             # Fallback: treat the dict as a single deprecated package.
-            # Note: this catches *any* cv.Invalid from the callback, which may
-            # mask real validation errors in named package dicts.
             # This block can be removed once the single-package
             # deprecation period (2026.7.0) is over.
             config[CONF_PACKAGES] = [packages]

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -482,7 +482,14 @@ class _PackageProcessor:
         # Push context from !include vars on the package root and on the packages key
         context_vars = push_context(package_config, context_vars)
         context_vars = push_context(package_config[CONF_PACKAGES], context_vars)
-        return _walk_packages(package_config, self.process_package, context_vars)
+        # Nested packages are always named package dicts, never the
+        # deprecated single-package form, so disable the fallback.
+        return _walk_packages(
+            package_config,
+            self.process_package,
+            context_vars,
+            validate_deprecated=False,
+        )
 
 
 def do_packages_pass(

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -329,24 +329,23 @@ def _walk_packages(
     with cv.prepend_path(CONF_PACKAGES):
         if not isinstance(packages, dict):
             _walk_package_list(packages, callback, context)
-        # Check if any values are clearly package definitions (not config
-        # fragments) before _walk_package_dict modifies the dict in-place.
-        # If so, this is a named packages dict and errors must be raised
-        # directly instead of triggering the deprecated single-package
-        # fallback.
-        elif (
-            is_named := any(is_package_definition(v) for v in packages.values()),
-            result := _walk_package_dict(packages, callback, context),
-        )[1] is None:
-            pass
-        elif not validate_deprecated or is_named:
-            raise result
         else:
-            # Fallback: treat the dict as a single deprecated package.
-            # This block can be removed once the single-package
-            # deprecation period (2026.7.0) is over.
-            config[CONF_PACKAGES] = [packages]
-            return _walk_packages(deprecate_single_package(config), callback, context)
+            # Check if any values are clearly package definitions (not
+            # config fragments) before _walk_package_dict modifies the
+            # dict in-place. If so, this is a named packages dict and
+            # errors must be raised directly instead of triggering the
+            # deprecated single-package fallback.
+            is_named = any(is_package_definition(v) for v in packages.values())
+            if (result := _walk_package_dict(packages, callback, context)) is not None:
+                if not validate_deprecated or is_named:
+                    raise result
+                # Fallback: treat the dict as a single deprecated package.
+                # This block can be removed once the single-package
+                # deprecation period (2026.7.0) is over.
+                config[CONF_PACKAGES] = [packages]
+                return _walk_packages(
+                    deprecate_single_package(config), callback, context
+                )
 
     config[CONF_PACKAGES] = packages
     return config

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -43,7 +43,7 @@ from esphome.const import (
 )
 from esphome.core import CORE
 from esphome.util import OrderedDict
-from esphome.yaml_util import add_context
+from esphome.yaml_util import IncludeFile, add_context
 
 # Test strings
 TEST_DEVICE_NAME = "test_device_name"
@@ -119,8 +119,6 @@ _INCLUDE_FILE = "INCLUDE_FILE"
 def test_is_package_definition(value: object, expected: bool) -> None:
     """Test that is_package_definition correctly identifies package definitions."""
     if value is _INCLUDE_FILE:
-        from esphome.yaml_util import IncludeFile
-
         value = MagicMock(spec=IncludeFile)
     assert is_package_definition(value) is expected
 
@@ -1164,8 +1162,6 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
     caused a false deprecation warning and wrong error paths (packages->0
     instead of packages-><package_name>).
     """
-    from esphome.yaml_util import IncludeFile
-
     good_include = MagicMock(spec=IncludeFile)
     bad_include = MagicMock(spec=IncludeFile)
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -5,7 +5,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from esphome.components.packages import CONFIG_SCHEMA, do_packages_pass, merge_packages
+from esphome.components.packages import (
+    CONFIG_SCHEMA,
+    _walk_packages,
+    do_packages_pass,
+    is_package_definition,
+    merge_packages,
+)
 from esphome.components.substitutions import do_substitution_pass
 import esphome.config as config_module
 from esphome.config import resolve_extend_remove
@@ -77,6 +83,44 @@ def packages_pass(config):
     config = merge_packages(config)
     resolve_extend_remove(config)
     return config
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # IncludeFile objects are package definitions
+        (MagicMock(spec="IncludeFile"), True),
+        # Git URL shorthand strings are package definitions
+        ("github://esphome/firmware/base.yaml@main", True),
+        # Remote package dicts (with url key) are package definitions
+        ({"url": "https://github.com/esphome/firmware", "file": "base.yaml"}, True),
+        # Plain config dicts are NOT package definitions (they are config fragments)
+        ({"wifi": {"ssid": "test"}}, False),
+        # None is not a package definition
+        (None, False),
+        # Lists are not package definitions
+        ([{"wifi": {"ssid": "test"}}], False),
+        # Empty dicts are not package definitions
+        ({}, False),
+    ],
+    ids=[
+        "include_file",
+        "git_shorthand",
+        "remote_package",
+        "config_fragment",
+        "none",
+        "list",
+        "empty_dict",
+    ],
+)
+def test_is_package_definition(value: object, expected: bool) -> None:
+    """Test that is_package_definition correctly identifies package definitions."""
+    from esphome.yaml_util import IncludeFile
+
+    if isinstance(value, MagicMock):
+        # Replace the mock with a real spec check
+        value = MagicMock(spec=IncludeFile)
+    assert is_package_definition(value) is expected
 
 
 def test_package_unused(basic_esphome, basic_wifi) -> None:
@@ -1105,6 +1149,47 @@ def test_invalid_package_contents_masked_by_deprecation(
     }
     with pytest.raises(cv.Invalid):
         do_packages_pass(config)
+
+
+def test_named_dict_with_include_files_no_false_deprecation_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Named package dicts with IncludeFile values must not trigger the deprecated single-package fallback.
+
+    Regression test: when a named package dict contained IncludeFile values
+    and one of the packages had an error (e.g. jinja syntax error), the error
+    was incorrectly caught by the deprecated single-package fallback. This
+    caused a false deprecation warning and wrong error paths (packages->0
+    instead of packages-><package_name>).
+    """
+    from esphome.yaml_util import IncludeFile
+
+    good_include = MagicMock(spec=IncludeFile)
+    bad_include = MagicMock(spec=IncludeFile)
+
+    config = {
+        CONF_PACKAGES: {
+            "good_pkg": good_include,
+            "bad_pkg": bad_include,
+        },
+    }
+
+    call_count = 0
+
+    def failing_callback(package_config, context):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First package processes fine
+            return {CONF_WIFI: {CONF_SSID: "test"}}
+        # Second package has an error (e.g. jinja syntax error)
+        raise cv.Invalid("simulated jinja error in bad_pkg")
+
+    with pytest.raises(cv.Invalid, match="simulated jinja error"):
+        _walk_packages(config, failing_callback)
+
+    # Must NOT emit the deprecated single-package warning
+    assert "deprecated" not in caplog.text.lower()
 
 
 def test_merge_packages_invalid_nested_type_raises() -> None:

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1154,14 +1154,7 @@ def test_invalid_package_contents_masked_by_deprecation(
 def test_named_dict_with_include_files_no_false_deprecation_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Named package dicts with IncludeFile values must not trigger the deprecated single-package fallback.
-
-    Regression test: when a named package dict contained IncludeFile values
-    and one of the packages had an error (e.g. jinja syntax error), the error
-    was incorrectly caught by the deprecated single-package fallback. This
-    caused a false deprecation warning and wrong error paths (packages->0
-    instead of packages-><package_name>).
-    """
+    """Package errors in named dicts must not trigger the deprecated fallback."""
     good_include = MagicMock(spec=IncludeFile)
     bad_include = MagicMock(spec=IncludeFile)
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1,5 +1,6 @@
 """Tests for the packages component."""
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1176,7 +1177,10 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
         # Second package has an error (e.g. jinja syntax error)
         raise cv.Invalid("simulated jinja error in bad_pkg")
 
-    with pytest.raises(cv.Invalid, match="simulated jinja error"):
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(cv.Invalid, match="simulated jinja error"),
+    ):
         _walk_packages(config, failing_callback)
 
     # Must NOT emit the deprecated single-package warning

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1187,10 +1187,14 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
     assert "deprecated" not in caplog.text.lower()
 
 
-def test_nested_dict_error_raises_directly_with_validate_deprecated_false(
+def test_validate_deprecated_false_raises_directly(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Errors in nested dicts raise directly when validate_deprecated=False."""
+    """With validate_deprecated=False, errors raise directly without fallback.
+
+    This is the codepath used for remote packages where _process_remote_package
+    returns already-resolved dicts that is_package_definition cannot detect.
+    """
     config = {
         CONF_PACKAGES: {
             "pkg_a": {CONF_WIFI: {CONF_SSID: "test"}},
@@ -1212,47 +1216,6 @@ def test_nested_dict_error_raises_directly_with_validate_deprecated_false(
         pytest.raises(cv.Invalid, match="nested error"),
     ):
         _walk_packages(config, failing_callback, validate_deprecated=False)
-
-    assert "deprecated" not in caplog.text.lower()
-
-
-def test_remote_package_resolved_dict_error_no_false_deprecation(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Resolved dicts from remote packages must not trigger the deprecated fallback.
-
-    Simulates the structure returned by _process_remote_package where values
-    are already-resolved YAML dicts (not IncludeFiles).
-    """
-    # Simulate _process_remote_package output: {"file.yaml0": loaded_content}
-    config = {
-        CONF_PACKAGES: {
-            "nspanel_esphome.yaml0": {
-                CONF_PACKAGES: {
-                    "core_package": MagicMock(spec=IncludeFile),
-                }
-            },
-        },
-    }
-
-    call_count = 0
-
-    def callback_with_nested_error(package_config: dict, context: object) -> dict:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            # First call processes the outer package successfully,
-            # but it contains nested packages that will error
-            nested = package_config.copy()
-            nested[CONF_PACKAGES] = {"core_package": MagicMock(spec=IncludeFile)}
-            raise cv.Invalid("error in nested package")
-        return package_config
-
-    with (
-        caplog.at_level(logging.WARNING),
-        pytest.raises(cv.Invalid, match="error in nested package"),
-    ):
-        _walk_packages(config, callback_with_nested_error, validate_deprecated=False)
 
     assert "deprecated" not in caplog.text.lower()
 

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1168,7 +1168,7 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
 
     call_count = 0
 
-    def failing_callback(package_config, context):
+    def failing_callback(package_config: dict, context: object) -> dict:
         nonlocal call_count
         call_count += 1
         if call_count == 1:
@@ -1185,6 +1185,136 @@ def test_named_dict_with_include_files_no_false_deprecation_warning(
 
     # Must NOT emit the deprecated single-package warning
     assert "deprecated" not in caplog.text.lower()
+
+
+def test_nested_dict_error_raises_directly_with_validate_deprecated_false(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Errors in nested dicts raise directly when validate_deprecated=False."""
+    config = {
+        CONF_PACKAGES: {
+            "pkg_a": {CONF_WIFI: {CONF_SSID: "test"}},
+            "pkg_b": {CONF_WIFI: {CONF_SSID: "test2"}},
+        },
+    }
+
+    call_count = 0
+
+    def failing_callback(package_config: dict, context: object) -> dict:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return package_config
+        raise cv.Invalid("nested error")
+
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(cv.Invalid, match="nested error"),
+    ):
+        _walk_packages(config, failing_callback, validate_deprecated=False)
+
+    assert "deprecated" not in caplog.text.lower()
+
+
+def test_remote_package_resolved_dict_error_no_false_deprecation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Resolved dicts from remote packages must not trigger the deprecated fallback.
+
+    Simulates the structure returned by _process_remote_package where values
+    are already-resolved YAML dicts (not IncludeFiles).
+    """
+    # Simulate _process_remote_package output: {"file.yaml0": loaded_content}
+    config = {
+        CONF_PACKAGES: {
+            "nspanel_esphome.yaml0": {
+                CONF_PACKAGES: {
+                    "core_package": MagicMock(spec=IncludeFile),
+                }
+            },
+        },
+    }
+
+    call_count = 0
+
+    def callback_with_nested_error(package_config: dict, context: object) -> dict:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First call processes the outer package successfully,
+            # but it contains nested packages that will error
+            nested = package_config.copy()
+            nested[CONF_PACKAGES] = {"core_package": MagicMock(spec=IncludeFile)}
+            raise cv.Invalid("error in nested package")
+        return package_config
+
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(cv.Invalid, match="error in nested package"),
+    ):
+        _walk_packages(config, callback_with_nested_error, validate_deprecated=False)
+
+    assert "deprecated" not in caplog.text.lower()
+
+
+def test_error_on_first_declared_package_still_detected() -> None:
+    """When the first declared package errors, it's the last processed in reverse.
+
+    All other entries are already resolved to dicts, but the failing entry
+    retains its original IncludeFile value since assignment was skipped.
+    """
+    config = {
+        CONF_PACKAGES: {
+            "first_pkg": MagicMock(spec=IncludeFile),
+            "second_pkg": MagicMock(spec=IncludeFile),
+            "third_pkg": MagicMock(spec=IncludeFile),
+        },
+    }
+
+    call_count = 0
+
+    def fail_on_last(package_config: dict, context: object) -> dict:
+        nonlocal call_count
+        call_count += 1
+        # Reverse iteration: third_pkg (1), second_pkg (2), first_pkg (3)
+        if call_count < 3:
+            return {CONF_WIFI: {CONF_SSID: "test"}}
+        raise cv.Invalid("error in first_pkg")
+
+    with pytest.raises(cv.Invalid, match="error in first_pkg"):
+        _walk_packages(config, fail_on_last)
+
+
+def test_deprecated_single_package_fallback_still_works(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The deprecated single-package form still falls back at the top level.
+
+    When a dict's values are plain config fragments (not package definitions)
+    and the callback fails, the deprecated fallback wraps the dict in a list
+    and retries with a deprecation warning.
+    """
+    config = {
+        CONF_PACKAGES: {
+            CONF_WIFI: {CONF_SSID: "test", CONF_PASSWORD: "secret"},
+        },
+    }
+
+    attempt = 0
+
+    def fail_then_succeed(package_config: dict, context: object) -> dict:
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            # First attempt: treating as named dict fails
+            raise cv.Invalid("not a valid package")
+        # Second attempt: after fallback wraps as list, succeeds
+        return package_config
+
+    with caplog.at_level(logging.WARNING):
+        _walk_packages(config, fail_then_succeed)
+
+    assert "deprecated" in caplog.text.lower()
 
 
 def test_merge_packages_invalid_nested_type_raises() -> None:

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -85,11 +85,14 @@ def packages_pass(config):
     return config
 
 
+_INCLUDE_FILE = "INCLUDE_FILE"
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
         # IncludeFile objects are package definitions
-        (MagicMock(spec="IncludeFile"), True),
+        (_INCLUDE_FILE, True),
         # Git URL shorthand strings are package definitions
         ("github://esphome/firmware/base.yaml@main", True),
         # Remote package dicts (with url key) are package definitions
@@ -115,10 +118,9 @@ def packages_pass(config):
 )
 def test_is_package_definition(value: object, expected: bool) -> None:
     """Test that is_package_definition correctly identifies package definitions."""
-    from esphome.yaml_util import IncludeFile
+    if value is _INCLUDE_FILE:
+        from esphome.yaml_util import IncludeFile
 
-    if isinstance(value, MagicMock):
-        # Replace the mock with a real spec check
         value = MagicMock(spec=IncludeFile)
     assert is_package_definition(value) is expected
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression from the package refactor (parts 2b-5, merged between 2026.3.3 and 2026.4.0b1) where errors in named package dicts are caught by the deprecated single-package fallback, causing:

1. A false *"Including a single package under `packages:` is deprecated"* warning even though the user is using modern dict/`!include`/remote packages
2. Error paths showing `packages->0` instead of the actual package name (e.g. `packages->hw_uart`), making it impossible to identify which package has the error
3. Error content sometimes pointing to the wrong package entirely

Two fixes:

**1. `is_package_definition()` check on the error path** — When `_walk_package_dict` returns an error, check if any dict values are clearly package definitions (`IncludeFile`, git URL shorthand, or remote package dict with `url:`). If so, raise the error directly instead of triggering the deprecated fallback. The failing entry always retains its original value since `_walk_package_dict` skips assignment on exception. This handles the common case of `!include`-based packages.

**2. Disable deprecated fallback for remote package processing** — `_process_remote_package` returns dicts with already-resolved values that `is_package_definition` cannot distinguish from config fragments. For these, `validate_deprecated=False` is passed to the recursive `_walk_packages` call, preventing the fallback from masking errors with wrong paths. Local nested includes still get the deprecated fallback, preserving the deprecation warning for any nested package files that use the deprecated single-package form.

**Breaking change:** Remote packages that internally use the deprecated single-package form (`packages: {component: {key: value}}` instead of named packages) will now get an error instead of the silent fallback. A search of popular ESPHome remote package repos ([NSPanel_HA_Blueprint](https://github.com/Blackymas/NSPanel_HA_Blueprint), [NSPanel-Easy](https://github.com/edwardtfn/NSPanel-Easy), [boneIO](https://github.com/boneIO-eu/esphome), [SiliconAvatar](https://github.com/SiliconAvatar/ESPHomePackages)) shows all use the modern named dict format with `!include` or remote URLs internally — none use the deprecated single-package form. Practical impact is zero. The deprecated form is being removed in 2026.7.0 regardless.

Tested with the [NSPanel-Easy](https://github.com/edwardtfn/NSPanel-Easy) project which has 3 levels of nested packages and triggered the original bug report.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - this is a config validation/error reporting fix
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).