### PR TITLE
[audio] Add/configure microDecoder library in preparation for use in future PRs

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -222,7 +222,7 @@ async def to_code(config):
     if data.micro_decoder_support:
         add_idf_component(name="esphome/micro-decoder", ref="0.1.1")
 
-        # All codecs are enbled by default in micro-decoder, so disable the ones that aren't requested to save flash
+        # All codecs are enabled by default in micro-decoder, so disable the ones that aren't requested to save flash
         if not data.flac_support:
             add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_FLAC", False)
         if not data.mp3_support:

--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -1,7 +1,11 @@
 from dataclasses import dataclass
 
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_component, include_builtin_idf_component
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    include_builtin_idf_component,
+)
 import esphome.config_validation as cv
 from esphome.const import CONF_BITS_PER_SAMPLE, CONF_NUM_CHANNELS, CONF_SAMPLE_RATE
 from esphome.core import CORE
@@ -27,6 +31,7 @@ class AudioData:
     flac_support: bool = False
     mp3_support: bool = False
     opus_support: bool = False
+    micro_decoder_support: bool = False
 
 
 def _get_data() -> AudioData:
@@ -48,6 +53,11 @@ def request_mp3_support() -> None:
 def request_opus_support() -> None:
     """Request Opus codec support for audio decoding."""
     _get_data().opus_support = True
+
+
+def request_micro_decoder_support() -> None:
+    """Request micro-decoder library support for audio decoding."""
+    _get_data().micro_decoder_support = True
 
 
 CONF_MIN_BITS_PER_SAMPLE = "min_bits_per_sample"
@@ -208,6 +218,19 @@ async def to_code(config):
     )
 
     data = _get_data()
+
+    if data.micro_decoder_support:
+        add_idf_component(name="esphome/micro-decoder", ref="0.1.1")
+
+        # All codecs are enbled by default in micro-decoder, so disable the ones that aren't requested to save flash
+        if not data.flac_support:
+            add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_FLAC", False)
+        if not data.mp3_support:
+            add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_MP3", False)
+        if not data.opus_support:
+            add_idf_sdkconfig_option("CONFIG_MICRO_DECODER_CODEC_OPUS", False)
+
+    # Legacy audio_decoder.cpp support defines and components
     if data.flac_support:
         cg.add_define("USE_AUDIO_FLAC_SUPPORT")
         add_idf_component(name="esphome/micro-flac", ref="0.1.1")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -3,6 +3,8 @@ dependencies:
     version: "7.4.2"
   esphome/esp-audio-libs:
     version: 2.0.4
+  esphome/micro-decoder:
+    version: 0.1.1
   esphome/micro-flac:
     version: 0.1.1
   esphome/micro-opus:


### PR DESCRIPTION
# What does this implement/fix?

Adds the microDecoder library ([GitHub](https://github.com/esphome-libs/micro-decoder) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-decoder/versions/0.1.1/readme)) to the ``audio`` component. The library supports decoding directly from a memory address/flash or from an http(s) source.

It is only added after the audio component's ``request_micro_decoder_support()`` is called. By default, all codecs are enabled (supporting MP3, FLAC, Opus, and WAV). To save flash, any codecs not enabled by the ``request_*_support()`` helpers gets disabled at the codegen stage.

This will be used by a new ``audio_http`` media source (as well as updating the current ``audio_file`` media source this handles all the complexity). Eventually, I want to deprecate/remove the existing AudioDecoder class and the importing the decoder libraries directly in ESPHome and let it all the reading/decoding/threading be handled by external libraries.

Marked as new feature, so the need-docs and need-tests labels will get applied automatically. Since this is not user facing in anyway, they are unnecessary.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

not applicable

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
