### PR TITLE
[esp32] Fix some compiler warnings & bugs

### DIFF
--- a/esphome/components/atm90e32/atm90e32.h
+++ b/esphome/components/atm90e32/atm90e32.h
@@ -111,14 +111,14 @@ class ATM90E32Component : public PollingComponent,
 #endif
   float get_reference_voltage(uint8_t phase) {
 #ifdef USE_NUMBER
-    return (phase >= 0 && phase < 3 && ref_voltages_[phase]) ? ref_voltages_[phase]->state : 120.0;  // Default voltage
+    return (phase < 3 && ref_voltages_[phase]) ? ref_voltages_[phase]->state : 120.0;  // Default voltage
 #else
     return 120.0;  // Default voltage
 #endif
   }
   float get_reference_current(uint8_t phase) {
 #ifdef USE_NUMBER
-    return (phase >= 0 && phase < 3 && ref_currents_[phase]) ? ref_currents_[phase]->state : 5.0f;  // Default current
+    return (phase < 3 && ref_currents_[phase]) ? ref_currents_[phase]->state : 5.0f;  // Default current
 #else
     return 5.0f;   // Default current
 #endif

--- a/esphome/components/midea/air_conditioner.cpp
+++ b/esphome/components/midea/air_conditioner.cpp
@@ -28,7 +28,8 @@ void AirConditioner::on_status_change() {
   if (this->base_.getAutoconfStatus() == dudanov::midea::AUTOCONF_OK &&
       this->base_.getCapabilities().supportFrostProtectionPreset() && !this->frost_protection_set_) {
     // Read existing presets (set by codegen), append frost protection, write back
-    const auto &existing = this->get_traits().get_supported_custom_presets();
+    auto traits = this->get_traits();
+    const auto &existing = traits.get_supported_custom_presets();
     bool found = false;
     for (const char *p : existing) {
       if (strcmp(p, Constants::FREEZE_PROTECTION) == 0) {

--- a/esphome/components/mipi_spi/mipi_spi.h
+++ b/esphome/components/mipi_spi/mipi_spi.h
@@ -234,9 +234,9 @@ class MipiSpi : public display::Display,
   }
 
   void dump_config() override {
-    internal_dump_config(this->model_, this->get_width(), this->get_height(), OFFSET_WIDTH, OFFSET_HEIGHT, MADCTL,
-                         this->invert_colors_, DISPLAYPIXEL * 8, IS_BIG_ENDIAN, this->brightness_, this->cs_,
-                         this->reset_pin_, this->dc_pin_, this->mode_, this->data_rate_, BUS_TYPE,
+    internal_dump_config(this->model_, this->get_width(), this->get_height(), OFFSET_WIDTH, OFFSET_HEIGHT,
+                         (uint8_t) MADCTL, this->invert_colors_, DISPLAYPIXEL * 8, IS_BIG_ENDIAN, this->brightness_,
+                         this->cs_, this->reset_pin_, this->dc_pin_, this->mode_, this->data_rate_, BUS_TYPE,
                          HAS_HARDWARE_ROTATION);
   }
 
@@ -305,7 +305,7 @@ class MipiSpi : public display::Display,
       this->write_command_(BRIGHTNESS, this->brightness_.value());
 
     // calculate new madctl value from base value adjusted for rotation
-    uint8_t madctl = MADCTL;  // lower 8 bits only
+    uint8_t madctl = (uint8_t) MADCTL;  // lower 8 bits only
     constexpr bool use_flips = (MADCTL & MADCTL_FLIP_FLAG) != 0;
     constexpr uint8_t x_mask = use_flips ? MADCTL_XFLIP : MADCTL_MX;
     constexpr uint8_t y_mask = use_flips ? MADCTL_YFLIP : MADCTL_MY;

--- a/esphome/components/tcs34725/tcs34725.cpp
+++ b/esphome/components/tcs34725/tcs34725.cpp
@@ -315,7 +315,7 @@ void TCS34725Component::set_integration_time(TCS34725IntegrationTime integration
     my_integration_time_regval = integration_time;
     this->integration_time_auto_ = false;
   }
-  this->integration_time_ = (256.f - my_integration_time_regval) * 2.4f;
+  this->integration_time_ = (256.f - (float) my_integration_time_regval) * 2.4f;
   ESP_LOGI(TAG, "TCS34725I Integration time set to: %.1fms", this->integration_time_);
 }
 void TCS34725Component::set_gain(TCS34725Gain gain) {

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -113,7 +113,8 @@ def _generate_source_table_code(
     entries = ", ".join(var_names)
     lines.append(f"static const char *const {table_var}[] PROGMEM = {{{entries}}};")
     lines.append(f"const LogString *{lookup_fn}(uint8_t index) {{")
-    lines.append(f'  if (index == 0 || index > {count}) return LOG_STR("<unknown>");')
+    cond = f"0 || index > {count}" if count < 255 else "0"
+    lines.append(f'  if (index == {cond}) return LOG_STR("<unknown>");')
     lines.append("  return reinterpret_cast<const LogString *>(")
     lines.append(f"    progmem_read_ptr(&{table_var}[index - 1]));")
     lines.append("}")

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -113,8 +113,8 @@ def _generate_source_table_code(
     entries = ", ".join(var_names)
     lines.append(f"static const char *const {table_var}[] PROGMEM = {{{entries}}};")
     lines.append(f"const LogString *{lookup_fn}(uint8_t index) {{")
-    cond = f"0 || index > {count}" if count < 255 else "0"
-    lines.append(f'  if (index == {cond}) return LOG_STR("<unknown>");')
+    cond = "index == 0" if count >= 255 else f"index == 0 || index > {count}"
+    lines.append(f'  if ({cond}) return LOG_STR("<unknown>");')
     lines.append("  return reinterpret_cast<const LogString *>(")
     lines.append(f"    progmem_read_ptr(&{table_var}[index - 1]));")
     lines.append("}")


### PR DESCRIPTION
# What does this implement/fix?

With IDF 6.0, additional compiler error flags are enabled, which expose several issues in the ESPHome codebase. This PR addresses the most obvious ones.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).