### PR TITLE
[debug] Add iram sensor for ESP32

### DIFF
--- a/esphome/components/debug/debug_component.h
+++ b/esphome/components/debug/debug_component.h
@@ -45,6 +45,7 @@ class DebugComponent : public PollingComponent {
   void set_loop_time_sensor(sensor::Sensor *loop_time_sensor) { loop_time_sensor_ = loop_time_sensor; }
 #ifdef USE_ESP32
   void set_psram_sensor(sensor::Sensor *psram_sensor) { this->psram_sensor_ = psram_sensor; }
+  void set_iram_sensor(sensor::Sensor *iram_sensor) { this->iram_sensor_ = iram_sensor; }
 #endif  // USE_ESP32
   void set_cpu_frequency_sensor(sensor::Sensor *cpu_frequency_sensor) {
     this->cpu_frequency_sensor_ = cpu_frequency_sensor;
@@ -71,6 +72,7 @@ class DebugComponent : public PollingComponent {
   sensor::Sensor *loop_time_sensor_{nullptr};
 #ifdef USE_ESP32
   sensor::Sensor *psram_sensor_{nullptr};
+  sensor::Sensor *iram_sensor_{nullptr};
 #endif  // USE_ESP32
   sensor::Sensor *cpu_frequency_sensor_{nullptr};
 #endif  // USE_SENSOR

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -302,7 +302,11 @@ void DebugComponent::update_platform_() {
     this->psram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
   }
   if (this->iram_sensor_ != nullptr) {
-    this->iram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_EXEC));
+    // IRAM-only free: 32-bit-accessible heap minus 8-bit-accessible heap.
+    // IRAM regions are registered as 32-bit-only; DRAM is both 8-bit and 32-bit.
+    size_t free_32bit = heap_caps_get_free_size(MALLOC_CAP_32BIT);
+    size_t free_8bit = heap_caps_get_free_size(MALLOC_CAP_8BIT);
+    this->iram_sensor_->publish_state(free_32bit > free_8bit ? free_32bit - free_8bit : 0);
   }
 #endif
 }

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -302,7 +302,7 @@ void DebugComponent::update_platform_() {
     this->psram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
   }
   if (this->iram_sensor_ != nullptr) {
-    this->iram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_IRAM_8BIT));
+    this->iram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_EXEC));
   }
 #endif
 }

--- a/esphome/components/debug/debug_esp32.cpp
+++ b/esphome/components/debug/debug_esp32.cpp
@@ -301,6 +301,9 @@ void DebugComponent::update_platform_() {
   if (this->psram_sensor_ != nullptr) {
     this->psram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
   }
+  if (this->iram_sensor_ != nullptr) {
+    this->iram_sensor_->publish_state(heap_caps_get_free_size(MALLOC_CAP_IRAM_8BIT));
+  }
 #endif
 }
 

--- a/esphome/components/debug/sensor.py
+++ b/esphome/components/debug/sensor.py
@@ -32,6 +32,7 @@ DEPENDENCIES = ["debug"]
 
 CONF_MIN_FREE = "min_free"
 CONF_PSRAM = "psram"
+CONF_IRAM = "iram"
 
 CONFIG_SCHEMA = {
     cv.GenerateID(CONF_DEBUG_ID): cv.use_id(DebugComponent),
@@ -98,6 +99,16 @@ CONFIG_SCHEMA = {
             state_class=STATE_CLASS_MEASUREMENT,
         ),
     ),
+    cv.Optional(CONF_IRAM): cv.All(
+        cv.only_on_esp32,
+        sensor.sensor_schema(
+            unit_of_measurement=UNIT_BYTES,
+            icon=ICON_COUNTER,
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+    ),
     cv.Optional(CONF_CPU_FREQUENCY): cv.All(
         sensor.sensor_schema(
             unit_of_measurement=UNIT_HERTZ,
@@ -137,6 +148,10 @@ async def to_code(config):
     if psram_conf := config.get(CONF_PSRAM):
         sens = await sensor.new_sensor(psram_conf)
         cg.add(debug_component.set_psram_sensor(sens))
+
+    if iram_conf := config.get(CONF_IRAM):
+        sens = await sensor.new_sensor(iram_conf)
+        cg.add(debug_component.set_iram_sensor(sens))
 
     if cpu_freq_conf := config.get(CONF_CPU_FREQUENCY):
         sens = await sensor.new_sensor(cpu_freq_conf)

--- a/tests/components/debug/test.esp32-ard.yaml
+++ b/tests/components/debug/test.esp32-ard.yaml
@@ -9,3 +9,5 @@ sensor:
       name: "Heap Fragmentation"
     min_free:
       name: "Heap Min Free"
+    iram:
+      name: "Free IRAM"

--- a/tests/components/debug/test.esp32-idf.yaml
+++ b/tests/components/debug/test.esp32-idf.yaml
@@ -13,5 +13,7 @@ sensor:
       name: "Heap Fragmentation"
     min_free:
       name: "Heap Min Free"
+    iram:
+      name: "Free IRAM"
 
 psram:

--- a/tests/components/debug/test.esp32-s2-idf.yaml
+++ b/tests/components/debug/test.esp32-s2-idf.yaml
@@ -6,3 +6,5 @@ sensor:
       name: "Heap Fragmentation"
     min_free:
       name: "Heap Min Free"
+    iram:
+      name: "Free IRAM"


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `iram` sensor to the `debug` component that reports free IRAM (instruction RAM) in bytes on ESP32. Uses `heap_caps_get_free_size(MALLOC_CAP_IRAM_8BIT)` to query the IRAM heap region, which is separate from the DRAM heap already reported by the existing `free`/`block`/`min_free` sensors.

This is useful for tracking IRAM headroom, which can be scarce on ESP32 when many components place code/data in IRAM (e.g., ISR handlers, IRAM-safe attributes).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6464

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: debug
    iram:
      name: "Free IRAM"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).