### PR TITLE
[light] Deduplicate color_uncorrect channel math via shared helper

### DIFF
--- a/esphome/components/light/esp_color_correction.cpp
+++ b/esphome/components/light/esp_color_correction.cpp
@@ -31,9 +31,11 @@ Color ESPColorCorrection::color_uncorrect(Color color) const {
 uint8_t ESPColorCorrection::color_uncorrect_channel_(uint8_t value, uint8_t max_brightness) const {
   if (max_brightness == 0 || this->local_brightness_ == 0)
     return 0;
-  uint16_t uncorrected = this->gamma_uncorrect_(value) * 255UL;
-  uint16_t res = ((uncorrected / max_brightness) * 255UL) / this->local_brightness_;
-  return (uint8_t) std::min(res, uint16_t(255));
+  // Use 32-bit intermediates: when max_brightness and local_brightness_ are small but non-zero,
+  // (uncorrected / max_brightness) * 255 can exceed 65535 before the std::min(255) clamp runs.
+  uint32_t uncorrected = this->gamma_uncorrect_(value) * 255UL;
+  uint32_t res = ((uncorrected / max_brightness) * 255UL) / this->local_brightness_;
+  return static_cast<uint8_t>(std::min(res, uint32_t(255)));
 }
 
 }  // namespace esphome::light

--- a/esphome/components/light/esp_color_correction.cpp
+++ b/esphome/components/light/esp_color_correction.cpp
@@ -22,4 +22,18 @@ uint8_t ESPColorCorrection::gamma_uncorrect_(uint8_t value) const {
   return (target - a <= b - target) ? lo : lo + 1;
 }
 
+Color ESPColorCorrection::color_uncorrect(Color color) const {
+  // uncorrected = corrected^(1/gamma) / (max_brightness * local_brightness)
+  return Color(this->color_uncorrect_red(color.red), this->color_uncorrect_green(color.green),
+               this->color_uncorrect_blue(color.blue), this->color_uncorrect_white(color.white));
+}
+
+uint8_t ESPColorCorrection::color_uncorrect_channel_(uint8_t value, uint8_t max_brightness) const {
+  if (max_brightness == 0 || this->local_brightness_ == 0)
+    return 0;
+  uint16_t uncorrected = this->gamma_uncorrect_(value) * 255UL;
+  uint16_t res = ((uncorrected / max_brightness) * 255UL) / this->local_brightness_;
+  return (uint8_t) std::min(res, uint16_t(255));
+}
+
 }  // namespace esphome::light

--- a/esphome/components/light/esp_color_correction.h
+++ b/esphome/components/light/esp_color_correction.h
@@ -46,38 +46,18 @@ class ESPColorCorrection {
     uint8_t res = esp_scale8_twice(white, this->max_brightness_.white, this->local_brightness_);
     return this->gamma_correct_(res);
   }
-  inline Color color_uncorrect(Color color) const ESPHOME_ALWAYS_INLINE {
-    // uncorrected = corrected^(1/gamma) / (max_brightness * local_brightness)
-    return Color(this->color_uncorrect_red(color.red), this->color_uncorrect_green(color.green),
-                 this->color_uncorrect_blue(color.blue), this->color_uncorrect_white(color.white));
-  }
+  Color color_uncorrect(Color color) const;
   inline uint8_t color_uncorrect_red(uint8_t red) const ESPHOME_ALWAYS_INLINE {
-    if (this->max_brightness_.red == 0 || this->local_brightness_ == 0)
-      return 0;
-    uint16_t uncorrected = this->gamma_uncorrect_(red) * 255UL;
-    uint16_t res = ((uncorrected / this->max_brightness_.red) * 255UL) / this->local_brightness_;
-    return (uint8_t) std::min(res, uint16_t(255));
+    return this->color_uncorrect_channel_(red, this->max_brightness_.red);
   }
   inline uint8_t color_uncorrect_green(uint8_t green) const ESPHOME_ALWAYS_INLINE {
-    if (this->max_brightness_.green == 0 || this->local_brightness_ == 0)
-      return 0;
-    uint16_t uncorrected = this->gamma_uncorrect_(green) * 255UL;
-    uint16_t res = ((uncorrected / this->max_brightness_.green) * 255UL) / this->local_brightness_;
-    return (uint8_t) std::min(res, uint16_t(255));
+    return this->color_uncorrect_channel_(green, this->max_brightness_.green);
   }
   inline uint8_t color_uncorrect_blue(uint8_t blue) const ESPHOME_ALWAYS_INLINE {
-    if (this->max_brightness_.blue == 0 || this->local_brightness_ == 0)
-      return 0;
-    uint16_t uncorrected = this->gamma_uncorrect_(blue) * 255UL;
-    uint16_t res = ((uncorrected / this->max_brightness_.blue) * 255UL) / this->local_brightness_;
-    return (uint8_t) std::min(res, uint16_t(255));
+    return this->color_uncorrect_channel_(blue, this->max_brightness_.blue);
   }
   inline uint8_t color_uncorrect_white(uint8_t white) const ESPHOME_ALWAYS_INLINE {
-    if (this->max_brightness_.white == 0 || this->local_brightness_ == 0)
-      return 0;
-    uint16_t uncorrected = this->gamma_uncorrect_(white) * 255UL;
-    uint16_t res = ((uncorrected / this->max_brightness_.white) * 255UL) / this->local_brightness_;
-    return (uint8_t) std::min(res, uint16_t(255));
+    return this->color_uncorrect_channel_(white, this->max_brightness_.white);
   }
 
  protected:
