### PR TITLE
[pca6416a] Add interrupt pin support

### DIFF
--- a/esphome/components/pca6416a/__init__.py
+++ b/esphome/components/pca6416a/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
+    CONF_INTERRUPT_PIN,
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
@@ -25,7 +26,12 @@ PCA6416AGPIOPin = pca6416a_ns.class_(
 
 CONF_PCA6416A = "pca6416a"
 CONFIG_SCHEMA = (
-    cv.Schema({cv.Required(CONF_ID): cv.declare_id(PCA6416AComponent)})
+    cv.Schema(
+        {
+            cv.Required(CONF_ID): cv.declare_id(PCA6416AComponent),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+        }
+    )
     .extend(cv.COMPONENT_SCHEMA)
     .extend(i2c.i2c_device_schema(0x21))
 )
@@ -35,6 +41,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
 
 
 def validate_mode(value):

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -49,11 +49,22 @@ void PCA6416AComponent::setup() {
 
   ESP_LOGD(TAG, "Initialization complete. Warning: %d, Error: %d", this->status_has_warning(),
            this->status_has_error());
+
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->setup();
+    this->interrupt_pin_->attach_interrupt(&PCA6416AComponent::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
+    this->set_invalidate_on_read_(false);
+  }
+  this->disable_loop();
 }
 
+void IRAM_ATTR PCA6416AComponent::gpio_intr(PCA6416AComponent *arg) { arg->enable_loop_soon_any_context(); }
 void PCA6416AComponent::loop() {
   // Invalidate cache at the start of each loop
   this->reset_pin_cache_();
+  if (this->interrupt_pin_ != nullptr) {
+    this->disable_loop();
+  }
 }
 
 void PCA6416AComponent::dump_config() {
@@ -62,6 +73,7 @@ void PCA6416AComponent::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "PCA6416A:");
   }
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   LOG_I2C_DEVICE(this)
   if (this->is_failed()) {
     ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
@@ -101,6 +113,9 @@ void PCA6416AComponent::pin_mode(uint8_t pin, gpio::Flags flags) {
       this->update_register_(pin, true, pull_dir);
       this->update_register_(pin, false, pull_en);
     }
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   } else if (flags == (gpio::FLAG_INPUT | gpio::FLAG_PULLUP)) {
     this->update_register_(pin, true, io_dir);
     if (has_pullup_) {
@@ -108,6 +123,9 @@ void PCA6416AComponent::pin_mode(uint8_t pin, gpio::Flags flags) {
       this->update_register_(pin, true, pull_en);
     } else {
       ESP_LOGW(TAG, "Your PCA6416A does not support pull-up resistors");
+    }
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
     }
   } else if (flags == gpio::FLAG_OUTPUT) {
     this->update_register_(pin, false, io_dir);

--- a/esphome/components/pca6416a/pca6416a.h
+++ b/esphome/components/pca6416a/pca6416a.h
@@ -24,7 +24,10 @@ class PCA6416AComponent : public Component,
 
   void dump_config() override;
 
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+
  protected:
+  static void IRAM_ATTR gpio_intr(PCA6416AComponent *arg);
   // Virtual methods from CachedGpioExpander
   bool digital_read_hw(uint8_t pin) override;
   bool digital_read_cache(uint8_t pin) override;
@@ -43,6 +46,7 @@ class PCA6416AComponent : public Component,
   esphome::i2c::ErrorCode last_error_;
   /// Only the PCAL6416A has pull-up resistors
   bool has_pullup_{false};
+  InternalGPIOPin *interrupt_pin_{nullptr};
 };
 
 /// Helper class to expose a PCA6416A pin as an internal input GPIO pin.

--- a/tests/components/pca6416a/common.yaml
+++ b/tests/components/pca6416a/common.yaml
@@ -2,6 +2,10 @@ pca6416a:
   - id: pca6416a_hub
     i2c_id: i2c_bus
     address: 0x21
+  - id: pca6416a_hub_int
+    i2c_id: i2c_bus
+    address: 0x22
+    interrupt_pin: ${interrupt_pin}
 
 binary_sensor:
   - platform: gpio

--- a/tests/components/pca6416a/test.esp32-idf.yaml
+++ b/tests/components/pca6416a/test.esp32-idf.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
 

--- a/tests/components/pca6416a/test.esp8266-ard.yaml
+++ b/tests/components/pca6416a/test.esp8266-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
 

--- a/tests/components/pca6416a/test.rp2040-ard.yaml
+++ b/tests/components/pca6416a/test.rp2040-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO2
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
 


### PR DESCRIPTION
# What does this implement/fix?

Add optional `interrupt_pin` configuration to the PCA6416A/PCAL6416A GPIO expander to eliminate I2C polling. When configured, the component disables its loop and only reads the I2C bus when the interrupt fires, matching the pattern already used by PCF8574, PCA9554, MCP23xxx, and PI4IOE5V6408 expanders.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6431

## Test Environment

Not hardware tested — I don't have this hardware. This is the same interrupt pattern already used by PCF8574, PCA9554, MCP23xxx, and PI4IOE5V6408, and it's opt-in (no behavior change without `interrupt_pin` configured).

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
pca6416a:
  id: my_pca6416a
  interrupt_pin: GPIO16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).