### PR TITLE
[ld2420] Add startup_delay to yaml config options

### DIFF
--- a/esphome/components/ld2420/__init__.py
+++ b/esphome/components/ld2420/__init__.py
@@ -3,7 +3,6 @@ from esphome.components import uart
 import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_STARTUP_DELAY
 
-
 CODEOWNERS = ["@descipher"]
 
 DEPENDENCIES = ["uart"]

--- a/esphome/components/ld2420/__init__.py
+++ b/esphome/components/ld2420/__init__.py
@@ -1,7 +1,8 @@
 import esphome.codegen as cg
 from esphome.components import uart
 import esphome.config_validation as cv
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_STARTUP_DELAY
+
 
 CODEOWNERS = ["@descipher"]
 
@@ -18,6 +19,9 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(LD2420Component),
+            cv.Optional(
+                CONF_STARTUP_DELAY, default="0s"
+            ): cv.positive_time_period_milliseconds,
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -37,3 +41,4 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)
+    cg.add(var.set_startup_delay(config[CONF_STARTUP_DELAY]))

--- a/esphome/components/ld2420/ld2420.cpp
+++ b/esphome/components/ld2420/ld2420.cpp
@@ -218,6 +218,9 @@ void LD2420Component::dump_config() {
 }
 
 void LD2420Component::setup() {
+  if (this->startup_delay_ > 0) {
+    delay(this->startup_delay_);
+  }
   if (this->set_config_mode(true) == LD2420_ERROR_TIMEOUT) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
     this->mark_failed();

--- a/esphome/components/ld2420/ld2420.h
+++ b/esphome/components/ld2420/ld2420.h
@@ -60,6 +60,7 @@ class LD2420Component : public Component, public uart::UARTDevice {
   };
 
   void setup() override;
+  void set_startup_delay(const uint32_t startup_delay) { this->startup_delay_ = startup_delay; }
   void dump_config() override;
   void loop() override;
 #ifdef USE_SELECT
@@ -183,6 +184,7 @@ class LD2420Component : public Component, public uart::UARTDevice {
   std::vector<number::Number *> gate_move_threshold_numbers_ = std::vector<number::Number *>(16);
 #endif
 
+  uint32_t startup_delay_{0};
   uint16_t distance_{0};
   uint16_t system_mode_;
   uint16_t gate_energy_[TOTAL_GATES];


### PR DESCRIPTION
# What does this implement/fix?

After a software restart of any of my esp32-p4-nano's a connected ld2420 consistently errors, whereas it works fine after a power cycle. The only resolution I could find was to introduce a delay before communication is made with the ld2420 at startup.

This PR adds a `startup_delay` setting to the `ld2420` component, borrowing the logic from the `interval` component (defaults to 0s).

For my devices, setting `startup_delay: 3s` reliably solves the issue.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15472 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6427

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ld2420:
  uart_id: uart_1
  startup_delay: 3s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
