### PR TITLE
[globals] Fix TemplatableFn deprecation warning for globals.set

### DIFF
--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass, field
 import hashlib
 
 from esphome import automation, codegen as cg, config_validation as cv
@@ -9,11 +8,10 @@ from esphome.const import (
     CONF_TYPE,
     CONF_VALUE,
 )
-from esphome.core import CORE, CoroPriority, coroutine_with_priority
+from esphome.core import CoroPriority, coroutine_with_priority
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
-DOMAIN = "globals"
 globals_ns = cg.esphome_ns.namespace("globals")
 GlobalsComponent = globals_ns.class_("GlobalsComponent", cg.Component)
 RestoringGlobalsComponent = globals_ns.class_(
@@ -62,25 +60,11 @@ MULTI_CONF = True
 CONFIG_SCHEMA = _globals_schema
 
 
-@dataclass
-class GlobalsData:
-    # Map of global id -> user-declared C++ type string (e.g. 'float') so the
-    # globals.set action can emit lambdas with the matching return type.
-    types: dict = field(default_factory=dict)
-
-
-def _get_data() -> GlobalsData:
-    if DOMAIN not in CORE.data:
-        CORE.data[DOMAIN] = GlobalsData()
-    return CORE.data[DOMAIN]
-
-
 # Run with low priority so that namespaces are registered first
 @coroutine_with_priority(CoroPriority.LATE)
 async def to_code(config):
     type_ = cg.RawExpression(config[CONF_TYPE])
     restore = config[CONF_RESTORE_VALUE]
-    _get_data().types[config[CONF_ID]] = config[CONF_TYPE]
 
     # Special casing the strings to their own class with a different save/restore mechanism
     if str(type_) == "std::string" and restore:
@@ -124,11 +108,11 @@ async def globals_set_to_code(config, action_id, template_arg, args):
     full_id, paren = await cg.get_variable_with_full_id(config[CONF_ID])
     template_arg = cg.TemplateArguments(full_id.type, *template_arg)
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    # Use the global's declared C++ type as the lambda return type so
+    # Use the global's value_type alias as the lambda return type so
     # TemplatableFn stores a direct function pointer instead of going through
     # the deprecated converting trampoline when the value expression deduces
     # to a different type (e.g. int literal assigned to a float global).
-    value_type = cg.RawExpression(_get_data().types[config[CONF_ID]])
+    value_type = cg.RawExpression(f"{full_id.type}::value_type")
     templ = await cg.templatable(
         config[CONF_VALUE], args, value_type, to_exp=cg.RawExpression
     )

--- a/esphome/components/globals/__init__.py
+++ b/esphome/components/globals/__init__.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 import hashlib
 
 from esphome import automation, codegen as cg, config_validation as cv
@@ -8,10 +9,11 @@ from esphome.const import (
     CONF_TYPE,
     CONF_VALUE,
 )
-from esphome.core import CoroPriority, coroutine_with_priority
+from esphome.core import CORE, CoroPriority, coroutine_with_priority
 from esphome.types import ConfigType
 
 CODEOWNERS = ["@esphome/core"]
+DOMAIN = "globals"
 globals_ns = cg.esphome_ns.namespace("globals")
 GlobalsComponent = globals_ns.class_("GlobalsComponent", cg.Component)
 RestoringGlobalsComponent = globals_ns.class_(
@@ -60,11 +62,25 @@ MULTI_CONF = True
 CONFIG_SCHEMA = _globals_schema
 
 
+@dataclass
+class GlobalsData:
+    # Map of global id -> user-declared C++ type string (e.g. 'float') so the
+    # globals.set action can emit lambdas with the matching return type.
+    types: dict = field(default_factory=dict)
+
+
+def _get_data() -> GlobalsData:
+    if DOMAIN not in CORE.data:
+        CORE.data[DOMAIN] = GlobalsData()
+    return CORE.data[DOMAIN]
+
+
 # Run with low priority so that namespaces are registered first
 @coroutine_with_priority(CoroPriority.LATE)
 async def to_code(config):
     type_ = cg.RawExpression(config[CONF_TYPE])
     restore = config[CONF_RESTORE_VALUE]
+    _get_data().types[config[CONF_ID]] = config[CONF_TYPE]
 
     # Special casing the strings to their own class with a different save/restore mechanism
     if str(type_) == "std::string" and restore:
@@ -108,8 +124,13 @@ async def globals_set_to_code(config, action_id, template_arg, args):
     full_id, paren = await cg.get_variable_with_full_id(config[CONF_ID])
     template_arg = cg.TemplateArguments(full_id.type, *template_arg)
     var = cg.new_Pvariable(action_id, template_arg, paren)
+    # Use the global's declared C++ type as the lambda return type so
+    # TemplatableFn stores a direct function pointer instead of going through
+    # the deprecated converting trampoline when the value expression deduces
+    # to a different type (e.g. int literal assigned to a float global).
+    value_type = cg.RawExpression(_get_data().types[config[CONF_ID]])
     templ = await cg.templatable(
-        config[CONF_VALUE], args, None, to_exp=cg.RawExpression, wrap_constant=True
+        config[CONF_VALUE], args, value_type, to_exp=cg.RawExpression
     )
     cg.add(var.set_value(templ))
     return var

--- a/tests/components/globals/common.yaml
+++ b/tests/components/globals/common.yaml
@@ -4,6 +4,14 @@ esphome:
       - globals.set:
           id: glob_int
           value: "10"
+      # Set a float global with an integer literal - must emit the correct
+      # return type so TemplatableFn stores a direct function pointer.
+      - globals.set:
+          id: glob_float
+          value: "102"
+      - globals.set:
+          id: glob_float
+          value: !lambda "return 42;"
 
 globals:
   - id: glob_int


### PR DESCRIPTION
# What does this implement/fix?

Fixes a `-Wdeprecated-declarations` warning emitted from `TemplatableFn` when a `globals.set` action assigns a value whose deduced type differs from the global's declared type (e.g. an integer literal or `int`-returning lambda assigned to a `float` global):

```
src/esphome/core/automation.h:96:64: warning: '...TemplatableFn(F) requires ...' is deprecated:
  Lambda return type does not match TemplatableFn<T> — use the correct type in codegen
```

The `globals.set` codegen now passes the global's `value_type` alias (e.g. `GlobalsComponent<float>::value_type`) as the lambda's return type, so the expression is cast to the right type inside the generated lambda. `TemplatableFn` stores it as a direct function pointer instead of going through the deprecated converting trampoline.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
globals:
  - id: my_float
    type: float
    initial_value: "0.0f"

esphome:
  on_boot:
    then:
      # Previously emitted a TemplatableFn deprecation warning at compile time
      # because "102" deduces to int while the global is float.
      - globals.set:
          id: my_float
          value: "102"
      - globals.set:
          id: my_float
          value: !lambda "return 42;"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).