### PR TITLE
[web_server_base] Fix auth 401 on button press for Arduino platforms

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -425,7 +425,9 @@ W55RP20_SCHEMA = cv.All(
     BASE_SCHEMA.extend(
         cv.Schema(
             {
-                cv.Optional(CONF_CS_PIN, default=17): pins.internal_gpio_output_pin_number,
+                cv.Optional(
+                    CONF_CS_PIN, default=17
+                ): pins.internal_gpio_output_pin_number,
             }
         ),
     ),

--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -125,6 +125,7 @@ ETHERNET_TYPES = {
     "ENC28J60": EthernetType.ETHERNET_TYPE_ENC28J60,
     "W6100": EthernetType.ETHERNET_TYPE_W6100,
     "W6300": EthernetType.ETHERNET_TYPE_W6300,
+    "W55RP20": EthernetType.ETHERNET_TYPE_W55RP20,
 }
 
 # PHY types that need compile-time defines for conditional compilation
@@ -144,6 +145,7 @@ _PHY_TYPE_TO_DEFINE = {
     "ENC28J60": "USE_ETHERNET_ENC28J60",
     "W6100": "USE_ETHERNET_W6100",
     "W6300": "USE_ETHERNET_W6300",
+    "W55RP20": "USE_ETHERNET_W55RP20",
 }
 
 
@@ -175,13 +177,14 @@ _ALWAYS_EXTERNAL_IDF_COMPONENTS = {"LAN8670", "ENC28J60"}
 # ESP32-only SPI ethernet types (W5100 is RP2040-only, no ESP-IDF driver)
 SPI_ETHERNET_TYPES = {"W5500", "DM9051", "ENC28J60"}
 # RP2040-supported ethernet types (SPI and PIO QSPI)
-RP2040_ETHERNET_TYPES = {"W5100", "W5500", "W6100", "W6300", "ENC28J60"}
+RP2040_ETHERNET_TYPES = {"W5100", "W5500", "W6100", "W6300", "ENC28J60", "W55RP20"}
 _RP2040_SPI_LIBRARIES = {
     "W5100": "lwIP_w5100",
     "W5500": "lwIP_w5500",
     "ENC28J60": "lwIP_enc28j60",
     "W6100": "lwIP_w6100",
     "W6300": "lwIP_w6300",
+    "W55RP20": "lwIP_w55rp20",
 }
 SPI_ETHERNET_DEFAULT_POLLING_INTERVAL = TimePeriodMilliseconds(milliseconds=10)
 
@@ -418,6 +421,17 @@ SPI_SCHEMA = cv.All(
     _validate_spi_interface,
 )
 
+W55RP20_SCHEMA = cv.All(
+    BASE_SCHEMA.extend(
+        cv.Schema(
+            {
+                cv.Optional(CONF_CS_PIN, default=17): pins.internal_gpio_output_pin_number,
+            }
+        ),
+    ),
+    cv.only_on([Platform.RP2040]),
+)
+
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
@@ -436,6 +450,7 @@ CONFIG_SCHEMA = cv.All(
             "W6100": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2040])),
             "W6300": cv.All(SPI_SCHEMA, cv.only_on([Platform.RP2040])),
             "LAN8670": RMII_SCHEMA,
+            "W55RP20": W55RP20_SCHEMA,
         },
         upper=True,
     ),
@@ -596,16 +611,20 @@ async def _to_code_esp32(var: cg.Pvariable, config: ConfigType) -> None:
 
 
 async def _to_code_rp2040(var: cg.Pvariable, config: ConfigType) -> None:
-    cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))
-    cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
-    cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
-    cg.add(var.set_cs_pin(config[CONF_CS_PIN]))
-    if CONF_INTERRUPT_PIN in config:
-        cg.add(var.set_interrupt_pin(config[CONF_INTERRUPT_PIN]))
-    if CONF_RESET_PIN in config:
-        cg.add(var.set_reset_pin(config[CONF_RESET_PIN]))
+    if config[CONF_TYPE] == "W55RP20":
+        # W55RP20 has internal SPI — only CS pin is needed
+        cg.add(var.set_cs_pin(config[CONF_CS_PIN]))
+    else:
+        cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))
+        cg.add(var.set_miso_pin(config[CONF_MISO_PIN]))
+        cg.add(var.set_mosi_pin(config[CONF_MOSI_PIN]))
+        cg.add(var.set_cs_pin(config[CONF_CS_PIN]))
+        if CONF_INTERRUPT_PIN in config:
+            cg.add(var.set_interrupt_pin(config[CONF_INTERRUPT_PIN]))
+        if CONF_RESET_PIN in config:
+            cg.add(var.set_reset_pin(config[CONF_RESET_PIN]))
+        cg.add_define("USE_ETHERNET_SPI")
 
