### PR TITLE
[remote_receiver] Place RMT receive functions in IRAM for cache safety

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1058,6 +1058,7 @@ CONF_DISABLE_MBEDTLS_PEER_CERT = "disable_mbedtls_peer_cert"
 CONF_DISABLE_MBEDTLS_PKCS7 = "disable_mbedtls_pkcs7"
 CONF_DISABLE_REGI2C_IN_IRAM = "disable_regi2c_in_iram"
 CONF_DISABLE_FATFS = "disable_fatfs"
+CONF_RMT_RECV_IN_IRAM = "rmt_recv_in_iram"
 
 # VFS requirement tracking
 # Components that need VFS features can call require_vfs_*() functions
@@ -1071,6 +1072,7 @@ KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
 KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
 KEY_MBEDTLS_SHA512_REQUIRED = "mbedtls_sha512_required"
+KEY_RMT_RECV_IRAM_REQUIRED = "rmt_recv_iram_required"
 
 
 def require_vfs_select() -> None:
@@ -1166,6 +1168,17 @@ def require_fatfs() -> None:
     This prevents FATFS from being disabled when disable_fatfs is set.
     """
     CORE.data[KEY_ESP32][KEY_FATFS_REQUIRED] = True
+
+
+def require_rmt_recv_iram() -> None:
+    """Mark that RMT receive IRAM safety is required by a component.
+
+    Call this from components that use the RMT receive driver. When flash cache is
+    disabled (e.g., during NVS writes by WiFi, BLE, Zigbee, or power management),
+    the RMT receive function must be in IRAM to avoid crashes.
+    This sets CONFIG_RMT_RECV_FUNC_IN_IRAM.
+    """
+    CORE.data[KEY_ESP32][KEY_RMT_RECV_IRAM_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -1268,6 +1281,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_MBEDTLS_PEER_CERT, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_MBEDTLS_PKCS7, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_REGI2C_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_RMT_RECV_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_DISABLE_FATFS, default=True): cv.boolean,
             }
         ),
@@ -2067,6 +2081,16 @@ async def to_code(config):
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
     if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:
         add_idf_sdkconfig_option("CONFIG_ESP_REGI2C_CTRL_FUNC_IN_IRAM", False)
+
+    # Place RMT receive functions in IRAM for cache safety
+    # When flash cache is disabled (during NVS writes by WiFi, BLE, Zigbee, Thread,
+    # power management, etc.), RMT receive will crash if these functions are in flash.
+    # Components using RMT receive call require_rmt_recv_iram() to force this.
+    if (
+        CORE.data[KEY_ESP32].get(KEY_RMT_RECV_IRAM_REQUIRED, False)
+        or advanced[CONF_RMT_RECV_IN_IRAM]
+    ):
+        add_idf_sdkconfig_option("CONFIG_RMT_RECV_FUNC_IN_IRAM", True)
 
     # Disable FATFS support
     # Components that need FATFS (SD card, etc.) can call require_fatfs()

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -201,6 +201,7 @@ async def to_code(config):
     if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
+        esp32.require_rmt_recv_iram()
 
         var = cg.new_Pvariable(config[CONF_ID], pin)
         cg.add(var.set_rmt_symbols(config[CONF_RMT_SYMBOLS]))

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -101,6 +101,13 @@ def validate_tolerance(value):
     )
 
 
+def _require_rmt_iram(config):
+    """Register RMT receive IRAM requirement during config validation."""
+    if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
+        esp32.require_rmt_recv_iram()
+    return config
+
+
 MULTI_CONF = True
 CONFIG_SCHEMA = remote_base.validate_triggers(
     cv.Schema(
@@ -193,6 +200,7 @@ CONFIG_SCHEMA = remote_base.validate_triggers(
         )
     )
     .add_extra(validate_config)
+    .add_extra(_require_rmt_iram)
 )
 
 
@@ -201,7 +209,6 @@ async def to_code(config):
     if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         # Re-enable ESP-IDF's RMT driver (excluded by default to save compile time)
         esp32.include_builtin_idf_component("esp_driver_rmt")
-        esp32.require_rmt_recv_iram()
 
         var = cg.new_Pvariable(config[CONF_ID], pin)
         cg.add(var.set_rmt_symbols(config[CONF_RMT_SYMBOLS]))

--- a/esphome/components/remote_receiver/__init__.py
+++ b/esphome/components/remote_receiver/__init__.py
@@ -21,6 +21,7 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE, TimePeriod
+from esphome.types import ConfigType
 
 CONF_FILTER_SYMBOLS = "filter_symbols"
 CONF_RECEIVE_SYMBOLS = "receive_symbols"
@@ -101,7 +102,7 @@ def validate_tolerance(value):
     )
 
 
-def _require_rmt_iram(config):
+def _require_rmt_iram(config: ConfigType) -> ConfigType:
     """Register RMT receive IRAM requirement during config validation."""
     if CORE.is_esp32 and esp32.get_esp32_variant() not in esp32_rmt.VARIANTS_NO_RMT:
         esp32.require_rmt_recv_iram()


### PR DESCRIPTION
# What does this implement/fix?

When flash cache is disabled during background flash operations (NVS writes by WiFi, BLE, Zigbee, Thread, power management, etc.), the RMT receive function can crash if it is in flash. This can happen on any ESP32 variant when remote_receiver is used alongside components that perform flash operations.

This adds `CONFIG_RMT_RECV_FUNC_IN_IRAM=y` when the remote_receiver component is used on ESP-IDF, placing the RMT receive functions in IRAM so they remain accessible when flash cache is disabled.

A `require_rmt_recv_iram()` helper is added following the existing `require_*` pattern, and an `rmt_recv_in_iram` advanced config option is available as a manual override.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: esphome/esphome#15717, esphome/esphome#15718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6453

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# remote_receiver automatically enables IRAM safety when used
remote_receiver:
  pin: GPIO19
  dump: all

# Manual override via advanced config (not normally needed):
esp32:
  framework:
    type: esp-idf
    advanced:
      rmt_recv_in_iram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).