### PR TITLE
[core] Remove pre-sleep socket scan from fast select path

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -15,33 +15,28 @@ BSDSocketImpl::BSDSocketImpl(int fd, bool monitor_loop) {
     return;
 #ifdef USE_LWIP_FAST_SELECT
   this->cached_sock_ = fast_select_hook_fd(this->fd_);
-  this->loop_monitored_ = this->cached_sock_ != nullptr;
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif
 }
 
-BSDSocketImpl::~BSDSocketImpl() {
-  if (!this->closed_) {
-    this->close();
-  }
-}
+BSDSocketImpl::~BSDSocketImpl() { this->close(); }
 
 int BSDSocketImpl::close() {
-  if (!this->closed_) {
-#ifndef USE_LWIP_FAST_SELECT
-    // All LwIP sockets share the same static event_callback, so on the fast-select path
-    // there is no per-socket unhook needed. cached_sock_ is not cleared because closed_
-    // makes the socket a corpse — no ready() or other member access is valid afterwards.
-    if (this->loop_monitored_) {
-      App.unregister_socket_fd(this->fd_);
-    }
-#endif
-    int ret = ::close(this->fd_);
-    this->closed_ = true;
-    return ret;
+  if (this->fd_ < 0) {
+    // Already closed, or never opened.
+    return 0;
   }
-  return 0;
+#ifndef USE_LWIP_FAST_SELECT
+  // On the fast-select path there is no per-socket unhook needed — all LwIP sockets
+  // share the same static event_callback.
+  if (this->loop_monitored_) {
+    App.unregister_socket_fd(this->fd_);
+  }
+#endif
+  int ret = ::close(this->fd_);
+  this->fd_ = -1;  // Sentinel for "closed" — prevents double-close and makes use-after-close visible.
+  return ret;
 }
 
 int BSDSocketImpl::setblocking(bool blocking) {

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -34,11 +34,10 @@ BSDSocketImpl::~BSDSocketImpl() {
 
 int BSDSocketImpl::close() {
   if (!this->closed_) {
-#ifdef USE_LWIP_FAST_SELECT
-    // All LwIP sockets share the same static event_callback, so there is no per-socket
-    // unhook needed — just drop the cached pointer before the socket is destroyed.
-    this->cached_sock_ = nullptr;
-#else
+#ifndef USE_LWIP_FAST_SELECT
+    // All LwIP sockets share the same static event_callback, so on the fast-select path
+    // there is no per-socket unhook needed. cached_sock_ is not cleared because closed_
+    // makes the socket a corpse — no ready() or other member access is valid afterwards.
     if (this->loop_monitored_) {
       App.unregister_socket_fd(this->fd_);
     }

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -27,9 +27,14 @@ int BSDSocketImpl::close() {
     // Already closed, or never opened.
     return 0;
   }
-#ifndef USE_LWIP_FAST_SELECT
-  // On the fast-select path there is no per-socket unhook needed — all LwIP sockets
-  // share the same static event_callback.
+#ifdef USE_LWIP_FAST_SELECT
+  // Null the cached lwip_sock pointer before closing. The underlying lwip slot can be
+  // recycled for a new connection as soon as ::close() returns, so anything that might
+  // dereference cached_sock_ post-close (e.g. setsockopt(TCP_NODELAY)) would otherwise
+  // touch an unrelated socket's pcb. No per-socket callback unhook is needed —
+  // all LwIP sockets share the same static event_callback.
+  this->cached_sock_ = nullptr;
+#else
   if (this->loop_monitored_) {
     App.unregister_socket_fd(this->fd_);
   }

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -14,9 +14,13 @@ BSDSocketImpl::BSDSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  // Cache lwip_sock pointer and register for monitoring (hooks callback internally)
+  // Cache lwip_sock pointer (used by ready() for direct rcvevent reads) and hook the
+  // netconn event callback so the main loop is notified via FreeRTOS task notifications.
   this->cached_sock_ = esphome_lwip_get_sock(this->fd_);
-  this->loop_monitored_ = App.register_socket(this->cached_sock_);
+  if (this->cached_sock_ != nullptr) {
+    esphome_lwip_hook_socket(this->cached_sock_);
+    this->loop_monitored_ = true;
+  }
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif
@@ -30,12 +34,10 @@ BSDSocketImpl::~BSDSocketImpl() {
 
 int BSDSocketImpl::close() {
   if (!this->closed_) {
-    // Unregister before closing to avoid dangling pointer in monitored set
 #ifdef USE_LWIP_FAST_SELECT
-    if (this->loop_monitored_) {
-      App.unregister_socket(this->cached_sock_);
-      this->cached_sock_ = nullptr;
-    }
+    // All LwIP sockets share the same static event_callback, so there is no per-socket
+    // unhook needed — just drop the cached pointer before the socket is destroyed.
+    this->cached_sock_ = nullptr;
 #else
     if (this->loop_monitored_) {
       App.unregister_socket_fd(this->fd_);

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -14,13 +14,8 @@ BSDSocketImpl::BSDSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  // Cache lwip_sock pointer (used by ready() for direct rcvevent reads) and hook the
-  // netconn event callback so the main loop is notified via FreeRTOS task notifications.
-  this->cached_sock_ = esphome_lwip_get_sock(this->fd_);
-  if (this->cached_sock_ != nullptr) {
-    esphome_lwip_hook_socket(this->cached_sock_);
-    this->loop_monitored_ = true;
-  }
+  this->cached_sock_ = fast_select_hook_fd(this->fd_);
+  this->loop_monitored_ = this->cached_sock_ != nullptr;
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif

--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -14,7 +14,7 @@ BSDSocketImpl::BSDSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  this->cached_sock_ = fast_select_hook_fd(this->fd_);
+  this->cached_sock_ = hook_fd_for_fast_select(this->fd_);
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif

--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -119,12 +119,17 @@ class BSDSocketImpl {
   int get_fd() const { return this->fd_; }
 
  protected:
+  // fd_ < 0 means "not open" — used both pre-open (initial state) and post-close. This
+  // replaces a separate closed_ flag: close() sets fd_ = -1 after ::close(), and the
+  // destructor / double-close path just check fd_ < 0.
   int fd_{-1};
 #ifdef USE_LWIP_FAST_SELECT
+  // Non-null iff this socket is being monitored for read events. Replaces loop_monitored_
+  // on the fast-select path: the pointer itself carries the "monitored" bit.
   struct lwip_sock *cached_sock_{nullptr};  // Cached for direct rcvevent read in ready()
-#endif
-  bool closed_{false};
+#else
   bool loop_monitored_{false};
+#endif
 };
 
 }  // namespace esphome::socket

--- a/esphome/components/socket/bsd_sockets_impl.h
+++ b/esphome/components/socket/bsd_sockets_impl.h
@@ -124,9 +124,13 @@ class BSDSocketImpl {
   // destructor / double-close path just check fd_ < 0.
   int fd_{-1};
 #ifdef USE_LWIP_FAST_SELECT
-  // Non-null iff this socket is being monitored for read events. Replaces loop_monitored_
-  // on the fast-select path: the pointer itself carries the "monitored" bit.
-  struct lwip_sock *cached_sock_{nullptr};  // Cached for direct rcvevent read in ready()
+  // Cached lwip_sock pointer used for direct rcvevent reads in ready() on the
+  // fast-select path. Replaces loop_monitored_: null means this socket is not being
+  // monitored for read events — either monitoring was not requested, the fd was
+  // invalid, or esphome_lwip_get_sock() failed. Non-null means the netconn event
+  // callback was hooked and notifications are flowing. close() nulls this to prevent
+  // use-after-free via a recycled lwip slot.
+  struct lwip_sock *cached_sock_{nullptr};
 #else
   bool loop_monitored_{false};
 #endif

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -15,33 +15,28 @@ LwIPSocketImpl::LwIPSocketImpl(int fd, bool monitor_loop) {
     return;
 #ifdef USE_LWIP_FAST_SELECT
   this->cached_sock_ = fast_select_hook_fd(this->fd_);
-  this->loop_monitored_ = this->cached_sock_ != nullptr;
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif
 }
 
-LwIPSocketImpl::~LwIPSocketImpl() {
-  if (!this->closed_) {
-    this->close();
-  }
-}
+LwIPSocketImpl::~LwIPSocketImpl() { this->close(); }
 
 int LwIPSocketImpl::close() {
-  if (!this->closed_) {
-#ifndef USE_LWIP_FAST_SELECT
-    // All LwIP sockets share the same static event_callback, so on the fast-select path
-    // there is no per-socket unhook needed. cached_sock_ is not cleared because closed_
-    // makes the socket a corpse — no ready() or other member access is valid afterwards.
-    if (this->loop_monitored_) {
-      App.unregister_socket_fd(this->fd_);
-    }
-#endif
-    int ret = lwip_close(this->fd_);
-    this->closed_ = true;
-    return ret;
+  if (this->fd_ < 0) {
+    // Already closed, or never opened.
+    return 0;
   }
-  return 0;
+#ifndef USE_LWIP_FAST_SELECT
+  // On the fast-select path there is no per-socket unhook needed — all LwIP sockets
+  // share the same static event_callback.
+  if (this->loop_monitored_) {
+    App.unregister_socket_fd(this->fd_);
+  }
+#endif
+  int ret = lwip_close(this->fd_);
+  this->fd_ = -1;  // Sentinel for "closed" — prevents double-close and makes use-after-close visible.
+  return ret;
 }
 
 int LwIPSocketImpl::setblocking(bool blocking) {

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -34,11 +34,10 @@ LwIPSocketImpl::~LwIPSocketImpl() {
 
 int LwIPSocketImpl::close() {
   if (!this->closed_) {
-#ifdef USE_LWIP_FAST_SELECT
-    // All LwIP sockets share the same static event_callback, so there is no per-socket
-    // unhook needed — just drop the cached pointer before the socket is destroyed.
-    this->cached_sock_ = nullptr;
-#else
+#ifndef USE_LWIP_FAST_SELECT
+    // All LwIP sockets share the same static event_callback, so on the fast-select path
+    // there is no per-socket unhook needed. cached_sock_ is not cleared because closed_
+    // makes the socket a corpse — no ready() or other member access is valid afterwards.
     if (this->loop_monitored_) {
       App.unregister_socket_fd(this->fd_);
     }

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -14,7 +14,7 @@ LwIPSocketImpl::LwIPSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  this->cached_sock_ = fast_select_hook_fd(this->fd_);
+  this->cached_sock_ = hook_fd_for_fast_select(this->fd_);
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -14,13 +14,8 @@ LwIPSocketImpl::LwIPSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  // Cache lwip_sock pointer (used by ready() for direct rcvevent reads) and hook the
-  // netconn event callback so the main loop is notified via FreeRTOS task notifications.
-  this->cached_sock_ = esphome_lwip_get_sock(this->fd_);
-  if (this->cached_sock_ != nullptr) {
-    esphome_lwip_hook_socket(this->cached_sock_);
-    this->loop_monitored_ = true;
-  }
+  this->cached_sock_ = fast_select_hook_fd(this->fd_);
+  this->loop_monitored_ = this->cached_sock_ != nullptr;
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -27,9 +27,14 @@ int LwIPSocketImpl::close() {
     // Already closed, or never opened.
     return 0;
   }
-#ifndef USE_LWIP_FAST_SELECT
-  // On the fast-select path there is no per-socket unhook needed — all LwIP sockets
-  // share the same static event_callback.
+#ifdef USE_LWIP_FAST_SELECT
+  // Null the cached lwip_sock pointer before closing. The underlying lwip slot can be
+  // recycled for a new connection as soon as lwip_close() returns, so anything that
+  // might dereference cached_sock_ post-close (e.g. setsockopt(TCP_NODELAY)) would
+  // otherwise touch an unrelated socket's pcb. No per-socket callback unhook is needed —
+  // all LwIP sockets share the same static event_callback.
+  this->cached_sock_ = nullptr;
+#else
   if (this->loop_monitored_) {
     App.unregister_socket_fd(this->fd_);
   }

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -14,9 +14,13 @@ LwIPSocketImpl::LwIPSocketImpl(int fd, bool monitor_loop) {
   if (!monitor_loop || this->fd_ < 0)
     return;
 #ifdef USE_LWIP_FAST_SELECT
-  // Cache lwip_sock pointer and register for monitoring (hooks callback internally)
+  // Cache lwip_sock pointer (used by ready() for direct rcvevent reads) and hook the
+  // netconn event callback so the main loop is notified via FreeRTOS task notifications.
   this->cached_sock_ = esphome_lwip_get_sock(this->fd_);
-  this->loop_monitored_ = App.register_socket(this->cached_sock_);
+  if (this->cached_sock_ != nullptr) {
+    esphome_lwip_hook_socket(this->cached_sock_);
+    this->loop_monitored_ = true;
+  }
 #else
   this->loop_monitored_ = App.register_socket_fd(this->fd_);
 #endif
@@ -30,12 +34,10 @@ LwIPSocketImpl::~LwIPSocketImpl() {
 
 int LwIPSocketImpl::close() {
   if (!this->closed_) {
-    // Unregister before closing to avoid dangling pointer in monitored set
 #ifdef USE_LWIP_FAST_SELECT
-    if (this->loop_monitored_) {
-      App.unregister_socket(this->cached_sock_);
-      this->cached_sock_ = nullptr;
-    }
+    // All LwIP sockets share the same static event_callback, so there is no per-socket
+    // unhook needed — just drop the cached pointer before the socket is destroyed.
+    this->cached_sock_ = nullptr;
 #else
     if (this->loop_monitored_) {
       App.unregister_socket_fd(this->fd_);

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -85,12 +85,17 @@ class LwIPSocketImpl {
   int get_fd() const { return this->fd_; }
 
  protected:
+  // fd_ < 0 means "not open" — used both pre-open (initial state) and post-close. This
+  // replaces a separate closed_ flag: close() sets fd_ = -1 after lwip_close(), and the
+  // destructor / double-close path just check fd_ < 0.
   int fd_{-1};
 #ifdef USE_LWIP_FAST_SELECT
+  // Non-null iff this socket is being monitored for read events. Replaces loop_monitored_
+  // on the fast-select path: the pointer itself carries the "monitored" bit.
   struct lwip_sock *cached_sock_{nullptr};  // Cached for direct rcvevent read in ready()
-#endif
-  bool closed_{false};
+#else
   bool loop_monitored_{false};
+#endif
 };
 
 }  // namespace esphome::socket

--- a/esphome/components/socket/lwip_sockets_impl.h
+++ b/esphome/components/socket/lwip_sockets_impl.h
@@ -90,9 +90,13 @@ class LwIPSocketImpl {
   // destructor / double-close path just check fd_ < 0.
   int fd_{-1};
 #ifdef USE_LWIP_FAST_SELECT
-  // Non-null iff this socket is being monitored for read events. Replaces loop_monitored_
-  // on the fast-select path: the pointer itself carries the "monitored" bit.
-  struct lwip_sock *cached_sock_{nullptr};  // Cached for direct rcvevent read in ready()
+  // Cached lwip_sock pointer used for direct rcvevent reads in ready() on the
+  // fast-select path. Replaces loop_monitored_: null means this socket is not being
+  // monitored for read events — either monitoring was not requested, the fd was
+  // invalid, or esphome_lwip_get_sock() failed. Non-null means the netconn event
+  // callback was hooked and notifications are flowing. close() nulls this to prevent
+  // use-after-free via a recycled lwip slot.
+  struct lwip_sock *cached_sock_{nullptr};
 #else
   bool loop_monitored_{false};
 #endif

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -42,8 +42,11 @@ using ListenSocket = LWIPRawListenImpl;
 
 #ifdef USE_LWIP_FAST_SELECT
 /// Shared ready() helper using cached lwip_sock pointer for direct rcvevent read.
-inline bool socket_ready(struct lwip_sock *cached_sock, bool loop_monitored) {
-  return !loop_monitored || (cached_sock != nullptr && esphome_lwip_socket_has_data(cached_sock));
+/// cached_sock == nullptr means the socket is not monitored (monitor_loop was false, fd
+/// was invalid, or esphome_lwip_get_sock() failed) — in that case return true so the
+/// caller attempts the read and handles blocking itself.
+inline bool socket_ready(struct lwip_sock *cached_sock) {
+  return cached_sock == nullptr || esphome_lwip_socket_has_data(cached_sock);
 }
 
 /// Resolve an fd to its lwip_sock and hook the netconn event callback so the main loop
@@ -80,7 +83,7 @@ bool socket_ready_fd(int fd, bool loop_monitored);
 #if defined(USE_SOCKET_IMPL_BSD_SOCKETS) || defined(USE_SOCKET_IMPL_LWIP_SOCKETS)
 inline bool Socket::ready() const {
 #ifdef USE_LWIP_FAST_SELECT
-  return socket_ready(this->cached_sock_, this->loop_monitored_);
+  return socket_ready(this->cached_sock_);
 #else
   return socket_ready_fd(this->fd_, this->loop_monitored_);
 #endif

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -45,6 +45,17 @@ using ListenSocket = LWIPRawListenImpl;
 inline bool socket_ready(struct lwip_sock *cached_sock, bool loop_monitored) {
   return !loop_monitored || (cached_sock != nullptr && esphome_lwip_socket_has_data(cached_sock));
 }
+
+/// Resolve an fd to its lwip_sock and hook the netconn event callback so the main loop
+/// is woken by FreeRTOS task notifications. Shared between BSD and LwIP socket impls.
+/// Returns the cached lwip_sock pointer (or nullptr if fd is invalid).
+inline struct lwip_sock *fast_select_hook_fd(int fd) {
+  struct lwip_sock *sock = esphome_lwip_get_sock(fd);
+  if (sock != nullptr) {
+    esphome_lwip_hook_socket(sock);
+  }
+  return sock;
+}
 #elif defined(USE_HOST)
 /// Shared ready() helper for fd-based socket implementations.
 /// Checks if the Application's select() loop has marked this fd as ready.

--- a/esphome/components/socket/socket.h
+++ b/esphome/components/socket/socket.h
@@ -49,10 +49,11 @@ inline bool socket_ready(struct lwip_sock *cached_sock) {
   return cached_sock == nullptr || esphome_lwip_socket_has_data(cached_sock);
 }
 
-/// Resolve an fd to its lwip_sock and hook the netconn event callback so the main loop
-/// is woken by FreeRTOS task notifications. Shared between BSD and LwIP socket impls.
-/// Returns the cached lwip_sock pointer (or nullptr if fd is invalid).
-inline struct lwip_sock *fast_select_hook_fd(int fd) {
+/// Resolve an fd to its lwip_sock and install the netconn event-callback hook so the
+/// main loop is woken by FreeRTOS task notifications when data arrives. Shared between
+/// BSD and LwIP socket impls on the fast-select path. Returns the cached lwip_sock
+/// pointer (or nullptr if the fd does not map to a valid lwip_sock).
+inline struct lwip_sock *hook_fd_for_fast_select(int fd) {
   struct lwip_sock *sock = esphome_lwip_get_sock(fd);
   if (sock != nullptr) {
     esphome_lwip_hook_socket(sock);

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -449,32 +449,7 @@ void Application::enable_pending_loops_() {
   }
 }
 
-#ifdef USE_LWIP_FAST_SELECT
-bool Application::register_socket(struct lwip_sock *sock) {
-  // It modifies monitored_sockets_ without locking — must only be called from the main loop.
-  if (sock == nullptr)
-    return false;
-  esphome_lwip_hook_socket(sock);
-  this->monitored_sockets_.push_back(sock);
-  return true;
-}
-
-void Application::unregister_socket(struct lwip_sock *sock) {
-  // It modifies monitored_sockets_ without locking — must only be called from the main loop.
-  for (size_t i = 0; i < this->monitored_sockets_.size(); i++) {
-    if (this->monitored_sockets_[i] != sock)
-      continue;
-
-    // Swap with last element and pop - O(1) removal since order doesn't matter.
-    // No need to unhook the netconn callback — all LwIP sockets share the same
-    // static event_callback, and the socket will be closed by the caller.
-    if (i < this->monitored_sockets_.size() - 1)
-      this->monitored_sockets_[i] = this->monitored_sockets_.back();
-    this->monitored_sockets_.pop_back();
-    return;
-  }
-}
-#elif defined(USE_HOST)
+#ifdef USE_HOST
 bool Application::register_socket_fd(int fd) {
   // WARNING: This function is NOT thread-safe and must only be called from the main loop
   // It modifies socket_fds_ and related variables without locking

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -534,12 +534,7 @@ class Application {
 
   /// Register/unregister a socket to be monitored for read events.
   /// WARNING: These functions are NOT thread-safe. They must only be called from the main loop.
-#ifdef USE_LWIP_FAST_SELECT
-  /// Fast select path: hooks netconn callback and registers for monitoring.
-  /// @return true if registration was successful, false if sock is null
-  bool register_socket(struct lwip_sock *sock);
-  void unregister_socket(struct lwip_sock *sock);
-#elif defined(USE_HOST)
+#ifdef USE_HOST
   /// Fallback select() path: monitors file descriptors.
   /// NOTE: File descriptors >= FD_SETSIZE (typically 10 on ESP) will be rejected with an error.
   /// @return true if registration was successful, false if fd exceeds limits
@@ -653,9 +648,7 @@ class Application {
   //   and active_end_ is incremented
   // - This eliminates branch mispredictions from flag checking in the hot loop
   FixedVector<Component *> looping_components_{};
-#ifdef USE_LWIP_FAST_SELECT
-  std::vector<struct lwip_sock *> monitored_sockets_;  // Cached lwip_sock pointers for direct rcvevent read
-#elif defined(USE_HOST)
+#ifdef USE_HOST
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
 #endif
 #ifdef USE_HOST
@@ -898,26 +891,16 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
 #ifndef USE_HOST
 inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay_ms) {
 #ifdef USE_LWIP_FAST_SELECT
-  // Fast path (ESP32/LibreTiny): reads rcvevent directly from cached lwip_sock pointers.
-  // Safe because this runs on the main loop which owns socket lifetime (create, read, close).
+  // Fast path (ESP32/LibreTiny): FreeRTOS task notifications posted by the lwip
+  // event_callback wrapper (see lwip_fast_select.c) are the single source of truth for
+  // socket wake-ups. Every NETCONN_EVT_RCVPLUS posts an xTaskNotifyGive, so any notification
+  // that lands between wakes keeps the counter non-zero (next ulTaskNotifyTake returns
+  // immediately) or wakes a blocked Take directly. Also woken by wake_loop_threadsafe()
+  // from background tasks, or timeout.
   if (delay_ms == 0) [[unlikely]] {
     yield();
     return;
   }
-
-  // Check if any socket already has pending data before sleeping.
-  // If a socket still has unread data (rcvevent > 0) but the task notification was already
-  // consumed, ulTaskNotifyTake would block until timeout — adding up to delay_ms latency.
-  // This scan preserves select() semantics: return immediately when any fd is ready.
-  for (struct lwip_sock *sock : this->monitored_sockets_) {
-    if (esphome_lwip_socket_has_data(sock)) {
-      yield();
-      return;
-    }
-  }
-
-  // Sleep with instant wake via FreeRTOS task notification.
-  // Woken by: callback wrapper (socket data), wake_loop_threadsafe() (background tasks), or timeout.
 #endif
   esphome::internal::wakeable_delay(delay_ms);
 }

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -895,8 +895,8 @@ inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay
   // event_callback wrapper (see lwip_fast_select.c) are the single source of truth for
   // socket wake-ups. Every NETCONN_EVT_RCVPLUS posts an xTaskNotifyGive, so any notification
   // that lands between wakes keeps the counter non-zero (next ulTaskNotifyTake returns
-  // immediately) or wakes a blocked Take directly. Also woken by wake_loop_threadsafe()
-  // from background tasks, or timeout.
+  // immediately) or wakes a blocked Take directly. Additional wake sources:
+  // wake_loop_threadsafe() from background tasks, and the delay_ms timeout.
   if (delay_ms == 0) [[unlikely]] {
     yield();
     return;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -535,7 +535,7 @@ class Application {
 #ifdef USE_HOST
   /// Register/unregister a socket file descriptor with the host select() fallback loop.
   /// USE_LWIP_FAST_SELECT builds do not use this API — sockets hook the lwIP netconn
-  /// event_callback directly (see socket.h fast_select_hook_fd) and rely on FreeRTOS
+  /// event_callback directly (see socket.h hook_fd_for_fast_select) and rely on FreeRTOS
   /// task notifications for wake-up.
   /// NOTE: File descriptors >= FD_SETSIZE (typically 10 on ESP) will be rejected with an error.
   /// WARNING: These functions are NOT thread-safe. They must only be called from the main loop.

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -532,11 +532,13 @@ class Application {
 
   Scheduler scheduler;
 
-  /// Register/unregister a socket to be monitored for read events.
-  /// WARNING: These functions are NOT thread-safe. They must only be called from the main loop.
 #ifdef USE_HOST
-  /// Fallback select() path: monitors file descriptors.
+  /// Register/unregister a socket file descriptor with the host select() fallback loop.
+  /// USE_LWIP_FAST_SELECT builds do not use this API — sockets hook the lwIP netconn
+  /// event_callback directly (see socket.h fast_select_hook_fd) and rely on FreeRTOS
+  /// task notifications for wake-up.
   /// NOTE: File descriptors >= FD_SETSIZE (typically 10 on ESP) will be rejected with an error.
+  /// WARNING: These functions are NOT thread-safe. They must only be called from the main loop.
   /// @return true if registration was successful, false if fd exceeds limits
   bool register_socket_fd(int fd);
   void unregister_socket_fd(int fd);


### PR DESCRIPTION
# What does this implement/fix?

Removes the pre-sleep socket scan from `Application::yield_with_select_()` on the `USE_LWIP_FAST_SELECT` path (ESP32 / LibreTiny), along with the now-unused `monitored_sockets_` vector and `Application::{register,unregister}_socket()`. Socket implementations now call `esphome_lwip_hook_socket()` directly to install the netconn event-callback wrapper.

`yield_with_select_()` on this path becomes exactly:

> If `delay_ms == 0`, `yield()`. Otherwise sleep on `ulTaskNotifyTake(pdTRUE, delay_ms)`.

FreeRTOS task notifications posted by the lwip event-callback wrapper (see `lwip_fast_select.c`) are the single source of truth for socket wake-ups. Every `NETCONN_EVT_RCVPLUS` posts an `xTaskNotifyGive`, so a notification that lands between wakes either keeps the counter non-zero (next `Take` returns immediately) or wakes a blocked `Take` directly.

## How task notifications cover the "data arrived after component ran" case

The case a reviewer typically worries about: the API component runs inside the main loop and drains the socket to `EWOULDBLOCK`. After it returns, but before the main loop calls `ulTaskNotifyTake`, new data arrives on the same socket. Why doesn't the loop sleep through it?

Because `xTaskNotifyGive` is a **counter**, not an edge. It persists across the entire "main task is awake" window. Walk the timeline:

```
T0: Main loop enters API component. Reader drains to EWOULDBLOCK.
    rcvevent = 0, notify counter = 0 (consumed by the Take at the start
    of this iteration).

T1: API component returns. Other components run.

T2: *** Data arrives on the socket while the main task is NOT sleeping ***
    lwip event_callback fires on the tcpip thread:
        rcvevent++           (now 1)
        xTaskNotifyGive(main_task)   → notify counter 0 → 1
    The main task keeps running. The notify counter is now 1.

T3: Main loop reaches yield_with_select_ and calls
    ulTaskNotifyTake(pdTRUE, delay_ms). Take enters its critical section,
    sees counter == 1, returns IMMEDIATELY, and clears the counter to 0
    (because of pdTRUE / xClearCountOnExit).

T4: Next loop iteration runs the API component, which reads the new data.
```

No stall, no lost wakeup, no scan needed. The counter captured the notification during the "awake" window, and `Take` consumed it without ever blocking.

There are exactly three windows where a notification can land, and all three are covered by `ulTaskNotifyTake`'s semantics:

| Window | Behaviour |
|---|---|
| Before `Take` is called (main task busy in components) | Counter increments and persists. Next `Take` returns immediately with `pdTRUE`. |
| Atomically inside `Take` (check-then-block under critical section) | FreeRTOS guarantees no lost wakeup — if a notify arrives between the check and the block, the block unblocks or the check sees it. |
| While `Take` is already blocked | `xTaskNotifyGive` from any context unblocks the task immediately. |

There is no fourth window. The notification path cannot drop a socket wake.

## History

The scan was added in #14249 based on a GitHub Copilot suggestion to "preserve select() semantics" by checking for pending socket data before sleeping. The reasoning at the time was defensive: if a notification was consumed while an `rcvevent` was still set on a socket, `ulTaskNotifyTake` could stall up to `loop_interval` ms.

#14475 attempted to remove it. **That PR was never merged.** During its review window, testing showed what appeared to be load-bearing hits on the scan, and those hits were accepted at face value as proof that the scan was still needed. The PR was closed with the comment:

> but there is another race so we do need it

At that time there was no deeper instrumentation: the testing could only observe "scan found data and no notify was pending" and infer that the scan must be rescuing a stall. What was actually happening is that the API-connection `Socket::ready()` contract was being violated — `MAX_MESSAGES_PER_LOOP=5` could stop reading while data was still queued, leaving `rcvevent > 0` with no pending notification. That is the same class of bug that produced #15589 on Ethernet devices, and #15590 documented and enforced the contract ("drain to EWOULDBLOCK or track early-exit and retry without re-calling `ready()`").

This PR re-lands the removal, but backs it with the kind of instrumentation #14475 didn't have — `micros()`-resolution bucketing that distinguishes "real stall" from "instruction-level race between `rcvevent` write and `xTaskNotifyGive`". Under that finer lens, post-#15590, every observed hit is a 2–14µs race artifact, not a real stall.

## When the scan could matter at all

For the scan to rescue anything, **all three** of these have to hold at the same time:

1. A socket has `rcvevent > 0` — some data is queued.
2. The task notification counter is 0 — the last `ulTaskNotifyTake` consumed all pending notifications.
3. No further packet arrives on any monitored socket before `Take` would time out (up to `loop_interval` ms).

If any new data arrives on any monitored socket during that window, the lwip callback posts a fresh `xTaskNotifyGive` and `Take` wakes immediately — with or without the scan. So the scan only ever matters when a reader has stopped early **and** the remote side has gone silent at exactly the same moment.

That combination is trivial to produce in a test harness that sends a fixed-size burst and then stops (which is what #14475's minimal testing did). It is essentially absent in real workloads, where continuous traffic from Home Assistant, BLE proxy, API state streams, etc. keeps the notification pipeline flowing. The instrumentation results below demonstrate that directly: ~275k scans, zero hits with a real stall.

Separately: when a reader stops early with data still on the socket, the reader is broken. That is a correctness bug in the component, and it is present with or without the scan — the scan only masks the visible timing symptom of that bug, not the bug itself. If a future regression reintroduces a contract violation, the correct fix is still to fix the component.

## Evidence

Instrumentation PR: #15638 (closed without merging, cited as the evidence base).

That PR added atomic counters plus a bounded `micros()` spin-poll on every "scan found data" event, bucketing each hit by how long `ulTaskNotifyTake` would have stalled in the no-scan counterfactual. The measurement is TOCTOU-free: the notification value is peeked with `ulTaskNotifyValueClear(nullptr, 0)` (pure read, zero bits cleared, state untouched) *before* the scan loop, so the comparison point is the value at the moment `Take` would have been called in the counterfactual world.

| Bucket | Condition | Interpretation |
|---|---|---|
| `race`  | notify arrived <10µs after scan start | instruction-level ordering race between the lwip callback writing `rcvevent` and calling `xTaskNotifyGive` a few instructions later |
| `micro` | notify arrived 10–100µs | same phenomenon, amplified slightly by CPU cache effects |
| `stall` | notify did not arrive within 100µs | the only case that could represent a real rescue |

### Results

5 devices, real-device soak across Home Assistant disconnect/reconnect cycles, up to 3 simultaneous API loggers, BLE GATT connect/service-discovery/write/disconnect storms:

| Device | Chip | Transport | Scans | found_data | race | micro | **stall** |
|---|---|---|---|---|---|---|---|
| upstairsdesk89proxy | ESP32 (Ethernet) | Eth | 44k+ | 4 | 0 | 0 | **0** |
| rackgli89proxy | ESP32 rev1 | Eth | 68k+ | 10 | 0 | 2 | **0** |
| livingroomgli89proxy | ESP32 (Ethernet) | Eth | 34k+ | 1 | 0 | 0 | **0** |
| laundry89proxy | ESP32 rev3.1 | Eth | 141k+ | 18 | 2 | 1 | **0** |
| athom-co2-sensor | ESP32-C3 | WiFi | 14k+ | 0 | 0 | 0 | **0** |
| bw15-device | RTL8720CF (LibreTiny) | WiFi | 10k+ | 0 | 0 | 0 | **0** |

### Sample hits

```
rackgli89proxy  #1 [micro]: sock=0x3ffc442c idx=6/8 rcvevent=1 delay_ms=10 sockets_with_data=1 gap_us=14
rackgli89proxy  #2 [micro]: sock=0x3ffc442c idx=6/7 rcvevent=1 delay_ms=2  sockets_with_data=1 gap_us=13
laundry89proxy  #1 [race] : sock=0x3ffc42fc idx=1/3 rcvevent=1 delay_ms=11 sockets_with_data=1 gap_us=2
laundry89proxy  #2 [race] : sock=0x3ffc4324 idx=3/4 rcvevent=1 delay_ms=6  sockets_with_data=1 gap_us=5
laundry89proxy  #3 [micro]: sock=0x3ffc4310 idx=2/4 rcvevent=2 delay_ms=4  sockets_with_data=1 gap_us=10
```

**Every single hit** was on a single socket with `rcvevent=1` or `2`, measuring `gap_us` between 2 and 14 — orders of magnitude smaller than `loop_interval`. **Zero hits** exceeded 100µs. The worst observed counterfactual stall was 14µs — a few instruction fetches, not a latency spike.

### What this rules out

The "other race" that caused #14475 to be self-closed does not exist in the post-#15590 codebase. If any such race still existed — whether from undrained sockets, a missed callback path, or any other source — it would produce a `stall` bucket hit: the notification counter would remain at 0 for ≥100µs while `rcvevent` stayed > 0. Zero stall hits across ~275,000 scans and 5 devices, specifically under the workloads that previously reproduced #15589, is strong evidence that the notification path is the sole source of truth.

## Minor behaviour changes (use-after-close edge cases)

Two small observable differences for callers that violate the "don't touch a closed socket" precondition:

1. **`get_fd()` returns `-1` after close** (previously returned the stale original descriptor). `close()` now sets `fd_ = -1` as the "not open" sentinel. Verified no current caller reaches `get_fd()` post-close.
2. **`ready()` returns `true` after close** on the fast-select path. Pre-PR, `loop_monitored_` stayed `true` while `cached_sock_` was nulled, so `ready()` returned `false`. Post-PR, `cached_sock_` being null is interpreted by `socket_ready()` as "not monitored" → returns `true`. A caller that reads after that would get `EBADF` from the kernel/lwip. This is arguably more correct (fail fast on caller bugs) and no current caller does this, but it is a behaviour change worth noting.

A guard on `fd_ < 0` inside `ready()` would restore the old post-close behaviour, but would also change the behaviour of never-opened sockets (pre-PR: `true`, guarded: `false`), so either choice is a change from the status quo. I chose to leave `ready()` delegating directly to `socket_ready(cached_sock_)` for simplicity.

## Performance impact

Beyond correctness, the scan is actively harmful on the hot path:

- `N` volatile 16-bit loads against cache-cold cross-thread `lwip_sock` structures on **every** `yield_with_select_()` call — i.e. once per loop-monitored socket per main-loop iteration.
- On Xtensa, volatile loads across cross-thread memory effectively act as synchronous fences (`MEMW`-gated reads).

Only sockets registered with `monitor_loop=true` were in `monitored_sockets_`. A representative set on a device with HA + log streaming + Z-Wave proxy connected is: OTA listener, API listener, API connection (HA), API log-streaming connection, Z-Wave proxy API connection — five sockets.

Concrete scale from a running device (`runtime_stats` on rackgli89proxy — ESP32 Ethernet, BLE proxy, HA connected): **~7,000 loop iterations per minute**. At ~5 loop-monitored sockets that is **~35,000 wasted fence-gated cross-thread reads per minute**, all producing information the notification path already has authoritatively.

Removing the scan also removes `monitored_sockets_` (a heap-allocated `std::vector<struct lwip_sock *>`) along with its per-socket `push_back`/`pop_back` and the linear search in `unregister_socket()`. See the memory-impact bot comment below for measured flash/RAM deltas.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reverts the scan added in #14249
- Re-land of #14475 (self-closed because of an unidentified "other race" — now ruled out by instrumentation)
- Depends on contract enforcement from #15590 (fix for #15589)
- Evidence: #15638

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required. No user-visible behaviour change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
