### PR TITLE
[core] Diagnose missing cg.templatable in codegen for TEMPLATABLE_VALUE fields

### DIFF
--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -62,6 +62,18 @@ template<typename T, typename... X> class TemplatableFn {
                                                 !std::convertible_to<std::invoke_result_t<F, X...>, T> ||
                                                 !std::default_initializable<F>) = delete;
 
+  // Reject raw (non-callable) values with a helpful diagnostic pointing at the Python-side fix.
+  // TemplatableFn stores only a function pointer (4 bytes), so constants must be wrapped in a
+  // stateless lambda by codegen. External components hitting this error should use
+  // `cg.templatable(value, args, type)` in their Python __init__.py before passing to the setter.
+  template<typename V> TemplatableFn(V) requires(!std::invocable<V, X...>) && (!std::convertible_to<V, T (*)(X...)>) {
+    static_assert(sizeof(V) == 0, "Missing cg.templatable(...) in Python codegen for this TEMPLATABLE_VALUE "
+                                  "field. The wrapper was always required; it worked by accident because the old "
+                                  "TemplatableValue implicitly converted raw constants. TemplatableFn cannot. See "
+                                  "https://developers.esphome.io/blog/2026/04/09/"
+                                  "templatablefn-4-byte-templatable-storage-for-trivially-copyable-types/");
+  }
+
   bool has_value() const { return this->f_ != nullptr; }
 
   T value(X... x) const { return this->f_ ? this->f_(x...) : T{}; }


### PR DESCRIPTION
# What does this implement/fix?

Improves the compiler diagnostic when a raw (non-callable) value is passed to a `TEMPLATABLE_VALUE` setter backed by `TemplatableFn`.

### Background

The `TEMPLATABLE_VALUE` macro has a Python-codegen half that **was never documented**: values must be wrapped with `cg.templatable()` before being passed to the setter. The automations architecture page showed the C++ side but never the Python pairing, so external component authors had no reference for the correct pattern. In-tree this was caught by review — roughly 97% of components already got it right, and the remaining 2-3% were fixed as part of the 2026.4.0 cycle. External components don't get that review and we don't control their code, so the only way to help their authors is to make the compile error itself point at the fix.

`TemplatableValue` had an implicit raw-constant constructor, so passing a raw value happened to work even though it was always the wrong pattern — authors who only tested with literal constants never hit a compile error. That silent-pass ends on 2026.4.0, where trivially copyable types are stored in `TemplatableFn` (function-pointer only). Raw values now fail to compile — but with a confusing "no matching constructor for initialization of `TemplatableFn<...>`" error that gives component authors no hint at what to fix on the Python side.

This PR adds a rejected-constructor overload with a `static_assert` that replaces the generic error with an actionable one pointing at the missing `cg.templatable()` call. **No new code is rejected** — only the message for an already-failing case changes.

The missing documentation is addressed by paired docs PR esphome/developers.esphome.io#130, which adds the `cg.templatable()` pairing to the automations architecture page and explains the storage split. Given the pairing was never documented, it's easy to understand why external components got it wrong.

### What the user sees

```
error: static assertion failed due to requirement 'sizeof(int) == 0':
Missing cg.templatable(...) in Python codegen for this TEMPLATABLE_VALUE field.
The wrapper was always required; it worked by accident because the old
TemplatableValue implicitly converted raw constants. TemplatableFn cannot. See
https://developers.esphome.io/blog/2026/04/09/templatablefn-4-byte-templatable-storage-for-trivially-copyable-types/
```

The fix on the component side is to wrap the value in `__init__.py`:

```python
template_ = await cg.templatable(config[CONF_FOO], args, cg.uint16)
cg.add(var.set_foo(template_))
```

### Why it's not just "make `operator=` implicitly convertible"

`TemplatableFn` is 4 bytes — exactly one function pointer — with no tag or union. Accepting a raw runtime value would require either capturing it (stateful lambda, no longer a function pointer) or adding a tagged union (back to 8 bytes, defeating the storage win). The contract is that codegen wraps constants in stateless lambdas; this diagnostic enforces that contract with a clear message.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (improves the compiler diagnostic for a failure mode that already exists on 2026.4.0+)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/developers.esphome.io#130 (paired docs PR on developers.esphome.io — documents the `TEMPLATABLE_VALUE` / `cg.templatable()` pairing that was previously missing)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — core/automation.h diagnostic only. No YAML surface.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).