### PR TITLE
[runtime_stats] Track main loop active time and report overhead

### DIFF
--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -32,13 +32,18 @@ void RuntimeStatsCollector::log_stats_() {
            " Period stats (last %" PRIu32 "ms): %zu active components",
            this->log_interval_, count);
 
-  // Sum component period time so we can derive main-loop overhead
+  // Sum component time so we can derive main-loop overhead
   // (active loop time minus time attributable to component loop()s).
+  // Period sum iterates the active-in-period subset; total sum must iterate
+  // all components since total_active_time_us_ includes iterations where
+  // currently-idle components previously ran.
   uint64_t period_component_sum_us = 0;
-  uint64_t total_component_sum_us = 0;
   for (size_t i = 0; i < count; i++) {
     period_component_sum_us += sorted[i]->runtime_stats_.period_time_us;
-    total_component_sum_us += sorted[i]->runtime_stats_.total_time_us;
+  }
+  uint64_t total_component_sum_us = 0;
+  for (auto *component : components) {
+    total_component_sum_us += component->runtime_stats_.total_time_us;
   }
 
   if (count > 0) {
@@ -61,7 +66,7 @@ void RuntimeStatsCollector::log_stats_() {
     uint64_t active = this->period_active_time_us_;
     uint64_t overhead = active > period_component_sum_us ? active - period_component_sum_us : 0;
     ESP_LOGI(TAG,
-             "  main_loop: iters=%" PRIu32 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
+             "  main_loop: iters=%" PRIu64 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
              "overhead_total=%.1fms",
              this->period_active_count_, active / (float) this->period_active_count_ / 1000.0f,
              this->period_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
@@ -87,7 +92,7 @@ void RuntimeStatsCollector::log_stats_() {
     uint64_t active = this->total_active_time_us_;
     uint64_t overhead = active > total_component_sum_us ? active - total_component_sum_us : 0;
     ESP_LOGI(TAG,
-             "  main_loop: iters=%" PRIu32 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
+             "  main_loop: iters=%" PRIu64 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
              "overhead_total=%.1fms",
              this->total_active_count_, active / (float) this->total_active_count_ / 1000.0f,
              this->total_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);

--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -65,17 +65,22 @@ void RuntimeStatsCollector::log_stats_() {
   if (this->period_active_count_ > 0) {
     uint64_t active = this->period_active_time_us_;
     uint64_t overhead = active > period_component_sum_us ? active - period_component_sum_us : 0;
+    // Use double for µs→ms conversion so multi-day uptimes (where total
+    // microsecond counters exceed float's ~7-digit mantissa) keep resolution.
     ESP_LOGI(TAG,
              "  main_loop: iters=%" PRIu64 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
              "overhead_total=%.1fms",
-             this->period_active_count_, active / (float) this->period_active_count_ / 1000.0f,
-             this->period_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
+             this->period_active_count_,
+             static_cast<double>(active) / static_cast<double>(this->period_active_count_) / 1000.0,
+             static_cast<double>(this->period_active_max_us_) / 1000.0, static_cast<double>(active) / 1000.0,
+             static_cast<double>(overhead) / 1000.0);
     uint64_t before = this->period_before_time_us_;
     uint64_t tail = this->period_tail_time_us_;
     uint64_t accounted = before + tail;
     uint64_t inter = overhead > accounted ? overhead - accounted : 0;
-    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms", before / 1000.0f,
-             tail / 1000.0f, inter / 1000.0f);
+    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms",
+             static_cast<double>(before) / 1000.0, static_cast<double>(tail) / 1000.0,
+             static_cast<double>(inter) / 1000.0);
   }
 
   // Log total stats since boot (only for active components - idle ones haven't changed)
@@ -100,14 +105,17 @@ void RuntimeStatsCollector::log_stats_() {
     ESP_LOGI(TAG,
              "  main_loop: iters=%" PRIu64 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
              "overhead_total=%.1fms",
-             this->total_active_count_, active / (float) this->total_active_count_ / 1000.0f,
-             this->total_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
+             this->total_active_count_,
+             static_cast<double>(active) / static_cast<double>(this->total_active_count_) / 1000.0,
+             static_cast<double>(this->total_active_max_us_) / 1000.0, static_cast<double>(active) / 1000.0,
+             static_cast<double>(overhead) / 1000.0);
     uint64_t before = this->total_before_time_us_;
     uint64_t tail = this->total_tail_time_us_;
     uint64_t accounted = before + tail;
     uint64_t inter = overhead > accounted ? overhead - accounted : 0;
-    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms", before / 1000.0f,
-             tail / 1000.0f, inter / 1000.0f);
+    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms",
+             static_cast<double>(before) / 1000.0, static_cast<double>(tail) / 1000.0,
+             static_cast<double>(inter) / 1000.0);
   }
 
   // Reset period stats

--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -32,40 +32,74 @@ void RuntimeStatsCollector::log_stats_() {
            " Period stats (last %" PRIu32 "ms): %zu active components",
            this->log_interval_, count);
 
-  if (count == 0) {
-    return;
+  // Sum component period time so we can derive main-loop overhead
+  // (active loop time minus time attributable to component loop()s).
+  uint64_t period_component_sum_us = 0;
+  uint64_t total_component_sum_us = 0;
+  for (size_t i = 0; i < count; i++) {
+    period_component_sum_us += sorted[i]->runtime_stats_.period_time_us;
+    total_component_sum_us += sorted[i]->runtime_stats_.total_time_us;
   }
 
-  // Sort by period runtime (descending)
-  std::sort(sorted, sorted + count, compare_period_time);
+  if (count > 0) {
+    // Sort by period runtime (descending)
+    std::sort(sorted, sorted + count, compare_period_time);
 
-  // Log top components by period runtime
-  for (size_t i = 0; i < count; i++) {
-    const auto &stats = sorted[i]->runtime_stats_;
-    ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.3fms, max=%.2fms, total=%.1fms",
-             LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.period_count,
-             stats.period_count > 0 ? stats.period_time_us / (float) stats.period_count / 1000.0f : 0.0f,
-             stats.period_max_time_us / 1000.0f, stats.period_time_us / 1000.0f);
+    // Log top components by period runtime
+    for (size_t i = 0; i < count; i++) {
+      const auto &stats = sorted[i]->runtime_stats_;
+      ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.3fms, max=%.2fms, total=%.1fms",
+               LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.period_count,
+               stats.period_count > 0 ? stats.period_time_us / (float) stats.period_count / 1000.0f : 0.0f,
+               stats.period_max_time_us / 1000.0f, stats.period_time_us / 1000.0f);
+    }
+  }
+
+  // Main-loop overhead for the period: active wall time minus component time.
+  // active = sum of per-iteration loop time excluding yield/sleep.
+  if (this->period_active_count_ > 0) {
+    uint64_t active = this->period_active_time_us_;
+    uint64_t overhead = active > period_component_sum_us ? active - period_component_sum_us : 0;
+    ESP_LOGI(TAG,
+             "  main_loop: iters=%" PRIu32 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
+             "overhead_total=%.1fms",
+             this->period_active_count_, active / (float) this->period_active_count_ / 1000.0f,
+             this->period_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
   }
 
   // Log total stats since boot (only for active components - idle ones haven't changed)
   ESP_LOGI(TAG, " Total stats (since boot): %zu active components", count);
 
-  // Re-sort by total runtime for all-time stats
-  std::sort(sorted, sorted + count, compare_total_time);
+  if (count > 0) {
+    // Re-sort by total runtime for all-time stats
+    std::sort(sorted, sorted + count, compare_total_time);
 
-  for (size_t i = 0; i < count; i++) {
-    const auto &stats = sorted[i]->runtime_stats_;
-    ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.3fms, max=%.2fms, total=%.1fms",
-             LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.total_count,
-             stats.total_count > 0 ? stats.total_time_us / (float) stats.total_count / 1000.0f : 0.0f,
-             stats.total_max_time_us / 1000.0f, stats.total_time_us / 1000.0);
+    for (size_t i = 0; i < count; i++) {
+      const auto &stats = sorted[i]->runtime_stats_;
+      ESP_LOGI(TAG, "  %s: count=%" PRIu32 ", avg=%.3fms, max=%.2fms, total=%.1fms",
+               LOG_STR_ARG(sorted[i]->get_component_log_str()), stats.total_count,
+               stats.total_count > 0 ? stats.total_time_us / (float) stats.total_count / 1000.0f : 0.0f,
+               stats.total_max_time_us / 1000.0f, stats.total_time_us / 1000.0);
+    }
+  }
+
+  if (this->total_active_count_ > 0) {
+    uint64_t active = this->total_active_time_us_;
+    uint64_t overhead = active > total_component_sum_us ? active - total_component_sum_us : 0;
+    ESP_LOGI(TAG,
+             "  main_loop: iters=%" PRIu32 ", active_avg=%.3fms, active_max=%.2fms, active_total=%.1fms, "
+             "overhead_total=%.1fms",
+             this->total_active_count_, active / (float) this->total_active_count_ / 1000.0f,
+             this->total_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
   }
 
   // Reset period stats
   for (auto *component : components) {
     component->runtime_stats_.reset_period();
   }
+  this->period_active_count_ = 0;
+  this->period_active_time_us_ = 0;
+  this->period_active_max_us_ = 0;
 }
 
 bool RuntimeStatsCollector::compare_period_time(Component *a, Component *b) {

--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -70,6 +70,12 @@ void RuntimeStatsCollector::log_stats_() {
              "overhead_total=%.1fms",
              this->period_active_count_, active / (float) this->period_active_count_ / 1000.0f,
              this->period_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
+    uint64_t before = this->period_before_time_us_;
+    uint64_t tail = this->period_tail_time_us_;
+    uint64_t accounted = before + tail;
+    uint64_t inter = overhead > accounted ? overhead - accounted : 0;
+    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms", before / 1000.0f,
+             tail / 1000.0f, inter / 1000.0f);
   }
 
   // Log total stats since boot (only for active components - idle ones haven't changed)
@@ -96,6 +102,12 @@ void RuntimeStatsCollector::log_stats_() {
              "overhead_total=%.1fms",
              this->total_active_count_, active / (float) this->total_active_count_ / 1000.0f,
              this->total_active_max_us_ / 1000.0f, active / 1000.0f, overhead / 1000.0f);
+    uint64_t before = this->total_before_time_us_;
+    uint64_t tail = this->total_tail_time_us_;
+    uint64_t accounted = before + tail;
+    uint64_t inter = overhead > accounted ? overhead - accounted : 0;
+    ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms", before / 1000.0f,
+             tail / 1000.0f, inter / 1000.0f);
   }
 
   // Reset period stats
