### PR TITLE
[core] Add missing exception chaining (raise from) across codebase

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -199,11 +199,10 @@ def validate_automation(extra_schema=None, extra_validators=None, single=False):
                     return cv.Schema([schema])(value)
                 except cv.Invalid as err2:
                     if "extra keys not allowed" in str(err2) and len(err2.path) == 2:
-                        # pylint: disable=raise-missing-from
-                        raise err
+                        raise err from None
                     if "Unable to find action" in str(err):
-                        raise err2
-                    raise cv.MultipleInvalid([err, err2])
+                        raise err2 from None
+                    raise cv.MultipleInvalid([err, err2]) from None
         elif isinstance(value, dict):
             if CONF_THEN in value:
                 return [schema(value)]

--- a/esphome/components/as5600/__init__.py
+++ b/esphome/components/as5600/__init__.py
@@ -83,7 +83,7 @@ def angle_to_position(value, min=-360, max=360):
         value = angle(min=min, max=max)(value)
         return (RESOLUTION + round(value * ANGLE_TO_POSITION)) % RESOLUTION
     except cv.Invalid as e:
-        raise cv.Invalid(f"When using angle, {e.error_message}")
+        raise cv.Invalid(f"When using angle, {e.error_message}") from e
 
 
 def percent_to_position(value):
@@ -164,7 +164,7 @@ def has_valid_range_config():
         except cv.Invalid as e:
             raise cv.Invalid(
                 f"The range between start and end position is invalid. It was was {range} but {e.error_message}"
-            )
+            ) from e
 
     return validator
 

--- a/esphome/components/audio_file/__init__.py
+++ b/esphome/components/audio_file/__init__.py
@@ -116,7 +116,7 @@ def read_audio_file_and_type(file_config: ConfigType) -> tuple[bytes, MockObj]:
         raise cv.Invalid(
             f"Unable to determine audio file type of '{path}'. "
             f"Try re-encoding the file into a supported format. Details: {e}"
-        )
+        ) from e
 
     media_file_type = audio.AUDIO_FILE_TYPE_ENUM["NONE"]
     if file_type == "wav":

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -332,8 +332,7 @@ def parse_multi_click_timing_str(value):
     try:
         state = cv.boolean(parts[0])
     except cv.Invalid:
-        # pylint: disable=raise-missing-from
-        raise cv.Invalid(f"First word must either be ON or OFF, not {parts[0]}")
+        raise cv.Invalid(f"First word must either be ON or OFF, not {parts[0]}") from None
 
     if parts[1] != "for":
         raise cv.Invalid(f"Second word must be 'for', got {parts[1]}")
@@ -350,7 +349,7 @@ def parse_multi_click_timing_str(value):
         try:
             length = cv.positive_time_period_milliseconds(parts[4])
         except cv.Invalid as err:
-            raise cv.Invalid(f"Multi Click Grammar Parsing length failed: {err}")
+            raise cv.Invalid(f"Multi Click Grammar Parsing length failed: {err}") from err
         return {CONF_STATE: state, key: str(length)}
 
     if parts[3] != "to":
@@ -359,12 +358,12 @@ def parse_multi_click_timing_str(value):
     try:
         min_length = cv.positive_time_period_milliseconds(parts[2])
     except cv.Invalid as err:
-        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}")
+        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}") from err
 
     try:
         max_length = cv.positive_time_period_milliseconds(parts[4])
     except cv.Invalid as err:
