### PR TITLE
[zephyr] Remove redundant yield() from main loop

### DIFF
--- a/esphome/components/zephyr/core.cpp
+++ b/esphome/components/zephyr/core.cpp
@@ -99,7 +99,6 @@ int main() {
   setup();
   while (true) {
     loop();
-    esphome::yield();
   }
   return 0;
 }


### PR DESCRIPTION
# What does this implement/fix?

Remove the redundant `esphome::yield()` call after `loop()` in Zephyr's `main()`.

This `yield()` was added in the initial nRF52/Zephyr port (#7049, July 2024). However, at that time `Application::loop()` already called `yield()` or `delay()` at the end of every iteration (the yield/delay sleep path has been in `Application::loop()` since before the Zephyr port). The external yield was redundant from day one.

No other platform has this extra yield — ESP32's `loop_task` and ESP8266's Arduino `loop_wrapper` both rely solely on `Application::loop()` to yield.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).