### PR TITLE
[fusb302b] Adds support for the FUSB302B USB Power Delivery

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -188,6 +188,7 @@ esphome/components/font/* @clydebarrow @esphome/core
 esphome/components/fs3000/* @kahrendt
 esphome/components/ft5x06/* @clydebarrow
 esphome/components/ft63x6/* @gpambrozio
+esphome/components/fusb302b/* @remcom
 esphome/components/gcja5/* @gcormier
 esphome/components/gdk101/* @Szewcson
 esphome/components/gl_r01_i2c/* @pkejval

--- a/esphome/components/fusb302b/__init__.py
+++ b/esphome/components/fusb302b/__init__.py
@@ -1,0 +1,123 @@
+from esphome import automation
+import esphome.codegen as cg
+from esphome.components import i2c, text_sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ID,
+    CONF_IRQ_PIN,
+    CONF_ON_CONNECT,
+    CONF_ON_DISCONNECT,
+    CONF_ON_ERROR,
+    CONF_TRIGGER_ID,
+)
+from esphome.pins import internal_gpio_input_pin_number
+
+CODEOWNERS = ["@remcom"]
+DEPENDENCIES = ["i2c"]
+
+pd_ns = cg.esphome_ns.namespace("fusb302b")
+PowerDelivery = pd_ns.class_("PowerDelivery", cg.Component)
+FUSB302B = pd_ns.class_("FUSB302B", PowerDelivery, cg.Component, i2c.I2CDevice)
+
+RequestVoltageAction = pd_ns.class_(
+    "PowerDeliveryRequestVoltage",
+    automation.Action,
+    cg.Parented.template(PowerDelivery),
+)
+
+ConnectedTrigger = pd_ns.class_("ConnectedTrigger", automation.Trigger.template())
+DisconnectedTrigger = pd_ns.class_("DisconnectedTrigger", automation.Trigger.template())
+ErrorTrigger = pd_ns.class_("ErrorTrigger", automation.Trigger.template())
+PowerReadyTrigger = pd_ns.class_("PowerReadyTrigger", automation.Trigger.template())
+
+IsConnectedCondition = pd_ns.class_("IsConnectedCondition", automation.Condition)
+
+CONF_REQUEST_VOLTAGE = "request_voltage"
+CONF_ON_POWER_READY = "on_power_ready"
+CONF_CONTRACT_SENSOR = "contract_sensor"
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(FUSB302B),
+            cv.Required(CONF_IRQ_PIN): internal_gpio_input_pin_number,
+            cv.Required(CONF_REQUEST_VOLTAGE): cv.int_range(min=5, max=20),
+            cv.Optional(CONF_CONTRACT_SENSOR): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_ON_CONNECT): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ConnectedTrigger)}
+            ),
+            cv.Optional(CONF_ON_DISCONNECT): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(DisconnectedTrigger)}
+            ),
+            cv.Optional(CONF_ON_ERROR): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ErrorTrigger)}
+            ),
+            cv.Optional(CONF_ON_POWER_READY): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(PowerReadyTrigger)}
+            ),
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+    .extend(i2c.i2c_device_schema(0x22)),
+    cv.only_on_esp32,
+)
+
+PD_ACTION_SCHEMA = automation.maybe_simple_id(
+    {cv.GenerateID(): cv.use_id(PowerDelivery)}
+)
+
+
+@automation.register_action(
+    "power_delivery.request_voltage",
+    RequestVoltageAction,
+    cv.maybe_simple_value(
+        {
+            cv.GenerateID(): cv.use_id(PowerDelivery),
+            cv.Required(CONF_REQUEST_VOLTAGE): cv.templatable(
+                cv.int_range(min=5, max=20)
+            ),
+        },
+        key=CONF_REQUEST_VOLTAGE,
+    ),
+    synchronous=True,
+)
+async def power_delivery_request_voltage_action(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    voltage = await cg.templatable(config[CONF_REQUEST_VOLTAGE], args, int)
+    cg.add(var.set_voltage(voltage))
+    return var
+
+
+@automation.register_condition(
+    "power_delivery.is_connected", IsConnectedCondition, PD_ACTION_SCHEMA
+)
+async def power_delivery_is_connected_condition(
+    config, condition_id, template_arg, args
+):
+    var = cg.new_Pvariable(condition_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await i2c.register_i2c_device(var, config)
+    cg.add(var.set_request_voltage(config[CONF_REQUEST_VOLTAGE]))
+    cg.add(var.set_irq_pin(config[CONF_IRQ_PIN]))
+    if contract_sensor_config := config.get(CONF_CONTRACT_SENSOR):
+        sens = await text_sensor.new_text_sensor(contract_sensor_config)
+        cg.add(var.set_contract_sensor(sens))
+    for conf in config.get(CONF_ON_CONNECT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_DISCONNECT, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_ERROR, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)
+    for conf in config.get(CONF_ON_POWER_READY, []):
+        trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
+        await automation.build_automation(trigger, [], conf)

--- a/esphome/components/fusb302b/automation.h
+++ b/esphome/components/fusb302b/automation.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "esphome/core/automation.h"
+#include "pd.h"
+
+namespace esphome {
+namespace fusb302b {
+
+template<typename... Ts> class PowerDeliveryRequestVoltage : public Action<Ts...>, public Parented<PowerDelivery> {
+ public:
+  TEMPLATABLE_VALUE(int, voltage)
+
+  void play(const Ts &...x) override { this->parent_->request_voltage(this->voltage_.value(x...)); }
+};
+
+class StateTrigger : public Trigger<> {
+ public:
+  explicit StateTrigger(PowerDelivery *pd) {
+    pd->add_on_state_callback([this]() { this->trigger(); });
+  }
+};
+
+template<PowerDeliveryState State> class PDStateTrigger : public Trigger<> {
+ public:
+  explicit PDStateTrigger(PowerDelivery *pd) {
+    pd->add_on_state_callback([this, pd]() {
+      if (pd->get_state() == State)
+        this->trigger();
+    });
+  }
+};
+
+class PowerReadyTrigger : public Trigger<> {
+ public:
+  explicit PowerReadyTrigger(PowerDelivery *pd) {
+    pd->add_on_state_callback([this, pd]() {
+      if (pd->get_state() == PD_STATE_EXPLICIT_SPR_CONTRACT || pd->get_state() == PD_STATE_EXPLICIT_EPR_CONTRACT ||
+          pd->get_state() == PD_STATE_PD_TIMEOUT)
+        this->trigger();
+    });
+  }
+};
+
+class ConnectedTrigger : public Trigger<> {
+ public:
+  explicit ConnectedTrigger(PowerDelivery *pd) {
+    pd->add_on_state_callback([this, pd]() {
+      if (pd->get_prev_state() == PD_STATE_DISCONNECTED && pd->get_state() == PD_STATE_DEFAULT_CONTRACT)
+        this->trigger();
+    });
+  }
+};
+
+using DisconnectedTrigger = PDStateTrigger<PowerDeliveryState::PD_STATE_DISCONNECTED>;
+using ErrorTrigger = PDStateTrigger<PowerDeliveryState::PD_STATE_ERROR>;
+
+template<typename... Ts> class IsConnectedCondition : public Condition<Ts...>, public Parented<PowerDelivery> {
+ public:
+  bool check(const Ts &...x) override {
+    return this->parent_->get_state() == PowerDeliveryState::PD_STATE_DEFAULT_CONTRACT ||
+           this->parent_->get_state() == PowerDeliveryState::PD_STATE_EXPLICIT_SPR_CONTRACT ||
+           this->parent_->get_state() == PowerDeliveryState::PD_STATE_EXPLICIT_EPR_CONTRACT;
+  }
+};
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/fusb302_defines.h
+++ b/esphome/components/fusb302b/fusb302_defines.h
@@ -1,0 +1,148 @@
+#pragma once
+#include <cstdint>
+
+namespace esphome {
+namespace fusb302b {
+
+// Register addresses
+static constexpr uint8_t FUSB_DEVICE_ID = 0x01;
+static constexpr uint8_t FUSB_SWITCHES0 = 0x02;
+static constexpr uint8_t FUSB_SWITCHES1 = 0x03;
+static constexpr uint8_t FUSB_MEASURE = 0x04;
+static constexpr uint8_t FUSB_SLICE = 0x05;
+static constexpr uint8_t FUSB_CONTROL0 = 0x06;
+static constexpr uint8_t FUSB_CONTROL1 = 0x07;
+static constexpr uint8_t FUSB_CONTROL2 = 0x08;
+static constexpr uint8_t FUSB_CONTROL3 = 0x09;
+static constexpr uint8_t FUSB_MASK1 = 0x0A;
+static constexpr uint8_t FUSB_POWER = 0x0B;
+static constexpr uint8_t FUSB_RESET = 0x0C;
+static constexpr uint8_t FUSB_OCPREG = 0x0D;
+static constexpr uint8_t FUSB_MASKA = 0x0E;
+static constexpr uint8_t FUSB_MASKB = 0x0F;
+static constexpr uint8_t FUSB_CONTROL4 = 0x10;
+static constexpr uint8_t FUSB_STATUS0A = 0x3C;
+static constexpr uint8_t FUSB_STATUS1A = 0x3D;
+static constexpr uint8_t FUSB_INTERRUPTA = 0x3E;
+static constexpr uint8_t FUSB_INTERRUPTB = 0x3F;
+static constexpr uint8_t FUSB_STATUS0 = 0x40;
+static constexpr uint8_t FUSB_STATUS1 = 0x41;
+static constexpr uint8_t FUSB_INTERRUPT = 0x42;
+static constexpr uint8_t FUSB_FIFOS = 0x43;
+
+// SWITCHES0 bits
+static constexpr uint8_t FUSB_SWITCHES0_PU_EN2 = (1 << 7);
+static constexpr uint8_t FUSB_SWITCHES0_PU_EN1 = (1 << 6);
+static constexpr uint8_t FUSB_SWITCHES0_VCONN_CC2 = (1 << 5);
+static constexpr uint8_t FUSB_SWITCHES0_VCONN_CC1 = (1 << 4);
+static constexpr uint8_t FUSB_SWITCHES0_MEAS_CC2 = (1 << 3);
+static constexpr uint8_t FUSB_SWITCHES0_MEAS_CC1 = (1 << 2);
+static constexpr uint8_t FUSB_SWITCHES0_PDWN_2 = (1 << 1);
+static constexpr uint8_t FUSB_SWITCHES0_PDWN_1 = 1;
+
+// SWITCHES1 bits
+static constexpr uint8_t FUSB_SWITCHES1_POWERROLE = (1 << 7);
+static constexpr uint8_t FUSB_SWITCHES1_SPECREV_SHIFT = 5;
+static constexpr uint8_t FUSB_SWITCHES1_SPECREV = (0x3 << FUSB_SWITCHES1_SPECREV_SHIFT);
+static constexpr uint8_t FUSB_SWITCHES1_DATAROLE = (1 << 4);
+static constexpr uint8_t FUSB_SWITCHES1_AUTO_CRC = (1 << 2);
+static constexpr uint8_t FUSB_SWITCHES1_TXCC2 = (1 << 1);
+static constexpr uint8_t FUSB_SWITCHES1_TXCC1 = 1;
+
+// CONTROL0 bits
+static constexpr uint8_t FUSB_CONTROL0_TX_FLUSH = (1 << 6);
+static constexpr uint8_t FUSB_CONTROL0_INT_MASK = (1 << 5);
+static constexpr uint8_t FUSB_CONTROL0_HOST_CUR_SHIFT = 2;
+static constexpr uint8_t FUSB_CONTROL0_HOST_CUR = (0x3 << FUSB_CONTROL0_HOST_CUR_SHIFT);
+static constexpr uint8_t FUSB_CONTROL0_AUTO_PRE = (1 << 1);
+static constexpr uint8_t FUSB_CONTROL0_TX_START = 1;
+
+// CONTROL1 bits
+static constexpr uint8_t FUSB_CONTROL1_ENSOP2DB = (1 << 6);
+static constexpr uint8_t FUSB_CONTROL1_ENSOP1DB = (1 << 5);
+static constexpr uint8_t FUSB_CONTROL1_BIST_MODE2 = (1 << 4);
+static constexpr uint8_t FUSB_CONTROL1_RX_FLUSH = (1 << 2);
+static constexpr uint8_t FUSB_CONTROL1_ENSOP2 = (1 << 1);
+static constexpr uint8_t FUSB_CONTROL1_ENSOP1 = 1;
+
+// CONTROL3 bits
+static constexpr uint8_t FUSB_CONTROL3_SEND_HARD_RESET = (1 << 6);
+static constexpr uint8_t FUSB_CONTROL3_BIST_TMODE = (1 << 5);
+static constexpr uint8_t FUSB_CONTROL3_AUTO_HARDRESET = (1 << 4);
+static constexpr uint8_t FUSB_CONTROL3_AUTO_SOFTRESET = (1 << 3);
+static constexpr uint8_t FUSB_CONTROL3_N_RETRIES_SHIFT = 1;
+static constexpr uint8_t FUSB_CONTROL3_N_RETRIES_MASK = (0x3 << FUSB_CONTROL3_N_RETRIES_SHIFT);
+static constexpr uint8_t FUSB_CONTROL3_AUTO_RETRY = 1;
+
+// POWER bits
+static constexpr uint8_t PWR_INT_OSC = (0x01 << 3);
+static constexpr uint8_t PWR_MEASURE = (0x01 << 2);
+static constexpr uint8_t PWR_RECEIVER = (0x01 << 1);
+static constexpr uint8_t PWR_BANDGAP = (0x01 << 0);
+
+// RESET bits
+static constexpr uint8_t FUSB_RESET_PD_RESET = (1 << 1);
+static constexpr uint8_t FUSB_RESET_SW_RES = 1;
+
+// MASKA bits
+static constexpr uint8_t FUSB_MASKA_M_OCP_TEMP = (1 << 7);
+static constexpr uint8_t FUSB_MASKA_M_TOGDONE = (1 << 6);
+static constexpr uint8_t FUSB_MASKA_M_SOFTFAIL = (1 << 5);
+static constexpr uint8_t FUSB_MASKA_M_RETRYFAIL = (1 << 4);
+static constexpr uint8_t FUSB_MASKA_M_HARDSENT = (1 << 3);
+static constexpr uint8_t FUSB_MASKA_M_TXSENT = (1 << 2);
+static constexpr uint8_t FUSB_MASKA_M_SOFTRST = (1 << 1);
+static constexpr uint8_t FUSB_MASKA_M_HARDRST = 1;
+
+// MASKB bits
+static constexpr uint8_t FUSB_MASKB_M_GCRCSENT = 1;
+
+// STATUS0A bits
+static constexpr uint8_t FUSB_STATUS0A_SOFTFAIL = (1 << 5);
+static constexpr uint8_t FUSB_STATUS0A_RETRYFAIL = (1 << 4);
+static constexpr uint8_t FUSB_STATUS0A_SOFTRST = (1 << 1);
+static constexpr uint8_t FUSB_STATUS0A_HARDRST = 1;
+
+// INTERRUPTA bits
+static constexpr uint8_t FUSB_INTERRUPTA_I_OCP_TEMP = (1 << 7);
+static constexpr uint8_t FUSB_INTERRUPTA_I_TOGDONE = (1 << 6);
+static constexpr uint8_t FUSB_INTERRUPTA_I_SOFTFAIL = (1 << 5);
+static constexpr uint8_t FUSB_INTERRUPTA_I_RETRYFAIL = (1 << 4);
+static constexpr uint8_t FUSB_INTERRUPTA_I_HARDSENT = (1 << 3);
+static constexpr uint8_t FUSB_INTERRUPTA_I_TXSENT = (1 << 2);
+static constexpr uint8_t FUSB_INTERRUPTA_I_SOFTRST = (1 << 1);
+static constexpr uint8_t FUSB_INTERRUPTA_I_HARDRST = 1;
+
+// INTERRUPTB bits
+static constexpr uint8_t FUSB_INTERRUPTB_I_GCRCSENT = 1;
+
+// STATUS0 bits
+static constexpr uint8_t FUSB_STATUS0_VBUSOK = (1 << 7);
+static constexpr uint8_t FUSB_STATUS0_ACTIVITY = (1 << 6);
+static constexpr uint8_t FUSB_STATUS0_COMP = (1 << 5);
+static constexpr uint8_t FUSB_STATUS0_CRC_CHK = (1 << 4);
+static constexpr uint8_t FUSB_STATUS0_ALERT = (1 << 3);
+static constexpr uint8_t FUSB_STATUS0_WAKE = (1 << 2);
+static constexpr uint8_t FUSB_STATUS0_BC_LVL_SHIFT = 0;
+static constexpr uint8_t FUSB_STATUS0_BC_LVL = (0x3 << FUSB_STATUS0_BC_LVL_SHIFT);
+
+// STATUS1 bits
+static constexpr uint8_t FUSB_STATUS1_RXSOP2 = (1 << 7);
+static constexpr uint8_t FUSB_STATUS1_RXSOP1 = (1 << 6);
+static constexpr uint8_t FUSB_STATUS1_RX_EMPTY = (1 << 5);
+static constexpr uint8_t FUSB_STATUS1_RX_FULL = (1 << 4);
+static constexpr uint8_t FUSB_STATUS1_TX_EMPTY = (1 << 3);
+static constexpr uint8_t FUSB_STATUS1_TX_FULL = (1 << 2);
+static constexpr uint8_t FUSB_STATUS1_OVRTEMP = (1 << 1);
+static constexpr uint8_t FUSB_STATUS1_OCP = 1;
+
+// FIFO RX token bits
+static constexpr uint8_t FUSB_FIFO_RX_TOKEN_BITS = 0xE0;
+static constexpr uint8_t FUSB_FIFO_RX_SOP = 0xE0;
+static constexpr uint8_t FUSB_FIFO_RX_SOP1 = 0xC0;
+static constexpr uint8_t FUSB_FIFO_RX_SOP2 = 0xA0;
+static constexpr uint8_t FUSB_FIFO_RX_SOP1DB = 0x80;
+static constexpr uint8_t FUSB_FIFO_RX_SOP2DB = 0x60;
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/fusb302b.cpp
+++ b/esphome/components/fusb302b/fusb302b.cpp
@@ -1,0 +1,490 @@
+#include "fusb302b.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include <driver/gpio.h>
+
+#include "fusb302_defines.h"
+
+namespace esphome {
+namespace fusb302b {
+
+static const char *const TAG = "fusb302b";
+
+enum Fusb302TxToken : uint8_t {
+  TX_TOKEN_TXON = 0xA1,
+  TX_TOKEN_SOP1 = 0x12,
+  TX_TOKEN_SOP2 = 0x13,
+  TX_TOKEN_SOP3 = 0x1B,
+  TX_TOKEN_RESET1 = 0x15,
+  TX_TOKEN_RESET2 = 0x16,
+  TX_TOKEN_PACKSYM = 0x80,
+  TX_TOKEN_JAM_CRC = 0xFF,
+  TX_TOKEN_EOP = 0x14,
+  TX_TOKEN_TXOFF = 0xFE,
+};
+
+// ISR handler — runs in ISR context, must be in IRAM
+void IRAM_ATTR fusb302b_isr_handler(void *arg) {
+  FUSB302B *fusb302b = static_cast<FUSB302B *>(arg);
+  BaseType_t higher_priority_task_woken = pdFALSE;
+  xTaskNotifyFromISR(fusb302b->reader_task_handle_, 0x01, eSetBits, &higher_priority_task_woken);
+  if (higher_priority_task_woken == pdTRUE) {
+    portYIELD_FROM_ISR();
+  }
+}
+
+void msg_reader_task(void *params) {
+  FUSB302B *fusb302b = static_cast<FUSB302B *>(params);
+  uint32_t notification_value;
+  FusbStatus regs;
+  PDEventInfo event_info;
+  PDMsg &msg = event_info.msg;
+
+  fusb302b->enable_auto_crc();
+  fusb302b->fusb_reset_();
+
+  while (true) {
+    xTaskNotifyWait(0x00, 0xFFFFFFFF, &notification_value, portMAX_DELAY);
+    fusb302b->read_status(regs);
+    if (regs.interruptb & FUSB_INTERRUPTB_I_GCRCSENT) {
+      event_info.event = PD_EVENT_RECEIVED_MSG;
+      while (!(regs.status1 & FUSB_STATUS1_RX_EMPTY)) {
+        if (fusb302b->read_message(msg)) {
+          xQueueSend(fusb302b->message_queue_, &event_info, 0);
+        } else {
+          ESP_LOGV(TAG, "Reading message failed");
+        }
+        fusb302b->read_status_register(FUSB_STATUS1, regs.status1);
+      }
+    }
+    if (regs.interrupta & FUSB_INTERRUPTA_I_HARDRST) {
+      ESP_LOGV(TAG, "Hard reset received");
+    } else if (regs.interrupta & FUSB_INTERRUPTA_I_SOFTRST) {
+      ESP_LOGV(TAG, "Soft reset request received");
+    } else if (regs.interrupta & FUSB_INTERRUPTA_I_RETRYFAIL) {
+      ESP_LOGV(TAG, "Message not acknowledged (retry failed)");
+    }
+  }
+}
+
+void trigger_task(void *params) {
+  FUSB302B *fusb302b = static_cast<FUSB302B *>(params);
+
+  fusb302b->message_queue_ = xQueueCreate(5, sizeof(PDEventInfo));
+  if (fusb302b->message_queue_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create message queue");
+    fusb302b->mark_failed();
+    vTaskDelete(nullptr);
+    return;
+  }
+
+  gpio_num_t irq_gpio_pin = static_cast<gpio_num_t>(fusb302b->irq_pin_);
+
+  gpio_config_t io_conf = {};
+  io_conf.pin_bit_mask = (1ULL << irq_gpio_pin);
+  io_conf.mode = GPIO_MODE_INPUT;
+  io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+  io_conf.pull_down_en = GPIO_PULLDOWN_DISABLE;
+  io_conf.intr_type = GPIO_INTR_NEGEDGE;
+  gpio_config(&io_conf);
+
+  gpio_set_intr_type(irq_gpio_pin, GPIO_INTR_NEGEDGE);
+  esp_err_t err = gpio_install_isr_service(0);
+  if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "Failed to install GPIO ISR service: %s", esp_err_to_name(err));
+    fusb302b->mark_failed();
+    vTaskDelete(nullptr);
+    return;
+  }
+  if (gpio_isr_handler_add(irq_gpio_pin, fusb302b_isr_handler, static_cast<void *>(fusb302b)) != ESP_OK) {
+    ESP_LOGE(TAG, "Failed to add GPIO ISR handler");
+    fusb302b->mark_failed();
+    vTaskDelete(nullptr);
+    return;
+  }
+
+  BaseType_t ret = xTaskCreatePinnedToCore(msg_reader_task, "fusb302b_read", 4096, fusb302b, configMAX_PRIORITIES / 2,
+                                           &fusb302b->reader_task_handle_, 1);
+  if (ret != pdPASS) {
+    ESP_LOGE(TAG, "Failed to create reader task");
+    fusb302b->mark_failed();
+    vQueueDelete(fusb302b->message_queue_);
+    fusb302b->message_queue_ = nullptr;
+    vTaskDelete(nullptr);
+    return;
+  }
+
+  PDEventInfo event_info;
+  while (true) {
+    if (xQueueReceive(fusb302b->message_queue_, &event_info, portMAX_DELAY) == pdTRUE) {
+      PDMsg &msg = event_info.msg;
+      fusb302b->handle_message(msg);
+    }
+  }
+}
+
+void FUSB302B::setup() {
+  this->i2c_lock_ = xSemaphoreCreateBinary();
+  if (this->i2c_lock_ == nullptr) {
+    ESP_LOGE(TAG, "Failed to create semaphore");
+    this->mark_failed();
+    return;
+  }
+  xSemaphoreGive(this->i2c_lock_);
+
+  if (!this->check_chip_id()) {
+    ESP_LOGE(TAG, "FUSB302B not found at I2C address 0x%02X", this->address_);
+    this->mark_failed();
+    return;
+  }
+  ESP_LOGD(TAG, "FUSB302B found, initializing...");
+
+  if (!this->init_fusb_settings_()) {
+    ESP_LOGE(TAG, "Failed to initialize FUSB302B");
+    this->mark_failed();
+    return;
+  }
+  this->startup_delay_ = millis();
+}
+
+void FUSB302B::dump_config() {
+  ESP_LOGCONFIG(TAG, "FUSB302B USB-PD Controller:");
+  LOG_I2C_DEVICE(this);
+  ESP_LOGCONFIG(TAG, "  IRQ Pin: %d", this->irq_pin_);
+  ESP_LOGCONFIG(TAG, "  Request Voltage: %dV", this->request_voltage_);
+}
+
+void FUSB302B::cleanup_() {
+  if (this->reader_task_handle_ != nullptr) {
+    vTaskDelete(this->reader_task_handle_);
+    this->reader_task_handle_ = nullptr;
+  }
+  if (this->process_task_handle_ != nullptr) {
+    vTaskDelete(this->process_task_handle_);
+    this->process_task_handle_ = nullptr;
+  }
+  if (this->message_queue_ != nullptr) {
+    vQueueDelete(this->message_queue_);
+    this->message_queue_ = nullptr;
+  }
+  if (this->i2c_lock_ != nullptr) {
+    vSemaphoreDelete(this->i2c_lock_);
+    this->i2c_lock_ = nullptr;
+  }
+}
+
+void FUSB302B::on_shutdown() { this->cleanup_(); }
+
+void FUSB302B::loop() {
+  this->check_status_();
+  if (this->contract_timer_ && (uint32_t) (millis() - this->contract_timer_) > 1000) {
+    this->publish();
+    this->contract_timer_ = 0;
+  }
+}
+
+bool FUSB302B::cc_line_selection_() {
+  /* Measure CC1 */
+  this->reg(FUSB_SWITCHES0) = FUSB_SWITCHES0_PDWN_1 | FUSB_SWITCHES0_PDWN_2 | FUSB_SWITCHES0_MEAS_CC1;
+  this->reg(FUSB_SWITCHES1) = 0x01 << FUSB_SWITCHES1_SPECREV_SHIFT;
+  this->reg(FUSB_MEASURE) = 49;
+  delay(5);
+
+  uint8_t cc1 = this->reg(FUSB_STATUS0).get() & FUSB_STATUS0_BC_LVL;
+  for (uint8_t i = 0; i < 5; i++) {
+    uint8_t tmp = this->reg(FUSB_STATUS0).get() & FUSB_STATUS0_BC_LVL;
+    if (cc1 != tmp) {
+      return false;
+    }
+  }
+
+  /* Measure CC2 */
+  this->reg(FUSB_SWITCHES0) = FUSB_SWITCHES0_PDWN_1 | FUSB_SWITCHES0_PDWN_2 | FUSB_SWITCHES0_MEAS_CC2;
+  delay(5);
+  uint8_t cc2 = this->reg(FUSB_STATUS0).get() & FUSB_STATUS0_BC_LVL;
+  for (uint8_t i = 0; i < 5; i++) {
+    uint8_t tmp = this->reg(FUSB_STATUS0).get() & FUSB_STATUS0_BC_LVL;
+    if (cc2 != tmp) {
+      return false;
+    }
+  }
+
+  /* Select the correct CC line for BMC signaling */
+  if (cc1 > 0 && cc2 == 0) {
+    ESP_LOGD(TAG, "CC select: 1");
+    this->reg(FUSB_SWITCHES0) = FUSB_SWITCHES0_PDWN_1 | FUSB_SWITCHES0_PDWN_2 | FUSB_SWITCHES0_MEAS_CC1;
+    this->reg(FUSB_SWITCHES1) = FUSB_SWITCHES1_TXCC1 | (0x01 << FUSB_SWITCHES1_SPECREV_SHIFT);
+  } else if (cc1 == 0 && cc2 > 0) {
+    ESP_LOGD(TAG, "CC select: 2");
+    this->reg(FUSB_SWITCHES0) = FUSB_SWITCHES0_PDWN_1 | FUSB_SWITCHES0_PDWN_2 | FUSB_SWITCHES0_MEAS_CC2;
+    this->reg(FUSB_SWITCHES1) = FUSB_SWITCHES1_TXCC2 | (0x01 << FUSB_SWITCHES1_SPECREV_SHIFT);
+  } else {
+    return false;
+  }
+
+  return true;
+}
+
+void FUSB302B::fusb_reset_unlocked_() {
+  /* Flush TX/RX buffers and reset PD logic — caller must hold i2c_lock_ */
+  this->reg(FUSB_CONTROL0) = FUSB_CONTROL0_TX_FLUSH;
+  this->reg(FUSB_CONTROL1) = FUSB_CONTROL1_RX_FLUSH;
+  this->reg(FUSB_RESET) = FUSB_RESET_PD_RESET;
+  this->last_received_msg_id_ = 255;
+  this->msg_counter_ = 0;
+}
+
+void FUSB302B::fusb_reset_() {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return;
+  }
+  this->fusb_reset_unlocked_();
+  xSemaphoreGive(this->i2c_lock_);
+}
+
+bool FUSB302B::read_status(FusbStatus &status) {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+  int err = this->read_register(FUSB_STATUS0A, status.bytes, 7);
+  xSemaphoreGive(this->i2c_lock_);
+  return err == 0;
+}
+
+void FUSB302B::check_status_() {
+  switch (this->hw_state_) {
+    case Fusb302State::UNATTACHED: {
+      if (this->startup_delay_ && (uint32_t) (millis() - this->startup_delay_) < 2000) {
+        return;
+      }
+
+      if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return;
+      }
+      this->reg(FUSB_POWER) = PWR_BANDGAP | PWR_RECEIVER | PWR_MEASURE | PWR_INT_OSC;
+      bool connected = this->cc_line_selection_();
+      xSemaphoreGive(this->i2c_lock_);
+
+      if (!connected) {
+        this->hw_state_ = Fusb302State::FAILED;
+        return;
+      }
+
+      if (this->startup_delay_) {
+        ESP_LOGD(TAG, "Startup delay reached, spawning tasks");
+        this->startup_delay_ = 0;
+
+        BaseType_t ret =
+            xTaskCreatePinnedToCore(trigger_task, "fusb302b_trigger", 4096, this, 18, &this->process_task_handle_, 1);
+        if (ret != pdPASS) {
+          ESP_LOGE(TAG, "Failed to create process task");
+          this->mark_failed();
+          this->hw_state_ = Fusb302State::FAILED;
+          return;
+        }
+        delay(1);
+      } else {
+        this->enable_auto_crc();
+        this->fusb_reset_();
+      }
+
+      this->get_src_cap_time_stamp_ = millis();
+      this->get_src_cap_retry_count_ = 0;
+      this->wait_src_cap_ = true;
+
+      this->hw_state_ = Fusb302State::ATTACHED;
+      this->set_state_(PD_STATE_DEFAULT_CONTRACT);
+      ESP_LOGD(TAG, "USB-C attached");
+      break;
+    }
+    case Fusb302State::ATTACHED:
+      if (this->check_ams()) {
+        return;
+      }
+
+      if (this->wait_src_cap_) {
+        if (this->get_src_cap_retry_count_ && (uint32_t) (millis() - this->get_src_cap_time_stamp_) < 5000) {
+          return;
+        }
+        if (!this->get_src_cap_retry_count_) {
+          this->get_src_cap_retry_count_++;
+          this->get_src_cap_time_stamp_ = millis();
+          return;
+        }
+        this->get_src_cap_retry_count_++;
+        this->get_src_cap_time_stamp_ = millis();
+        if (this->get_src_cap_retry_count_ < 2) {
+          /* Clear interrupts, then request source capabilities */
+          FusbStatus regs;
+          this->read_status(regs);
+          this->send_message(PDMsg(this, PD_CNTRL_GET_SOURCE_CAP));
+        } else {
+          ESP_LOGD(TAG, "GET_SOURCE_CAP reached max retries");
+          if (!this->tried_soft_reset_) {
+            this->fusb_reset_();
+            this->send_message(PDMsg(this, PD_CNTRL_SOFT_RESET));
+            this->get_src_cap_retry_count_ = 2;
+            this->tried_soft_reset_ = true;
+          } else {
+            ESP_LOGD(TAG, "PD negotiation failed, staying at 5V");
+            this->wait_src_cap_ = false;
+            this->active_ams_ = false;
+            this->set_state_(PD_STATE_PD_TIMEOUT);
+            this->publish();
+          }
+        }
+      }
+      break;
+
+    case Fusb302State::FAILED:
+      break;
+  }
+}
+
+bool FUSB302B::check_chip_id() {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(1000)) != pdTRUE) {
+    return false;
+  }
+  uint8_t dev_id = this->reg(FUSB_DEVICE_ID).get();
+  xSemaphoreGive(this->i2c_lock_);
+  ESP_LOGD(TAG, "FUSB302B device ID: 0x%02X", dev_id);
+  return (dev_id == 0x81) || (dev_id == 0x91);
+}
+
+bool FUSB302B::enable_auto_crc() {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+  uint8_t sw1 = this->reg(FUSB_SWITCHES1).get();
+  this->reg(FUSB_SWITCHES1) = sw1 | FUSB_SWITCHES1_AUTO_CRC;
+  xSemaphoreGive(this->i2c_lock_);
+  return true;
+}
+
+bool FUSB302B::disable_auto_crc() {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+  uint8_t sw1 = this->reg(FUSB_SWITCHES1).get();
+  this->reg(FUSB_SWITCHES1) = sw1 & ~FUSB_SWITCHES1_AUTO_CRC;
+  xSemaphoreGive(this->i2c_lock_);
+  return true;
+}
+
+bool FUSB302B::read_status_register(uint8_t reg_addr, uint8_t &value) {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+  int err = this->read_register(reg_addr, &value, 1);
+  xSemaphoreGive(this->i2c_lock_);
+  return err == 0;
+}
+
+bool FUSB302B::init_fusb_settings_() {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+
+  /* Software reset to restore all registers to default */
+  this->reg(FUSB_RESET) = FUSB_RESET_SW_RES;
+
+  /* Flush buffers and reset PD logic (lock already held) */
+  this->fusb_reset_unlocked_();
+
+  /* Set interrupt masks */
+  this->reg(FUSB_MASK1) = 0x51;
+  this->reg(FUSB_MASKA) = 0;
+  this->reg(FUSB_MASKB) = 0;
+
+  /* Disable global interrupt masking */
+  uint8_t cntrl0 = this->reg(FUSB_CONTROL0).get();
+  this->reg(FUSB_CONTROL0) = cntrl0 & ~FUSB_CONTROL0_INT_MASK;
+
+  /* Enable automatic retransmission (3 retries) */
+  uint8_t cntrl3 = this->reg(FUSB_CONTROL3).get();
+  cntrl3 &= ~FUSB_CONTROL3_N_RETRIES_MASK;
+  cntrl3 |= (0x03 << FUSB_CONTROL3_N_RETRIES_SHIFT) | FUSB_CONTROL3_AUTO_RETRY;
+  this->reg(FUSB_CONTROL3) = cntrl3;
+
+  /* Power on all blocks */
+  this->reg(FUSB_POWER) = 0x0F;
+
+  /* Flush again after full power-on */
+  this->fusb_reset_unlocked_();
+
+  xSemaphoreGive(this->i2c_lock_);
+  return true;
+}
+
+bool FUSB302B::read_message(PDMsg &msg) {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+
+  uint8_t fifo_byte = this->reg(FUSB_FIFOS).get();
+  bool ok = (fifo_byte & FUSB_FIFO_RX_TOKEN_BITS) == FUSB_FIFO_RX_SOP;
+
+  uint16_t header = 0;
+  ok &= (this->read_register(FUSB_FIFOS, reinterpret_cast<uint8_t *>(&header), 2) == 0);
+  msg.set_header(header);
+
+  if (msg.num_of_obj > 7) {
+    xSemaphoreGive(this->i2c_lock_);
+    return false;
+  }
+  if (msg.num_of_obj > 0) {
+    ok &= (this->read_register(FUSB_FIFOS, reinterpret_cast<uint8_t *>(msg.data_objects),
+                               msg.num_of_obj * sizeof(uint32_t)) == 0);
+  }
+
+  /* Read CRC32 to advance FIFO pointer (PHY already verified it) */
+  uint8_t dummy[4];
+  ok &= (this->read_register(FUSB_FIFOS, dummy, 4) == 0);
+
+  xSemaphoreGive(this->i2c_lock_);
+  return ok;
+}
+
+bool FUSB302B::send_message(const PDMsg &msg) {
+  if (xSemaphoreTake(this->i2c_lock_, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+
+  uint8_t buf[40];
+  uint8_t *pbuf = buf;
+
+  uint16_t header = msg.get_coded_header();
+  uint8_t obj_count = msg.num_of_obj;
+
+  *pbuf++ = TX_TOKEN_SOP1;
+  *pbuf++ = TX_TOKEN_SOP1;
+  *pbuf++ = TX_TOKEN_SOP1;
+  *pbuf++ = TX_TOKEN_SOP2;
+  *pbuf++ = TX_TOKEN_PACKSYM | ((obj_count << 2) + 2);
+  *pbuf++ = header & 0xFF;
+  *pbuf++ = (header >> 8) & 0xFF;
+  for (uint8_t i = 0; i < obj_count; i++) {
+    uint32_t d = msg.data_objects[i];
+    *pbuf++ = d & 0xFF;
+    *pbuf++ = (d >> 8) & 0xFF;
+    *pbuf++ = (d >> 16) & 0xFF;
+    *pbuf++ = (d >> 24) & 0xFF;
+  }
+  *pbuf++ = TX_TOKEN_JAM_CRC;
+  *pbuf++ = TX_TOKEN_EOP;
+  *pbuf++ = TX_TOKEN_TXOFF;
+  *pbuf++ = TX_TOKEN_TXON;
+
+  int err = this->write_register(FUSB_FIFOS, buf, pbuf - buf);
+  if (err != i2c::ERROR_OK) {
+    ESP_LOGW(TAG, "Sending message type %d failed (err=%d)", static_cast<int>(msg.type), err);
+  }
+
+  xSemaphoreGive(this->i2c_lock_);
+  return err == i2c::ERROR_OK;
+}
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/fusb302b.cpp
+++ b/esphome/components/fusb302b/fusb302b.cpp
@@ -1,5 +1,7 @@
 #include "fusb302b.h"
 
+#ifdef USE_ESP_IDF
+
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 
@@ -47,7 +49,9 @@ void msg_reader_task(void *params) {
 
   while (true) {
     xTaskNotifyWait(0x00, 0xFFFFFFFF, &notification_value, portMAX_DELAY);
-    fusb302b->read_status(regs);
+    if (!fusb302b->read_status(regs)) {
+      continue;
+    }
     if (regs.interruptb & FUSB_INTERRUPTB_I_GCRCSENT) {
       event_info.event = PD_EVENT_RECEIVED_MSG;
       while (!(regs.status1 & FUSB_STATUS1_RX_EMPTY)) {
@@ -488,3 +492,5 @@ bool FUSB302B::send_message(const PDMsg &msg) {
 
 }  // namespace fusb302b
 }  // namespace esphome
+
+#endif  // USE_ESP_IDF

--- a/esphome/components/fusb302b/fusb302b.h
+++ b/esphome/components/fusb302b/fusb302b.h
@@ -8,7 +8,9 @@
 
 #ifdef USE_ESP_IDF
 
+#ifdef USE_TEXT_SENSOR
 #include "esphome/components/text_sensor/text_sensor.h"
+#endif
 
 namespace esphome {
 namespace fusb302b {
@@ -59,10 +61,12 @@ class FUSB302B : public PowerDelivery, public Component, public i2c::I2CDevice {
   void publish() override {
     this->defer([this]() {
       this->state_callback_.call();
+#ifdef USE_TEXT_SENSOR
       if (this->contract_sensor_ != nullptr) {
         std::string val = (this->state_ == PD_STATE_DISCONNECTED) ? "Detached" : this->contract_;
         this->contract_sensor_->publish_state(val);
       }
+#endif
     });
   }
   bool init_fusb_settings_();

--- a/esphome/components/fusb302b/fusb302b.h
+++ b/esphome/components/fusb302b/fusb302b.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "esphome/components/i2c/i2c.h"
+#include "esphome/core/component.h"
+#include "esphome/core/hal.h"
+
+#include "pd.h"
+
+namespace esphome {
+namespace fusb302b {
+
+enum class Fusb302State { UNATTACHED, ATTACHED, FAILED };
+
+union FusbStatus {
+  uint8_t bytes[7];
+  struct {
+    uint8_t status0a;
+    uint8_t status1a;
+    uint8_t interrupta;
+    uint8_t interruptb;
+    uint8_t status0;
+    uint8_t status1;
+    uint8_t interrupt;
+  };
+};
+
+class FUSB302B : public PowerDelivery, public Component, public i2c::I2CDevice {
+  friend void msg_reader_task(void *params);
+  friend void trigger_task(void *params);
+  friend void fusb302b_isr_handler(void *arg);
+
+ public:
+  void setup() override;
+  void dump_config() override;
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void loop() override;
+  void on_shutdown() override;
+
+  bool send_message(const PDMsg &msg) override;
+  bool read_message(PDMsg &msg) override;
+  bool read_status(FusbStatus &status);
+  bool read_status_register(uint8_t reg, uint8_t &value);
+
+  void set_irq_pin(int irq_pin) { this->irq_pin_ = irq_pin; }
+
+  bool check_chip_id();
+  bool enable_auto_crc();
+  bool disable_auto_crc();
+
+ protected:
+  bool cc_line_selection_();
+  void fusb_reset_unlocked_();
+  void fusb_reset_();
+  void check_status_();
+  void publish() override {
+    this->defer([this]() {
+      this->state_callback_.call();
+      if (this->contract_sensor_ != nullptr) {
+        std::string val = (this->state_ == PD_STATE_DISCONNECTED) ? "Detached" : this->contract_;
+        this->contract_sensor_->publish_state(val);
+      }
+    });
+  }
+  bool init_fusb_settings_();
+  void cleanup_();
+
+  Fusb302State hw_state_{Fusb302State::UNATTACHED};
+  uint32_t startup_delay_{0};
+  int irq_pin_{0};
+
+  SemaphoreHandle_t i2c_lock_{nullptr};
+  TaskHandle_t reader_task_handle_{nullptr};
+  TaskHandle_t process_task_handle_{nullptr};
+  QueueHandle_t message_queue_{nullptr};
+};
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/fusb302b.h
+++ b/esphome/components/fusb302b/fusb302b.h
@@ -6,6 +6,10 @@
 
 #include "pd.h"
 
+#ifdef USE_ESP_IDF
+
+#include "esphome/components/text_sensor/text_sensor.h"
+
 namespace esphome {
 namespace fusb302b {
 
@@ -76,3 +80,5 @@ class FUSB302B : public PowerDelivery, public Component, public i2c::I2CDevice {
 
 }  // namespace fusb302b
 }  // namespace esphome
+
+#endif  // USE_ESP_IDF

--- a/esphome/components/fusb302b/pd.cpp
+++ b/esphome/components/fusb302b/pd.cpp
@@ -1,0 +1,260 @@
+#include "pd.h"
+
+#include <cstdio>
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace fusb302b {
+
+static const char *const TAG = "PowerDelivery";
+
+static PdContract pd_parse_power_info(const PdPdo &pdo) {
+  PdContract power_info{};
+  power_info.type = static_cast<PdPowerDataObjType>(pdo >> 30);
+  switch (power_info.type) {
+    case PD_PDO_TYPE_FIXED_SUPPLY:
+      /* Reference: 6.4.1.2.3 Source Fixed Supply Power Data Object */
+      power_info.min_v = 0;
+      power_info.max_v = (pdo >> 10) & 0x3FF; /* B19...10 Voltage in 50mV units */
+      power_info.max_i = (pdo >> 0) & 0x3FF;  /* B9...0   Max Current in 10mA units */
+      power_info.max_p = 0;
+      break;
+    case PD_PDO_TYPE_BATTERY:
+      /* Reference: 6.4.1.2.5 Battery Supply Power Data Object */
+      power_info.min_v = (pdo >> 10) & 0x3FF; /* B19...10 Min Voltage in 50mV units */
+      power_info.max_v = (pdo >> 20) & 0x3FF; /* B29...20 Max Voltage in 50mV units */
+      power_info.max_i = 0;
+      power_info.max_p = (pdo >> 0) & 0x3FF; /* B9...0   Max Allowable Power in 250mW units */
+      break;
+    case PD_PDO_TYPE_VARIABLE_SUPPLY:
+      /* Reference: 6.4.1.2.4 Variable Supply (non-Battery) Power Data Object */
+      power_info.min_v = (pdo >> 10) & 0x3FF; /* B19...10 Min Voltage in 50mV units */
+      power_info.max_v = (pdo >> 20) & 0x3FF; /* B29...20 Max Voltage in 50mV units */
+      power_info.max_i = (pdo >> 0) & 0x3FF;  /* B9...0   Max Current in 10mA units */
+      power_info.max_p = 0;
+      break;
+    case PD_PDO_TYPE_AUGMENTED_PDO:
+      /* Reference: 6.4.1.3.4 Programmable Power Supply Augmented Power Data Object */
+      power_info.max_v = ((pdo >> 17) & 0xFF) * 2; /* B24...17 Max Voltage in 100mV units */
+      power_info.min_v = ((pdo >> 8) & 0xFF) * 2;  /* B15...8  Min Voltage in 100mV units */
+      power_info.max_i = ((pdo >> 0) & 0x7F) * 5;  /* B6...0   Max Current in 50mA units */
+      power_info.max_p = 0;
+      break;
+  }
+  return power_info;
+}
+
+static PDMsg build_source_cap_response(const PowerDelivery *pd, PdContract pwr_info, uint8_t pos) {
+  /* Reference: 6.4.2 Request Message */
+  constexpr uint32_t templ = (((uint32_t) 1 << 24) | /* B24 No USB Suspend */
+                              ((uint32_t) 1 << 25)   /* B25 USB Communication Capable */
+  );
+  uint32_t data = templ;
+  if (pwr_info.type != PD_PDO_TYPE_AUGMENTED_PDO) {
+    uint32_t req = pwr_info.max_i ? pwr_info.max_i : pwr_info.max_p;
+    data |= ((uint32_t) req << 0) |  /* B9...0   Max Operating Current 10mA / Max Operating Power 250mW units */
+            ((uint32_t) req << 10) | /* B19...10 Operating Current 10mA / Operating Power 250mW units */
+            ((uint32_t) pos << 28);  /* B30...28 Object position (000b is Reserved) */
+  } else {
+    ESP_LOGE(TAG, "Augmented PDO is not supported yet");
+  }
+  return PDMsg(pd, PD_DATA_REQUEST, &data, 1);
+}
+
+PDMsg build_get_sink_cap_response(const PowerDelivery *pd) {
+  /* Reference: 6.4.1.2.3 Sink Fixed Supply Power Data Object */
+  constexpr uint32_t data = (((uint32_t) 500 << 0) |  /* B9...0   Operational Current in 10mA units */
+                             ((uint32_t) 100 << 10) | /* B19...10 Voltage in 50mV units (5V) */
+                             ((uint32_t) 1 << 26) |   /* B26 USB Communications Capable */
+                             ((uint32_t) PD_PDO_TYPE_FIXED_SUPPLY << 30) /* B31...30 Fixed supply */
+  );
+  return PDMsg(pd, PD_DATA_SINK_CAP, &data, 1);
+}
+
+bool PowerDelivery::handle_message(const PDMsg &msg) {
+  if (msg.num_of_obj == 0) {
+    if (msg.type == PD_CNTRL_GOODCRC) {
+      this->msg_counter_++;
+      return true;
+    }
+    return this->handle_cntrl_message_(msg);
+  }
+  return this->handle_data_message_(msg);
+}
+
+bool PowerDelivery::handle_data_message_(const PDMsg &msg) {
+  if (msg.id == this->last_received_msg_id_) {
+    return false;
+  }
+  this->last_received_msg_id_ = msg.id;
+  switch (msg.type) {
+    case PD_DATA_SOURCE_CAP:
+      this->set_ams(true);
+      this->wait_src_cap_ = false;
+      this->respond_to_src_cap_msg_(msg);
+      break;
+    default:
+      break;
+  }
+  return true;
+}
+
+bool PowerDelivery::handle_cntrl_message_(const PDMsg &msg) {
+  if (msg.id == this->last_received_msg_id_) {
+    return false;
+  }
+  this->last_received_msg_id_ = msg.id;
+  switch (msg.type) {
+    case PD_CNTRL_GOODCRC:
+      break;
+    case PD_CNTRL_ACCEPT:
+      if (this->active_ams_) {
+        if (this->requested_contract_ != this->accepted_contract_) {
+          this->set_state_(PD_STATE_TRANSITION);
+        }
+        this->set_contract_(this->requested_contract_);
+      }
+      break;
+    case PD_CNTRL_PS_RDY:
+      this->set_ams(false);
+      this->set_state_(PD_STATE_EXPLICIT_SPR_CONTRACT);
+      break;
+    case PD_CNTRL_SOFT_RESET:
+      this->send_message(PDMsg(this, PD_CNTRL_ACCEPT, 0));
+      this->set_state_(PD_STATE_DEFAULT_CONTRACT);
+      this->msg_counter_ = 0;
+      break;
+    case PD_CNTRL_GET_SINK_CAP:
+      this->send_message(build_get_sink_cap_response(this));
+      break;
+    default:
+      this->send_message(PDMsg(this, PD_CNTRL_NOT_SUPPORTED));
+      break;
+  }
+  return true;
+}
+
+PDMsg PowerDelivery::create_fallback_request_message() const {
+  /* Request first PDO (always the 5V Fixed Supply), max current 500mA */
+  constexpr uint32_t data = ((uint32_t) 30 << 0) |  /* B9...0   Max Operating Current 10mA units (300mA) */
+                            ((uint32_t) 10 << 10) | /* B19...10 Operating Current 10mA units (100mA) */
+                            ((uint32_t) 1 << 24) |  /* B24 No USB Suspend */
+                            ((uint32_t) 1 << 25) |  /* B25 USB Communication Capable */
+                            ((uint32_t) 1 << 28);   /* B31...28 Object position 1 */
+  return PDMsg(this, PD_DATA_REQUEST, &data, 1);
+}
+
+bool PowerDelivery::respond_to_src_cap_msg_(const PDMsg &msg) {
+  PdContract selected_info{};
+  uint8_t selected = 255;
+  for (int idx = 0; idx < msg.num_of_obj; idx++) {
+    PdContract pwr_info = pd_parse_power_info(msg.data_objects[idx]);
+    if (pwr_info.type == PD_PDO_TYPE_AUGMENTED_PDO) {
+      continue;
+    }
+    if (pwr_info.max_v * 50 / 1000 <= this->request_voltage_ || selected == 255) {
+      selected_info = pwr_info;
+      selected = idx;
+    }
+  }
+  this->requested_contract_ = selected_info;
+
+  PDMsg response = build_source_cap_response(this, selected_info, selected + 1);
+  this->send_message(response);
+
+  return true;
+}
+
+void PowerDelivery::set_ams(bool ams) {
+  this->active_ams_ = ams;
+  if (ams) {
+    this->active_ams_timer_ = millis();
+  }
+}
+
+bool PowerDelivery::check_ams() {
+  if (this->active_ams_ && ((uint32_t) (millis() - this->active_ams_timer_) > 2000)) {
+    this->active_ams_ = false;
+  }
+  return this->active_ams_;
+}
+
+std::string PowerDelivery::get_contract_string(PdContract contract) const {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%.1fA @ %.0fV", contract.max_i / 100.0f, contract.max_v * 5 / 100.0f);
+  return buf;
+}
+
+void PowerDelivery::set_contract_(PdContract contract) {
+  this->accepted_contract_ = contract;
+  this->contract_ = this->get_contract_string(contract);
+  this->contract_voltage_ = contract.max_v * 5 / 100;
+  this->contract_timer_ = millis();
+}
+
+bool PowerDelivery::request_voltage(int voltage) {
+  if (!this->active_ams_) {
+    this->set_request_voltage(voltage);
+    this->wait_src_cap_ = true;
+    this->get_src_cap_retry_count_ = 0;
+    return true;
+  }
+  return false;
+}
+
+PDMsg::PDMsg(uint16_t header) { this->set_header(header); }
+
+bool PDMsg::set_header(uint16_t header) {
+  this->type = static_cast<PdDataMsgType>((header >> 0) & 0x1F);     /* 4...0  Message Type */
+  this->spec_rev = static_cast<PdSpecRevision>((header >> 6) & 0x3); /* 7...6  Specification Revision */
+  this->id = (header >> 9) & 0x7;                                    /* 11...9  MessageID */
+  this->num_of_obj = (header >> 12) & 0x7;                           /* 14...12 Number of Data Objects */
+  this->extended = (header >> 15) & 0x1;
+  return true;
+}
+
+PDMsg::PDMsg(const PowerDelivery *pd, PdControlMsgType cntrl_msg_type) {
+  this->type = cntrl_msg_type;
+  this->spec_rev = pd->msg_spec_rev_;
+  this->id = (pd->msg_counter_) % 8;
+  this->num_of_obj = 0;
+  this->extended = false;
+}
+
+PDMsg::PDMsg(const PowerDelivery *pd, PdControlMsgType cntrl_msg_type, uint8_t msg_id) {
+  this->type = cntrl_msg_type;
+  this->spec_rev = pd->msg_spec_rev_;
+  this->id = msg_id;
+  this->num_of_obj = 0;
+  this->extended = false;
+}
+
+PDMsg::PDMsg(const PowerDelivery *pd, PdDataMsgType msg_type, const uint32_t *objects, uint8_t len) {
+  if (len == 0 || len > PD_MAX_NUM_DATA_OBJECTS) {
+    ESP_LOGE(TAG, "Invalid data object count: %d", len);
+    this->num_of_obj = 0;
+    return;
+  }
+  this->type = msg_type;
+  this->spec_rev = pd->msg_spec_rev_;
+  this->id = (pd->msg_counter_) % 8;
+  this->num_of_obj = len;
+  this->extended = false;
+  memcpy(this->data_objects, objects, len * sizeof(uint32_t));
+}
+
+uint16_t PDMsg::get_coded_header() const {
+  return ((uint16_t) this->type << 0) | ((uint16_t) 0x00 << 5) |     /* DataRole 0: UFP */
+         ((uint16_t) this->spec_rev << 6) | ((uint16_t) 0x00 << 8) | /* PowerRole 0: sink */
+         ((uint16_t) this->id << 9) | ((uint16_t) this->num_of_obj << 12) | ((uint16_t) !!(this->extended) << 15);
+}
+
+void PDMsg::debug_log() const {
+  ESP_LOGD(TAG, "PD Message type=%d rev=%d id=%d obj=%d ext=%d coded=%d", this->type, this->spec_rev, this->id,
+           this->num_of_obj, !!(this->extended), this->get_coded_header());
+}
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -1,0 +1,212 @@
+#pragma once
+
+#include <atomic>
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/helpers.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome {
+namespace fusb302b {
+
+static constexpr uint8_t PD_MAX_NUM_DATA_OBJECTS = 7;
+
+// Forward declaration
+class PowerDelivery;
+
+enum PdSpecRevision {
+  PD_SPEC_REV_1 = 0,
+  PD_SPEC_REV_2 = 1,
+  PD_SPEC_REV_3 = 2
+  /* 3 Reserved */
+};
+
+enum PdDataMsgType {
+  /* 0 Reserved */
+  PD_DATA_SOURCE_CAP = 0x01,
+  PD_DATA_REQUEST = 0x02,
+  PD_DATA_BIST = 0x03,
+  PD_DATA_SINK_CAP = 0x04,
+  PD_DATA_BATTERY_STATUS = 0x05,
+  PD_DATA_ALERT = 0x06,
+  PD_DATA_GET_COUNTRY_INFO = 0x07,
+  PD_DATA_ENTER_USB = 0x08,
+  PD_DATA_EPR_REQUEST = 0x09,
+  PD_DATA_EPR_MODE = 0x0A,
+  PD_DATA_SOURCE_INFO = 0x0B,
+  PD_DATA_REVISION = 0x0C,
+  PD_DATA_VENDOR_DEF = 0x0F
+};
+
+enum PdControlMsgType {
+  PD_CNTRL_GOODCRC = 0x01,
+  PD_CNTRL_GOTOMIN = 0x02,
+  PD_CNTRL_ACCEPT = 0x03,
+  PD_CNTRL_REJECT = 0x04,
+  PD_CNTRL_PING = 0x05,
+  PD_CNTRL_PS_RDY = 0x06,
+  PD_CNTRL_GET_SOURCE_CAP = 0x07,
+  PD_CNTRL_GET_SINK_CAP = 0x08,
+  PD_CNTRL_DR_SWAP = 0x09,
+  PD_CNTRL_PR_SWAP = 0x0A,
+  PD_CNTRL_VCONN_SWAP = 0x0B,
+  PD_CNTRL_WAIT = 0x0C,
+  PD_CNTRL_SOFT_RESET = 0x0D,
+  PD_CNTRL_NOT_SUPPORTED = 0x10,
+  PD_CNTRL_GET_SOURCE_CAP_EXTENDED = 0x11,
+  PD_CNTRL_GET_STATUS = 0x12,
+  PD_CNTRL_FR_SWAP = 0x13,
+  PD_CNTRL_GET_PPS_STATUS = 0x14,
+  PD_CNTRL_GET_COUNTRY_CODES = 0x15,
+  PD_CNTRL_GET_SINK_CAP_EXTENDED = 0x16,
+  PD_CNTRL_GET_SOURCE_INFO = 0x17,
+  PD_CNTRL_GET_REVISION = 0x18
+};
+
+enum PdPowerDataObjType {
+  PD_PDO_TYPE_FIXED_SUPPLY = 0,
+  PD_PDO_TYPE_BATTERY = 1,
+  PD_PDO_TYPE_VARIABLE_SUPPLY = 2,
+  PD_PDO_TYPE_AUGMENTED_PDO = 3 /* USB PD 3.0 */
+};
+
+enum PowerDeliveryState : uint8_t {
+  PD_STATE_DISCONNECTED,
+  PD_STATE_PD_TIMEOUT,
+  PD_STATE_DEFAULT_CONTRACT,
+  PD_STATE_TRANSITION,
+  PD_STATE_EXPLICIT_SPR_CONTRACT,
+  PD_STATE_EXPLICIT_EPR_CONTRACT,
+  PD_STATE_ERROR
+};
+
+enum PowerDeliveryEvent : uint8_t {
+  PD_EVENT_ATTACHED,
+  PD_EVENT_DETACHED,
+  PD_EVENT_RECEIVED_MSG,
+  PD_EVENT_SENDING_MSG_FAILED,
+  PD_EVENT_SOFT_RESET,
+  PD_EVENT_HARD_RESET
+};
+
+struct PdContract {
+  PdPowerDataObjType type;
+  uint16_t min_v; /* Voltage in 50mV units */
+  uint16_t max_v; /* Voltage in 50mV units */
+  uint16_t max_i; /* Current in 10mA units */
+  uint16_t max_p; /* Power in 250mW units */
+
+  bool operator==(const PdContract &other) const {
+    return max_v == other.max_v && max_i == other.max_i && type == other.type;
+  }
+  bool operator!=(const PdContract &other) const { return !(*this == other); }
+};
+
+using PdPdo = uint32_t;
+
+class PDMsg {
+ public:
+  PDMsg() = default;
+  PDMsg(uint16_t header);
+  PDMsg(const PowerDelivery *pd, PdControlMsgType cntrl_msg_type);
+  PDMsg(const PowerDelivery *pd, PdControlMsgType cntrl_msg_type, uint8_t msg_id);
+  PDMsg(const PowerDelivery *pd, PdDataMsgType data_msg_type, const uint32_t *objects, uint8_t len);
+
+  uint16_t get_coded_header() const;
+  bool set_header(uint16_t header);
+
+  uint8_t type;
+  PdSpecRevision spec_rev;
+  uint8_t id;
+  uint8_t num_of_obj;
+  bool extended;
+  uint32_t data_objects[PD_MAX_NUM_DATA_OBJECTS];
+
+  void debug_log() const;
+};
+
+class PDEventInfo {
+ public:
+  PowerDeliveryEvent event;
+  PDMsg msg;
+};
+
+class PowerDelivery {
+  friend class PDMsg;
+
+ public:
+  PowerDeliveryState get_state() const { return this->state_; }
+  int get_contract_voltage() const { return this->contract_voltage_; }
+  std::string get_contract() const { return this->contract_; }
+
+  PowerDeliveryState get_prev_state() const { return this->prev_state_; }
+
+  bool request_voltage(int voltage);
+
+  virtual bool send_message(const PDMsg &msg) = 0;
+  virtual bool read_message(PDMsg &msg) = 0;
+
+  PDMsg create_fallback_request_message() const;
+  bool handle_message(const PDMsg &msg);
+
+  void set_request_voltage(int voltage) { this->request_voltage_ = voltage; }
+  std::string get_contract_string(PdContract contract) const;
+  template<typename F> void add_on_state_callback(F &&callback) {
+    this->state_callback_.add(std::forward<F>(callback));
+  }
+
+  void set_ams(bool ams);
+  bool check_ams();
+
+  void set_contract_sensor(text_sensor::TextSensor *sensor) { this->contract_sensor_ = sensor; }
+
+ protected:
+  text_sensor::TextSensor *contract_sensor_{nullptr};
+  uint32_t active_ams_timer_{0};
+  bool active_ams_{false};
+
+  uint8_t last_received_msg_id_{255};
+  PdSpecRevision msg_spec_rev_{PD_SPEC_REV_2};
+  std::atomic<uint8_t> msg_counter_{0};
+
+  bool handle_data_message_(const PDMsg &msg);
+  bool handle_cntrl_message_(const PDMsg &msg);
+
+  bool respond_to_src_cap_msg_(const PDMsg &msg);
+
+  void set_contract_(PdContract contract);
+  PdContract requested_contract_{};
+  PdContract accepted_contract_{};
+  PdContract previous_contract_{};
+  uint32_t contract_timer_{0};
+
+  void set_state_(PowerDeliveryState new_state) {
+    this->prev_state_ = this->state_;
+    this->state_ = new_state;
+  }
+
+  virtual void publish() {}
+
+  PdSpecRevision spec_revision_{PD_SPEC_REV_2};
+
+  bool wait_src_cap_{true};
+  bool tried_soft_reset_{false};
+  int get_src_cap_retry_count_{0};
+  uint32_t get_src_cap_time_stamp_{0};
+
+  int request_voltage_{5};
+
+  PowerDeliveryState state_{PD_STATE_DISCONNECTED};
+  int contract_voltage_{5};
+  std::string contract_{"0.5A @ 5V"};
+
+  CallbackManager<void()> state_callback_{};
+
+ private:
+  PowerDeliveryState prev_state_{PD_STATE_DISCONNECTED};
+};
+
+PDMsg build_get_sink_cap_response(const PowerDelivery *pd);
+
+}  // namespace fusb302b
+}  // namespace esphome

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -6,9 +6,11 @@
 #include "esphome/core/helpers.h"
 
 namespace esphome {
+#ifdef USE_TEXT_SENSOR
 namespace text_sensor {
 class TextSensor;
 }  // namespace text_sensor
+#endif
 namespace fusb302b {
 
 static constexpr uint8_t PD_MAX_NUM_DATA_OBJECTS = 7;
@@ -160,10 +162,14 @@ class PowerDelivery {
   void set_ams(bool ams);
   bool check_ams();
 
+#ifdef USE_TEXT_SENSOR
   void set_contract_sensor(text_sensor::TextSensor *sensor) { this->contract_sensor_ = sensor; }
+#endif
 
  protected:
+#ifdef USE_TEXT_SENSOR
   text_sensor::TextSensor *contract_sensor_{nullptr};
+#endif
   uint32_t active_ams_timer_{0};
   bool active_ams_{false};
 

--- a/esphome/components/fusb302b/pd.h
+++ b/esphome/components/fusb302b/pd.h
@@ -4,9 +4,11 @@
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
-#include "esphome/components/text_sensor/text_sensor.h"
 
 namespace esphome {
+namespace text_sensor {
+class TextSensor;
+}  // namespace text_sensor
 namespace fusb302b {
 
 static constexpr uint8_t PD_MAX_NUM_DATA_OBJECTS = 7;

--- a/tests/components/fusb302b/common.yaml
+++ b/tests/components/fusb302b/common.yaml
@@ -1,0 +1,29 @@
+fusb302b:
+  id: pd
+  i2c_id: i2c_bus
+  address: 0x22
+  irq_pin: 4
+  request_voltage: 9
+  on_connect:
+    - logger.log: "USB-C connected"
+  on_disconnect:
+    - logger.log: "USB-C disconnected"
+  on_error:
+    - logger.log: "USB-PD error"
+  on_power_ready:
+    - logger.log: "Power negotiation complete"
+    - power_delivery.request_voltage:
+        id: pd
+        request_voltage: 12
+
+interval:
+  - interval: 10s
+    then:
+      - if:
+          condition:
+            power_delivery.is_connected:
+              id: pd
+          then:
+            - power_delivery.request_voltage:
+                id: pd
+                request_voltage: !lambda "return 20;"

--- a/tests/components/fusb302b/test.esp32-idf.yaml
+++ b/tests/components/fusb302b/test.esp32-idf.yaml
@@ -1,0 +1,4 @@
+packages:
+  i2c: !include ../../test_build_components/common/i2c/esp32-idf.yaml
+
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

  Adds support for the FUSB302B USB Power Delivery (USB-PD) sink controller. The FUSB302B is a small I²C-connected chip that negotiates USB-PD contracts with a source, allowing an ESP32 device to request a
   specific voltage (5 V – 20 V) over USB-C.

  The component implements the USB-PD state machine in software on top of the FUSB302B's register interface. A FreeRTOS reader task handles hardware interrupts and FIFO draining, while a trigger task
  processes the incoming messages and advances the PD state machine.

  **Features:**

  - Negotiates USB-PD SPR contracts (request a target voltage between 5 V and 20 V)
  - Exposes the active contract as an optional `text_sensor`
  - Automations: `on_connect`, `on_disconnect`, `on_error`, `on_power_ready`
  - Action: `power_delivery.request_voltage` (supports lambdas / templates)
  - Condition: `power_delivery.is_connected`

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6459

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
i2c:
    sda: GPIO21
    scl: GPIO22

  fusb302b:
    address: 0x22
    irq_pin: GPIO19
    request_voltage: 9
    on_connect:
      - logger.log: "USB-C connected"
    on_power_ready:
      - logger.log: "Power contract established"
    on_disconnect:
      - logger.log: "USB-C disconnected"

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
