### PR TITLE
[adc] Place ADC oneshot control functions in IRAM for cache safety

### DIFF
--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -69,6 +69,13 @@ def validate_config(config):
     return config
 
 
+def _require_adc_iram(config):
+    """Register ADC oneshot IRAM requirement during config validation."""
+    if CORE.is_esp32:
+        require_adc_oneshot_iram()
+    return config
+
+
 ADCSensor = adc_ns.class_(
     "ADCSensor", sensor.Sensor, cg.PollingComponent, voltage_sampler.VoltageSampler
 )
@@ -99,6 +106,7 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(cv.polling_component_schema("60s")),
     validate_config,
+    _require_adc_iram,
 )
 
 CONF_ADC_CHANNEL_ID = "adc_channel_id"
@@ -124,7 +132,6 @@ async def to_code(config):
     if CORE.is_esp32:
         # Re-enable ESP-IDF's ADC driver (excluded by default to save compile time)
         include_builtin_idf_component("esp_adc")
-        require_adc_oneshot_iram()
 
         if attenuation := config.get(CONF_ATTENUATION):
             if attenuation == "auto":

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -28,6 +28,7 @@ from esphome.const import (
     PlatformFramework,
 )
 from esphome.core import CORE
+from esphome.types import ConfigType
 
 from . import (
     ATTENUATION_MODES,
@@ -69,7 +70,7 @@ def validate_config(config):
     return config
 
 
-def _require_adc_iram(config):
+def _require_adc_iram(config: ConfigType) -> ConfigType:
     """Register ADC oneshot IRAM requirement during config validation."""
     if CORE.is_esp32:
         require_adc_oneshot_iram()

--- a/esphome/components/adc/sensor.py
+++ b/esphome/components/adc/sensor.py
@@ -2,7 +2,11 @@ import logging
 
 import esphome.codegen as cg
 from esphome.components import sensor, voltage_sampler
-from esphome.components.esp32 import get_esp32_variant, include_builtin_idf_component
+from esphome.components.esp32 import (
+    get_esp32_variant,
+    include_builtin_idf_component,
+    require_adc_oneshot_iram,
+)
 from esphome.components.nrf52.const import AIN_TO_GPIO, EXTRA_ADC
 from esphome.components.zephyr import (
     zephyr_add_overlay,
@@ -120,6 +124,7 @@ async def to_code(config):
     if CORE.is_esp32:
         # Re-enable ESP-IDF's ADC driver (excluded by default to save compile time)
         include_builtin_idf_component("esp_adc")
+        require_adc_oneshot_iram()
 
         if attenuation := config.get(CONF_ATTENUATION):
             if attenuation == "auto":

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1058,6 +1058,7 @@ CONF_DISABLE_MBEDTLS_PEER_CERT = "disable_mbedtls_peer_cert"
 CONF_DISABLE_MBEDTLS_PKCS7 = "disable_mbedtls_pkcs7"
 CONF_DISABLE_REGI2C_IN_IRAM = "disable_regi2c_in_iram"
 CONF_DISABLE_FATFS = "disable_fatfs"
+CONF_ADC_ONESHOT_IN_IRAM = "adc_oneshot_in_iram"
 
 # VFS requirement tracking
 # Components that need VFS features can call require_vfs_*() functions
@@ -1071,6 +1072,7 @@ KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
 KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
 KEY_MBEDTLS_SHA512_REQUIRED = "mbedtls_sha512_required"
+KEY_ADC_ONESHOT_IRAM_REQUIRED = "adc_oneshot_iram_required"
 
 
 def require_vfs_select() -> None:
@@ -1166,6 +1168,17 @@ def require_fatfs() -> None:
     This prevents FATFS from being disabled when disable_fatfs is set.
     """
     CORE.data[KEY_ESP32][KEY_FATFS_REQUIRED] = True
+
+
+def require_adc_oneshot_iram() -> None:
+    """Mark that ADC oneshot IRAM safety is required by a component.
+
+    Call this from components that use the ADC oneshot driver. When flash cache is
+    disabled (e.g., during NVS writes by WiFi, BLE, Zigbee, or power management),
+    the ADC oneshot read function must be in IRAM to avoid crashes.
+    This sets CONFIG_ADC_ONESHOT_CTRL_FUNC_IN_IRAM.
+    """
+    CORE.data[KEY_ESP32][KEY_ADC_ONESHOT_IRAM_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -1268,6 +1281,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_MBEDTLS_PEER_CERT, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_MBEDTLS_PKCS7, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_REGI2C_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_ADC_ONESHOT_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_DISABLE_FATFS, default=True): cv.boolean,
             }
         ),
@@ -2067,6 +2081,16 @@ async def to_code(config):
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
     if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:
         add_idf_sdkconfig_option("CONFIG_ESP_REGI2C_CTRL_FUNC_IN_IRAM", False)
+
+    # Place ADC oneshot control functions in IRAM for cache safety
+    # When flash cache is disabled (during NVS writes by WiFi, BLE, Zigbee, Thread,
+    # power management, etc.), ADC reads will crash if these functions are in flash.
+    # Components using ADC call require_adc_oneshot_iram() to force this.
+    if (
+        CORE.data[KEY_ESP32].get(KEY_ADC_ONESHOT_IRAM_REQUIRED, False)
+        or advanced[CONF_ADC_ONESHOT_IN_IRAM]
+    ):
+        add_idf_sdkconfig_option("CONFIG_ADC_ONESHOT_CTRL_FUNC_IN_IRAM", True)
 
     # Disable FATFS support
     # Components that need FATFS (SD card, etc.) can call require_fatfs()


### PR DESCRIPTION
# What does this implement/fix?

When flash cache is disabled during background flash operations (NVS writes by WiFi, BLE, Zigbee, Thread, power management, etc.), the ADC oneshot read function (`adc_oneshot_hal_convert`) will crash if it is in flash. This was [reported on Discord](https://ptb.discord.com/channels/429907082951524364/524177279270780928/1493339869425045564) as an interrupt watchdog timeout on ESP32-H2 with Zigbee, but can happen on any ESP32 variant when ADC is used alongside components that perform flash operations.

This adds `CONFIG_ADC_ONESHOT_CTRL_FUNC_IN_IRAM=y` when the ADC component is used, placing the ADC oneshot control functions in IRAM so they remain accessible when flash cache is disabled.

A `require_adc_oneshot_iram()` helper is added following the existing `require_*` pattern, and an `adc_oneshot_in_iram` advanced config option is available as a manual override.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: esphome/esphome#15716, esphome/esphome#15718

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6452

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# ADC automatically enables IRAM safety when used
sensor:
  - platform: adc
    pin: GPIO34
    name: "ADC Voltage"

# Manual override via advanced config (not normally needed):
esp32:
  framework:
    type: esp-idf
    advanced:
      adc_oneshot_in_iram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).