### PR TITLE
[canbus] Fix canbus.send can_id compile error

### DIFF
--- a/esphome/components/canbus/__init__.py
+++ b/esphome/components/canbus/__init__.py
@@ -162,7 +162,6 @@ async def canbus_action_to_code(config, action_id, template_arg, args):
     await cg.register_parented(var, config[CONF_CANBUS_ID])
 
     if (can_id := config.get(CONF_CAN_ID)) is not None:
-        can_id = await cg.templatable(can_id, args, cg.uint32)
         cg.add(var.set_can_id(can_id))
         cg.add(var.set_use_extended_id(config[CONF_USE_EXTENDED_ID]))
 

--- a/tests/components/canbus/common.yaml
+++ b/tests/components/canbus/common.yaml
@@ -50,6 +50,13 @@ button:
   - platform: template
     name: Canbus Actions
     on_press:
+      - canbus.send:
+          can_id: 0x601
+          data: [0, 1, 2]
+      - canbus.send:
+          can_id: 0x1FFFFFFF
+          use_extended_id: true
+          data: [0, 1, 2]
       - canbus.send: "abc"
       - canbus.send: [0, 1, 2]
       - canbus.send: !lambda return {0, 1, 2};


### PR DESCRIPTION
# What does this implement/fix?

The `TemplatableFn` PR (#15545) changed `cg.templatable()` to wrap all non-string constants in stateless lambdas for `TemplatableFn`-backed fields. However, `can_id` in the `canbus.send` action is not templatable in the schema — it's a plain `cv.int_range()`. The `cg.templatable()` call was unnecessary and now generates a lambda where `set_can_id(uint32_t)` expects a plain integer, causing a compile error.

Fix: remove the `cg.templatable()` call and pass the integer directly. Also add test coverage for `canbus.send` with an explicit `can_id`, which was previously untested.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15660

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
canbus:
  - platform: esp32_can
    id: my_can
    rx_pin: 4
    tx_pin: 5
    can_id: 4
    bit_rate: 250kbps

button:
  - platform: template
    name: Send
    on_press:
      - canbus.send:
          can_id: 0x601
          data: [0x01, 0x02]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).