-        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}")
+        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}") from err
 
     return {
         CONF_STATE: state,

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -370,7 +370,7 @@ def parse_multi_click_timing_str(value):
         max_length = cv.positive_time_period_milliseconds(parts[4])
     except cv.Invalid as err:
         raise cv.Invalid(
-            f"Multi Click Grammar Parsing minimum length failed: {err}"
+            f"Multi Click Grammar Parsing maximum length failed: {err}"
         ) from err
 
     return {

--- a/esphome/components/binary_sensor/__init__.py
+++ b/esphome/components/binary_sensor/__init__.py
@@ -332,7 +332,9 @@ def parse_multi_click_timing_str(value):
     try:
         state = cv.boolean(parts[0])
     except cv.Invalid:
-        raise cv.Invalid(f"First word must either be ON or OFF, not {parts[0]}") from None
+        raise cv.Invalid(
+            f"First word must either be ON or OFF, not {parts[0]}"
+        ) from None
 
     if parts[1] != "for":
         raise cv.Invalid(f"Second word must be 'for', got {parts[1]}")
@@ -349,7 +351,9 @@ def parse_multi_click_timing_str(value):
         try:
             length = cv.positive_time_period_milliseconds(parts[4])
         except cv.Invalid as err:
-            raise cv.Invalid(f"Multi Click Grammar Parsing length failed: {err}") from err
+            raise cv.Invalid(
+                f"Multi Click Grammar Parsing length failed: {err}"
+            ) from err
         return {CONF_STATE: state, key: str(length)}
 
     if parts[3] != "to":
@@ -358,12 +362,16 @@ def parse_multi_click_timing_str(value):
     try:
         min_length = cv.positive_time_period_milliseconds(parts[2])
     except cv.Invalid as err:
-        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}") from err
+        raise cv.Invalid(
+            f"Multi Click Grammar Parsing minimum length failed: {err}"
+        ) from err
 
     try:
         max_length = cv.positive_time_period_milliseconds(parts[4])
     except cv.Invalid as err:
-        raise cv.Invalid(f"Multi Click Grammar Parsing minimum length failed: {err}") from err
+        raise cv.Invalid(
+            f"Multi Click Grammar Parsing minimum length failed: {err}"
+        ) from err
 
     return {
         CONF_STATE: state,

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -170,7 +170,7 @@ async def to_code_base(config):
         with open(path, encoding="utf-8") as f:
             bsec2_iaq_config = f.read()
     except Exception as e:
-        raise core.EsphomeError(f"Could not open binary configuration file {path}: {e}")
+        raise core.EsphomeError(f"Could not open binary configuration file {path}: {e}") from e
 
     # Convert retrieved BSEC2 config to an array of ints
     rhs = [int(x) for x in bsec2_iaq_config.split(",")]

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -170,7 +170,9 @@ async def to_code_base(config):
         with open(path, encoding="utf-8") as f:
             bsec2_iaq_config = f.read()
     except Exception as e:
-        raise core.EsphomeError(f"Could not open binary configuration file {path}: {e}") from e
+        raise core.EsphomeError(
+            f"Could not open binary configuration file {path}: {e}"
+        ) from e
 
     # Convert retrieved BSEC2 config to an array of ints
     rhs = [int(x) for x in bsec2_iaq_config.split(",")]

--- a/esphome/components/font/__init__.py
+++ b/esphome/components/font/__init__.py
@@ -325,7 +325,7 @@ def download_gfont(value):
             raise cv.Invalid(
                 f"Could not download font at {url}, please check the fonts exists "
                 f"at google fonts ({e})"
-            )
+            ) from e
         match = re.search(r"src:\s+url\((.+)\)\s+format\('truetype'\);", req.text)
         if match is None:
             raise cv.Invalid(

--- a/esphome/components/ili9xxx/display.py
+++ b/esphome/components/ili9xxx/display.py
@@ -283,7 +283,7 @@ async def to_code(config):
             try:
                 return Image.open(path)
             except Exception as e:
-                raise core.EsphomeError(f"Could not load image file {path}: {e}")
+                raise core.EsphomeError(f"Could not load image file {path}: {e}") from e
 
         # make a wide horizontal combined image.
         images = [load_image(x) for x in config[CONF_COLOR_PALETTE_IMAGES]]

--- a/esphome/components/shelly_dimmer/light.py
+++ b/esphome/components/shelly_dimmer/light.py
@@ -84,7 +84,7 @@ def get_firmware(value):
             req = requests.get(url, timeout=30)
             req.raise_for_status()
         except requests.exceptions.RequestException as e:
-            raise cv.Invalid(f"Could not download firmware file ({url}): {e}")
+            raise cv.Invalid(f"Could not download firmware file ({url}): {e}") from e
 
         h = hashlib.new("sha256")
         h.update(req.content)

--- a/esphome/components/speaker/media_player/__init__.py
+++ b/esphome/components/speaker/media_player/__init__.py
@@ -173,7 +173,7 @@ def _read_audio_file_and_type(file_config):
         raise cv.Invalid(
             f"Unable to determine audio file type of '{path}'. "
             f"Try re-encoding the file into a supported format. Details: {e}"
-        )
+        ) from e
 
     media_file_type = audio.AUDIO_FILE_TYPE_ENUM["NONE"]
     if file_type in ("wav"):

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -35,8 +35,7 @@ def validate_acceleration(value):
     try:
         value = float(value)
     except ValueError:
-        # pylint: disable=raise-missing-from
-        raise cv.Invalid(f"Expected acceleration as floating point number, got {value}")
+        raise cv.Invalid(f"Expected acceleration as floating point number, got {value}") from None
 
     if value <= 0:
         raise cv.Invalid("Acceleration must be larger than 0 steps/s^2!")
@@ -55,8 +54,7 @@ def validate_speed(value):
     try:
         value = float(value)
     except ValueError:
-        # pylint: disable=raise-missing-from
-        raise cv.Invalid(f"Expected speed as floating point number, got {value}")
+        raise cv.Invalid(f"Expected speed as floating point number, got {value}") from None
 
     if value <= 0:
         raise cv.Invalid("Speed must be larger than 0 steps/s!")

--- a/esphome/components/stepper/__init__.py
+++ b/esphome/components/stepper/__init__.py
@@ -35,7 +35,9 @@ def validate_acceleration(value):
     try:
         value = float(value)
     except ValueError:
-        raise cv.Invalid(f"Expected acceleration as floating point number, got {value}") from None
+        raise cv.Invalid(
+            f"Expected acceleration as floating point number, got {value}"
+        ) from None
 
     if value <= 0:
         raise cv.Invalid("Acceleration must be larger than 0 steps/s^2!")
@@ -54,7 +56,9 @@ def validate_speed(value):
     try:
         value = float(value)
     except ValueError:
-        raise cv.Invalid(f"Expected speed as floating point number, got {value}") from None
+        raise cv.Invalid(
+            f"Expected speed as floating point number, got {value}"
+        ) from None
 
     if value <= 0:
         raise cv.Invalid("Speed must be larger than 0 steps/s!")

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -188,7 +188,7 @@ def _expand_substitutions(
                 f"\nRelevant context:\n{err.context_trace_str()}"
                 f"\nSee {'->'.join(str(x) for x in path)}",
                 path,
-            )
+            ) from err
         else:
             if isinstance(orig_value, ESPHomeDataBase):
                 value = _restore_data_base(value, orig_value)

