### PR TITLE
[scheduler] Force-inline cleanup_() fast path

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -302,7 +302,7 @@ class Scheduler {
   // loop thread structurally modifies items_ (push/pop/erase). Other threads may
   // iterate items_ and mark items removed under lock_, but never change the
   // vector's size or data pointer.
-  inline bool HOT cleanup_() {
+  inline bool ESPHOME_ALWAYS_INLINE HOT cleanup_() {
     if (this->to_remove_empty_())
       return !this->items_.empty();
     return this->cleanup_slow_path_();


### PR DESCRIPTION
# What does this implement/fix?

`cleanup_()` has a two-line fast path (check `to_remove` count, return `!items_.empty()`) with the slow path already out-of-line in `cleanup_slow_path_()`. Despite the `inline` hint, GCC on Xtensa emits it as a separate 27-byte function, adding unnecessary call overhead on every `Scheduler::call()` invocation — even when there is nothing to clean up.

`process_to_add()` has the identical pattern (inline fast path + out-of-line slow path) and GCC *does* inline that one. The difference is likely that `cleanup_()` returns a `bool`, which changes GCC's cost model slightly.

Use `ESPHOME_ALWAYS_INLINE` to guarantee inlining. Verified on ESP8266 (xtensa-lx106):
- `cleanup_()` symbol eliminated from binary
- `Scheduler::call()` grows 4 bytes (inlined fast path replaces call instruction)
- Net savings: 23 bytes (27-byte out-of-line body removed)
- Idle loop path: 1 out-of-line call instead of 2

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).