### PR TITLE
[sx1509] Add interrupt pin support

### DIFF
--- a/esphome/components/sx1509/__init__.py
+++ b/esphome/components/sx1509/__init__.py
@@ -5,6 +5,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_ID,
     CONF_INPUT,
+    CONF_INTERRUPT_PIN,
     CONF_INVERTED,
     CONF_MODE,
     CONF_NUMBER,
@@ -75,6 +76,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(): cv.declare_id(SX1509Component),
             cv.Optional(CONF_KEYPAD): cv.Schema(KEYPAD_SCHEMA),
+            cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -86,6 +88,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await i2c.register_i2c_device(var, config)
+    if interrupt_pin := config.get(CONF_INTERRUPT_PIN):
+        cg.add(var.set_interrupt_pin(await cg.gpio_pin_expression(interrupt_pin)))
     if conf := config.get(CONF_KEYPAD):
         cg.add(var.set_rows_cols(conf[CONF_KEY_ROWS], conf[CONF_KEY_COLUMNS]))
         if (

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -347,8 +347,6 @@ void SX1509Component::enable_pin_interrupt_(uint8_t pin) {
   this->write_byte_16(REG_INTERRUPT_MASK_B, mask);
 
   // Configure sense to trigger on both edges
-  // Each sense register covers 4 pins with 2 bits per pin
-  static constexpr uint8_t SENSE_REGS[] = {REG_SENSE_LOW_A, REG_SENSE_HIGH_A, REG_SENSE_LOW_B, REG_SENSE_HIGH_B};
   uint8_t sense_reg = SENSE_REGS[pin / 4];
   uint8_t sense_val = 0;
   this->read_byte(sense_reg, &sense_val);

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -52,15 +52,15 @@ void SX1509Component::dump_config() {
 }
 
 void SX1509Component::loop() {
-  // Reset cache at the start of each loop
-  this->reset_pin_cache_();
   if (this->interrupt_pin_ != nullptr) {
-    // Clear interrupt source to deassert INT line
+    // Clear interrupt source before resetting cache to avoid losing
+    // pin changes that occur between cache reset and interrupt clear
     uint16_t interrupt_source = 0;
     this->read_byte_16(REG_INTERRUPT_SOURCE_B, &interrupt_source);
-    if (!this->has_keypad_) {
-      this->disable_loop();
-    }
+  }
+  this->reset_pin_cache_();
+  if (this->interrupt_pin_ != nullptr && !this->has_keypad_) {
+    this->disable_loop();
   }
 
   if (this->has_keypad_) {

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -361,9 +361,6 @@ void SX1509Component::enable_pin_interrupt_(uint8_t pin) {
   sense_val &= ~(SENSE_BOTH_EDGES << shift);
   sense_val |= (SENSE_BOTH_EDGES << shift);
   this->write_byte(sense_reg, sense_val);
-
-  // Clear any pending interrupt for this pin
-  this->write_byte_16(REG_INTERRUPT_SOURCE_B, 1 << pin);
 }
 
 }  // namespace sx1509

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -28,10 +28,23 @@ void SX1509Component::setup() {
   delayMicroseconds(500);
   if (this->has_keypad_)
     this->setup_keypad_();
+
+  if (this->interrupt_pin_ != nullptr) {
+    this->interrupt_pin_->setup();
+    this->interrupt_pin_->attach_interrupt(&SX1509Component::gpio_intr, this, gpio::INTERRUPT_FALLING_EDGE);
+    this->set_invalidate_on_read_(false);
+  }
+  // Disable loop until an input pin is configured via pin_mode()
+  // or keypad is active. For interrupt-driven mode, loop is re-enabled by the ISR.
+  if (!this->has_keypad_) {
+    this->disable_loop();
+  }
 }
 
+void IRAM_ATTR SX1509Component::gpio_intr(SX1509Component *arg) { arg->enable_loop_soon_any_context(); }
 void SX1509Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SX1509:");
+  LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
   if (this->is_failed()) {
     ESP_LOGE(TAG, "Setting up SX1509 failed!");
   }
@@ -41,6 +54,9 @@ void SX1509Component::dump_config() {
 void SX1509Component::loop() {
   // Reset cache at the start of each loop
   this->reset_pin_cache_();
+  if (this->interrupt_pin_ != nullptr && !this->has_keypad_) {
+    this->disable_loop();
+  }
 
   if (this->has_keypad_) {
     if (millis() - this->last_loop_timestamp_ < min_loop_period_)
@@ -169,6 +185,9 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     // Set direction to input
     this->ddr_mask_ |= (1 << pin);
     this->write_byte_16(REG_DIR_B, this->ddr_mask_);
+    if (this->interrupt_pin_ == nullptr) {
+      this->enable_loop();
+    }
   }
 }
 

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -348,7 +348,6 @@ void SX1509Component::enable_pin_interrupt_(uint8_t pin) {
 
   // Configure sense to trigger on both edges
   // Sense registers use 2 bits per pin, 4 pins per byte
-  static constexpr uint8_t SENSE_BOTH_EDGES = 0x03;
   uint8_t sense_reg = pin < 4    ? REG_SENSE_LOW_A
                       : pin < 8  ? REG_SENSE_HIGH_A
                       : pin < 12 ? REG_SENSE_LOW_B

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -191,28 +191,7 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     this->ddr_mask_ |= (1 << pin);
     this->write_byte_16(REG_DIR_B, this->ddr_mask_);
     if (this->interrupt_pin_ != nullptr) {
-      // Unmask this pin's interrupt (clear bit = enabled)
-      this->read_byte_16(REG_INTERRUPT_MASK_B, &temp_word);
-      temp_word &= ~(1 << pin);
-      this->write_byte_16(REG_INTERRUPT_MASK_B, temp_word);
-
-      // Configure sense to trigger on both edges (0b11)
-      // Sense registers: 2 bits per pin, 4 pins per byte
-      // REG_SENSE_HIGH_B: pins 12-15, REG_SENSE_LOW_B: pins 8-11
-      // REG_SENSE_HIGH_A: pins 4-7, REG_SENSE_LOW_A: pins 0-3
-      uint8_t sense_reg = pin < 4    ? REG_SENSE_LOW_A
-                          : pin < 8  ? REG_SENSE_HIGH_A
-                          : pin < 12 ? REG_SENSE_LOW_B
-                                     : REG_SENSE_HIGH_B;
-      uint8_t sense_val = 0;
-      this->read_byte(sense_reg, &sense_val);
-      uint8_t shift = (pin % 4) * 2;
-      sense_val &= ~(0x03 << shift);
-      sense_val |= (0x03 << shift);  // Both edges
-      this->write_byte(sense_reg, sense_val);
-
-      // Clear any pending interrupt for this pin
-      this->write_byte_16(REG_INTERRUPT_SOURCE_B, 1 << pin);
+      this->enable_pin_interrupt_(pin);
     } else {
       this->enable_loop();
     }
@@ -358,6 +337,31 @@ void SX1509Component::set_debounce_keypad_(uint8_t time, uint8_t num_rows, uint8
     set_debounce_pin_(i);
   for (uint16_t i = 0; i < num_cols; i++)
     set_debounce_pin_(i + 8);
+}
+
+void SX1509Component::enable_pin_interrupt_(uint8_t pin) {
+  // Unmask this pin's interrupt (clear bit = enabled)
+  uint16_t mask = 0;
+  this->read_byte_16(REG_INTERRUPT_MASK_B, &mask);
+  mask &= ~(1 << pin);
+  this->write_byte_16(REG_INTERRUPT_MASK_B, mask);
+
+  // Configure sense to trigger on both edges
+  // Sense registers use 2 bits per pin, 4 pins per byte
+  static constexpr uint8_t SENSE_BOTH_EDGES = 0x03;
+  uint8_t sense_reg = pin < 4    ? REG_SENSE_LOW_A
+                      : pin < 8  ? REG_SENSE_HIGH_A
+                      : pin < 12 ? REG_SENSE_LOW_B
+                                 : REG_SENSE_HIGH_B;
+  uint8_t sense_val = 0;
+  this->read_byte(sense_reg, &sense_val);
+  uint8_t shift = (pin % 4) * 2;
+  sense_val &= ~(SENSE_BOTH_EDGES << shift);
+  sense_val |= (SENSE_BOTH_EDGES << shift);
+  this->write_byte(sense_reg, sense_val);
+
+  // Clear any pending interrupt for this pin
+  this->write_byte_16(REG_INTERRUPT_SOURCE_B, 1 << pin);
 }
 
 }  // namespace sx1509

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -347,13 +347,12 @@ void SX1509Component::enable_pin_interrupt_(uint8_t pin) {
   this->write_byte_16(REG_INTERRUPT_MASK_B, mask);
 
   // Configure sense to trigger on both edges
-  // Sense registers use 2 bits per pin, 4 pins per byte
-  uint8_t sense_reg = pin < 4    ? REG_SENSE_LOW_A
-                      : pin < 8  ? REG_SENSE_HIGH_A
-                      : pin < 12 ? REG_SENSE_LOW_B
-                                 : REG_SENSE_HIGH_B;
+  // Each sense register covers 4 pins with 2 bits per pin
+  static constexpr uint8_t SENSE_REGS[] = {REG_SENSE_LOW_A, REG_SENSE_HIGH_A, REG_SENSE_LOW_B, REG_SENSE_HIGH_B};
+  uint8_t sense_reg = SENSE_REGS[pin / 4];
   uint8_t sense_val = 0;
   this->read_byte(sense_reg, &sense_val);
+  // 2-bit field position within the sense register (4 pins per register, 2 bits each)
   uint8_t shift = (pin % 4) * 2;
   sense_val &= ~(SENSE_BOTH_EDGES << shift);
   sense_val |= (SENSE_BOTH_EDGES << shift);

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -59,8 +59,7 @@ void SX1509Component::loop() {
     this->interrupt_pending_ = false;
     // Clear interrupt source before resetting cache to avoid losing
     // pin changes that occur between cache reset and interrupt clear
-    uint16_t interrupt_source = 0;
-    this->read_byte_16(REG_INTERRUPT_SOURCE_B, &interrupt_source);
+    this->clear_interrupt_();
     this->reset_pin_cache_();
     if (!this->has_keypad_) {
       this->disable_loop();

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -41,7 +41,10 @@ void SX1509Component::setup() {
   }
 }
 
-void IRAM_ATTR SX1509Component::gpio_intr(SX1509Component *arg) { arg->enable_loop_soon_any_context(); }
+void IRAM_ATTR SX1509Component::gpio_intr(SX1509Component *arg) {
+  arg->interrupt_pending_ = true;
+  arg->enable_loop_soon_any_context();
+}
 void SX1509Component::dump_config() {
   ESP_LOGCONFIG(TAG, "SX1509:");
   LOG_PIN("  Interrupt Pin: ", this->interrupt_pin_);
@@ -52,16 +55,19 @@ void SX1509Component::dump_config() {
 }
 
 void SX1509Component::loop() {
-  if (this->interrupt_pin_ != nullptr) {
+  if (this->interrupt_pending_) {
+    this->interrupt_pending_ = false;
     // Clear interrupt source before resetting cache to avoid losing
     // pin changes that occur between cache reset and interrupt clear
     uint16_t interrupt_source = 0;
     this->read_byte_16(REG_INTERRUPT_SOURCE_B, &interrupt_source);
+    this->reset_pin_cache_();
+    if (!this->has_keypad_) {
+      this->disable_loop();
+    }
+    return;
   }
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr && !this->has_keypad_) {
-    this->disable_loop();
-  }
 
   if (this->has_keypad_) {
     if (millis() - this->last_loop_timestamp_ < min_loop_period_)

--- a/esphome/components/sx1509/sx1509.cpp
+++ b/esphome/components/sx1509/sx1509.cpp
@@ -54,8 +54,13 @@ void SX1509Component::dump_config() {
 void SX1509Component::loop() {
   // Reset cache at the start of each loop
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr && !this->has_keypad_) {
-    this->disable_loop();
+  if (this->interrupt_pin_ != nullptr) {
+    // Clear interrupt source to deassert INT line
+    uint16_t interrupt_source = 0;
+    this->read_byte_16(REG_INTERRUPT_SOURCE_B, &interrupt_source);
+    if (!this->has_keypad_) {
+      this->disable_loop();
+    }
   }
 
   if (this->has_keypad_) {
@@ -185,7 +190,30 @@ void SX1509Component::pin_mode(uint8_t pin, gpio::Flags flags) {
     // Set direction to input
     this->ddr_mask_ |= (1 << pin);
     this->write_byte_16(REG_DIR_B, this->ddr_mask_);
-    if (this->interrupt_pin_ == nullptr) {
+    if (this->interrupt_pin_ != nullptr) {
+      // Unmask this pin's interrupt (clear bit = enabled)
+      this->read_byte_16(REG_INTERRUPT_MASK_B, &temp_word);
+      temp_word &= ~(1 << pin);
+      this->write_byte_16(REG_INTERRUPT_MASK_B, temp_word);
+
+      // Configure sense to trigger on both edges (0b11)
+      // Sense registers: 2 bits per pin, 4 pins per byte
+      // REG_SENSE_HIGH_B: pins 12-15, REG_SENSE_LOW_B: pins 8-11
+      // REG_SENSE_HIGH_A: pins 4-7, REG_SENSE_LOW_A: pins 0-3
+      uint8_t sense_reg = pin < 4    ? REG_SENSE_LOW_A
+                          : pin < 8  ? REG_SENSE_HIGH_A
+                          : pin < 12 ? REG_SENSE_LOW_B
+                                     : REG_SENSE_HIGH_B;
+      uint8_t sense_val = 0;
+      this->read_byte(sense_reg, &sense_val);
+      uint8_t shift = (pin % 4) * 2;
+      sense_val &= ~(0x03 << shift);
+      sense_val |= (0x03 << shift);  // Both edges
+      this->write_byte(sense_reg, sense_val);
+
+      // Clear any pending interrupt for this pin
+      this->write_byte_16(REG_INTERRUPT_SOURCE_B, 1 << pin);
+    } else {
       this->enable_loop();
     }
   }

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -92,6 +92,7 @@ class SX1509Component : public Component,
   uint32_t last_loop_timestamp_ = 0;
   const uint32_t min_loop_period_ = 15;  // ms
 
+  void enable_pin_interrupt_(uint8_t pin);
   void setup_keypad_();
   void set_debounce_config_(uint8_t config_value);
   void set_debounce_time_(uint8_t time);

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -89,6 +89,7 @@ class SX1509Component : public Component,
   std::vector<SX1509KeyTrigger *> key_triggers_;
 
   InternalGPIOPin *interrupt_pin_{nullptr};
+  volatile bool interrupt_pending_{false};
   uint32_t last_loop_timestamp_ = 0;
   const uint32_t min_loop_period_ = 15;  // ms
 

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -46,6 +46,7 @@ class SX1509Component : public Component,
   uint16_t read_key_data();
   void set_pin_value(uint8_t pin, uint8_t i_on) { this->write_byte(REG_I_ON[pin], i_on); };
   void pin_mode(uint8_t pin, gpio::Flags flags);
+  void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
   uint32_t get_clock() { return this->clk_x_; };
   void set_rows_cols(uint8_t rows, uint8_t cols) {
     this->rows_ = rows;
@@ -63,6 +64,8 @@ class SX1509Component : public Component,
   void setup_led_driver(uint8_t pin);
 
  protected:
+  static void IRAM_ATTR gpio_intr(SX1509Component *arg);
+
   // Virtual methods from CachedGpioExpander
   bool digital_read_hw(uint8_t pin) override;
   bool digital_read_cache(uint8_t pin) override;
@@ -85,6 +88,7 @@ class SX1509Component : public Component,
   std::vector<SX1509Processor *> keypad_binary_sensors_;
   std::vector<SX1509KeyTrigger *> key_triggers_;
 
+  InternalGPIOPin *interrupt_pin_{nullptr};
   uint32_t last_loop_timestamp_ = 0;
   const uint32_t min_loop_period_ = 15;  // ms
 

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -78,6 +78,7 @@ class SX1509Component : public Component,
   uint16_t port_mask_ = 0x00;
   uint16_t output_state_ = 0x00;
   bool has_keypad_ = false;
+  volatile bool interrupt_pending_{false};
   uint8_t rows_ = 0;
   uint8_t cols_ = 0;
   std::string keys_;
@@ -89,7 +90,6 @@ class SX1509Component : public Component,
   std::vector<SX1509KeyTrigger *> key_triggers_;
 
   InternalGPIOPin *interrupt_pin_{nullptr};
-  volatile bool interrupt_pending_{false};
   uint32_t last_loop_timestamp_ = 0;
   const uint32_t min_loop_period_ = 15;  // ms
 

--- a/esphome/components/sx1509/sx1509.h
+++ b/esphome/components/sx1509/sx1509.h
@@ -94,6 +94,10 @@ class SX1509Component : public Component,
   const uint32_t min_loop_period_ = 15;  // ms
 
   void enable_pin_interrupt_(uint8_t pin);
+  void clear_interrupt_() {
+    uint16_t interrupt_source = 0;
+    this->read_byte_16(REG_INTERRUPT_SOURCE_B, &interrupt_source);
+  }
   void setup_keypad_();
   void set_debounce_config_(uint8_t config_value);
   void set_debounce_time_(uint8_t time);

--- a/esphome/components/sx1509/sx1509_registers.h
+++ b/esphome/components/sx1509/sx1509_registers.h
@@ -57,6 +57,8 @@ const uint8_t REG_SENSE_HIGH_B = 0x14;  //    RegSenseHighB Sense register for I
 const uint8_t REG_SENSE_LOW_B = 0x15;   //    RegSenseLowB Sense register for I/O[11:8] 0000 0000
 const uint8_t REG_SENSE_HIGH_A = 0x16;  //    RegSenseHighA Sense register for I/O[7:4] 0000 0000
 const uint8_t REG_SENSE_LOW_A = 0x17;   //    RegSenseLowA Sense register for I/O[3:0] 0000 0000
+// Sense register values (2 bits per pin): 00=None, 01=Rising, 10=Falling, 11=Both
+const uint8_t SENSE_BOTH_EDGES = 0x03;
 const uint8_t REG_INTERRUPT_SOURCE_B =
     0x18;  //    RegInterruptSourceB Interrupt source register _ I/O[15_8] (Bank B) 0000 0000
 const uint8_t REG_INTERRUPT_SOURCE_A =

--- a/esphome/components/sx1509/sx1509_registers.h
+++ b/esphome/components/sx1509/sx1509_registers.h
@@ -59,6 +59,8 @@ const uint8_t REG_SENSE_HIGH_A = 0x16;  //    RegSenseHighA Sense register for I
 const uint8_t REG_SENSE_LOW_A = 0x17;   //    RegSenseLowA Sense register for I/O[3:0] 0000 0000
 // Sense register values (2 bits per pin): 00=None, 01=Rising, 10=Falling, 11=Both
 const uint8_t SENSE_BOTH_EDGES = 0x03;
+// Sense register lookup: each register covers 4 pins (pins 0-3, 4-7, 8-11, 12-15)
+const uint8_t SENSE_REGS[] = {REG_SENSE_LOW_A, REG_SENSE_HIGH_A, REG_SENSE_LOW_B, REG_SENSE_HIGH_B};
 const uint8_t REG_INTERRUPT_SOURCE_B =
     0x18;  //    RegInterruptSourceB Interrupt source register _ I/O[15_8] (Bank B) 0000 0000
 const uint8_t REG_INTERRUPT_SOURCE_A =

--- a/tests/components/sx1509/common.yaml
+++ b/tests/components/sx1509/common.yaml
@@ -2,6 +2,7 @@ sx1509:
   - id: sx1509_hub
     i2c_id: i2c_bus
     address: 0x3E
+    interrupt_pin: ${interrupt_pin}
     keypad:
       key_rows: 2
       key_columns: 2

--- a/tests/components/sx1509/test.esp32-idf.yaml
+++ b/tests/components/sx1509/test.esp32-idf.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
 

--- a/tests/components/sx1509/test.esp8266-ard.yaml
+++ b/tests/components/sx1509/test.esp8266-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO15
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/esp8266-ard.yaml
 

--- a/tests/components/sx1509/test.rp2040-ard.yaml
+++ b/tests/components/sx1509/test.rp2040-ard.yaml
@@ -1,3 +1,6 @@
+substitutions:
+  interrupt_pin: GPIO2
+
 packages:
   i2c: !include ../../test_build_components/common/i2c/rp2040-ard.yaml
 


### PR DESCRIPTION
# What does this implement/fix?

Add optional `interrupt_pin` configuration to the SX1509 GPIO expander to eliminate I2C polling for GPIO reads. When configured, the component disables its loop and only reads the I2C bus when the interrupt fires, matching the pattern already used by PCF8574, PCA9554, MCP23xxx, and PI4IOE5V6408 expanders.

Unlike simpler expanders, the SX1509 requires explicit per-pin interrupt configuration ([datasheet](https://cdn.sparkfun.com/datasheets/BreakoutBoards/sx1509.pdf), Section 4.7):
- **RegInterruptMask** (0x12-0x13): Unmask each input pin (clear bit = enabled)
- **RegSense** (0x14-0x17): Set both-edge detection (2 bits per pin, `0b11` = both edges)
- **RegInterruptSource** (0x18-0x19): Read to clear pending interrupts and deassert NINT

The ISR sets an `interrupt_pending_` flag. In `loop()`, when the flag is set, the interrupt source is cleared and the pin cache is reset so the next `digital_read()` fetches fresh data. When keypad mode is active, the loop continues running for key scanning; the interrupt source is only read when a GPIO interrupt actually fired.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6433

## Test Environment

Not hardware tested — I don't have this hardware. This is opt-in (no behavior change without `interrupt_pin` configured).

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sx1509:
  id: my_sx1509
  interrupt_pin: GPIO16
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).