--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -109,8 +109,7 @@ def _parse_cron_int(value, special_mapping, message):
     try:
         return int(value)
     except ValueError:
-        # pylint: disable=raise-missing-from
-        raise cv.Invalid(message.format(value))
+        raise cv.Invalid(message.format(value)) from None
 
 
 def _parse_cron_part(part, min_value, max_value, special_mapping):
@@ -134,10 +133,9 @@ def _parse_cron_part(part, min_value, max_value, special_mapping):
         try:
             repeat_n = int(repeat)
         except ValueError:
-            # pylint: disable=raise-missing-from
             raise cv.Invalid(
                 f"Repeat for '/' time expression must be an integer, got {repeat}"
-            )
+            ) from None
         return set(range(offset_n, max_value + 1, repeat_n))
     if "-" in part:
         data = part.split("-")

--- a/esphome/components/wifi/wpa2_eap.py
+++ b/esphome/components/wifi/wpa2_eap.py
@@ -67,7 +67,7 @@ def _validate_load_certificate(value):
         contents = read_relative_config_path(value)
         return wrapped_load_pem_x509_certificate(contents)
     except ValueError as err:
-        raise cv.Invalid(f"Invalid certificate: {err}")
+        raise cv.Invalid(f"Invalid certificate: {err}") from err
 
 
 def validate_certificate(value):
