### PR TITLE
[benchmark] Use -Os to match firmware optimization level

### DIFF
--- a/script/cpp_benchmark.py
+++ b/script/cpp_benchmark.py
@@ -27,7 +27,10 @@ STUBS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "stubs"
 
 PLATFORMIO_OPTIONS = {
     "build_flags": [
+        "-Os",  # match firmware optimization level (detects inlining regressions)
         "-g",  # debug symbols for profiling
+        "-ffunction-sections",  # required for dead-code stripping with -Os
+        "-fdata-sections",  # required for dead-code stripping with -Os
         "-DUSE_BENCHMARK",  # disable WarnIfComponentBlockingGuard in finish()
         f"-I{STUBS_DIR}",  # stub headers for ESP32-only components
     ],

--- a/script/cpp_benchmark.py
+++ b/script/cpp_benchmark.py
@@ -26,11 +26,7 @@ CORE_BENCHMARKS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "core"
 STUBS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "stubs"
 
 PLATFORMIO_OPTIONS = {
-    "build_unflags": [
-        "-Os",  # remove default size-opt
-    ],
     "build_flags": [
-        "-O2",  # optimize for speed (CodSpeed recommends RelWithDebInfo)
         "-g",  # debug symbols for profiling
         "-DUSE_BENCHMARK",  # disable WarnIfComponentBlockingGuard in finish()
         f"-I{STUBS_DIR}",  # stub headers for ESP32-only components


### PR DESCRIPTION
# What does this implement/fix?

CodSpeed benchmarks were building with `-O2` (unflagging the default `-Os` and replacing it), while all firmware targets (ESP8266, ESP32, LibreTiny) use `-Os`. This mismatch meant the benchmarks could not detect optimization opportunities that exist on real devices.

We discovered this when investigating `Scheduler::call()` inlining — `cleanup_()`, `process_to_add()`, and `Millis64Impl::compute()` were all outlined on firmware but always inlined in benchmarks. More critically, the mismatch led to **false conclusions about what could be optimized**: BLE advertisement encoding benchmarks appeared to be at their performance ceiling under `-O2`, when in reality the same code under `-Os` had significant room for improvement. Switching to `-Os` revealed that protobuf encode helpers were not being inlined on actual devices, leading to #15691 which recovered up to 40% on `calculate_size` and 14% on the full encode path on real ESP32 hardware.

This removes the `-Os` unflag and `-O2` override, adding `-Os` with `-ffunction-sections`/`-fdata-sections` for proper dead-code stripping (needed because `-Os` preserves references that `-O2` optimizes away at compile time).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes — affects CI benchmark builds only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).