### PR TITLE
[benchmark] Add SubscribeLogsResponse encode benchmarks

### DIFF
--- a/tests/benchmarks/components/api/bench_log_response.cpp
+++ b/tests/benchmarks/components/api/bench_log_response.cpp
@@ -1,0 +1,118 @@
+#include <benchmark/benchmark.h>
+
+#include "esphome/components/api/api_pb2.h"
+#include "esphome/components/api/api_buffer.h"
+
+namespace esphome::api::benchmarks {
+
+// Inner iteration count to amortize CodSpeed instrumentation overhead.
+static constexpr int kInnerIterations = 2000;
+
+// Typical log line: "[12:34:56][D][sensor:094]: 'Temperature': Sending state 23.50000 with 1 decimals of accuracy"
+static constexpr const char *kTypicalLogLine =
+    "[12:34:56][D][sensor:094]: 'Temperature': Sending state 23.50000 with 1 decimals of accuracy";
+
+// Short log line: "[12:34:56][I][app:029]: Running..."
+static constexpr const char *kShortLogLine = "[12:34:56][I][app:029]: Running...";
+
+// --- Encode ---
+
+static void Encode_LogResponse_Typical(benchmark::State &state) {
+  APIBuffer buffer;
+  SubscribeLogsResponse msg;
+  msg.level = enums::LOG_LEVEL_DEBUG;
+  msg.set_message(reinterpret_cast<const uint8_t *>(kTypicalLogLine), strlen(kTypicalLogLine));
+  uint32_t size = msg.calculate_size();
+  buffer.resize(size);
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+    }
+    benchmark::DoNotOptimize(buffer.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Encode_LogResponse_Typical);
+
+static void Encode_LogResponse_Short(benchmark::State &state) {
+  APIBuffer buffer;
+  SubscribeLogsResponse msg;
+  msg.level = enums::LOG_LEVEL_INFO;
+  msg.set_message(reinterpret_cast<const uint8_t *>(kShortLogLine), strlen(kShortLogLine));
+  uint32_t size = msg.calculate_size();
+  buffer.resize(size);
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+    }
+    benchmark::DoNotOptimize(buffer.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(Encode_LogResponse_Short);
+
+// --- Calculate Size ---
+
+static void CalculateSize_LogResponse_Typical(benchmark::State &state) {
+  SubscribeLogsResponse msg;
+  msg.level = enums::LOG_LEVEL_DEBUG;
+  msg.set_message(reinterpret_cast<const uint8_t *>(kTypicalLogLine), strlen(kTypicalLogLine));
+
+  for (auto _ : state) {
+    uint32_t result = 0;
+    for (int i = 0; i < kInnerIterations; i++) {
+      result += msg.calculate_size();
+    }
+    benchmark::DoNotOptimize(result);
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalculateSize_LogResponse_Typical);
+
+// --- Calc + Encode (steady state) ---
+
+static void CalcAndEncode_LogResponse_Typical(benchmark::State &state) {
+  APIBuffer buffer;
+  SubscribeLogsResponse msg;
+  msg.level = enums::LOG_LEVEL_DEBUG;
+  msg.set_message(reinterpret_cast<const uint8_t *>(kTypicalLogLine), strlen(kTypicalLogLine));
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      uint32_t size = msg.calculate_size();
+      buffer.resize(size);
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+    }
+    benchmark::DoNotOptimize(buffer.data());
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalcAndEncode_LogResponse_Typical);
+
+// --- Calc + Encode (fresh allocation each time) ---
+
+static void CalcAndEncode_LogResponse_Typical_Fresh(benchmark::State &state) {
+  SubscribeLogsResponse msg;
+  msg.level = enums::LOG_LEVEL_DEBUG;
+  msg.set_message(reinterpret_cast<const uint8_t *>(kTypicalLogLine), strlen(kTypicalLogLine));
+
+  for (auto _ : state) {
+    for (int i = 0; i < kInnerIterations; i++) {
+      APIBuffer buffer;
+      uint32_t size = msg.calculate_size();
+      buffer.resize(size);
+      ProtoWriteBuffer writer(&buffer, 0);
+      msg.encode(writer);
+      benchmark::DoNotOptimize(buffer.data());
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kInnerIterations);
+}
+BENCHMARK(CalcAndEncode_LogResponse_Typical_Fresh);
+
+}  // namespace esphome::api::benchmarks


### PR DESCRIPTION
# What does this implement/fix?

Add benchmarks for `SubscribeLogsResponse` protobuf encoding. Log messages are among the most frequent messages sent over the API, especially during debug sessions.

Benchmarks:
- `Encode_LogResponse_Typical` — 89-char debug log line encode
- `Encode_LogResponse_Short` — 32-char info log line encode
- `CalculateSize_LogResponse_Typical` — size calculation only
- `CalcAndEncode_LogResponse_Typical` — steady-state calc+encode (buffer reused)
- `CalcAndEncode_LogResponse_Typical_Fresh` — with buffer allocation each iteration

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes — benchmark only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).