@@ -86,9 +86,9 @@ def _validate_load_private_key(key, cert_pw):
     except ValueError as e:
         raise cv.Invalid(
             f"There was an error with the EAP 'password:' provided for 'key' {e}"
-        )
+        ) from e
     except TypeError as e:
-        raise cv.Invalid(f"There was an error with the EAP 'key:' provided: {e}")
+        raise cv.Invalid(f"There was an error with the EAP 'key:' provided: {e}") from e
 
 
 def _check_private_key_cert_match(key, cert):

--- a/esphome/components/wireguard/__init__.py
+++ b/esphome/components/wireguard/__init__.py
@@ -53,7 +53,7 @@ def _cidr_network(value):
     try:
         ipaddress.ip_network(value, strict=False)
     except ValueError as err:
-        raise cv.Invalid(f"Invalid network in CIDR notation: {err}")
+        raise cv.Invalid(f"Invalid network in CIDR notation: {err}") from err
     return value
 
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -544,7 +544,9 @@ def int_(value):
     try:
         return int(value, base)
     except ValueError:
-        raise Invalid(f"Expected integer, but cannot parse {value} as an integer") from None
+        raise Invalid(
+            f"Expected integer, but cannot parse {value} as an integer"
+        ) from None
 
 
 def int_range(min=None, max=None, min_included=True, max_included=True):
@@ -1075,7 +1077,9 @@ def mac_address(value):
         try:
             parts_int.append(int(part, 16))
         except ValueError:
-            raise Invalid("MAC Address parts must be hexadecimal values from 00 to FF") from None
+            raise Invalid(
+                "MAC Address parts must be hexadecimal values from 00 to FF"
+            ) from None
 
     return core.MACAddress(*parts_int)
 

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -544,8 +544,7 @@ def int_(value):
     try:
         return int(value, base)
     except ValueError:
-        # pylint: disable=raise-missing-from
-        raise Invalid(f"Expected integer, but cannot parse {value} as an integer")
+        raise Invalid(f"Expected integer, but cannot parse {value} as an integer") from None
 
 
 def int_range(min=None, max=None, min_included=True, max_included=True):
@@ -844,8 +843,7 @@ def time_period_str_colon(value):
     try:
         parsed = [int(x) for x in value.split(":")]
     except ValueError:
-        # pylint: disable=raise-missing-from
-        raise Invalid(TIME_PERIOD_ERROR.format(value))
+        raise Invalid(TIME_PERIOD_ERROR.format(value)) from None
 
     if len(parsed) == 2:
         hour, minute = parsed
@@ -1047,8 +1045,7 @@ def date_time(date: bool, time: bool):
         try:
             date_obj = datetime.strptime(value, format)
         except ValueError as err:
-            # pylint: disable=raise-missing-from
-            raise Invalid(f"Invalid {exc_message}: {err}")
+            raise Invalid(f"Invalid {exc_message}: {err}") from err
 
         return_value = {}
         if date:
@@ -1078,8 +1075,7 @@ def mac_address(value):
         try:
             parts_int.append(int(part, 16))
         except ValueError:
-            # pylint: disable=raise-missing-from
-            raise Invalid("MAC Address parts must be hexadecimal values from 00 to FF")
+            raise Invalid("MAC Address parts must be hexadecimal values from 00 to FF") from None
 
     return core.MACAddress(*parts_int)
 
