### PR TITLE
[api] Add speed_optimized proto option for hot encode paths

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -671,6 +671,7 @@ message SensorStateResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_SENSOR";
   option (no_delay) = true;
+  option (speed_optimized) = true;
 
   fixed32 key = 1 [(force) = true];
   float state = 2;
@@ -1638,6 +1639,7 @@ message BluetoothLERawAdvertisementsResponse {
   option (source) = SOURCE_SERVER;
   option (ifdef) = "USE_BLUETOOTH_PROXY";
   option (no_delay) = true;
+  option (speed_optimized) = true;
 
   repeated BluetoothLERawAdvertisement advertisements = 1 [(fixed_array_with_length_define) = "BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE"];
 }

--- a/esphome/components/api/api_options.proto
+++ b/esphome/components/api/api_options.proto
@@ -23,6 +23,7 @@ extend google.protobuf.MessageOptions {
     optional bool no_delay = 1040 [default=false];
     optional string base_class = 1041;
     optional bool inline_encode = 1042 [default=false];
+    optional bool speed_optimized = 1043 [default=false];
 }
 
 extend google.protobuf.FieldOptions {

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1,33 +1,29 @@
 // This file was automatically generated with a tool.
 // See script/api_protobuf/api_protobuf.py
-#include "api_pb2.h"
-#include "esphome/core/log.h"
-#include "esphome/core/helpers.h"
-#include <cstring>
+    #include "api_pb2.h"
+    #include "esphome/core/log.h"
+    #include "esphome/core/helpers.h"
+    #include <cstring>
 
 namespace esphome::api {
 
+
+
 bool HelloRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->api_version_major = value;
-      break;
-    case 3:
-      this->api_version_minor = value;
-      break;
-    default:
-      return false;
+    case 2: this->api_version_major = value; break;
+    case 3: this->api_version_minor = value; break;
+    default: return false;
   }
   return true;
 }
 bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -336,38 +332,22 @@ uint32_t CoverStateResponse::calculate_size() const {
 }
 bool CoverCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 4:
-      this->has_position = value != 0;
-      break;
-    case 6:
-      this->has_tilt = value != 0;
-      break;
-    case 8:
-      this->stop = value != 0;
-      break;
+    case 4: this->has_position = value != 0; break;
+    case 6: this->has_tilt = value != 0; break;
+    case 8: this->stop = value != 0; break;
 #ifdef USE_DEVICES
-    case 9:
-      this->device_id = value;
-      break;
+    case 9: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 5:
-      this->position = value.as_float();
-      break;
-    case 7:
-      this->tilt = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 5: this->position = value.as_float(); break;
+    case 7: this->tilt = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -447,61 +427,36 @@ uint32_t FanStateResponse::calculate_size() const {
 }
 bool FanCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_state = value != 0;
-      break;
-    case 3:
-      this->state = value != 0;
-      break;
-    case 6:
-      this->has_oscillating = value != 0;
-      break;
-    case 7:
-      this->oscillating = value != 0;
-      break;
-    case 8:
-      this->has_direction = value != 0;
-      break;
-    case 9:
-      this->direction = static_cast<enums::FanDirection>(value);
-      break;
-    case 10:
-      this->has_speed_level = value != 0;
-      break;
-    case 11:
-      this->speed_level = static_cast<int32_t>(value);
-      break;
-    case 12:
-      this->has_preset_mode = value != 0;
-      break;
+    case 2: this->has_state = value != 0; break;
+    case 3: this->state = value != 0; break;
+    case 6: this->has_oscillating = value != 0; break;
+    case 7: this->oscillating = value != 0; break;
+    case 8: this->has_direction = value != 0; break;
+    case 9: this->direction = static_cast<enums::FanDirection>(value); break;
+    case 10: this->has_speed_level = value != 0; break;
+    case 11: this->speed_level = static_cast<int32_t>(value); break;
+    case 12: this->has_preset_mode = value != 0; break;
 #ifdef USE_DEVICES
-    case 14:
-      this->device_id = value;
-      break;
+    case 14: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool FanCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 13: {
-      this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -597,109 +552,52 @@ uint32_t LightStateResponse::calculate_size() const {
 }
 bool LightCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_state = value != 0;
-      break;
-    case 3:
-      this->state = value != 0;
-      break;
-    case 4:
-      this->has_brightness = value != 0;
-      break;
-    case 22:
-      this->has_color_mode = value != 0;
-      break;
-    case 23:
-      this->color_mode = static_cast<enums::ColorMode>(value);
-      break;
-    case 20:
-      this->has_color_brightness = value != 0;
-      break;
-    case 6:
-      this->has_rgb = value != 0;
-      break;
-    case 10:
-      this->has_white = value != 0;
-      break;
-    case 12:
-      this->has_color_temperature = value != 0;
-      break;
-    case 24:
-      this->has_cold_white = value != 0;
-      break;
-    case 26:
-      this->has_warm_white = value != 0;
-      break;
-    case 14:
-      this->has_transition_length = value != 0;
-      break;
-    case 15:
-      this->transition_length = value;
-      break;
-    case 16:
-      this->has_flash_length = value != 0;
-      break;
-    case 17:
-      this->flash_length = value;
-      break;
-    case 18:
-      this->has_effect = value != 0;
-      break;
+    case 2: this->has_state = value != 0; break;
+    case 3: this->state = value != 0; break;
+    case 4: this->has_brightness = value != 0; break;
+    case 22: this->has_color_mode = value != 0; break;
+    case 23: this->color_mode = static_cast<enums::ColorMode>(value); break;
+    case 20: this->has_color_brightness = value != 0; break;
+    case 6: this->has_rgb = value != 0; break;
+    case 10: this->has_white = value != 0; break;
+    case 12: this->has_color_temperature = value != 0; break;
+    case 24: this->has_cold_white = value != 0; break;
+    case 26: this->has_warm_white = value != 0; break;
+    case 14: this->has_transition_length = value != 0; break;
+    case 15: this->transition_length = value; break;
+    case 16: this->has_flash_length = value != 0; break;
+    case 17: this->flash_length = value; break;
+    case 18: this->has_effect = value != 0; break;
 #ifdef USE_DEVICES
-    case 28:
-      this->device_id = value;
-      break;
+    case 28: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool LightCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 19: {
-      this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 5:
-      this->brightness = value.as_float();
-      break;
-    case 21:
-      this->color_brightness = value.as_float();
-      break;
-    case 7:
-      this->red = value.as_float();
-      break;
-    case 8:
-      this->green = value.as_float();
-      break;
-    case 9:
-      this->blue = value.as_float();
-      break;
-    case 11:
-      this->white = value.as_float();
-      break;
-    case 13:
-      this->color_temperature = value.as_float();
-      break;
-    case 25:
-      this->cold_white = value.as_float();
-      break;
-    case 27:
-      this->warm_white = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 5: this->brightness = value.as_float(); break;
+    case 21: this->color_brightness = value.as_float(); break;
+    case 7: this->red = value.as_float(); break;
+    case 8: this->green = value.as_float(); break;
+    case 9: this->blue = value.as_float(); break;
+    case 11: this->white = value.as_float(); break;
+    case 13: this->color_temperature = value.as_float(); break;
+    case 25: this->cold_white = value.as_float(); break;
+    case 27: this->warm_white = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -745,8 +643,8 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
 #endif
   return size;
 }
-__attribute__((optimize("O2"))) uint8_t *SensorStateResponse::encode(
-    ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
+uint8_t *SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   ProtoEncode::write_tag_and_fixed32(pos PROTO_ENCODE_DEBUG_ARG, 13, this->key);
   ProtoEncode::encode_float(pos PROTO_ENCODE_DEBUG_ARG, 2, this->state);
@@ -756,7 +654,8 @@ __attribute__((optimize("O2"))) uint8_t *SensorStateResponse::encode(
 #endif
   return pos;
 }
-__attribute__((optimize("O2"))) uint32_t SensorStateResponse::calculate_size() const {
+__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
+uint32_t SensorStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
   size += ProtoSize::calc_float(1, this->state);
@@ -822,26 +721,18 @@ uint32_t SwitchStateResponse::calculate_size() const {
 }
 bool SwitchCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->state = value != 0;
-      break;
+    case 2: this->state = value != 0; break;
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -902,14 +793,9 @@ uint32_t TextSensorStateResponse::calculate_size() const {
 #endif
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->level = static_cast<enums::LogLevel>(value);
-      break;
-    case 2:
-      this->dump_config = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->level = static_cast<enums::LogLevel>(value); break;
+    case 2: this->dump_config = value != 0; break;
+    default: return false;
   }
   return true;
 }
@@ -929,12 +815,11 @@ uint32_t SubscribeLogsResponse::calculate_size() const {
 bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->key = value.data();
-      this->key_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->key = value.data();
+          this->key_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -1020,32 +905,26 @@ uint32_t HomeassistantActionRequest::calculate_size() const {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 bool HomeassistantActionResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->call_id = value;
-      break;
-    case 2:
-      this->success = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->call_id = value; break;
+    case 2: this->success = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool HomeassistantActionResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
     case 4: {
-      this->response_data = value.data();
-      this->response_data_len = value.size();
-      break;
-    }
+          this->response_data = value.data();
+          this->response_data_len = value.size();
+          break;
+        }
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
@@ -1068,95 +947,65 @@ uint32_t SubscribeHomeAssistantStateResponse::calculate_size() const {
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 2: {
-      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 3: {
-      this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 #endif
 bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->time_seconds = decode_zigzag32(static_cast<uint32_t>(value));
-      break;
-    case 2:
-      this->day = value;
-      break;
-    case 3:
-      this->type = static_cast<enums::DSTRuleType>(value);
-      break;
-    case 4:
-      this->month = value;
-      break;
-    case 5:
-      this->week = value;
-      break;
-    case 6:
-      this->day_of_week = value;
-      break;
-    default:
-      return false;
+    case 1: this->time_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
+    case 2: this->day = value; break;
+    case 3: this->type = static_cast<enums::DSTRuleType>(value); break;
+    case 4: this->month = value; break;
+    case 5: this->week = value; break;
+    case 6: this->day_of_week = value; break;
+    default: return false;
   }
   return true;
 }
 bool ParsedTimezone::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->std_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
-      break;
-    case 2:
-      this->dst_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
-      break;
-    default:
-      return false;
+    case 1: this->std_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
+    case 2: this->dst_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
+    default: return false;
   }
   return true;
 }
 bool ParsedTimezone::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 3:
-      value.decode_to_message(this->dst_start);
-      break;
-    case 4:
-      value.decode_to_message(this->dst_end);
-      break;
-    default:
-      return false;
+    case 3: value.decode_to_message(this->dst_start); break;
+    case 4: value.decode_to_message(this->dst_end); break;
+    default: return false;
   }
   return true;
 }
 bool GetTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    case 3:
