### PR TITLE
[audio_http] Add a media source for playing audio from HTTP URLs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,6 +56,7 @@ esphome/components/audio_adc/* @kbx81
 esphome/components/audio_dac/* @kbx81
 esphome/components/audio_file/* @kahrendt
 esphome/components/audio_file/media_source/* @kahrendt
+esphome/components/audio_http/* @kahrendt
 esphome/components/axs15231/* @clydebarrow
 esphome/components/b_parasite/* @rbaron
 esphome/components/ballu/* @bazuchan

--- a/esphome/components/audio_http/audio_http_media_source.cpp
+++ b/esphome/components/audio_http/audio_http_media_source.cpp
@@ -1,0 +1,136 @@
+#include "audio_http_media_source.h"
+
+#ifdef USE_ESP32
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace esphome::audio_http {
+
+static const char *const TAG = "audio_http_media_source";
+
+// Decoder task / buffer tuning. Kept here as constants so the header stays free of magic numbers.
+static constexpr size_t DEFAULT_TRANSFER_BUFFER_SIZE = 8 * 1024;  // Staging buffer between HTTP reader and decoder
+static constexpr uint32_t HTTP_TIMEOUT_MS = 5000;                 // HTTP connect/read timeout
+static constexpr uint32_t AUDIO_WRITE_TIMEOUT_MS = 50;            // Max blocking time per on_audio_write() call
+static constexpr uint32_t READER_WRITE_TIMEOUT_MS = 50;           // Max blocking time when writing into the ring buffer
+static constexpr uint8_t READER_TASK_PRIORITY = 2;
+static constexpr uint8_t DECODER_TASK_PRIORITY = 2;
+static constexpr size_t READER_TASK_STACK_SIZE = 4096;
+static constexpr size_t DECODER_TASK_STACK_SIZE = 5120;
+static constexpr uint32_t PAUSE_POLL_DELAY_MS = 20;
+
+void AudioHTTPMediaSource::dump_config() {
+  ESP_LOGCONFIG(TAG, "Audio HTTP Media Source:");
+  ESP_LOGCONFIG(TAG, "  Buffer Size: %zu bytes", this->buffer_size_);
+  ESP_LOGCONFIG(TAG, "  Decoder Task Stack in PSRAM: %s", this->decoder_task_stack_in_psram_ ? "Yes" : "No");
+}
+
+void AudioHTTPMediaSource::setup() {
+  this->disable_loop();
+
+  micro_decoder::DecoderConfig config;
+  config.ring_buffer_size = this->buffer_size_;
+  // Keep the transfer buffer smaller than the ring buffer so the reader can top up the ring
+  // while the decoder is still draining it, instead of oscillating between empty and full.
+  config.transfer_buffer_size = std::min(DEFAULT_TRANSFER_BUFFER_SIZE, this->buffer_size_ / 2);
+  config.http_timeout_ms = HTTP_TIMEOUT_MS;
+  config.audio_write_timeout_ms = AUDIO_WRITE_TIMEOUT_MS;
+  config.reader_write_timeout_ms = READER_WRITE_TIMEOUT_MS;
+  config.reader_priority = READER_TASK_PRIORITY;
+  config.decoder_priority = DECODER_TASK_PRIORITY;
+  config.reader_stack_size = READER_TASK_STACK_SIZE;
+  config.decoder_stack_size = DECODER_TASK_STACK_SIZE;
+  config.decoder_stack_in_psram = this->decoder_task_stack_in_psram_;
+
+  this->decoder_ = std::make_unique<micro_decoder::DecoderSource>(config);
+  this->decoder_->set_listener(this);  // We inherit from micro_decoder::DecoderListener
+}
+
+void AudioHTTPMediaSource::loop() { this->decoder_->loop(); }
+
+// Called from the orchestrator's main loop, so no synchronization needed with loop()
+bool AudioHTTPMediaSource::play_uri(const std::string &uri) {
+  if (!this->is_ready() || this->is_failed() || this->status_has_error() || !this->has_listener()) {
+    return false;
+  }
+
+  // Check if source is already playing
+  if (this->get_state() != media_source::MediaSourceState::IDLE) {
+    ESP_LOGE(TAG, "Cannot play '%s': source is busy", uri.c_str());
+    return false;
+  }
+
+  // Validate URI starts with "http://" or "https://"
+  if (!uri.starts_with("http://") && !uri.starts_with("https://")) {
+    ESP_LOGE(TAG, "Invalid URI: '%s'", uri.c_str());
+    return false;
+  }
+
+  if (this->decoder_->play_url(uri)) {
+    this->pause_.store(false, std::memory_order_relaxed);
+    this->enable_loop();
+    return true;
+  }
+
+  ESP_LOGE(TAG, "Failed to start playback");
+  return false;
+}
+
+// Called from the orchestrator's main loop, so no synchronization needed with loop()
+void AudioHTTPMediaSource::handle_command(media_source::MediaSourceCommand command) {
+  switch (command) {
+    case media_source::MediaSourceCommand::STOP:
+      this->decoder_->stop();
+      break;
+    case media_source::MediaSourceCommand::PAUSE:
+      // PAUSE does not stop the decoder task. Instead, on_audio_write() returns 0 and temporarily
+      // yields, which fills the ring buffer and applies back pressure that effectively pauses both
+      // the decoder and HTTP reader tasks.
+      this->set_state_(media_source::MediaSourceState::PAUSED);
+      this->pause_.store(true, std::memory_order_relaxed);
+      break;
+    case media_source::MediaSourceCommand::PLAY:
+      this->set_state_(media_source::MediaSourceState::PLAYING);
+      this->pause_.store(false, std::memory_order_relaxed);
+      break;
+    default:
+      break;
+  }
+}
+
+// Called from the decoder task. Forwards to the orchestrator's listener, which is responsible for
+// being thread-safe with respect to its own audio writer.
+size_t AudioHTTPMediaSource::on_audio_write(const uint8_t *data, size_t length, uint32_t timeout_ms) {
+  if (this->pause_.load(std::memory_order_relaxed)) {
+    vTaskDelay(pdMS_TO_TICKS(PAUSE_POLL_DELAY_MS));
+    return 0;
+  }
+  return this->write_output(data, length, timeout_ms, this->stream_info_);
+}
+
+// Called from the decoder task before the first on_audio_write().
+void AudioHTTPMediaSource::on_stream_info(const micro_decoder::AudioStreamInfo &info) {
+  this->stream_info_ = audio::AudioStreamInfo(info.get_bits_per_sample(), info.get_channels(), info.get_sample_rate());
+}
+
+// microDecoder invokes on_state_change() from inside decoder_->loop(), so this runs on the main
+// loop thread and its safe to call set_state_() directly.
+void AudioHTTPMediaSource::on_state_change(micro_decoder::DecoderState state) {
+  switch (state) {
+    case micro_decoder::DecoderState::IDLE:
+      this->set_state_(media_source::MediaSourceState::IDLE);
+      this->disable_loop();
+      break;
+    case micro_decoder::DecoderState::PLAYING:
+      this->set_state_(media_source::MediaSourceState::PLAYING);
+      break;
+    case micro_decoder::DecoderState::FAILED:
+      this->set_state_(media_source::MediaSourceState::ERROR);
+      break;
+  }
+}
+
+}  // namespace esphome::audio_http
+
+#endif  // USE_ESP32

--- a/esphome/components/audio_http/audio_http_media_source.cpp
+++ b/esphome/components/audio_http/audio_http_media_source.cpp
@@ -115,7 +115,7 @@ void AudioHTTPMediaSource::on_stream_info(const micro_decoder::AudioStreamInfo &
 }
 
 // microDecoder invokes on_state_change() from inside decoder_->loop(), so this runs on the main
-// loop thread and its safe to call set_state_() directly.
+// loop thread and it's safe to call set_state_() directly.
 void AudioHTTPMediaSource::on_state_change(micro_decoder::DecoderState state) {
   switch (state) {
     case micro_decoder::DecoderState::IDLE:

--- a/esphome/components/audio_http/audio_http_media_source.h
+++ b/esphome/components/audio_http/audio_http_media_source.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#ifdef USE_ESP32
+
+#include "esphome/components/audio/audio.h"
+#include "esphome/components/media_source/media_source.h"
+#include "esphome/core/component.h"
+
+#include <micro_decoder/decoder_source.h>
+#include <micro_decoder/types.h>
+
+#include <atomic>
+
+namespace esphome::audio_http {
+
+// Inherits from two unrelated listener-style interfaces:
+//   - media_source::MediaSource: this source reports state and writes audio *to* an orchestrator
+//     (the orchestrator calls set_listener() on us with a MediaSourceListener*).
+//   - micro_decoder::DecoderListener: the underlying decoder calls back *into* us with decoded
+//     audio and state changes (we call decoder_->set_listener(this) in setup()).
+// The two set_listener() methods live on different base classes and serve opposite directions.
+class AudioHTTPMediaSource : public Component, public media_source::MediaSource, public micro_decoder::DecoderListener {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_buffer_size(size_t buffer_size) { this->buffer_size_ = buffer_size; }
+  void set_task_stack_in_psram(bool task_stack_in_psram) { this->decoder_task_stack_in_psram_ = task_stack_in_psram; }
+
+  // MediaSource interface implementation
+  bool play_uri(const std::string &uri) override;
+  void handle_command(media_source::MediaSourceCommand command) override;
+  bool can_handle(const std::string &uri) const override {
+    return uri.starts_with("http://") || uri.starts_with("https://");
+  }
+
+  // DecoderListener interface implementation
+  size_t on_audio_write(const uint8_t *data, size_t length, uint32_t timeout_ms) override;
+  void on_stream_info(const micro_decoder::AudioStreamInfo &info) override;
+  void on_state_change(micro_decoder::DecoderState state) override;
+
+ protected:
+  std::unique_ptr<micro_decoder::DecoderSource> decoder_;
+  audio::AudioStreamInfo stream_info_;
+
+  size_t buffer_size_{50000};
+
+  // Written from the main loop in handle_command(), read from the decoder task in
+  // on_audio_write(). Must be atomic to avoid a data race.
+  std::atomic<bool> pause_{false};
+  bool decoder_task_stack_in_psram_{false};
+};
+
+}  // namespace esphome::audio_http
+
+#endif  // USE_ESP32

--- a/esphome/components/audio_http/media_source.py
+++ b/esphome/components/audio_http/media_source.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+from esphome.components import audio, media_source, psram
+import esphome.config_validation as cv
+from esphome.const import CONF_BUFFER_SIZE, CONF_ID, CONF_TASK_STACK_IN_PSRAM
+from esphome.types import ConfigType
+
+CODEOWNERS = ["@kahrendt"]
+AUTO_LOAD = ["audio"]
+
+audio_http_ns = cg.esphome_ns.namespace("audio_http")
+AudioHTTPMediaSource = audio_http_ns.class_(
+    "AudioHTTPMediaSource", cg.Component, media_source.MediaSource
+)
+
+
+def _request_micro_decoder(config):
+    audio.request_micro_decoder_support()
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    media_source.media_source_schema(
+        AudioHTTPMediaSource,
+    )
+    .extend(
+        {
+            cv.Optional(CONF_BUFFER_SIZE, default=50000): cv.int_range(
+                min=5000, max=1000000
+            ),
+            cv.Optional(CONF_TASK_STACK_IN_PSRAM): cv.All(
+                cv.boolean, cv.requires_component(psram.DOMAIN)
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA),
+    cv.only_on_esp32,
+    _request_micro_decoder,
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await media_source.register_media_source(var, config)
+
+    if CONF_TASK_STACK_IN_PSRAM in config:
+        cg.add(var.set_task_stack_in_psram(config[CONF_TASK_STACK_IN_PSRAM]))
+    cg.add(var.set_buffer_size(config[CONF_BUFFER_SIZE]))

--- a/tests/components/audio_http/common.yaml
+++ b/tests/components/audio_http/common.yaml
@@ -1,0 +1,7 @@
+psram:
+
+media_source:
+  - platform: audio_http
+    id: audio_http_source
+    buffer_size: 100000
+    task_stack_in_psram: true

--- a/tests/components/audio_http/test.esp32-idf.yaml
+++ b/tests/components/audio_http/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
 # What does this implement/fix?

Adds a new media source for playing audio from HTTP URLs. It uses the new microDecoder library (this PR is chained onto #15679, which adds microDecoder) for reading the audio from the HTTP URL and decoding it. 

There is a big advantage to using microDecoder: all codecs either stream or buffer internally. This eliminates an entire staging buffer that the current ``audio_decoder.cpp`` code requires while also avoids needing expensive``memmove`` operations in that staging buffer. This dramatically speeds up decoding! For example, 48 kHz stereo MP3 decodes using ~40% less CPU on an ESP32-S3 because of the reduced memory overhead. WAV files should benefit as well (FLAC and Opus already avoid the unnecessary ``memmove`` operations in the current ``audio_decoder.cpp``, but they still benefit from one less staging buffer needing to be allocated while avoiding one memory copy overall).

Serves as a replacement and closes #14510 as the microDecoder library manually handles the HTTP reads.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6446

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_source:
  - platform: audio_http
    id: media_http_source

media_player:
  - platform: speaker_source
    id: external_media_player
    name: Media Player
    media_pipeline:
      speaker: box_speaker
      format: MP3
      sample_rate: 48000
      num_channels: 2
      sources:
        - media_http_source

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
