### PR TITLE
[openthread] Add build flag to disable SRP & DNS64

### DIFF
--- a/esphome/components/factory_reset/button/factory_reset_button.cpp
+++ b/esphome/components/factory_reset/button/factory_reset_button.cpp
@@ -19,7 +19,7 @@ void FactoryResetButton::press_action() {
   ESP_LOGI(TAG, "Resetting");
   // Let MQTT settle a bit
   delay(100);  // NOLINT
-#ifdef USE_OPENTHREAD
+#ifdef USE_OPENTHREAD_SRP
   openthread::global_openthread_component->on_factory_reset(FactoryResetButton::factory_reset_callback);
 #else
   global_preferences->reset();
@@ -27,7 +27,7 @@ void FactoryResetButton::press_action() {
 #endif
 }
 
-#ifdef USE_OPENTHREAD
+#ifdef USE_OPENTHREAD_SRP
 void FactoryResetButton::factory_reset_callback() {
   global_preferences->reset();
   App.safe_reboot();

--- a/esphome/components/factory_reset/switch/factory_reset_switch.cpp
+++ b/esphome/components/factory_reset/switch/factory_reset_switch.cpp
@@ -23,7 +23,7 @@ void FactoryResetSwitch::write_state(bool state) {
     ESP_LOGI(TAG, "Resetting");
     // Let MQTT settle a bit
     delay(100);  // NOLINT
-#ifdef USE_OPENTHREAD
+#ifdef USE_OPENTHREAD_SRP
     openthread::global_openthread_component->on_factory_reset(FactoryResetSwitch::factory_reset_callback);
 #else
     global_preferences->reset();
@@ -32,7 +32,7 @@ void FactoryResetSwitch::write_state(bool state) {
   }
 }
 
-#ifdef USE_OPENTHREAD
+#ifdef USE_OPENTHREAD_SRP
 void FactoryResetSwitch::factory_reset_callback() {
   global_preferences->reset();
   App.safe_reboot();

--- a/esphome/components/openthread/__init__.py
+++ b/esphome/components/openthread/__init__.py
@@ -62,6 +62,8 @@ CONF_DEVICE_TYPES = [
     "FTD",
     "MTD",
 ]
+CONF_ENABLE_DNS64 = "enable_dns64"
+CONF_ENABLE_SRP = "enable_srp"
 
 
 def _validate_txpower(value):
@@ -126,8 +128,10 @@ def set_sdkconfig_options(config):
     if config.get(CONF_FORCE_DATASET):
         cg.add_define("USE_OPENTHREAD_FORCE_DATASET")
 
-    add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS64_CLIENT", True)
-    add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", True)
+    enable_dns64 = config[CONF_ENABLE_DNS64]
+    add_idf_sdkconfig_option("CONFIG_OPENTHREAD_DNS64_CLIENT", enable_dns64)
+    enable_srp = config[CONF_ENABLE_SRP]
+    add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT", enable_srp)
     add_idf_sdkconfig_option("CONFIG_OPENTHREAD_SRP_CLIENT_MAX_SERVICES", 5)
 
     # TODO: Add support for synchronized sleepy end devices (SSED)
@@ -175,12 +179,20 @@ def _require_vfs_select(config):
     return config
 
 
+def _apply_mdns(config):
+    """Resembles "cv.GenerateID(CONF_MDNS_ID): cv.use_id(MDNSComponent)",
+    but only if SRP is enabled, to avoid MDNS dependency if SRP disabled."""
+    if config[CONF_ENABLE_SRP]:
+        config[CONF_MDNS_ID] = cv.use_id(MDNSComponent)(config.get(CONF_MDNS_ID))
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(OpenThreadComponent),
             cv.GenerateID(CONF_SRP_ID): cv.declare_id(OpenThreadSrpComponent),
-            cv.GenerateID(CONF_MDNS_ID): cv.use_id(MDNSComponent),
+            cv.Optional(CONF_MDNS_ID): cv.string_strict,
             cv.Optional(CONF_DEVICE_TYPE, default="FTD"): cv.one_of(
                 *CONF_DEVICE_TYPES, upper=True
             ),
@@ -192,11 +204,14 @@ CONFIG_SCHEMA = cv.All(
                 cv.decibel,
                 _validate_txpower,
             ),
+            cv.Optional(CONF_ENABLE_DNS64, default=True): cv.boolean,
+            cv.Optional(CONF_ENABLE_SRP, default=True): cv.boolean,
         }
     ).extend(_CONNECTION_SCHEMA),
     cv.has_exactly_one_key(CONF_NETWORK_KEY, CONF_TLV),
     only_on_variant(supported=[VARIANT_ESP32C5, VARIANT_ESP32C6, VARIANT_ESP32H2]),
     _validate,
+    _apply_mdns,
     _require_vfs_select,
 )
 
