### PR TITLE
[mdns] Bump espressif/mdns to 1.11.0

### DIFF
--- a/esphome/components/mdns/__init__.py
+++ b/esphome/components/mdns/__init__.py
@@ -170,7 +170,7 @@ async def to_code(config):
             cg.add_library("LEAmDNS", None)
 
     if CORE.is_esp32:
-        add_idf_component(name="espressif/mdns", ref="1.10.0")
+        add_idf_component(name="espressif/mdns", ref="1.11.0")
 
     cg.add_define("USE_MDNS")
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -14,7 +14,7 @@ dependencies:
   espressif/esp32-camera:
     version: 2.1.6
   espressif/mdns:
-    version: 1.10.0
+    version: 1.11.0
   espressif/esp_wifi_remote:
     version: 1.4.0
     rules:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the ESP-IDF mDNS component from 1.10.0 to 1.11.0, picking up two bug fixes:

- **1.10.1**: Fix incorrect server initialization condition in `mdns_browse_new` ([dcc33d69](https://github.com/espressif/esp-protocols/commit/dcc33d69)) — this caused heap corruption when processing sustained mDNS browse traffic, leading to deterministic LoadProhibited crashes
- **1.11.0**: Fix null pointer exception in `mdns_parse_packet` ([56812092](https://github.com/espressif/esp-protocols/commit/56812092))

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15655

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Default config — mdns is auto-included
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).