### PR TITLE
[sx127x][cc1101] Disable loop when packet mode is inactive

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -150,6 +150,10 @@ void CC1101Component::setup() {
   if (this->gdo0_pin_ != nullptr) {
     this->defer([this]() { this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT); });
   }
+
+  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
+    this->disable_loop();
+  }
 }
 
 void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) {

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -664,13 +664,16 @@ void CC1101Component::set_packet_mode(bool value) {
     this->state_.FIFO_THR = 15;
     // Don't append status bytes to FIFO - we read from registers instead
     this->state_.APPEND_STATUS = 0;
-    this->enable_loop();
   } else {
     // Configure GDO0 for serial data (async serial mode)
     this->state_.GDO0_CFG = 0x0D;
-    this->disable_loop();
   }
   if (this->initialized_) {
+    if (value) {
+      this->enable_loop();
+    } else {
+      this->disable_loop();
+    }
     this->write_(Register::PKTCTRL0);
     this->write_(Register::PKTCTRL1);
     this->write_(Register::IOCFG0);

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -664,9 +664,11 @@ void CC1101Component::set_packet_mode(bool value) {
     this->state_.FIFO_THR = 15;
     // Don't append status bytes to FIFO - we read from registers instead
     this->state_.APPEND_STATUS = 0;
+    this->enable_loop();
   } else {
     // Configure GDO0 for serial data (async serial mode)
     this->state_.GDO0_CFG = 0x0D;
+    this->disable_loop();
   }
   if (this->initialized_) {
     this->write_(Register::PKTCTRL0);

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -386,6 +386,11 @@ void SX127x::set_mode_(uint8_t modulation, uint8_t mode) {
       break;
     }
   }
+  if (mode == MODE_RX && (modulation == MOD_LORA || this->packet_mode_)) {
+    this->enable_loop();
+  } else {
+    this->disable_loop();
+  }
 }
 
 void SX127x::set_mode_rx() {

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -383,7 +383,7 @@ void SX127x::set_mode_(uint8_t modulation, uint8_t mode) {
     if (millis() - start > 20) {
       ESP_LOGE(TAG, "Set mode failure");
       this->mark_failed();
-      break;
+      return;
     }
   }
   if (mode == MODE_RX && (modulation == MOD_LORA || this->packet_mode_)) {


### PR DESCRIPTION
# What does this implement/fix?

Disable the component loop when packet reception is not possible, avoiding unnecessary calls that would just early-return.

- **SX127x**: Enable/disable loop in `set_mode_()` based on whether the mode is RX and the modulation supports packet reception (LoRa or packet mode).
- **CC1101**: Enable/disable loop in `set_packet_mode()` based on whether FIFO packet mode is active.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).