-      value.decode_to_message(this->parsed_timezone);
-      break;
-    default:
-      return false;
+          this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    case 3: value.decode_to_message(this->parsed_timezone); break;
+    default: return false;
   }
   return true;
 }
 bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->epoch_seconds = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->epoch_seconds = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -1197,50 +1046,31 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
 }
 bool ExecuteServiceArgument::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->bool_ = value != 0;
-      break;
-    case 2:
-      this->legacy_int = static_cast<int32_t>(value);
-      break;
-    case 5:
-      this->int_ = decode_zigzag32(static_cast<uint32_t>(value));
-      break;
-    case 6:
-      this->bool_array.push_back(value != 0);
-      break;
-    case 7:
-      this->int_array.push_back(decode_zigzag32(static_cast<uint32_t>(value)));
-      break;
-    default:
-      return false;
+    case 1: this->bool_ = value != 0; break;
+    case 2: this->legacy_int = static_cast<int32_t>(value); break;
+    case 5: this->int_ = decode_zigzag32(static_cast<uint32_t>(value)); break;
+    case 6: this->bool_array.push_back(value != 0); break;
+    case 7: this->int_array.push_back(decode_zigzag32(static_cast<uint32_t>(value))); break;
+    default: return false;
   }
   return true;
 }
 bool ExecuteServiceArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    case 9:
-      this->string_array.push_back(value.as_string());
-      break;
-    default:
-      return false;
+          this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    case 9: this->string_array.push_back(value.as_string()); break;
+    default: return false;
   }
   return true;
 }
 bool ExecuteServiceArgument::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 3:
-      this->float_ = value.as_float();
-      break;
-    case 8:
-      this->float_array.push_back(value.as_float());
-      break;
-    default:
-      return false;
+    case 3: this->float_ = value.as_float(); break;
+    case 8: this->float_array.push_back(value.as_float()); break;
+    default: return false;
   }
   return true;
 }
@@ -1258,38 +1088,26 @@ void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
 bool ExecuteServiceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-    case 3:
-      this->call_id = value;
-      break;
+    case 3: this->call_id = value; break;
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-    case 4:
-      this->return_response = value != 0;
-      break;
+    case 4: this->return_response = value != 0; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2:
-      this->args.emplace_back();
-      value.decode_to_message(this->args.back());
-      break;
-    default:
-      return false;
+    case 2: this->args.emplace_back(); value.decode_to_message(this->args.back()); break;
+    default: return false;
   }
   return true;
 }
 bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -1374,14 +1192,9 @@ uint32_t CameraImageResponse::calculate_size() const {
 }
 bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->single = value != 0;
-      break;
-    case 2:
-      this->stream = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->single = value != 0; break;
+    case 2: this->stream = value != 0; break;
+    default: return false;
   }
   return true;
 }
@@ -1525,92 +1338,49 @@ uint32_t ClimateStateResponse::calculate_size() const {
 }
 bool ClimateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_mode = value != 0;
-      break;
-    case 3:
-      this->mode = static_cast<enums::ClimateMode>(value);
-      break;
-    case 4:
-      this->has_target_temperature = value != 0;
-      break;
-    case 6:
-      this->has_target_temperature_low = value != 0;
-      break;
-    case 8:
-      this->has_target_temperature_high = value != 0;
-      break;
-    case 12:
-      this->has_fan_mode = value != 0;
-      break;
-    case 13:
-      this->fan_mode = static_cast<enums::ClimateFanMode>(value);
-      break;
-    case 14:
-      this->has_swing_mode = value != 0;
-      break;
-    case 15:
-      this->swing_mode = static_cast<enums::ClimateSwingMode>(value);
-      break;
-    case 16:
-      this->has_custom_fan_mode = value != 0;
-      break;
-    case 18:
-      this->has_preset = value != 0;
-      break;
-    case 19:
-      this->preset = static_cast<enums::ClimatePreset>(value);
-      break;
-    case 20:
-      this->has_custom_preset = value != 0;
-      break;
-    case 22:
-      this->has_target_humidity = value != 0;
-      break;
+    case 2: this->has_mode = value != 0; break;
+    case 3: this->mode = static_cast<enums::ClimateMode>(value); break;
+    case 4: this->has_target_temperature = value != 0; break;
+    case 6: this->has_target_temperature_low = value != 0; break;
+    case 8: this->has_target_temperature_high = value != 0; break;
+    case 12: this->has_fan_mode = value != 0; break;
+    case 13: this->fan_mode = static_cast<enums::ClimateFanMode>(value); break;
+    case 14: this->has_swing_mode = value != 0; break;
+    case 15: this->swing_mode = static_cast<enums::ClimateSwingMode>(value); break;
+    case 16: this->has_custom_fan_mode = value != 0; break;
+    case 18: this->has_preset = value != 0; break;
+    case 19: this->preset = static_cast<enums::ClimatePreset>(value); break;
+    case 20: this->has_custom_preset = value != 0; break;
+    case 22: this->has_target_humidity = value != 0; break;
 #ifdef USE_DEVICES
-    case 24:
-      this->device_id = value;
-      break;
+    case 24: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool ClimateCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 17: {
-      this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 21: {
-      this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 5:
-      this->target_temperature = value.as_float();
-      break;
-    case 7:
-      this->target_temperature_low = value.as_float();
-      break;
-    case 9:
-      this->target_temperature_high = value.as_float();
-      break;
-    case 23:
-      this->target_humidity = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 5: this->target_temperature = value.as_float(); break;
+    case 7: this->target_temperature_low = value.as_float(); break;
+    case 9: this->target_temperature_high = value.as_float(); break;
+    case 23: this->target_humidity = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -1690,41 +1460,23 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
 }
 bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_fields = value;
-      break;
-    case 3:
-      this->mode = static_cast<enums::WaterHeaterMode>(value);
-      break;
+    case 2: this->has_fields = value; break;
+    case 3: this->mode = static_cast<enums::WaterHeaterMode>(value); break;
 #ifdef USE_DEVICES
-    case 5:
-      this->device_id = value;
-      break;
+    case 5: this->device_id = value; break;
 #endif
-    case 6:
-      this->state = value;
-      break;
-    default:
-      return false;
+    case 6: this->state = value; break;
+    default: return false;
   }
   return true;
 }
 bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 4:
