### PR TITLE
[cc1101] Extract chip configuration into configure() method

### DIFF
--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -107,7 +107,7 @@ void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) { arg->enable_lo
 void CC1101Component::setup() {
   this->spi_setup();
 
-    if (this->gdo0_pin_ != nullptr) {
+  if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->setup();
   }
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -106,7 +106,6 @@ void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) { arg->enable_lo
 
 void CC1101Component::setup() {
   this->spi_setup();
-
   if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->setup();
   }

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -280,7 +280,7 @@ void CC1101Component::begin_rx() {
 }
 
 void CC1101Component::reset() {
-  ESP_LOGD(TAG, "Resetting CC1101");
+  this->strobe_(Command::RES);
   this->configure();
 }
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -106,14 +106,6 @@ void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) { arg->enable_lo
 
 void CC1101Component::setup() {
   this->spi_setup();
-  this->cs_->digital_write(true);
-  delayMicroseconds(1);
-  this->cs_->digital_write(false);
-  delayMicroseconds(1);
-  this->cs_->digital_write(true);
-  delayMicroseconds(41);
-  this->cs_->digital_write(false);
-  delay(5);
 
   if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->setup();
@@ -137,6 +129,16 @@ void CC1101Component::setup() {
 }
 
 void CC1101Component::configure() {
+  // Manual reset sequence per CC1101 datasheet section 19.1.2
+  this->cs_->digital_write(true);
+  delayMicroseconds(1);
+  this->cs_->digital_write(false);
+  delayMicroseconds(1);
+  this->cs_->digital_write(true);
+  delayMicroseconds(41);
+  this->cs_->digital_write(false);
+  delay(5);
+
   this->strobe_(Command::RES);
   delay(5);
 

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -115,6 +115,28 @@ void CC1101Component::setup() {
   this->cs_->digital_write(false);
   delay(5);
 
+  if (this->gdo0_pin_ != nullptr) {
+    this->gdo0_pin_->setup();
+  }
+
+  this->configure();
+  if (this->is_failed()) {
+    return;
+  }
+
+  // Defer pin mode setup until after all components have completed setup()
+  // This handles the case where remote_transmitter runs after CC1101 and changes pin mode
+  if (this->gdo0_pin_ != nullptr) {
+    this->defer([this]() {
+      this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT);
+      if (this->state_.PKT_FORMAT == static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
+        this->gdo0_pin_->attach_interrupt(&CC1101Component::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+      }
+    });
+  }
+}
+
+void CC1101Component::configure() {
   this->strobe_(Command::RES);
   delay(5);
 
@@ -128,11 +150,6 @@ void CC1101Component::setup() {
     return;
   }
 
-  // Setup GDO0 pin if configured
-  if (this->gdo0_pin_ != nullptr) {
-    this->gdo0_pin_->setup();
-  }
-
   this->initialized_ = true;
 
   for (uint8_t i = 0; i <= static_cast<uint8_t>(Register::TEST0); i++) {
@@ -142,20 +159,10 @@ void CC1101Component::setup() {
     this->write_(static_cast<Register>(i));
   }
   this->set_output_power(this->output_power_requested_);
+
   if (!this->enter_rx_()) {
     this->mark_failed();
     return;
-  }
-
-  // Defer pin mode setup until after all components have completed setup()
-  // This handles the case where remote_transmitter runs after CC1101 and changes pin mode
-  if (this->gdo0_pin_ != nullptr) {
-    this->defer([this]() {
-      this->gdo0_pin_->pin_mode(gpio::FLAG_INPUT);
-      if (this->state_.PKT_FORMAT == static_cast<uint8_t>(PacketFormat::PACKET_FORMAT_FIFO)) {
-        this->gdo0_pin_->attach_interrupt(&CC1101Component::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
-      }
-    });
   }
 }
 
@@ -272,8 +279,8 @@ void CC1101Component::begin_rx() {
 }
 
 void CC1101Component::reset() {
-  this->strobe_(Command::RES);
-  this->setup();
+  ESP_LOGD(TAG, "Resetting CC1101");
+  this->configure();
 }
 
 void CC1101Component::set_idle() {

--- a/esphome/components/cc1101/cc1101.cpp
+++ b/esphome/components/cc1101/cc1101.cpp
@@ -106,7 +106,8 @@ void IRAM_ATTR CC1101Component::gpio_intr(CC1101Component *arg) { arg->enable_lo
 
 void CC1101Component::setup() {
   this->spi_setup();
-  if (this->gdo0_pin_ != nullptr) {
+
+    if (this->gdo0_pin_ != nullptr) {
     this->gdo0_pin_->setup();
   }
 

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -26,6 +26,9 @@ class CC1101Component : public Component,
   void loop() override;
   void dump_config() override;
 
+  // Apply chip configuration: RES strobe, verify, write all registers, enter RX.
+  void configure();
+
   // Actions
   void begin_tx();
   void begin_rx();

--- a/esphome/components/cc1101/cc1101.h
+++ b/esphome/components/cc1101/cc1101.h
@@ -25,8 +25,6 @@ class CC1101Component : public Component,
   void setup() override;
   void loop() override;
   void dump_config() override;
-
-  // Apply chip configuration: RES strobe, verify, write all registers, enter RX.
   void configure();
 
   // Actions


### PR DESCRIPTION
# What does this implement/fix?

Pulls the chip-level configuration (RES strobe, version check, register writes, `set_output_power`, `enter_rx_`) out of `setup()` into a new public `configure()` method, mirroring the `sx127x` pattern.

`setup()` now does only one-shot SPI/GPIO init then delegates to `configure()`. `reset()` now calls `configure()` instead of `setup()`, which fixes a bug where `reset()` would re-run `spi_setup()`, redo the CS init dance, and schedule a second deferred `attach_interrupt()` on `gdo0_pin_` — double-registering the GDO0 ISR on every reset.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
cc1101:
  id: my_cc1101
  cs_pin: GPIO5
  gdo0_pin: GPIO4
  frequency: 433.92MHz

# Reset action no longer double-registers the GDO0 ISR
on_...:
  then:
    - cc1101.reset: my_cc1101
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).