-    cg.add_define("USE_ETHERNET_SPI")
     cg.add_library(_RP2040_SPI_LIBRARIES[config[CONF_TYPE]], None)
 
 

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -46,6 +46,8 @@ class Wiznet6300NoSPI : public Wiznet6300 {
 using Wiznet6300lwIPFixed = LwipIntfDev<Wiznet6300NoSPI>;
 #elif defined(USE_ETHERNET_ENC28J60)
 #include <ENC28J60lwIP.h>
+#elif defined(USE_ETHERNET_W55RP20)
+#include <W55RP20lwIP.h>
 #else
 #error "Unsupported RP2040 SPI Ethernet type"
 #endif
@@ -86,6 +88,7 @@ enum EthernetType : uint8_t {
   ETHERNET_TYPE_ENC28J60,
   ETHERNET_TYPE_W6100,
   ETHERNET_TYPE_W6300,
+  ETHERNET_TYPE_W55RP20,
 };
 
 struct ManualIP {
@@ -263,6 +266,8 @@ class EthernetComponent final : public Component {
   Wiznet6300lwIPFixed *eth_{nullptr};
 #elif defined(USE_ETHERNET_ENC28J60)
   ENC28J60lwIP *eth_{nullptr};
+#elif defined(USE_ETHERNET_W55RP20)
+  Wiznet55rp20lwIP *eth_{nullptr};
 #else
 #error "Unsupported RP2040 SPI Ethernet type"
 #endif

--- a/esphome/components/ethernet/ethernet_component_rp2040.cpp
+++ b/esphome/components/ethernet/ethernet_component_rp2040.cpp
@@ -18,7 +18,7 @@ static const char *const TAG = "ethernet";
 
 void EthernetComponent::setup() {
   // Configure SPI pins
-#if !defined(USE_ETHERNET_W6300)
+#if !defined(USE_ETHERNET_W6300) && !defined(USE_ETHERNET_W55RP20)
   SPI.setRX(this->miso_pin_);
   SPI.setTX(this->mosi_pin_);
   SPI.setSCK(this->clk_pin_);
@@ -26,6 +26,7 @@ void EthernetComponent::setup() {
   // W6300 uses PIO QSPI with hardcoded pins, not Arduino SPI.
   // SPI pin config is skipped; Wiznet6300lwIPFixed (needsSPI()=false)
   // prevents LwipIntfDev::begin() from calling SPI.begin().
+  // W55RP20 has the Ethernet MAC+PHY integrated with internal SPI — only CS pin is needed.
 
   // Toggle reset pin if configured
   if (this->reset_pin_ >= 0) {
@@ -51,6 +52,8 @@ void EthernetComponent::setup() {
   this->eth_ = new Wiznet6300lwIPFixed(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
 #elif defined(USE_ETHERNET_ENC28J60)
   this->eth_ = new ENC28J60lwIP(this->cs_pin_, SPI, this->interrupt_pin_);  // NOLINT
+#elif defined(USE_ETHERNET_W55RP20)
+  this->eth_ = new Wiznet55rp20lwIP(this->cs_pin_);  // NOLINT — internal SPI, CS only
 #endif
 
   // Set hostname before begin() so the LWIP netif gets it
@@ -109,9 +112,11 @@ void EthernetComponent::loop() {
   // value, which is benign for polling.
   if (this->eth_ != nullptr && now - this->last_link_check_ >= LINK_CHECK_INTERVAL) {
     this->last_link_check_ = now;
-#if defined(USE_ETHERNET_W5100)
+#if defined(USE_ETHERNET_W5100) || defined(USE_ETHERNET_W55RP20)
     // W5100 can't detect link (isLinkDetectable() returns false), so linkStatus()
-    // returns Unknown — assume link is up after successful begin()
+    // returns Unknown — assume link is up after successful begin().
+    // W55RP20 isLinked() reads PHY register which may not report correctly
+    // on all boards despite the physical link being up — use connected() only.
     bool link_up = true;
 #else
     bool link_up = this->eth_->linkStatus() == LinkON;
@@ -198,8 +203,18 @@ void EthernetComponent::dump_config() {
   type_str = "W6300";
 #elif defined(USE_ETHERNET_ENC28J60)
   type_str = "ENC28J60";
+#elif defined(USE_ETHERNET_W55RP20)
+  type_str = "W55RP20";
 #endif
-#if defined(USE_ETHERNET_W6300)
+#if defined(USE_ETHERNET_W55RP20)
+  // W55RP20 has internal SPI — only CS pin is relevant
+  ESP_LOGCONFIG(TAG,
+                "Ethernet:\n"
+                "  Type: %s (internal SPI)\n"
+                "  Connected: %s\n"
+                "  CS Pin: %u",
+                type_str, YESNO(this->is_connected()), this->cs_pin_);
+#elif defined(USE_ETHERNET_W6300)
   // W6300 uses PIO QSPI with hardcoded pins — SPI pin fields are not used
   ESP_LOGCONFIG(TAG,
                 "Ethernet:\n"

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -59,7 +59,15 @@ class AuthMiddlewareHandler : public MiddlewareHandler {
   bool check_auth(AsyncWebServerRequest *request) {
     bool success = request->authenticate(credentials_->username.c_str(), credentials_->password.c_str());
     if (!success) {
+#if USE_ESP32
       request->requestAuthentication();
+#else
+      // Force Basic auth on Arduino platforms (ESP8266, RP2040).
+      // ESPAsyncWebServer defaults to Digest auth, which browsers don't
+      // preemptively send with XHR/fetch requests, causing 401 failures
+      // on button presses and other JS-initiated actions.
+      request->requestAuthentication(nullptr, false);
+#endif
     }
     return success;
   }

--- a/tests/components/ethernet/common-w55rp20-rp2040.yaml
+++ b/tests/components/ethernet/common-w55rp20-rp2040.yaml
@@ -1,0 +1,8 @@
+ethernet:
+  type: W55RP20
+  cs_pin: 17
+  manual_ip:
+    static_ip: 192.168.178.56
+    gateway: 192.168.178.1
+    subnet: 255.255.255.0
+  domain: .local

--- a/tests/components/ethernet/test-w55rp20.rp2040-ard.yaml
+++ b/tests/components/ethernet/test-w55rp20.rp2040-ard.yaml
@@ -1,0 +1,1 @@
+<<: !include common-w55rp20-rp2040.yaml


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
