### PR TITLE
[api] Unroll varint encode loop for compile-time bounded types

### DIFF
--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -304,7 +304,8 @@ class ProtoEncode {
   /// data-dependent back-edge branch, which measurably speeds up BLE raw
   /// advertisement MAC encoding (always 7-byte varints) among other hot paths.
   template<typename T>
-  static inline void encode_varint_raw_loop(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, T value) {
+  static inline void ESPHOME_ALWAYS_INLINE encode_varint_raw_loop(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
+                                                                  T value) {
     constexpr int MAX_VARINT_BYTES = (sizeof(T) * 8 + 6) / 7;  // 5 for u32, 10 for u64
 #pragma GCC unroll 10
     for (int i = 0; i < MAX_VARINT_BYTES - 1; i++) {

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -298,13 +298,25 @@ constexpr uint32_t VARINT_MAX_2_BYTE = 1 << 14;  // 16384
 class ProtoEncode {
  public:
   /// Write a multi-byte varint directly through a pos pointer.
+  /// Unrolled based on the compile-time max varint length for T
+  /// (5 bytes for uint32_t, 10 bytes for uint64_t). The explicit unroll gives
+  /// the compiler straight-line code with early exits instead of a
+  /// data-dependent back-edge branch, which measurably speeds up BLE raw
+  /// advertisement MAC encoding (always 7-byte varints) among other hot paths.
   template<typename T>
   static inline void encode_varint_raw_loop(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM, T value) {
-    do {
+    constexpr int MAX_VARINT_BYTES = (sizeof(T) * 8 + 6) / 7;  // 5 for u32, 10 for u64
+#pragma GCC unroll 10
+    for (int i = 0; i < MAX_VARINT_BYTES - 1; i++) {
       PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
-      *pos++ = static_cast<uint8_t>(value | 0x80);
+      *pos++ = static_cast<uint8_t>(value) | 0x80;
       value >>= 7;
-    } while (value > 0x7F);
+      if (value <= 0x7F) {
+        PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
+        *pos++ = static_cast<uint8_t>(value);
+        return;
+      }
+    }
     PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
     *pos++ = static_cast<uint8_t>(value);
   }

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -303,9 +303,13 @@ class ProtoEncode {
   /// the compiler straight-line code with early exits instead of a
   /// data-dependent back-edge branch, which measurably speeds up BLE raw
   /// advertisement MAC encoding (always 7-byte varints) among other hot paths.
+  ///
+  /// Takes/returns pos by value so this function can remain out-of-line without
+  /// forcing the caller to spill pos to memory on every byte write. Callers
+  /// (which are ALWAYS_INLINE) should assign the returned pos back to their
+  /// local. Code size win vs. inlining the whole unroll at every call site.
   template<typename T>
-  static inline void ESPHOME_ALWAYS_INLINE encode_varint_raw_loop(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
-                                                                  T value) {
+  static uint8_t *encode_varint_raw_loop(uint8_t *__restrict__ pos PROTO_ENCODE_DEBUG_PARAM, T value) {
     constexpr int MAX_VARINT_BYTES = (sizeof(T) * 8 + 6) / 7;  // 5 for u32, 10 for u64
 #pragma GCC unroll 10
     for (int i = 0; i < MAX_VARINT_BYTES - 1; i++) {
@@ -315,11 +319,12 @@ class ProtoEncode {
       if (value <= 0x7F) {
         PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
         *pos++ = static_cast<uint8_t>(value);
-        return;
+        return pos;
       }
     }
     PROTO_ENCODE_CHECK_BOUNDS(pos, 1);
     *pos++ = static_cast<uint8_t>(value);
+    return pos;
   }
   static inline void ESPHOME_ALWAYS_INLINE encode_varint_raw(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
                                                              uint32_t value) {
@@ -328,7 +333,7 @@ class ProtoEncode {
       *pos++ = static_cast<uint8_t>(value);
       return;
     }
-    encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
+    pos = encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
   }
   /// Encode a varint that is expected to be 1-2 bytes (e.g. zigzag RSSI, small lengths).
   static inline void ESPHOME_ALWAYS_INLINE encode_varint_raw_short(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
@@ -344,7 +349,7 @@ class ProtoEncode {
       *pos++ = static_cast<uint8_t>(value >> 7);
       return;
     }
-    encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
+    pos = encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
   }
   static inline void ESPHOME_ALWAYS_INLINE encode_varint_raw_64(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
                                                                 uint64_t value) {
@@ -353,7 +358,7 @@ class ProtoEncode {
       *pos++ = static_cast<uint8_t>(value);
       return;
     }
-    encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
+    pos = encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, value);
   }
   static inline void ESPHOME_ALWAYS_INLINE encode_field_raw(uint8_t *__restrict__ &pos PROTO_ENCODE_DEBUG_PARAM,
                                                             uint32_t field_id, uint32_t type) {
@@ -415,7 +420,7 @@ class ProtoEncode {
       PROTO_ENCODE_CHECK_BOUNDS(pos, 1 + len);
       *pos++ = static_cast<uint8_t>(len);
     } else {
-      encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, len);
+      pos = encode_varint_raw_loop(pos PROTO_ENCODE_DEBUG_ARG, len);
       PROTO_ENCODE_CHECK_BOUNDS(pos, len);
     }
     std::memcpy(pos, string, len);


### PR DESCRIPTION
# What does this implement/fix?

`ProtoEncode::encode_varint_raw_loop` previously used a `do...while` with a data-dependent trip count, which the compiler cannot unroll. Profiling `CalcAndEncode_BLERawAdvs12` showed the varint loop accounting for ~30% of encode cost — BLE MAC addresses are effectively random 48-bit values, so every call walks the full 7-byte path through the loop.

This change rewrites the loop as a template parameterized on the max varint length implied by `sizeof(T)`:

- `uint32_t` → 5-byte unroll
- `uint64_t` → 10-byte unroll

Each stage writes a continuation byte, shifts, and early-exits if the remainder fits in one byte. With a compile-time trip count, `#pragma GCC unroll` produces straight-line code with no back-edge branch, benefitting all varint-encoded fields (not just BLE MAC addresses).

Opening as draft to let CodSpeed confirm the improvement.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal optimization in the API protobuf encoder.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).