@@ -229,8 +244,14 @@ async def to_code(config):
 
     cg.add_define("USE_OPENTHREAD")
 
-    # OpenThread SRP needs access to mDNS services after setup
-    enable_mdns_storage()
+    enable_srp = config[CONF_ENABLE_SRP]
+
+    if enable_srp:
+        # OpenThread SRP needs access to mDNS services after setup
+        enable_mdns_storage()
+        # USE_OPENTHREAD_SRP implies USE_OPENTHREAD above.
+        # Code expecting both may only check this define for simplicity.
+        cg.add_define("USE_OPENTHREAD_SRP")
 
     ot = cg.new_Pvariable(config[CONF_ID])
     cg.add(ot.set_use_address(config[CONF_USE_ADDRESS]))
@@ -238,10 +259,11 @@ async def to_code(config):
     if (poll_period := config.get(CONF_POLL_PERIOD)) is not None:
         cg.add(ot.set_poll_period(poll_period))
 
-    srp = cg.new_Pvariable(config[CONF_SRP_ID])
-    mdns_component = await cg.get_variable(config[CONF_MDNS_ID])
-    cg.add(srp.set_mdns(mdns_component))
-    await cg.register_component(srp, config)
+    if enable_srp:
+        srp = cg.new_Pvariable(config[CONF_SRP_ID])
+        mdns_component = await cg.get_variable(config[CONF_MDNS_ID])
+        cg.add(srp.set_mdns(mdns_component))
+        await cg.register_component(srp, config)
 
     if (output_power := config.get(CONF_OUTPUT_POWER)) is not None:
         cg.add(ot.set_output_power(output_power))

--- a/esphome/components/openthread/openthread.cpp
+++ b/esphome/components/openthread/openthread.cpp
@@ -84,6 +84,7 @@ std::optional<otIp6Address> OpenThreadComponent::get_omr_address_(InstanceLock &
   return {};
 }
 
