### PR TITLE
[tca9555] Add interrupt pin support

### DIFF
--- a/esphome/components/tca9555/__init__.py
+++ b/esphome/components/tca9555/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
+    CONF_INTERRUPT_PIN,
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.declare_id(TCA9555Component),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -38,6 +40,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
 
 
 def validate_mode(value):

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -24,9 +24,18 @@ void TCA9555Component::setup() {
     this->mark_failed();
     return;
   }
+
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->setup();
+    this->interrupt_pin_->attach_interrupt(&TCA9555Component::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
+    this->set_invalidate_on_read_(false);
+  }
+  this->disable_loop();
 }
+void IRAM_ATTR TCA9555Component::gpio_intr(TCA9555Component *arg) { arg->enable_loop_soon_any_context(); }
 void TCA9555Component::dump_config() {
   ESP_LOGCONFIG(TAG, "TCA9555:");
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_I2C_DEVICE(this)
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
@@ -36,6 +45,9 @@ void TCA9555Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
     // Set mode mask bit
     this->mode_mask_ |= 1 << pin;
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   } else if (flags == gpio::FLAG_OUTPUT) {
     // Clear mode mask bit
     this->mode_mask_ &= ~(1 << pin);
@@ -43,7 +55,12 @@ void TCA9555Component::pin_mode(uint8_t pin, gpio::Flags flags) {
   // Write GPIO to enable input mode
   this->write_gpio_modes_();
 }
-void TCA9555Component::loop() { this->reset_pin_cache_(); }
+void TCA9555Component::loop() {
+  this->reset_pin_cache_();
+  if (this->interrupt_pin_ != nullptr) {
+    this->disable_loop();
+  }
+}
 
 bool TCA9555Component::read_gpio_outputs_() {
   if (this->is_failed())

--- a/esphome/components/tca9555/tca9555.h
+++ b/esphome/components/tca9555/tca9555.h
@@ -24,7 +24,10 @@ class TCA9555Component : public Component,
 
   void loop() override;
 
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+
  protected:
+  static void IRAM_ATTR gpio_intr(TCA9555Component *arg);
   bool digital_read_hw(uint8_t pin) override;
   bool digital_read_cache(uint8_t pin) override;
   void digital_write_hw(uint8_t pin, bool value) override;
@@ -39,6 +42,8 @@ class TCA9555Component : public Component,
   bool read_gpio_modes_();
   bool write_gpio_modes_();
   bool read_gpio_outputs_();
+
+  InternalGPIOPin *interrupt_pin_{nullptr};
 };
 
 /// Helper class to expose a TCA9555 pin as an internal input GPIO pin.

--- a/tests/components/tca9555/common.yaml
+++ b/tests/components/tca9555/common.yaml
@@ -2,6 +2,10 @@ tca9555:
   - id: tca9555_hub
     i2c_id: i2c_bus
     address: 0x21
+  - id: tca9555_hub_int
+    i2c_id: i2c_bus
+    address: 0x22
+    interrupt_pin: ${interrupt_pin}
 
 binary_sensor:
   - platform: gpio

--- a/tests/components/tca9555/test.esp32-idf.yaml
+++ b/tests/components/tca9555/test.esp32-idf.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
 

--- a/tests/components/tca9555/test.esp8266-ard.yaml
+++ b/tests/components/tca9555/test.esp8266-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
 

--- a/tests/components/tca9555/test.rp2040-ard.yaml
+++ b/tests/components/tca9555/test.rp2040-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO2
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
 


### PR DESCRIPTION
# What does this implement/fix?

Add optional `interrupt_pin` configuration to the TCA9555 GPIO expander to eliminate I2C polling. When configured, the component disables its loop and only reads the I2C bus when the interrupt fires, matching the pattern already used by PCF8574, PCA9554, MCP23xxx, and PI4IOE5V6408 expanders.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6430

## Test Environment

Not hardware tested — I don't have this hardware. This is the same interrupt pattern already used by PCF8574, PCA9554, MCP23xxx, and PI4IOE5V6408, and it's opt-in (no behavior change without `interrupt_pin` configured).

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
tca9555:
  id: my_tca9555
  interrupt_pin: GPIO16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).