-      this->target_temperature = value.as_float();
-      break;
-    case 7:
-      this->target_temperature_low = value.as_float();
-      break;
-    case 8:
-      this->target_temperature_high = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 4: this->target_temperature = value.as_float(); break;
+    case 7: this->target_temperature_low = value.as_float(); break;
+    case 8: this->target_temperature_high = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -1795,25 +1547,17 @@ uint32_t NumberStateResponse::calculate_size() const {
 bool NumberCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 2:
-      this->state = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 2: this->state = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -1880,33 +1624,26 @@ uint32_t SelectStateResponse::calculate_size() const {
 bool SelectCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -1974,55 +1711,34 @@ uint32_t SirenStateResponse::calculate_size() const {
 }
 bool SirenCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_state = value != 0;
-      break;
-    case 3:
-      this->state = value != 0;
-      break;
-    case 4:
-      this->has_tone = value != 0;
-      break;
-    case 6:
-      this->has_duration = value != 0;
-      break;
-    case 7:
-      this->duration = value;
-      break;
-    case 8:
-      this->has_volume = value != 0;
-      break;
+    case 2: this->has_state = value != 0; break;
+    case 3: this->state = value != 0; break;
+    case 4: this->has_tone = value != 0; break;
+    case 6: this->has_duration = value != 0; break;
+    case 7: this->duration = value; break;
+    case 8: this->has_volume = value != 0; break;
 #ifdef USE_DEVICES
-    case 10:
-      this->device_id = value;
-      break;
+    case 10: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool SirenCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 5: {
-      this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 9:
-      this->volume = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 9: this->volume = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -2086,40 +1802,29 @@ uint32_t LockStateResponse::calculate_size() const {
 }
 bool LockCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->command = static_cast<enums::LockCommand>(value);
-      break;
-    case 3:
-      this->has_code = value != 0;
-      break;
+    case 2: this->command = static_cast<enums::LockCommand>(value); break;
+    case 3: this->has_code = value != 0; break;
 #ifdef USE_DEVICES
-    case 5:
-      this->device_id = value;
-      break;
+    case 5: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool LockCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -2160,22 +1865,16 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
 bool ButtonCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 2:
-      this->device_id = value;
-      break;
+    case 2: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -2265,55 +1964,34 @@ uint32_t MediaPlayerStateResponse::calculate_size() const {
 }
 bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_command = value != 0;
-      break;
-    case 3:
-      this->command = static_cast<enums::MediaPlayerCommand>(value);
-      break;
-    case 4:
-      this->has_volume = value != 0;
-      break;
-    case 6:
-      this->has_media_url = value != 0;
-      break;
-    case 8:
-      this->has_announcement = value != 0;
-      break;
-    case 9:
-      this->announcement = value != 0;
-      break;
+    case 2: this->has_command = value != 0; break;
+    case 3: this->command = static_cast<enums::MediaPlayerCommand>(value); break;
+    case 4: this->has_volume = value != 0; break;
+    case 6: this->has_media_url = value != 0; break;
+    case 8: this->has_announcement = value != 0; break;
+    case 9: this->announcement = value != 0; break;
 #ifdef USE_DEVICES
-    case 10:
-      this->device_id = value;
-      break;
+    case 10: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool MediaPlayerCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 7: {
-      this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 5:
-      this->volume = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 5: this->volume = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -2321,38 +1999,36 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 #ifdef USE_BLUETOOTH_PROXY
 bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->flags = value;
-      break;
-    default:
-      return false;
+    case 1: this->flags = value; break;
+    default: return false;
   }
   return true;
 }
-__attribute__((optimize("O2"))) uint8_t *BluetoothLERawAdvertisementsResponse::encode(
-    ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
+uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
-    uint8_t *len_pos = pos;
-    ProtoEncode::reserve_byte(pos PROTO_ENCODE_DEBUG_ARG);
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
-    ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
-    ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
-    if (sub_msg.address_type) {
-      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
-      ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
-    }
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
-    ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
-    *len_pos = static_cast<uint8_t>(pos - len_pos - 1);
+  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
+  uint8_t *len_pos = pos;
+  ProtoEncode::reserve_byte(pos PROTO_ENCODE_DEBUG_ARG);
+  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
+  ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
+  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
+  ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
+  if (sub_msg.address_type) {
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
+  ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
+  }
+  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
+  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
+  ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
+  *len_pos = static_cast<uint8_t>(pos - len_pos - 1);
   }
   return pos;
 }
-__attribute__((optimize("O2"))) uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
+__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
+uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
@@ -2366,20 +2042,11 @@ __attribute__((optimize("O2"))) uint32_t BluetoothLERawAdvertisementsResponse::c
 }
 bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value);
-      break;
-    case 3:
-      this->has_address_type = value != 0;
-      break;
-    case 4:
-      this->address_type = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value); break;
+    case 3: this->has_address_type = value != 0; break;
+    case 4: this->address_type = value; break;
+    default: return false;
   }
   return true;
 }
@@ -2401,11 +2068,8 @@ uint32_t BluetoothDeviceConnectionResponse::calculate_size() const {
 }
 bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    default: return false;
   }
   return true;
 }
@@ -2517,14 +2181,9 @@ uint32_t BluetoothGATTGetServicesDoneResponse::calculate_size() const {
 }
 bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->handle = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->handle = value; break;
+    default: return false;
   }
   return true;
 }
@@ -2544,83 +2203,57 @@ uint32_t BluetoothGATTReadResponse::calculate_size() const {
 }
 bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->handle = value;
-      break;
-    case 3:
-      this->response = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->handle = value; break;
+    case 3: this->response = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->handle = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->handle = value; break;
+    default: return false;
   }
   return true;
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->handle = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->handle = value; break;
+    default: return false;
   }
   return true;
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->handle = value;
-      break;
-    case 3:
-      this->enable = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->handle = value; break;
+    case 3: this->enable = value != 0; break;
+    default: return false;
   }
   return true;
 }
@@ -2756,11 +2389,8 @@ uint32_t BluetoothScannerStateResponse::calculate_size() const {
 }
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->mode = static_cast<enums::BluetoothScannerMode>(value);
-      break;
-    default:
-      return false;
+    case 1: this->mode = static_cast<enums::BluetoothScannerMode>(value); break;
+    default: return false;
   }
   return true;
 }
@@ -2768,14 +2398,9 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_vari
 #ifdef USE_VOICE_ASSISTANT
 bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->subscribe = value != 0;
-      break;
-    case 2:
-      this->flags = value;
-      break;
-    default:
-      return false;
+    case 1: this->subscribe = value != 0; break;
+    case 2: this->flags = value; break;
+    default: return false;
   }
   return true;
 }
@@ -2813,72 +2438,55 @@ uint32_t VoiceAssistantRequest::calculate_size() const {
 }
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->port = value;
-      break;
-    case 2:
-      this->error = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->port = value; break;
+    case 2: this->error = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 2: {
-      this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->event_type = static_cast<enums::VoiceAssistantEvent>(value);
-      break;
-    default:
-      return false;
+    case 1: this->event_type = static_cast<enums::VoiceAssistantEvent>(value); break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2:
-      this->data.emplace_back();
-      value.decode_to_message(this->data.back());
-      break;
-    default:
-      return false;
+    case 2: this->data.emplace_back(); value.decode_to_message(this->data.back()); break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->end = value != 0;
-      break;
-    default:
-      return false;
+    case 2: this->end = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantAudio::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -2896,64 +2504,50 @@ uint32_t VoiceAssistantAudio::calculate_size() const {
 }
 bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value);
-      break;
-    case 4:
-      this->total_seconds = value;
-      break;
-    case 5:
-      this->seconds_left = value;
-      break;
-    case 6:
-      this->is_active = value != 0;
-      break;
-    default:
-      return false;
+    case 1: this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value); break;
+    case 4: this->total_seconds = value; break;
+    case 5: this->seconds_left = value; break;
+    case 6: this->is_active = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 3: {
-      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 4:
-      this->start_conversation = value != 0;
-      break;
-    default:
-      return false;
+    case 4: this->start_conversation = value != 0; break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 2: {
-      this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 3: {
-      this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -2989,52 +2583,42 @@ uint32_t VoiceAssistantWakeWord::calculate_size() const {
 }
 bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 5:
-      this->model_size = value;
-      break;
-    default:
-      return false;
+    case 5: this->model_size = value; break;
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 2: {
-      this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    case 3:
-      this->trained_languages.push_back(value.as_string());
-      break;
+          this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    case 3: this->trained_languages.push_back(value.as_string()); break;
     case 4: {
-      this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 6: {
-      this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
+          this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
     case 7: {
-      this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->external_wake_words.emplace_back();
-      value.decode_to_message(this->external_wake_words.back());
-      break;
-    default:
-      return false;
+    case 1: this->external_wake_words.emplace_back(); value.decode_to_message(this->external_wake_words.back()); break;
+    default: return false;
   }
   return true;
 }
@@ -3066,11 +2650,8 @@ uint32_t VoiceAssistantConfigurationResponse::calculate_size() const {
 }
 bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1:
-      this->active_wake_words.push_back(value.as_string());
-      break;
-    default:
-      return false;
+    case 1: this->active_wake_words.push_back(value.as_string()); break;
+    default: return false;
   }
   return true;
 }
@@ -3132,37 +2713,28 @@ uint32_t AlarmControlPanelStateResponse::calculate_size() const {
 }
 bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->command = static_cast<enums::AlarmControlPanelStateCommand>(value);
-      break;
+    case 2: this->command = static_cast<enums::AlarmControlPanelStateCommand>(value); break;
 #ifdef USE_DEVICES
-    case 4:
-      this->device_id = value;
-      break;
+    case 4: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool AlarmControlPanelCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3229,33 +2801,26 @@ uint32_t TextStateResponse::calculate_size() const {
 bool TextCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3317,32 +2882,20 @@ uint32_t DateStateResponse::calculate_size() const {
 }
 bool DateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->year = value;
-      break;
-    case 3:
-      this->month = value;
-      break;
-    case 4:
-      this->day = value;
-      break;
+    case 2: this->year = value; break;
+    case 3: this->month = value; break;
+    case 4: this->day = value; break;
 #ifdef USE_DEVICES
-    case 5:
-      this->device_id = value;
-      break;
+    case 5: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3404,32 +2957,20 @@ uint32_t TimeStateResponse::calculate_size() const {
 }
 bool TimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->hour = value;
-      break;
-    case 3:
-      this->minute = value;
-      break;
-    case 4:
-      this->second = value;
-      break;
+    case 2: this->hour = value; break;
+    case 3: this->minute = value; break;
+    case 4: this->second = value; break;
 #ifdef USE_DEVICES
-    case 5:
-      this->device_id = value;
-      break;
+    case 5: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3555,32 +3096,20 @@ uint32_t ValveStateResponse::calculate_size() const {
 }
 bool ValveCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->has_position = value != 0;
-      break;
-    case 4:
-      this->stop = value != 0;
-      break;
+    case 2: this->has_position = value != 0; break;
+    case 4: this->stop = value != 0; break;
 #ifdef USE_DEVICES
-    case 5:
-      this->device_id = value;
-      break;
+    case 5: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 3:
-      this->position = value.as_float();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 3: this->position = value.as_float(); break;
+    default: return false;
   }
   return true;
 }
@@ -3639,25 +3168,17 @@ uint32_t DateTimeStateResponse::calculate_size() const {
 bool DateTimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    case 2:
-      this->epoch_seconds = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    case 2: this->epoch_seconds = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3731,26 +3252,18 @@ uint32_t UpdateStateResponse::calculate_size() const {
 }
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2:
-      this->command = static_cast<enums::UpdateCommand>(value);
-      break;
+    case 2: this->command = static_cast<enums::UpdateCommand>(value); break;
 #ifdef USE_DEVICES
-    case 3:
-      this->device_id = value;
-      break;
+    case 3: this->device_id = value; break;
 #endif
-    default:
-      return false;
+    default: return false;
   }
   return true;
 }
 bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 1: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3759,12 +3272,11 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 bool ZWaveProxyFrame::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -3780,23 +3292,19 @@ uint32_t ZWaveProxyFrame::calculate_size() const {
 }
 bool ZWaveProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->type = static_cast<enums::ZWaveProxyRequestType>(value);
-      break;
-    default:
-      return false;
+    case 1: this->type = static_cast<enums::ZWaveProxyRequestType>(value); break;
+    default: return false;
   }
   return true;
 }
 bool ZWaveProxyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
