### PR TITLE
[web_server] Reset OTA backend on new upload to avoid brick after interrupted OTA

### DIFF
--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -64,10 +64,6 @@ class OTARequestHandler : public AsyncWebHandler {
   void report_ota_progress_(AsyncWebServerRequest *request);
   void schedule_ota_reboot_();
   void ota_init_(const char *filename);
-  void ota_end_session_() {
-    this->ota_backend_.reset();
-    this->ota_request_ = nullptr;
-  }
 
   uint32_t last_ota_progress_{0};
   uint32_t ota_read_length_{0};
@@ -76,11 +72,6 @@ class OTARequestHandler : public AsyncWebHandler {
 
  private:
   ota::OTABackendPtr ota_backend_{nullptr};
-  // Tracks the request that owns the current ota_backend_ session so we can
-  // detect when a new (retry) request arrives while a previous session is
-  // still open -- without re-triggering on the multiple index==0 callbacks
-  // web_server_idf makes for a single upload (Start + first data chunk).
-  AsyncWebServerRequest *ota_request_{nullptr};
 };
 
 void OTARequestHandler::report_ota_progress_(AsyncWebServerRequest *request) {
@@ -123,18 +114,20 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
                                      uint8_t *data, size_t len, bool final) {
   ota::OTAResponseTypes error_code = ota::OTA_RESPONSE_OK;
 
-  if (index == 0 && this->ota_request_ != request) {
-    // A new request is starting an upload. If a previous upload was interrupted
-    // (e.g. TCP reset) the backend from that session may still be open; tear it
-    // down so flash state doesn't get concatenated with the new image (which
-    // can produce a technically-valid-sized but corrupted firmware that
-    // bricks the device once it reboots).
+  // First byte of a new upload: index==0 with actual data. (web_server_idf
+  // fires a separate start-marker call with data==nullptr/len==0 before the
+  // first real chunk; gate on len>0 so we only trigger once per upload.)
+  if (index == 0 && len > 0) {
+    // If a previous upload was interrupted (e.g. client closed the tab, TCP
+    // reset) the backend from that session may still be open. Tear it down
+    // so flash state doesn't get concatenated with the new image (which can
+    // produce a technically-valid-sized but corrupted firmware that bricks
+    // the device once it reboots).
     if (this->ota_backend_) {
       ESP_LOGW(TAG, "New OTA upload received while previous session was still open; aborting previous session");
       this->ota_backend_->abort();
-      this->ota_end_session_();
+      this->ota_backend_.reset();
     }
-    this->ota_request_ = request;
 
     // Initialize OTA on first call
     this->ota_init_(filename.c_str());
@@ -169,7 +162,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     error_code = this->ota_backend_->begin(0);
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGE(TAG, "OTA begin failed: %d", error_code);
-      this->ota_end_session_();
+      this->ota_backend_.reset();
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -187,7 +180,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGE(TAG, "OTA write failed: %d", error_code);
       this->ota_backend_->abort();
-      this->ota_end_session_();
+      this->ota_backend_.reset();
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -219,7 +212,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
     }
-    this->ota_end_session_();
+    this->ota_backend_.reset();
   }
 }
 

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -72,6 +72,11 @@ class OTARequestHandler : public AsyncWebHandler {
 
  private:
   ota::OTABackendPtr ota_backend_{nullptr};
+  // Tracks the request that owns the current ota_backend_ session so we can
+  // detect when a new (retry) request arrives while a previous session is
+  // still open -- without re-triggering on the multiple index==0 callbacks
+  // web_server_idf makes for a single upload (Start + first data chunk).
+  AsyncWebServerRequest *ota_request_{nullptr};
 };
 
 void OTARequestHandler::report_ota_progress_(AsyncWebServerRequest *request) {
@@ -114,8 +119,8 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
                                      uint8_t *data, size_t len, bool final) {
   ota::OTAResponseTypes error_code = ota::OTA_RESPONSE_OK;
 
-  if (index == 0) {
-    // A new multipart upload is starting. If a previous upload was interrupted
+  if (index == 0 && this->ota_request_ != request) {
+    // A new request is starting an upload. If a previous upload was interrupted
     // (e.g. TCP reset) the backend from that session may still be open; tear it
     // down so flash state doesn't get concatenated with the new image (which
     // can produce a technically-valid-sized but corrupted firmware that
@@ -125,6 +130,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
       this->ota_backend_->abort();
       this->ota_backend_.reset();
     }
+    this->ota_request_ = request;
 
     // Initialize OTA on first call
     this->ota_init_(filename.c_str());
@@ -160,6 +166,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGE(TAG, "OTA begin failed: %d", error_code);
       this->ota_backend_.reset();
+      this->ota_request_ = nullptr;
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -178,6 +185,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
       ESP_LOGE(TAG, "OTA write failed: %d", error_code);
       this->ota_backend_->abort();
       this->ota_backend_.reset();
+      this->ota_request_ = nullptr;
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -210,6 +218,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
 #endif
     }
     this->ota_backend_.reset();
+    this->ota_request_ = nullptr;
   }
 }
 

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -64,6 +64,10 @@ class OTARequestHandler : public AsyncWebHandler {
   void report_ota_progress_(AsyncWebServerRequest *request);
   void schedule_ota_reboot_();
   void ota_init_(const char *filename);
+  void ota_end_session_() {
+    this->ota_backend_.reset();
+    this->ota_request_ = nullptr;
+  }
 
   uint32_t last_ota_progress_{0};
   uint32_t ota_read_length_{0};
@@ -128,7 +132,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     if (this->ota_backend_) {
       ESP_LOGW(TAG, "New OTA upload received while previous session was still open; aborting previous session");
       this->ota_backend_->abort();
-      this->ota_backend_.reset();
+      this->ota_end_session_();
     }
     this->ota_request_ = request;
 
@@ -165,8 +169,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     error_code = this->ota_backend_->begin(0);
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGE(TAG, "OTA begin failed: %d", error_code);
-      this->ota_backend_.reset();
-      this->ota_request_ = nullptr;
+      this->ota_end_session_();
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -184,8 +187,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGE(TAG, "OTA write failed: %d", error_code);
       this->ota_backend_->abort();
-      this->ota_backend_.reset();
-      this->ota_request_ = nullptr;
+      this->ota_end_session_();
 #ifdef USE_OTA_STATE_LISTENER
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
@@ -217,8 +219,7 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
       this->parent_->notify_state_deferred_(ota::OTA_ERROR, 0.0f, static_cast<uint8_t>(error_code));
 #endif
     }