+#ifdef USE_OPENTHREAD_SRP
 void OpenThreadComponent::defer_factory_reset_external_callback() {
   ESP_LOGD(TAG, "Defer factory_reset_external_callback_");
   this->defer([this]() { this->factory_reset_external_callback_(); });
@@ -218,10 +219,13 @@ void *OpenThreadSrpComponent::pool_alloc_(size_t size) {
 }
 
 void OpenThreadSrpComponent::set_mdns(esphome::mdns::MDNSComponent *mdns) { this->mdns_ = mdns; }
+#endif  // USE_OPENTHREAD_SRP
 
 bool OpenThreadComponent::teardown() {
   if (!this->teardown_started_) {
     this->teardown_started_ = true;
+
+#ifdef USE_OPENTHREAD_SRP
     ESP_LOGD(TAG, "Clear Srp");
     auto lock = InstanceLock::try_acquire(100);
     if (!lock) {
@@ -231,6 +235,10 @@ bool OpenThreadComponent::teardown() {
     otInstance *instance = lock->get_instance();
     otSrpClientClearHostAndServices(instance);
     otSrpClientBuffersFreeAllServices(instance);
+    // Only OT API functions with instance (i.e. Srp) need lock
+    // So lock not needed anymore
+#endif  // USE_OPENTHREAD_SRP
+
     global_openthread_component = nullptr;
     ESP_LOGD(TAG, "Exit main loop ");
     int error = this->openthread_stop_();
@@ -242,6 +250,7 @@ bool OpenThreadComponent::teardown() {
   return this->teardown_complete_;
 }
 
+#ifdef USE_OPENTHREAD_SRP
 void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
   factory_reset_external_callback_ = callback;
   ESP_LOGD(TAG, "Start Removal SRP Host and Services");
@@ -256,6 +265,7 @@ void OpenThreadComponent::on_factory_reset(std::function<void()> callback) {
   }
   ESP_LOGD(TAG, "Waiting on Confirmation Removal SRP Host and Services");
 }
+#endif  // USE_OPENTHREAD_SRP
 
 }  // namespace esphome::openthread
 #endif

--- a/esphome/components/openthread/openthread.h
+++ b/esphome/components/openthread/openthread.h
@@ -2,12 +2,16 @@
 #include "esphome/core/defines.h"
 #ifdef USE_OPENTHREAD
 
+#ifdef USE_OPENTHREAD_SRP
 #include "esphome/components/mdns/mdns_component.h"
+#endif
 #include "esphome/components/network/ip_address.h"
 #include "esphome/core/component.h"
 
+#ifdef USE_OPENTHREAD_SRP
 #include <openthread/srp_client.h>
 #include <openthread/srp_client_buffers.h>
+#endif
 #include <openthread/instance.h>
 #include <openthread/thread.h>
 
@@ -34,8 +38,10 @@ class OpenThreadComponent : public Component {
   network::IPAddresses get_ip_addresses();
   std::optional<otIp6Address> get_omr_address();
   void ot_main();
+#ifdef USE_OPENTHREAD_SRP
   void on_factory_reset(std::function<void()> callback);
   void defer_factory_reset_external_callback();
+#endif
 
   const char *get_use_address() const { return this->use_address_; }
   void set_use_address(const char *use_address) { this->use_address_ = use_address; }
@@ -49,7 +55,9 @@ class OpenThreadComponent : public Component {
   static void on_state_changed_(otChangedFlags flags, void *context);
   otInstance *get_openthread_instance_();
   int openthread_stop_();
+#ifdef USE_OPENTHREAD_SRP
   std::function<void()> factory_reset_external_callback_;
+#endif
 #if CONFIG_OPENTHREAD_MTD
   uint32_t poll_period_{0};
 #endif
@@ -67,6 +75,7 @@ class OpenThreadComponent : public Component {
 
 extern OpenThreadComponent *global_openthread_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+#ifdef USE_OPENTHREAD_SRP
 class OpenThreadSrpComponent : public Component {
  public:
   void set_mdns(esphome::mdns::MDNSComponent *mdns);
@@ -85,6 +94,7 @@ class OpenThreadSrpComponent : public Component {
   std::vector<std::unique_ptr<uint8_t[]>> memory_pool_;
   void *pool_alloc_(size_t size);
 };
+#endif
 
 class InstanceLock {
  public:

--- a/esphome/core/defines.h
+++ b/esphome/core/defines.h
@@ -318,6 +318,7 @@
 #define USE_MICRO_WAKE_WORD_VAD
 #if defined(USE_ESP32_VARIANT_ESP32C6) || defined(USE_ESP32_VARIANT_ESP32H2)
 #define USE_OPENTHREAD
+#define USE_OPENTHREAD_SRP
 #endif
 #endif
 

--- a/tests/components/openthread/test.esp32-c6-idf-mtd-nodns64.yaml
+++ b/tests/components/openthread/test.esp32-c6-idf-mtd-nodns64.yaml
@@ -4,14 +4,6 @@ esp32:
     type: esp-idf
     log_level: DEBUG
 
-# Test: Factory reset callbacks into Openthread SRP
-button:
-  - platform: factory_reset
-    name: "Factory Reset Button"
-switch:
-  - platform: factory_reset
-    name: "Factory Reset Switch"
-
 network:
   enable_ipv6: true
 
@@ -24,7 +16,6 @@ openthread:
   ext_pan_id: 0xd63e8e3e495ebbc3
   pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
-  force_dataset: true
-  use_address: open-thread-test.local
-  poll_period: 20sec
-  output_power: 1dBm
+
+  # Test: Disable DNS64
+  enable_dns64: false

--- a/tests/components/openthread/test.esp32-c6-idf-mtd-nosrp.yaml
+++ b/tests/components/openthread/test.esp32-c6-idf-mtd-nosrp.yaml
@@ -4,13 +4,17 @@ esp32:
     type: esp-idf
     log_level: DEBUG
 
-# Test: Factory reset callbacks into Openthread SRP
+# Test: Factory reset hooks compile after SRP disabled below
 button:
   - platform: factory_reset
     name: "Factory Reset Button"
 switch:
   - platform: factory_reset
     name: "Factory Reset Switch"
+
+# Test: MDNS can be disabled after SRP disabled below
+mdns:
+  disable: true
 
 network:
   enable_ipv6: true
@@ -24,7 +28,6 @@ openthread:
   ext_pan_id: 0xd63e8e3e495ebbc3
   pskc: 0xc23a76e98f1a6483639b1ac1271e2e27
   mesh_local_prefix: fd53:145f:ed22:ad81::/64
-  force_dataset: true
-  use_address: open-thread-test.local
-  poll_period: 20sec
-  output_power: 1dBm
+
+  # Test: Disable SRP
+  enable_srp: false


### PR DESCRIPTION
# What does this implement/fix?

Currently, `openthread` package

1. enables `OpenThreadComponent`,
2. but before this sets up `OpenThreadSrpComponent` for SRP client registration.

SRP (or its mDNS translation) is often unneeded for regular "Home Assistant over Thread" setups, unlike for "Matter over Thread" where SRP is likely required.

This PR adds two flags to disable
- SRP activation
- DNS64 client activation

SRP has quite some resource consumption, when trying out newly possible configurations e.g. with belowmentioned YAML sample:

| Config | RAM | Flash |
|--------|-----|-------|
| Default (all enabled) | 44664 | 643314 |
| `enable_dns64:false` | 43592 | 640334 |
| `enable_srp:false` | 42512 | 556010 |
| `enable_dns64:false`<br>`enable_srp:false` | 41440 | 553034 |
| `enable_dns64:false`<br>`enable_srp:false`<br>`mdns` `disabled:true` | 41416 | 552724 |

Overall, more then 90kB flash reduction possible.

Furthermore, bootup time is impacted: During bootup, the SRP init must be done before actual OpenThread setup due to component priority. It can take quite long, more so if e.g. due to previous unclean shutdown/sleep/..., the old SRP service entry was not unregistered cleanly and some server lease time must be waited before new entry creation.

Simple Thread setups work surprisingly well without SRP/DNS64 in local test runs:
E.g. in setups where Home Assistant collects information from Thread based ESP sensor devices.
This resembles situation for e.g. WiFi as documented in https://esphome.io/guides/faq/#notes-on-disabling-mdns . For OpenThread, there is only minor coupling with SRP, which is preferred by Thread standard over mDNS within the radio network and translated to mDNS by OTBR. See doc.

In future, also other OpenThread build modes like RCP_UART etc without network connection may plan to disable SRP.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6470

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: openthread

esp32:
  variant: esp32c6

network:
  enable_ipv6: true

mdns:
  #disabled: true

openthread:
  tlv: ""  # Required, but irrelevant for sample

  # New flags:
  #enable_dns64: false
  #enable_srp: false
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [X] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
