### PR TITLE
[packages] fix support `packages: !include mypackages.yaml`

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -321,12 +321,15 @@ def _walk_packages(
         return config
     packages = config[CONF_PACKAGES]
 
-    if not isinstance(packages, (dict, list)):
-        raise cv.Invalid(
-            f"Packages must be a key to value mapping or list, got {type(packages)} instead"
-        )
-
     with cv.prepend_path(CONF_PACKAGES):
+        if isinstance(packages, yaml_util.IncludeFile):
+            # If the packages key is an IncludeFile, resolve it first before processing.
+            packages, _ = resolve_include(packages, [], context, strict_undefined=False)
+        if not isinstance(packages, (dict, list)):
+            raise cv.Invalid(
+                f"Packages must be a key to value mapping or list, got {type(packages)} instead"
+            )
+
         if not isinstance(packages, dict):
             _walk_package_list(packages, callback, context)
         elif (result := _walk_package_dict(packages, callback, context)) is not None:

--- a/tests/component_tests/packages/test_packages.py
+++ b/tests/component_tests/packages/test_packages.py
@@ -1106,6 +1106,51 @@ def test_packages_invalid_type_raises() -> None:
         do_packages_pass(config)
 
 
+@patch("esphome.components.packages.resolve_include")
+def test_packages_include_file_resolves_to_list(mock_resolve_include) -> None:
+    """When packages: is an IncludeFile that resolves to a list, it is processed correctly."""
+    include_file = MagicMock(spec=IncludeFile)
+    package_content = {CONF_WIFI: {CONF_SSID: TEST_PACKAGE_WIFI_SSID}}
+    mock_resolve_include.return_value = ([package_content], None)
+
+    config = {CONF_PACKAGES: include_file}
+    result = do_packages_pass(config)
+    result = merge_packages(result)
+
+    assert result == {CONF_WIFI: {CONF_SSID: TEST_PACKAGE_WIFI_SSID}}
+
+
+@patch("esphome.components.packages.resolve_include")
+def test_packages_include_file_resolves_to_dict(mock_resolve_include) -> None:
+    """When packages: is an IncludeFile that resolves to a dict, it is processed correctly."""
+    include_file = MagicMock(spec=IncludeFile)
+    package_content = {CONF_WIFI: {CONF_SSID: TEST_PACKAGE_WIFI_SSID}}
+    mock_resolve_include.return_value = ({"network": package_content}, None)
+
+    config = {CONF_PACKAGES: include_file}
+    result = do_packages_pass(config)
+    result = merge_packages(result)
+
+    assert result == {CONF_WIFI: {CONF_SSID: TEST_PACKAGE_WIFI_SSID}}
+
+
+@patch("esphome.components.packages.resolve_include")
+def test_packages_include_file_resolves_to_invalid_type_raises(
+    mock_resolve_include,
+) -> None:
+    """When packages: is an IncludeFile that resolves to an invalid type, cv.Invalid is raised."""
+    include_file = MagicMock(spec=IncludeFile)
+    mock_resolve_include.return_value = ("not_a_dict_or_list", None)
+
+    config = {CONF_PACKAGES: include_file}
+    with pytest.raises(
+        cv.Invalid, match="Packages must be a key to value mapping or list"
+    ) as exc_info:
+        do_packages_pass(config)
+
+    assert exc_info.value.path == [CONF_PACKAGES]
+
+
 @pytest.mark.parametrize(
     "invalid_package",
     [

--- a/tests/unit_tests/fixtures/substitutions/13-packages_as_included_list.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/13-packages_as_included_list.approved.yaml
@@ -1,0 +1,3 @@
+wifi:
+  password: pkg_password
+  ssid: main_ssid

--- a/tests/unit_tests/fixtures/substitutions/13-packages_as_included_list.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/13-packages_as_included_list.input.yaml
@@ -1,0 +1,4 @@
+packages: !include 13-packages_list.yaml
+
+wifi:
+  ssid: main_ssid

--- a/tests/unit_tests/fixtures/substitutions/13-packages_list.yaml
+++ b/tests/unit_tests/fixtures/substitutions/13-packages_list.yaml
@@ -1,0 +1,2 @@
+- wifi:
+    password: pkg_password

--- a/tests/unit_tests/fixtures/substitutions/14-packages_as_included_dict.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/14-packages_as_included_dict.approved.yaml
@@ -1,0 +1,3 @@
+wifi:
+  password: pkg_password
+  ssid: main_ssid

--- a/tests/unit_tests/fixtures/substitutions/14-packages_as_included_dict.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/14-packages_as_included_dict.input.yaml
@@ -1,0 +1,4 @@
+packages: !include 14-packages_dict.yaml
+
+wifi:
+  ssid: main_ssid

--- a/tests/unit_tests/fixtures/substitutions/14-packages_dict.yaml
+++ b/tests/unit_tests/fixtures/substitutions/14-packages_dict.yaml
@@ -1,0 +1,3 @@
+network:
+  wifi:
+    password: pkg_password


### PR DESCRIPTION
# What does this implement/fix?

Using `packages: !include mypackages.yaml` where the included file contains a list or dict of packages raises:

```
Packages must be a key to value mapping or list, got <class 'esphome.yaml_util.IncludeFile'> instead
```

This fix resolves the `IncludeFile` first (inside the `with cv.prepend_path(CONF_PACKAGES):` context for correct error paths) before checking whether the result is a dict or list.

This enables the following pattern:

```yaml
# config.yaml
packages: !include my_packages.yaml
```

```yaml
# my_packages.yaml (list form)
- wifi:
    ssid: my_ssid
    password: my_password
```

or

```yaml
# my_packages.yaml (dict form)
network:
  wifi:
    ssid: my_ssid
    password: my_password
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# config.yaml — packages as an included list
packages: !include my_packages.yaml

wifi:
  ssid: override_ssid
```

```yaml
# my_packages.yaml
- wifi:
    password: my_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).