### PR TITLE
[micro_wake_word] Pin esp-nn version

### DIFF
--- a/esphome/components/micro_wake_word/__init__.py
+++ b/esphome/components/micro_wake_word/__init__.py
@@ -451,6 +451,8 @@ async def to_code(config):
     ota.request_ota_state_listeners()
 
     esp32.add_idf_component(name="espressif/esp-tflite-micro", ref="1.3.3~1")
+    # Pin esp-nn for stable future builds (esp-tflite-micro depends on esp-nn)
+    esp32.add_idf_component(name="espressif/esp-nn", ref="1.2.1")
 
     cg.add_build_flag("-DTF_LITE_STATIC_MEMORY")
     cg.add_build_flag("-DTF_LITE_DISABLE_X86_NEON")

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -109,10 +109,12 @@ bool StreamingModel::load_model_() {
 size_t StreamingModel::probe_arena_size_() {
   RAMAllocator<uint8_t> arena_allocator;
 
-  // Try with the manifest size first, then escalate to 2x if it fails. Different platforms and different versions of
-  // the esp-nn library require different amounts of memory, so the manifest size may not always be correct, and probing
-  // allows us to find the actual required size for the current build and platform. Aligns test sizes to 16 bytes.
-  size_t attempt_sizes[] = {(this->tensor_arena_size_ + 15) & ~15, (this->tensor_arena_size_ * 2 + 15) & ~15};
+  // Try with the manifest size first, then escalates to 1.5, then 2x if it fails. Different platforms and different
+  // versions of the esp-nn library require different amounts of memory, so the manifest size may not always be correct,
+  // and probing allows us to find the actual required size for the current build and platform. Aligns test sizes to 16
+  // bytes.
+  size_t attempt_sizes[] = {(this->tensor_arena_size_ + 15) & ~15, (this->tensor_arena_size_ * 3 / 2 + 15) & ~15,
+                            (this->tensor_arena_size_ * 2 + 15) & ~15};
 
   for (size_t attempt_size : attempt_sizes) {
     uint8_t *probe_arena = arena_allocator.allocate(attempt_size);

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -111,8 +111,8 @@ size_t StreamingModel::probe_arena_size_() {
 
   // Try with the manifest size first, then escalate to 2x if it fails. Different platforms and different versions of
   // the esp-nn library require different amounts of memory, so the manifest size may not always be correct, and probing
-  // allows us to find the actual required size for the current build and platform.
-  size_t attempt_sizes[] = {this->tensor_arena_size_, this->tensor_arena_size_ * 2};
+  // allows us to find the actual required size for the current build and platform. Aligns test sizes to 16 bytes.
+  size_t attempt_sizes[] = {(this->tensor_arena_size_ + 15) & ~15, (this->tensor_arena_size_ * 2 + 15) & ~15};
 
   for (size_t attempt_size : attempt_sizes) {
     uint8_t *probe_arena = arena_allocator.allocate(attempt_size);

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -29,14 +29,6 @@ void VADModel::log_model_config() {
 bool StreamingModel::load_model_() {
   RAMAllocator<uint8_t> arena_allocator;
 
-  if (this->tensor_arena_ == nullptr) {
-    this->tensor_arena_ = arena_allocator.allocate(this->tensor_arena_size_);
-    if (this->tensor_arena_ == nullptr) {
-      ESP_LOGE(TAG, "Could not allocate the streaming model's tensor arena.");
-      return false;
-    }
-  }
-
   if (this->var_arena_ == nullptr) {
     this->var_arena_ = arena_allocator.allocate(STREAMING_MODEL_VARIABLE_ARENA_SIZE);
     if (this->var_arena_ == nullptr) {
@@ -51,6 +43,26 @@ bool StreamingModel::load_model_() {
   if (model->version() != TFLITE_SCHEMA_VERSION) {
     ESP_LOGE(TAG, "Streaming model's schema is not supported");
     return false;
+  }
+
+  // Probe for the actual required tensor arena size if not yet determined
+  if (!this->tensor_arena_size_probed_) {
+    size_t probed_size = this->probe_arena_size_();
+    if (probed_size > 0) {
+      ESP_LOGD(TAG, "Probed tensor arena size: %zu bytes", probed_size);
+      this->tensor_arena_size_ = probed_size;
+    } else {
+      ESP_LOGW(TAG, "Arena size probe failed, using manifest size: %zu bytes", this->tensor_arena_size_);
+    }
+    this->tensor_arena_size_probed_ = true;
+  }
+
+  if (this->tensor_arena_ == nullptr) {
+    this->tensor_arena_ = arena_allocator.allocate(this->tensor_arena_size_);
+    if (this->tensor_arena_ == nullptr) {
+      ESP_LOGE(TAG, "Could not allocate the streaming model's tensor arena.");
+      return false;
+    }
   }
 
   if (this->interpreter_ == nullptr) {
@@ -92,6 +104,38 @@ bool StreamingModel::load_model_() {
   this->loaded_ = true;
   this->reset_probabilities();
   return true;
+}
+
+size_t StreamingModel::probe_arena_size_() {
+  RAMAllocator<uint8_t> arena_allocator;
+
+  // Try with the manifest size first, then escalate to 2x if it fails
+  size_t attempt_sizes[] = {this->tensor_arena_size_, this->tensor_arena_size_ * 2};
+
+  for (size_t attempt_size : attempt_sizes) {
+    uint8_t *probe_arena = arena_allocator.allocate(attempt_size);
+    if (probe_arena == nullptr) {
+      continue;
+    }
+
+    auto probe_interpreter = make_unique<tflite::MicroInterpreter>(
+        tflite::GetModel(this->model_start_), this->streaming_op_resolver_, probe_arena, attempt_size, this->mrv_);
+
+    size_t needed = 0;
+    if (probe_interpreter->AllocateTensors() == kTfLiteOk) {
+      // Add 16 and then round to nearest 16 for a safe alignment
+      needed = (probe_interpreter->arena_used_bytes() + 16) & ~15;
+    }
+
+    probe_interpreter.reset();
+    arena_allocator.deallocate(probe_arena, attempt_size);
+
+    if (needed > 0) {
+      return needed;
+    }
+  }
+
+  return 0;
 }
 
 void StreamingModel::unload_model() {

--- a/esphome/components/micro_wake_word/streaming_model.cpp
+++ b/esphome/components/micro_wake_word/streaming_model.cpp
@@ -109,7 +109,9 @@ bool StreamingModel::load_model_() {
 size_t StreamingModel::probe_arena_size_() {
   RAMAllocator<uint8_t> arena_allocator;
 
-  // Try with the manifest size first, then escalate to 2x if it fails
+  // Try with the manifest size first, then escalate to 2x if it fails. Different platforms and different versions of
+  // the esp-nn library require different amounts of memory, so the manifest size may not always be correct, and probing
+  // allows us to find the actual required size for the current build and platform.
   size_t attempt_sizes[] = {this->tensor_arena_size_, this->tensor_arena_size_ * 2};
 
   for (size_t attempt_size : attempt_sizes) {
@@ -118,21 +120,49 @@ size_t StreamingModel::probe_arena_size_() {
       continue;
     }
 
+    // Verify the model works at all with this arena size
     auto probe_interpreter = make_unique<tflite::MicroInterpreter>(
         tflite::GetModel(this->model_start_), this->streaming_op_resolver_, probe_arena, attempt_size, this->mrv_);
 
-    size_t needed = 0;
-    if (probe_interpreter->AllocateTensors() == kTfLiteOk) {
-      // Add 16 and then round to nearest 16 for a safe alignment
-      needed = (probe_interpreter->arena_used_bytes() + 16) & ~15;
+    if (probe_interpreter->AllocateTensors() != kTfLiteOk) {
+      probe_interpreter.reset();
+      arena_allocator.deallocate(probe_arena, attempt_size);
+      this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+      this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+      continue;
     }
 
+    // Try to shrink the arena. Start with arena_used_bytes() + 16 (rounded to 16-byte alignment).
+    // If that works, use it. Otherwise, try midpoints between that and the full size until one succeeds.
+    size_t lower = (probe_interpreter->arena_used_bytes() + 16 + 15) & ~15;
     probe_interpreter.reset();
-    arena_allocator.deallocate(probe_arena, attempt_size);
+    this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+    this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
 
-    if (needed > 0) {
-      return needed;
+    size_t upper = attempt_size;
+
+    while (lower < upper) {
+      auto test_interpreter = make_unique<tflite::MicroInterpreter>(
+          tflite::GetModel(this->model_start_), this->streaming_op_resolver_, probe_arena, lower, this->mrv_);
+
+      bool ok = test_interpreter->AllocateTensors() == kTfLiteOk;
+
+      test_interpreter.reset();
+      this->ma_ = tflite::MicroAllocator::Create(this->var_arena_, STREAMING_MODEL_VARIABLE_ARENA_SIZE);
+      this->mrv_ = tflite::MicroResourceVariables::Create(this->ma_, 20);
+
+      if (ok) {
+        // Found a working size smaller than the full arena
+        upper = lower + 16;  // Pad by 16 bytes to be safe for future allocations
+        break;
+      }
+
+      // Try the midpoint between current attempt and full size
+      lower = ((lower + upper) / 2 + 15) & ~15;
     }
+
+    arena_allocator.deallocate(probe_arena, attempt_size);
+    return upper;
   }
 
   return 0;

--- a/esphome/components/micro_wake_word/streaming_model.h
+++ b/esphome/components/micro_wake_word/streaming_model.h
@@ -63,6 +63,10 @@ class StreamingModel {
   /// @brief Allocates tensor and variable arenas and sets up the model interpreter
   /// @return True if successful, false otherwise
   bool load_model_();
+  /// @brief Probes the actual required tensor arena size by trial allocation.
+  /// Tries the manifest size first, then 2x if that fails.
+  /// @return The required arena size rounded up to 16-byte alignment, or 0 on failure.
+  size_t probe_arena_size_();
   /// @brief Returns true if successfully registered the streaming model's TensorFlow operations
   bool register_streaming_ops_(tflite::MicroMutableOpResolver<20> &op_resolver);
 
@@ -70,6 +74,7 @@ class StreamingModel {
 
   bool loaded_{false};
   bool enabled_{true};
+  bool tensor_arena_size_probed_{false};
   bool unprocessed_probability_status_{false};
   uint8_t current_stride_step_{0};
   int16_t ignore_windows_{-MIN_SLICES_BEFORE_DETECTION};


### PR DESCRIPTION
# What does this implement/fix?

The esp-nn library ([Espressif Registry](https://components.espressif.com/components/espressif/esp-nn/versions/1.2.1/readme)) recently had a new version released. The esp-tflite-micro library micro_wake_word uses always pulls latest esp-nn version, so it was silently bumped. This new esp-nn version requires a larger tensor arena on an ESP32-S3, causing micro_wake_word to fail to start with recently built firmwares.

This PR pins esp-nn to 1.2.1 for future stability. Additionally, when a model is first loaded, mWW now probes to determine the best tensor arena size. It will first try the manifest's size. If it fails, it then doubles it and tries again (solving the too small arena size on an S3). Once its finds a working size, it uses the TFLite helper ``arena_used_bytes()`` (plus a 16 byte margin and then rounded to 16 bytes, following guidance from upstream TFLite Micro for handling potentially different memory alignments in future allocations) to get a lower bound of a working arena size. This value works on an ESP32-S3, but it is too small on an ESP32. So, the probe will keep trying until it finds a value that actually works by using the mid-point between the current lower bound and the known working upper bound (rounded to a 16 byte alignment). Once it finds a working value it adds a 16 byte safety margin in case a future allocation is aligned differently.

While this is an annoying extra complication, we do have some benefits: The new esp-nn version gives faster inference on an ESP32-S3 (7% faster on a VPE with 1 active wake word + VAD). On an ESP32, it now uses less memory than before (the manifest arena size was always measured on an S3 since it required more memory compared to an ESP32).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15603
- fixes https://github.com/esphome/issues/issues/7242

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

micro_wake_word:
  id: mww
  microphone:
    microphone: i2s_mics
    channels: 1
    gain_factor: 4
  stop_after_detection: false
  models:
    - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
      id: okay_nabu
    - model: hey_jarvis
      id: hey_jarvis
    - model: hey_mycroft
      id: hey_mycroft
    - model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
      id: stop
      internal: true
  vad:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