-    this->ota_backend_.reset();
-    this->ota_request_ = nullptr;
+    this->ota_end_session_();
   }
 }
 

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -114,7 +114,18 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
                                      uint8_t *data, size_t len, bool final) {
   ota::OTAResponseTypes error_code = ota::OTA_RESPONSE_OK;
 
-  if (index == 0 && !this->ota_backend_) {
+  if (index == 0) {
+    // A new multipart upload is starting. If a previous upload was interrupted
+    // (e.g. TCP reset) the backend from that session may still be open; tear it
+    // down so flash state doesn't get concatenated with the new image (which
+    // can produce a technically-valid-sized but corrupted firmware that
+    // bricks the device once it reboots).
+    if (this->ota_backend_) {
+      ESP_LOGW(TAG, "New OTA upload received while previous session was still open; aborting previous session");
+      this->ota_backend_->abort();
+      this->ota_backend_.reset();
+    }
+
     // Initialize OTA on first call
     this->ota_init_(filename.c_str());
 

--- a/esphome/components/web_server/ota/ota_web_server.cpp
+++ b/esphome/components/web_server/ota/ota_web_server.cpp
@@ -126,6 +126,10 @@ void OTARequestHandler::handleUpload(AsyncWebServerRequest *request, const Platf
     if (this->ota_backend_) {
       ESP_LOGW(TAG, "New OTA upload received while previous session was still open; aborting previous session");
       this->ota_backend_->abort();
+#ifdef USE_OTA_STATE_LISTENER
+      // Notify listeners that the previous session was aborted before the new one starts.
+      this->parent_->notify_state_deferred_(ota::OTA_ABORT, 0.0f, 0);
+#endif
       this->ota_backend_.reset();
     }
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a brick hazard in the captive_portal / web_server OTA flow when an upload is interrupted and the user re-sends the form.

The `OTARequestHandler` in `esphome/components/web_server/ota/ota_web_server.cpp` is registered as a single shared handler (`add_handler(new OTARequestHandler(this))`), so its `ota_backend_`, `ota_read_length_`, and `ota_success_` fields persist across HTTP requests. The guard that initialised a new OTA session was:

```cpp
if (index == 0 && !this->ota_backend_) { ... }
```

If an upload was interrupted mid-stream (TCP reset, client disconnect, browser tab closed, etc.), `handleUpload` never receives `final=true` for that request, so `end()` / `abort()` / `reset()` are never called and the backend stays open at the partial `current_address_` / `bytes_received_`.

When the browser resubmits the multipart form (e.g. Firefox's "resend POST data?" prompt, or a fresh upload started in another tab after the first was abandoned), the new request's first chunk arrives with `index == 0` but `ota_backend_` is still set, so the init block is skipped and the new file's bytes are `write()`-ed into the previous in-progress OTA session at the stale flash offset. On ESP8266's lenient-mode `end()` (no MD5 — which is what the browser upload uses), `bytes_received_` exceeds zero and the firmware header at `start_address_` is still the (valid) header from upload #1, so verification passes and eboot is told to copy a concatenated frankenstein image at next boot — bricking the device, as reported in #15710. On ESP-IDF the symptom is a failed `esp_image` verification that also leaves the partition in an unbootable state.

Fix: when `handleUpload` sees the first real byte of a new upload (`index == 0 && len > 0`), abort and reset any still-open backend before initialising a new session. Gating on `len > 0` correctly handles `web_server_idf`'s two-phase start (it fires a marker call with `data == nullptr, len == 0` before the first real data chunk) without re-triggering on an in-flight upload. This also generalises the existing LibreTiny-only `Update.abort()` guard to all backends.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15710

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduce: configure captive portal or web_server OTA, trigger an OTA via
# the web form, and disconnect the client partway through the upload. Then
# re-submit the form (same tab) or start a fresh upload from a new tab.
# Without this patch, the second upload silently corrupts the staged
# firmware and bricks the device on reboot.
captive_portal:

ota:
  - platform: esphome
  - platform: web_server
```

## Test Output

Verified on an ESP32-PoE-ISO (ESP-IDF) and a d1_mini (ESP8266/Arduino) with `web_server` OTA.

### ESP32-IDF — uninterrupted upload (clean single session, no spurious abort)

```
[12:59:03][I][web_server.ota:108][httpd]: OTA Update Start: firmware.bin
[12:59:09][D][web_server.ota:087][httpd]: OTA in progress: 0.2%
[12:59:10][D][web_server.ota:087][httpd]: OTA in progress: 32.9%
[12:59:11][D][web_server.ota:087][httpd]: OTA in progress: 64.7%
[12:59:12][D][web_server.ota:087][httpd]: OTA in progress: 96.3%
[12:59:12][D][web_server.ota:195][httpd]: OTA final chunk: index=575536, len=0, total_read=575536, contentLength=575735
[12:59:12][I][web_server.ota:100][httpd]: OTA update successful!
[12:59:12][I][web_server.ota:102]: Performing OTA reboot now
```

### ESP32-IDF — upload interrupted by TCP reset, then resubmitted from the same tab

```
[12:58:00][I][web_server.ota:108][httpd]: OTA Update Start: firmware.bin
[12:58:01][D][web_server.ota:087][httpd]: OTA in progress: 30.9%
[12:58:01][D][web_server_idf:083]: send error: errno 128
[12:58:01][D][web_server_idf:083]: send error: errno 128
[12:58:01][D][web_server_idf:500]: Removing dead event source session
[12:58:18][W][web_server.ota:127][httpd]: New OTA upload received while previous session was still open; aborting previous session
[12:58:19][I][web_server.ota:108][httpd]: OTA Update Start: firmware.bin
[12:58:25][D][web_server.ota:087][httpd]: OTA in progress: 0.2%
[12:58:26][D][web_server.ota:087][httpd]: OTA in progress: 30.2%
[12:58:27][D][web_server.ota:087][httpd]: OTA in progress: 61.5%
[12:58:29][D][web_server.ota:087][httpd]: OTA in progress: 92.7%
[12:58:29][D][web_server.ota:195][httpd]: OTA final chunk: index=575536, len=0, total_read=575536, contentLength=575735
[12:58:29][I][web_server.ota:100][httpd]: OTA update successful!
[12:58:29][I][web_server.ota:102]: Performing OTA reboot now
```

Progress stays ≤100%, `total_read == index` on the final chunk, and the second upload is accepted as a fresh session.

### ESP32-IDF — browser tab closed mid-upload, fresh upload started in a new tab

```
[12:58:00][I][web_server.ota:108][httpd]: OTA Update Start: firmware.bin
[12:58:01][D][web_server.ota:087][httpd]: OTA in progress: 30.9%
<tab closed>
[12:58:18][W][web_server.ota:127][httpd]: New OTA upload received while previous session was still open; aborting previous session
[12:58:19][I][web_server.ota:108][httpd]: OTA Update Start: firmware.bin
[12:58:29][D][web_server.ota:195][httpd]: OTA final chunk: index=575536, len=0, total_read=575536, contentLength=575735
[12:58:29][I][web_server.ota:100][httpd]: OTA update successful!
```

Without the patch, this scenario produced `total_read=712183` (≈ partial of upload 1 + full upload 2) with no warning, progress went to `113.9%`, and `esp_image` rejected the concatenated image:

```
[12:51:12][D][web_server.ota:087][httpd]: OTA in progress: 113.9%
[12:51:12][D][web_server.ota:202][httpd]: OTA final chunk: index=575536, len=0, total_read=712183, contentLength=575735
[12:51:14][D][esp-idf:000][httpd]: E (57022) esp_image: bootloader_flash_read failed at 0x00515efc
[12:51:14][D][esp-idf:000][httpd]: E (57023) esp_ota_ops: New image failed verification
[12:51:14][E][web_server.ota:217][httpd]: OTA end failed: 132
```

### ESP8266 (d1_mini) — upload interrupted mid-stream, then resubmitted

```
[13:02:01][I][web_server.ota:108]: OTA Update Start: firmware.bin
[13:02:01][D][ota.esp8266:121]: OTA begin: start=0x00075000, size=3694592
[13:02:01][D][web_server.ota:087]: OTA in progress: 0.3%
[13:02:02][D][web_server.ota:087]: OTA in progress: 19.1%
[13:02:05][D][web_server.ota:087]: OTA in progress: 58.8%
<tab closed>
[13:02:18][W][web_server.ota:127]: New OTA upload received while previous session was still open; aborting previous session
[13:02:18][I][web_server.ota:108]: OTA Update Start: firmware.bin
[13:02:18][D][ota.esp8266:121]: OTA begin: start=0x00075000, size=3694592
[13:02:18][D][web_server.ota:087]: OTA in progress: 0.3%
[13:02:24][D][web_server.ota:087]: OTA in progress: 83.1%
[13:02:25][D][web_server.ota:195]: OTA final chunk: index=472887, len=1241, total_read=474128, contentLength=474327
[13:02:25][I][ota.esp8266:296]: OTA update staged: 0x00075000 -> 0x00000, size=474128
[13:02:25][I][web_server.ota:100]: OTA update successful!
[13:02:25][I][web_server.ota:102]: Performing OTA reboot now
```

`OTA update staged` reports the correct image size (474128, matching `total_read`) rather than a concatenated total, confirming the previous session was properly torn down before the new one began.

### ESP8266 (d1_mini) — uninterrupted upload

```
[13:02:48][I][web_server.ota:108]: OTA Update Start: firmware.bin
[13:02:48][D][ota.esp8266:121]: OTA begin: start=0x00075000, size=3694592
[13:02:48][D][web_server.ota:087]: OTA in progress: 0.3%
[13:02:50][D][web_server.ota:087]: OTA in progress: 20.6%
[13:02:51][D][web_server.ota:087]: OTA in progress: 52.0%
[13:02:53][D][web_server.ota:087]: OTA in progress: 74.5%
[13:02:54][D][web_server.ota:087]: OTA in progress: 96.0%
[13:02:54][D][web_server.ota:195]: OTA final chunk: index=472887, len=1241, total_read=474128, contentLength=474327
[13:02:54][I][ota.esp8266:296]: OTA update staged: 0x00075000 -> 0x00000, size=474128
[13:02:54][I][web_server.ota:100]: OTA update successful!
[13:02:54][I][web_server.ota:102]: Performing OTA reboot now
```

Single clean session with no spurious abort warning.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
