### PR TITLE
[scheduler] Force-inline process_to_add() fast path

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -138,7 +138,7 @@ class Scheduler {
   // (single-threaded). This is safe because the main loop is the only thread
   // that reads to_add_ without holding lock_; other threads may read it only
   // while holding the mutex (e.g. cancel_item_locked_).
-  inline void HOT process_to_add() {
+  inline void ESPHOME_ALWAYS_INLINE HOT process_to_add() {
     if (this->to_add_empty_())
       return;
     this->process_to_add_slow_path_();


### PR DESCRIPTION
# What does this implement/fix?

`process_to_add()` has the same pattern as `cleanup_()`: a one-line fast path (check if `to_add_` is empty via atomic load or `.empty()`) with the slow path already out-of-line in `process_to_add_slow_path_()`.

GCC inlines it on ESP8266 (Xtensa LX106) but **not** on ESP32 (Xtensa LX6), emitting a 20-byte out-of-line function. The fast path is just an atomic load + branch — exactly the kind of thing that should always be inlined.

Use `ESPHOME_ALWAYS_INLINE` to guarantee inlining on all platforms.

Verified on ESP32 (xtensa-esp32, gatetrigger.yaml):
- `process_to_add()` symbol eliminated from binary (only `process_to_add_slow_path_()` remains)
- `Scheduler::call()` idle path reduced to 1 out-of-line call (`millis_64()` — unavoidable HAL)
- `Scheduler::call()` grew +12 bytes (inlined fast path), net -8 bytes (20-byte body removed)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).