### PR TITLE
[api] Compile noise-c and libsodium with -O2 for speed

### DIFF
--- a/esphome/components/api/__init__.py
+++ b/esphome/components/api/__init__.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import pathlib
 
 from esphome import automation
 from esphome.automation import Condition
@@ -458,11 +459,26 @@ async def to_code(config: ConfigType) -> None:
         # Enable optimized memzero/memcmp in libsodium instead of volatile byte loops
         cg.add_build_flag("-DHAVE_WEAK_SYMBOLS=1")
         cg.add_build_flag("-DHAVE_INLINE_ASM=1")
+        # Compile crypto libraries with -O2 for speed instead of -Os.
+        # Crypto is CPU-bound and benefits significantly from speed optimization.
+        # GCC uses the last -O flag, so appending -O2 overrides the global -Os.
+        _write_crypto_optimize_script()
     else:
         cg.add_define("USE_API_PLAINTEXT")
 
     cg.add_define("USE_API")
     cg.add_global(api_ns.using)
+
+
+_CRYPTO_OPTIMIZE_SCRIPT = "crypto_optimize.py"
+
+
+def _write_crypto_optimize_script() -> None:
+    from esphome.helpers import copy_file_if_changed
+
+    script_src = pathlib.Path(__file__).parent / f"{_CRYPTO_OPTIMIZE_SCRIPT}.script"
+    copy_file_if_changed(script_src, CORE.relative_build_path(_CRYPTO_OPTIMIZE_SCRIPT))
+    cg.add_platformio_option("extra_scripts", [f"post:{_CRYPTO_OPTIMIZE_SCRIPT}"])
 
 
 KEY_VALUE_SCHEMA = cv.Schema({cv.string: cv.templatable(cv.string_strict)})

--- a/esphome/components/api/crypto_optimize.py.script
+++ b/esphome/components/api/crypto_optimize.py.script
@@ -1,9 +1,9 @@
-# Compile crypto libraries with -O2 for speed instead of the default -Os.
-# Crypto is CPU-bound and benefits significantly from speed optimization.
-# GCC uses the last -O flag, so appending -O2 overrides the global -Os
-# for these libraries only.
+# Compile libsodium with -O2 for speed instead of the default -Os.
+# libsodium provides the crypto primitives (Curve25519, ChaCha20, Poly1305)
+# used by the Noise protocol and benefits significantly from speed optimization.
+# GCC uses the last -O flag, so appending -O2 overrides the global -Os.
 Import("env")
 
 for lb in env.GetLibBuilders():
-    if lb.name in ("noise-c", "libsodium"):
+    if lb.name == "libsodium":
         lb.env.Append(CCFLAGS=["-O2"])

--- a/esphome/components/api/crypto_optimize.py.script
+++ b/esphome/components/api/crypto_optimize.py.script
@@ -1,0 +1,9 @@
+# Compile crypto libraries with -O2 for speed instead of the default -Os.
+# Crypto is CPU-bound and benefits significantly from speed optimization.
+# GCC uses the last -O flag, so appending -O2 overrides the global -Os
+# for these libraries only.
+Import("env")
+
+for lb in env.GetLibBuilders():
+    if lb.name in ("noise-c", "libsodium"):
+        lb.env.Append(CCFLAGS=["-O2"])


### PR DESCRIPTION
# What does this implement/fix?

Chained on top of #15688 which switched benchmarks to `-Os` to match firmware. That change revealed that noise-c and libsodium suffer significantly under `-Os` (17-20% slower for noise encrypt/decrypt).

Crypto libraries are CPU-bound and benefit from speed optimization. This adds a `post:` PlatformIO extra_script that appends `-O2` to the build flags for noise-c and libsodium when API noise encryption is enabled. GCC uses the last `-O` flag, so this overrides the global `-Os` for these libraries only — ESPHome source code continues to build with `-Os`.

This applies to **all firmware builds** with noise encryption, not just benchmarks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #15688

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
api:
  encryption:
    key: !secret api_encryption_key
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).