### PR TITLE
[st7789v] Fix swapped offset_width/offset_height in model presets

### DIFF
--- a/esphome/components/st7789v/display.py
+++ b/esphome/components/st7789v/display.py
@@ -45,8 +45,8 @@ MODELS = {
         presets={
             CONF_HEIGHT: 240,
             CONF_WIDTH: 135,
-            CONF_OFFSET_HEIGHT: 52,
-            CONF_OFFSET_WIDTH: 40,
+            CONF_OFFSET_HEIGHT: 40,
+            CONF_OFFSET_WIDTH: 52,
             CONF_CS_PIN: "GPIO5",
             CONF_DC_PIN: "GPIO16",
             CONF_RESET_PIN: "GPIO23",
@@ -68,8 +68,8 @@ MODELS = {
         presets={
             CONF_HEIGHT: 280,
             CONF_WIDTH: 240,
-            CONF_OFFSET_HEIGHT: 0,
-            CONF_OFFSET_WIDTH: 20,
+            CONF_OFFSET_HEIGHT: 20,
+            CONF_OFFSET_WIDTH: 0,
         }
     ),
     "ADAFRUIT_S2_TFT_FEATHER_240X135": model_spec(
@@ -77,8 +77,8 @@ MODELS = {
         presets={
             CONF_HEIGHT: 240,
             CONF_WIDTH: 135,
-            CONF_OFFSET_HEIGHT: 52,
-            CONF_OFFSET_WIDTH: 40,
+            CONF_OFFSET_HEIGHT: 40,
+            CONF_OFFSET_WIDTH: 52,
             CONF_CS_PIN: "GPIO7",
             CONF_DC_PIN: "GPIO39",
             CONF_RESET_PIN: "GPIO40",
@@ -89,8 +89,8 @@ MODELS = {
         presets={
             CONF_HEIGHT: 320,
             CONF_WIDTH: 170,
-            CONF_OFFSET_HEIGHT: 35,
-            CONF_OFFSET_WIDTH: 0,
+            CONF_OFFSET_HEIGHT: 0,
+            CONF_OFFSET_WIDTH: 35,
             CONF_ROTATION: 270,
             CONF_CS_PIN: "GPIO10",
             CONF_DC_PIN: "GPIO13",
@@ -102,8 +102,8 @@ MODELS = {
         presets={
             CONF_HEIGHT: 320,
             CONF_WIDTH: 172,
-            CONF_OFFSET_HEIGHT: 34,
-            CONF_OFFSET_WIDTH: 0,
+            CONF_OFFSET_HEIGHT: 0,
+            CONF_OFFSET_WIDTH: 34,
             CONF_ROTATION: 90,
             CONF_CS_PIN: "GPIO21",
             CONF_DC_PIN: "GPIO22",


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression introduced in #14916 (shipped in 2026.4.0) where every `st7789v` model preset with non-zero offsets displays shifted.

#14916 correctly renamed the offset variables in `write_display_data()` so that `x1` comes from `offset_width_` and `y1` from `offset_height_` — matching the documentation and the convention used by every other display driver. However, the `MODEL_PRESETS` in `esphome/components/st7789v/display.py` had been written to compensate for the old, pre-#14916 swap, so after the rename every non-zero preset now applies the offsets to the wrong axes. Panels ship visibly shifted (issue #15754 reports a ~12px shift on `TTGO_TDISPLAY_135X240`, which matches the numeric difference between its `CONF_OFFSET_HEIGHT=52` and `CONF_OFFSET_WIDTH=40`).

This PR updates the 5 affected presets to use the correct per-axis offsets. The `CONF_HEIGHT` and `CONF_WIDTH` values are unchanged — they were never affected, because `width_` / `height_` have always been used consistently with their names; only the `offset_*` pair was swapped. The `ADAFRUIT_FUNHOUSE_240X240` preset has zero offsets and is unaffected.

| Model | Panel (W×H) | Old (offset_h, offset_w) | New (offset_h, offset_w) |
|---|---|---|---|
| `TTGO_TDISPLAY_135X240` | 135×240 | 52, 40 | **40, 52** |
| `ADAFRUIT_RR_280X240` | 240×280 | 0, 20 | **20, 0** |
| `ADAFRUIT_S2_TFT_FEATHER_240X135` | 135×240 | 52, 40 | **40, 52** |
| `LILYGO_T-EMBED_170X320` | 170×320 | 35, 0 | **0, 35** |
| `WAVESHARE_1.47IN_172X320` | 172×320 | 34, 0 | **0, 34** |

The new values are what you'd derive naturally from panel geometry: the panel sits in a sub-rectangle of the ST7789's 240×320 framebuffer, with `offset_width` = column offset (left margin) and `offset_height` = row offset (top margin). This also agrees with the TTGO custom example in the `ili9xxx` docs, which uses `offset_width: 52, offset_height: 40` for the same panel.

**Note for `model: CUSTOM` users:** anyone who tuned `offset_width` / `offset_height` empirically on 2026.4.0 will have written them *against* the fixed code, so no change is needed on their side. Anyone who tuned them empirically on ≤2026.3.x was writing them against the buggy code, and will need to swap their two values when upgrading past this PR. The docs have always described the non-swapped interpretation, so configs that follow the docs are unaffected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15754

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no doc changes; existing docs already describe the correct `offset_width`/`offset_height` meaning)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Unchanged user config — preset now applies the correct offsets internally
display:
  - platform: st7789v
    model: "TTGO_TDISPLAY_135X240"
    cs_pin: GPIO10
    dc_pin: GPIO8
    reset_pin: GPIO9
    rotation: 270
    update_interval: 500ms
    lambda: |-
      it.print(0, 0, id(font_title), "General:");
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).