### PR TITLE
[bl0942] Remove broken 24-bit overflow tracking

### DIFF
--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -137,9 +137,11 @@ void BL0942::setup() {
   }
 
   this->write_reg_(BL0942_REG_USR_WRPROT, BL0942_REG_USR_WRPROT_MAGIC);
-  if (this->reset_)
+  if (this->reset_) {
     this->write_reg_(BL0942_REG_SOFT_RESET, BL0942_REG_SOFT_RESET_MAGIC);
-
+    ESP_LOGV(TAG, "Reset sent");
+    /* this->prev_cf_cnt = 0;*/
+  }
   uint32_t mode = BL0942_REG_MODE_DEFAULT;
   mode |= BL0942_REG_MODE_RMS_UPDATE_SEL; /* 800ms refresh time */
   if (this->line_freq_ == LINE_FREQUENCY_60HZ)
@@ -161,11 +163,14 @@ void BL0942::received_package_(DataPacket *data) {
     return;
   }
 
-  // cf_cnt is only 24 bits, so track overflows
   uint32_t cf_cnt = (uint24_t) data->cf_cnt;
-  cf_cnt |= this->prev_cf_cnt_ & 0xff000000;
-  if (cf_cnt < this->prev_cf_cnt_) {
-    cf_cnt += 0x1000000;
+
+  // cf_cnt is only 24 bits, so track overflows
+  if (!this->cf_cnt_native_size_) {
+    cf_cnt |= this->prev_cf_cnt_ & 0xff000000;
+    if (cf_cnt < this->prev_cf_cnt_) {
+      cf_cnt += 0x1000000;
+    }
   }
   this->prev_cf_cnt_ = cf_cnt;
 
@@ -202,11 +207,12 @@ void BL0942::dump_config() {  // NOLINT(readability-function-cognitive-complexit
                 "  Address: %d\n"
                 "  Nominal line frequency: %d Hz\n"
                 "  Current reference: %f\n"
-                "  Energy reference: %f\n"
+                "  Energy reference: %f, native size: %s\n"
                 "  Power reference: %f\n"
                 "  Voltage reference: %f",
                 TRUEFALSE(this->reset_), this->address_, this->line_freq_, this->current_reference_,
-                this->energy_reference_, this->power_reference_, this->voltage_reference_);
+                this->energy_reference_, TRUEFALSE(this->cf_cnt_native_size_), this->power_reference_,
+                this->voltage_reference_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/bl0942/bl0942.cpp
+++ b/esphome/components/bl0942/bl0942.cpp
@@ -137,11 +137,9 @@ void BL0942::setup() {
   }
 
   this->write_reg_(BL0942_REG_USR_WRPROT, BL0942_REG_USR_WRPROT_MAGIC);
-  if (this->reset_) {
+  if (this->reset_)
     this->write_reg_(BL0942_REG_SOFT_RESET, BL0942_REG_SOFT_RESET_MAGIC);
-    ESP_LOGV(TAG, "Reset sent");
-    /* this->prev_cf_cnt = 0;*/
-  }
+
   uint32_t mode = BL0942_REG_MODE_DEFAULT;
   mode |= BL0942_REG_MODE_RMS_UPDATE_SEL; /* 800ms refresh time */
   if (this->line_freq_ == LINE_FREQUENCY_60HZ)
@@ -163,16 +161,9 @@ void BL0942::received_package_(DataPacket *data) {
     return;
   }
 
+  // cf_cnt wraps at 24 bits; total_increasing on the energy sensor handles the
+  // wrap (and any spurious chip resets) downstream.
   uint32_t cf_cnt = (uint24_t) data->cf_cnt;
-
-  // cf_cnt is only 24 bits, so track overflows
-  if (!this->cf_cnt_native_size_) {
-    cf_cnt |= this->prev_cf_cnt_ & 0xff000000;
-    if (cf_cnt < this->prev_cf_cnt_) {
-      cf_cnt += 0x1000000;
-    }
-  }
-  this->prev_cf_cnt_ = cf_cnt;
 
   float v_rms = (uint24_t) data->v_rms / voltage_reference_;
   float i_rms = (uint24_t) data->i_rms / current_reference_;
@@ -207,12 +198,11 @@ void BL0942::dump_config() {  // NOLINT(readability-function-cognitive-complexit
                 "  Address: %d\n"
                 "  Nominal line frequency: %d Hz\n"
                 "  Current reference: %f\n"
-                "  Energy reference: %f, native size: %s\n"
+                "  Energy reference: %f\n"
                 "  Power reference: %f\n"
                 "  Voltage reference: %f",
                 TRUEFALSE(this->reset_), this->address_, this->line_freq_, this->current_reference_,
-                this->energy_reference_, TRUEFALSE(this->cf_cnt_native_size_), this->power_reference_,
-                this->voltage_reference_);
+                this->energy_reference_, this->power_reference_, this->voltage_reference_);
   LOG_SENSOR("", "Voltage", this->voltage_sensor_);
   LOG_SENSOR("", "Current", this->current_sensor_);
   LOG_SENSOR("", "Power", this->power_sensor_);

