### PR TITLE
[sx127x][cc1101][sx126x] Use GPIO interrupt to wake loop

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -102,6 +102,11 @@ CC1101Component::CC1101Component() {
   memset(this->pa_table_, 0, sizeof(this->pa_table_));
 }
 
+void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) {
+  arg->gdo0_triggered_ = true;
+  arg->enable_loop_soon_any_context();
+}
+
 void CC1101Component::setup() {
   this->spi_setup();
   this->cs_->digital_write(true);
@@ -148,12 +153,16 @@ void CC1101Component::setup() {
   // Defer pin mode setup until after all components have completed setup()
   // This handles the case where remote_transmitter runs after CC1101 and changes pin mode
   if (this->gdo0_pin_ != nullptr) {
-    this->defer([this]() { this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT); });
+    this->defer([this]() {
+      this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT);
+      if (this->state_.PKT_FORMAT == static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
+        this->gdo0_pin_->attach_interrupt(&CC1101Component::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+      }
+    });
   }
 
-  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
-    this->disable_loop();
-  }
+  // wake the loop only on gdo0 interrupt
+  this->disable_loop();
 }
 
 void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) {
@@ -164,8 +173,12 @@ void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float 
 }
 
 void CC1101Component::loop() {
-  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO) || this->gdo0_pin_ == nullptr ||
-      !this->gdo0_pin_->digital_read()) {
+  if (!this->gdo0_triggered_) {
+    this->disable_loop();
+    return;
+  }
+  this->gdo0_triggered_ = false;
+  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
     return;
   }
 
@@ -244,6 +257,7 @@ void CC1101Component::begin_tx() {
   this->write_(Register::PKTCTRL0, 0x32);
   ESP_LOGV(TAG, "Beginning TX sequence");
   if (this->gdo0_pin_ != nullptr) {
+    this->gdo0_pin_->detach_interrupt();
     this->gdo0_pin_->pin_mode(gpio::FLAG_OUTPUT);
   }
   // Transition through IDLE to bypass CCA (Clear Channel Assessment) which can
@@ -673,10 +687,12 @@ void CC1101Component::set_packet_mode(bool value) {
     this->state_.GDO0_CFG = 0x0D;
   }
   if (this->initialized_) {
-    if (value) {
-      this->enable_loop();
-    } else {
-      this->disable_loop();
+    if (this->gdo0_pin_ != nullptr) {
+      if (value) {
+        this->gdo0_pin_->attach_interrupt(&CC1101Component::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+      } else {
+        this->gdo0_pin_->detach_interrupt();
+      }
     }
     this->write_(Register::PKTCTRL0);
     this->write_(Register::PKTCTRL1);

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -102,10 +102,7 @@ CC1101Component::CC1101Component() {
   memset(this->pa_table_, 0, sizeof(this->pa_table_));
 }
 
-void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) {
-  arg->gdo0_triggered_ = true;
-  arg->enable_loop_soon_any_context();
-}
+void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) { arg->enable_loop_soon_any_context(); }
 
 void CC1101Component::setup() {
   this->spi_setup();
@@ -173,12 +170,9 @@ void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float 
 }
 
 void CC1101Component::loop() {
-  if (!this->gdo0_triggered_) {
-    this->disable_loop();
-    return;
-  }
-  this->gdo0_triggered_ = false;
-  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
+  this->disable_loop();
+  if (this->state_.PKT_FORMAT != static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO) || this->gdo0_pin_ == nullptr ||
+      !this->gdo0_pin_->digital_read()) {
     return;
   }
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -157,9 +157,6 @@ void CC1101Component::setup() {
       }
     });
   }
-
-  // wake the loop only on gdo0 interrupt
-  this->disable_loop();
 }
 
 void CC1101Component::call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi) {

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -94,7 +94,6 @@ class CC1101Component : public Component,
   // GDO pin for packet reception
   InternalGPIOPin *gdo0_pin_{nullptr};
   static void IRAM_ATTR gpio_intr(CC1101Component *arg);
-  volatile bool gdo0_triggered_{false};
 
   // Packet handling
   void call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi);

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -93,6 +93,8 @@ class CC1101Component : public Component,
 
   // GDO pin for packet reception
   InternalGPIOPin *gdo0_pin_{nullptr};
+  static void IRAM_ATTR gpio_intr(CC1101Component *arg);
+  volatile bool gdo0_triggered_{false};
 
   // Packet handling
   void call_listeners_(const std::vector<uint8_t> &packet, float freq_offset, float rssi, uint8_t lqi);

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -104,17 +104,31 @@ void SX126x::write_register_(uint16_t reg, uint8_t *data, uint8_t size) {
   delayMicroseconds(SWITCHING_DELAY_US);
 }
 
