### PR TITLE
[ld24xx] Replace heap-allocated SensorWithDedup with inline SensorWithDedup

### DIFF
--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -360,8 +360,8 @@ void LD2410Component::handle_periodic_data_() {
   */
 #ifdef USE_SENSOR
   SAFE_PUBLISH_SENSOR(this->moving_target_distance_sensor_,
-                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]))
-  SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
+                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]));
+  SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY]);
   SAFE_PUBLISH_SENSOR(this->still_target_distance_sensor_,
                       encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]));
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY]);
@@ -375,26 +375,26 @@ void LD2410Component::handle_periodic_data_() {
       Moving energy: 20~28th bytes
     */
     for (uint8_t i = 0; i < TOTAL_GATES; i++) {
-      SAFE_PUBLISH_SENSOR(this->gate_move_sensors_[i], this->buffer_data_[MOVING_SENSOR_START + i])
+      SAFE_PUBLISH_SENSOR(this->gate_move_sensors_[i], this->buffer_data_[MOVING_SENSOR_START + i]);
     }
     /*
       Still energy: 29~37th bytes
     */
     for (uint8_t i = 0; i < TOTAL_GATES; i++) {
-      SAFE_PUBLISH_SENSOR(this->gate_still_sensors_[i], this->buffer_data_[STILL_SENSOR_START + i])
+      SAFE_PUBLISH_SENSOR(this->gate_still_sensors_[i], this->buffer_data_[STILL_SENSOR_START + i]);
     }
     /*
       Light sensor: 38th bytes
     */
-    SAFE_PUBLISH_SENSOR(this->light_sensor_, this->buffer_data_[LIGHT_SENSOR])
+    SAFE_PUBLISH_SENSOR(this->light_sensor_, this->buffer_data_[LIGHT_SENSOR]);
   } else {
     for (auto &gate_move_sensor : this->gate_move_sensors_) {
-      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_move_sensor)
+      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_move_sensor);
     }
     for (auto &gate_still_sensor : this->gate_still_sensors_) {
-      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_still_sensor)
+      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_still_sensor);
     }
-    SAFE_PUBLISH_SENSOR_UNKNOWN(this->light_sensor_)
+    SAFE_PUBLISH_SENSOR_UNKNOWN(this->light_sensor_);
   }
 #endif
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/ld2410/ld2410.cpp
+++ b/esphome/components/ld2410/ld2410.cpp
@@ -786,13 +786,12 @@ void LD2410Component::set_light_out_control() {
 }
 
 #ifdef USE_SENSOR
-// These could leak memory, but they are only set once prior to 'setup()' and should never be used again.
 void LD2410Component::set_gate_move_sensor(uint8_t gate, sensor::Sensor *s) {
-  this->gate_move_sensors_[gate] = new SensorWithDedup<uint8_t>(s);
+  this->gate_move_sensors_[gate].set_sensor(s);
 }
 
 void LD2410Component::set_gate_still_sensor(uint8_t gate, sensor::Sensor *s) {
-  this->gate_still_sensors_[gate] = new SensorWithDedup<uint8_t>(s);
+  this->gate_still_sensors_[gate].set_sensor(s);
 }
 #endif
 

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -129,8 +129,8 @@ class LD2410Component : public Component, public uart::UARTDevice {
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};
 #endif
 #ifdef USE_SENSOR
-  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
-  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
 #endif
 };
 

--- a/esphome/components/ld2410/ld2410.h
+++ b/esphome/components/ld2410/ld2410.h
@@ -129,8 +129,8 @@ class LD2410Component : public Component, public uart::UARTDevice {
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};
 #endif
 #ifdef USE_SENSOR
