### PR TITLE
[core] Fix PlatformIO progress bar rendering in subprocess mode

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -65,9 +65,6 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ.setdefault("UV_HTTP_RETRIES", "10")
     cmd = [sys.executable, "-m", "esphome.platformio_runner"] + list(args)
 
-    if not CORE.verbose:
-        kwargs["filter_lines"] = FILTER_PLATFORMIO_LINES
-
     return run_external_process(*cmd, **kwargs)
 
 

--- a/esphome/platformio_runner.py
+++ b/esphome/platformio_runner.py
@@ -122,11 +122,18 @@ def main() -> int:
     #    that was lost when we switched from in-process to subprocess — the
     #    parent's ``subprocess.run`` uses ``.fileno()`` on RedirectText and
     #    bypasses its ``write()`` path entirely.
+    #
+    # Filtering is disabled when the user passed -v / --verbose to
+    # ``esphome compile``, preserving the previous in-process behavior where
+    # verbose mode let all PlatformIO output through unfiltered.
     from esphome.platformio_api import FILTER_PLATFORMIO_LINES
     from esphome.util import RedirectText
 
-    sys.stdout = RedirectText(sys.stdout, filter_lines=FILTER_PLATFORMIO_LINES)
-    sys.stderr = RedirectText(sys.stderr, filter_lines=FILTER_PLATFORMIO_LINES)
+    is_verbose = any(arg in ("-v", "--verbose") for arg in sys.argv[1:])
+    filter_lines = None if is_verbose else FILTER_PLATFORMIO_LINES
+
+    sys.stdout = RedirectText(sys.stdout, filter_lines=filter_lines)
+    sys.stderr = RedirectText(sys.stderr, filter_lines=filter_lines)
 
     import platformio.__main__
 

--- a/esphome/platformio_runner.py
+++ b/esphome/platformio_runner.py
@@ -105,6 +105,29 @@ def main() -> int:
     patch_structhash()
     patch_file_downloader()
 
+    # Wrap stdout/stderr with RedirectText before PlatformIO runs:
+    #
+    # 1. RedirectText.isatty() unconditionally returns True. Click, tqdm, and
+    #    PlatformIO's own progress-bar code check ``stream.isatty()`` to
+    #    decide whether to emit TTY-format output (``\r`` cursor moves, ANSI
+    #    colors, fancy progress bars). With the wrapper in place they always
+    #    emit TTY format, even when our real stdout is a pipe to the parent
+    #    process. Downstream consumers (local terminals and the Home
+    #    Assistant dashboard log viewer) render the TTY control sequences
+    #    correctly, so the user sees real progress bars.
+    #
+    # 2. FILTER_PLATFORMIO_LINES is applied inside RedirectText.write() in
+    #    this subprocess, so noisy PlatformIO output is dropped before it
+    #    ever leaves the runner. This replaces the parent-side filtering
+    #    that was lost when we switched from in-process to subprocess — the
+    #    parent's ``subprocess.run`` uses ``.fileno()`` on RedirectText and
+    #    bypasses its ``write()`` path entirely.
+    from esphome.platformio_api import FILTER_PLATFORMIO_LINES
+    from esphome.util import RedirectText
+
+    sys.stdout = RedirectText(sys.stdout, filter_lines=FILTER_PLATFORMIO_LINES)
+    sys.stderr = RedirectText(sys.stderr, filter_lines=FILTER_PLATFORMIO_LINES)
+
     import platformio.__main__
 
     return platformio.__main__.main() or 0


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #15666. When PlatformIO runs as a subprocess via `esphome.platformio_runner`, the child's stdout is whatever fd the parent inherited — a real TTY in a local terminal, but a pipe back to the dashboard when running inside the Home Assistant add-on. PlatformIO's progress-bar code checks `stream.isatty()` to choose between fancy TTY rendering and a plain fallback, so in the HA add-on the download/unpack progress fell back to something like:

```
Downloading 0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
```

Locally in a terminal it rendered fine because the child process genuinely had a TTY.

## Fix

Wrap `sys.stdout` / `sys.stderr` with `RedirectText` inside `platformio_runner.main()` before invoking PlatformIO:

1. **Rendering:** `RedirectText.isatty()` unconditionally returns `True`. Click, tqdm, and PlatformIO's own progress-bar code all emit TTY-format output (`\r` cursor moves, ANSI colors, real progress bars) regardless of whether the runner's actual stdout is a pipe. The TTY bytes are forwarded untouched to the parent's stdout, which local terminals and the HA dashboard log viewer both render correctly — same path as `esptool`, which already works this way.

2. **Filtering:** `FILTER_PLATFORMIO_LINES` is applied inside `RedirectText.write()` in the runner subprocess, so noisy PlatformIO output is dropped before it leaves the runner. Parent-side filtering was lost when we switched from in-process to subprocess — the parent's `subprocess.run` uses `.fileno()` on `RedirectText` and bypasses its `write()` path entirely — so filtering now lives in the runner itself.

No new dependencies, no PTY allocation, no cross-platform branches — it's just a `sys.stdout` wrap.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to esphome/esphome#15666

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — build/progress rendering only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).