### PR TITLE
[mcp23016] Add interrupt pin support

### DIFF
--- a/esphome/components/mcp23016/__init__.py
+++ b/esphome/components/mcp23016/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
+    CONF_INTERRUPT_PIN,
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
@@ -24,6 +25,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.Required(CONF_ID): cv.declare_id(MCP23016),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -35,6 +37,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
 
 
 def validate_mode(value):

--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -24,11 +24,22 @@ void MCP23016::setup() {
 
   // all pins input
   this->write_reg_(MCP23016_IODIR1, 0xFFFF);
+
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->setup();
+    this->interrupt_pin_->attach_interrupt(&MCP23016::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
+    this->set_invalidate_on_read_(false);
+  }
+  this->disable_loop();
 }
 
+void IRAM_ATTR MCP23016::gpio_intr(MCP23016 *arg) { arg->enable_loop_soon_any_context(); }
 void MCP23016::loop() {
   // Invalidate cache at the start of each loop
   this->reset_pin_cache_();
+  if (this->interrupt_pin_ != nullptr) {
+    this->disable_loop();
+  }
 }
 bool MCP23016::digital_read_hw(uint8_t pin) { return this->read_reg_(MCP23016_GP1, &this->input_mask_); }
 
@@ -37,6 +48,9 @@ void MCP23016::digital_write_hw(uint8_t pin, bool value) { this->update_reg_(pin
 void MCP23016::pin_mode(uint8_t pin, gpio::Flags flags) {
   if (flags == gpio::FLAG_INPUT) {
     this->update_reg_(pin, true, MCP23016_IODIR1);
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   } else if (flags == gpio::FLAG_OUTPUT) {
     this->update_reg_(pin, false, MCP23016_IODIR1);
   }

--- a/esphome/components/mcp23016/mcp23016.h
+++ b/esphome/components/mcp23016/mcp23016.h
@@ -35,7 +35,10 @@ class MCP23016 : public Component, public i2c::I2CDevice, public gpio_expander::
 
   float get_setup_priority() const override;
 
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+
  protected:
+  static void IRAM_ATTR gpio_intr(MCP23016 *arg);
   // Virtual methods from CachedGpioExpander
   bool digital_read_hw(uint8_t pin) override;
   bool digital_read_cache(uint8_t pin) override;
@@ -51,6 +54,7 @@ class MCP23016 : public Component, public i2c::I2CDevice, public gpio_expander::
   uint16_t olat_{0x0000};
   // Cache for input values (16-bit combined for both banks)
   uint16_t input_mask_{0x0000};
+  InternalGPIOPin *interrupt_pin_{nullptr};
 };
 
 class MCP23016GPIOPin : public GPIOPin {

--- a/tests/components/mcp23016/common.yaml
+++ b/tests/components/mcp23016/common.yaml
@@ -1,6 +1,10 @@
 mcp23016:
-  i2c_id: i2c_bus
-  id: mcp23016_hub
+  - i2c_id: i2c_bus
+    id: mcp23016_hub
+  - i2c_id: i2c_bus
+    id: mcp23016_hub_int
+    address: 0x21
+    interrupt_pin: ${interrupt_pin}
 
 binary_sensor:
   - platform: gpio

--- a/tests/components/mcp23016/test.esp32-idf.yaml
+++ b/tests/components/mcp23016/test.esp32-idf.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
 

--- a/tests/components/mcp23016/test.esp8266-ard.yaml
+++ b/tests/components/mcp23016/test.esp8266-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
 

--- a/tests/components/mcp23016/test.rp2040-ard.yaml
+++ b/tests/components/mcp23016/test.rp2040-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO2
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
 


### PR DESCRIPTION
# What does this implement/fix?

Add optional `interrupt_pin` configuration to the MCP23016 GPIO expander to eliminate I2C polling. When configured, the component disables its loop and only reads the I2C bus when the interrupt fires, matching the pattern already used by PCF8574, PCA9554, MCP23008/MCP23017, and PI4IOE5V6408 expanders.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6432

## Test Environment

Not hardware tested — I don't have this hardware. This is the same interrupt pattern already used by PCF8574, PCA9554, MCP23008/MCP23017, and PI4IOE5V6408, and it's opt-in (no behavior change without `interrupt_pin` configured).

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
mcp23016:
  id: my_mcp23016
  interrupt_pin: GPIO16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).