### PR TITLE
[core] next schedule calculation adjustment fix

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -917,7 +917,9 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
     uint32_t next_schedule = this->scheduler.next_schedule_in(last_op_end_time).value_or(delay_time);
     // next_schedule is max of next_schedule and 0.5*default (16ms) delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep
-    next_schedule = std::max(next_schedule, ((16 - elapsed) / 2));
+    if (elapsed < 16) {
+      next_schedule = std::max(next_schedule, ((16 - elapsed) / 2));
+    }
     delay_time = std::min(next_schedule, delay_time);
   }
   this->yield_with_select_(delay_time);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -915,7 +915,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   if (elapsed < this->loop_interval_ && !HighFrequencyLoopRequester::is_high_frequency()) {
     delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in(last_op_end_time).value_or(delay_time);
-    // next_schedule is max 0.5*original delay_time
+    // next_schedule is max of next_schedule and 0.5*default (16ms) delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep
     next_schedule = std::max(next_schedule, ((16 - elapsed) / 2));
     delay_time = std::min(next_schedule, delay_time);

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -915,9 +915,9 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   if (elapsed < this->loop_interval_ && !HighFrequencyLoopRequester::is_high_frequency()) {
     delay_time = this->loop_interval_ - elapsed;
     uint32_t next_schedule = this->scheduler.next_schedule_in(last_op_end_time).value_or(delay_time);
-    // next_schedule is max 0.5*delay_time
+    // next_schedule is max 0.5*original delay_time
     // otherwise interval=0 schedules result in constant looping with almost no sleep
-    next_schedule = std::max(next_schedule, delay_time / 2);
+    next_schedule = std::max(next_schedule, ((16 - elapsed) / 2));
     delay_time = std::min(next_schedule, delay_time);
   }
   this->yield_with_select_(delay_time);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
There is code when calculating the timing of the next loop that is preventing very fast runs of PollingComponents (Interval=0).

It uses delay_time = this->loop_interval_ - elapsed; and use 1/2 that value to determine the minimum amount of time until the next main loop occurs.  loop_interval_ can be set by the public method Application.set_loop_interval(), so the current technique does not work when loop_interval_ is set to larger values.  I am currently testing the external_component power_management that needs longer loop intervals to allow device to go into extended automatic light sleep durations.

This change hardcodes the time used for calculating minimum delay to use the default 16ms.
```cpp
next_schedule = std::max(next_schedule, ((16 - elapsed) / 2));
```

I'm documenting as a breaking change because Application.set_loop_interval() is a public function.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
esphome:
  on_boot:
    then:
      - delay: 20s
      - lambda: |-
          App.set_loop_interval(5000);
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