@@ -3853,41 +3361,30 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
 bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 1:
-      this->device_id = value;
-      break;
+    case 1: this->device_id = value; break;
 #endif
-    case 3:
-      this->carrier_frequency = value;
-      break;
-    case 4:
-      this->repeat_count = value;
-      break;
-    default:
-      return false;
+    case 3: this->carrier_frequency = value; break;
+    case 4: this->repeat_count = value; break;
+    default: return false;
   }
   return true;
 }
 bool InfraredRFTransmitRawTimingsRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 5: {
-      this->timings_data_ = value.data();
-      this->timings_length_ = value.size();
-      this->timings_count_ = count_packed_varints(value.data(), value.size());
-      break;
-    }
-    default:
-      return false;
+          this->timings_data_ = value.data();
+          this->timings_length_ = value.size();
+          this->timings_count_ = count_packed_varints(value.data(), value.size());
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool InfraredRFTransmitRawTimingsRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 2:
-      this->key = value.as_fixed32();
-      break;
-    default:
-      return false;
+    case 2: this->key = value.as_fixed32(); break;
+    default: return false;
   }
   return true;
 }
@@ -3919,26 +3416,13 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 #ifdef USE_SERIAL_PROXY
 bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->instance = value;
-      break;
-    case 2:
-      this->baudrate = value;
-      break;
-    case 3:
-      this->flow_control = value != 0;
-      break;
-    case 4:
-      this->parity = static_cast<enums::SerialProxyParity>(value);
-      break;
-    case 5:
-      this->stop_bits = value;
-      break;
-    case 6:
-      this->data_size = value;
-      break;
-    default:
-      return false;
+    case 1: this->instance = value; break;
+    case 2: this->baudrate = value; break;
+    case 3: this->flow_control = value != 0; break;
+    case 4: this->parity = static_cast<enums::SerialProxyParity>(value); break;
+    case 5: this->stop_bits = value; break;
+    case 6: this->data_size = value; break;
+    default: return false;
   }
   return true;
 }
@@ -3956,46 +3440,34 @@ uint32_t SerialProxyDataReceived::calculate_size() const {
 }
 bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->instance = value;
-      break;
-    default:
-      return false;
+    case 1: this->instance = value; break;
+    default: return false;
   }
   return true;
 }
 bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-      this->data = value.data();
-      this->data_len = value.size();
-      break;
-    }
-    default:
-      return false;
+          this->data = value.data();
+          this->data_len = value.size();
+          break;
+        }
+    default: return false;
   }
   return true;
 }
 bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->instance = value;
-      break;
-    case 2:
-      this->line_states = value;
-      break;
-    default:
-      return false;
+    case 1: this->instance = value; break;
+    case 2: this->line_states = value; break;
+    default: return false;
   }
   return true;
 }
 bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->instance = value;
-      break;
-    default:
-      return false;
+    case 1: this->instance = value; break;
+    default: return false;
   }
   return true;
 }
@@ -4013,14 +3485,9 @@ uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
 }
 bool SerialProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->instance = value;
-      break;
-    case 2:
-      this->type = static_cast<enums::SerialProxyRequestType>(value);
-      break;
-    default:
-      return false;
+    case 1: this->instance = value; break;
+    case 2: this->type = static_cast<enums::SerialProxyRequestType>(value); break;
+    default: return false;
   }
   return true;
 }
@@ -4044,23 +3511,12 @@ uint32_t SerialProxyRequestResponse::calculate_size() const {
 #ifdef USE_BLUETOOTH_PROXY
 bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1:
-      this->address = value;
-      break;
-    case 2:
-      this->min_interval = value;
-      break;
-    case 3:
-      this->max_interval = value;
-      break;
-    case 4:
-      this->latency = value;
-      break;
-    case 5:
-      this->timeout = value;
-      break;
-    default:
-      return false;
+    case 1: this->address = value; break;
+    case 2: this->min_interval = value; break;
+    case 3: this->max_interval = value; break;
+    case 4: this->latency = value; break;
+    case 5: this->timeout = value; break;
+    default: return false;
   }
   return true;
 }

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -745,7 +745,8 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
 #endif
   return size;
 }
-uint8_t *SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+__attribute__((optimize("O2"))) uint8_t *SensorStateResponse::encode(
+    ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   ProtoEncode::write_tag_and_fixed32(pos PROTO_ENCODE_DEBUG_ARG, 13, this->key);
   ProtoEncode::encode_float(pos PROTO_ENCODE_DEBUG_ARG, 2, this->state);
@@ -755,7 +756,7 @@ uint8_t *SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG
 #endif
   return pos;
 }
-uint32_t SensorStateResponse::calculate_size() const {
+__attribute__((optimize("O2"))) uint32_t SensorStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
   size += ProtoSize::calc_float(1, this->state);
@@ -2328,7 +2329,8 @@ bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id,
   }
   return true;
 }
-uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+__attribute__((optimize("O2"))) uint8_t *BluetoothLERawAdvertisementsResponse::encode(
+    ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
@@ -2350,7 +2352,7 @@ uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer P
   }
   return pos;
 }
-uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
+__attribute__((optimize("O2"))) uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -1,29 +1,33 @@
 // This file was automatically generated with a tool.
 // See script/api_protobuf/api_protobuf.py
