### PR TITLE
[bme68x_bsec2] use esphome-libs wrappers for ESP32

### DIFF
--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -17,6 +17,7 @@ CODEOWNERS = ["@neffs", "@kbx81"]
 DOMAIN = "bme68x_bsec2"
 
 BSEC2_LIBRARY_VERSION = "1.10.2610"
+BME68x_LIBRARY_VERSION = "v1.3.40408"
 
 CONF_ALGORITHM_OUTPUT = "algorithm_output"
 CONF_BME68X_BSEC2_ID = "bme68x_bsec2_id"
@@ -184,16 +185,31 @@ async def to_code_base(config):
     if core.CORE.using_arduino:
         cg.add_library("Wire", None)
         cg.add_library("SPI", None)
-    cg.add_library(
-        "BME68x Sensor library",
-        None,
-        "https://github.com/boschsensortec/Bosch-BME68x-Library#v1.3.40408",
-    )
-    cg.add_library(
-        "BSEC2 Software Library",
-        None,
-        f"https://github.com/boschsensortec/Bosch-BSEC2-Library.git#{BSEC2_LIBRARY_VERSION}",
-    )
+
+    if core.CORE.is_esp32:
+        from esphome.components.esp32 import add_idf_component
+
+        add_idf_component(
+            name="boschsensortec/Bosch-BME68x-Library",
+            repo="https://github.com/esphome-libs/Bosch-BME68x-Library",
+            ref=BME68x_LIBRARY_VERSION,
+        )
+        add_idf_component(
+            name="boschsensortec/Bosch-BSEC2-Library",
+            repo="https://github.com/esphome-libs/Bosch-BSEC2-Library",
+            ref=BSEC2_LIBRARY_VERSION,
+        )
+    else:
+        cg.add_library(
+            "BME68x Sensor library",
+            None,
+            f"https://github.com/boschsensortec/Bosch-BME68x-Library#{BME68x_LIBRARY_VERSION}",
+        )
+        cg.add_library(
+            "BSEC2 Software Library",
+            None,
+            f"https://github.com/boschsensortec/Bosch-BSEC2-Library.git#{BSEC2_LIBRARY_VERSION}",
+        )
 
     cg.add_define("USE_BSEC2")
 


### PR DESCRIPTION
# What does this implement/fix?

This PR updates the bme68x_bsec2 component to use the esphome-libs wrapped versions of the Bosch libraries when building for ESP32 with ESP-IDF.

For non-ESP32 platforms (or Arduino framework), the previous behavior using cg.add_library() is preserved.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
