### PR TITLE
[automation] Outline TemplatableValue<std::string>::value() non-callable arms

### DIFF
--- a/esphome/core/automation.cpp
+++ b/esphome/core/automation.cpp
@@ -1,0 +1,47 @@
+#include "esphome/core/automation.h"
+#include "esphome/core/defines.h"
+#include <cstring>
+
+#ifdef USE_ESP8266
+#include "esphome/core/progmem.h"
+#endif
+
+namespace esphome::detail {
+
+// Must match the enum order in TemplatableValue<std::string, X...>::type_.
+// LAMBDA (2) and STATELESS_LAMBDA (3) are handled inline by the caller
+// because they depend on the X... pack.
+static constexpr uint8_t TSS_NONE = 0;
+static constexpr uint8_t TSS_VALUE = 1;
+static constexpr uint8_t TSS_STATIC_STRING = 4;
+static constexpr uint8_t TSS_FLASH_STRING = 5;
+
+std::string load_string_storage(uint8_t type, const char *storage) {
+  // Build into one `result` via out-of-line std::string methods so each arm
+  // avoids its own inline SSO-branch construction body.
+  std::string result;
+  switch (type) {
+    case TSS_VALUE: {
+      const auto *s = reinterpret_cast<const std::string *>(storage);
+      result.assign(s->data(), s->size());
+      break;
+    }
+    case TSS_STATIC_STRING:
+      result.assign(storage, strlen(storage));
+      break;
+#ifdef USE_ESP8266
+    case TSS_FLASH_STRING: {
+      size_t len = strlen_P(storage);
+      result.assign(len, '\0');
+      memcpy_P(&result[0], storage, len);
+      break;
+    }
+#endif
+    case TSS_NONE:
+    default:
+      break;
+  }
+  return result;
+}
+
+}  // namespace esphome::detail

--- a/esphome/core/automation.cpp
+++ b/esphome/core/automation.cpp
@@ -17,31 +17,26 @@ static constexpr uint8_t TSS_STATIC_STRING = 4;
 static constexpr uint8_t TSS_FLASH_STRING = 5;
 
 std::string load_string_storage(uint8_t type, const char *storage) {
-  // Build into one `result` via out-of-line std::string methods so each arm
-  // avoids its own inline SSO-branch construction body.
-  std::string result;
+  // Use NRVO-friendly constructors so libstdc++'s existing _M_construct helpers
+  // (already present in most firmwares) are reused, avoiding net growth from
+  // pulling in a distinct assign/_M_replace_cold set of out-of-line symbols.
   switch (type) {
-    case TSS_VALUE: {
-      const auto *s = reinterpret_cast<const std::string *>(storage);
-      result.assign(s->data(), s->size());
-      break;
-    }
+    case TSS_VALUE:
+      return *reinterpret_cast<const std::string *>(storage);
     case TSS_STATIC_STRING:
-      result.assign(storage, strlen(storage));
-      break;
+      return std::string(storage);
 #ifdef USE_ESP8266
     case TSS_FLASH_STRING: {
       size_t len = strlen_P(storage);
-      result.assign(len, '\0');
+      std::string result(len, '\0');
       memcpy_P(&result[0], storage, len);
-      break;
+      return result;
     }
 #endif
     case TSS_NONE:
     default:
-      break;
+      return {};
   }
-  return result;
 }
 
 }  // namespace esphome::detail

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -221,6 +221,12 @@ template<typename T, typename... X> class TemplatableValue {
   } storage_;
 };
 
+namespace detail {
+/// Shared body for the non-lambda arms of TemplatableValue<std::string>::value().
+/// Defined in automation.cpp so every `X...` instantiation links to one copy.
+std::string load_string_storage(uint8_t type, const char *storage);
+}  // namespace detail
+
 /// Specialization for std::string: supports VALUE, STATIC_STRING, FLASH_STRING,
 /// stateless lambdas, and stateful lambdas (std::function).
 template<typename... X> class TemplatableValue<std::string, X...> {
@@ -316,28 +322,13 @@ template<typename... X> class TemplatableValue<std::string, X...> {
   bool has_value() const { return this->type_ != NONE; }
 
   std::string value(X... x) const {
-    switch (this->type_) {
-      case STATELESS_LAMBDA:
-        return this->stateless_f_(x...);  // Direct function pointer call
-      case LAMBDA:
-        return (*this->f_)(x...);  // std::function call
-      case VALUE:
-        return *this->value_;
-      case STATIC_STRING:
-        return std::string(this->static_str_);
-#ifdef USE_ESP8266
-      case FLASH_STRING: {
-        // PROGMEM pointer — must use _P functions to access on ESP8266
-        size_t len = strlen_P(this->static_str_);
-        std::string result(len, '\0');
-        memcpy_P(result.data(), this->static_str_, len);
-        return result;
-      }
-#endif
-      case NONE:
-      default:
-        return {};
-    }
+    // Callable arms depend on X... so stay inline; everything else delegates to
+    // a non-template helper so the materialization body exists once in flash.
+    if (this->type_ == STATELESS_LAMBDA)
+      return this->stateless_f_(x...);
+    if (this->type_ == LAMBDA)
+      return (*this->f_)(x...);
+    return detail::load_string_storage(this->type_, this->static_str_);
   }
 
   optional<std::string> optional_value(X... x) const {


### PR DESCRIPTION
# What does this implement/fix?

The `TemplatableValue<std::string>` specialization's `value()` method had its entire non-callable materialization body (`NONE`/`VALUE`/`STATIC_STRING`/`FLASH_STRING`) inlined into every caller. On ESP8266, `TextSensorPublishAction<>::play()` compiled to **392 B** of flash per instantiation, dominated by three separate inline SSO-aware `std::string` construction paths plus the `strlen_P`/`memcpy_P` PROGMEM arm.

This PR moves the non-callable arms into a single non-template helper `esphome::detail::load_string_storage()` in a new `automation.cpp`. The callable arms (`LAMBDA`, `STATELESS_LAMBDA`) stay inline because they depend on the `X...` pack. Inside the helper, the construction paths collapse to out-of-line `std::string::assign` overloads, so one shared `_M_replace`/`_M_mutate` call replaces three inline SSO branches.

Per-call overhead is one extra `call0` plus the helper's prologue/epilogue — about 15 cycles (~200 ns at 80 MHz). `TextSensor::publish_state` is not in a hot loop, so this is invisible.

### Measured on `athom-rgb-light-d981f7` (ESP8266)

| Symbol | Before | After | Delta |
|---|---|---|---|
| `TextSensorPublishAction<>::play()` | 392 B | 79 B | **-313 B** |
| `detail::load_string_storage` (new, shared) | — | 194 B | +194 B |

Net single-user: **-119 B**. Each additional `TemplatableValue<std::string, X...>` instantiation now saves another ~313 B because its `value()` call site shrinks from ~392 B to ~79 B while the 194 B helper is amortized across all users.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-facing config changes — internal refactor of the TemplatableValue<std::string>
# specialization used by any component with a TEMPLATABLE_VALUE(std::string, ...) field,
# e.g. text_sensor actions.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).