### PR TITLE
[light] Avoid addressable transition stall at low gamma-corrected values

### DIFF
--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -66,11 +66,15 @@ void AddressableLightTransformer::start() {
   this->uniform_start_color_.reset();
   if (this->light_.size() > 0) {
     Color first = this->light_[0].get();
+    bool uniform = true;
     for (int32_t i = 1; i < this->light_.size(); i++) {
-      if (this->light_[i].get() != first)
-        return;
+      if (this->light_[i].get() != first) {
+        uniform = false;
+        break;
+      }
     }
-    this->uniform_start_color_ = first;
+    if (uniform)
+      this->uniform_start_color_ = first;
   }
 }
 
@@ -115,6 +119,11 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
       // All LEDs started at the same color: compute the interpolated value once and write it to
       // every LED. No read-back, so each LED's stored byte advances through every gamma threshold
       // as smoothed_progress crosses it, instead of stalling at 0 for low pre-gamma values.
+      //
+      // Trade-off: any mid-transition writes to individual LEDs (e.g. from a user lambda) will be
+      // overwritten on the next apply() here. The fallback path below would have respected them
+      // via its read-back. Concurrent per-LED mutation during a transition isn't a pattern we
+      // support, so this is acceptable.
       // lerp(start, target, progress) via existing helper: target - (target-start)*(1-progress).
       const Color &start = *this->uniform_start_color_;
       int32_t remaining = int32_t(256.f * (1.f - smoothed_progress));

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -65,12 +65,21 @@ void AddressableLightTransformer::start() {
   // at low values (e.g. gamma 2.8 pre-gamma values <27 round to stored 0, freezing progress).
   this->uniform_start_color_.reset();
   if (this->light_.size() > 0) {
-    Color first = this->light_[0].get();
+    // Compare raw (post-gamma) bytes across LEDs for uniformity. This avoids N calls to the
+    // gamma-uncorrecting get_red/green/blue/white accessors, which would otherwise discourage
+    // the compiler from inlining them inside the apply() fallback path.
+    auto first = this->light_[0];
+    uint8_t r_raw = first.get_red_raw();
+    uint8_t g_raw = first.get_green_raw();
+    uint8_t b_raw = first.get_blue_raw();
+    uint8_t w_raw = first.get_white_raw();
     for (int32_t i = 1; i < this->light_.size(); i++) {
-      if (this->light_[i].get() != first)
+      auto view = this->light_[i];
+      if (view.get_red_raw() != r_raw || view.get_green_raw() != g_raw || view.get_blue_raw() != b_raw ||
+          view.get_white_raw() != w_raw)
         return;
     }
-    this->uniform_start_color_ = first;
+    this->uniform_start_color_ = first.get();
   }
 }
 

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -65,21 +65,12 @@ void AddressableLightTransformer::start() {
   // at low values (e.g. gamma 2.8 pre-gamma values <27 round to stored 0, freezing progress).
   this->uniform_start_color_.reset();
   if (this->light_.size() > 0) {
-    // Compare raw (post-gamma) bytes across LEDs for uniformity. This avoids N calls to the
-    // gamma-uncorrecting get_red/green/blue/white accessors, which would otherwise discourage
-    // the compiler from inlining them inside the apply() fallback path.
-    auto first = this->light_[0];
-    uint8_t r_raw = first.get_red_raw();
-    uint8_t g_raw = first.get_green_raw();
-    uint8_t b_raw = first.get_blue_raw();
-    uint8_t w_raw = first.get_white_raw();
+    Color first = this->light_[0].get();
     for (int32_t i = 1; i < this->light_.size(); i++) {
-      auto view = this->light_[i];
-      if (view.get_red_raw() != r_raw || view.get_green_raw() != g_raw || view.get_blue_raw() != b_raw ||
-          view.get_white_raw() != w_raw)
+      if (this->light_[i].get() != first)
         return;
     }
-    this->uniform_start_color_ = first.get();
+    this->uniform_start_color_ = first;
   }
 }
 

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -58,6 +58,26 @@ void AddressableLightTransformer::start() {
   // our transition will handle brightness, disable brightness in correction.
   this->light_.correction_.set_local_brightness(255);
   this->target_color_ *= to_uint8_scale(end_values.get_brightness() * end_values.get_state());
+
+  // When every LED starts at the same color (the common case: plain turn_on/turn_off on a uniform
+  // strip), interpolate math-only against a single start color. Avoiding the per-step read-back
+  // through the 8-bit stored byte prevents gamma round-trip quantization from stalling the fade
+  // at low values (e.g. gamma 2.8 pre-gamma values <27 round to stored 0, freezing progress).
+  this->uniform_start_ = false;
+  if (this->light_.size() > 0) {
+    Color first = this->light_[0].get();
+    bool uniform = true;
+    for (int32_t i = 1; i < this->light_.size(); i++) {
+      if (this->light_[i].get() != first) {
+        uniform = false;
+        break;
+      }
+    }
+    if (uniform) {
+      this->uniform_start_ = true;
+      this->start_color_ = first;
+    }
+  }
 }
 
 inline constexpr uint8_t subtract_scaled_difference(uint8_t a, uint8_t b, int32_t scale) {
@@ -97,12 +117,28 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   // non-linear when applying small deltas.
 
   if (smoothed_progress > this->last_transition_progress_ && this->last_transition_progress_ < 1.f) {
-    int32_t scale = int32_t(256.f * std::max((1.f - smoothed_progress) / (1.f - this->last_transition_progress_), 0.f));
-    for (auto led : this->light_) {
-      led.set_rgbw(subtract_scaled_difference(this->target_color_.red, led.get_red(), scale),
-                   subtract_scaled_difference(this->target_color_.green, led.get_green(), scale),
-                   subtract_scaled_difference(this->target_color_.blue, led.get_blue(), scale),
-                   subtract_scaled_difference(this->target_color_.white, led.get_white(), scale));
+    if (this->uniform_start_) {
+      // All LEDs started at the same color: compute the interpolated value once and write it to
+      // every LED. No read-back, so each LED's stored byte advances through every gamma threshold
+      // as smoothed_progress crosses it, instead of stalling at 0 for low pre-gamma values.
+      // lerp(start, target, progress) via existing helper: target - (target-start)*(1-progress).
+      int32_t remaining = int32_t(256.f * (1.f - smoothed_progress));
+      uint8_t r = subtract_scaled_difference(this->target_color_.red, this->start_color_.red, remaining);
+      uint8_t g = subtract_scaled_difference(this->target_color_.green, this->start_color_.green, remaining);
+      uint8_t b = subtract_scaled_difference(this->target_color_.blue, this->start_color_.blue, remaining);
+      uint8_t w = subtract_scaled_difference(this->target_color_.white, this->start_color_.white, remaining);
+      for (auto led : this->light_) {
+        led.set_rgbw(r, g, b, w);
+      }
+    } else {
+      int32_t scale =
+          int32_t(256.f * std::max((1.f - smoothed_progress) / (1.f - this->last_transition_progress_), 0.f));
+      for (auto led : this->light_) {
+        led.set_rgbw(subtract_scaled_difference(this->target_color_.red, led.get_red(), scale),
+                     subtract_scaled_difference(this->target_color_.green, led.get_green(), scale),
+                     subtract_scaled_difference(this->target_color_.blue, led.get_blue(), scale),
+                     subtract_scaled_difference(this->target_color_.white, led.get_white(), scale));
+      }
     }
     this->last_transition_progress_ = smoothed_progress;
     this->light_.schedule_show();

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -59,23 +59,11 @@ void AddressableLightTransformer::start() {
   this->light_.correction_.set_local_brightness(255);
   this->target_color_ *= to_uint8_scale(end_values.get_brightness() * end_values.get_state());
 
-  // When every LED starts at the same color (the common case: plain turn_on/turn_off on a uniform
-  // strip), interpolate math-only against a single start color. Avoiding the per-step read-back
-  // through the 8-bit stored byte prevents gamma round-trip quantization from stalling the fade
-  // at low values (e.g. gamma 2.8 pre-gamma values <27 round to stored 0, freezing progress).
-  this->uniform_start_color_.reset();
-  if (this->light_.size() > 0) {
-    Color first = this->light_[0].get();
-    bool uniform = true;
-    for (int32_t i = 1; i < this->light_.size(); i++) {
-      if (this->light_[i].get() != first) {
-        uniform = false;
-        break;
-      }
-    }
-    if (uniform)
-      this->uniform_start_color_ = first;
-  }
+  // Uniformity scan is deferred to the first apply() call. start() can run before the underlying
+  // LED output's setup() has allocated its frame buffer (e.g. on_boot at priority > HARDWARE
+  // triggering a transition), and reading through ESPColorView would deref a null buffer.
+  this->uniform_start_scanned_ = false;
+  this->uniform_start_is_uniform_ = false;
 }
 
 inline constexpr uint8_t subtract_scaled_difference(uint8_t a, uint8_t b, int32_t scale) {
@@ -115,7 +103,30 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   // non-linear when applying small deltas.
 
   if (smoothed_progress > this->last_transition_progress_ && this->last_transition_progress_ < 1.f) {
-    if (this->uniform_start_color_.has_value()) {
+    // Lazy uniformity scan: deferred from start() so the LED output's setup() has run and the
+    // frame buffer is valid. When every LED already has the same color (the common case: plain
+    // turn_on/turn_off on a uniform strip), interpolate math-only against a single start color.
+    // Avoiding the per-step read-back through the 8-bit stored byte prevents gamma round-trip
+    // quantization from stalling the fade at low values (e.g. gamma 2.8 pre-gamma values <27
+    // round to stored 0, freezing progress).
+    if (!this->uniform_start_scanned_) {
+      this->uniform_start_scanned_ = true;
+      if (this->light_.size() > 0) {
+        Color first = this->light_[0].get();
+        bool uniform = true;
+        for (int32_t i = 1; i < this->light_.size(); i++) {
+          if (this->light_[i].get() != first) {
+            uniform = false;
+            break;
+          }
+        }
+        if (uniform) {
+          this->uniform_start_color_ = first;
+          this->uniform_start_is_uniform_ = true;
+        }
+      }
+    }
+    if (this->uniform_start_is_uniform_) {
       // All LEDs started at the same color: compute the interpolated value once and write it to
       // every LED. No read-back, so each LED's stored byte advances through every gamma threshold
       // as smoothed_progress crosses it, instead of stalling at 0 for low pre-gamma values.
@@ -125,7 +136,7 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
       // via its read-back. Concurrent per-LED mutation during a transition isn't a pattern we
       // support, so this is acceptable.
       // lerp(start, target, progress) via existing helper: target - (target-start)*(1-progress).
-      const Color &start = *this->uniform_start_color_;
+      const Color &start = this->uniform_start_color_;
       int32_t remaining = int32_t(256.f * (1.f - smoothed_progress));
       uint8_t r = subtract_scaled_difference(this->target_color_.red, start.red, remaining);
       uint8_t g = subtract_scaled_difference(this->target_color_.green, start.green, remaining);

--- a/esphome/components/light/addressable_light.cpp
+++ b/esphome/components/light/addressable_light.cpp
@@ -63,20 +63,14 @@ void AddressableLightTransformer::start() {
   // strip), interpolate math-only against a single start color. Avoiding the per-step read-back
   // through the 8-bit stored byte prevents gamma round-trip quantization from stalling the fade
   // at low values (e.g. gamma 2.8 pre-gamma values <27 round to stored 0, freezing progress).
-  this->uniform_start_ = false;
+  this->uniform_start_color_.reset();
   if (this->light_.size() > 0) {
     Color first = this->light_[0].get();
-    bool uniform = true;
     for (int32_t i = 1; i < this->light_.size(); i++) {
-      if (this->light_[i].get() != first) {
-        uniform = false;
-        break;
-      }
+      if (this->light_[i].get() != first)
+        return;
     }
-    if (uniform) {
-      this->uniform_start_ = true;
-      this->start_color_ = first;
-    }
+    this->uniform_start_color_ = first;
   }
 }
 
@@ -117,16 +111,17 @@ optional<LightColorValues> AddressableLightTransformer::apply() {
   // non-linear when applying small deltas.
 
   if (smoothed_progress > this->last_transition_progress_ && this->last_transition_progress_ < 1.f) {
-    if (this->uniform_start_) {
+    if (this->uniform_start_color_.has_value()) {
       // All LEDs started at the same color: compute the interpolated value once and write it to
       // every LED. No read-back, so each LED's stored byte advances through every gamma threshold
       // as smoothed_progress crosses it, instead of stalling at 0 for low pre-gamma values.
       // lerp(start, target, progress) via existing helper: target - (target-start)*(1-progress).
+      const Color &start = *this->uniform_start_color_;
       int32_t remaining = int32_t(256.f * (1.f - smoothed_progress));
-      uint8_t r = subtract_scaled_difference(this->target_color_.red, this->start_color_.red, remaining);
-      uint8_t g = subtract_scaled_difference(this->target_color_.green, this->start_color_.green, remaining);
-      uint8_t b = subtract_scaled_difference(this->target_color_.blue, this->start_color_.blue, remaining);
-      uint8_t w = subtract_scaled_difference(this->target_color_.white, this->start_color_.white, remaining);
+      uint8_t r = subtract_scaled_difference(this->target_color_.red, start.red, remaining);
+      uint8_t g = subtract_scaled_difference(this->target_color_.green, start.green, remaining);
+      uint8_t b = subtract_scaled_difference(this->target_color_.blue, start.blue, remaining);
+      uint8_t w = subtract_scaled_difference(this->target_color_.white, start.white, remaining);
       for (auto led : this->light_) {
         led.set_rgbw(r, g, b, w);
       }

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -115,6 +115,8 @@ class AddressableLightTransformer : public LightTransformer {
   AddressableLight &light_;
   float last_transition_progress_{0.0f};
   Color target_color_{};
+  Color start_color_{};
+  bool uniform_start_{false};
 };
 
 }  // namespace esphome::light

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -115,8 +115,7 @@ class AddressableLightTransformer : public LightTransformer {
   AddressableLight &light_;
   float last_transition_progress_{0.0f};
   Color target_color_{};
-  Color start_color_{};
-  bool uniform_start_{false};
+  optional<Color> uniform_start_color_{};
 };
 
 }  // namespace esphome::light

--- a/esphome/components/light/addressable_light.h
+++ b/esphome/components/light/addressable_light.h
@@ -115,7 +115,9 @@ class AddressableLightTransformer : public LightTransformer {
   AddressableLight &light_;
   float last_transition_progress_{0.0f};
   Color target_color_{};
-  optional<Color> uniform_start_color_{};
+  Color uniform_start_color_{};
+  bool uniform_start_scanned_{false};
+  bool uniform_start_is_uniform_{false};
 };
 
 }  // namespace esphome::light

--- a/tests/integration/fixtures/addressable_light_transition.yaml
+++ b/tests/integration/fixtures/addressable_light_transition.yaml
@@ -1,0 +1,29 @@
+esphome:
+  name: addr-light-transition
+host:
+api:
+logger:
+  level: DEBUG
+
+external_components:
+  - source:
+      type: local
+      path: EXTERNAL_COMPONENT_PATH
+
+light:
+  - platform: mock_addressable_light
+    output_id: strip_output
+    id: strip
+    name: "Test Strip"
+    num_leds: 4
+    gamma_correct: 2.8
+    default_transition_length: 0s
+
+sensor:
+  - platform: template
+    name: "led0_red_raw"
+    id: led0_red_raw
+    update_interval: 10ms
+    accuracy_decimals: 0
+    lambda: |-
+      return (float) id(strip_output).get_raw_red(0);

--- a/tests/integration/fixtures/external_components/mock_addressable_light/__init__.py
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/__init__.py
@@ -1,0 +1,1 @@
+CODEOWNERS = ["@esphome/tests"]

--- a/tests/integration/fixtures/external_components/mock_addressable_light/light.py
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/light.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import light
 import esphome.config_validation as cv
 from esphome.const import CONF_NUM_LEDS, CONF_OUTPUT_ID
+from esphome.types import ConfigType
 
 mock_addressable_light_ns = cg.esphome_ns.namespace("mock_addressable_light")
 MockAddressableLight = mock_addressable_light_ns.class_(
@@ -16,7 +17,7 @@ CONFIG_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_OUTPUT_ID], config[CONF_NUM_LEDS])
     await light.register_light(var, config)
     await cg.register_component(var, config)

--- a/tests/integration/fixtures/external_components/mock_addressable_light/light.py
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/light.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+from esphome.components import light
+import esphome.config_validation as cv
+from esphome.const import CONF_NUM_LEDS, CONF_OUTPUT_ID
+
+mock_addressable_light_ns = cg.esphome_ns.namespace("mock_addressable_light")
+MockAddressableLight = mock_addressable_light_ns.class_(
+    "MockAddressableLight", light.AddressableLight
+)
+
+CONFIG_SCHEMA = light.ADDRESSABLE_LIGHT_SCHEMA.extend(
+    {
+        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(MockAddressableLight),
+        cv.Optional(CONF_NUM_LEDS, default=4): cv.positive_not_null_int,
+    }
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_OUTPUT_ID], config[CONF_NUM_LEDS])
+    await light.register_light(var, config)
+    await cg.register_component(var, config)

--- a/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
 #include "esphome/components/light/addressable_light.h"
 #include "esphome/core/component.h"
 

--- a/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
+++ b/tests/integration/fixtures/external_components/mock_addressable_light/mock_addressable_light.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "esphome/components/light/addressable_light.h"
+#include "esphome/core/component.h"
+
+namespace esphome::mock_addressable_light {
+
+// In-memory addressable light for host-mode integration tests. Exposes the raw
+// per-LED byte buffer (post-gamma-correction, as the hardware would see it)
+// so tests can observe transition behavior without real hardware.
+class MockAddressableLight : public light::AddressableLight {
+ public:
+  explicit MockAddressableLight(uint16_t num_leds)
+      : num_leds_(num_leds), buf_(new uint8_t[num_leds * 4]()), effect_data_(new uint8_t[num_leds]()) {}
+
+  void setup() override {}
+  void write_state(light::LightState *state) override {}
+  int32_t size() const override { return this->num_leds_; }
+  void clear_effect_data() override {
+    for (uint16_t i = 0; i < this->num_leds_; i++)
+      this->effect_data_[i] = 0;
+  }
+  light::LightTraits get_traits() override {
+    auto traits = light::LightTraits();
+    traits.set_supported_color_modes({light::ColorMode::RGB});
+    return traits;
+  }
+
+  // Accessors for tests: return the raw stored byte (post gamma correction),
+  // which is what actual LED hardware would receive.
+  uint8_t get_raw_red(uint16_t index) const { return this->buf_[index * 4 + 0]; }
+  uint8_t get_raw_green(uint16_t index) const { return this->buf_[index * 4 + 1]; }
+  uint8_t get_raw_blue(uint16_t index) const { return this->buf_[index * 4 + 2]; }
+  uint8_t get_raw_white(uint16_t index) const { return this->buf_[index * 4 + 3]; }
+
+ protected:
+  light::ESPColorView get_view_internal(int32_t index) const override {
+    size_t pos = index * 4;
+    return {this->buf_.get() + pos + 0, this->buf_.get() + pos + 1,       this->buf_.get() + pos + 2,
+            this->buf_.get() + pos + 3, this->effect_data_.get() + index, &this->correction_};
+  }
+
+  uint16_t num_leds_;
+  std::unique_ptr<uint8_t[]> buf_;
+  std::unique_ptr<uint8_t[]> effect_data_;
+};
+
+}  // namespace esphome::mock_addressable_light

--- a/tests/integration/test_addressable_light_transition.py
+++ b/tests/integration/test_addressable_light_transition.py
@@ -20,9 +20,10 @@ from __future__ import annotations
 
 import asyncio
 
-from aioesphomeapi import SensorState
+from aioesphomeapi import LightInfo, SensorInfo, SensorState
 import pytest
 
+from .state_utils import InitialStateHelper, require_entity
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -35,8 +36,8 @@ async def test_addressable_light_transition(
     """With gamma 2.8, the stored raw byte must rise visibly well before the end."""
     async with run_compiled(yaml_config), api_client_connected() as client:
         entities, _ = await client.list_entities_services()
-        light = next(e for e in entities if e.object_id == "test_strip")
-        sensor = next(e for e in entities if e.object_id == "led0_red_raw")
+        light = require_entity(entities, "test_strip", LightInfo)
+        sensor = require_entity(entities, "led0_red_raw", SensorInfo)
 
         # Track the raw-byte sensor. It polls every 10ms in the fixture, and
         # ESPHome sensors publish on every change, so we collect a time series.
@@ -55,10 +56,11 @@ async def test_addressable_light_transition(
             origin = command_time if command_time is not None else now
             samples.append((now - origin, state.state))
 
-        client.subscribe_states(on_state)
-
-        # Give the first poll a chance to land so we have a baseline of 0.
-        await asyncio.sleep(0.1)
+        # InitialStateHelper swallows the first state ESPHome sends per entity
+        # on subscribe, so on_state only sees real post-subscribe updates.
+        initial_state_helper = InitialStateHelper(entities)
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        await initial_state_helper.wait_for_initial_states()
 
         # Start transition: off -> full white over 1 second. This is the
         # scenario from the bug report, compressed in time.

--- a/tests/integration/test_addressable_light_transition.py
+++ b/tests/integration/test_addressable_light_transition.py
@@ -1,0 +1,119 @@
+"""Integration test for addressable light transitions with gamma correction.
+
+Regression test for a bug where a long turn-on transition on an addressable
+light with gamma correction (e.g. gamma_correct: 2.8) produced no visible
+output for ~90% of the transition duration, then jumped to the target in the
+final ~10%. Root cause: the transition algorithm read each LED's current value
+back through the 8-bit stored byte every step; at gamma 2.8 any pre-gamma value
+below ~27 rounds to stored byte 0, so the stored byte stalled at 0 until
+progress was high enough for a single step to produce a large-enough pre-gamma
+value to clear the gamma threshold.
+
+The fix interpolates against a cached start color when all LEDs started at the
+same value (the common case for plain turn_on/turn_off), avoiding the round-trip.
+
+This test uses a host-only mock addressable light that exposes the raw stored
+byte of each LED, so we can observe the transition directly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import SensorState
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_addressable_light_transition(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """With gamma 2.8, the stored raw byte must rise visibly well before the end."""
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        entities, _ = await client.list_entities_services()
+        light = next(e for e in entities if e.object_id == "test_strip")
+        sensor = next(e for e in entities if e.object_id == "led0_red_raw")
+
+        # Track the raw-byte sensor. It polls every 10ms in the fixture, and
+        # ESPHome sensors publish on every change, so we collect a time series.
+        loop = asyncio.get_event_loop()
+        samples: list[tuple[float, float]] = []
+        start_time: float | None = None
+
+        def on_state(state: object) -> None:
+            nonlocal start_time
+            if not isinstance(state, SensorState) or state.key != sensor.key:
+                return
+            now = loop.time()
+            if start_time is None:
+                start_time = now
+            samples.append((now - start_time, state.state))
+
+        client.subscribe_states(on_state)
+
+        # Give the first poll a chance to land so we have a baseline of 0.
+        await asyncio.sleep(0.1)
+
+        # Start transition: off -> full white over 1 second. This is the
+        # scenario from the bug report, compressed in time.
+        transition_s = 1.0
+        client.light_command(
+            key=light.key,
+            state=True,
+            rgb=(1.0, 1.0, 1.0),
+            brightness=1.0,
+            transition_length=transition_s,
+        )
+
+        # Let the full transition run, plus margin for the final sample.
+        await asyncio.sleep(transition_s + 0.2)
+
+        # Partition samples by transition progress. We reset the time origin
+        # at the moment the first post-command sample arrives, since there is
+        # some latency between issuing the command and the sensor observing
+        # the transition begin.
+        assert samples, "no sensor samples received"
+
+        # Find first sample where the transition started producing nonzero
+        # output (or fall back to the first sample).
+        first_nonzero_idx = next((i for i, (_, v) in enumerate(samples) if v > 0), None)
+        assert first_nonzero_idx is not None, (
+            "raw byte never rose above 0 during the transition — the fade stalled"
+        )
+
+        t0 = samples[first_nonzero_idx][0]
+        # Collect samples from the first nonzero point onward, re-based to t=0.
+        rel = [(t - t0, v) for (t, v) in samples[first_nonzero_idx:]]
+
+        # Assertion 1: the transition is not stalled. With the bug, the raw
+        # byte stays at 0 until ~90% of the transition duration. With the fix,
+        # it becomes nonzero in the first ~30% (for gamma 2.8, pre-gamma 76
+        # clears the gamma threshold at progress ~0.30). We assert that the
+        # first nonzero sample arrives well before 70% of the transition,
+        # giving generous slack for scheduling jitter.
+        first_nonzero_time = samples[first_nonzero_idx][0] - samples[0][0]
+        assert first_nonzero_time < transition_s * 0.7, (
+            f"raw byte only rose above 0 at t={first_nonzero_time:.3f}s "
+            f"(>{transition_s * 0.7:.3f}s) — transition is stalling"
+        )
+
+        # Assertion 2: by the time the transition has had 70% of its duration
+        # to run from its first visible step, the raw byte should be at least
+        # ~half of its final value. This catches "barely moves then jumps at
+        # the end" regressions.
+        late_samples = [v for (t, v) in rel if t >= transition_s * 0.7]
+        assert late_samples, "no samples captured late in transition"
+        assert max(late_samples) >= 100, (
+            f"raw byte peaked at only {max(late_samples)} late in transition "
+            "(expected >= 100 for white target at gamma 2.8)"
+        )
+
+        # Assertion 3: final value reaches target. Gamma 2.8 of 255 is 255.
+        final_samples = [v for (_, v) in samples[-5:]]
+        assert max(final_samples) >= 250, (
+            f"final raw byte was {max(final_samples)}, expected >= 250"
+        )

--- a/tests/integration/test_addressable_light_transition.py
+++ b/tests/integration/test_addressable_light_transition.py
@@ -40,18 +40,20 @@ async def test_addressable_light_transition(
 
         # Track the raw-byte sensor. It polls every 10ms in the fixture, and
         # ESPHome sensors publish on every change, so we collect a time series.
-        loop = asyncio.get_event_loop()
+        # Samples are stored as (seconds_since_command_issue, value). Times
+        # before the command was issued are negative.
+        loop = asyncio.get_running_loop()
         samples: list[tuple[float, float]] = []
-        start_time: float | None = None
+        command_time: float | None = None
 
         def on_state(state: object) -> None:
-            nonlocal start_time
             if not isinstance(state, SensorState) or state.key != sensor.key:
                 return
             now = loop.time()
-            if start_time is None:
-                start_time = now
-            samples.append((now - start_time, state.state))
+            # If the command hasn't been issued yet, use 0 as the origin;
+            # those samples get negative times and are excluded below.
+            origin = command_time if command_time is not None else now
+            samples.append((now - origin, state.state))
 
         client.subscribe_states(on_state)
 
@@ -61,6 +63,7 @@ async def test_addressable_light_transition(
         # Start transition: off -> full white over 1 second. This is the
         # scenario from the bug report, compressed in time.
         transition_s = 1.0
+        command_time = loop.time()
         client.light_command(
             key=light.key,
             state=True,
@@ -72,48 +75,38 @@ async def test_addressable_light_transition(
         # Let the full transition run, plus margin for the final sample.
         await asyncio.sleep(transition_s + 0.2)
 
-        # Partition samples by transition progress. We reset the time origin
-        # at the moment the first post-command sample arrives, since there is
-        # some latency between issuing the command and the sensor observing
-        # the transition begin.
-        assert samples, "no sensor samples received"
-
-        # Find first sample where the transition started producing nonzero
-        # output (or fall back to the first sample).
-        first_nonzero_idx = next((i for i, (_, v) in enumerate(samples) if v > 0), None)
-        assert first_nonzero_idx is not None, (
-            "raw byte never rose above 0 during the transition — the fade stalled"
-        )
-
-        t0 = samples[first_nonzero_idx][0]
-        # Collect samples from the first nonzero point onward, re-based to t=0.
-        rel = [(t - t0, v) for (t, v) in samples[first_nonzero_idx:]]
+        # Only look at samples that arrived after the command was issued.
+        post_command = [(t, v) for (t, v) in samples if t >= 0]
+        assert post_command, "no sensor samples received after command was issued"
 
         # Assertion 1: the transition is not stalled. With the bug, the raw
         # byte stays at 0 until ~90% of the transition duration. With the fix,
         # it becomes nonzero in the first ~30% (for gamma 2.8, pre-gamma 76
-        # clears the gamma threshold at progress ~0.30). We assert that the
-        # first nonzero sample arrives well before 70% of the transition,
-        # giving generous slack for scheduling jitter.
-        first_nonzero_time = samples[first_nonzero_idx][0] - samples[0][0]
-        assert first_nonzero_time < transition_s * 0.7, (
-            f"raw byte only rose above 0 at t={first_nonzero_time:.3f}s "
-            f"(>{transition_s * 0.7:.3f}s) — transition is stalling"
+        # clears the gamma threshold at progress ~0.30). Require the first
+        # nonzero sample to land well before 70% of the transition duration,
+        # measured from the command-issue time.
+        first_nonzero = next(((t, v) for (t, v) in post_command if v > 0), None)
+        assert first_nonzero is not None, (
+            "raw byte never rose above 0 during the transition — the fade stalled"
+        )
+        assert first_nonzero[0] < transition_s * 0.7, (
+            f"raw byte only rose above 0 at t={first_nonzero[0]:.3f}s "
+            f"(>{transition_s * 0.7:.3f}s after command) — transition is stalling"
         )
 
-        # Assertion 2: by the time the transition has had 70% of its duration
-        # to run from its first visible step, the raw byte should be at least
-        # ~half of its final value. This catches "barely moves then jumps at
-        # the end" regressions.
-        late_samples = [v for (t, v) in rel if t >= transition_s * 0.7]
+        # Assertion 2: by 70% of the transition duration after the command,
+        # the raw byte should have reached a substantial fraction of its final
+        # value. This catches "barely moves then jumps at the end" regressions
+        # that pass assertion 1 but still stall most of the range.
+        late_samples = [v for (t, v) in post_command if t >= transition_s * 0.7]
         assert late_samples, "no samples captured late in transition"
         assert max(late_samples) >= 100, (
-            f"raw byte peaked at only {max(late_samples)} late in transition "
-            "(expected >= 100 for white target at gamma 2.8)"
+            f"raw byte peaked at only {max(late_samples)} at/after 70% of "
+            "transition (expected >= 100 for white target at gamma 2.8)"
         )
 
         # Assertion 3: final value reaches target. Gamma 2.8 of 255 is 255.
-        final_samples = [v for (_, v) in samples[-5:]]
+        final_samples = [v for (_, v) in post_command[-5:]]
         assert max(final_samples) >= 250, (
             f"final raw byte was {max(final_samples)}, expected >= 250"
         )

--- a/tests/integration/test_addressable_light_transition.py
+++ b/tests/integration/test_addressable_light_transition.py
@@ -41,20 +41,16 @@ async def test_addressable_light_transition(
 
         # Track the raw-byte sensor. It polls every 10ms in the fixture, and
         # ESPHome sensors publish on every change, so we collect a time series.
-        # Samples are stored as (seconds_since_command_issue, value). Times
-        # before the command was issued are negative.
+        # Samples are stored as absolute (loop_time, value); we rebase to the
+        # command-issue time after the run so pre-command samples are strictly
+        # negative and reliably excluded.
         loop = asyncio.get_running_loop()
         samples: list[tuple[float, float]] = []
-        command_time: float | None = None
 
         def on_state(state: object) -> None:
             if not isinstance(state, SensorState) or state.key != sensor.key:
                 return
-            now = loop.time()
-            # If the command hasn't been issued yet, use 0 as the origin;
-            # those samples get negative times and are excluded below.
-            origin = command_time if command_time is not None else now
-            samples.append((now - origin, state.state))
+            samples.append((loop.time(), state.state))
 
         # InitialStateHelper swallows the first state ESPHome sends per entity
         # on subscribe, so on_state only sees real post-subscribe updates.
@@ -77,33 +73,42 @@ async def test_addressable_light_transition(
         # Let the full transition run, plus margin for the final sample.
         await asyncio.sleep(transition_s + 0.2)
 
-        # Only look at samples that arrived after the command was issued.
-        post_command = [(t, v) for (t, v) in samples if t >= 0]
+        # Rebase to command-issue time. Pre-command samples have t < 0 and are
+        # excluded; everything else is in seconds since the command was issued.
+        post_command = [
+            (t - command_time, v) for (t, v) in samples if t >= command_time
+        ]
         assert post_command, "no sensor samples received after command was issued"
 
         # Assertion 1: the transition is not stalled. With the bug, the raw
         # byte stays at 0 until ~90% of the transition duration. With the fix,
         # it becomes nonzero in the first ~30% (for gamma 2.8, pre-gamma 76
         # clears the gamma threshold at progress ~0.30). Require the first
-        # nonzero sample to land well before 70% of the transition duration,
-        # measured from the command-issue time.
+        # nonzero sample to land well before 50% of the transition duration,
+        # measured from the command-issue time. The 50% bound (rather than
+        # 70%) leaves headroom for assertion 2's mid-window check.
         first_nonzero = next(((t, v) for (t, v) in post_command if v > 0), None)
         assert first_nonzero is not None, (
             "raw byte never rose above 0 during the transition — the fade stalled"
         )
-        assert first_nonzero[0] < transition_s * 0.7, (
+        assert first_nonzero[0] < transition_s * 0.5, (
             f"raw byte only rose above 0 at t={first_nonzero[0]:.3f}s "
-            f"(>{transition_s * 0.7:.3f}s after command) — transition is stalling"
+            f"(>{transition_s * 0.5:.3f}s after command) — transition is stalling"
         )
 
-        # Assertion 2: by 70% of the transition duration after the command,
-        # the raw byte should have reached a substantial fraction of its final
-        # value. This catches "barely moves then jumps at the end" regressions
-        # that pass assertion 1 but still stall most of the range.
-        late_samples = [v for (t, v) in post_command if t >= transition_s * 0.7]
-        assert late_samples, "no samples captured late in transition"
-        assert max(late_samples) >= 100, (
-            f"raw byte peaked at only {max(late_samples)} at/after 70% of "
+        # Assertion 2: by mid-late transition, the raw byte should have reached
+        # a substantial fraction of its final value. Bound the window to
+        # [50%, 90%] of the transition so the post-transition settled value
+        # (which always reaches 255) can't satisfy this assertion — that would
+        # let "stays at 0 then jumps at 99%" regressions slip through.
+        mid_window = [
+            v
+            for (t, v) in post_command
+            if transition_s * 0.5 <= t <= transition_s * 0.9
+        ]
+        assert mid_window, "no samples captured in mid-transition window"
+        assert max(mid_window) >= 100, (
+            f"raw byte peaked at only {max(mid_window)} between 50%–90% of "
             "transition (expected >= 100 for white target at gamma 2.8)"
         )
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a long-standing bug where a turn-on transition on an addressable light with gamma correction (e.g. `gamma_correct: 2.8`) produced no visible output for ~90% of the transition duration and then jumped to the target in the final ~10%. Fade-down had the same root cause (visible as jitter).

## Why this happens — the gamma 2.8 "dead zone"

Addressable hardware (WS2812 et al.) is 8-bit per channel. Gamma correction maps a pre-gamma byte `v` to a stored/wire byte `round((v/255)^2.8 * 255)`. At gamma 2.8 the low end compresses *hard*:

```
pre-gamma byte   :  0   5  10  15  20  25  27  28  30  40  50  60  76 100 128 200 255
stored (on wire) :  0   0   0   0   0   0   0   1   1   1   3   4   9  19  37 129 255
                    └─────────── any pre ≤ 27 rounds to stored 0 ───────────┘
```

So the first ~11% of the pre-gamma input range produces zero visible light. A correctly-shaped fade still has to *pass through* this range monotonically — i.e. on a 1 s transition you'd spend ~300 ms at pre-gamma values that correctly produce stored 0–3.

## Root cause of the bug

`AddressableLightTransformer::apply()` sourced the delta from each LED's current value on every step via `led.get_red()` etc. That read round-tripped through gamma-uncorrect → 8-bit stored byte → gamma-correct. Any pre-gamma value below ~27 rounded to stored `0`, so early-transition steps wrote `0` to the LED, the next step read `0` back, produced another small delta (which also rounded to `0`), and progress **stalled** in the dead zone. The stored byte only started moving once a single step produced a pre-gamma value large enough to clear the gamma threshold — around ~90% of the way through. Not a perceptual issue with the curve; an algorithmic one that traps the feedback loop at 0.

Verified trace on a 1 s off→full-white transition at gamma 2.8:

```
time %:      0   10   20   30   40   50   60   70   80   90   100
buggy:       0    0    0    0    0    0    0    0    0    4  255   ← stuck at 0, then jumps
fixed:       0    4   20   58  100  127  160  193  220  247  255   ← traces the gamma curve
```

## Fix — scoped to the uniform-start case

Detect whether every LED already has the same color — the common case for plain `light.turn_on`/`light.turn_off` on a uniform strip. When uniform, cache the **scalar** start color on the transformer and interpolate math-only against it in `apply()`: compute `lerp(start, target, smoothed_progress)` once and write to all LEDs, with gamma correction applied once on write. No per-step read-back, so the stored byte can advance through each gamma threshold exactly when `smoothed_progress` crosses it — the feedback loop that trapped the old code at 0 is gone.

### Why the uniformity scan is lazy (deferred to first `apply()`)

The scan reads through `light_[i].get()`, which dereferences the LED output's frame buffer. That buffer is allocated in the output component's `setup()` (priority `HARDWARE = 200`). A user can configure `on_boot` at a higher priority (the Athom CO₂ sensor config that surfaced this uses `priority: 800`) which fires `StartupTrigger::setup()` *before* the LED output's `setup()` has run. That trigger can call `light.turn_on`, which constructs an `AddressableLightTransformer` and invokes its `start()` against a still-null `buf_` — a load-access fault on RV32 (ESP32-C3).

Doing the scan in `start()` is therefore unsafe regardless of where the optimization is implemented. By the time `apply()` runs from the main loop, every component's `setup()` has completed and the buffer is valid. The scan is run once, on the first `apply()` step, gated by a `bool` flag — same result as scanning in `start()`, but ordering-safe.

Cost on the transformer is one `Color` (4 B) plus two adjacent `bool`s for the `scanned`/`is_uniform` state, and the transformer itself is heap-allocated only while a transition is running, so **steady-state RAM cost is 0**.

## Non-uniform starts are intentionally not fixed

Non-uniform starts — typically transitioning out of an addressable effect that left LEDs at different colors — continue to use the existing per-LED read-back algorithm and retain the dead-zone stall. This is a **deliberate trade-off, not an oversight**.

A correct fix for the non-uniform case requires caching the per-LED start color so the same math-only approach can be applied without reading back through gamma. That's `sizeof(Color) × num_leds` = 4 bytes per LED, transient but allocated at every transition start: 224 B for a 56-LED strip, 1.2 KB for 300 LEDs, 2 KB for 500. On ESP8266 (and on long strips on any target) that's a concerning transient allocation to pay on every fade — it would fragment the heap over a device's lifetime even though it's freed each time, and it would be paid even for the common uniform case unless we gate it (which is what this PR effectively does, minus the allocation).

The uniform path covers the overwhelming majority of user-visible transitions (plain turn-on/turn-off from HA, automations, schedules). Users hitting a transition mid-effect are a narrow edge case, and the existing behavior there is a pre-existing stall, not a regression introduced by this PR.

If a future contributor wants to address the non-uniform case, the options are:
1. Cache per-LED start colors unconditionally (simple, +4 B/LED RAM per active transition).
2. Cache them only on the first non-uniform transition and hope fragmentation is acceptable.
3. Use a running fractional residual per LED (complex, smaller but still per-LED).

All of them are non-trivial RAM decisions that deserve their own PR and review.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/10965
- fixes https://github.com/esphome/issues/issues/2397

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested via host-mode integration test (`tests/integration/test_addressable_light_transition.py`) which drives the fixed code path directly.

## Example entry for `config.yaml`:

```yaml
light:
  - platform: neopixelbus
    variant: WS2812
    pin: D1
    num_leds: 56
    type: GRB
    gamma_correct: 2.8
    name: "LED Ring"
# light.turn_on with transition: 10 now fades smoothly from the start
# instead of staying dark for ~9s and jumping on in the final 1s.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

New test infrastructure:
  - `tests/integration/fixtures/external_components/mock_addressable_light/` — a host-runnable `AddressableLight` subclass exposing per-LED raw bytes so integration tests can observe transition behavior without real LED hardware. Usable by future addressable-light integration tests as well.
  - `tests/integration/test_addressable_light_transition.py` — drives a 1s off→full-white transition at gamma 2.8 and asserts the raw byte rises well before 70% of the transition duration, reaches at least half the target mid-transition, and lands on target. Verified to fail on the pre-fix code with the expected `transition is stalling` error.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
