### PR TITLE
[api] Inline LogResponse length varint via max_data_length bound

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -781,7 +781,9 @@ message SubscribeLogsResponse {
   option (speed_optimized) = true;
 
   LogLevel level = 1 [(force) = true];
-  bytes message = 3 [(force) = true];
+  // Bounded by logger tx_buffer_size (capped at 16383 in logger config) so the
+  // length varint is always 1-2 bytes; enables the short/inline encode path.
+  bytes message = 3 [(force) = true, (max_data_length) = 16383];
 }
 
 // ==================== NOISE ENCRYPTION ====================

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -922,7 +922,7 @@ SubscribeLogsResponse::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM)
   uint8_t *__restrict__ pos = buffer.get_pos();
   ProtoEncode::encode_uint32(pos PROTO_ENCODE_DEBUG_ARG, 1, static_cast<uint32_t>(this->level), true);
   ProtoEncode::write_raw_byte(pos PROTO_ENCODE_DEBUG_ARG, 26);
-  ProtoEncode::encode_varint_raw(pos PROTO_ENCODE_DEBUG_ARG, this->message_len_);
+  ProtoEncode::encode_varint_raw_short(pos PROTO_ENCODE_DEBUG_ARG, this->message_len_);
   ProtoEncode::encode_raw(pos PROTO_ENCODE_DEBUG_ARG, this->message_ptr_, this->message_len_);
   return pos;
 }
@@ -931,7 +931,7 @@ uint32_t
 SubscribeLogsResponse::calculate_size() const {
   uint32_t size = 0;
   size += 2;
-  size += ProtoSize::calc_length_force(1, this->message_len_);
+  size += ProtoSize::calc_length_force_short(1, this->message_len_);
   return size;
 }
 #ifdef USE_API_NOISE