-    #include "api_pb2.h"
-    #include "esphome/core/log.h"
-    #include "esphome/core/helpers.h"
-    #include <cstring>
+#include "api_pb2.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include <cstring>
 
 namespace esphome::api {
 
-
-
 bool HelloRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->api_version_major = value; break;
-    case 3: this->api_version_minor = value; break;
-    default: return false;
+    case 2:
+      this->api_version_major = value;
+      break;
+    case 3:
+      this->api_version_minor = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool HelloRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->client_info = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -332,22 +336,38 @@ uint32_t CoverStateResponse::calculate_size() const {
 }
 bool CoverCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 4: this->has_position = value != 0; break;
-    case 6: this->has_tilt = value != 0; break;
-    case 8: this->stop = value != 0; break;
+    case 4:
+      this->has_position = value != 0;
+      break;
+    case 6:
+      this->has_tilt = value != 0;
+      break;
+    case 8:
+      this->stop = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 9: this->device_id = value; break;
+    case 9:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool CoverCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 5: this->position = value.as_float(); break;
-    case 7: this->tilt = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 5:
+      this->position = value.as_float();
+      break;
+    case 7:
+      this->tilt = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -427,36 +447,61 @@ uint32_t FanStateResponse::calculate_size() const {
 }
 bool FanCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_state = value != 0; break;
-    case 3: this->state = value != 0; break;
-    case 6: this->has_oscillating = value != 0; break;
-    case 7: this->oscillating = value != 0; break;
-    case 8: this->has_direction = value != 0; break;
-    case 9: this->direction = static_cast<enums::FanDirection>(value); break;
-    case 10: this->has_speed_level = value != 0; break;
-    case 11: this->speed_level = static_cast<int32_t>(value); break;
-    case 12: this->has_preset_mode = value != 0; break;
+    case 2:
+      this->has_state = value != 0;
+      break;
+    case 3:
+      this->state = value != 0;
+      break;
+    case 6:
+      this->has_oscillating = value != 0;
+      break;
+    case 7:
+      this->oscillating = value != 0;
+      break;
+    case 8:
+      this->has_direction = value != 0;
+      break;
+    case 9:
+      this->direction = static_cast<enums::FanDirection>(value);
+      break;
+    case 10:
+      this->has_speed_level = value != 0;
+      break;
+    case 11:
+      this->speed_level = static_cast<int32_t>(value);
+      break;
+    case 12:
+      this->has_preset_mode = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 14: this->device_id = value; break;
+    case 14:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool FanCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 13: {
-          this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->preset_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool FanCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -552,52 +597,109 @@ uint32_t LightStateResponse::calculate_size() const {
 }
 bool LightCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_state = value != 0; break;
-    case 3: this->state = value != 0; break;
-    case 4: this->has_brightness = value != 0; break;
-    case 22: this->has_color_mode = value != 0; break;
-    case 23: this->color_mode = static_cast<enums::ColorMode>(value); break;
-    case 20: this->has_color_brightness = value != 0; break;
-    case 6: this->has_rgb = value != 0; break;
-    case 10: this->has_white = value != 0; break;
-    case 12: this->has_color_temperature = value != 0; break;
-    case 24: this->has_cold_white = value != 0; break;
-    case 26: this->has_warm_white = value != 0; break;
-    case 14: this->has_transition_length = value != 0; break;
-    case 15: this->transition_length = value; break;
-    case 16: this->has_flash_length = value != 0; break;
-    case 17: this->flash_length = value; break;
-    case 18: this->has_effect = value != 0; break;
+    case 2:
+      this->has_state = value != 0;
+      break;
+    case 3:
+      this->state = value != 0;
+      break;
+    case 4:
+      this->has_brightness = value != 0;
+      break;
+    case 22:
+      this->has_color_mode = value != 0;
+      break;
+    case 23:
+      this->color_mode = static_cast<enums::ColorMode>(value);
+      break;
+    case 20:
+      this->has_color_brightness = value != 0;
+      break;
+    case 6:
+      this->has_rgb = value != 0;
+      break;
+    case 10:
+      this->has_white = value != 0;
+      break;
+    case 12:
+      this->has_color_temperature = value != 0;
+      break;
+    case 24:
+      this->has_cold_white = value != 0;
+      break;
+    case 26:
+      this->has_warm_white = value != 0;
+      break;
+    case 14:
+      this->has_transition_length = value != 0;
+      break;
+    case 15:
+      this->transition_length = value;
+      break;
+    case 16:
+      this->has_flash_length = value != 0;
+      break;
+    case 17:
+      this->flash_length = value;
+      break;
+    case 18:
+      this->has_effect = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 28: this->device_id = value; break;
+    case 28:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool LightCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 19: {
-          this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->effect = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool LightCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 5: this->brightness = value.as_float(); break;
-    case 21: this->color_brightness = value.as_float(); break;
-    case 7: this->red = value.as_float(); break;
-    case 8: this->green = value.as_float(); break;
-    case 9: this->blue = value.as_float(); break;
-    case 11: this->white = value.as_float(); break;
-    case 13: this->color_temperature = value.as_float(); break;
-    case 25: this->cold_white = value.as_float(); break;
-    case 27: this->warm_white = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 5:
+      this->brightness = value.as_float();
+      break;
+    case 21:
+      this->color_brightness = value.as_float();
+      break;
+    case 7:
+      this->red = value.as_float();
+      break;
+    case 8:
+      this->green = value.as_float();
+      break;
+    case 9:
+      this->blue = value.as_float();
+      break;
+    case 11:
+      this->white = value.as_float();
+      break;
+    case 13:
+      this->color_temperature = value.as_float();
+      break;
+    case 25:
+      this->cold_white = value.as_float();
+      break;
+    case 27:
+      this->warm_white = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -644,7 +746,8 @@ uint32_t ListEntitiesSensorResponse::calculate_size() const {
   return size;
 }
 __attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
-uint8_t *SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+uint8_t *
+SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   ProtoEncode::write_tag_and_fixed32(pos PROTO_ENCODE_DEBUG_ARG, 13, this->key);
   ProtoEncode::encode_float(pos PROTO_ENCODE_DEBUG_ARG, 2, this->state);
@@ -655,7 +758,8 @@ uint8_t *SensorStateResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG
   return pos;
 }
 __attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
-uint32_t SensorStateResponse::calculate_size() const {
+uint32_t
+SensorStateResponse::calculate_size() const {
   uint32_t size = 0;
   size += 5;
   size += ProtoSize::calc_float(1, this->state);
@@ -721,18 +825,26 @@ uint32_t SwitchStateResponse::calculate_size() const {
 }
 bool SwitchCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->state = value != 0; break;
+    case 2:
+      this->state = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool SwitchCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -793,9 +905,14 @@ uint32_t TextSensorStateResponse::calculate_size() const {
 #endif
 bool SubscribeLogsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->level = static_cast<enums::LogLevel>(value); break;
-    case 2: this->dump_config = value != 0; break;
-    default: return false;
+    case 1:
+      this->level = static_cast<enums::LogLevel>(value);
+      break;
+    case 2:
+      this->dump_config = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -815,11 +932,12 @@ uint32_t SubscribeLogsResponse::calculate_size() const {
 bool NoiseEncryptionSetKeyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->key = value.data();
-          this->key_len = value.size();
-          break;
-        }
-    default: return false;
+      this->key = value.data();
+      this->key_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -905,26 +1023,32 @@ uint32_t HomeassistantActionRequest::calculate_size() const {
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES
 bool HomeassistantActionResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->call_id = value; break;
-    case 2: this->success = value != 0; break;
-    default: return false;
+    case 1:
+      this->call_id = value;
+      break;
+    case 2:
+      this->success = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool HomeassistantActionResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-          this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->error_message = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
 #ifdef USE_API_HOMEASSISTANT_ACTION_RESPONSES_JSON
     case 4: {
-          this->response_data = value.data();
-          this->response_data_len = value.size();
-          break;
-        }
+      this->response_data = value.data();
+      this->response_data_len = value.size();
+      break;
+    }
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
@@ -947,65 +1071,95 @@ uint32_t SubscribeHomeAssistantStateResponse::calculate_size() const {
 bool HomeAssistantStateResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->entity_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 2: {
-          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 3: {
-          this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->attribute = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 #endif
 bool DSTRule::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->time_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
-    case 2: this->day = value; break;
-    case 3: this->type = static_cast<enums::DSTRuleType>(value); break;
-    case 4: this->month = value; break;
-    case 5: this->week = value; break;
-    case 6: this->day_of_week = value; break;
-    default: return false;
+    case 1:
+      this->time_seconds = decode_zigzag32(static_cast<uint32_t>(value));
+      break;
+    case 2:
+      this->day = value;
+      break;
+    case 3:
+      this->type = static_cast<enums::DSTRuleType>(value);
+      break;
+    case 4:
+      this->month = value;
+      break;
+    case 5:
+      this->week = value;
+      break;
+    case 6:
+      this->day_of_week = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ParsedTimezone::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->std_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
-    case 2: this->dst_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value)); break;
-    default: return false;
+    case 1:
+      this->std_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
+      break;
+    case 2:
+      this->dst_offset_seconds = decode_zigzag32(static_cast<uint32_t>(value));
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ParsedTimezone::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 3: value.decode_to_message(this->dst_start); break;
-    case 4: value.decode_to_message(this->dst_end); break;
-    default: return false;
+    case 3:
+      value.decode_to_message(this->dst_start);
+      break;
+    case 4:
+      value.decode_to_message(this->dst_end);
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool GetTimeResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    case 3: value.decode_to_message(this->parsed_timezone); break;
-    default: return false;
+      this->timezone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    case 3:
+      value.decode_to_message(this->parsed_timezone);
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool GetTimeResponse::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->epoch_seconds = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->epoch_seconds = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1046,31 +1200,50 @@ uint32_t ListEntitiesServicesResponse::calculate_size() const {
 }
 bool ExecuteServiceArgument::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->bool_ = value != 0; break;
-    case 2: this->legacy_int = static_cast<int32_t>(value); break;
-    case 5: this->int_ = decode_zigzag32(static_cast<uint32_t>(value)); break;
-    case 6: this->bool_array.push_back(value != 0); break;
-    case 7: this->int_array.push_back(decode_zigzag32(static_cast<uint32_t>(value))); break;
-    default: return false;
+    case 1:
+      this->bool_ = value != 0;
+      break;
+    case 2:
+      this->legacy_int = static_cast<int32_t>(value);
+      break;
+    case 5:
+      this->int_ = decode_zigzag32(static_cast<uint32_t>(value));
+      break;
+    case 6:
+      this->bool_array.push_back(value != 0);
+      break;
+    case 7:
+      this->int_array.push_back(decode_zigzag32(static_cast<uint32_t>(value)));
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ExecuteServiceArgument::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-          this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    case 9: this->string_array.push_back(value.as_string()); break;
-    default: return false;
+      this->string_ = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    case 9:
+      this->string_array.push_back(value.as_string());
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ExecuteServiceArgument::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 3: this->float_ = value.as_float(); break;
-    case 8: this->float_array.push_back(value.as_float()); break;
-    default: return false;
+    case 3:
+      this->float_ = value.as_float();
+      break;
+    case 8:
+      this->float_array.push_back(value.as_float());
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1088,26 +1261,38 @@ void ExecuteServiceArgument::decode(const uint8_t *buffer, size_t length) {
 bool ExecuteServiceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-    case 3: this->call_id = value; break;
+    case 3:
+      this->call_id = value;
+      break;
 #endif
 #ifdef USE_API_USER_DEFINED_ACTION_RESPONSES
-    case 4: this->return_response = value != 0; break;
+    case 4:
+      this->return_response = value != 0;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool ExecuteServiceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2: this->args.emplace_back(); value.decode_to_message(this->args.back()); break;
-    default: return false;
+    case 2:
+      this->args.emplace_back();
+      value.decode_to_message(this->args.back());
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ExecuteServiceRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1192,9 +1377,14 @@ uint32_t CameraImageResponse::calculate_size() const {
 }
 bool CameraImageRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->single = value != 0; break;
-    case 2: this->stream = value != 0; break;
-    default: return false;
+    case 1:
+      this->single = value != 0;
+      break;
+    case 2:
+      this->stream = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1338,49 +1528,92 @@ uint32_t ClimateStateResponse::calculate_size() const {
 }
 bool ClimateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_mode = value != 0; break;
-    case 3: this->mode = static_cast<enums::ClimateMode>(value); break;
-    case 4: this->has_target_temperature = value != 0; break;
-    case 6: this->has_target_temperature_low = value != 0; break;
-    case 8: this->has_target_temperature_high = value != 0; break;
-    case 12: this->has_fan_mode = value != 0; break;
-    case 13: this->fan_mode = static_cast<enums::ClimateFanMode>(value); break;
-    case 14: this->has_swing_mode = value != 0; break;
-    case 15: this->swing_mode = static_cast<enums::ClimateSwingMode>(value); break;
-    case 16: this->has_custom_fan_mode = value != 0; break;
-    case 18: this->has_preset = value != 0; break;
-    case 19: this->preset = static_cast<enums::ClimatePreset>(value); break;
-    case 20: this->has_custom_preset = value != 0; break;
-    case 22: this->has_target_humidity = value != 0; break;
+    case 2:
+      this->has_mode = value != 0;
+      break;
+    case 3:
+      this->mode = static_cast<enums::ClimateMode>(value);
+      break;
+    case 4:
+      this->has_target_temperature = value != 0;
+      break;
+    case 6:
+      this->has_target_temperature_low = value != 0;
+      break;
+    case 8:
+      this->has_target_temperature_high = value != 0;
+      break;
+    case 12:
+      this->has_fan_mode = value != 0;
+      break;
+    case 13:
+      this->fan_mode = static_cast<enums::ClimateFanMode>(value);
+      break;
+    case 14:
+      this->has_swing_mode = value != 0;
+      break;
+    case 15:
+      this->swing_mode = static_cast<enums::ClimateSwingMode>(value);
+      break;
+    case 16:
+      this->has_custom_fan_mode = value != 0;
+      break;
+    case 18:
+      this->has_preset = value != 0;
+      break;
+    case 19:
+      this->preset = static_cast<enums::ClimatePreset>(value);
+      break;
+    case 20:
+      this->has_custom_preset = value != 0;
+      break;
+    case 22:
+      this->has_target_humidity = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 24: this->device_id = value; break;
+    case 24:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool ClimateCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 17: {
-          this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->custom_fan_mode = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 21: {
-          this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->custom_preset = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool ClimateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 5: this->target_temperature = value.as_float(); break;
-    case 7: this->target_temperature_low = value.as_float(); break;
-    case 9: this->target_temperature_high = value.as_float(); break;
-    case 23: this->target_humidity = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 5:
+      this->target_temperature = value.as_float();
+      break;
+    case 7:
+      this->target_temperature_low = value.as_float();
+      break;
+    case 9:
+      this->target_temperature_high = value.as_float();
+      break;
+    case 23:
+      this->target_humidity = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1460,23 +1693,41 @@ uint32_t WaterHeaterStateResponse::calculate_size() const {
 }
 bool WaterHeaterCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_fields = value; break;
-    case 3: this->mode = static_cast<enums::WaterHeaterMode>(value); break;
+    case 2:
+      this->has_fields = value;
+      break;
+    case 3:
+      this->mode = static_cast<enums::WaterHeaterMode>(value);
+      break;
 #ifdef USE_DEVICES
-    case 5: this->device_id = value; break;
+    case 5:
+      this->device_id = value;
+      break;
 #endif
-    case 6: this->state = value; break;
-    default: return false;
+    case 6:
+      this->state = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool WaterHeaterCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 4: this->target_temperature = value.as_float(); break;
-    case 7: this->target_temperature_low = value.as_float(); break;
-    case 8: this->target_temperature_high = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 4:
+      this->target_temperature = value.as_float();
+      break;
+    case 7:
+      this->target_temperature_low = value.as_float();
+      break;
+    case 8:
+      this->target_temperature_high = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1547,17 +1798,25 @@ uint32_t NumberStateResponse::calculate_size() const {
 bool NumberCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool NumberCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 2: this->state = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 2:
+      this->state = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1624,26 +1883,33 @@ uint32_t SelectStateResponse::calculate_size() const {
 bool SelectCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool SelectCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool SelectCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1711,34 +1977,55 @@ uint32_t SirenStateResponse::calculate_size() const {
 }
 bool SirenCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_state = value != 0; break;
-    case 3: this->state = value != 0; break;
-    case 4: this->has_tone = value != 0; break;
-    case 6: this->has_duration = value != 0; break;
-    case 7: this->duration = value; break;
-    case 8: this->has_volume = value != 0; break;
+    case 2:
+      this->has_state = value != 0;
+      break;
+    case 3:
+      this->state = value != 0;
+      break;
+    case 4:
+      this->has_tone = value != 0;
+      break;
+    case 6:
+      this->has_duration = value != 0;
+      break;
+    case 7:
+      this->duration = value;
+      break;
+    case 8:
+      this->has_volume = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 10: this->device_id = value; break;
+    case 10:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool SirenCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 5: {
-          this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->tone = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool SirenCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 9: this->volume = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 9:
+      this->volume = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1802,29 +2089,40 @@ uint32_t LockStateResponse::calculate_size() const {
 }
 bool LockCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->command = static_cast<enums::LockCommand>(value); break;
-    case 3: this->has_code = value != 0; break;
+    case 2:
+      this->command = static_cast<enums::LockCommand>(value);
+      break;
+    case 3:
+      this->has_code = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 5: this->device_id = value; break;
+    case 5:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool LockCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-          this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool LockCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1865,16 +2163,22 @@ uint32_t ListEntitiesButtonResponse::calculate_size() const {
 bool ButtonCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 2: this->device_id = value; break;
+    case 2:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool ButtonCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1964,34 +2268,55 @@ uint32_t MediaPlayerStateResponse::calculate_size() const {
 }
 bool MediaPlayerCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_command = value != 0; break;
-    case 3: this->command = static_cast<enums::MediaPlayerCommand>(value); break;
-    case 4: this->has_volume = value != 0; break;
-    case 6: this->has_media_url = value != 0; break;
-    case 8: this->has_announcement = value != 0; break;
-    case 9: this->announcement = value != 0; break;
+    case 2:
+      this->has_command = value != 0;
+      break;
+    case 3:
+      this->command = static_cast<enums::MediaPlayerCommand>(value);
+      break;
+    case 4:
+      this->has_volume = value != 0;
+      break;
+    case 6:
+      this->has_media_url = value != 0;
+      break;
+    case 8:
+      this->has_announcement = value != 0;
+      break;
+    case 9:
+      this->announcement = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 10: this->device_id = value; break;
+    case 10:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool MediaPlayerCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 7: {
-          this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->media_url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 5: this->volume = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 5:
+      this->volume = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -1999,36 +2324,41 @@ bool MediaPlayerCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value
 #ifdef USE_BLUETOOTH_PROXY
 bool SubscribeBluetoothLEAdvertisementsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->flags = value; break;
-    default: return false;
+    case 1:
+      this->flags = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 __attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
-uint8_t *BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
+uint8_t *
+BluetoothLERawAdvertisementsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {
   uint8_t *__restrict__ pos = buffer.get_pos();
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
-  uint8_t *len_pos = pos;
-  ProtoEncode::reserve_byte(pos PROTO_ENCODE_DEBUG_ARG);
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
-  ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
-  ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
-  if (sub_msg.address_type) {
-    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
-  ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
-  }
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
-  ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
-  ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
-  *len_pos = static_cast<uint8_t>(pos - len_pos - 1);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 10);
+    uint8_t *len_pos = pos;
+    ProtoEncode::reserve_byte(pos PROTO_ENCODE_DEBUG_ARG);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 8);
+    ProtoEncode::encode_varint_raw_64(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 16);
+    ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, encode_zigzag32(sub_msg.rssi));
+    if (sub_msg.address_type) {
+      ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 24);
+      ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.address_type);
+    }
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 34);
+    ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, static_cast<uint8_t>(sub_msg.data_len));
+    ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, sub_msg.data, sub_msg.data_len);
+    *len_pos = static_cast<uint8_t>(pos - len_pos - 1);
   }
   return pos;
 }
 __attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)
-uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
+uint32_t
+BluetoothLERawAdvertisementsResponse::calculate_size() const {
   uint32_t size = 0;
   for (uint16_t i = 0; i < this->advertisements_len; i++) {
     auto &sub_msg = this->advertisements[i];
@@ -2042,11 +2372,20 @@ uint32_t BluetoothLERawAdvertisementsResponse::calculate_size() const {
 }
 bool BluetoothDeviceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value); break;
-    case 3: this->has_address_type = value != 0; break;
-    case 4: this->address_type = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->request_type = static_cast<enums::BluetoothDeviceRequestType>(value);
+      break;
+    case 3:
+      this->has_address_type = value != 0;
+      break;
+    case 4:
+      this->address_type = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2068,8 +2407,11 @@ uint32_t BluetoothDeviceConnectionResponse::calculate_size() const {
 }
 bool BluetoothGATTGetServicesRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2181,9 +2523,14 @@ uint32_t BluetoothGATTGetServicesDoneResponse::calculate_size() const {
 }
 bool BluetoothGATTReadRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->handle = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->handle = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2203,57 +2550,83 @@ uint32_t BluetoothGATTReadResponse::calculate_size() const {
 }
 bool BluetoothGATTWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->handle = value; break;
-    case 3: this->response = value != 0; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->handle = value;
+      break;
+    case 3:
+      this->response = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool BluetoothGATTWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 4: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool BluetoothGATTReadDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->handle = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->handle = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->handle = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->handle = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool BluetoothGATTWriteDescriptorRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool BluetoothGATTNotifyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->handle = value; break;
-    case 3: this->enable = value != 0; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->handle = value;
+      break;
+    case 3:
+      this->enable = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2389,8 +2762,11 @@ uint32_t BluetoothScannerStateResponse::calculate_size() const {
 }
 bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->mode = static_cast<enums::BluetoothScannerMode>(value); break;
-    default: return false;
+    case 1:
+      this->mode = static_cast<enums::BluetoothScannerMode>(value);
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2398,9 +2774,14 @@ bool BluetoothScannerSetModeRequest::decode_varint(uint32_t field_id, proto_vari
 #ifdef USE_VOICE_ASSISTANT
 bool SubscribeVoiceAssistantRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->subscribe = value != 0; break;
-    case 2: this->flags = value; break;
-    default: return false;
+    case 1:
+      this->subscribe = value != 0;
+      break;
+    case 2:
+      this->flags = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2438,55 +2819,72 @@ uint32_t VoiceAssistantRequest::calculate_size() const {
 }
 bool VoiceAssistantResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->port = value; break;
-    case 2: this->error = value != 0; break;
-    default: return false;
+    case 1:
+      this->port = value;
+      break;
+    case 2:
+      this->error = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantEventData::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 2: {
-          this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->value = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->event_type = static_cast<enums::VoiceAssistantEvent>(value); break;
-    default: return false;
+    case 1:
+      this->event_type = static_cast<enums::VoiceAssistantEvent>(value);
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 2: this->data.emplace_back(); value.decode_to_message(this->data.back()); break;
-    default: return false;
+    case 2:
+      this->data.emplace_back();
+      value.decode_to_message(this->data.back());
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantAudio::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->end = value != 0; break;
-    default: return false;
+    case 2:
+      this->end = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantAudio::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -2504,50 +2902,64 @@ uint32_t VoiceAssistantAudio::calculate_size() const {
 }
 bool VoiceAssistantTimerEventResponse::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value); break;
-    case 4: this->total_seconds = value; break;
-    case 5: this->seconds_left = value; break;
-    case 6: this->is_active = value != 0; break;
-    default: return false;
+    case 1:
+      this->event_type = static_cast<enums::VoiceAssistantTimerEvent>(value);
+      break;
+    case 4:
+      this->total_seconds = value;
+      break;
+    case 5:
+      this->seconds_left = value;
+      break;
+    case 6:
+      this->is_active = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantTimerEventResponse::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->timer_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 3: {
-          this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->name = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantAnnounceRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 4: this->start_conversation = value != 0; break;
-    default: return false;
+    case 4:
+      this->start_conversation = value != 0;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantAnnounceRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 2: {
-          this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->text = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 3: {
-          this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->preannounce_media_id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -2583,42 +2995,52 @@ uint32_t VoiceAssistantWakeWord::calculate_size() const {
 }
 bool VoiceAssistantExternalWakeWord::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 5: this->model_size = value; break;
-    default: return false;
+    case 5:
+      this->model_size = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantExternalWakeWord::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->id = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 2: {
-          this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    case 3: this->trained_languages.push_back(value.as_string()); break;
+      this->wake_word = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    case 3:
+      this->trained_languages.push_back(value.as_string());
+      break;
     case 4: {
-          this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->model_type = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 6: {
-          this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
+      this->model_hash = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
     case 7: {
-          this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->url = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool VoiceAssistantConfigurationRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1: this->external_wake_words.emplace_back(); value.decode_to_message(this->external_wake_words.back()); break;
-    default: return false;
+    case 1:
+      this->external_wake_words.emplace_back();
+      value.decode_to_message(this->external_wake_words.back());
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2650,8 +3072,11 @@ uint32_t VoiceAssistantConfigurationResponse::calculate_size() const {
 }
 bool VoiceAssistantSetConfiguration::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
-    case 1: this->active_wake_words.push_back(value.as_string()); break;
-    default: return false;
+    case 1:
+      this->active_wake_words.push_back(value.as_string());
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2713,28 +3138,37 @@ uint32_t AlarmControlPanelStateResponse::calculate_size() const {
 }
 bool AlarmControlPanelCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->command = static_cast<enums::AlarmControlPanelStateCommand>(value); break;
+    case 2:
+      this->command = static_cast<enums::AlarmControlPanelStateCommand>(value);
+      break;
 #ifdef USE_DEVICES
-    case 4: this->device_id = value; break;
+    case 4:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool AlarmControlPanelCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 3: {
-          this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->code = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool AlarmControlPanelCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2801,26 +3235,33 @@ uint32_t TextStateResponse::calculate_size() const {
 bool TextCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool TextCommandRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
-          break;
-        }
-    default: return false;
+      this->state = StringRef(reinterpret_cast<const char *>(value.data()), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool TextCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2882,20 +3323,32 @@ uint32_t DateStateResponse::calculate_size() const {
 }
 bool DateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->year = value; break;
-    case 3: this->month = value; break;
-    case 4: this->day = value; break;
+    case 2:
+      this->year = value;
+      break;
+    case 3:
+      this->month = value;
+      break;
+    case 4:
+      this->day = value;
+      break;
 #ifdef USE_DEVICES
-    case 5: this->device_id = value; break;
+    case 5:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool DateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -2957,20 +3410,32 @@ uint32_t TimeStateResponse::calculate_size() const {
 }
 bool TimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->hour = value; break;
-    case 3: this->minute = value; break;
-    case 4: this->second = value; break;
+    case 2:
+      this->hour = value;
+      break;
+    case 3:
+      this->minute = value;
+      break;
+    case 4:
+      this->second = value;
+      break;
 #ifdef USE_DEVICES
-    case 5: this->device_id = value; break;
+    case 5:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool TimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3096,20 +3561,32 @@ uint32_t ValveStateResponse::calculate_size() const {
 }
 bool ValveCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->has_position = value != 0; break;
-    case 4: this->stop = value != 0; break;
+    case 2:
+      this->has_position = value != 0;
+      break;
+    case 4:
+      this->stop = value != 0;
+      break;
 #ifdef USE_DEVICES
-    case 5: this->device_id = value; break;
+    case 5:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool ValveCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 3: this->position = value.as_float(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 3:
+      this->position = value.as_float();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3168,17 +3645,25 @@ uint32_t DateTimeStateResponse::calculate_size() const {
 bool DateTimeCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool DateTimeCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    case 2: this->epoch_seconds = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    case 2:
+      this->epoch_seconds = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3252,18 +3737,26 @@ uint32_t UpdateStateResponse::calculate_size() const {
 }
 bool UpdateCommandRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 2: this->command = static_cast<enums::UpdateCommand>(value); break;
+    case 2:
+      this->command = static_cast<enums::UpdateCommand>(value);
+      break;
 #ifdef USE_DEVICES
-    case 3: this->device_id = value; break;
+    case 3:
+      this->device_id = value;
+      break;
 #endif
-    default: return false;
+    default:
+      return false;
   }
   return true;
 }
 bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 1: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 1:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3272,11 +3765,12 @@ bool UpdateCommandRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
 bool ZWaveProxyFrame::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 1: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -3292,19 +3786,23 @@ uint32_t ZWaveProxyFrame::calculate_size() const {
 }
 bool ZWaveProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->type = static_cast<enums::ZWaveProxyRequestType>(value); break;
-    default: return false;
+    case 1:
+      this->type = static_cast<enums::ZWaveProxyRequestType>(value);
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool ZWaveProxyRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
@@ -3361,30 +3859,41 @@ uint32_t ListEntitiesInfraredResponse::calculate_size() const {
 bool InfraredRFTransmitRawTimingsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
 #ifdef USE_DEVICES
-    case 1: this->device_id = value; break;
+    case 1:
+      this->device_id = value;
+      break;
 #endif
-    case 3: this->carrier_frequency = value; break;
-    case 4: this->repeat_count = value; break;
-    default: return false;
+    case 3:
+      this->carrier_frequency = value;
+      break;
+    case 4:
+      this->repeat_count = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool InfraredRFTransmitRawTimingsRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 5: {
-          this->timings_data_ = value.data();
-          this->timings_length_ = value.size();
-          this->timings_count_ = count_packed_varints(value.data(), value.size());
-          break;
-        }
-    default: return false;
+      this->timings_data_ = value.data();
+      this->timings_length_ = value.size();
+      this->timings_count_ = count_packed_varints(value.data(), value.size());
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool InfraredRFTransmitRawTimingsRequest::decode_32bit(uint32_t field_id, Proto32Bit value) {
   switch (field_id) {
-    case 2: this->key = value.as_fixed32(); break;
-    default: return false;
+    case 2:
+      this->key = value.as_fixed32();
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3416,13 +3925,26 @@ uint32_t InfraredRFReceiveEvent::calculate_size() const {
 #ifdef USE_SERIAL_PROXY
 bool SerialProxyConfigureRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->instance = value; break;
-    case 2: this->baudrate = value; break;
-    case 3: this->flow_control = value != 0; break;
-    case 4: this->parity = static_cast<enums::SerialProxyParity>(value); break;
-    case 5: this->stop_bits = value; break;
-    case 6: this->data_size = value; break;
-    default: return false;
+    case 1:
+      this->instance = value;
+      break;
+    case 2:
+      this->baudrate = value;
+      break;
+    case 3:
+      this->flow_control = value != 0;
+      break;
+    case 4:
+      this->parity = static_cast<enums::SerialProxyParity>(value);
+      break;
+    case 5:
+      this->stop_bits = value;
+      break;
+    case 6:
+      this->data_size = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3440,34 +3962,46 @@ uint32_t SerialProxyDataReceived::calculate_size() const {
 }
 bool SerialProxyWriteRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->instance = value; break;
-    default: return false;
+    case 1:
+      this->instance = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool SerialProxyWriteRequest::decode_length(uint32_t field_id, ProtoLengthDelimited value) {
   switch (field_id) {
     case 2: {
-          this->data = value.data();
-          this->data_len = value.size();
-          break;
-        }
-    default: return false;
+      this->data = value.data();
+      this->data_len = value.size();
+      break;
+    }
+    default:
+      return false;
   }
   return true;
 }
 bool SerialProxySetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->instance = value; break;
-    case 2: this->line_states = value; break;
-    default: return false;
+    case 1:
+      this->instance = value;
+      break;
+    case 2:
+      this->line_states = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
 bool SerialProxyGetModemPinsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->instance = value; break;
-    default: return false;
+    case 1:
+      this->instance = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3485,9 +4019,14 @@ uint32_t SerialProxyGetModemPinsResponse::calculate_size() const {
 }
 bool SerialProxyRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->instance = value; break;
-    case 2: this->type = static_cast<enums::SerialProxyRequestType>(value); break;
-    default: return false;
+    case 1:
+      this->instance = value;
+      break;
+    case 2:
+      this->type = static_cast<enums::SerialProxyRequestType>(value);
+      break;
+    default:
+      return false;
   }
   return true;
 }
@@ -3511,12 +4050,23 @@ uint32_t SerialProxyRequestResponse::calculate_size() const {
 #ifdef USE_BLUETOOTH_PROXY
 bool BluetoothSetConnectionParamsRequest::decode_varint(uint32_t field_id, proto_varint_value_t value) {
   switch (field_id) {
-    case 1: this->address = value; break;
-    case 2: this->min_interval = value; break;
-    case 3: this->max_interval = value; break;
-    case 4: this->latency = value; break;
-    case 5: this->timeout = value; break;
-    default: return false;
+    case 1:
+      this->address = value;
+      break;
+    case 2:
+      this->min_interval = value;
+      break;
+    case 3:
+      this->max_interval = value;
+      break;
+    case 4:
+      this->latency = value;
+      break;
+    case 5:
+      this->timeout = value;
+      break;
+    default:
+      return false;
   }
   return true;
 }

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2679,6 +2679,13 @@ def build_message_type(
         and get_opt(desc, inline_opt, False)
     )
 
+    # Check if this message wants speed-optimized encode/calculate_size.
+    # When set, __attribute__((optimize("O2"))) is added to the definitions
+    # so GCC inlines the small ProtoEncode helpers even under -Os.
+    speed_opt = getattr(pb, "speed_optimized", None)
+    is_speed_optimized = speed_opt is not None and get_opt(desc, speed_opt, False)
+    speed_attr = '__attribute__((optimize("O2"))) ' if is_speed_optimized else ""
+
     # Only generate encode method if this message needs encoding and has fields
     if needs_encode and encode and not is_inline_only:
         # Add PROTO_ENCODE_DEBUG_ARG after pos in all proto_* calls
@@ -2688,7 +2695,7 @@ def build_message_type(
             )
             for line in encode
         ]
-        o = f"uint8_t *{desc.name}::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {{\n"
+        o = f"{speed_attr}uint8_t *{desc.name}::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const {{\n"
         o += "  uint8_t *__restrict__ pos = buffer.get_pos();\n"
         o += indent("\n".join(encode_debug)) + "\n"
         o += "  return pos;\n"
@@ -2702,7 +2709,7 @@ def build_message_type(
 
     # Add calculate_size method only if this message needs encoding and has fields
     if needs_encode and size_calc and not is_inline_only:
-        o = f"uint32_t {desc.name}::calculate_size() const {{\n"
+        o = f"{speed_attr}uint32_t {desc.name}::calculate_size() const {{\n"
         o += "  uint32_t size = 0;\n"
         o += indent("\n".join(size_calc)) + "\n"
         o += "  return size;\n"

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2683,7 +2683,11 @@ def build_message_type(
     # When set, __attribute__((optimize("O2"))) is added to the definitions
     # so GCC inlines the small ProtoEncode helpers even under -Os.
     is_speed_optimized = get_opt(desc, pb.speed_optimized, False)
-    speed_attr = '__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)\n' if is_speed_optimized else ""
+    speed_attr = (
+        '__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)\n'
+        if is_speed_optimized
+        else ""
+    )
 
     # Only generate encode method if this message needs encoding and has fields
     if needs_encode and encode and not is_inline_only:

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2682,8 +2682,7 @@ def build_message_type(
     # Check if this message wants speed-optimized encode/calculate_size.
     # When set, __attribute__((optimize("O2"))) is added to the definitions
     # so GCC inlines the small ProtoEncode helpers even under -Os.
-    speed_opt = getattr(pb, "speed_optimized", None)
-    is_speed_optimized = speed_opt is not None and get_opt(desc, speed_opt, False)
+    is_speed_optimized = get_opt(desc, pb.speed_optimized, False)
     speed_attr = '__attribute__((optimize("O2"))) ' if is_speed_optimized else ""
 
     # Only generate encode method if this message needs encoding and has fields

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -2683,7 +2683,7 @@ def build_message_type(
     # When set, __attribute__((optimize("O2"))) is added to the definitions
     # so GCC inlines the small ProtoEncode helpers even under -Os.
     is_speed_optimized = get_opt(desc, pb.speed_optimized, False)
-    speed_attr = '__attribute__((optimize("O2"))) ' if is_speed_optimized else ""
+    speed_attr = '__attribute__((optimize("O2")))  // NOLINT(clang-diagnostic-unknown-attributes)\n' if is_speed_optimized else ""
 
     # Only generate encode method if this message needs encoding and has fields
     if needs_encode and encode and not is_inline_only:

--- a/script/cpp_benchmark.py
+++ b/script/cpp_benchmark.py
@@ -27,7 +27,10 @@ STUBS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "stubs"
 
 PLATFORMIO_OPTIONS = {
     "build_flags": [
+        "-Os",  # match firmware optimization level (detects inlining regressions)
         "-g",  # debug symbols for profiling
+        "-ffunction-sections",  # required for dead-code stripping with -Os
+        "-fdata-sections",  # required for dead-code stripping with -Os
         "-DUSE_BENCHMARK",  # disable WarnIfComponentBlockingGuard in finish()
         f"-I{STUBS_DIR}",  # stub headers for ESP32-only components
     ],

--- a/script/cpp_benchmark.py
+++ b/script/cpp_benchmark.py
@@ -26,11 +26,7 @@ CORE_BENCHMARKS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "core"
 STUBS_DIR: Path = Path(root_path) / "tests" / "benchmarks" / "stubs"
 
 PLATFORMIO_OPTIONS = {
-    "build_unflags": [
-        "-Os",  # remove default size-opt
-    ],
     "build_flags": [
-        "-O2",  # optimize for speed (CodSpeed recommends RelWithDebInfo)
         "-g",  # debug symbols for profiling
         "-DUSE_BENCHMARK",  # disable WarnIfComponentBlockingGuard in finish()
         f"-I{STUBS_DIR}",  # stub headers for ESP32-only components


### PR DESCRIPTION
# What does this implement/fix?

Chained on top of #15688.

After #15688 switched benchmarks to `-Os` to match firmware, CodSpeed revealed that protobuf encode helpers (`write_raw_byte`, `encode_varint`, `encode_fixed32`, etc.) were not being inlined into the generated `encode()` and `calculate_size()` methods under `-Os`. Previously, benchmarks ran with `-O2` which inlined everything — this masked the optimization opportunity and led to the false assumption that BLE advertisement and sensor state encoding were already at their performance ceiling.

This adds a new `(speed_optimized)` message option in `api_options.proto` that emits `__attribute__((optimize("O2")))` on the generated `encode()` and `calculate_size()` method definitions. This tells GCC to optimize those specific functions for speed regardless of the global `-Os` flag. Unlike compiling entire libraries with `-O2` (which was tested and caused icache thrashing on ESP32 — see #15689), this targets only individual hot functions with minimal code size impact.

Applied to:
- `SensorStateResponse` — highest frequency sensor state encoding
- `BluetoothLERawAdvertisementsResponse` — BLE advertisement batching

### On-device benchmark results

**ESP32 — BLE Raw Advertisement encoding (12 advertisements, 571 bytes):**

| Benchmark | Before | After | Change |
|---|---|---|---|
| calculate_size | 3,681.7 ns/op | 2,183.9 ns/op | **+41% faster** |
| encode | 12,560.0 ns/op | 11,640.2 ns/op | **+7% faster** |
| calc+encode | 16,245.9 ns/op | 13,970.3 ns/op | **+14% faster** |

**ESP8266 — SensorStateResponse (10 bytes encoded):**

| Benchmark | Before | After | Change |
|---|---|---|---|
| calculate_size | 288.0 ns/op | 252.0 ns/op | **+12% faster** |
| encode | 1,469.5 ns/op | 614.9 ns/op | **+58% faster** |
| calc+encode | 1,790.0 ns/op | 902.1 ns/op | **+50% faster** |

Flash impact: **+104 bytes** on ESP32, **+96 bytes** on ESP8266 (from memory impact analysis).

Requires a corresponding update to `aioesphomeapi` to add the `speed_optimized` extension: esphome/aioesphomeapi#1578

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Depends on #15688

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).