### PR TITLE
[core] Instrument fast_select pre-sleep socket scan to prove it is unused

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -450,6 +450,18 @@ void Application::enable_pending_loops_() {
 }
 
 #ifdef USE_LWIP_FAST_SELECT
+std::atomic<uint32_t> Application::fast_select_scan_total_{0};
+std::atomic<uint32_t> Application::fast_select_scan_found_data_{0};
+std::atomic<uint32_t> Application::fast_select_scan_load_bearing_{0};
+
+void Application::log_fast_select_scan_stats_() {
+  uint32_t total = fast_select_scan_total_.load(std::memory_order_relaxed);
+  uint32_t found = fast_select_scan_found_data_.load(std::memory_order_relaxed);
+  uint32_t load_bearing = fast_select_scan_load_bearing_.load(std::memory_order_relaxed);
+  ESP_LOGD(TAG, "fast_select scan: total=%" PRIu32 " found_data=%" PRIu32 " load_bearing=%" PRIu32, total, found,
+           load_bearing);
+}
+
 bool Application::register_socket(struct lwip_sock *sock) {
   // It modifies monitored_sockets_ without locking — must only be called from the main loop.
   if (sock == nullptr)

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -462,6 +462,34 @@ void Application::log_fast_select_scan_stats_() {
            load_bearing);
 }
 
