### PR TITLE
[rp2040] Fix W5500 Ethernet pbuf corruption by mirroring LWIPMutex semantics

### DIFF
--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -9,7 +9,7 @@
 #include <WiFi.h>
 #include <pico/cyw43_arch.h>  // For cyw43_arch_lwip_begin/end (LwIPLock)
 #elif defined(USE_ETHERNET)
-#include <lwip_wrap.h>  // For LWIPMutex — LwIPLock delegates to it (see below)
+#include <lwip_wrap.h>  // For LWIPMutex — LwIPLock mirrors its semantics (see below)
 #include "esphome/components/ethernet/ethernet_component.h"
 #endif
 #include <hardware/structs/rosc.h>

--- a/esphome/components/rp2040/helpers.cpp
+++ b/esphome/components/rp2040/helpers.cpp
@@ -9,7 +9,7 @@
 #include <WiFi.h>
 #include <pico/cyw43_arch.h>  // For cyw43_arch_lwip_begin/end (LwIPLock)
 #elif defined(USE_ETHERNET)
-#include <LwipEthernet.h>  // For ethernet_arch_lwip_begin/end (LwIPLock)
+#include <lwip_wrap.h>  // For LWIPMutex — LwIPLock delegates to it (see below)
 #include "esphome/components/ethernet/ethernet_component.h"
 #endif
 #include <hardware/structs/rosc.h>
@@ -43,9 +43,18 @@ IRAM_ATTR InterruptLock::~InterruptLock() { restore_interrupts(state_); }
 // main loop, corrupting the shared rx_buf_ pbuf chain (use-after-free, pbuf_cat
 // assertion failures). See esphome#10681.
 //
-// WiFi uses cyw43_arch_lwip_begin/end; Ethernet uses ethernet_arch_lwip_begin/end.
-// Both acquire the async_context recursive mutex to prevent IRQ callbacks from
-// firing during critical sections.
+// WiFi uses cyw43_arch_lwip_begin/end.
+//
+// For wired Ethernet, taking only the async_context lock is NOT enough. The
+// W5500 GPIO IRQ path (LwipIntfDev::_irq) checks arduino-pico's `__inLWIP`
+// counter to decide whether to defer packet processing. If we hold the
+// async_context lock without bumping `__inLWIP`, an interrupt-driven packet
+// arrival re-enters lwIP from IRQ context and corrupts pbufs (the `pbuf_cat`
+// assertion crash on wiznet-w5500-evb-pico). We mirror arduino-pico's
+// LWIPMutex (cores/rp2040/lwip_wrap.h) exactly: bump `__inLWIP`, take the
+// lock, and on release re-unmask any GPIO IRQs that were deferred while we
+// held it. We can't `using LwIPLock = LWIPMutex;` in helpers.h because
+// pulling lwip_wrap.h there poisons many TUs with lwIP types.
 //
 // When neither WiFi nor Ethernet is configured, this is a no-op since
 // there's no network stack and no lwip callbacks to race with.
@@ -53,8 +62,18 @@ IRAM_ATTR InterruptLock::~InterruptLock() { restore_interrupts(state_); }
 LwIPLock::LwIPLock() { cyw43_arch_lwip_begin(); }
 LwIPLock::~LwIPLock() { cyw43_arch_lwip_end(); }
 #elif defined(USE_ETHERNET)
-LwIPLock::LwIPLock() { ethernet_arch_lwip_begin(); }
-LwIPLock::~LwIPLock() { ethernet_arch_lwip_end(); }
+LwIPLock::LwIPLock() {
+  __inLWIP++;
+  ethernet_arch_lwip_begin();
+}
+LwIPLock::~LwIPLock() {
+  ethernet_arch_lwip_end();
+  __inLWIP--;
+  if (__needsIRQEN && !__inLWIP) {
+    __needsIRQEN = false;
+    ethernet_arch_lwip_gpio_unmask();
+  }
+}
 #else
 LwIPLock::LwIPLock() {}
 LwIPLock::~LwIPLock() {}


### PR DESCRIPTION
# What does this implement/fix?

Fixes a `pbuf_cat` assertion crash on RP2040 boards using a wired W5500 (and likely W5100/W6100/ENC28J60) Ethernet interface configured with an interrupt pin. Affected devices repeatedly panic and reboot — uptime drops from ~30 minutes to crash, then safe-mode boot, then crash again.

## Crash trace from a wiznet-w5500-evb-pico