--- a/esphome/components/api/proto.h
+++ b/esphome/components/api/proto.h
@@ -823,6 +823,14 @@ class ProtoSize {
   static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_length_force(uint32_t field_id_size, size_t len) {
     return field_id_size + varint(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len);
   }
+  /// Length calc for fields bounded by max_data_length < 16384 (varint is 1-2 bytes).
+  /// Uses varint_short which inlines both cases, avoiding the 3+ byte slow path.
+  static constexpr uint32_t calc_length_short(uint32_t field_id_size, size_t len) {
+    return len ? field_id_size + varint_short(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len) : 0;
+  }
+  static constexpr inline uint32_t ESPHOME_ALWAYS_INLINE calc_length_force_short(uint32_t field_id_size, size_t len) {
+    return field_id_size + varint_short(static_cast<uint32_t>(len)) + static_cast<uint32_t>(len);
+  }
   static constexpr uint32_t calc_sint64(uint32_t field_id_size, int64_t value) {
     return value ? field_id_size + varint(encode_zigzag64(value)) : 0;
   }

--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -231,7 +231,11 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Logger),
             cv.Optional(CONF_BAUD_RATE, default=115200): cv.positive_int,
             cv.Optional(CONF_TX_BUFFER_SIZE, default=512): cv.All(
-                cv.validate_bytes, cv.int_range(min=160, max=65535)
+                # Upper bound of 16383 keeps the SubscribeLogsResponse message
+                # length varint within 2 bytes (see api.proto max_data_length),
+                # enabling a fully-inlined encode path for log messages.
+                cv.validate_bytes,
+                cv.int_range(min=160, max=16383),
             ),
             cv.Optional(CONF_DEASSERT_RTS_DTR, default=False): cv.boolean,
             cv.SplitDefault(

--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -292,12 +292,18 @@ class TypeInfo(ABC):
         tag = self.calculate_tag()
         if tag >= 128:
             return None
-        # When max_len < 128, length varint is always 1 byte
-        len_encode = (
-            f"ProtoEncode::write_raw_byte(pos, static_cast<uint8_t>({len_expr}));"
-            if max_len is not None and max_len < 128
-            else f"ProtoEncode::encode_varint_raw(pos, {len_expr});"
-        )
+        # Choose length-varint writer based on max_len bound:
+        #   < 128    → always 1 byte, direct write
+        #   < 16384  → 1 or 2 bytes, fully-inlined short path
+        #   otherwise → generic varint encoder
+        if max_len is not None and max_len < 128:
+            len_encode = (
+                f"ProtoEncode::write_raw_byte(pos, static_cast<uint8_t>({len_expr}));"
+            )
+        elif max_len is not None and max_len < 16384:
+            len_encode = f"ProtoEncode::encode_varint_raw_short(pos, {len_expr});"
+        else:
+            len_encode = f"ProtoEncode::encode_varint_raw(pos, {len_expr});"
         return (
             f"ProtoEncode::write_raw_byte(pos, {tag});\n"
             f"{len_encode}\n"
@@ -970,7 +976,9 @@ class BytesType(TypeInfo):
     @property
     def encode_content(self) -> str:
         if result := self._encode_bytes_with_precomputed_tag(
-            f"this->{self.field_name}_ptr_", f"this->{self.field_name}_len_"
+            f"this->{self.field_name}_ptr_",
+            f"this->{self.field_name}_len_",
+            max_len=self.max_data_length,
         ):
             return result
         if self.force:
@@ -1028,8 +1036,17 @@ class BytesType(TypeInfo):
         )
 
     def get_size_calculation(self, name: str, force: bool = False) -> str:
+        max_len = self.max_data_length
+        length_field = f"this->{self.field_name}_len_"
+        if max_len is not None and max_len < 128:
+            return self._get_single_byte_varint_size(
+                length_field, force, extra_expr=length_field
+            )
+        if max_len is not None and max_len < 16384:
+            calc_fn = "calc_length_force_short" if force else "calc_length_short"
+            return f"size += ProtoSize::{calc_fn}({self.calculate_field_id_size()}, {length_field});"
         calc_fn = "calc_length_force" if force else "calc_length"
-        return f"size += ProtoSize::{calc_fn}({self.calculate_field_id_size()}, this->{self.field_name}_len_);"
+        return f"size += ProtoSize::{calc_fn}({self.calculate_field_id_size()}, {length_field});"
 
     def get_estimated_size(self) -> int:
         return self.calculate_field_id_size() + 8  # field ID + 8 bytes typical bytes


### PR DESCRIPTION
# What does this implement/fix?

Optimizes the encode/size path for `SubscribeLogsResponse` (a very hot, high-frequency message) by bounding the `message` field length so its varint is always 1–2 bytes, and teaching the codegen to emit the inlined short-varint helpers.

Changes:

- **api.proto**: add `[(max_data_length) = 16383]` to `SubscribeLogsResponse.message`. The field is already `(force) = true`, so the length varint is always emitted.
- **logger `__init__.py`**: cap `tx_buffer_size` max at `16383` (was `65535`). 16383 = `2^14 − 1`, keeping the length varint within 2 bytes. The existing default (512) and min (160) are unchanged.
- **api_protobuf.py codegen**:
  - `_encode_bytes_with_precomputed_tag`: add a 2-byte path — when `128 ≤ max_data_length < 16384`, emit `ProtoEncode::encode_varint_raw_short(...)` (fully inlines the 1- and 2-byte cases) instead of the generic `encode_varint_raw` (which inlines only the 1-byte case and calls a slow path for ≥128).
  - `BytesType.encode_content`: pass `max_data_length` to the precomputed-tag encoder so the bytes message field actually gets the new path.
  - `BytesType.get_size_calculation`: use `calc_length[_force]_short` when `max_data_length < 16384` (and keep the existing `< 128` single-byte specialization). Previously bytes fields never consulted `max_data_length` for size calc.
- **proto.h**: add `ProtoSize::calc_length_short` / `calc_length_force_short`, thin wrappers around `varint_short(...)` so bounded-length fields avoid the 3+ byte varint slow path in the size calc.
- **api_pb2.cpp**: regenerated. Net effect for `SubscribeLogsResponse`:
  ```diff
  -  ProtoEncode::encode_varint_raw(pos ..., this->message_len_);
  +  ProtoEncode::encode_varint_raw_short(pos ..., this->message_len_);
  ...
  -  size += ProtoSize::calc_length_force(1, this->message_len_);
  +  size += ProtoSize::calc_length_force_short(1, this->message_len_);
  ```

Every log line sent to connected API clients now takes the fully-inlined 1–2 byte varint path for both size calculation and encoding. No behavior change for users; only configurations that had explicitly set `logger.tx_buffer_size` above 16383 would need to lower it (default is 512).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml
logger:
  level: DEBUG
  # Default 512 is unchanged; max is now 16383 (was 65535)
  tx_buffer_size: 512

api:
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).