### PR TITLE
[light] Force-inline LightCall::set_flag_/clear_flag_

### DIFF
--- a/esphome/components/light/light_call.h
+++ b/esphome/components/light/light_call.h
@@ -222,7 +222,7 @@ class LightCall {
   inline bool get_save_() { return (this->flags_ & FLAG_SAVE) != 0; }
 
   // Helper to set flag - defaults to true for common case
-  void set_flag_(FieldFlags flag, bool value = true) {
+  void set_flag_(FieldFlags flag, bool value = true) ESPHOME_ALWAYS_INLINE {
     if (value) {
       this->flags_ |= flag;
     } else {
@@ -231,7 +231,7 @@ class LightCall {
   }
 
   // Helper to clear flag - reduces code size for common case
-  void clear_flag_(FieldFlags flag) { this->flags_ &= ~flag; }
+  void clear_flag_(FieldFlags flag) ESPHOME_ALWAYS_INLINE { this->flags_ &= ~flag; }
 
   // Helper to log unsupported feature and clear flag - reduces code duplication
   void log_and_clear_unsupported_(FieldFlags flag, const LogString *feature, bool use_color_mode_log);


### PR DESCRIPTION
# What does this implement/fix?

Force-inline `LightCall::set_flag_()` and `LightCall::clear_flag_()` in `light_call.h`.

Both methods are trivial bit operations on a `uint16_t` — `flags_ |= flag` and `flags_ &= ~flag` respectively — but without `ESPHOME_ALWAYS_INLINE` each call costs a `call0`/`call8` plus the return and register-window rotation, which is strictly more work than the body itself. `LightCall::validate_()` invokes these helpers ~8 times per light command, and `LightCall::transform_parameters_()` adds more, so the call overhead is measurable on the hot path.

A previous attempt at this change (#15402) was closed based on flash-size deltas alone. Reopening because CodSpeed in CI now quantifies the actual runtime effect — which is the metric that matters for this kind of optimization.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing light configs are unaffected.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