```
[15:37:38.238][S][sensor]: 'Uptime' >> 1984 s
INFO Processing unexpected disconnect from ESPHome API for wiznet-w5500-evb-pico @ 192.168.106.163
WARNING Disconnected from API
INFO Successfully resolved wiznet-w5500-evb-pico @ 192.168.106.163 in 0.000s
INFO Successfully connected to wiznet-w5500-evb-pico @ 192.168.106.163 in 0.005s
INFO Successful handshake with wiznet-w5500-evb-pico @ 192.168.106.163 in 0.190s
[15:38:15.402][E][rp2040.crash:103]: *** CRASH DETECTED ON PREVIOUS BOOT ***
ERROR RP2040 crash detected - decoding addresses
[15:38:15.403][E][rp2040.crash:104]:   PC:  0x100369AE  (fault location)
ERROR   0x100369AE => 0x100369ae: _exit at ??:?
[15:38:15.433][E][rp2040.crash:105]:   LR:  0x1001DB4F  (return address)
ERROR   0x1001DB4F => 0x1001db4f: panic at /home/earle/Arduino/hardware/pico/rp2040/pico-sdk/src/rp2_common/pico_platform_panic/panic.c:82
[15:38:15.436][E][rp2040.crash:106]:   SP:  0x20041D38
[15:38:15.436][E][rp2040.crash:108]:   BT0: 0x10037AF4  (stack backtrace)
ERROR   0x10037AF4 => 0x10037af4: ?? ??:0
[15:38:15.444][E][rp2040.crash:108]:   BT1: 0x10018271  (stack backtrace)
ERROR   0x10018271 => 0x10018271: pbuf_cat at ??:?
[15:38:15.452][E][rp2040.crash:108]:   BT2: 0x10037AF4  (stack backtrace)
ERROR   0x10037AF4 => 0x10037af4: ?? ??:0
[15:38:15.460][E][rp2040.crash:108]:   BT3: 0x1001C753  (stack backtrace)
ERROR   0x1001C753 => 0x1001c753: __wrap_pbuf_cat at ??:?
[15:38:15.468][E][rp2040.crash:117]: Use: addr2line -pfiaC -e firmware.elf 0x100369AE 0x1001DB4F 0x10037AF4 0x10018271 0x10037AF4 0x1001C753
[15:39:07.920][I][safe_mode:094]: Boot seems successful; resetting boot loop counter
```

The crash is the lwIP assertion `LWIP_ASSERT("p->tot_len == p->len (of last pbuf in chain)", p->tot_len == p->len)` at `lwip/src/core/pbuf.c:866` — the pbuf chain is corrupted before `pbuf_cat` ever runs. The same backtrace repeats every few minutes after each reboot.

## Root cause

ESPHome's `LwIPLock` for `USE_RP2040 + USE_ETHERNET` only called `ethernet_arch_lwip_begin/end`, which acquires arduino-pico's `async_context_threadsafe_background` recursive mutex. **It never bumped arduino-pico's `__inLWIP` counter.**

The wired-Ethernet GPIO IRQ path in arduino-pico checks `__inLWIP` to decide whether to defer packet processing:

```cpp
// arduino-pico libraries/lwIP_Ethernet/src/LwipIntfDev.h
void LwipIntfDev<RawDev>::_irq(void *param) {
    LwipIntfDev *d = static_cast<LwipIntfDev*>(param);
    ethernet_arch_lwip_gpio_mask();
    if (__inLWIP) {
        __needsIRQEN = true;
        return;          // Deferred — re-runs when LWIPMutex releases
    }
    lwip_callback(_lwipCallback, param, &d->_irqBuffer);
}
```

In baremetal mode (no FreeRTOS), `lwip_callback` immediately calls the callback. Because `LwIPLock` never set `__inLWIP`, an interrupt-driven W5500 packet arrival would proceed and run `_lwipCallback` → `handlePackets()` → `_netif.input()` from IRQ context **while the main thread held the async_context lock**, re-entering lwIP and corrupting pbuf chains. The corruption surfaces later as the `pbuf_cat` assertion.

## The fix

Mirror arduino-pico's `LWIPMutex` (`cores/rp2040/lwip_wrap.h`) exactly in `LwIPLock`'s constructor/destructor:

- Constructor: `__inLWIP++`, then `ethernet_arch_lwip_begin()`
- Destructor: `ethernet_arch_lwip_end()`, `__inLWIP--`, and re-unmask any GPIO IRQs that were deferred while we held the lock (`__needsIRQEN`)

This makes `LwIPLock` behave identically to a `LWIPMutex` instance — IRQ-driven packet receive will defer when ESPHome holds the lock and re-fire safely once we release it.

## Why not `using LwIPLock = LWIPMutex;`?

The cleanest fix would be a type alias, but that requires `#include <lwip_wrap.h>` to be visible at every `LwIPLock` call site (i.e. in `core/helpers.h`). That header transitively pulls pico-sdk's `lwip/err.h` into many translation units that already include lwIP via a different path; the headers don't agree on `err_t` and the build breaks across api/socket/mqtt/wireguard/e131/etc. The include is therefore scoped to `esphome/components/rp2040/helpers.cpp` and the body inlined to match `LWIPMutex` exactly. A code comment points to the upstream class so the two stay in sync.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Affected hardware: RP2040 board with a wired W5500/W5100/W6100/ENC28J60
# and an interrupt pin configured.
esphome:
  name: wiznet-w5500-evb-pico

rp2040:
  board: rpipicow
  framework:
    version: recommended

ethernet:
  type: W5500
  clk_pin: GPIO18
  mosi_pin: GPIO19
  miso_pin: GPIO16
  cs_pin: GPIO17
  reset_pin: GPIO20
  interrupt_pin: GPIO21   # Triggers the bug — without this the polling path is used.

api:
logger:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).