+void IRAM_ATTR SX126x::gpio_intr(SX126x *arg) {
+  arg->dio1_triggered_ = true;
+  arg->enable_loop_soon_any_context();
+}
+
 void SX126x::setup() {
   // setup pins
   this->busy_pin_->setup();
   this->rst_pin_->setup();
   this->dio1_pin_->setup();
+  if (this->dio1_pin_->is_internal()) {
+    static_cast<InternalGPIOPin *>(this->dio1_pin_)
+        ->attach_interrupt(&SX126x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+  }
 
   // start spi
   this->spi_setup();
 
   // configure rf
   this->configure();
+
+  // wake the loop only on dio1 interrupt (when internal pin)
+  if (this->dio1_pin_->is_internal()) {
+    this->disable_loop();
+  }
 }
 
 void SX126x::configure() {
@@ -324,6 +338,8 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
       break;
     }
   }
+  // discard the dio1 trigger from tx completion so loop does not act on it
+  this->dio1_triggered_ = false;
 
   uint8_t buf[2];
   buf[0] = 0xFF;
@@ -348,7 +364,13 @@ void SX126x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
 }
 
 void SX126x::loop() {
-  if (!this->dio1_pin_->digital_read()) {
+  if (this->dio1_pin_->is_internal()) {
+    if (!this->dio1_triggered_) {
+      this->disable_loop();
+      return;
+    }
+    this->dio1_triggered_ = false;
+  } else if (!this->dio1_pin_->digital_read()) {
     return;
   }
 

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -104,10 +104,7 @@ void SX126x::write_register_(uint16_t reg, uint8_t *data, uint8_t size) {
   delayMicroseconds(SWITCHING_DELAY_US);
 }
 
-void IRAM_ATTR SX126x::gpio_intr(SX126x *arg) {
-  arg->dio1_triggered_ = true;
-  arg->enable_loop_soon_any_context();
-}
+void IRAM_ATTR SX126x::gpio_intr(SX126x *arg) { arg->enable_loop_soon_any_context(); }
 
 void SX126x::setup() {
   // setup pins
@@ -338,8 +335,6 @@ SX126xError SX126x::transmit_packet(const std::vector<uint8_t> &packet) {
       break;
     }
   }
-  // discard the dio1 trigger from tx completion so loop does not act on it
-  this->dio1_triggered_ = false;
 
   uint8_t buf[2];
   buf[0] = 0xFF;
@@ -365,12 +360,9 @@ void SX126x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
 
 void SX126x::loop() {
   if (this->dio1_pin_->is_internal()) {
-    if (!this->dio1_triggered_) {
-      this->disable_loop();
-      return;
-    }
-    this->dio1_triggered_ = false;
-  } else if (!this->dio1_pin_->digital_read()) {
+    this->disable_loop();
+  }
+  if (!this->dio1_pin_->digital_read()) {
     return;
   }
 

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -121,11 +121,6 @@ void SX126x::setup() {
 
   // configure rf
   this->configure();
-
-  // wake the loop only on dio1 interrupt (when internal pin)
-  if (this->dio1_pin_->is_internal()) {
-    this->disable_loop();
-  }
 }
 
 void SX126x::configure() {

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -3,6 +3,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/hal.h"
 #include "sx126x_reg.h"
 #include <utility>
 #include <vector>
@@ -100,6 +101,7 @@ class SX126x : public Component,
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() { return &this->packet_trigger_; }
 
  protected:
+  static void IRAM_ATTR gpio_intr(SX126x *arg);
   void configure_fsk_ook_();
   void configure_lora_();
   void set_packet_params_(uint8_t payload_length);
@@ -111,6 +113,7 @@ class SX126x : public Component,
   void read_register_(uint16_t reg, uint8_t *data, uint8_t size);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   void wait_busy_();
+  volatile bool dio1_triggered_{false};
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -113,7 +113,6 @@ class SX126x : public Component,
   void read_register_(uint16_t reg, uint8_t *data, uint8_t size);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   void wait_busy_();
-  volatile bool dio1_triggered_{false};
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX126xListener *> listeners_;
   std::vector<uint8_t> packet_;

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -70,9 +70,6 @@ void SX127x::setup() {
 
   // configure rf
   this->configure();
-
-  // wake the loop only on dio0 interrupt
-  this->disable_loop();
 }
 
 void SX127x::configure() {

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -53,10 +53,7 @@ void SX127x::write_fifo_(const std::vector<uint8_t> &packet) {
   this->disable();
 }
 
-void IRAM_ATTR SX127x::gpio_intr(SX127x *arg) {
-  arg->dio0_triggered_ = true;
-  arg->enable_loop_soon_any_context();
-}
+void IRAM_ATTR SX127x::gpio_intr(SX127x *arg) { arg->enable_loop_soon_any_context(); }
 
 void SX127x::setup() {
   // setup reset
@@ -306,8 +303,6 @@ SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
       break;
     }
   }
-  // discard the dio0 trigger from tx completion so loop does not act on it
-  this->dio0_triggered_ = false;
   if (this->rx_start_) {
     this->set_mode_rx();
   } else {
@@ -324,11 +319,10 @@ void SX127x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
 }
 
 void SX127x::loop() {
-  if (!this->dio0_triggered_) {
-    this->disable_loop();
+  this->disable_loop();
+  if (this->dio0_pin_ == nullptr || !this->dio0_pin_->digital_read()) {
     return;
   }
-  this->dio0_triggered_ = false;
 
   if (this->modulation_ == MOD_LORA) {
     uint8_t status = this->read_register_(REG_IRQ_FLAGS);

--- a/esphome/components/sx127x/sx127x.cpp
+++ b/esphome/components/sx127x/sx127x.cpp
@@ -53,6 +53,11 @@ void SX127x::write_fifo_(const std::vector<uint8_t> &packet) {
   this->disable();
 }
 
+void IRAM_ATTR SX127x::gpio_intr(SX127x *arg) {
+  arg->dio0_triggered_ = true;
+  arg->enable_loop_soon_any_context();
+}
+
 void SX127x::setup() {
   // setup reset
   this->rst_pin_->setup();
@@ -60,6 +65,7 @@ void SX127x::setup() {
   // setup dio0
   if (this->dio0_pin_) {
     this->dio0_pin_->setup();
+    this->dio0_pin_->attach_interrupt(&SX127x::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
   }
 
   // start spi
@@ -67,6 +73,9 @@ void SX127x::setup() {
 
   // configure rf
   this->configure();
+
+  // wake the loop only on dio0 interrupt
+  this->disable_loop();
 }
 
 void SX127x::configure() {
@@ -297,6 +306,8 @@ SX127xError SX127x::transmit_packet(const std::vector<uint8_t> &packet) {
       break;
     }
   }
+  // discard the dio0 trigger from tx completion so loop does not act on it
+  this->dio0_triggered_ = false;
   if (this->rx_start_) {
     this->set_mode_rx();
   } else {
@@ -313,9 +324,11 @@ void SX127x::call_listeners_(const std::vector<uint8_t> &packet, float rssi, flo
 }
 
 void SX127x::loop() {
-  if (this->dio0_pin_ == nullptr || !this->dio0_pin_->digital_read()) {
+  if (!this->dio0_triggered_) {
+    this->disable_loop();
     return;
   }
+  this->dio0_triggered_ = false;
 
   if (this->modulation_ == MOD_LORA) {
     uint8_t status = this->read_register_(REG_IRQ_FLAGS);
@@ -385,11 +398,6 @@ void SX127x::set_mode_(uint8_t modulation, uint8_t mode) {
       this->mark_failed();
       return;
     }
-  }
-  if (mode == MODE_RX && (modulation == MOD_LORA || this->packet_mode_)) {
-    this->enable_loop();
-  } else {
-    this->disable_loop();
   }
 }
 

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -96,7 +96,6 @@ class SX127x : public Component,
   void write_register_(uint8_t reg, uint8_t value);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   uint8_t read_register_(uint8_t reg);
-  volatile bool dio0_triggered_{false};
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX127xListener *> listeners_;
   std::vector<uint8_t> packet_;

--- a/esphome/components/sx127x/sx127x.h
+++ b/esphome/components/sx127x/sx127x.h
@@ -4,6 +4,7 @@
 #include "esphome/components/spi/spi.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
+#include "esphome/core/hal.h"
 #include <vector>
 
 namespace esphome {
@@ -86,6 +87,7 @@ class SX127x : public Component,
   Trigger<std::vector<uint8_t>, float, float> *get_packet_trigger() { return &this->packet_trigger_; }
 
  protected:
+  static void IRAM_ATTR gpio_intr(SX127x *arg);
   void configure_fsk_ook_();
   void configure_lora_();
   void set_mode_(uint8_t modulation, uint8_t mode);
@@ -94,6 +96,7 @@ class SX127x : public Component,
   void write_register_(uint8_t reg, uint8_t value);
   void call_listeners_(const std::vector<uint8_t> &packet, float rssi, float snr);
   uint8_t read_register_(uint8_t reg);
+  volatile bool dio0_triggered_{false};
   Trigger<std::vector<uint8_t>, float, float> packet_trigger_;
   std::vector<SX127xListener *> listeners_;
   std::vector<uint8_t> packet_;


### PR DESCRIPTION
# What does this implement/fix?

Convert RX packet handling from polling the DIO/GDO pin every loop iteration to attaching a GPIO interrupt that wakes the loop only when needed. Builds on esphome/esphome#15606 to eliminate unnecessary polling entirely.

The pattern is the same in all three components:
- ISR is a one-liner that calls `enable_loop_soon_any_context()`
- `loop()` calls `disable_loop()` immediately, then reads the pin level — if low, returns; if high, processes the packet (which causes the chip to de-assert the pin)
- The pin level is the source of truth, so no flag is needed

**SX127x** — `dio0_pin` is `InternalGPIOPin*`. Interrupt is attached unconditionally in `setup()` if configured. Removes the prior `set_mode_`-based loop enable/disable since the loop is now driven entirely by the ISR.

**CC1101** — `gdo0_pin` is `InternalGPIOPin*`. Interrupt is attached when entering FIFO packet mode (`set_packet_mode(true)` and the deferred setup callback) and detached when entering async serial mode (`set_packet_mode(false)` and `begin_tx()`, where the pin is repurposed for serial data).

**SX126x** — `dio1_pin` is `GPIOPin*` and may be on an expander. `is_internal()` is checked at runtime; internal pins get the interrupt path, expander pins keep the existing polling path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No config changes required
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).