### PR TITLE
[equitherm] Add runtime tuning number entities

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -157,6 +157,7 @@ esphome/components/ens160_i2c/* @latonita
 esphome/components/ens160_spi/* @latonita
 esphome/components/ens210/* @itn3rd77
 esphome/components/epaper_spi/* @esphome/core
+esphome/components/equitherm/* @P4uLT
 esphome/components/es7210/* @kahrendt
 esphome/components/es7243e/* @kbx81
 esphome/components/es8156/* @kbx81

--- a/esphome/components/equitherm/__init__.py
+++ b/esphome/components/equitherm/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@P4uLT"]

--- a/esphome/components/equitherm/climate.py
+++ b/esphome/components/equitherm/climate.py
@@ -1,0 +1,237 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import climate, number, output, sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+CODEOWNERS = ["@P4uLT"]
+
+CONF_DEFAULT_TARGET_TEMPERATURE = "default_target_temperature"
+CONF_OUTDOOR_SENSOR = "outdoor_sensor"
+CONF_INDOOR_SENSOR = "indoor_sensor"
+CONF_FLOW_SETPOINT = "flow_setpoint"
+CONF_MANUAL_FLOW_TEMP = "manual_flow_temp"
+CONF_HEAT_OUTPUT = "heat_output"
+CONF_CONTROL_PARAMETERS = "control_parameters"
+CONF_OUTPUT_PARAMETERS = "output_parameters"
+CONF_DEADBAND_PARAMETERS = "deadband_parameters"
+
+# Heating curve parameters
+CONF_HEAT_CURVE_COEFFICIENT = "heat_curve_coefficient"
+CONF_HEAT_CURVE_EXPONENT = "heat_curve_exponent"
+CONF_HEAT_CURVE_SHIFT = "heat_curve_shift"
+
+CONF_MIN_FLOW_TEMP = "min_flow_temp"
+CONF_MAX_FLOW_TEMP = "max_flow_temp"
+
+# Output behavior parameters
+CONF_WRITE_DEADBAND = "write_deadband"
+
+# PID parameters
+CONF_KP = "kp"
+CONF_KI = "ki"
+CONF_KD = "kd"
+CONF_MIN_INTEGRAL = "min_integral"
+CONF_MAX_INTEGRAL = "max_integral"
+CONF_DERIVATIVE_AVERAGING_SAMPLES = "derivative_averaging_samples"
+
+# Deadband parameters
+CONF_THRESHOLD_HIGH = "threshold_high"
+CONF_THRESHOLD_LOW = "threshold_low"
+CONF_KP_MULTIPLIER = "kp_multiplier"
+CONF_KI_MULTIPLIER = "ki_multiplier"
+CONF_KD_MULTIPLIER = "kd_multiplier"
+
+# Action configuration
+CONF_UPDATE_PID = "update_pid"
+
+# Automation triggers
+CONF_ON_HEATING_START = "on_heating_start"
+CONF_ON_HEATING_STOP = "on_heating_stop"
+
+equitherm_ns = cg.esphome_ns.namespace("equitherm")
+EquithermClimate = equitherm_ns.class_(
+    "EquithermClimate", climate.Climate, cg.Component
+)
+EquithermForceRecalculateAction = equitherm_ns.class_(
+    "EquithermForceRecalculateAction", automation.Action
+)
+
+CONTROL_PARAMETERS_SCHEMA = cv.Schema(
+    {
+        # Heating curve parameters
+        cv.Required(CONF_HEAT_CURVE_COEFFICIENT): cv.float_range(min=0.5, max=5.0),
+        cv.Required(CONF_HEAT_CURVE_EXPONENT): cv.float_range(min=0.5, max=3.0),
+        cv.Optional(CONF_HEAT_CURVE_SHIFT, default="0°C"): cv.temperature_delta,
+        # PID parameters for room temperature correction
+        cv.Optional(CONF_KP, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_KI, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_KD, default=0.0): cv.float_range(min=0.0),
+        cv.Optional(CONF_MIN_INTEGRAL, default=-1): cv.float_,
+        cv.Optional(CONF_MAX_INTEGRAL, default=1): cv.float_,
+        cv.Optional(CONF_DERIVATIVE_AVERAGING_SAMPLES, default=1): cv.int_range(
+            min=1, max=16
+        ),
+    }
+)
+
+
+def _validate_output_parameters(config):
+    """Validate output_parameters."""
+    # Validate min/max flow temp
+    if config[CONF_MIN_FLOW_TEMP] >= config[CONF_MAX_FLOW_TEMP]:
+        raise cv.Invalid(
+            f"{CONF_MIN_FLOW_TEMP} ({config[CONF_MIN_FLOW_TEMP]}) must be less than "
+            f"{CONF_MAX_FLOW_TEMP} ({config[CONF_MAX_FLOW_TEMP]})"
+        )
+
+    return config
+
+
+OUTPUT_PARAMETERS_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_MIN_FLOW_TEMP): cv.temperature,
+            cv.Required(CONF_MAX_FLOW_TEMP): cv.temperature,
+            cv.Optional(CONF_WRITE_DEADBAND, default="0.05°C"): cv.temperature_delta,
+        }
+    ),
+    _validate_output_parameters,
+)
+
+
+def _validate_deadband_thresholds(config):
+    """Validate that threshold_high > threshold_low for a valid deadband range."""
+    threshold_low = config[CONF_THRESHOLD_LOW]
+    threshold_high = config[CONF_THRESHOLD_HIGH]
+    if threshold_high <= threshold_low:
+        raise cv.Invalid(
+            f"threshold_high ({threshold_high}) must be greater than "
+            f"threshold_low ({threshold_low})"
+        )
+    return config
+
+
+DEADBAND_PARAMETERS_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.Required(CONF_THRESHOLD_LOW): cv.temperature_delta,
+            cv.Required(CONF_THRESHOLD_HIGH): cv.temperature_delta,
+            cv.Optional(CONF_KP_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+            cv.Optional(CONF_KI_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+            cv.Optional(CONF_KD_MULTIPLIER, default=0.0): cv.float_range(min=0.0),
+        }
+    ),
+    _validate_deadband_thresholds,
+)
+
+CONFIG_SCHEMA = cv.All(
+    climate.climate_schema(EquithermClimate)
+    .extend(
+        {
+            cv.Required(CONF_OUTDOOR_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_INDOOR_SENSOR): cv.use_id(sensor.Sensor),
+            cv.Required(CONF_DEFAULT_TARGET_TEMPERATURE): cv.temperature,
+            cv.Optional(CONF_FLOW_SETPOINT): cv.use_id(number.Number),
+            cv.Optional(CONF_MANUAL_FLOW_TEMP): cv.use_id(number.Number),
+            cv.Optional(CONF_HEAT_OUTPUT): cv.use_id(output.FloatOutput),
+            cv.Required(CONF_CONTROL_PARAMETERS): CONTROL_PARAMETERS_SCHEMA,
+            cv.Required(CONF_OUTPUT_PARAMETERS): OUTPUT_PARAMETERS_SCHEMA,
+            cv.Optional(CONF_DEADBAND_PARAMETERS): DEADBAND_PARAMETERS_SCHEMA,
+            cv.Optional(CONF_ON_HEATING_START): automation.validate_automation({}),
+            cv.Optional(CONF_ON_HEATING_STOP): automation.validate_automation({}),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.has_exactly_one_key(CONF_FLOW_SETPOINT, CONF_HEAT_OUTPUT),
+)
+
+
+async def to_code(config):
+    var = await climate.new_climate(config)
+    await cg.register_component(var, config)
+
+    # Sensors
+    outdoor = await cg.get_variable(config[CONF_OUTDOOR_SENSOR])
+    cg.add(var.set_outdoor_sensor(outdoor))
+
+    indoor = await cg.get_variable(config[CONF_INDOOR_SENSOR])
+    cg.add(var.set_indoor_sensor(indoor))
+
+    # Output (mutually exclusive)
+    if CONF_FLOW_SETPOINT in config:
+        flow_setpoint = await cg.get_variable(config[CONF_FLOW_SETPOINT])
+        cg.add(var.set_flow_setpoint_output(flow_setpoint))
+    if CONF_HEAT_OUTPUT in config:
+        heat_output = await cg.get_variable(config[CONF_HEAT_OUTPUT])
+        cg.add(var.set_heat_output(heat_output))
+        cg.add_define("USE_EQUITHERM_HEAT_OUTPUT")
+
+    # Manual flow temperature number entity (for CLIMATE_PRESET_MANUAL)
+    if CONF_MANUAL_FLOW_TEMP in config:
+        manual_flow_temp = await cg.get_variable(config[CONF_MANUAL_FLOW_TEMP])
+        cg.add(var.set_manual_flow_temp(manual_flow_temp))
+
+    # Climate defaults
+    cg.add(var.set_default_target_temperature(config[CONF_DEFAULT_TARGET_TEMPERATURE]))
+
+    # Control parameters (heating curve + PID)
+    params = config[CONF_CONTROL_PARAMETERS]
+    cg.add(var.set_heat_curve_coefficient(params[CONF_HEAT_CURVE_COEFFICIENT]))
+    cg.add(var.set_heat_curve_exponent(params[CONF_HEAT_CURVE_EXPONENT]))
+    cg.add(var.set_heat_curve_shift(params[CONF_HEAT_CURVE_SHIFT]))
+    # PID parameters
+    cg.add(var.set_kp(params[CONF_KP]))
+    cg.add(var.set_ki(params[CONF_KI]))
+    cg.add(var.set_kd(params[CONF_KD]))
+    cg.add(var.set_min_integral(params[CONF_MIN_INTEGRAL]))
+    cg.add(var.set_max_integral(params[CONF_MAX_INTEGRAL]))
+    cg.add(var.set_derivative_samples(params[CONF_DERIVATIVE_AVERAGING_SAMPLES]))
+
+    # Output parameters
+    params = config[CONF_OUTPUT_PARAMETERS]
+    cg.add(var.set_min_flow_temp(params[CONF_MIN_FLOW_TEMP]))
+    cg.add(var.set_max_flow_temp(params[CONF_MAX_FLOW_TEMP]))
+    cg.add(var.set_write_deadband(params[CONF_WRITE_DEADBAND]))
+
+    # Deadband parameters - optional
+    if CONF_DEADBAND_PARAMETERS in config:
+        params = config[CONF_DEADBAND_PARAMETERS]
+        cg.add(var.set_threshold_high(params[CONF_THRESHOLD_HIGH]))
+        cg.add(var.set_threshold_low(params[CONF_THRESHOLD_LOW]))
+        cg.add(var.set_kp_multiplier(params[CONF_KP_MULTIPLIER]))
+        cg.add(var.set_ki_multiplier(params[CONF_KI_MULTIPLIER]))
+        cg.add(var.set_kd_multiplier(params[CONF_KD_MULTIPLIER]))
+
+    # Automation triggers (callback-based, supports multiple entries)
+    for conf in config.get(CONF_ON_HEATING_START, []):
+        await automation.build_callback_automation(
+            var, "add_on_heating_start_callback", [], conf
+        )
+    for conf in config.get(CONF_ON_HEATING_STOP, []):
+        await automation.build_callback_automation(
+            var, "add_on_heating_stop_callback", [], conf
+        )
+
+
+# Action: equitherm.force_recalculate
+EQUITHERM_FORCE_RECALCULATE_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.Required(CONF_ID): cv.use_id(EquithermClimate),
+        cv.Optional(CONF_UPDATE_PID, default=True): cv.templatable(cv.boolean),
+    }
+)
+
+
+@automation.register_action(
+    "climate.equitherm.force_recalculate",
+    EquithermForceRecalculateAction,
+    EQUITHERM_FORCE_RECALCULATE_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def equitherm_force_recalculate_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, paren)
+    update_pid_template_ = await cg.templatable(config[CONF_UPDATE_PID], args, bool)
+    cg.add(var.set_update_pid(update_pid_template_))
+    return var

--- a/esphome/components/equitherm/equitherm.cpp
+++ b/esphome/components/equitherm/equitherm.cpp
@@ -1,0 +1,347 @@
+#include "equitherm.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+
+#ifdef USE_NUMBER
+#include "esphome/components/number/number.h"
+#endif
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "equitherm";
+
+// Outdoor sensor validation range (°C). Readings outside this range are considered sensor failure.
+// Covers all realistic climates: --55°C (extreme cold) to +50°C (extreme heat).
+static constexpr float OUTDOOR_SENSOR_MIN_VALID = -55.0f;
+static constexpr float OUTDOOR_SENSOR_MAX_VALID = 50.0f;
+
+void EquithermClimate::setup() {
+  // Register callback for indoor sensor updates — recompute on every update so the climate
+  // reflects the latest reading (the validity check itself lives in compute_and_apply_()).
+  this->indoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+
+  // Register callback for outdoor sensor updates — same rationale.
+  this->outdoor_sensor_->add_on_state_callback([this](float) { this->compute_and_apply_(); });
+
+  // Restore previous state or set defaults
+  auto restore = this->restore_state_();
+  if (restore.has_value()) {
+    restore->to_call(this).perform();
+  } else {
+    this->mode = climate::CLIMATE_MODE_HEAT;
+    this->target_temperature = this->default_target_temperature_;
+    // On first boot, trigger initial calculation
+    this->compute_and_apply_();
+  }
+}
+
+void EquithermClimate::control(const climate::ClimateCall &call) {
+  auto mode_opt = call.get_mode();
+  if (mode_opt.has_value()) {
+    auto mode = *mode_opt;
+    // Only accept supported modes (OFF and HEAT)
+    if (mode == climate::CLIMATE_MODE_OFF || mode == climate::CLIMATE_MODE_HEAT) {
+      this->mode = mode;
+    }
+  }
+  auto target_opt = call.get_target_temperature();
+  if (target_opt.has_value()) {
+    float new_target = *target_opt;
+    // Reset PID integral on setpoint change to prevent overshoot from old error context
+    if (new_target != this->target_temperature) {
+      ESP_LOGD(TAG, "Target temperature changed: %.1f°C → %.1f°C, resetting PID integral", this->target_temperature,
+               new_target);
+      this->pid_controller_.reset_accumulated_integral();
+      this->pid_correction_ = 0.0f;
+    }
+    this->target_temperature = new_target;
+  }
+
+  if (call.has_custom_preset()) {
+    this->set_custom_preset_(call.get_custom_preset());
+    ESP_LOGI(TAG, "Preset changed to 'manual' — bypassing heating curve");
+  } else {
+    auto preset_opt = call.get_preset();
+    if (preset_opt.has_value() && *preset_opt == climate::CLIMATE_PRESET_NONE) {
+      this->clear_custom_preset_();
+      ESP_LOGI(TAG, "Preset cleared — resuming normal equitherm calculation");
+    }
+  }
+
+  this->compute_and_apply_();
+}
+
+climate::ClimateTraits EquithermClimate::traits() {
+  auto traits = climate::ClimateTraits();
+  traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
+  traits.set_supported_modes({
+      climate::CLIMATE_MODE_OFF,
+      climate::CLIMATE_MODE_HEAT,
+  });
+  traits.set_visual_min_temperature(15.0f);
+  traits.set_visual_max_temperature(25.0f);
+  traits.set_visual_temperature_step(0.5f);
+  if (this->manual_flow_temp_ != nullptr) {
+    traits.add_supported_preset(climate::CLIMATE_PRESET_NONE);
+    traits.set_supported_custom_presets({"Manual"});
+  }
+  return traits;
+}
+
+void EquithermClimate::dump_config() {
+  LOG_CLIMATE("", "Equitherm", this);
+
+  ESP_LOGCONFIG(TAG,
+                "  Heating Curve (industry standard):\n"
+                "    hc: %.2f, n: %.2f, shift: %.2f",
+                heating_curve_.get_hc(), heating_curve_.get_n(), heating_curve_.get_shift());
+
+  ESP_LOGCONFIG(TAG,
+                "  PID Parameters:\n"
+                "    kp: %.3f, ki: %.3f, kd: %.3f",
+                pid_controller_.kp_, pid_controller_.ki_, pid_controller_.kd_);
+
+  ESP_LOGCONFIG(TAG,
+                "  Output Parameters:\n"
+                "    min_flow_temp: %.1f°C, max_flow_temp: %.1f°C",
+                heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+}
+
+void EquithermClimate::write_setpoint_(float temp_c) {
+  // Don't write invalid values to output
+  if (std::isnan(temp_c)) {
+    ESP_LOGW(TAG, "write_setpoint_ called with NAN, ignoring");
+    return;
+  }
+
+  // Curve returns 0.0f in WWS — that's a stop signal, not a temperature.
+  // Without this guard, clamp(0, min_flow_temp, max_flow_temp) would
+  // raise 0 to min_flow_temp and produce unwanted heat output.
+  if (temp_c == 0.0f) {
+    this->write_setpoint_off_();
+    return;
+  }
+
+  // Defensive clamp (heating_curve also clamps, but this ensures safety)
+  float clamped_flow = clamp(temp_c, heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+
+  ESP_LOGD(TAG, "write_setpoint_: %.1f°C (clamped: %.1f°C)", temp_c, clamped_flow);
+
+#ifdef USE_NUMBER
+  if (this->flow_setpoint_output_ != nullptr) {
+    // Direct °C for OpenTherm - preferred
+    ESP_LOGD(TAG, "Writing to flow_setpoint_output: %.1f°C", clamped_flow);
+    this->flow_setpoint_output_->make_call().set_value(clamped_flow).perform();
+    return;
+  }
+#endif
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  if (this->heat_output_ != nullptr) {
+    // Normalize only at boundary - never in calculation
+    float flow_range = heating_curve_.get_max_flow_temp() - heating_curve_.get_min_flow_temp();
+    // Guard against division by zero
+    if (flow_range < 0.01f) {
+      this->heat_output_->set_level(0.0f);
+      return;
+    }
+    float normalized_level = clamp((clamped_flow - heating_curve_.get_min_flow_temp()) / flow_range, 0.0f, 1.0f);
+    ESP_LOGD(TAG, "Writing to heat_output: %.2f (normalized)", normalized_level);
+    this->heat_output_->set_level(normalized_level);
+    return;
+  }
+#endif
+
+  ESP_LOGW(TAG, "write_setpoint_: No output configured (flow_setpoint and heat_output are both null)");
+}
+
+void EquithermClimate::write_setpoint_off_() {
+  // For flow_setpoint_ (number): no action. There is no universal "off" value for a number —
+  // min_value is still a heat request, not an off signal. Use on_heating_stop to do
+  // whatever your hardware requires (turn off ch_enable, send MQTT, etc.).
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  if (this->heat_output_ != nullptr) {
+    // For normalized float output: 0.0 is universally correct — no signal, no heat.
+    // Built-in so users get safe default behavior without needing on_heating_stop.
+    this->heat_output_->set_level(0.0f);
+  }
+#endif
+}
+
+void EquithermClimate::compute_and_apply_(bool update_pid) {
+  // Target temperature must be valid
+  if (std::isnan(this->target_temperature)) {
+    this->state_callback_.call();
+    return;
+  }
+
+  // --- OUTDOOR SENSOR HANDLING ---
+  // Straight read: if the outdoor reading is present, finite and in range use it; otherwise
+  // mark it invalid. With no configured substitute in core, an invalid outdoor sensor skips
+  // recalculation and holds the last setpoint (see guard below). No fault flag here.
+  bool outdoor_valid = this->outdoor_sensor_->has_state() && !std::isnan(this->outdoor_sensor_->state) &&
+                       this->outdoor_sensor_->state >= OUTDOOR_SENSOR_MIN_VALID &&
+                       this->outdoor_sensor_->state <= OUTDOOR_SENSOR_MAX_VALID;
+
+  // --- INDOOR SENSOR HANDLING ---
+  // Straight read: t_indoor is the current indoor state when present and finite, else NAN.
+  // No range check (the transient filter is gone). current_temperature is published only
+  // when the reading is not NAN so HA does not show a garbage value.
+  bool indoor_valid = this->indoor_sensor_->has_state() && !std::isnan(this->indoor_sensor_->state);
+  float t_indoor = indoor_valid ? this->indoor_sensor_->state : NAN;
+
+  if (!std::isnan(t_indoor)) {
+    this->current_temperature = t_indoor;
+  }
+
+  if (this->mode == climate::CLIMATE_MODE_OFF) {
+    // Reset PID integral only on transition to OFF (not every update)
+    if (this->action != climate::CLIMATE_ACTION_OFF) {
+      this->pid_controller_.reset_accumulated_integral();
+      this->pid_correction_ = 0.0f;
+      // Turn off output only on transition - boiler's frost protection handles freeze prevention
+      this->write_setpoint_off_();
+      // Fire stop callback only if we were actually heating
+      if (this->action == climate::CLIMATE_ACTION_HEATING) {
+        this->on_heating_stop_callback_.call();
+      }
+    }
+    this->action = climate::CLIMATE_ACTION_OFF;
+    this->prev_action_ = climate::CLIMATE_ACTION_OFF;
+    this->heating_curve_output_ = NAN;
+    this->pid_adjusted_output_ = NAN;
+    this->wws_active_ = false;
+    this->flow_setpoint_ = NAN;
+    this->active_setpoint_ = NAN;
+    this->publish_state();
+    this->state_callback_.call();
+    return;  // Don't write any setpoint to boiler
+  }
+
+  // --- MANUAL PRESET OR NORMAL EQUITHERM ---
+  bool manual_active = false;
+#ifdef USE_NUMBER
+  manual_active = this->has_custom_preset() && strcmp(this->get_custom_preset().c_str(), "Manual") == 0 &&
+                  this->manual_flow_temp_ != nullptr && this->manual_flow_temp_->has_state() &&
+                  !std::isnan(this->manual_flow_temp_->state);
+#endif
+
+  // Without a configured substitute, an invalid outdoor reading makes the curve incalculable.
+  // In normal (non-manual, non-OFF) mode we hold the last setpoint rather than drive the
+  // boiler from a garbage reading. Manual mode bypasses the curve entirely.
+  if (!manual_active && !outdoor_valid) {
+    ESP_LOGD(TAG, "Outdoor sensor invalid, holding last setpoint");
+    this->publish_state();
+    this->state_callback_.call();
+    return;
+  }
+
+  float t_flow;
+
+  if (manual_active) {
+#ifdef USE_NUMBER
+    // Bypass curve and PID: use manual flow temperature directly
+    t_flow = this->manual_flow_temp_->state;
+    ESP_LOGD(TAG, "Manual preset active: using manual flow temp %.1f°C", t_flow);
+    this->wws_active_ = false;
+    this->heating_curve_output_ = t_flow;
+    this->pid_correction_ = 0.0f;
+    this->pid_adjusted_output_ = t_flow;
+#endif
+  } else {
+    // Normal equitherm curve (outdoor_valid is guaranteed true here)
+    float t_outdoor = this->outdoor_sensor_->state;
+    // WWS decision is owned by the controller, not the curve calculator.
+    // This keeps HeatingCurve stateless and allows the formula to change independently.
+    this->wws_active_ = (this->target_temperature - t_outdoor) <= 0.0f;
+
+    t_flow = heating_curve_.compute_flow_temperature(this->target_temperature, t_outdoor);
+
+    // Clamp to [min, max] only when there's positive heating demand
+    if (!this->wws_active_) {
+      t_flow = std::clamp(t_flow, heating_curve_.get_min_flow_temp(), heating_curve_.get_max_flow_temp());
+    }
+
+    // Store raw curve output for diagnostics (before PID)
+    this->heating_curve_output_ = t_flow;
+
+    // PID correction (ONLY when indoor sensor is valid)
+    if (indoor_valid && update_pid) {
+      this->pid_correction_ = this->pid_controller_.update(this->target_temperature, t_indoor);
+      // Guard against nan from PID controller (can happen on first call)
+      if (std::isnan(this->pid_correction_)) {
+        this->pid_correction_ = 0.0f;
+      }
+    } else {
+      // Indoor sensor invalid - disable PID correction (pure equitherm mode)
+      this->pid_correction_ = 0.0f;
+    }
+
+    // Apply PID correction to flow temperature
+    t_flow += this->pid_correction_;
+
+    // Store setpoint for diagnostics (curve + PID)
+    this->pid_adjusted_output_ = t_flow;
+  }
+
+  // Set action based on heating demand
+  // Manual mode always calls for heat. In normal mode, WWS = off (no demand).
+  // Any positive demand (delta_t > 0) = heating, even when clamped to minimum flow temp.
+  bool calling_for_heat = manual_active || !this->wws_active_;
+  climate::ClimateAction new_action = calling_for_heat ? climate::CLIMATE_ACTION_HEATING : climate::CLIMATE_ACTION_IDLE;
+
+  if (new_action != this->prev_action_) {
+    if (new_action == climate::CLIMATE_ACTION_HEATING) {
+      this->on_heating_start_callback_.call();
+    } else if (this->prev_action_ == climate::CLIMATE_ACTION_HEATING) {
+      this->on_heating_stop_callback_.call();
+    }
+    this->prev_action_ = new_action;
+  }
+  this->action = new_action;
+
+  // WWS: don't send a setpoint to the boiler (only in normal mode — manual mode bypasses curve)
+  if (!manual_active && this->wws_active_) {
+    this->flow_setpoint_ = 0.0f;
+    if (std::isnan(this->active_setpoint_) || this->active_setpoint_ != 0.0f) {
+      this->active_setpoint_ = 0.0f;
+      this->write_setpoint_off_();
+    }
+    this->publish_state();
+    this->state_callback_.call();
+    return;
+  }
+
+  // Final guard: never write nan to output
+  if (std::isnan(t_flow)) {
+    this->state_callback_.call();
+    return;
+  }
+
+  // Round to 0.1°C precision before write deadband check.
+  // Matches real thermostat behavior and eliminates sub-0.1°C noise.
+  t_flow = roundf(t_flow * 10.0f) / 10.0f;
+
+  // Store the rounded value for diagnostics
+  this->flow_setpoint_ = t_flow;
+
+  // Only write to output if setpoint actually changed (avoid spamming boiler)
+  // Uses half-step threshold so any 0.1°C change triggers a write
+  bool setpoint_changed =
+      std::isnan(this->active_setpoint_) || fabsf(t_flow - this->active_setpoint_) > this->write_deadband_;
+
+  ESP_LOGD(TAG, "setpoint check: t_flow=%.1f°C, active_setpoint=%.1f°C, delta=%.2f°C, changed=%s", t_flow,
+           this->active_setpoint_, fabsf(t_flow - this->active_setpoint_), setpoint_changed ? "YES" : "NO");
+
+  if (setpoint_changed) {
+    this->active_setpoint_ = t_flow;
+    this->write_setpoint_(t_flow);
+  }
+  this->publish_state();
+  this->state_callback_.call();
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm.cpp
+++ b/esphome/components/equitherm/equitherm.cpp
@@ -6,8 +6,7 @@
 #include "esphome/components/number/number.h"
 #endif
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "equitherm";
 
@@ -343,5 +342,4 @@ void EquithermClimate::compute_and_apply_(bool update_pid) {
   this->state_callback_.call();
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm.h
+++ b/esphome/components/equitherm/equitherm.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <functional>
+
+#include "esphome/core/automation.h"
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/climate/climate.h"
+#include "esphome/components/sensor/sensor.h"
+
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+#include "esphome/components/output/float_output.h"
+#endif
+
+#include "equitherm_controller.h"
+#include "pid_controller.h"
+
+namespace esphome {
+namespace number {
+class Number;  // Forward declaration
+}
+namespace equitherm {
+
+class EquithermClimate : public climate::Climate, public Component {
+ public:
+  EquithermClimate() = default;
+  void setup() override;
+  void dump_config() override;
+
+  // Sensor inputs
+  void set_outdoor_sensor(sensor::Sensor *sensor) { outdoor_sensor_ = sensor; }
+  void set_indoor_sensor(sensor::Sensor *sensor) { indoor_sensor_ = sensor; }
+
+  // Output (mutually exclusive - only one should be set)
+  void set_flow_setpoint_output(number::Number *number) { flow_setpoint_output_ = number; }
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  void set_heat_output(output::FloatOutput *output) { heat_output_ = output; }
+#endif
+
+  // Optional manual flow temperature (used when manual preset is active)
+  void set_manual_flow_temp(number::Number *number) { manual_flow_temp_ = number; }
+
+  // Climate defaults
+  void set_default_target_temperature(float temp) { default_target_temperature_ = temp; }
+
+  // Heating curve parameters (delegated to heating curve)
+  void set_heat_curve_coefficient(float hc) { heating_curve_.set_hc(hc); }
+  void set_heat_curve_exponent(float n) { heating_curve_.set_n(n); }
+  void set_heat_curve_shift(float shift) { heating_curve_.set_shift(shift); }
+
+  // Output parameters
+  void set_min_flow_temp(float temp) { heating_curve_.set_min_flow_temp(temp); }
+  void set_max_flow_temp(float temp) { heating_curve_.set_max_flow_temp(temp); }
+  void set_write_deadband(float deadband) { write_deadband_ = deadband; }
+
+  // PID parameters
+  void set_kp(float kp) { pid_controller_.kp_ = kp; }
+  void set_ki(float ki) { pid_controller_.ki_ = ki; }
+  void set_kd(float kd) { pid_controller_.kd_ = kd; }
+  void set_min_integral(float min_integral) { pid_controller_.min_integral_ = min_integral; }
+  void set_max_integral(float max_integral) { pid_controller_.max_integral_ = max_integral; }
+  void set_derivative_samples(int samples) {
+    pid_controller_.derivative_samples_ = samples;
+    if (samples > 1)  // No allocation needed when samples=1 (ring_buffer_average_ short-circuits)
+      pid_controller_.derivative_window_.init(samples);
+  }
+
+  // Deadband parameters
+  void set_threshold_low(float threshold) { pid_controller_.threshold_low_ = threshold; }
+  void set_threshold_high(float threshold) { pid_controller_.threshold_high_ = threshold; }
+  void set_kp_multiplier(float mult) { pid_controller_.kp_multiplier_ = mult; }
+  void set_ki_multiplier(float mult) { pid_controller_.ki_multiplier_ = mult; }
+  void set_kd_multiplier(float mult) { pid_controller_.kd_multiplier_ = mult; }
+
+  bool is_wws_active() const { return wws_active_; }
+
+  // State getters (for diagnostics)
+  float get_heating_curve_output() const { return heating_curve_output_; }
+  float get_pid_adjusted_output() const { return pid_adjusted_output_; }
+  float get_flow_setpoint() const { return flow_setpoint_; }
+  float get_active_setpoint() const { return active_setpoint_; }
+  float get_pid_correction() const { return pid_correction_; }
+  bool in_deadband() { return pid_controller_.in_deadband(); }
+  bool is_pid_active() const {
+    // Check if any PID gain is effectively non-zero (handles runtime tuning)
+    constexpr float epsilon = 0.0001f;
+    return fabsf(pid_controller_.kp_) > epsilon || fabsf(pid_controller_.ki_) > epsilon ||
+           fabsf(pid_controller_.kd_) > epsilon;
+  }
+
+  // Parameter getters (for runtime tuning)
+  float get_hc() const { return heating_curve_.get_hc(); }
+  float get_n() const { return heating_curve_.get_n(); }
+  float get_shift() const { return heating_curve_.get_shift(); }
+  float get_min_flow_temp() const { return heating_curve_.get_min_flow_temp(); }
+  float get_max_flow_temp() const { return heating_curve_.get_max_flow_temp(); }
+  float get_kp() const { return pid_controller_.kp_; }
+  float get_ki() const { return pid_controller_.ki_; }
+  float get_kd() const { return pid_controller_.kd_; }
+  float get_proportional_term() const { return pid_controller_.proportional_term_; }
+  float get_integral_term() const { return pid_controller_.integral_term_; }
+  float get_derivative_term() const { return pid_controller_.derivative_term_; }
+
+  // Callback for diagnostic sensors
+  void add_on_state_callback(std::function<void()> &&callback) { state_callback_.add(std::move(callback)); }
+
+  // Callbacks for heating state transitions
+  template<typename F> void add_on_heating_start_callback(F &&callback) {
+    this->on_heating_start_callback_.add(std::forward<F>(callback));
+  }
+  template<typename F> void add_on_heating_stop_callback(F &&callback) {
+    this->on_heating_stop_callback_.add(std::forward<F>(callback));
+  }
+
+  // Force immediate recalculation (used by runtime tuning numbers)
+  void force_recalculate(bool update_pid = false) { this->compute_and_apply_(update_pid); }
+
+ protected:
+  /// Override control to handle climate calls from HA
+  void control(const climate::ClimateCall &call) override;
+  /// Return the traits of this controller
+  climate::ClimateTraits traits() override;
+
+  void compute_and_apply_(bool update_pid = true);
+  void write_setpoint_(float temp_c);
+  void write_setpoint_off_();
+
+  /// Outdoor temperature sensor (required)
+  sensor::Sensor *outdoor_sensor_{nullptr};
+  /// Indoor temperature sensor (required - for current_temperature display and room correction)
+  sensor::Sensor *indoor_sensor_{nullptr};
+  /// Flow temperature setpoint output (direct °C control, e.g., OpenTherm)
+  number::Number *flow_setpoint_output_{nullptr};
+#ifdef USE_EQUITHERM_HEAT_OUTPUT
+  /// Alternative: generic float output (normalized 0-1)
+  output::FloatOutput *heat_output_{nullptr};
+#endif
+  /// Manual flow temperature override (used when custom preset "manual" is active)
+  number::Number *manual_flow_temp_{nullptr};
+
+  /// Curve calculation engine
+  HeatingCurve heating_curve_;
+  /// PID controller for fine-tuning equitherm output
+  PIDController pid_controller_;
+  /// Default target temperature when no state restored
+  float default_target_temperature_{20.0f};
+  /// Raw heating curve output before PID (for diagnostics)
+  float heating_curve_output_{NAN};
+  /// Setpoint after PID (for diagnostics)
+  float pid_adjusted_output_{NAN};
+  /// Whether warm weather shutdown is active (delta_t <= 0, no heating demand)
+  bool wws_active_{false};
+  /// Flow setpoint (after PID, for diagnostics)
+  float flow_setpoint_{NAN};
+  /// Last value actually written to boiler (confirmed active setpoint)
+  float active_setpoint_{NAN};
+  /// PID correction (for diagnostics)
+  float pid_correction_{NAN};
+  /// Minimum setpoint change (°C) required to write to boiler output
+  float write_deadband_{0.05f};
+
+  /// Callback for diagnostic sensors
+  CallbackManager<void()> state_callback_;
+  /// Previous climate action — used to detect heating start/stop transitions
+  climate::ClimateAction prev_action_{climate::CLIMATE_ACTION_OFF};
+  /// Callback fired when transitioning into CLIMATE_ACTION_HEATING
+  CallbackManager<void()> on_heating_start_callback_;
+  /// Callback fired when transitioning out of CLIMATE_ACTION_HEATING
+  CallbackManager<void()> on_heating_stop_callback_;
+};
+
+template<typename... Ts> class EquithermForceRecalculateAction : public Action<Ts...> {
+ public:
+  EquithermForceRecalculateAction(EquithermClimate *parent) : parent_(parent) {}
+
+  void set_update_pid(bool update_pid) { update_pid_ = update_pid; }
+
+  void play(const Ts &...x) override { this->parent_->force_recalculate(this->update_pid_); }
+
+ protected:
+  EquithermClimate *parent_;
+  bool update_pid_{true};
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm.h
+++ b/esphome/components/equitherm/equitherm.h
@@ -15,11 +15,11 @@
 #include "equitherm_controller.h"
 #include "pid_controller.h"
 
-namespace esphome {
-namespace number {
+namespace esphome::number {
 class Number;  // Forward declaration
-}
-namespace equitherm {
+}  // namespace esphome::number
+
+namespace esphome::equitherm {
 
 class EquithermClimate : public climate::Climate, public Component {
  public:
@@ -182,5 +182,4 @@ template<typename... Ts> class EquithermForceRecalculateAction : public Action<T
   bool update_pid_{true};
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm_controller.cpp
+++ b/esphome/components/equitherm/equitherm_controller.cpp
@@ -1,8 +1,7 @@
 #include "equitherm_controller.h"
 #include "esphome/core/helpers.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
   // Guard against invalid inputs
@@ -29,5 +28,4 @@ float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
   return clamp(t_flow, this->min_flow_temp_, this->max_flow_temp_);
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/equitherm_controller.cpp
+++ b/esphome/components/equitherm/equitherm_controller.cpp
@@ -1,0 +1,33 @@
+#include "equitherm_controller.h"
+#include "esphome/core/helpers.h"
+
+namespace esphome {
+namespace equitherm {
+
+float HeatingCurve::compute_flow_temperature(float t_target, float t_outdoor) {
+  // Guard against invalid inputs
+  if (std::isnan(t_target) || std::isnan(t_outdoor)) {
+    return min_flow_temp_;
+  }
+
+  float delta_t = t_target - t_outdoor;
+
+  // Warm weather shutdown: outdoor >= target — bypass formula entirely.
+  // Return 0 to signal no heating demand.
+  // Shift is only valid within the heating domain (delta_t > 0); applying it
+  // at delta_t <= 0 would defeat warm weather shutdown and supply heat
+  // unnecessarily. See: Viessmann, Buderus, EN 12831, Versatile Thermostat.
+  if (delta_t <= 0.0f) {
+    return 0.0f;
+  }
+
+  // Industry-standard European heating curve:
+  // t_flow = t_target + shift + hc * (t_target - t_outdoor)^(1/n)
+  float t_flow = t_target + this->shift_ + this->hc_ * powf(delta_t, 1.0f / this->n_);
+
+  // Clamp to boiler limits
+  return clamp(t_flow, this->min_flow_temp_, this->max_flow_temp_);
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm_controller.h
+++ b/esphome/components/equitherm/equitherm_controller.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "esphome/core/hal.h"
+#include <cmath>
+
+namespace esphome {
+namespace equitherm {
+
+/// Standard European heating curve (Buderus/Viessmann style).
+/// Pure calculator — no side effects, testable in isolation.
+///
+/// Formula: t_flow = t_target + shift + hc * (t_target - t_outdoor)^(1/n)
+///
+/// Parameters:
+///   hc: heat curve coefficient (0.5-1.5), maps to building insulation
+///   n:  radiator exponent (1.2-1.33 panels, 1.0 underfloor) per EN 442
+///   shift: flat offset in °C for fine-tuning
+class HeatingCurve {
+ public:
+  /// Compute supply temperature from target and outdoor temperatures
+  /// @param t_target Room target temperature in °C
+  /// @param t_outdoor Outdoor temperature in °C
+  /// @return Calculated supply temperature in °C, clamped to [min_flow_temp_, max_flow_temp_].
+  ///         Returns 0.0f when delta_t <= 0 (warm weather shutdown).
+  float compute_flow_temperature(float t_target, float t_outdoor);
+
+  // Parameter setters (called from EquithermClimate)
+  void set_hc(float hc) { hc_ = hc; }
+  void set_n(float n) { n_ = n; }
+  void set_shift(float shift) { shift_ = shift; }
+  void set_min_flow_temp(float temp) { min_flow_temp_ = temp; }
+  void set_max_flow_temp(float temp) { max_flow_temp_ = temp; }
+
+  // Parameter getters (for dump_config and diagnostics)
+  float get_hc() const { return hc_; }
+  float get_n() const { return n_; }
+  float get_shift() const { return shift_; }
+  float get_min_flow_temp() const { return min_flow_temp_; }
+  float get_max_flow_temp() const { return max_flow_temp_; }
+
+ protected:
+  /// Heat curve coefficient (industry: 0.5-1.5 depending on insulation)
+  /// Higher values = more aggressive heating
+  float hc_{1.0f};
+  /// Radiator exponent (industry: 1.2-1.33 for panel radiators, 1.0 for underfloor)
+  float n_{1.25f};
+  /// Flat offset in °C for fine-tuning
+  float shift_{0.0f};
+  /// Minimum supply temperature to boiler
+  float min_flow_temp_{25.0f};
+  /// Maximum supply temperature to boiler
+  float max_flow_temp_{70.0f};
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/equitherm_controller.h
+++ b/esphome/components/equitherm/equitherm_controller.h
@@ -3,8 +3,7 @@
 #include "esphome/core/hal.h"
 #include <cmath>
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 /// Standard European heating curve (Buderus/Viessmann style).
 /// Pure calculator — no side effects, testable in isolation.
@@ -52,5 +51,4 @@ class HeatingCurve {
   float max_flow_temp_{70.0f};
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/__init__.py
+++ b/esphome/components/equitherm/number/__init__.py
@@ -1,0 +1,264 @@
+import esphome.codegen as cg
+from esphome.components import number
+from esphome.components.const import CONF_CLIMATE_ID
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_MODE,
+    CONF_RESTORE_VALUE,
+    CONF_STEP,
+    DEVICE_CLASS_TEMPERATURE,
+    ENTITY_CATEGORY_CONFIG,
+    UNIT_CELSIUS,
+)
+
+from ..climate import EquithermClimate, equitherm_ns
+
+# =============================================================================
+# C++ Class Declarations
+# =============================================================================
+
+HeatCurveCoefficientNumber = equitherm_ns.class_(
+    "HeatCurveCoefficientNumber", number.Number, cg.Component
+)
+HeatCurveExponentNumber = equitherm_ns.class_(
+    "HeatCurveExponentNumber", number.Number, cg.Component
+)
+HeatCurveShiftNumber = equitherm_ns.class_(
+    "HeatCurveShiftNumber", number.Number, cg.Component
+)
+PIDProportionalGainNumber = equitherm_ns.class_(
+    "PIDProportionalGainNumber", number.Number, cg.Component
+)
+PIDIntegralGainNumber = equitherm_ns.class_(
+    "PIDIntegralGainNumber", number.Number, cg.Component
+)
+PIDDerivativeGainNumber = equitherm_ns.class_(
+    "PIDDerivativeGainNumber", number.Number, cg.Component
+)
+
+# Heating curve parameters
+CONF_HEAT_CURVE_COEFFICIENT = "heat_curve_coefficient"
+CONF_HEAT_CURVE_EXPONENT = "heat_curve_exponent"
+CONF_HEAT_CURVE_SHIFT = "heat_curve_shift"
+
+# PID tuning parameters
+CONF_PID_PROPORTIONAL_GAIN = "pid_proportional_gain"
+CONF_PID_INTEGRAL_GAIN = "pid_integral_gain"
+CONF_PID_DERIVATIVE_GAIN = "pid_derivative_gain"
+
+# =============================================================================
+# Icons (component-specific, not in esphome/const.py)
+# =============================================================================
+
+# Heating curve icons - each represents a specific aspect of the heating curve
+CONF_ICON_HEATING_CURVE_SLOPE = (
+    "mdi:slope-uphill"  # Coefficient - controls curve steepness
+)
+CONF_ICON_HEATING_CURVE_CURVATURE = (
+    "mdi:tune-variant"  # Exponent - controls curve shape
+)
+CONF_ICON_HEATING_CURVE_OFFSET = "mdi:arrow-up-down"  # Shift - parallel displacement
+CONF_ICON_PID_TUNING = "mdi:tune"  # PID gains - tuning parameters
+
+# =============================================================================
+# Default Values
+# =============================================================================
+
+# Heating curve defaults
+DEFAULT_HC_MIN, DEFAULT_HC_MAX, DEFAULT_HC_STEP = 0.5, 5.0, 0.05
+DEFAULT_N_MIN, DEFAULT_N_MAX, DEFAULT_N_STEP = 0.5, 3.0, 0.05
+DEFAULT_SHIFT_MIN, DEFAULT_SHIFT_MAX, DEFAULT_SHIFT_STEP = -20.0, 20.0, 0.5
+
+# PID defaults
+DEFAULT_KP_MIN, DEFAULT_KP_MAX, DEFAULT_KP_STEP = 0.0, 20.0, 0.01
+DEFAULT_KI_MIN, DEFAULT_KI_MAX, DEFAULT_KI_STEP = 0.0, 10.0, 0.0001
+DEFAULT_KD_MIN, DEFAULT_KD_MAX, DEFAULT_KD_STEP = 0.0, 10.0, 0.01
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+
+def _validate_min_max(config):
+    """Validate that max_value > min_value if both are specified."""
+    min_val = config.get(CONF_MIN_VALUE)
+    max_val = config.get(CONF_MAX_VALUE)
+    if min_val is not None and max_val is not None and max_val <= min_val:
+        raise cv.Invalid("max_value must be greater than min_value")
+    return config
+
+
+# =============================================================================
+# Schema Helpers
+# =============================================================================
+
+
+def _number_schema(number_class, icon, device_class=None, unit=None):
+    """Generate schema for a number with sensible defaults and full customization.
+
+    These numbers are runtime tuning interfaces for parameters defined in the climate
+    component's YAML config. The initial value comes from the climate config, not from
+    an initial_value option here. restore_value controls whether user tuning persists.
+
+    Args:
+        number_class: The C++ number class to instantiate
+        icon: Default icon (can be overridden by user)
+        device_class: Optional device class for semantic meaning
+        unit: Optional unit of measurement
+
+    Returns:
+        Schema that extends number_schema with min/max/step/mode/restore_value
+    """
+    kwargs = {
+        "icon": icon,
+        "entity_category": ENTITY_CATEGORY_CONFIG,
+    }
+    if device_class:
+        kwargs["device_class"] = device_class
+    if unit:
+        kwargs["unit_of_measurement"] = unit
+
+    return cv.All(
+        number.number_schema(number_class, **kwargs).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE): cv.float_,
+                cv.Optional(CONF_MAX_VALUE): cv.float_,
+                cv.Optional(CONF_STEP): cv.positive_float,
+                cv.Optional(CONF_MODE, default="AUTO"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=True): cv.boolean,
+            }
+        ),
+        _validate_min_max,
+    )
+
+
+# =============================================================================
+# Grouped Schemas
+# =============================================================================
+
+HEATING_CURVE_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_HEAT_CURVE_COEFFICIENT): _number_schema(
+            HeatCurveCoefficientNumber, icon=CONF_ICON_HEATING_CURVE_SLOPE
+        ),
+        cv.Optional(CONF_HEAT_CURVE_EXPONENT): _number_schema(
+            HeatCurveExponentNumber, icon=CONF_ICON_HEATING_CURVE_CURVATURE
+        ),
+        cv.Optional(CONF_HEAT_CURVE_SHIFT): _number_schema(
+            HeatCurveShiftNumber,
+            icon=CONF_ICON_HEATING_CURVE_OFFSET,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit=UNIT_CELSIUS,
+        ),
+    }
+)
+
+PID_GAINS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_PID_PROPORTIONAL_GAIN): _number_schema(
+            PIDProportionalGainNumber, icon=CONF_ICON_PID_TUNING
+        ),
+        cv.Optional(CONF_PID_INTEGRAL_GAIN): _number_schema(
+            PIDIntegralGainNumber, icon=CONF_ICON_PID_TUNING
+        ),
+        cv.Optional(CONF_PID_DERIVATIVE_GAIN): _number_schema(
+            PIDDerivativeGainNumber, icon=CONF_ICON_PID_TUNING
+        ),
+    }
+)
+
+# =============================================================================
+# Main Configuration Schema
+# =============================================================================
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ID): cv.declare_id(cg.EntityBase),
+            cv.GenerateID(CONF_CLIMATE_ID): cv.use_id(EquithermClimate),
+        }
+    )
+    .extend(HEATING_CURVE_SCHEMA)
+    .extend(PID_GAINS_SCHEMA)
+)
+
+# =============================================================================
+# Code Generation Helpers
+# =============================================================================
+
+
+async def _register_number(config, parent_id, default_min, default_max, default_step):
+    """Register a number entity with defaults for min/max/step.
+
+    The initial value is read from the parent climate component in C++ setup(),
+    so we don't set an initial_value here. restore_value controls persistence.
+    """
+    min_val = config.get(CONF_MIN_VALUE, default_min)
+    max_val = config.get(CONF_MAX_VALUE, default_max)
+    step = config.get(CONF_STEP, default_step)
+    restore_val = config.get(CONF_RESTORE_VALUE, True)
+
+    n = await number.new_number(config, min_value=min_val, max_value=max_val, step=step)
+    await cg.register_component(n, config)
+    await cg.register_parented(n, parent_id)
+    cg.add(n.set_restore_value(restore_val))
+
+    return n
+
+
+async def _register_heating_curve_numbers(config, parent_id):
+    """Register all heating curve number entities."""
+    if hc_config := config.get(CONF_HEAT_CURVE_COEFFICIENT):
+        await _register_number(
+            hc_config, parent_id, DEFAULT_HC_MIN, DEFAULT_HC_MAX, DEFAULT_HC_STEP
+        )
+
+    if n_config := config.get(CONF_HEAT_CURVE_EXPONENT):
+        await _register_number(
+            n_config, parent_id, DEFAULT_N_MIN, DEFAULT_N_MAX, DEFAULT_N_STEP
+        )
+
+    if shift_config := config.get(CONF_HEAT_CURVE_SHIFT):
+        await _register_number(
+            shift_config,
+            parent_id,
+            DEFAULT_SHIFT_MIN,
+            DEFAULT_SHIFT_MAX,
+            DEFAULT_SHIFT_STEP,
+        )
+
+
+async def _register_pid_numbers(config, parent_id):
+    """Register all PID gain number entities."""
+    if kp_config := config.get(CONF_PID_PROPORTIONAL_GAIN):
+        await _register_number(
+            kp_config, parent_id, DEFAULT_KP_MIN, DEFAULT_KP_MAX, DEFAULT_KP_STEP
+        )
+
+    if ki_config := config.get(CONF_PID_INTEGRAL_GAIN):
+        await _register_number(
+            ki_config, parent_id, DEFAULT_KI_MIN, DEFAULT_KI_MAX, DEFAULT_KI_STEP
+        )
+
+    if kd_config := config.get(CONF_PID_DERIVATIVE_GAIN):
+        await _register_number(
+            kd_config, parent_id, DEFAULT_KD_MIN, DEFAULT_KD_MAX, DEFAULT_KD_STEP
+        )
+
+
+# =============================================================================
+# Code Generation Entry Point
+# =============================================================================
+
+
+async def to_code(config):
+    """Generate C++ code for all equitherm number entities."""
+    parent_id = config[CONF_CLIMATE_ID]
+
+    await _register_heating_curve_numbers(config, parent_id)
+    await _register_pid_numbers(config, parent_id)

--- a/esphome/components/equitherm/number/equitherm_number_base.cpp
+++ b/esphome/components/equitherm/number/equitherm_number_base.cpp
@@ -1,7 +1,6 @@
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 void EquithermNumberBase::init_state_(float value) {
   if (this->restore_value_) {
@@ -17,5 +16,4 @@ void EquithermNumberBase::save_state_(float value) {
   }
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/equitherm_number_base.cpp
+++ b/esphome/components/equitherm/number/equitherm_number_base.cpp
@@ -1,0 +1,21 @@
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+void EquithermNumberBase::init_state_(float value) {
+  if (this->restore_value_) {
+    this->pref_ = this->make_entity_preference<float>();
+    this->pref_.load(&value);  // overwrites on success, keeps default on failure
+  }
+  this->publish_state(value);
+}
+
+void EquithermNumberBase::save_state_(float value) {
+  if (this->restore_value_) {
+    this->pref_.save(&value);
+  }
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/equitherm_number_base.h
+++ b/esphome/components/equitherm/number/equitherm_number_base.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include "esphome/components/number/number.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 /// Base class for equitherm climate number entities with common restore logic.
 ///
@@ -24,5 +23,4 @@ class EquithermNumberBase : public number::Number, public Component {
   ESPPreferenceObject pref_;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/equitherm_number_base.h
+++ b/esphome/components/equitherm/number/equitherm_number_base.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/number/number.h"
+
+namespace esphome {
+namespace equitherm {
+
+/// Base class for equitherm climate number entities with common restore logic.
+///
+/// These numbers are runtime tuning interfaces for parameters defined in the climate
+/// component's YAML config. The initial value is read from the parent climate in setup().
+/// If restore_value is true, user's runtime tuning persists across reboots.
+class EquithermNumberBase : public number::Number, public Component {
+ public:
+  void set_restore_value(bool restore_value) { restore_value_ = restore_value; }
+
+ protected:
+  void init_state_(float value);
+  void save_state_(float value);
+
+  bool restore_value_{false};
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_coefficient_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_coefficient_number.cpp
@@ -1,0 +1,28 @@
+#include "heat_curve_coefficient_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "heat_curve_coefficient_number";
+
+void HeatCurveCoefficientNumber::setup() {
+  this->init_state_(this->parent_->get_hc());
+  this->parent_->set_heat_curve_coefficient(this->state);
+}
+
+void HeatCurveCoefficientNumber::control(float value) {
+  this->parent_->set_heat_curve_coefficient(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void HeatCurveCoefficientNumber::dump_config() {
+  LOG_NUMBER("", "HeatCurveCoefficientNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_coefficient_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_coefficient_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "heat_curve_coefficient_number";
 
@@ -24,5 +23,4 @@ void HeatCurveCoefficientNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_coefficient_number.h
+++ b/esphome/components/equitherm/number/heat_curve_coefficient_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class HeatCurveCoefficientNumber : public EquithermNumberBase, public Parented<E
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_coefficient_number.h
+++ b/esphome/components/equitherm/number/heat_curve_coefficient_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// Heat curve coefficient (hc) - controls the slope of the heating curve
+class HeatCurveCoefficientNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_exponent_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_exponent_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "heat_curve_exponent_number";
 
@@ -24,5 +23,4 @@ void HeatCurveExponentNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_exponent_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_exponent_number.cpp
@@ -1,0 +1,28 @@
+#include "heat_curve_exponent_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "heat_curve_exponent_number";
+
+void HeatCurveExponentNumber::setup() {
+  this->init_state_(this->parent_->get_n());
+  this->parent_->set_heat_curve_exponent(this->state);
+}
+
+void HeatCurveExponentNumber::control(float value) {
+  this->parent_->set_heat_curve_exponent(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void HeatCurveExponentNumber::dump_config() {
+  LOG_NUMBER("", "HeatCurveExponentNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_exponent_number.h
+++ b/esphome/components/equitherm/number/heat_curve_exponent_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// Radiator exponent (n) - controls curve curvature based on radiator type
+class HeatCurveExponentNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_exponent_number.h
+++ b/esphome/components/equitherm/number/heat_curve_exponent_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class HeatCurveExponentNumber : public EquithermNumberBase, public Parented<Equi
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_shift_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_shift_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "heat_curve_shift_number";
 
@@ -24,5 +23,4 @@ void HeatCurveShiftNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_shift_number.cpp
+++ b/esphome/components/equitherm/number/heat_curve_shift_number.cpp
@@ -1,0 +1,28 @@
+#include "heat_curve_shift_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "heat_curve_shift_number";
+
+void HeatCurveShiftNumber::setup() {
+  this->init_state_(this->parent_->get_shift());
+  this->parent_->set_heat_curve_shift(this->state);
+}
+
+void HeatCurveShiftNumber::control(float value) {
+  this->parent_->set_heat_curve_shift(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void HeatCurveShiftNumber::dump_config() {
+  LOG_NUMBER("", "HeatCurveShiftNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/heat_curve_shift_number.h
+++ b/esphome/components/equitherm/number/heat_curve_shift_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class HeatCurveShiftNumber : public EquithermNumberBase, public Parented<Equithe
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/heat_curve_shift_number.h
+++ b/esphome/components/equitherm/number/heat_curve_shift_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// Heat curve shift - parallel displacement of the heating curve
+class HeatCurveShiftNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_derivative_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_derivative_gain_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "pid_derivative_gain_number";
 
@@ -24,5 +23,4 @@ void PIDDerivativeGainNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/pid_derivative_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_derivative_gain_number.cpp
@@ -1,0 +1,28 @@
+#include "pid_derivative_gain_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "pid_derivative_gain_number";
+
+void PIDDerivativeGainNumber::setup() {
+  this->init_state_(this->parent_->get_kd());
+  this->parent_->set_kd(this->state);
+}
+
+void PIDDerivativeGainNumber::control(float value) {
+  this->parent_->set_kd(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void PIDDerivativeGainNumber::dump_config() {
+  LOG_NUMBER("", "PIDDerivativeGainNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_derivative_gain_number.h
+++ b/esphome/components/equitherm/number/pid_derivative_gain_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class PIDDerivativeGainNumber : public EquithermNumberBase, public Parented<Equi
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/pid_derivative_gain_number.h
+++ b/esphome/components/equitherm/number/pid_derivative_gain_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// PID derivative gain (Kd) - anticipates future error
+class PIDDerivativeGainNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_integral_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_integral_gain_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "pid_integral_gain_number";
 
@@ -24,5 +23,4 @@ void PIDIntegralGainNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/pid_integral_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_integral_gain_number.cpp
@@ -1,0 +1,28 @@
+#include "pid_integral_gain_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "pid_integral_gain_number";
+
+void PIDIntegralGainNumber::setup() {
+  this->init_state_(this->parent_->get_ki());
+  this->parent_->set_ki(this->state);
+}
+
+void PIDIntegralGainNumber::control(float value) {
+  this->parent_->set_ki(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void PIDIntegralGainNumber::dump_config() {
+  LOG_NUMBER("", "PIDIntegralGainNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_integral_gain_number.h
+++ b/esphome/components/equitherm/number/pid_integral_gain_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class PIDIntegralGainNumber : public EquithermNumberBase, public Parented<Equith
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/pid_integral_gain_number.h
+++ b/esphome/components/equitherm/number/pid_integral_gain_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// PID integral gain (Ki) - eliminates steady-state error over time
+class PIDIntegralGainNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_proportional_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_proportional_gain_number.cpp
@@ -1,0 +1,28 @@
+#include "pid_proportional_gain_number.h"
+#include "esphome/core/log.h"
+#include "../equitherm.h"
+
+namespace esphome {
+namespace equitherm {
+
+static const char *const TAG = "pid_proportional_gain_number";
+
+void PIDProportionalGainNumber::setup() {
+  this->init_state_(this->parent_->get_kp());
+  this->parent_->set_kp(this->state);
+}
+
+void PIDProportionalGainNumber::control(float value) {
+  this->parent_->set_kp(value);
+  this->save_state_(value);
+  this->publish_state(value);
+  this->parent_->force_recalculate();
+}
+
+void PIDProportionalGainNumber::dump_config() {
+  LOG_NUMBER("", "PIDProportionalGainNumber", this);
+  ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_proportional_gain_number.cpp
+++ b/esphome/components/equitherm/number/pid_proportional_gain_number.cpp
@@ -2,8 +2,7 @@
 #include "esphome/core/log.h"
 #include "../equitherm.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 static const char *const TAG = "pid_proportional_gain_number";
 
@@ -24,5 +23,4 @@ void PIDProportionalGainNumber::dump_config() {
   ESP_LOGCONFIG(TAG, "  Restore value: %s", YESNO(this->restore_value_));
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/number/pid_proportional_gain_number.h
+++ b/esphome/components/equitherm/number/pid_proportional_gain_number.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "equitherm_number_base.h"
+
+namespace esphome {
+namespace equitherm {
+
+class EquithermClimate;
+
+/// PID proportional gain (Kp) - room temperature correction factor
+class PIDProportionalGainNumber : public EquithermNumberBase, public Parented<EquithermClimate> {
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/number/pid_proportional_gain_number.h
+++ b/esphome/components/equitherm/number/pid_proportional_gain_number.h
@@ -2,8 +2,7 @@
 
 #include "equitherm_number_base.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 class EquithermClimate;
 
@@ -18,5 +17,4 @@ class PIDProportionalGainNumber : public EquithermNumberBase, public Parented<Eq
   void control(float value) override;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/pid_controller.cpp
+++ b/esphome/components/equitherm/pid_controller.cpp
@@ -1,7 +1,6 @@
 #include "pid_controller.h"
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 float PIDController::update(float setpoint, float process_value) {
   // e(t) ... error at timestamp t
@@ -123,5 +122,4 @@ float PIDController::calculate_relative_time_() {
   return dt / 1000.0f;
 }
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/esphome/components/equitherm/pid_controller.cpp
+++ b/esphome/components/equitherm/pid_controller.cpp
@@ -1,0 +1,127 @@
+#include "pid_controller.h"
+
+namespace esphome {
+namespace equitherm {
+
+float PIDController::update(float setpoint, float process_value) {
+  // e(t) ... error at timestamp t
+  // r(t) ... setpoint
+  // y(t) ... process value (sensor reading)
+  // u(t) ... output value
+
+  dt_ = calculate_relative_time_();
+
+  // e(t) := r(t) - y(t)
+  error_ = setpoint - process_value;
+
+  calculate_proportional_term_();
+  calculate_integral_term_();
+  calculate_derivative_term_(setpoint);
+
+  // u(t) := p(t) + i(t) + d(t)
+  float output = proportional_term_ + integral_term_ + derivative_term_;
+
+  // smooth/sample the output using shared buffer with mode-appropriate sample count
+  int samples = in_deadband() ? deadband_output_samples_ : output_samples_;
+  return ring_buffer_average_(output_window_, output, samples);
+}
+
+bool PIDController::in_deadband() {
+  // return (fabs(error) < deadband_threshold);
+  float err = -error_;
+  return (threshold_low_ < err && err < threshold_high_);
+}
+
+void PIDController::calculate_proportional_term_() {
+  // p(t) := K_p * e(t)
+  proportional_term_ = kp_ * error_;
+
+  // set dead-zone to -X to +X
+  if (in_deadband()) {
+    // shallow the proportional_term in the deadband by the pdm
+    proportional_term_ *= kp_multiplier_;
+
+  } else {
+    // pdm_offset prevents a jump when leaving the deadband
+    float threshold = (error_ < 0) ? threshold_high_ : threshold_low_;
+    float pdm_offset = (threshold - (kp_multiplier_ * threshold)) * kp_;
+    proportional_term_ += pdm_offset;
+  }
+}
+
+void PIDController::calculate_integral_term_() {
+  // i(t) := K_i * \int_{0}^{t} e(t) dt
+  float new_integral = error_ * dt_ * ki_;
+
+  if (in_deadband()) {
+    // shallow the integral when in the deadband
+    accumulated_integral_ += new_integral * ki_multiplier_;
+  } else {
+    accumulated_integral_ += new_integral;
+  }
+
+  // constrain accumulated integral value
+  if (!std::isnan(min_integral_) && accumulated_integral_ < min_integral_)
+    accumulated_integral_ = min_integral_;
+  if (!std::isnan(max_integral_) && accumulated_integral_ > max_integral_)
+    accumulated_integral_ = max_integral_;
+
+  integral_term_ = accumulated_integral_;
+}
+
+void PIDController::calculate_derivative_term_(float setpoint) {
+  // derivative_term_
+  // d(t) := K_d * de(t)/dt
+  float derivative = 0.0f;
+  if (dt_ != 0.0f) {
+    // remove changes to setpoint from error
+    if (!std::isnan(previous_setpoint_) && previous_setpoint_ != setpoint)
+      previous_error_ -= previous_setpoint_ - setpoint;
+    derivative = (error_ - previous_error_) / dt_;
+  }
+  previous_error_ = error_;
+  previous_setpoint_ = setpoint;
+
+  // smooth the derivative samples
+  derivative = ring_buffer_average_(derivative_window_, derivative, derivative_samples_);
+
+  derivative_term_ = kd_ * derivative;
+
+  if (in_deadband()) {
+    // shallow the derivative when in the deadband
+    derivative_term_ *= kd_multiplier_;
+  }
+}
+
+float PIDController::ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples) {
+  // if only 1 sample needed (or invalid), clear the buffer and return
+  if (max_samples <= 1) {
+    buf.clear();
+    return new_value;
+  }
+
+  // Trim oldest entries to make room (handles mode-switching where buffer
+  // may have more entries than the current mode needs)
+  while (buf.size() >= static_cast<size_t>(max_samples))
+    buf.pop();
+  buf.push(new_value);
+
+  float sum = 0;
+  for (auto val : buf)
+    sum += val;
+  return sum / buf.size();
+}
+
+float PIDController::calculate_relative_time_() {
+  uint32_t now = millis();
+  uint32_t dt = now - this->last_time_;
+  if (last_time_ == 0) {
+    last_time_ = now;
+    return 0.0f;
+  }
+  last_time_ = now;
+  return dt / 1000.0f;
+}
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/pid_controller.h
+++ b/esphome/components/equitherm/pid_controller.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include <cmath>
+
+namespace esphome {
+namespace equitherm {
+
+/// Embedded PID controller — avoids dependency on pid component.
+/// Kept in sync with esphome/components/pid/pid_controller.
+struct PIDController {
+  float update(float setpoint, float process_value);
+
+  void reset_accumulated_integral() { accumulated_integral_ = 0; }
+  void set_starting_integral_term(float in) { accumulated_integral_ = in; }
+
+  bool in_deadband();
+
+  friend class EquithermClimate;
+
+ private:
+  /// Proportional gain K_p.
+  float kp_ = 0;
+  /// Integral gain K_i.
+  float ki_ = 0;
+  /// Differential gain K_d.
+  float kd_ = 0;
+
+  // smooth the derivative value using an average over X samples
+  int derivative_samples_ = 1;
+
+  /// smooth the output value using an average over X values
+  int output_samples_ = 1;
+
+  float threshold_low_ = 0.0f;
+  float threshold_high_ = 0.0f;
+  float kp_multiplier_ = 0.0f;
+  float ki_multiplier_ = 0.0f;
+  float kd_multiplier_ = 0.0f;
+  int deadband_output_samples_ = 1;
+
+  float min_integral_ = NAN;
+  float max_integral_ = NAN;
+
+  // Store computed values in struct so that values can be monitored through sensors
+  float error_;
+  float dt_;
+  float proportional_term_;
+  float integral_term_;
+  float derivative_term_;
+
+  void calculate_proportional_term_();
+  void calculate_integral_term_();
+  void calculate_derivative_term_(float setpoint);
+
+  /// Ring buffer smoothing using FixedRingBuffer (single allocation at setup)
+  float ring_buffer_average_(FixedRingBuffer<float> &buf, float new_value, int max_samples);
+
+  float calculate_relative_time_();
+
+  /// Error from previous update used for derivative term
+  float previous_error_ = 0;
+  float previous_setpoint_ = NAN;
+  /// Accumulated integral value
+  float accumulated_integral_ = 0;
+  uint32_t last_time_ = 0;
+
+  // Ring buffer for derivative smoothing
+  FixedRingBuffer<float> derivative_window_;
+
+  // Ring buffer for output smoothing (shared between normal and deadband modes)
+  FixedRingBuffer<float> output_window_;
+};
+
+}  // namespace equitherm
+}  // namespace esphome

--- a/esphome/components/equitherm/pid_controller.h
+++ b/esphome/components/equitherm/pid_controller.h
@@ -4,8 +4,7 @@
 #include "esphome/core/helpers.h"
 #include <cmath>
 
-namespace esphome {
-namespace equitherm {
+namespace esphome::equitherm {
 
 /// Embedded PID controller — avoids dependency on pid component.
 /// Kept in sync with esphome/components/pid/pid_controller.
@@ -73,5 +72,4 @@ struct PIDController {
   FixedRingBuffer<float> output_window_;
 };
 
-}  // namespace equitherm
-}  // namespace esphome
+}  // namespace esphome::equitherm

--- a/tests/components/equitherm/common.yaml
+++ b/tests/components/equitherm/common.yaml
@@ -1,0 +1,58 @@
+sensor:
+  - platform: template
+    id: outdoor_sensor
+    lambda: return 12.0;
+    update_interval: 60s
+
+  - platform: template
+    id: indoor_sensor
+    lambda: return 19.5;
+    update_interval: 60s
+
+output:
+  - platform: slow_pwm
+    pin: 4
+    id: heat_output
+    period: 15s
+
+climate:
+  - platform: equitherm
+    id: heating_controller
+    name: Equitherm Climate
+    outdoor_sensor: outdoor_sensor
+    indoor_sensor: indoor_sensor
+    default_target_temperature: 20°C
+    heat_output: heat_output
+    control_parameters:
+      heat_curve_coefficient: 3.0
+      heat_curve_exponent: 1.5
+      heat_curve_shift: 0.0
+      kp: 2.0
+      ki: 0.5
+      kd: 0.0
+      min_integral: -5.0
+      max_integral: 5.0
+      derivative_averaging_samples: 4
+    output_parameters:
+      min_flow_temp: 25.0
+      max_flow_temp: 70.0
+    deadband_parameters:
+      threshold_high: 0.5
+      threshold_low: -0.5
+      kp_multiplier: 0.1
+      ki_multiplier: 0.0
+
+# Test action
+wifi:
+  ssid: "test"
+
+api:
+  actions:
+    - action: test_force_recalculate
+      then:
+        - climate.equitherm.force_recalculate: heating_controller
+    - action: test_force_recalculate_no_pid
+      then:
+        - climate.equitherm.force_recalculate:
+            id: heating_controller
+            update_pid: false

--- a/tests/components/equitherm/test.esp32-idf.yaml
+++ b/tests/components/equitherm/test.esp32-idf.yaml
@@ -1,0 +1,12 @@
+esphome:
+  name: test-equitherm-esp32-idf
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test.esp8266-ard.yaml
+++ b/tests/components/equitherm/test.esp8266-ard.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test-equitherm-climate-esp8266
+
+esp8266:
+  board: esp01_1m
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test.rp2040-ard.yaml
+++ b/tests/components/equitherm/test.rp2040-ard.yaml
@@ -1,0 +1,10 @@
+esphome:
+  name: test-equitherm-climate-rp2040
+
+rp2040:
+  board: rpipicow
+
+logger:
+  level: DEBUG
+
+<<: !include common.yaml

--- a/tests/components/equitherm/test_manual_preset.yaml
+++ b/tests/components/equitherm/test_manual_preset.yaml
@@ -1,0 +1,45 @@
+esphome:
+  name: test-equitherm-manual
+
+esp32:
+  board: esp32dev
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+  - platform: template
+    id: manual_flow_temp
+    name: "Manual Flow Temperature"
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+    initial_value: 45
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    manual_flow_temp: manual_flow_temp
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_numbers.yaml
+++ b/tests/components/equitherm/test_numbers.yaml
@@ -1,0 +1,47 @@
+esphome:
+  name: test-equitherm-numbers
+esp32:
+  board: esp32dev
+logger:
+  level: DEBUG
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+  - platform: equitherm
+    climate_id: equitherm_climate
+    heat_curve_coefficient:
+      name: "Heating Curve Coefficient"
+    heat_curve_exponent:
+      name: "Heating Curve Exponent"
+    heat_curve_shift:
+      name: "Heating Curve Shift"
+    pid_proportional_gain:
+      name: "PID Proportional Gain"
+    pid_integral_gain:
+      name: "PID Integral Gain"
+    pid_derivative_gain:
+      name: "PID Derivative Gain"
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70

--- a/tests/components/equitherm/test_triggers.yaml
+++ b/tests/components/equitherm/test_triggers.yaml
@@ -1,0 +1,49 @@
+esphome:
+  name: test-equitherm-triggers
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+logger:
+  level: DEBUG
+
+sensor:
+  - platform: template
+    id: outdoor_temp
+    lambda: "return 5.0f;"
+  - platform: template
+    id: indoor_temp
+    lambda: "return 20.0f;"
+
+number:
+  - platform: template
+    id: ch_setpoint
+    min_value: 20
+    max_value: 85
+    step: 0.5
+    optimistic: true
+
+switch:
+  - platform: template
+    id: ch_enable
+    optimistic: true
+
+climate:
+  - platform: equitherm
+    id: equitherm_climate
+    outdoor_sensor: outdoor_temp
+    indoor_sensor: indoor_temp
+    default_target_temperature: 20
+    flow_setpoint: ch_setpoint
+    on_heating_start:
+      - switch.turn_on: ch_enable
+    on_heating_stop:
+      - switch.turn_off: ch_enable
+    control_parameters:
+      heat_curve_coefficient: 1.4
+      heat_curve_exponent: 1.3
+    output_parameters:
+      min_flow_temp: 20
+      max_flow_temp: 70


### PR DESCRIPTION
# What does this implement/fix?

Adds runtime-tunable number entities for the `equitherm` climate component, so heating parameters can be adjusted from Home Assistant without reflashing.

Six number entities:
- **Heating curve** — coefficient, exponent, shift
- **PID gains** — proportional, integral, derivative

All numbers support `restore_value` for persistence across reboots; initial values are read from the parent climate's YAML configuration.

Part of the equitherm PR split (#14738):
- **Prerequisite:** #15672 (core climate, PID, automations)
- **Sibling:** #15674 (diagnostic sensors and binary sensors)

Additional runtime-tunable entities (fallback outdoor temperature, output rate limits) are planned for separate follow-up PRs.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

**Related issue or feature (if applicable):**

- Part of #14738 split

**Pull request in [esphome.io](https://github.com/esphome/esphome.io) with documentation (if applicable):**

- esphome/esphome.io#6271 *(closed; documentation pending resubmission)*

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Core climate (from PR #15672)
climate:
  - platform: equitherm
    id: heating_controller
    name: "Equitherm Climate"
    outdoor_sensor: outdoor_temp_sensor
    indoor_sensor: indoor_temp_sensor
    default_target_temperature: 20degC
    heat_output: boiler_output
    control_parameters:
      heat_curve_coefficient: 3.0
      heat_curve_exponent: 1.5
      heat_curve_shift: 0.0
      kp: 2.0
      ki: 0.5
      kd: 0.0
    output_parameters:
      min_flow_temp: 25.0
      max_flow_temp: 70.0

# Runtime tuning numbers (this PR)
number:
  - platform: equitherm
    climate_id: heating_controller
    heat_curve_coefficient:
      name: "Heating Curve Coefficient"
    heat_curve_exponent:
      name: "Heating Curve Exponent"
    heat_curve_shift:
      name: "Heating Curve Shift"
    pid_proportional_gain:
      name: "PID Proportional Gain"
    pid_integral_gain:
      name: "PID Integral Gain"
    pid_derivative_gain:
      name: "PID Derivative Gain"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome.io](https://github.com/esphome/esphome.io).
