### PR TITLE
[hbridge] Move light pin switching to loop

### DIFF
--- a/esphome/components/hbridge/light/__init__.py
+++ b/esphome/components/hbridge/light/__init__.py
@@ -8,7 +8,7 @@ from .. import hbridge_ns
 CODEOWNERS = ["@DotNetDann"]
 
 HBridgeLightOutput = hbridge_ns.class_(
-    "HBridgeLightOutput", cg.PollingComponent, light.LightOutput
+    "HBridgeLightOutput", cg.Component, light.LightOutput
 )
 
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(

--- a/esphome/components/hbridge/light/hbridge_light_output.h
+++ b/esphome/components/hbridge/light/hbridge_light_output.h
@@ -8,13 +8,10 @@
 namespace esphome {
 namespace hbridge {
 
-// Using PollingComponent as the updates are more consistent and reduces flickering
-class HBridgeLightOutput : public PollingComponent, public light::LightOutput {
+class HBridgeLightOutput : public Component, public light::LightOutput {
  public:
-  HBridgeLightOutput() : PollingComponent(1) {}
-
-  void set_pina_pin(output::FloatOutput *pina_pin) { pina_pin_ = pina_pin; }
-  void set_pinb_pin(output::FloatOutput *pinb_pin) { pinb_pin_ = pinb_pin; }
+  void set_pina_pin(output::FloatOutput *pina_pin) { this->pina_pin_ = pina_pin; }
+  void set_pinb_pin(output::FloatOutput *pinb_pin) { this->pinb_pin_ = pinb_pin; }
 
   light::LightTraits get_traits() override {
     auto traits = light::LightTraits();
@@ -24,16 +21,16 @@ class HBridgeLightOutput : public PollingComponent, public light::LightOutput {
     return traits;
   }
 
-  void setup() override { this->forward_direction_ = false; }
+  void setup() override { this->disable_loop(); }
 
-  void update() override {
-    // This method runs around 60 times per second
-    // We cannot do the PWM ourselves so we are reliant on the hardware PWM
-    if (!this->forward_direction_) {  // First LED Direction
+  void loop() override {
+    // Only called when both channels are active — alternate H-bridge direction
+    // each iteration to multiplex cold and warm white.
+    if (!this->forward_direction_) {
       this->pina_pin_->set_level(this->pina_duty_);
       this->pinb_pin_->set_level(0);
       this->forward_direction_ = true;
-    } else {  // Second LED Direction
+    } else {
       this->pina_pin_->set_level(0);
       this->pinb_pin_->set_level(this->pinb_duty_);
       this->forward_direction_ = false;
@@ -43,15 +40,28 @@ class HBridgeLightOutput : public PollingComponent, public light::LightOutput {
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
   void write_state(light::LightState *state) override {
-    state->current_values_as_cwww(&this->pina_duty_, &this->pinb_duty_, false);
+    float new_pina, new_pinb;
+    state->current_values_as_cwww(&new_pina, &new_pinb, false);
+    this->pina_duty_ = new_pina;
+    this->pinb_duty_ = new_pinb;
+
+    if (new_pina != 0.0f && new_pinb != 0.0f) {
+      // Both channels active — need loop to alternate H-bridge direction
+      this->enable_loop();
+    } else {
+      // Zero or one channel active — drive pins directly, no multiplexing needed
+      this->disable_loop();
+      this->pina_pin_->set_level(new_pina);
+      this->pinb_pin_->set_level(new_pinb);
+    }
   }
 
  protected:
   output::FloatOutput *pina_pin_;
   output::FloatOutput *pinb_pin_;
-  float pina_duty_ = 0;
-  float pinb_duty_ = 0;
-  bool forward_direction_ = false;
+  float pina_duty_{0};
+  float pinb_duty_{0};
+  bool forward_direction_{false};
 };
 
 }  // namespace hbridge

--- a/esphome/components/hbridge/light/hbridge_light_output.h
+++ b/esphome/components/hbridge/light/hbridge_light_output.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "esphome/core/component.h"
-#include "esphome/components/output/float_output.h"
 #include "esphome/components/light/light_output.h"
-#include "esphome/core/log.h"
+#include "esphome/components/output/float_output.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 namespace hbridge {
@@ -42,14 +42,17 @@ class HBridgeLightOutput : public Component, public light::LightOutput {
   void write_state(light::LightState *state) override {
     float new_pina, new_pinb;
     state->current_values_as_cwww(&new_pina, &new_pinb, false);
+
     this->pina_duty_ = new_pina;
     this->pinb_duty_ = new_pinb;
 
     if (new_pina != 0.0f && new_pinb != 0.0f) {
       // Both channels active — need loop to alternate H-bridge direction
+      this->high_freq_.start();
       this->enable_loop();
     } else {
       // Zero or one channel active — drive pins directly, no multiplexing needed
+      this->high_freq_.stop();
       this->disable_loop();
       this->pina_pin_->set_level(new_pina);
       this->pinb_pin_->set_level(new_pinb);
@@ -62,6 +65,7 @@ class HBridgeLightOutput : public Component, public light::LightOutput {
   float pina_duty_{0};
   float pinb_duty_{0};
   bool forward_direction_{false};
+  HighFrequencyLoopRequester high_freq_;
 };
 
 }  // namespace hbridge


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Refactor the H-bridge light platform to use `Component` with `loop()` instead of `PollingComponent` with a hardcoded 1ms polling interval. The loop is only enabled when both cold and warm white channels are active and multiplexing is needed. When the light is off or only one channel is active, the pins are set directly in `write_state()` and the loop is disabled, eliminating unnecessary CPU overhead and producing flicker-free single-channel output.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
