### PR TITLE
[core] Move FILTER_PLATFORMIO_LINES into platformio_runner

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -14,45 +14,6 @@ from esphome.util import run_external_process
 _LOGGER = logging.getLogger(__name__)
 
 
-IGNORE_LIB_WARNINGS = f"(?:{'|'.join(['Hash', 'Update'])})"
-FILTER_PLATFORMIO_LINES = [
-    r"Verbose mode can be enabled via `-v, --verbose` option.*",
-    r"CONFIGURATION: https://docs.platformio.org/.*",
-    r"DEBUG: Current.*",
-    r"LDF Modes:.*",
-    r"LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf.*",
-    f"Looking for {IGNORE_LIB_WARNINGS} library in registry",
-    f"Warning! Library `.*'{IGNORE_LIB_WARNINGS}.*` has not been found in PlatformIO Registry.",
-    f"You can ignore this message, if `.*{IGNORE_LIB_WARNINGS}.*` is a built-in library.*",
-    r"Scanning dependencies...",
-    r"Found \d+ compatible libraries",
-    r"Memory Usage -> https://bit.ly/pio-memory-usage",
-    r"Found: https://platformio.org/lib/show/.*",
-    r"Using cache: .*",
-    r"Installing dependencies",
-    r"Library Manager: Already installed, built-in library",
-    r"Building in .* mode",
-    r"Advanced Memory Usage is available via .*",
-    r"Merged .* ELF section",
-    r"esptool.py v.*",
-    r"esptool v.*",
-    r"Checking size .*",
-    r"Retrieving maximum program size .*",
-    r"PLATFORM: .*",
-    r"PACKAGES:.*",
-    r" - framework-arduinoespressif.* \(.*\)",
-    r" - tool-esptool.* \(.*\)",
-    r" - toolchain-.* \(.*\)",
-    r"Creating BIN file .*",
-    r"Warning! Could not find file \".*.crt\"",
-    r"Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.",
-    r"Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.",
-    r"Warning: esp-idf-size exited with code 2",
-    r"esp_idf_size: error: unrecognized arguments: --ng",
-    r"Package configuration completed successfully",
-]
-
-
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())

--- a/esphome/platformio_runner.py
+++ b/esphome/platformio_runner.py
@@ -101,6 +101,50 @@ def patch_file_downloader() -> None:
     FileDownloader.__init__ = patched_init
 
 
+_IGNORE_LIB_WARNINGS = f"(?:{'|'.join(['Hash', 'Update'])})"
+# Regex patterns matched against each line of PlatformIO output. Lines that
+# match are dropped by RedirectText before they reach the parent process.
+# Patterns are anchored at the start of the line (RedirectText uses
+# ``re.match``). Disabled when the user passes ``-v`` / ``--verbose`` to
+# ``esphome compile``.
+FILTER_PLATFORMIO_LINES = [
+    r"Verbose mode can be enabled via `-v, --verbose` option.*",
+    r"CONFIGURATION: https://docs.platformio.org/.*",
+    r"DEBUG: Current.*",
+    r"LDF Modes:.*",
+    r"LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf.*",
+    f"Looking for {_IGNORE_LIB_WARNINGS} library in registry",
+    f"Warning! Library `.*'{_IGNORE_LIB_WARNINGS}.*` has not been found in PlatformIO Registry.",
+    f"You can ignore this message, if `.*{_IGNORE_LIB_WARNINGS}.*` is a built-in library.*",
+    r"Scanning dependencies...",
+    r"Found \d+ compatible libraries",
+    r"Memory Usage -> https://bit.ly/pio-memory-usage",
+    r"Found: https://platformio.org/lib/show/.*",
+    r"Using cache: .*",
+    r"Installing dependencies",
+    r"Library Manager: Already installed, built-in library",
+    r"Building in .* mode",
+    r"Advanced Memory Usage is available via .*",
+    r"Merged .* ELF section",
+    r"esptool.py v.*",
+    r"esptool v.*",
+    r"Checking size .*",
+    r"Retrieving maximum program size .*",
+    r"PLATFORM: .*",
+    r"PACKAGES:.*",
+    r" - framework-arduinoespressif.* \(.*\)",
+    r" - tool-esptool.* \(.*\)",
+    r" - toolchain-.* \(.*\)",
+    r"Creating BIN file .*",
+    r"Warning! Could not find file \".*.crt\"",
+    r"Warning! Arduino framework as an ESP-IDF component doesn't handle the `variant` field! The default `esp32` variant will be used.",
+    r"Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.",
+    r"Warning: esp-idf-size exited with code 2",
+    r"esp_idf_size: error: unrecognized arguments: --ng",
+    r"Package configuration completed successfully",
+]
+
+
 def main() -> int:
     patch_structhash()
     patch_file_downloader()
@@ -126,7 +170,6 @@ def main() -> int:
     # Filtering is disabled when the user passed -v / --verbose to
     # ``esphome compile``, preserving the previous in-process behavior where
     # verbose mode let all PlatformIO output through unfiltered.
-    from esphome.platformio_api import FILTER_PLATFORMIO_LINES
     from esphome.util import RedirectText
 
     is_verbose = any(arg in ("-v", "--verbose") for arg in sys.argv[1:])

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -906,7 +906,7 @@ def _filter_through_redirect(line: str) -> str:
 
     captured = io.StringIO()
     redirect = RedirectText(
-        captured, filter_lines=platformio_api.FILTER_PLATFORMIO_LINES
+        captured, filter_lines=platformio_runner.FILTER_PLATFORMIO_LINES
     )
     redirect.write(line + "\n")
     return captured.getvalue()


### PR DESCRIPTION
# What does this implement/fix?

Cleanup/refactor. The ``FILTER_PLATFORMIO_LINES`` regex list has exactly one consumer — ``platformio_runner.main()`` wrapping ``sys.stdout`` / ``sys.stderr`` in ``RedirectText``. Since #15666 made subprocess the only code path for PlatformIO, ``run_platformio_cli`` in ``platformio_api`` no longer passes the filter as a kwarg, so the constant has been dead weight in ``platformio_api.py`` ever since.

Move ``FILTER_PLATFORMIO_LINES`` (and its ``IGNORE_LIB_WARNINGS`` helper, now module-private as ``_IGNORE_LIB_WARNINGS``) into ``platformio_runner.py`` next to the ``RedirectText`` wiring that actually uses it. This matches the pattern established by ``espidf_runner.py``, where ``FILTER_IDF_LINES`` lives inside the runner file.

Drops the stale ``from esphome.platformio_api import FILTER_PLATFORMIO_LINES`` lazy import from ``platformio_runner.main()``. Updates the ``_filter_through_redirect`` test-helper in ``test_platformio_api.py`` to reference ``platformio_runner.FILTER_PLATFORMIO_LINES``.

No behaviour change. 57 unit tests in ``test_platformio_api.py`` pass.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15666 / #15681

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal refactor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).