-  std::array<SensorWithDedup<uint8_t> *, TOTAL_GATES> gate_move_sensors_{};
-  std::array<SensorWithDedup<uint8_t> *, TOTAL_GATES> gate_still_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
 #endif
 };
 

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -397,11 +397,11 @@ void LD2412Component::handle_periodic_data_() {
   */
 #ifdef USE_SENSOR
   SAFE_PUBLISH_SENSOR(this->moving_target_distance_sensor_,
-                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]))
-  SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY])
+                      encode_uint16(this->buffer_data_[MOVING_TARGET_HIGH], this->buffer_data_[MOVING_TARGET_LOW]));
+  SAFE_PUBLISH_SENSOR(this->moving_target_energy_sensor_, this->buffer_data_[MOVING_ENERGY]);
   SAFE_PUBLISH_SENSOR(this->still_target_distance_sensor_,
-                      encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]))
-  SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY])
+                      encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]));
+  SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY]);
   if (this->detection_distance_sensor_.has_sensor()) {
     int new_detect_distance = 0;
     if (target_state != 0x00 && (target_state & MOVE_BITMASK)) {
@@ -423,27 +423,27 @@ void LD2412Component::handle_periodic_data_() {
         Moving energy: 20~28th bytes
       */
       for (uint8_t i = 0; i < TOTAL_GATES; i++) {
-        SAFE_PUBLISH_SENSOR(this->gate_move_sensors_[i], this->buffer_data_[MOVING_SENSOR_START + i])
+        SAFE_PUBLISH_SENSOR(this->gate_move_sensors_[i], this->buffer_data_[MOVING_SENSOR_START + i]);
       }
       /*
         Still energy: 29~37th bytes
       */
       for (uint8_t i = 0; i < TOTAL_GATES; i++) {
-        SAFE_PUBLISH_SENSOR(this->gate_still_sensors_[i], this->buffer_data_[STILL_SENSOR_START + i])
+        SAFE_PUBLISH_SENSOR(this->gate_still_sensors_[i], this->buffer_data_[STILL_SENSOR_START + i]);
       }
       /*
         Light sensor value
       */
-      SAFE_PUBLISH_SENSOR(this->light_sensor_, this->buffer_data_[LIGHT_SENSOR])
+      SAFE_PUBLISH_SENSOR(this->light_sensor_, this->buffer_data_[LIGHT_SENSOR]);
     }
   } else {
     for (auto &gate_move_sensor : this->gate_move_sensors_) {
-      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_move_sensor)
+      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_move_sensor);
     }
     for (auto &gate_still_sensor : this->gate_still_sensors_) {
-      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_still_sensor)
+      SAFE_PUBLISH_SENSOR_UNKNOWN(gate_still_sensor);
     }
-    SAFE_PUBLISH_SENSOR_UNKNOWN(this->light_sensor_)
+    SAFE_PUBLISH_SENSOR_UNKNOWN(this->light_sensor_);
   }
 #endif
   // the radar module won't tell us when it's done, so we just have to keep polling...

--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -402,7 +402,7 @@ void LD2412Component::handle_periodic_data_() {
   SAFE_PUBLISH_SENSOR(this->still_target_distance_sensor_,
                       encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]))
   SAFE_PUBLISH_SENSOR(this->still_target_energy_sensor_, this->buffer_data_[STILL_ENERGY])
