### PR TITLE
[scheduler] Force-inline process_defer_queue_() fast path

### DIFF
--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -407,7 +407,7 @@ class Scheduler {
   // Process defer queue for FIFO execution of deferred items.
   // IMPORTANT: This method should only be called from the main thread (loop task).
   // Inlined: the fast path (nothing deferred) is just an atomic load check.
-  inline void HOT process_defer_queue_(uint32_t &now) {
+  inline void ESPHOME_ALWAYS_INLINE HOT process_defer_queue_(uint32_t &now) {
     // Fast path: nothing to process, avoid lock entirely.
     // Worst case is a one-loop-iteration delay before newly deferred items are processed.
     if (this->defer_empty_())


### PR DESCRIPTION
# What does this implement/fix?

`process_defer_queue_()` follows the same fast-path/slow-path pattern as `cleanup_()` and `process_to_add()`: an atomic load + branch that skips to the out-of-line slow path only when work is pending. GCC currently inlines it, but past experience shows the compiler can silently outline these fast paths when surrounding code changes (as happened with `cleanup_()` and `process_to_add()`).

Use `ESPHOME_ALWAYS_INLINE` to lock in the intended behavior and prevent future regressions.

This completes the series: all three scheduler fast-path/slow-path splits now use `ESPHOME_ALWAYS_INLINE`:
- `cleanup_()` — #15683
- `process_to_add()` — #15685
- `process_defer_queue_()` — this PR

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).