@@ -105,6 +117,8 @@ void RuntimeStatsCollector::log_stats_() {
   this->period_active_count_ = 0;
   this->period_active_time_us_ = 0;
   this->period_active_max_us_ = 0;
+  this->period_before_time_us_ = 0;
+  this->period_tail_time_us_ = 0;
 }
 
 bool RuntimeStatsCollector::compare_period_time(Component *a, Component *b) {

--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -29,6 +29,21 @@ class RuntimeStatsCollector {
   // Process any pending stats printing (should be called after component loop)
   void process_pending_stats(uint32_t current_time);
 
+  // Record the wall time of one main loop iteration excluding the yield/sleep.
+  // Called once per loop from Application::loop(). Overhead (loop machinery,
+  // scheduler, before/after-loop tasks) is derived at log time as
+  // (loop_active_time) - (sum of per-component time).
+  void record_loop_active(uint32_t duration_us) {
+    this->period_active_count_++;
+    this->period_active_time_us_ += duration_us;
+    if (duration_us > this->period_active_max_us_)
+      this->period_active_max_us_ = duration_us;
+    this->total_active_count_++;
+    this->total_active_time_us_ += duration_us;
+    if (duration_us > this->total_active_max_us_)
+      this->total_active_max_us_ = duration_us;
+  }
+
  protected:
   void log_stats_();
   // Static comparators — member functions have friend access, lambdas do not
@@ -37,6 +52,14 @@ class RuntimeStatsCollector {
 
   uint32_t log_interval_;
   uint32_t next_log_time_{0};
+
+  // Main loop active-time stats (wall time per iteration, excluding yield/sleep)
+  uint32_t period_active_count_{0};
+  uint64_t period_active_time_us_{0};
+  uint32_t period_active_max_us_{0};
+  uint32_t total_active_count_{0};
+  uint64_t total_active_time_us_{0};
+  uint32_t total_active_max_us_{0};
 };
 
 }  // namespace runtime_stats

--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -30,18 +30,28 @@ class RuntimeStatsCollector {
   void process_pending_stats(uint32_t current_time);
 
   // Record the wall time of one main loop iteration excluding the yield/sleep.
-  // Called once per loop from Application::loop(). Overhead (loop machinery,
-  // scheduler, before/after-loop tasks) is derived at log time as
-  // (loop_active_time) - (sum of per-component time).
-  void record_loop_active(uint32_t duration_us) {
+  // Called once per loop from Application::loop().
+  //   active_us = total time between loop start and just before yield.
+  //   before_us = time spent in before_loop_tasks_ (scheduler + ISR enable_loop).
+  //   tail_us   = time spent in after_loop_tasks_ + the trailing record/stats prefix.
+  // Residual overhead at log time = active − Σ(component) − before − tail,
+  // which captures per-iteration inter-component bookkeeping (set_current_component,
+  // WarnIfComponentBlockingGuard construction/destruction, feed_wdt_with_time calls,
+  // the for-loop itself).
+  void record_loop_active(uint32_t active_us, uint32_t before_us, uint32_t tail_us) {
     this->period_active_count_++;
-    this->period_active_time_us_ += duration_us;
-    if (duration_us > this->period_active_max_us_)
-      this->period_active_max_us_ = duration_us;
+    this->period_active_time_us_ += active_us;
+    if (active_us > this->period_active_max_us_)
+      this->period_active_max_us_ = active_us;
     this->total_active_count_++;
-    this->total_active_time_us_ += duration_us;
-    if (duration_us > this->total_active_max_us_)
-      this->total_active_max_us_ = duration_us;
+    this->total_active_time_us_ += active_us;
+    if (active_us > this->total_active_max_us_)
+      this->total_active_max_us_ = active_us;
+
+    this->period_before_time_us_ += before_us;
+    this->total_before_time_us_ += before_us;
+    this->period_tail_time_us_ += tail_us;
+    this->total_tail_time_us_ += tail_us;
   }
 
  protected:
@@ -62,6 +72,12 @@ class RuntimeStatsCollector {
   uint64_t total_active_count_{0};
   uint64_t total_active_time_us_{0};
   uint32_t total_active_max_us_{0};
+
+  // Split of overhead sections — accumulated per iteration.
+  uint64_t period_before_time_us_{0};
+  uint64_t total_before_time_us_{0};
+  uint64_t period_tail_time_us_{0};
+  uint64_t total_tail_time_us_{0};
 };
 
 }  // namespace runtime_stats

--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -53,11 +53,13 @@ class RuntimeStatsCollector {
   uint32_t log_interval_;
   uint32_t next_log_time_{0};
 
-  // Main loop active-time stats (wall time per iteration, excluding yield/sleep)
-  uint32_t period_active_count_{0};
+  // Main loop active-time stats (wall time per iteration, excluding yield/sleep).
+  // Counters are uint64_t — at sub-millisecond loop times a uint32_t can wrap in
+  // a few weeks of uptime, which is well within ESPHome device lifetimes.
+  uint64_t period_active_count_{0};
   uint64_t period_active_time_us_{0};
   uint32_t period_active_max_us_{0};
-  uint32_t total_active_count_{0};
+  uint64_t total_active_count_{0};
   uint64_t total_active_time_us_{0};
   uint32_t total_active_max_us_{0};
 };

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -877,6 +877,11 @@ inline void ESPHOME_ALWAYS_INLINE Application::before_loop_tasks_(uint32_t loop_
 }
 
 inline void ESPHOME_ALWAYS_INLINE Application::loop() {
+#ifdef USE_RUNTIME_STATS
+  // Capture the start of the active (non-sleeping) portion of this iteration.
+  // Used to derive main-loop overhead = active time − Σ(component time).
+  uint32_t loop_active_start_us = micros();
+#endif
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
 
@@ -905,6 +910,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // Process any pending runtime stats printing after all components have run
   // This ensures stats printing doesn't affect component timing measurements
   if (global_runtime_stats != nullptr) {
+    global_runtime_stats->record_loop_active(micros() - loop_active_start_us);
     global_runtime_stats->process_pending_stats(last_op_end_time);
   }
 #endif

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -886,7 +886,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // slice that the scheduler spends inside its own WarnIfComponentBlockingGuard
   // (scheduler.cpp) — that time is already counted in per-component stats,
   // so charging it again to "before" would double-count.
-  uint64_t loop_recorded_snap = ComponentRuntimeStats::global_recorded_us_;
+  uint64_t loop_recorded_snap = ComponentRuntimeStats::global_recorded_us;
 #endif
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
@@ -894,7 +894,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   this->before_loop_tasks_(last_op_end_time);
 #ifdef USE_RUNTIME_STATS
   uint32_t loop_before_end_us = micros();
-  uint64_t loop_before_scheduled_us = ComponentRuntimeStats::global_recorded_us_ - loop_recorded_snap;
+  uint64_t loop_before_scheduled_us = ComponentRuntimeStats::global_recorded_us - loop_recorded_snap;
 #endif
 
   for (this->current_loop_index_ = 0; this->current_loop_index_ < this->looping_components_active_end_;

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -879,13 +879,17 @@ inline void ESPHOME_ALWAYS_INLINE Application::before_loop_tasks_(uint32_t loop_
 inline void ESPHOME_ALWAYS_INLINE Application::loop() {
 #ifdef USE_RUNTIME_STATS
   // Capture the start of the active (non-sleeping) portion of this iteration.
-  // Used to derive main-loop overhead = active time − Σ(component time).
+  // Used to derive main-loop overhead = active time − Σ(component time) −
+  // before/tail splits recorded below.
   uint32_t loop_active_start_us = micros();
 #endif
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
 
   this->before_loop_tasks_(last_op_end_time);
+#ifdef USE_RUNTIME_STATS
+  uint32_t loop_before_end_us = micros();
+#endif
 
   for (this->current_loop_index_ = 0; this->current_loop_index_ < this->looping_components_active_end_;
        this->current_loop_index_++) {
@@ -904,13 +908,19 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
     this->feed_wdt_with_time(last_op_end_time);
   }
 
+#ifdef USE_RUNTIME_STATS
+  uint32_t loop_tail_start_us = micros();
+#endif
   this->after_loop_tasks_();
 
 #ifdef USE_RUNTIME_STATS
   // Process any pending runtime stats printing after all components have run
   // This ensures stats printing doesn't affect component timing measurements
   if (global_runtime_stats != nullptr) {
-    global_runtime_stats->record_loop_active(micros() - loop_active_start_us);
+    uint32_t loop_now_us = micros();
+    global_runtime_stats->record_loop_active(loop_now_us - loop_active_start_us,
+                                             loop_before_end_us - loop_active_start_us,
+                                             loop_now_us - loop_tail_start_us);
     global_runtime_stats->process_pending_stats(last_op_end_time);
   }
 #endif

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -882,6 +882,11 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // Used to derive main-loop overhead = active time − Σ(component time) −
   // before/tail splits recorded below.
   uint32_t loop_active_start_us = micros();
+  // Snapshot the cumulative component-recorded time so we can subtract the
+  // slice that the scheduler spends inside its own WarnIfComponentBlockingGuard
+  // (scheduler.cpp) — that time is already counted in per-component stats,
+  // so charging it again to "before" would double-count.
+  uint64_t loop_recorded_snap = ComponentRuntimeStats::global_recorded_us_;
 #endif
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
@@ -889,6 +894,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   this->before_loop_tasks_(last_op_end_time);
 #ifdef USE_RUNTIME_STATS
   uint32_t loop_before_end_us = micros();
+  uint64_t loop_before_scheduled_us = ComponentRuntimeStats::global_recorded_us_ - loop_recorded_snap;
 #endif
 
   for (this->current_loop_index_ = 0; this->current_loop_index_ < this->looping_components_active_end_;
@@ -918,8 +924,13 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // This ensures stats printing doesn't affect component timing measurements
   if (global_runtime_stats != nullptr) {
     uint32_t loop_now_us = micros();
-    global_runtime_stats->record_loop_active(loop_now_us - loop_active_start_us,
-                                             loop_before_end_us - loop_active_start_us,
+    // Subtract scheduled-component time from the "before" bucket so it is
+    // not double-counted (it is already attributed to per-component stats).
+    uint32_t loop_before_wall_us = loop_before_end_us - loop_active_start_us;
+    uint32_t loop_before_overhead_us = loop_before_wall_us > loop_before_scheduled_us
+                                           ? loop_before_wall_us - static_cast<uint32_t>(loop_before_scheduled_us)
+                                           : 0;
+    global_runtime_stats->record_loop_active(loop_now_us - loop_active_start_us, loop_before_overhead_us,
                                              loop_now_us - loop_tail_start_us);
     global_runtime_stats->process_pending_stats(last_op_end_time);
   }

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -507,7 +507,7 @@ void PollingComponent::stop_poller() {
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }
 
 #ifdef USE_RUNTIME_STATS
-uint64_t ComponentRuntimeStats::global_recorded_us_ = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+uint64_t ComponentRuntimeStats::global_recorded_us = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 #endif
 
 void __attribute__((noinline, cold))

--- a/esphome/core/component.cpp
+++ b/esphome/core/component.cpp
@@ -506,6 +506,10 @@ void PollingComponent::stop_poller() {
 
 uint32_t PollingComponent::get_update_interval() const { return this->update_interval_; }
 
+#ifdef USE_RUNTIME_STATS
+uint64_t ComponentRuntimeStats::global_recorded_us_ = 0;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#endif
+
 void __attribute__((noinline, cold))
 WarnIfComponentBlockingGuard::warn_blocking(Component *component, uint32_t blocking_time) {
   bool should_warn;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -121,7 +121,7 @@ struct ComponentRuntimeStats {
   // WarnIfComponentBlockingGuard (including guards constructed by the
   // scheduler at scheduler.cpp) so main-loop overhead accounting can
   // subtract scheduled-callback time from the before_loop_tasks_ wall time.
-  static uint64_t global_recorded_us_;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+  static uint64_t global_recorded_us;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
   void record_time(uint32_t duration_us) {
     this->period_count++;
@@ -132,7 +132,7 @@ struct ComponentRuntimeStats {
     this->total_time_us += duration_us;
     if (duration_us > this->total_max_time_us)
       this->total_max_time_us = duration_us;
-    global_recorded_us_ += duration_us;
+    global_recorded_us += duration_us;
   }
   void reset_period() {
     this->period_count = 0;

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -116,6 +116,13 @@ struct ComponentRuntimeStats {
   uint64_t total_time_us{0};
   uint32_t total_max_time_us{0};
 
+  // Cumulative sum of every record_time() duration since boot, across all
+  // components. Used by Application::loop() to snapshot time spent inside
+  // WarnIfComponentBlockingGuard (including guards constructed by the
+  // scheduler at scheduler.cpp) so main-loop overhead accounting can
+  // subtract scheduled-callback time from the before_loop_tasks_ wall time.
+  static uint64_t global_recorded_us_;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
   void record_time(uint32_t duration_us) {
     this->period_count++;
     this->period_time_us += duration_us;
@@ -125,6 +132,7 @@ struct ComponentRuntimeStats {
     this->total_time_us += duration_us;
     if (duration_us > this->total_max_time_us)
       this->total_max_time_us = duration_us;
+    global_recorded_us_ += duration_us;
   }
   void reset_period() {
     this->period_count = 0;

--- a/tests/integration/test_runtime_stats.py
+++ b/tests/integration/test_runtime_stats.py
@@ -26,6 +26,7 @@ async def test_runtime_stats(
 
     # Track component stats
     component_stats_found = set()
+    main_loop_lines: list[dict[str, str]] = []
 
     # Patterns to match - need to handle ANSI color codes and timestamps
     # The log format is: [HH:MM:SS][color codes][I][tag]: message
@@ -33,6 +34,14 @@ async def test_runtime_stats(
     # Match component names that may include dots (e.g., template.sensor)
     component_pattern = re.compile(
         r"^\[[^\]]+\].*?\s+([\w.]+):\s+count=(\d+),\s+avg=([\d.]+)ms"
+    )
+    # Main loop overhead line emitted by runtime_stats
+    main_loop_pattern = re.compile(
+        r"main_loop:\s+iters=(?P<iters>\d+),\s+"
+        r"active_avg=(?P<active_avg>[\d.]+)ms,\s+"
+        r"active_max=(?P<active_max>[\d.]+)ms,\s+"
+        r"active_total=(?P<active_total>[\d.]+)ms,\s+"
+        r"overhead_total=(?P<overhead_total>[\d.]+)ms"
     )
 
     def check_output(line: str) -> None:
@@ -53,6 +62,11 @@ async def test_runtime_stats(
         if match:
             component_name = match.group(1)
             component_stats_found.add(component_name)
+
+        # Check for main_loop overhead line
+        ml_match = main_loop_pattern.search(line)
+        if ml_match:
+            main_loop_lines.append(ml_match.groupdict())
 
     async with (
         run_compiled(yaml_config, line_callback=check_output),
@@ -86,3 +100,22 @@ async def test_runtime_stats(
         assert "template.switch" in component_stats_found, (
             f"Expected template.switch stats, found: {component_stats_found}"
         )
+
+        # Verify the main_loop overhead line is emitted (at least once for
+        # the period section and once for the total section, per log cycle).
+        assert len(main_loop_lines) >= 2, (
+            f"Expected at least 2 main_loop lines, got {len(main_loop_lines)}"
+        )
+        for fields in main_loop_lines:
+            assert int(fields["iters"]) > 0, f"iters should be > 0: {fields}"
+            assert float(fields["active_total"]) > 0.0, (
+                f"active_total should be > 0: {fields}"
+            )
+            assert float(fields["active_avg"]) >= 0.0, (
+                f"active_avg should be >= 0: {fields}"
+            )
+            # overhead_total is derived and may be 0 if components dominate,
+            # but the field must still be present and parseable as a float.
+            assert float(fields["overhead_total"]) >= 0.0, (
+                f"overhead_total should be >= 0: {fields}"
+            )


### PR DESCRIPTION
# What does this implement/fix?

Adds main-loop active-time tracking to `runtime_stats` and reports the
derived overhead alongside the existing component table, with a second
line breaking overhead down by loop section.

Each iteration of `Application::loop()` captures `micros()` at four
points (loop start, end of `before_loop_tasks_`, start of
`after_loop_tasks_`, and just before `process_pending_stats`) so we can
attribute time to three buckets:

- `before`          — time in `before_loop_tasks_` minus any scheduled
                      callback time already counted against components
                      (scheduler walk + ISR `enable_loop` processing).
- `tail`            — time in `after_loop_tasks_` + the trailing record
                      prefix. Mostly measurement artifact.
- `inter_component` — residual per-iteration bookkeeping between
                      components (`set_current_component`,
                      `WarnIfComponentBlockingGuard` construction /
                      destruction, `feed_wdt_with_time`, the for-loop
                      itself).

`overhead_total = active_total − Σ(component period_time)` is computed
at log time, where `active_total` is the sum of per-iteration loop time
excluding the `yield_with_select_` sleep at the end of the iteration.
The split in `main_loop_overhead_section` lets a single log sample
identify whether a regression came from the scheduler, per-component
dispatch, or the trailing teardown.

Output adds two lines per section (period and total):

```
[runtime_stats] Component Runtime Statistics
 Period stats (last 60000ms): 12 active components
   ...component lines...
   main_loop: iters=58231, active_avg=0.412ms, active_max=14.30ms, active_total=23998.1ms, overhead_total=842.5ms
   main_loop_overhead_section: before=412.0ms, tail=0.3ms, inter_component=430.2ms
 Total stats (since boot): 12 active components
   ...component lines...
   main_loop: iters=580121, active_avg=0.408ms, active_max=18.10ms, active_total=236689.4ms, overhead_total=8210.7ms
   main_loop_overhead_section: before=3920.0ms, tail=3.1ms, inter_component=4287.6ms
```

Cost per loop iteration: four `micros()` calls (~100ns each on ESP32)
and a small accumulator update. Compiled out entirely when
`USE_RUNTIME_STATS` is not defined.

## Measurement resolution and intent

The instrumentation adds ~2-3µs/iter of measurement overhead (component
guards + loop-level `micros()` calls + accumulator updates). FreeRTOS
preemption and IRQ jitter (WiFi/BLE) add another ~1-2µs/iter of noise.
Together this sets a **~1-3µs/iter noise floor**, so branch-vs-branch
microbenchmarks that differ by fractions of a microsecond per iteration
are not distinguishable here.

This component is intentionally tuned for **catching real regressions**,
not for splitting microseconds:

- a component that starts blocking in `loop()` — immediately visible in
  `active_max` and the component's `max` / `avg`;
- a scheduler bug dispatching far more items than expected — `before`
  jumps well beyond noise;
- a stray `delay()` or flash write in the hot path — `active_max`
  spikes, the offender's row balloons;
- a component leaking `set_interval` callbacks — its `count` and `total`
  climb linearly over time.

Real regressions are typically 10×+ the noise floor and obvious at a
glance. Sub-µs micro-optimisations need a different tool (cycle-counted
benchmark, or CodSpeed-style external harness).

## What actually shows up clearly

Cross-platform data from two real devices on the same build
demonstrates the tool's useful signal scale:

| device | components | iters/60s | active/iter | inter_component/iter | per-component dispatch |
|---|---|---|---|---|---|
| ESP32 (BLE proxy) | 8 | 7665 | 64.6µs | 9.7µs | **~1.3µs/component** |
| ESP32 (14 sensors + radar) | 14 | 7870 | 93.9µs | 18.6µs | **~1.3µs/component** |
| ESP8266 (ratgdo + wifi + mdns) | 7 | 7774 | 75.7µs | 13.5µs | **~1.9µs/component** |

Per-component dispatch is stable across two very different ESP32 configs
(same ~1.3µs/component) and measurably higher on ESP8266 (~1.9µs), which
is consistent with the 80MHz vs 240MHz CPU gap and ESP32's dual-issue
pipeline. `before` is roughly 2× on ESP8266 (14µs vs 6-7µs) because
`millis_64_from_` takes the 32-bit rollover-tracking path on platforms
without `USE_NATIVE_64BIT_TIME`, so each scheduler call pays more.

That's the scale of difference the tool resolves cleanly. A future
change that pushed per-component dispatch from 1.3µs → 2µs would show
up as a proportional jump on every device instantly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6465

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
runtime_stats:
  log_interval: 60s
```

(no configuration changes — overhead reporting is automatic when
`runtime_stats` is enabled)

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).