-  if (this->detection_distance_sensor_ != nullptr) {
+  if (this->detection_distance_sensor_.has_sensor()) {
     int new_detect_distance = 0;
     if (target_state != 0x00 && (target_state & MOVE_BITMASK)) {
       new_detect_distance =
@@ -410,7 +410,7 @@ void LD2412Component::handle_periodic_data_() {
     } else if (target_state != 0x00) {
       new_detect_distance = encode_uint16(this->buffer_data_[STILL_TARGET_HIGH], this->buffer_data_[STILL_TARGET_LOW]);
     }
-    this->detection_distance_sensor_->publish_state_if_not_dup(new_detect_distance);
+    this->detection_distance_sensor_.publish_state_if_not_dup(new_detect_distance);
   }
   if (engineering_mode) {
     // Engineering mode needs at least LIGHT_SENSOR + 1 bytes
@@ -846,12 +846,11 @@ void LD2412Component::set_light_out_control() {
 }
 
 #ifdef USE_SENSOR
-// These could leak memory, but they are only set once prior to 'setup()' and should never be used again.
 void LD2412Component::set_gate_move_sensor(uint8_t gate, sensor::Sensor *s) {
-  this->gate_move_sensors_[gate] = new SensorWithDedup<uint8_t>(s);
+  this->gate_move_sensors_[gate].set_sensor(s);
 }
 void LD2412Component::set_gate_still_sensor(uint8_t gate, sensor::Sensor *s) {
-  this->gate_still_sensors_[gate] = new SensorWithDedup<uint8_t>(s);
+  this->gate_still_sensors_[gate].set_sensor(s);
 }
 #endif
 

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -133,8 +133,8 @@ class LD2412Component : public Component, public uart::UARTDevice {
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};
 #endif
 #ifdef USE_SENSOR
-  std::array<SensorWithDedup<uint8_t> *, TOTAL_GATES> gate_move_sensors_{};
-  std::array<SensorWithDedup<uint8_t> *, TOTAL_GATES> gate_still_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
 #endif
 };
 

--- a/esphome/components/ld2412/ld2412.h
+++ b/esphome/components/ld2412/ld2412.h
@@ -133,8 +133,8 @@ class LD2412Component : public Component, public uart::UARTDevice {
   std::array<number::Number *, TOTAL_GATES> gate_still_threshold_numbers_{};
 #endif
 #ifdef USE_SENSOR
-  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
-  std::array<LazySensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_move_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, TOTAL_GATES> gate_still_sensors_{};
 #endif
 };
 

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -565,6 +565,7 @@ void LD2450Component::handle_periodic_data_() {
   SAFE_PUBLISH_SENSOR(this->still_target_count_sensor_, still_target_count);
   // Moving Target Count
   SAFE_PUBLISH_SENSOR(this->moving_target_count_sensor_, moving_target_count);
+
 #endif
 
 #ifdef USE_BINARY_SENSOR

--- a/esphome/components/ld2450/ld2450.cpp
+++ b/esphome/components/ld2450/ld2450.cpp
@@ -872,33 +872,32 @@ void LD2450Component::query_target_tracking_mode_() { this->send_command_(CMD_QU
 void LD2450Component::query_zone_() { this->send_command_(CMD_QUERY_ZONE, nullptr, 0); }
 
 #ifdef USE_SENSOR
-// These could leak memory, but they are only set once prior to 'setup()' and should never be used again.
 void LD2450Component::set_move_x_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_x_sensors_[target] = new SensorWithDedup<int16_t>(s);
+  this->move_x_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_move_y_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_y_sensors_[target] = new SensorWithDedup<int16_t>(s);
+  this->move_y_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_move_speed_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_speed_sensors_[target] = new SensorWithDedup<int16_t>(s);
+  this->move_speed_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_move_angle_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_angle_sensors_[target] = new SensorWithDedup<float>(s);
+  this->move_angle_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_move_distance_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_distance_sensors_[target] = new SensorWithDedup<uint16_t>(s);
+  this->move_distance_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_move_resolution_sensor(uint8_t target, sensor::Sensor *s) {
-  this->move_resolution_sensors_[target] = new SensorWithDedup<uint16_t>(s);
+  this->move_resolution_sensors_[target].set_sensor(s);
 }
 void LD2450Component::set_zone_target_count_sensor(uint8_t zone, sensor::Sensor *s) {
-  this->zone_target_count_sensors_[zone] = new SensorWithDedup<uint8_t>(s);
+  this->zone_target_count_sensors_[zone].set_sensor(s);
 }
 void LD2450Component::set_zone_still_target_count_sensor(uint8_t zone, sensor::Sensor *s) {
-  this->zone_still_target_count_sensors_[zone] = new SensorWithDedup<uint8_t>(s);
+  this->zone_still_target_count_sensors_[zone].set_sensor(s);
 }
 void LD2450Component::set_zone_moving_target_count_sensor(uint8_t zone, sensor::Sensor *s) {
-  this->zone_moving_target_count_sensors_[zone] = new SensorWithDedup<uint8_t>(s);
+  this->zone_moving_target_count_sensors_[zone].set_sensor(s);
 }
 #endif
 #ifdef USE_TEXT_SENSOR

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -182,15 +182,15 @@ class LD2450Component : public Component, public uart::UARTDevice {
   ZoneOfNumbers zone_numbers_[MAX_ZONES];
 #endif
 #ifdef USE_SENSOR
-  std::array<SensorWithDedup<int16_t> *, MAX_TARGETS> move_x_sensors_{};
-  std::array<SensorWithDedup<int16_t> *, MAX_TARGETS> move_y_sensors_{};
-  std::array<SensorWithDedup<int16_t> *, MAX_TARGETS> move_speed_sensors_{};
-  std::array<SensorWithDedup<float> *, MAX_TARGETS> move_angle_sensors_{};
-  std::array<SensorWithDedup<uint16_t> *, MAX_TARGETS> move_distance_sensors_{};
-  std::array<SensorWithDedup<uint16_t> *, MAX_TARGETS> move_resolution_sensors_{};
-  std::array<SensorWithDedup<uint8_t> *, MAX_ZONES> zone_target_count_sensors_{};
-  std::array<SensorWithDedup<uint8_t> *, MAX_ZONES> zone_still_target_count_sensors_{};
-  std::array<SensorWithDedup<uint8_t> *, MAX_ZONES> zone_moving_target_count_sensors_{};
+  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_x_sensors_{};
+  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_y_sensors_{};
+  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_speed_sensors_{};
+  std::array<LazySensorWithDedup<float>, MAX_TARGETS> move_angle_sensors_{};
+  std::array<LazySensorWithDedup<uint16_t>, MAX_TARGETS> move_distance_sensors_{};
+  std::array<LazySensorWithDedup<uint16_t>, MAX_TARGETS> move_resolution_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_target_count_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_still_target_count_sensors_{};
+  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_moving_target_count_sensors_{};
 #endif
 #ifdef USE_TEXT_SENSOR
   std::array<text_sensor::TextSensor *, MAX_TARGETS> direction_text_sensors_{};

--- a/esphome/components/ld2450/ld2450.h
+++ b/esphome/components/ld2450/ld2450.h
@@ -182,15 +182,15 @@ class LD2450Component : public Component, public uart::UARTDevice {
   ZoneOfNumbers zone_numbers_[MAX_ZONES];
 #endif
 #ifdef USE_SENSOR
-  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_x_sensors_{};
-  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_y_sensors_{};
-  std::array<LazySensorWithDedup<int16_t>, MAX_TARGETS> move_speed_sensors_{};
-  std::array<LazySensorWithDedup<float>, MAX_TARGETS> move_angle_sensors_{};
-  std::array<LazySensorWithDedup<uint16_t>, MAX_TARGETS> move_distance_sensors_{};
-  std::array<LazySensorWithDedup<uint16_t>, MAX_TARGETS> move_resolution_sensors_{};
-  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_target_count_sensors_{};
-  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_still_target_count_sensors_{};
-  std::array<LazySensorWithDedup<uint8_t>, MAX_ZONES> zone_moving_target_count_sensors_{};
+  std::array<SensorWithDedup<int16_t>, MAX_TARGETS> move_x_sensors_{};
+  std::array<SensorWithDedup<int16_t>, MAX_TARGETS> move_y_sensors_{};
+  std::array<SensorWithDedup<int16_t>, MAX_TARGETS> move_speed_sensors_{};
+  std::array<SensorWithDedup<float>, MAX_TARGETS> move_angle_sensors_{};
+  std::array<SensorWithDedup<uint16_t>, MAX_TARGETS> move_distance_sensors_{};
+  std::array<SensorWithDedup<uint16_t>, MAX_TARGETS> move_resolution_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, MAX_ZONES> zone_target_count_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, MAX_ZONES> zone_still_target_count_sensors_{};
+  std::array<SensorWithDedup<uint8_t>, MAX_ZONES> zone_moving_target_count_sensors_{};
 #endif
 #ifdef USE_TEXT_SENSOR
   std::array<text_sensor::TextSensor *, MAX_TARGETS> direction_text_sensors_{};

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -11,7 +11,7 @@
 
 #define SUB_SENSOR_WITH_DEDUP(name, dedup_type) \
  protected: \
-  ld24xx::LazySensorWithDedup<dedup_type> name##_sensor_{}; \
+  ld24xx::SensorWithDedup<dedup_type> name##_sensor_{}; \
 \
  public: \
   void set_##name##_sensor(sensor::Sensor *sensor) { this->name##_sensor_.set_sensor(sensor); }
@@ -69,9 +69,8 @@ inline void format_version_str(const uint8_t *version, std::span<char, 20> buffe
 
 #ifdef USE_SENSOR
 /// Sensor with deduplication — sensor may be null, null check is internal.
-/// Analogous to LazyCallbackManager: does nothing when no sensor is set,
-/// avoids heap allocation by storing everything inline.
-template<typename T> class LazySensorWithDedup {
+/// Stored inline, no heap allocation. Does nothing when no sensor is set.
+template<typename T> class SensorWithDedup {
  public:
   void set_sensor(sensor::Sensor *sens) { this->sens_ = sens; }
 

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -22,15 +22,9 @@
     LOG_SENSOR(tag, name, (sensor).get_sensor()); \
   }
 
-#define SAFE_PUBLISH_SENSOR(sensor, value) \
-  if (true) { \
-    (sensor).publish_state_if_not_dup(value); \
-  }
+#define SAFE_PUBLISH_SENSOR(sensor, value) (sensor).publish_state_if_not_dup(value)
 
-#define SAFE_PUBLISH_SENSOR_UNKNOWN(sensor) \
-  if (true) { \
-    (sensor).publish_state_unknown(); \
-  }
+#define SAFE_PUBLISH_SENSOR_UNKNOWN(sensor) (sensor).publish_state_unknown()
 
 #define highbyte(val) (uint8_t)((val) >> 8)
 #define lowbyte(val) (uint8_t)((val) &0xff)
@@ -72,7 +66,10 @@ inline void format_version_str(const uint8_t *version, std::span<char, 20> buffe
 /// Stored inline, no heap allocation. Does nothing when no sensor is set.
 template<typename T> class SensorWithDedup {
  public:
-  void set_sensor(sensor::Sensor *sens) { this->sens_ = sens; }
+  void set_sensor(sensor::Sensor *sens) {
+    this->sens_ = sens;
+    this->dedup_ = {};
+  }
 
   void publish_state_if_not_dup(T state) {
     if (this->sens_ != nullptr && this->dedup_.next(state)) {

--- a/esphome/components/ld24xx/ld24xx.h
+++ b/esphome/components/ld24xx/ld24xx.h
@@ -11,27 +11,25 @@
 
 #define SUB_SENSOR_WITH_DEDUP(name, dedup_type) \
  protected: \
-  ld24xx::SensorWithDedup<dedup_type> *name##_sensor_{nullptr}; \
+  ld24xx::LazySensorWithDedup<dedup_type> name##_sensor_{}; \
 \
  public: \
-  void set_##name##_sensor(sensor::Sensor *sensor) { \
-    this->name##_sensor_ = new ld24xx::SensorWithDedup<dedup_type>(sensor); \
-  }
+  void set_##name##_sensor(sensor::Sensor *sensor) { this->name##_sensor_.set_sensor(sensor); }
 #endif
 
 #define LOG_SENSOR_WITH_DEDUP_SAFE(tag, name, sensor) \
-  if ((sensor) != nullptr) { \
-    LOG_SENSOR(tag, name, (sensor)->sens); \
+  if ((sensor).has_sensor()) { \
+    LOG_SENSOR(tag, name, (sensor).get_sensor()); \
   }
 
 #define SAFE_PUBLISH_SENSOR(sensor, value) \
-  if ((sensor) != nullptr) { \
-    (sensor)->publish_state_if_not_dup(value); \
+  if (true) { \
+    (sensor).publish_state_if_not_dup(value); \
   }
 
 #define SAFE_PUBLISH_SENSOR_UNKNOWN(sensor) \
-  if ((sensor) != nullptr) { \
-    (sensor)->publish_state_unknown(); \
+  if (true) { \
+    (sensor).publish_state_unknown(); \
   }
 
 #define highbyte(val) (uint8_t)((val) >> 8)
@@ -70,25 +68,31 @@ inline void format_version_str(const uint8_t *version, std::span<char, 20> buffe
 }
 
 #ifdef USE_SENSOR
-// Helper class to store a sensor with a deduplicator & publish state only when the value changes
-template<typename T> class SensorWithDedup {
+/// Sensor with deduplication — sensor may be null, null check is internal.
+/// Analogous to LazyCallbackManager: does nothing when no sensor is set,
+/// avoids heap allocation by storing everything inline.
+template<typename T> class LazySensorWithDedup {
  public:
-  SensorWithDedup(sensor::Sensor *sens) : sens(sens) {}
+  void set_sensor(sensor::Sensor *sens) { this->sens_ = sens; }
 
   void publish_state_if_not_dup(T state) {
-    if (this->publish_dedup.next(state)) {
-      this->sens->publish_state(static_cast<float>(state));
+    if (this->sens_ != nullptr && this->dedup_.next(state)) {
+      this->sens_->publish_state(static_cast<float>(state));
     }
   }
 
   void publish_state_unknown() {
-    if (this->publish_dedup.next_unknown()) {
-      this->sens->publish_state(NAN);
+    if (this->sens_ != nullptr && this->dedup_.next_unknown()) {
+      this->sens_->publish_state(NAN);
     }
   }
 
-  sensor::Sensor *sens;
-  Deduplicator<T> publish_dedup;
+  bool has_sensor() const { return this->sens_ != nullptr; }
+  sensor::Sensor *get_sensor() const { return this->sens_; }
+
+ protected:
+  sensor::Sensor *sens_{nullptr};
+  Deduplicator<T> dedup_;
 };
 #endif
 }  // namespace esphome::ld24xx


### PR DESCRIPTION
# What does this implement/fix?

Replace heap-allocated `SensorWithDedup` wrapper with an inline `SensorWithDedup` that stores the sensor pointer and deduplicator directly in the component, eliminating heap allocations across ld2410, ld2412, and ld2450.

**Before:** Each sensor was heap-allocated via `new SensorWithDedup<T>(sensor)`, storing a pointer (4 bytes) in the component plus the object on the heap (8-12 bytes) plus heap header overhead (~8 bytes) = 20-24 bytes per configured sensor.

**After:** `SensorWithDedup<T>` is stored inline in the component (8-12 bytes). The null check is internal, so callers don't need to check before publishing. Inline storage also improves cache locality — the deduplicator state is adjacent to the sensor pointer rather than scattered across the heap.

### RAM tradeoff (32-bit)

| Scenario | Old (heap) | New (inline) | Delta |
|----------|-----------|-------------|-------|
| Configured `uint8_t` sensor | 20 bytes (4 ptr + 8 obj + 8 heap hdr) | 8 bytes | **-12 bytes** |
| Configured `int` sensor | 24 bytes (4 ptr + 12 obj + 8 heap hdr) | 12 bytes | **-12 bytes** |
| Unconfigured `uint8_t` sensor | 4 bytes (null ptr) | 8 bytes | +4 bytes |
| Unconfigured `int` sensor | 4 bytes (null ptr) | 12 bytes | +8 bytes |

Static RAM increases for unconfigured sensor slots (null pointer → inline struct), but configured sensors save 12 bytes of heap each. In practice, most users configure most of these sensors — that's the whole point of using these radar modules.

### Real device measurement

Tested on an ESP32 with LD2412 + LD2450 (typical config with most sensors configured):

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Free heap | 299,164 bytes | 299,216 bytes | **+52 bytes freed** |

The static analysis CI shows +392 bytes of static RAM because the dedup structs moved from heap to static — what was previously invisible to static analysis (heap allocations at runtime) is now visible as static RAM. The net effect on a real device is +52 bytes of free heap because the per-allocation heap header overhead is eliminated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

No config changes required — this is an internal optimization.

```yaml
# No changes to user-facing configuration
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).