### PR TITLE
[core] Make buf_append_str PROGMEM-aware on ESP8266

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1109,10 +1109,7 @@ inline size_t buf_append_str_p(char *buf, size_t size, size_t pos, PGM_P str) {
     return size;
   }
   size_t remaining = size - pos - 1;  // reserve space for null terminator
-  size_t len = strlen_P(str);
-  if (len > remaining) {
-    len = remaining;
-  }
+  size_t len = strnlen_P(str, remaining);
   memcpy_P(buf + pos, str, len);
   pos += len;
   buf[pos] = '\0';
@@ -1135,10 +1132,7 @@ inline size_t buf_append_str(char *buf, size_t size, size_t pos, const char *str
     return size;
   }
   size_t remaining = size - pos - 1;  // reserve space for null terminator
-  size_t len = strlen(str);
-  if (len > remaining) {
-    len = remaining;
-  }
+  size_t len = strnlen(str, remaining);
   memcpy(buf + pos, str, len);
   pos += len;
   buf[pos] = '\0';

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1095,7 +1095,35 @@ __attribute__((format(printf, 4, 5))) inline size_t buf_append_printf(char *buf,
 }
 #endif
 
-/// Safely append a string to buffer without format parsing, returning new position (capped at size).
+#ifdef USE_ESP8266
+/// Safely append a PROGMEM string to buffer, returning new position (capped at size).
+/// ESP8266 internal implementation — prefer the `buf_append_str` macro which wraps
+/// literals with `PSTR()` automatically so they stay in flash instead of eating RAM.
+/// @param buf Output buffer
+/// @param size Total buffer size
+/// @param pos Current position in buffer
+/// @param str PROGMEM-resident string to append (must not be null)
+/// @return New position after appending (capped at size on overflow)
+inline size_t buf_append_str_p(char *buf, size_t size, size_t pos, PGM_P str) {
+  if (pos >= size) {
+    return size;
+  }
+  size_t remaining = size - pos - 1;  // reserve space for null terminator
+  size_t len = strlen_P(str);
+  if (len > remaining) {
+    len = remaining;
+  }
+  memcpy_P(buf + pos, str, len);
+  pos += len;
+  buf[pos] = '\0';
+  return pos;
+}
+/// Safely append a string to buffer, returning new position (capped at size).
+/// More efficient than buf_append_printf for plain string literals.
+/// On ESP8266 the literal is wrapped with PSTR() so it stays in flash.
+#define buf_append_str(buf, size, pos, str) buf_append_str_p(buf, size, pos, PSTR(str))
+#else
+/// Safely append a string to buffer, returning new position (capped at size).
 /// More efficient than buf_append_printf for plain string literals.
 /// @param buf Output buffer
 /// @param size Total buffer size
@@ -1116,6 +1144,7 @@ inline size_t buf_append_str(char *buf, size_t size, size_t pos, const char *str
   buf[pos] = '\0';
   return pos;
 }
+#endif
 
 /// Concatenate a name with a separator and suffix using an efficient stack-based approach.
 /// This avoids multiple heap allocations during string construction.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1103,7 +1103,8 @@ __attribute__((format(printf, 4, 5))) inline size_t buf_append_printf(char *buf,
 /// @param size Total buffer size
 /// @param pos Current position in buffer
 /// @param str PROGMEM-resident string to append (must not be null)
-/// @return New position after appending (capped at size on overflow)
+/// @return New position after appending; returns `size` if `pos >= size`, otherwise
+///         returns at most `size - 1` because one byte is reserved for the null terminator
 inline size_t buf_append_str_p(char *buf, size_t size, size_t pos, PGM_P str) {
   if (pos >= size) {
     return size;


### PR DESCRIPTION
# What does this implement/fix?

Makes `buf_append_str` PROGMEM-aware on ESP8266 so trivial `buf_append_printf` call sites (literal format strings, single-`%s`) can be migrated to the lighter helper without regressing ESP8266 RAM usage.

**Problem:** `buf_append_printf` on ESP8266 is defined as a macro that wraps the format string with `PSTR()` and calls `vsnprintf_P`, keeping the literal in flash. `buf_append_str` was a plain inline using `strlen` + `memcpy`, so any literal passed to it landed in `.rodata` (RAM-resident on ESP8266). That meant `buf_append_printf(... "literal")` was effectively being used as a poor-man's flash-resident string appender just to keep the literal out of RAM — wasteful on printf machinery but necessary.

**Change:** Mirror the `buf_append_printf` pattern for `buf_append_str`:

- On ESP8266: add a `buf_append_str_p(buf, size, pos, PGM_P str)` function that uses `strlen_P` + `memcpy_P`, and a `buf_append_str` macro that wraps the literal with `PSTR()`.
- On other platforms: the plain inline function is unchanged.

Existing callers (all in `esphome/components/debug/debug_rp2040.cpp`) pass string literals, so the macro expansion works without changes.

Follow-up PRs can now convert the trivial `buf_append_printf` call sites (debug `dump_config`, uptime sensor, etc.) to `buf_append_str` and shed printf machinery on all platforms while keeping literals in flash on ESP8266.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible configuration change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