+void Application::note_fast_select_load_bearing_(struct lwip_sock *sock, uint32_t delay_ms) {
+  uint32_t load_bearing = fast_select_scan_load_bearing_.fetch_add(1, std::memory_order_relaxed) + 1;
+  // Find the socket's index in monitored_sockets_ for easier correlation with registration order.
+  int index = -1;
+  for (size_t i = 0; i < this->monitored_sockets_.size(); i++) {
+    if (this->monitored_sockets_[i] == sock) {
+      index = static_cast<int>(i);
+      break;
+    }
+  }
+  // Read the rcvevent value directly. This is the same offset-based read used by
+  // esphome_lwip_socket_has_data(); value > 0 means unread data is queued.
+  int16_t rcvevent =
+      *reinterpret_cast<volatile int16_t *>(reinterpret_cast<char *>(sock) + ESPHOME_LWIP_SOCK_RCVEVENT_OFFSET);
+  // Count how many other sockets also had data at this scan (could reveal whether it's always
+  // the same socket or a burst across multiple).
+  size_t sockets_with_data = 0;
+  for (struct lwip_sock *s : this->monitored_sockets_) {
+    if (esphome_lwip_socket_has_data(s))
+      sockets_with_data++;
+  }
+  ESP_LOGW(TAG,
+           "fast_select LOAD-BEARING hit #%" PRIu32 ": sock=%p idx=%d/%u rcvevent=%d delay_ms=%" PRIu32
+           " sockets_with_data=%u",
+           load_bearing, sock, index, static_cast<unsigned>(this->monitored_sockets_.size()), rcvevent, delay_ms,
+           static_cast<unsigned>(sockets_with_data));
+}
+
 bool Application::register_socket(struct lwip_sock *sock) {
   // It modifies monitored_sockets_ without locking — must only be called from the main loop.
   if (sock == nullptr)

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -453,17 +453,62 @@ void Application::enable_pending_loops_() {
 std::atomic<uint32_t> Application::fast_select_scan_total_{0};
 std::atomic<uint32_t> Application::fast_select_scan_found_data_{0};
 std::atomic<uint32_t> Application::fast_select_scan_load_bearing_{0};
+std::atomic<uint32_t> Application::fast_select_scan_load_bearing_race_{0};
+std::atomic<uint32_t> Application::fast_select_scan_load_bearing_micro_{0};
+std::atomic<uint32_t> Application::fast_select_scan_load_bearing_stall_{0};
 
 void Application::log_fast_select_scan_stats_() {
   uint32_t total = fast_select_scan_total_.load(std::memory_order_relaxed);
   uint32_t found = fast_select_scan_found_data_.load(std::memory_order_relaxed);
   uint32_t load_bearing = fast_select_scan_load_bearing_.load(std::memory_order_relaxed);
-  ESP_LOGD(TAG, "fast_select scan: total=%" PRIu32 " found_data=%" PRIu32 " load_bearing=%" PRIu32, total, found,
-           load_bearing);
+  uint32_t lb_race = fast_select_scan_load_bearing_race_.load(std::memory_order_relaxed);
+  uint32_t lb_micro = fast_select_scan_load_bearing_micro_.load(std::memory_order_relaxed);
+  uint32_t lb_stall = fast_select_scan_load_bearing_stall_.load(std::memory_order_relaxed);
+  ESP_LOGD(TAG,
+           "fast_select scan: total=%" PRIu32 " found_data=%" PRIu32 " load_bearing=%" PRIu32 " (race<10us=%" PRIu32
+           " micro<100us=%" PRIu32 " stall>100us=%" PRIu32 ")",
+           total, found, load_bearing, lb_race, lb_micro, lb_stall);
 }
 
 void Application::note_fast_select_load_bearing_(struct lwip_sock *sock, uint32_t delay_ms) {
   uint32_t load_bearing = fast_select_scan_load_bearing_.fetch_add(1, std::memory_order_relaxed) + 1;
+
+  // Spin-poll the task notification value for a short bounded window to measure how long
+  // the counterfactual ulTaskNotifyTake would actually have blocked. This distinguishes
+  // three cases:
+  //   race  (<10µs)   — notification arrived within ~10µs of scan start: callback-ordering
+  //                     race between the lwip event_callback writing rcvevent and calling
+  //                     xTaskNotifyGive a few instructions later. Scan is noise.
+  //   micro (<100µs)  — notification arrived within 100µs: still noise at loop_interval scale.
+  //   stall (≥100µs)  — notification did not arrive within our polling window. This is the
+  //                     only case where the scan could be rescuing a real latency spike.
+  // Cap the spin at 100µs so that if we're wrong and this IS a real stall, we only add
+  // 100µs of extra work to that one unlucky loop iteration.
+  uint32_t t_start = micros();
+  uint32_t gap_us = UINT32_MAX;
+  while (true) {
+    if (ulTaskNotifyValueClear(nullptr, 0) != 0) {
+      gap_us = micros() - t_start;
+      break;
+    }
+    uint32_t elapsed = micros() - t_start;
+    if (elapsed >= 100) {
+      break;
+    }
+  }
+
+  const char *bucket;
+  if (gap_us == UINT32_MAX) {
+    fast_select_scan_load_bearing_stall_.fetch_add(1, std::memory_order_relaxed);
+    bucket = "STALL";
+  } else if (gap_us < 10) {
+    fast_select_scan_load_bearing_race_.fetch_add(1, std::memory_order_relaxed);
+    bucket = "race";
+  } else {
+    fast_select_scan_load_bearing_micro_.fetch_add(1, std::memory_order_relaxed);
+    bucket = "micro";
+  }
+
   // Find the socket's index in monitored_sockets_ for easier correlation with registration order.
   int index = -1;
   for (size_t i = 0; i < this->monitored_sockets_.size(); i++) {
@@ -483,11 +528,19 @@ void Application::note_fast_select_load_bearing_(struct lwip_sock *sock, uint32_
     if (esphome_lwip_socket_has_data(s))
       sockets_with_data++;
   }
-  ESP_LOGW(TAG,
-           "fast_select LOAD-BEARING hit #%" PRIu32 ": sock=%p idx=%d/%u rcvevent=%d delay_ms=%" PRIu32
-           " sockets_with_data=%u",
-           load_bearing, sock, index, static_cast<unsigned>(this->monitored_sockets_.size()), rcvevent, delay_ms,
-           static_cast<unsigned>(sockets_with_data));
+  if (gap_us == UINT32_MAX) {
+    ESP_LOGW(TAG,
+             "fast_select LOAD-BEARING #%" PRIu32 " [%s]: sock=%p idx=%d/%u rcvevent=%d delay_ms=%" PRIu32
+             " sockets_with_data=%u gap_us=>100",
+             load_bearing, bucket, sock, index, static_cast<unsigned>(this->monitored_sockets_.size()), rcvevent,
+             delay_ms, static_cast<unsigned>(sockets_with_data));
+  } else {
+    ESP_LOGW(TAG,
+             "fast_select LOAD-BEARING #%" PRIu32 " [%s]: sock=%p idx=%d/%u rcvevent=%d delay_ms=%" PRIu32
+             " sockets_with_data=%u gap_us=%" PRIu32,
+             load_bearing, bucket, sock, index, static_cast<unsigned>(this->monitored_sockets_.size()), rcvevent,
+             delay_ms, static_cast<unsigned>(sockets_with_data), gap_us);
+  }
 }
 
 bool Application::register_socket(struct lwip_sock *sock) {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -933,7 +933,14 @@ inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay
   // current value and clears zero bits, leaving the notification state untouched. Reading
   // before the loop (rather than after finding data) makes the answer TOCTOU-free: the
   // value we compare against is the value at the moment Take would have been called.
+  // LibreTiny's FreeRTOS port predates ulTaskNotifyValueClear (added in FreeRTOS 10.4.0),
+  // so we fall back to a pessimistic 0, which makes load_bearing an upper bound == found_data
+  // on that platform. Zero there is still a valid proof that the scan is unused.
+#ifdef USE_ESP32
   uint32_t fast_select_notify_value_before_scan = ulTaskNotifyValueClear(nullptr, 0);
+#else
+  uint32_t fast_select_notify_value_before_scan = 0;
+#endif
   fast_select_scan_total_.fetch_add(1, std::memory_order_relaxed);
   for (struct lwip_sock *sock : this->monitored_sockets_) {
     if (esphome_lwip_socket_has_data(sock)) {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <ctime>
 #include <limits>
 #include <span>
@@ -655,6 +656,14 @@ class Application {
   FixedVector<Component *> looping_components_{};
 #ifdef USE_LWIP_FAST_SELECT
   std::vector<struct lwip_sock *> monitored_sockets_;  // Cached lwip_sock pointers for direct rcvevent read
+  // Stats to verify whether the pre-sleep socket scan in yield_with_select_() is ever load-bearing.
+  // If fast_select_scan_load_bearing_ stays 0 under real workloads, the scan can be removed.
+  // These are static because yield_with_select_() is inlined at every call site.
+  static std::atomic<uint32_t> fast_select_scan_total_;
+  static std::atomic<uint32_t> fast_select_scan_found_data_;
+  static std::atomic<uint32_t> fast_select_scan_load_bearing_;
+  uint32_t fast_select_scan_stats_last_log_{0};
+  void log_fast_select_scan_stats_();
 #elif defined(USE_HOST)
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
 #endif
@@ -889,6 +898,14 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   this->yield_with_select_(delay_time);
   this->last_loop_ = last_op_end_time;
 
+#ifdef USE_LWIP_FAST_SELECT
+  // Periodic fast-select scan stats (debug). Remove once the scan is proven unneeded.
+  if (last_op_end_time - this->fast_select_scan_stats_last_log_ >= 30000) {
+    this->fast_select_scan_stats_last_log_ = last_op_end_time;
+    this->log_fast_select_scan_stats_();
+  }
+#endif
+
   if (this->dump_config_at_ < this->components_.size()) {
     this->process_dump_config_();
   }
@@ -909,8 +926,22 @@ inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay
   // If a socket still has unread data (rcvevent > 0) but the task notification was already
   // consumed, ulTaskNotifyTake would block until timeout — adding up to delay_ms latency.
   // This scan preserves select() semantics: return immediately when any fd is ready.
+  //
+  // Debug stats: peek the task notification value BEFORE scanning. This answers the
+  // counterfactual "if the scan did not exist and we called ulTaskNotifyTake right now,
+  // would it stall?". ulTaskNotifyValueClear(nullptr, 0) is a pure read — it returns the
+  // current value and clears zero bits, leaving the notification state untouched. Reading
+  // before the loop (rather than after finding data) makes the answer TOCTOU-free: the
+  // value we compare against is the value at the moment Take would have been called.
+  uint32_t fast_select_notify_value_before_scan = ulTaskNotifyValueClear(nullptr, 0);
+  fast_select_scan_total_.fetch_add(1, std::memory_order_relaxed);
   for (struct lwip_sock *sock : this->monitored_sockets_) {
     if (esphome_lwip_socket_has_data(sock)) {
+      fast_select_scan_found_data_.fetch_add(1, std::memory_order_relaxed);
+      if (fast_select_notify_value_before_scan == 0) {
+        // Scan was load-bearing: no notification pending, so Take would have stalled.
+        fast_select_scan_load_bearing_.fetch_add(1, std::memory_order_relaxed);
+      }
       yield();
       return;
     }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -664,6 +664,8 @@ class Application {
   static std::atomic<uint32_t> fast_select_scan_load_bearing_;
   uint32_t fast_select_scan_stats_last_log_{0};
   void log_fast_select_scan_stats_();
+  // Non-inline, called only on the rare load-bearing event so the hot path stays unchanged.
+  void note_fast_select_load_bearing_(struct lwip_sock *sock, uint32_t delay_ms);
 #elif defined(USE_HOST)
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
 #endif
@@ -947,7 +949,8 @@ inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay
       fast_select_scan_found_data_.fetch_add(1, std::memory_order_relaxed);
       if (fast_select_notify_value_before_scan == 0) {
         // Scan was load-bearing: no notification pending, so Take would have stalled.
-        fast_select_scan_load_bearing_.fetch_add(1, std::memory_order_relaxed);
+        // Delegate to a non-inline helper so the hot path stays the same size.
+        this->note_fast_select_load_bearing_(sock, delay_ms);
       }
       yield();
       return;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -661,7 +661,16 @@ class Application {
   // These are static because yield_with_select_() is inlined at every call site.
   static std::atomic<uint32_t> fast_select_scan_total_;
   static std::atomic<uint32_t> fast_select_scan_found_data_;
+  // Umbrella counter: pre-scan notify peek was 0 and scan found data.
+  // Broken down into three buckets based on the post-scan spin-poll result:
+  //   _race_  — notify arrived in < 10µs   (callback-ordering race, scan is noise)
+  //   _micro_ — notify arrived in 10..100µs (still noise at loop_interval scale)
+  //   _stall_ — notify did not arrive within 100µs (the only case that could be a real stall)
+  // If _stall_ stays 0, the scan is provably irrelevant under this workload.
   static std::atomic<uint32_t> fast_select_scan_load_bearing_;
+  static std::atomic<uint32_t> fast_select_scan_load_bearing_race_;
+  static std::atomic<uint32_t> fast_select_scan_load_bearing_micro_;
+  static std::atomic<uint32_t> fast_select_scan_load_bearing_stall_;
   uint32_t fast_select_scan_stats_last_log_{0};
   void log_fast_select_scan_stats_();
   // Non-inline, called only on the rare load-bearing event so the hot path stays unchanged.


### PR DESCRIPTION
# What does this implement/fix?

**This PR is a test/instrumentation PR. Not intended for merge.** It gathers real-device evidence about whether the pre-sleep socket scan in `Application::yield_with_select_()` is actually load-bearing under the post-#15590 socket `ready()` contract. The follow-up PR (#15639, re-landing #14475) cites this PR as the source of evidence.

## Background

- **Origin of the scan**: #14249 added it based on a GitHub Copilot suggestion, to "preserve select() semantics" by checking for pending socket data before sleeping.
- **Original problem (pre-#15590)**: The API connection's `MAX_MESSAGES_PER_LOOP=5` throttle could stop reading while data was still queued. If that happened **and** no further packet arrived on any monitored socket in the same window, `ulTaskNotifyTake` would stall up to `loop_interval` ms before waking to process the stranded data. The pre-sleep scan was the safety net. In practice the "no further packet" half of that race is rare outside of test harnesses that send a fixed burst and then fall silent, but it was reproducible enough that #14475's minimal testing concluded the scan was load-bearing.
- **#14475**: Attempted to remove the scan. **Never merged.** During review, minimal testing showed what looked like load-bearing hits on the scan, and those hits were accepted at face value as proof that removing the scan was unsafe. The PR was closed with the comment *"but there is another race so we do need it"*. The underlying cause was the same class of `Socket::ready()` contract violation that produced #15589, but without bucketed `micros()`-resolution instrumentation there was no way to distinguish "real stall" from "instruction-level race between `rcvevent` write and `xTaskNotifyGive`".
- **#15590**: Documented and enforced the `ready()` contract ("drain to EWOULDBLOCK or track early-exit and retry without re-calling `ready()`").

With #15590 in place, the original justification for the scan is gone — every `rcvevent > 0` should have a matching pending notification. This PR adds instrumentation to prove or disprove that under real workloads, and specifically to rule out any "other race" that motivated the #14475 self-close.

## Instrumentation

Five atomic counters plus an immediate `ESP_LOGW` on each load-bearing hit:

| Counter | Meaning |
| --- | --- |
| `fast_select_scan_total_` | Every scan call. |
| `fast_select_scan_found_data_` | Scan saw `rcvevent > 0` on some socket. |
| `fast_select_scan_load_bearing_` | Umbrella: `found_data` AND pre-scan peek of the task notification counter was 0. |
| `..._load_bearing_race_` | Sub-bucket: notification arrived within 10µs of scan start. |
| `..._load_bearing_micro_` | Sub-bucket: notification arrived within 100µs. |
| `..._load_bearing_stall_` | Sub-bucket: notification did **not** arrive within 100µs. |

### Why peek before the scan

`ulTaskNotifyValueClear(nullptr, 0)` is a pure read (zero bits cleared, state untouched). Reading it **before** the scan loop makes the `load_bearing` measurement TOCTOU-free: the value we compare against is the value at the moment `Take` would have been called in the no-scan counterfactual.

### Why the race/micro/stall buckets

The pre-scan peek alone isn't sufficient — it answers "was a notify pending at scan start?" but not "would `Take` actually have stalled?". If the lwip callback writes `rcvevent` a few instructions before calling `xTaskNotifyGive`, a scan that inspects the socket in that window sees data with no pending notify — but Take would have woken a microsecond later when the notify completed. A real stall ("scan rescues a real latency spike") only exists if the notification doesn't arrive for a long time.

After a `load_bearing` hit, we spin-poll the notification value (bounded to 100µs) with `micros()` resolution and measure the actual "time until notify would have arrived". Bucket by gap:
- `race` (<10µs) = instruction-level ordering between `rcvevent` write and `xTaskNotifyGive`. Scan is noise.
- `micro` (10–100µs) = still noise at `loop_interval` scale (16ms).
- `stall` (≥100µs) = the only case that could represent a real rescue.

The 100µs spin cap is intentional: if we're wrong and it IS a real stall, we've only added 100µs to that one unlucky loop iteration.

### LibreTiny

LibreTiny's FreeRTOS port predates `ulTaskNotifyValueClear` (added in FreeRTOS 10.4.0). On non-ESP32 platforms the peek is replaced with a pessimistic `0`, making `load_bearing` an upper bound equal to `found_data`. Zero there is still valid proof.

## Results

Tested across 5 devices, with Home Assistant disconnect/reconnect cycles, multi-client API logger attachments (up to 3 simultaneous), BLE GATT connect/service-discovery/write/disconnect storms (including "no free connections" bursts), over several minutes on each device.

**Fleet total: ~275,000+ scans, 5 load-bearing hits, 0 stall hits.**

| Device | Chip | Transport | Scans | found_data | race | micro | **stall** |
|---|---|---|---|---|---|---|---|
| upstairsdesk89proxy | ESP32 (Ethernet) | Eth | 44k+ | 4 | 0 | 0 | **0** |
| rackgli89proxy | ESP32 rev1 | Eth | 68k+ | 10 | 0 | 2 | **0** |
| livingroomgli89proxy | ESP32 (Ethernet) | Eth | 34k+ | 1 | 0 | 0 | **0** |
| laundry89proxy | ESP32 rev3.1 | Eth | 141k+ | 18 | 2 | 1 | **0** |
| athom-co2-sensor | ESP32-C3 | WiFi | 14k+ | 0 | 0 | 0 | **0** |
| bw15-device | RTL8720CF | WiFi | 10k+ | 0 | 0 | 0 | **0** |

### Hit details

```
rackgli89proxy  #1 [micro]: sock=0x3ffc442c idx=6/8 rcvevent=1 delay_ms=10 sockets_with_data=1 gap_us=14
rackgli89proxy  #2 [micro]: sock=0x3ffc442c idx=6/7 rcvevent=1 delay_ms=2  sockets_with_data=1 gap_us=13
laundry89proxy  #1 [race] : sock=0x3ffc42fc idx=1/3 rcvevent=1 delay_ms=11 sockets_with_data=1 gap_us=2
laundry89proxy  #2 [race] : sock=0x3ffc4324 idx=3/4 rcvevent=1 delay_ms=6  sockets_with_data=1 gap_us=5
laundry89proxy  #3 [micro]: sock=0x3ffc4310 idx=2/4 rcvevent=2 delay_ms=4  sockets_with_data=1 gap_us=10
```

Every single hit:
- Was on a **single** socket (`sockets_with_data=1`).
- Had `rcvevent` of 1 or 2 (a single unread recv event, not a burst).
- Measured `gap_us` between 2 and 14 — well inside both the `race` and `micro` buckets.
- Occurred during HA disconnect/reconnect or BLE connect bursts, i.e. when the lwip event callback is firing most frequently.

### Interpretation

- `race` (<10µs) hits are the instruction-level window between the lwip callback writing `rcvevent` and calling `xTaskNotifyGive` a few instructions later.
- `micro` (<100µs) hits are the same phenomenon, slightly amplified by CPU cache effects.
- **Zero `stall` hits.** In the no-scan counterfactual, `ulTaskNotifyTake` would have stalled for between 2 and 14 microseconds on the worst observed hit, then woken immediately. That is not a stall at `loop_interval` scale (16ms); it's a few instruction fetches.

## Why the scan is actively harmful

The scan does a `volatile int16_t` read into each entry of `monitored_sockets_` on every single `yield_with_select_` call (every main-loop iteration). On Xtensa, volatile loads across cache-cold cross-thread memory effectively become `L16SI` + memory-barrier fences. At typical 5000+ loops/sec with 5-10 sockets, that's tens of thousands of fence-gated cold reads per second, all to reproduce a 2-15µs instruction-gap artifact the notification path is already handling authoritatively.

Removing the scan makes `yield_with_select_` strictly: *"if delay==0 yield; otherwise `ulTaskNotifyTake(pdTRUE, delay_ms)`"*. Single source of truth.

## Conclusion

The scan was useful pre-#15590 because the API throttle left sockets undrained, and that genuinely caused `Take` to miss data. Post-#15590 it no longer is: every `rcvevent > 0` is accompanied by a pending (or about-to-be-pending) notification, and the instrumentation bucket `stall>100µs` — the only case where the scan could be providing real value — stayed at 0 across ~275k scans on 5 devices under workloads specifically chosen to stress the failure modes.

**Next step: a follow-up PR (#15639) re-lands #14475 (removes the scan) and cites this PR as the evidence base.**

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15589 / #15590
- Instrumentation backing the re-land in #15639
- Origin of the scan: #14249

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (investigation PR, will not merge)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes. Enable debug logs to observe stats on ESP32/LibreTiny:
logger:
  level: DEBUG
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