@@ -85,6 +65,9 @@ class ESPColorCorrection {
   uint8_t gamma_correct_(uint8_t value) const;
   /// Reverse gamma: binary search the forward PROGMEM table
   uint8_t gamma_uncorrect_(uint8_t value) const;
+  /// Shared body of color_uncorrect_{red,green,blue,white}. Kept out-of-line
+  /// to avoid duplicating two 16-bit divides at every call site.
+  uint8_t color_uncorrect_channel_(uint8_t value, uint8_t max_brightness) const;
 
   const uint16_t *gamma_table_{nullptr};
   Color max_brightness_{255, 255, 255, 255};


### PR DESCRIPTION
# What does this implement/fix?

Collapses the four near-identical `ESPColorCorrection::color_uncorrect_{red,green,blue,white}` bodies into one shared out-of-line helper, `color_uncorrect_channel_(uint8_t value, uint8_t max_brightness)`, and moves the `Color`-wrapping `color_uncorrect()` overload to `.cpp` alongside it. The four public channel methods become trivial `ESPHOME_ALWAYS_INLINE` wrappers that pass the per-channel `max_brightness_` byte into the helper.

## Why

Each of the four channel methods contains the same body: a zero-guard, a call into the out-of-line `gamma_uncorrect_` LUT binary search, a multiply-by-255, a 16-bit divide by `max_brightness_.{channel}`, another multiply-by-255, another 16-bit divide by `local_brightness_`, and a `std::min` clamp. On ESP8266 Xtensa (no fast 16-bit hardware divide), the two 16-bit divides dominate — each function body compiles to ~90 bytes.

All four methods were marked `ESPHOME_ALWAYS_INLINE`, an annotation inherited from the 2019 C++ port (#504) back when gamma was a single `powf()` call and the methods were trivially small. That made sense then. After the 16-bit gamma LUT landed (#14123, Feb 2026), the bodies grew, but the annotation was preserved verbatim through the 2021 file split (#1893) and never revisited. Every addressable effect (`addressable_light_effect.h`: ScanEffect, AddressableTwinkle, FireflyEffect, AddressableColorWipe, etc.), every range op (`esp_range_view.cpp`), and every `AddressableLightTransformer::apply()` step that reads a pixel back through the gamma curve was getting four inlined copies of the heavy math duplicated at every call site.

After this change:
- Exactly **one** copy of the heavy body lives in flash (`color_uncorrect_channel_` in the `.cpp`).
- The four public methods are trivial `ALWAYS_INLINE` wrappers in the header — each compiles to a single tail-call passing the channel's `max_brightness_` byte. Callers get a direct call to the helper with no intermediate jump.
- `color_uncorrect(Color)` moves to the `.cpp` too (it's just a wrapper that builds a `Color` from the four channel results; no need to inline that at every caller).
- The forward `color_correct_*` methods are untouched — they're small (just `esp_scale8_twice` + a PROGMEM read via the already-out-of-line `gamma_correct_`) and keep their `ESPHOME_ALWAYS_INLINE` hint.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to https://github.com/esphome/esphome/pull/15726 (surfaced the symbol duplication when analyzing its memory impact)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing API changes)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Verified locally with host-mode `tests/integration/test_light_calls.py` (all existing light behavior still passes).

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

No new tests — pure refactor with no semantic change. Existing coverage (light integration tests, gamma LUT unit tests) exercises the same code paths.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).