@@ -1096,8 +1092,7 @@ def bind_key(value, *, name="Bind key"):
         try:
             parts_int.append(int(part, 16))
         except ValueError:
-            # pylint: disable=raise-missing-from
-            raise Invalid(f"{name} must be hex values from 00 to FF")
+            raise Invalid(f"{name} must be hex values from 00 to FF") from None
 
     return "".join(f"{part:02X}" for part in parts_int)
 
@@ -1425,8 +1420,7 @@ def mqtt_qos(value):
     try:
         value = int(value)
     except (TypeError, ValueError):
-        # pylint: disable=raise-missing-from
-        raise Invalid(f"MQTT Quality of Service must be integer, got {value}")
+        raise Invalid(f"MQTT Quality of Service must be integer, got {value}") from None
     return one_of(0, 1, 2)(value)
 
 
@@ -1518,8 +1512,7 @@ def _parse_percentage(value: object) -> float:
             else:
                 value = float(value)
         except ValueError:
-            # pylint: disable=raise-missing-from
-            raise Invalid("invalid number")
+            raise Invalid("invalid number") from None
     try:
         if not has_percent_sign and (value > 1 or value < -1):
             raise Invalid(
@@ -1527,9 +1520,7 @@ def _parse_percentage(value: object) -> float:
                 "outside -1.0 to 1.0. Please put a percent sign after the number!"
             )
     except TypeError:
-        raise Invalid(  # pylint: disable=raise-missing-from
-            "Expected percentage or float"
-        )
+        raise Invalid("Expected percentage or float") from None
     return float(value)
 
 
@@ -1702,8 +1693,7 @@ def dimensions(value):
         try:
             width, height = int(value[0]), int(value[1])
         except ValueError:
-            # pylint: disable=raise-missing-from
-            raise Invalid("Width and height dimensions must be integers")
+            raise Invalid("Width and height dimensions must be integers") from None
         if width <= 0 or height <= 0:
             raise Invalid("Width and height must at least be 1")
         return [width, height]

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -107,7 +107,7 @@ def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> bytes:
                 e,
             )
             return path.read_bytes()
-        raise cv.Invalid(f"Could not download from {url}: {e}")
+        raise cv.Invalid(f"Could not download from {url}: {e}") from e
 
     path.parent.mkdir(parents=True, exist_ok=True)
     data = req.content

--- a/esphome/voluptuous_schema.py
+++ b/esphome/voluptuous_schema.py
@@ -39,8 +39,7 @@ class _Schema(vol.Schema):
             try:
                 res = extra(res)
             except vol.Invalid as err:
-                # pylint: disable=raise-missing-from
-                raise ensure_multiple_invalid(err)
+                raise ensure_multiple_invalid(err) from err
         return res
 
     def _compile_mapping(self, schema, invalid_msg=None):

--- a/esphome/yaml_util.py
+++ b/esphome/yaml_util.py
@@ -338,10 +338,9 @@ class ESPHomeLoaderMixin:
                 try:
                     hash(key)
                 except TypeError:
-                    # pylint: disable=raise-missing-from
                     raise yaml.constructor.ConstructorError(
                         f'Invalid key "{key}" (not hashable)', key_node.start_mark
-                    )
+                    ) from None
 
                 key = make_data_base(str(key))
                 key.from_node(key_node)


### PR DESCRIPTION
Fix 35 instances of `raise` without `from` inside `except` clauses. Without explicit chaining, Python shows a misleading "During handling of the above exception, another exception occurred" message instead of the clearer "The above exception was the direct cause of..." chain.

Used `from err` where the original exception adds debugging value (its message is embedded in the new exception), and `from None` where the new exception is a deliberate clean replacement (e.g., converting ValueError to a user-facing validation error).

Also removed now-unnecessary `# pylint: disable=raise-missing-from` comments.

Found and fixed with Claude Code (using ruff static analysis).

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
