### PR TITLE
[light] Force-inline ColorModeBitPolicy::to_bit

### DIFF
--- a/esphome/components/light/color_mode.h
+++ b/esphome/components/light/color_mode.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include "esphome/core/finite_set_mask.h"
+#include "esphome/core/helpers.h"  // ESPHOME_ALWAYS_INLINE
 
 namespace esphome::light {
 
@@ -128,7 +129,7 @@ struct ColorModeBitPolicy {
   using mask_t = uint16_t;  // 10 bits requires uint16_t
   static constexpr int MAX_BITS = sizeof(COLOR_MODE_LOOKUP) / sizeof(COLOR_MODE_LOOKUP[0]);
 
-  static constexpr unsigned to_bit(ColorMode mode) {
+  static constexpr unsigned ESPHOME_ALWAYS_INLINE to_bit(ColorMode mode) {
     // Linear search through lookup table
     // Compiler optimizes this to efficient code since array is constexpr
     for (int i = 0; i < MAX_BITS; ++i) {


### PR DESCRIPTION
# What does this implement/fix?

Force-inline `ColorModeBitPolicy::to_bit()` in `color_mode.h`.

Although `to_bit` is `constexpr` and defined in the header, the compiler leaves it as a standalone out-of-line function when called with a runtime `ColorMode` argument — on ESP8266 the baseline build produces a 26-byte symbol for it, and every call site pays a `call0`/`call8` plus the return overhead for what is a short linear search over a 10-entry compile-time lookup table.

Marking it `ESPHOME_ALWAYS_INLINE` lets the compiler fold the lookup into each caller (`LightCall::validate_()`, `color_mode_to_human()`, `get_suitable_color_modes_mask_()`, `light_json_schema.cpp`). After the change the `to_bit` symbol disappears from the link output entirely. Flash grows by a few bytes from the per-call-site inlining (+16 B ESP8266, +44 B ESP32-IDF in the isolated light component build); the intent is the runtime win which CodSpeed will measure in CI.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; existing light configs are unaffected.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
