### PR TITLE
[core] Inline Millis64Impl::compute() on single-threaded platforms

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -286,7 +286,7 @@ class Scheduler {
   // Extend a 32-bit millis() value to 64-bit. Use when the caller already has a fresh now.
   // On platforms with native 64-bit time, ignores now and uses millis_64() directly.
   // On other platforms, extends now to 64-bit using rollover tracking.
-  uint64_t millis_64_from_(uint32_t now) {
+  uint64_t ESPHOME_ALWAYS_INLINE millis_64_from_(uint32_t now) {
 #ifdef USE_NATIVE_64BIT_TIME
     (void) now;
     return millis_64();

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -57,7 +57,7 @@ uint64_t Millis64Impl::compute(uint32_t now) {
 #endif
 
   // THREAD SAFETY NOTE:
-  // This function has two out-of-line implementations, based on the precompiler flags:
+  // This function has two out-of-line implementations, based on the preprocessor flags:
   // - ESPHOME_THREAD_MULTI_NO_ATOMICS - Runs on multi-threaded platforms without atomics (LibreTiny BK72xx)
   // - ESPHOME_THREAD_MULTI_ATOMICS - Runs on multi-threaded platforms with atomics (LibreTiny RTL87xx/LN882x, etc.)
   //

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -20,6 +20,12 @@ namespace esphome {
 static const char *const TAG = "time_64";
 #endif
 
+#ifdef ESPHOME_THREAD_SINGLE
+// Storage for Millis64Impl inline compute() — defined here so all TUs share one copy.
+uint32_t Millis64Impl::last_millis_{0};
+uint16_t Millis64Impl::millis_major_{0};
+#else
+
 uint64_t Millis64Impl::compute(uint32_t now) {
   // Half the 32-bit range - used to detect rollovers vs normal time progression
   static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
@@ -44,51 +50,25 @@ uint64_t Millis64Impl::compute(uint32_t now) {
    * to last_millis is provided by its release store and the corresponding acquire loads.
    */
   static std::atomic<uint16_t> millis_major{0};
-#elif !defined(ESPHOME_THREAD_SINGLE) /* ESPHOME_THREAD_MULTI_NO_ATOMICS */
+#else /* ESPHOME_THREAD_MULTI_NO_ATOMICS */
   static Mutex lock;
-  static uint32_t last_millis{0};
-  static uint16_t millis_major{0};
-#else                                 /* ESPHOME_THREAD_SINGLE */
   static uint32_t last_millis{0};
   static uint16_t millis_major{0};
 #endif
 
   // THREAD SAFETY NOTE:
-  // This function has three implementations, based on the precompiler flags
-  // - ESPHOME_THREAD_SINGLE - Runs on single-threaded platforms (ESP8266, etc.)
+  // This function has two out-of-line implementations, based on the precompiler flags:
   // - ESPHOME_THREAD_MULTI_NO_ATOMICS - Runs on multi-threaded platforms without atomics (LibreTiny BK72xx)
   // - ESPHOME_THREAD_MULTI_ATOMICS - Runs on multi-threaded platforms with atomics (LibreTiny RTL87xx/LN882x, etc.)
   //
+  // The ESPHOME_THREAD_SINGLE path is inlined in time_64.h.
   // Make sure all changes are synchronized if you edit this function.
   //
   // IMPORTANT: Always pass fresh millis() values to this function. The implementation
   // handles out-of-order timestamps between threads, but minimizing time differences
   // helps maintain accuracy.
 
-#ifdef ESPHOME_THREAD_SINGLE
-  // Single-core platforms have no concurrency, so this is a simple implementation
-  // that just tracks 32-bit rollover (every 49.7 days) without any locking or atomics.
-
-  uint16_t major = millis_major;
-  uint32_t last = last_millis;
-
-  // Check for rollover
-  if (now < last && (last - now) > HALF_MAX_UINT32) {
-    millis_major++;
-    major++;
-    last_millis = now;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
-#endif /* ESPHOME_DEBUG_SCHEDULER */
-  } else if (now > last) {
-    // Only update if time moved forward
-    last_millis = now;
-  }
-
-  // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
-  return now + (static_cast<uint64_t>(major) << 32);
-
-#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+#if defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
   // Without atomics, this implementation uses locks more aggressively:
   // 1. Always locks when near the rollover boundary (within 10 seconds)
   // 2. Always locks when detecting a large backwards jump
@@ -201,6 +181,8 @@ uint64_t Millis64Impl::compute(uint32_t now) {
     "No platform threading model defined. One of ESPHOME_THREAD_SINGLE, ESPHOME_THREAD_MULTI_NO_ATOMICS, or ESPHOME_THREAD_MULTI_ATOMICS must be defined."
 #endif
 }
+
+#endif  // !ESPHOME_THREAD_SINGLE
 
 }  // namespace esphome
 

--- a/esphome/core/time_64.h
+++ b/esphome/core/time_64.h
@@ -4,6 +4,9 @@
 #ifndef USE_NATIVE_64BIT_TIME
 
 #include <cstdint>
+#include <limits>
+
+#include "esphome/core/helpers.h"
 
 namespace esphome {
 
@@ -16,7 +19,36 @@ class Millis64Impl {
   friend uint64_t millis_64();
   friend class Scheduler;
 
+#ifdef ESPHOME_THREAD_SINGLE
+  // Storage defined in time_64.cpp — declared here so the inline body can access them.
+  static uint32_t last_millis_;
+  static uint16_t millis_major_;
+
+  static inline uint64_t ESPHOME_ALWAYS_INLINE compute(uint32_t now) {
+    // Half the 32-bit range - used to detect rollovers vs normal time progression
+    static constexpr uint32_t HALF_MAX_UINT32 = std::numeric_limits<uint32_t>::max() / 2;
+
+    // Single-core platforms have no concurrency, so this is a simple implementation
+    // that just tracks 32-bit rollover (every 49.7 days) without any locking or atomics.
+    uint16_t major = millis_major_;
+    uint32_t last = last_millis_;
+
+    // Check for rollover
+    if (now < last && (last - now) > HALF_MAX_UINT32) {
+      millis_major_++;
+      major++;
+      last_millis_ = now;
+    } else if (now > last) {
+      // Only update if time moved forward
+      last_millis_ = now;
+    }
+
+    // Combine major (high 32 bits) and now (low 32 bits) into 64-bit time
+    return now + (static_cast<uint64_t>(major) << 32);
+  }
+#else
   static uint64_t compute(uint32_t now);
+#endif
 };
 
 }  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

On `ESPHOME_THREAD_SINGLE` platforms (ESP8266), `Millis64Impl::compute()` is a trivial function (39 bytes on Xtensa): two loads from BSS, a rollover branch taken every ~49.7 days, a store, and a shift+add. Despite this, it was out-of-line in `time_64.cpp`, forcing a function call on every `Scheduler::call()` invocation.

This PR:
1. Moves the `ESPHOME_THREAD_SINGLE` `compute()` body into `time_64.h` as `ESPHOME_ALWAYS_INLINE`
2. Declares the static storage (`last_millis_`, `millis_major_`) as class statics defined in `time_64.cpp` so all TUs share one copy (avoids the ODR problem with function-local statics in inline functions)
3. Force-inlines `millis_64_from_()` which wraps `compute()` — GCC was creating an `$isra$` (interprocedural scalar replacement) clone instead of inlining the trivial wrapper

Multi-threaded paths (`ESPHOME_THREAD_MULTI_ATOMICS`, `ESPHOME_THREAD_MULTI_NO_ATOMICS`) remain out-of-line in `time_64.cpp` — those have locks, atomics, and CAS loops that shouldn't be inlined.

Verified on ESP8266 (xtensa-lx106):
- `Millis64Impl::compute()` and `millis_64_from_` symbols eliminated from binary
- `Scheduler::call()` idle path now has zero out-of-line calls (was 1)
- `compute()` body inlined into 3 call sites (`Scheduler::call`, `next_schedule_in`, `loop`/`millis_64`)

Also verified ESP32-IDF (multi-threaded) compiles cleanly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).