--- a/esphome/components/bl0942/bl0942.h
+++ b/esphome/components/bl0942/bl0942.h
@@ -94,6 +94,7 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   void set_line_freq(LineFrequency freq) { this->line_freq_ = freq; }
   void set_address(uint8_t address) { this->address_ = address; }
   void set_reset(bool reset) { this->reset_ = reset; }
+  void set_cf_native_size(bool native) { this->cf_cnt_native_size_ = native; }
   void set_current_reference(float current_ref) {
     this->current_reference_ = current_ref;
     this->current_reference_set_ = true;
@@ -139,6 +140,7 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   bool energy_reference_set_ = false;
   uint8_t address_ = 0;
   bool reset_ = false;
+  bool cf_cnt_native_size_ = false;
   LineFrequency line_freq_ = LINE_FREQUENCY_50HZ;
   optional<uint32_t> rx_start_{};
   uint32_t prev_cf_cnt_ = 0;

--- a/esphome/components/bl0942/bl0942.h
+++ b/esphome/components/bl0942/bl0942.h
@@ -94,7 +94,6 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   void set_line_freq(LineFrequency freq) { this->line_freq_ = freq; }
   void set_address(uint8_t address) { this->address_ = address; }
   void set_reset(bool reset) { this->reset_ = reset; }
-  void set_cf_native_size(bool native) { this->cf_cnt_native_size_ = native; }
   void set_current_reference(float current_ref) {
     this->current_reference_ = current_ref;
     this->current_reference_set_ = true;
@@ -140,10 +139,8 @@ class BL0942 : public PollingComponent, public uart::UARTDevice {
   bool energy_reference_set_ = false;
   uint8_t address_ = 0;
   bool reset_ = false;
-  bool cf_cnt_native_size_ = false;
   LineFrequency line_freq_ = LINE_FREQUENCY_50HZ;
   optional<uint32_t> rx_start_{};
-  uint32_t prev_cf_cnt_ = 0;
 
   bool validate_checksum_(DataPacket *data);
   int read_reg_(uint8_t reg);

--- a/esphome/components/bl0942/sensor.py
+++ b/esphome/components/bl0942/sensor.py
@@ -29,6 +29,7 @@ CONF_CURRENT_REFERENCE = "current_reference"
 CONF_ENERGY_REFERENCE = "energy_reference"
 CONF_POWER_REFERENCE = "power_reference"
 CONF_VOLTAGE_REFERENCE = "voltage_reference"
+CONF_ENERGY_NATIVE_SIZE = "energy_native_size"
 
 DEPENDENCIES = ["uart"]
 
@@ -84,6 +85,7 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_ADDRESS, default=0): cv.int_range(min=0, max=3),
             cv.Optional(CONF_RESET, default=True): cv.boolean,
+            cv.Optional(CONF_ENERGY_NATIVE_SIZE, default=False): cv.boolean,
             cv.Optional(CONF_CURRENT_REFERENCE): cv.float_,
             cv.Optional(CONF_ENERGY_REFERENCE): cv.float_,
             cv.Optional(CONF_POWER_REFERENCE): cv.float_,
@@ -118,6 +120,7 @@ async def to_code(config):
     cg.add(var.set_line_freq(config[CONF_LINE_FREQUENCY]))
     cg.add(var.set_address(config[CONF_ADDRESS]))
     cg.add(var.set_reset(config[CONF_RESET]))
+    cg.add(var.set_cf_native_size(config[CONF_ENERGY_NATIVE_SIZE]))
     if (current_reference := config.get(CONF_CURRENT_REFERENCE, None)) is not None:
         cg.add(var.set_current_reference(current_reference))
     if (voltage_reference := config.get(CONF_VOLTAGE_REFERENCE, None)) is not None:

--- a/esphome/components/bl0942/sensor.py
+++ b/esphome/components/bl0942/sensor.py
@@ -29,7 +29,6 @@ CONF_CURRENT_REFERENCE = "current_reference"
 CONF_ENERGY_REFERENCE = "energy_reference"
 CONF_POWER_REFERENCE = "power_reference"
 CONF_VOLTAGE_REFERENCE = "voltage_reference"
-CONF_ENERGY_NATIVE_SIZE = "energy_native_size"
 
 DEPENDENCIES = ["uart"]
 
@@ -85,7 +84,6 @@ CONFIG_SCHEMA = (
             ),
             cv.Optional(CONF_ADDRESS, default=0): cv.int_range(min=0, max=3),
             cv.Optional(CONF_RESET, default=True): cv.boolean,
-            cv.Optional(CONF_ENERGY_NATIVE_SIZE, default=False): cv.boolean,
             cv.Optional(CONF_CURRENT_REFERENCE): cv.float_,
             cv.Optional(CONF_ENERGY_REFERENCE): cv.float_,
             cv.Optional(CONF_POWER_REFERENCE): cv.float_,
@@ -120,7 +118,6 @@ async def to_code(config):
     cg.add(var.set_line_freq(config[CONF_LINE_FREQUENCY]))
     cg.add(var.set_address(config[CONF_ADDRESS]))
     cg.add(var.set_reset(config[CONF_RESET]))
-    cg.add(var.set_cf_native_size(config[CONF_ENERGY_NATIVE_SIZE]))
     if (current_reference := config.get(CONF_CURRENT_REFERENCE, None)) is not None:
         cg.add(var.set_current_reference(current_reference))
     if (voltage_reference := config.get(CONF_VOLTAGE_REFERENCE, None)) is not None:


### PR DESCRIPTION
# What does this implement/fix?

Issue #15280: BL0942's internal energy counter is stored on 24 bits, ESPHome was tracking it with a 32-bit counter and trying to detect wraps to maintain a monotonic value. The problem: the chip occasionally resets its internal counter on its own (power glitches, etc.), and the overflow-detection code interprets the drop-to-zero as a wrap and adds `0x1000000` to the running total — a phantom +5 MWh jump in the published energy value.

Real overflow and chip reset look identical from the driver's perspective, so the heuristic cannot be made correct.

This PR removes the overflow tracking entirely and publishes the raw 24-bit counter directly. The energy sensor's default `state_class: total_increasing` already handles wraps and resets correctly on the Home Assistant side: any decrease is treated as a reset, and accumulation continues from the new value. Net result for default configurations: no more phantom +5 MWh jumps; real wraps every ~5 MWh become invisible accumulations downstream.

## Migration

Default behavior is unchanged for the common case (`state_class: total_increasing` on the energy sensor, which is the schema default). No user action required.

Users who explicitly override the energy sensor's `state_class` to `total` or `measurement` may now see a visible reset every ~5 MWh as the 24-bit chip counter wraps. They were already getting incorrect values during chip resets — this just makes the wrap visible at the actual rollover point.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15280

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no new config option)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes — the existing schema default (`state_class: total_increasing` on the energy sensor) is what makes this work.

```yaml
sensor:
  - platform: bl0942
    id: energy_sensor
    uart_id: uart_bus
    energy:
      name: 'Energy'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).