### PR TITLE
[ledc] Place LEDC control functions in IRAM for cache safety

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1058,6 +1058,7 @@ CONF_DISABLE_MBEDTLS_PEER_CERT = "disable_mbedtls_peer_cert"
 CONF_DISABLE_MBEDTLS_PKCS7 = "disable_mbedtls_pkcs7"
 CONF_DISABLE_REGI2C_IN_IRAM = "disable_regi2c_in_iram"
 CONF_DISABLE_FATFS = "disable_fatfs"
+CONF_LEDC_IN_IRAM = "ledc_in_iram"
 
 # VFS requirement tracking
 # Components that need VFS features can call require_vfs_*() functions
@@ -1071,6 +1072,7 @@ KEY_MBEDTLS_PEER_CERT_REQUIRED = "mbedtls_peer_cert_required"
 KEY_MBEDTLS_PKCS7_REQUIRED = "mbedtls_pkcs7_required"
 KEY_FATFS_REQUIRED = "fatfs_required"
 KEY_MBEDTLS_SHA512_REQUIRED = "mbedtls_sha512_required"
+KEY_LEDC_IRAM_REQUIRED = "ledc_iram_required"
 
 
 def require_vfs_select() -> None:
@@ -1166,6 +1168,17 @@ def require_fatfs() -> None:
     This prevents FATFS from being disabled when disable_fatfs is set.
     """
     CORE.data[KEY_ESP32][KEY_FATFS_REQUIRED] = True
+
+
+def require_ledc_iram() -> None:
+    """Mark that LEDC IRAM safety is required by a component.
+
+    Call this from components that use the LEDC (PWM) driver. When flash cache is
+    disabled (e.g., during NVS writes by WiFi, BLE, Zigbee, or power management),
+    the LEDC control functions must be in IRAM to avoid crashes.
+    This sets CONFIG_LEDC_CTRL_FUNC_IN_IRAM.
+    """
+    CORE.data[KEY_ESP32][KEY_LEDC_IRAM_REQUIRED] = True
 
 
 def _parse_idf_component(value: str) -> ConfigType:
@@ -1268,6 +1281,7 @@ FRAMEWORK_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DISABLE_MBEDTLS_PEER_CERT, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_MBEDTLS_PKCS7, default=True): cv.boolean,
                 cv.Optional(CONF_DISABLE_REGI2C_IN_IRAM, default=True): cv.boolean,
+                cv.Optional(CONF_LEDC_IN_IRAM, default=False): cv.boolean,
                 cv.Optional(CONF_DISABLE_FATFS, default=True): cv.boolean,
             }
         ),
@@ -2067,6 +2081,16 @@ async def to_code(config):
     # Only needed if using analog peripherals (ADC, DAC, etc.) from ISRs while cache is disabled
     if advanced[CONF_DISABLE_REGI2C_IN_IRAM]:
         add_idf_sdkconfig_option("CONFIG_ESP_REGI2C_CTRL_FUNC_IN_IRAM", False)
+
+    # Place LEDC control functions in IRAM for cache safety
+    # When flash cache is disabled (during NVS writes by WiFi, BLE, Zigbee, Thread,
+    # power management, etc.), LEDC operations will crash if these functions are in flash.
+    # Components using LEDC call require_ledc_iram() to force this.
+    if (
+        CORE.data[KEY_ESP32].get(KEY_LEDC_IRAM_REQUIRED, False)
+        or advanced[CONF_LEDC_IN_IRAM]
+    ):
+        add_idf_sdkconfig_option("CONFIG_LEDC_CTRL_FUNC_IN_IRAM", True)
 
     # Disable FATFS support
     # Components that need FATFS (SD card, etc.) can call require_fatfs()

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -42,28 +42,29 @@ ledc_ns = cg.esphome_ns.namespace("ledc")
 LEDCOutput = ledc_ns.class_("LEDCOutput", output.FloatOutput, cg.Component)
 SetFrequencyAction = ledc_ns.class_("SetFrequencyAction", automation.Action)
 
-CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
-    {
-        cv.Required(CONF_ID): cv.declare_id(LEDCOutput),
-        cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
-        cv.Optional(CONF_FREQUENCY, default="1kHz"): cv.All(
-            cv.frequency, cv.float_range(min=0, min_included=False)
-        ),
-        cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=15),
-        cv.Optional(CONF_PHASE_ANGLE): cv.All(
-            cv.angle, cv.float_range(min=0.0, max=360.0)
-        ),
-    }
-).extend(cv.COMPONENT_SCHEMA)
 
-
-def _require_ledc_iram(config):
+def _require_ledc_iram_validator(config):
     """Register LEDC IRAM requirement during config validation."""
     require_ledc_iram()
     return config
 
 
-FINAL_VALIDATE_SCHEMA = _require_ledc_iram
+CONFIG_SCHEMA = cv.All(
+    output.FLOAT_OUTPUT_SCHEMA.extend(
+        {
+            cv.Required(CONF_ID): cv.declare_id(LEDCOutput),
+            cv.Required(CONF_PIN): pins.internal_gpio_output_pin_schema,
+            cv.Optional(CONF_FREQUENCY, default="1kHz"): cv.All(
+                cv.frequency, cv.float_range(min=0, min_included=False)
+            ),
+            cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=15),
+            cv.Optional(CONF_PHASE_ANGLE): cv.All(
+                cv.angle, cv.float_range(min=0.0, max=360.0)
+            ),
+        }
+    ).extend(cv.COMPONENT_SCHEMA),
+    _require_ledc_iram_validator,
+)
 
 
 async def to_code(config):

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_PHASE_ANGLE,
     CONF_PIN,
 )
+from esphome.types import ConfigType
 
 DEPENDENCIES = ["esp32"]
 
@@ -43,7 +44,7 @@ LEDCOutput = ledc_ns.class_("LEDCOutput", output.FloatOutput, cg.Component)
 SetFrequencyAction = ledc_ns.class_("SetFrequencyAction", automation.Action)
 
 
-def _require_ledc_iram_validator(config):
+def _require_ledc_iram_validator(config: ConfigType) -> ConfigType:
     """Register LEDC IRAM requirement during config validation."""
     require_ledc_iram()
     return config

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -57,8 +57,16 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 ).extend(cv.COMPONENT_SCHEMA)
 
 
-async def to_code(config):
+def _require_ledc_iram(config):
+    """Register LEDC IRAM requirement during config validation."""
     require_ledc_iram()
+    return config
+
+
+FINAL_VALIDATE_SCHEMA = _require_ledc_iram
+
+
+async def to_code(config):
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
     await cg.register_component(var, config)

--- a/esphome/components/ledc/output.py
+++ b/esphome/components/ledc/output.py
@@ -1,6 +1,7 @@
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import output
+from esphome.components.esp32 import require_ledc_iram
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CHANNEL,
@@ -57,6 +58,7 @@ CONFIG_SCHEMA = output.FLOAT_OUTPUT_SCHEMA.extend(
 
 
 async def to_code(config):
+    require_ledc_iram()
     gpio = await cg.gpio_pin_expression(config[CONF_PIN])
     var = cg.new_Pvariable(config[CONF_ID], gpio)
     await cg.register_component(var, config)


### PR DESCRIPTION
# What does this implement/fix?

Places LEDC control functions (`ledc_update_duty()` and `ledc_stop()`) in IRAM so they remain accessible when flash cache is disabled during background flash operations (NVS writes by WiFi, BLE, Zigbee, Thread, power management, etc.).

LEDC crashes have been observed under high update pressure (esphome/esphome#14720) where `ledc_update_duty()` / `ledc_ll_set_duty_start()` would crash. While the exact root cause was not confirmed, flash cache being disabled during LEDC updates is a plausible trigger. `CONFIG_LEDC_CTRL_FUNC_IN_IRAM=y` ensures these functions are always accessible regardless of cache state.

This may also address PWM instability on ESP32-C6 (esphome/esphome#15438) where flickering was only resolved by disabling WiFi power save mode — suggesting WiFi power management was disabling flash cache during LEDC updates.

A `require_ledc_iram()` helper is added following the existing `require_*` pattern, and a `ledc_in_iram` advanced config option is available as a manual override.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Related: esphome/esphome#14720, esphome/esphome#15438, esphome/esphome#15717, esphome/esphome#15716

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6454

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# LEDC automatically enables IRAM safety when used
output:
  - platform: ledc
    pin: GPIO19
    id: pwm_output

# Manual override via advanced config (not normally needed):
esp32:
  framework:
    type: esp-idf
    advanced:
      ledc_in_iram: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).