### PR TITLE
[bundle] Force-resolve nested IncludeFile during file discovery

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1969,21 +1969,13 @@ def run_esphome(argv):
 
     # For logs command, skip updating external components
     skip_external = args.command == "logs"
-    # Track YAML files loaded during real config processing (with substitutions
-    # applied) so downstream actions like ``command_bundle`` have an
-    # authoritative list of files the config actually depends on — including
-    # only the branches selected by substitutions.
-    from esphome.yaml_util import track_yaml_loads
-
-    with track_yaml_loads() as loaded_yaml_files:
-        config = read_config(
-            dict(args.substitution) if args.substitution else {},
-            skip_external_update=skip_external,
-        )
+    config = read_config(
+        dict(args.substitution) if args.substitution else {},
+        skip_external_update=skip_external,
+    )
     if config is None:
         return 2
     CORE.config = config
-    CORE.data["_loaded_yaml_files"] = list(loaded_yaml_files)
 
     if args.command not in POST_CONFIG_ACTIONS:
         safe_print(f"Unknown command {args.command}")

--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1969,13 +1969,21 @@ def run_esphome(argv):
 
     # For logs command, skip updating external components
     skip_external = args.command == "logs"
-    config = read_config(
-        dict(args.substitution) if args.substitution else {},
-        skip_external_update=skip_external,
-    )
+    # Track YAML files loaded during real config processing (with substitutions
+    # applied) so downstream actions like ``command_bundle`` have an
+    # authoritative list of files the config actually depends on — including
+    # only the branches selected by substitutions.
+    from esphome.yaml_util import track_yaml_loads
+
+    with track_yaml_loads() as loaded_yaml_files:
+        config = read_config(
+            dict(args.substitution) if args.substitution else {},
+            skip_external_update=skip_external,
+        )
     if config is None:
         return 2
     CORE.config = config
+    CORE.data["_loaded_yaml_files"] = list(loaded_yaml_files)
 
     if args.command not in POST_CONFIG_ACTIONS:
         safe_print(f"Unknown command {args.command}")

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -258,41 +258,20 @@ class ConfigBundleCreator:
     def _discover_yaml_includes(self) -> None:
         """Discover YAML files loaded during config parsing.
 
-        Prefers the authoritative list captured during the real config load
-        (``CORE.data["_loaded_yaml_files"]``), which reflects substitution
-        choices — e.g. a conditional ``${p1 if sel == 1 else p2}`` only
-        actually loads one of the two referenced files.
+        Deliberately uses a fresh re-parse and force-loads every deferred
+        ``IncludeFile`` to include *all* potentially-reachable includes,
+        even branches not selected by the local substitutions. Bundles are
+        meant to be compiled on another system where command-line
+        substitution overrides may choose a different branch — e.g.
+        ``!include network/${eth_model}/config.yaml`` must ship every
+        candidate so the remote build can pick any one.
 
-        Falls back to a re-parse + force-load of deferred ``IncludeFile``
-        nodes when the real list is unavailable (e.g. programmatic callers
-        or tests that construct a ``ConfigBundleCreator`` directly).
+        Entries with unresolved substitution variables in the filename
+        path are skipped with a warning (they cannot be resolved without
+        the substitution pass).
 
         Secrets files are tracked separately so we can filter them to
         only include the keys this config actually references.
-        """
-        loaded_files = CORE.data.get("_loaded_yaml_files")
-        if loaded_files is None:
-            loaded_files = self._reparse_for_include_discovery()
-
-        config_resolved = self._config_path.resolve()
-        for fpath in loaded_files:
-            fpath = Path(fpath).resolve()
-            if fpath == config_resolved:
-                continue  # Already added as config
-            if fpath.name in const.SECRETS_FILES:
-                self._secrets_paths.add(fpath)
-            self._add_file(fpath)
-
-    def _reparse_for_include_discovery(self) -> list[Path]:
-        """Fallback include discovery by re-parsing YAML without substitutions.
-
-        This is used when no authoritative file list was captured during the
-        real config load. Nested ``!include`` returns a deferred
-        ``IncludeFile`` that is normally resolved during the substitution
-        pass, so we force-load every ``IncludeFile`` to make the tracker
-        fire for nested includes. Over-inclusion is possible here because
-        substitution-dependent branches cannot be resolved without running
-        the substitution pass.
         """
         with yaml_util.track_yaml_loads() as loaded_files:
             try:
@@ -304,7 +283,13 @@ class ConfigBundleCreator:
                 )
             else:
                 _force_load_include_files(data)
-        return loaded_files
+
+        for fpath in loaded_files:
+            if fpath == self._config_path.resolve():
+                continue  # Already added as config
+            if fpath.name in const.SECRETS_FILES:
+                self._secrets_paths.add(fpath)
+            self._add_file(fpath)
 
     def _discover_component_files(self) -> None:
         """Walk the validated config for file references.

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -273,6 +273,11 @@ class ConfigBundleCreator:
         Secrets files are tracked separately so we can filter them to
         only include the keys this config actually references.
         """
+        # NOTE: this must be a *fresh* parse. _force_load_include_files()
+        # relies on every IncludeFile being newly constructed (with an unset
+        # _content cache) so that .load() actually invokes the loader and the
+        # track_yaml_loads listener fires. Reusing an already-parsed tree
+        # would silently reintroduce the original bug.
         with yaml_util.track_yaml_loads() as loaded_files:
             try:
                 data = yaml_util.load_yaml(self._config_path)

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -631,27 +631,40 @@ def _force_load_include_files(obj: Any, _seen: set[int] | None = None) -> None:
     """
     if _seen is None:
         _seen = set()
-    if id(obj) in _seen:
-        return
-    _seen.add(id(obj))
 
     if isinstance(obj, yaml_util.IncludeFile):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
         if obj.has_unresolved_expressions():
             _LOGGER.warning(
-                "Bundle: cannot resolve !include with substitutions in path: %s",
+                "Bundle: cannot resolve !include %s (referenced from %s) "
+                "with substitutions in path",
                 obj.file,
+                obj.parent_file,
             )
             return
         try:
             loaded = obj.load()
         except EsphomeError as err:
-            _LOGGER.warning("Bundle: failed to load !include %s: %s", obj.file, err)
+            _LOGGER.warning(
+                "Bundle: failed to load !include %s (referenced from %s): %s",
+                obj.file,
+                obj.parent_file,
+                err,
+            )
             return
         _force_load_include_files(loaded, _seen)
     elif isinstance(obj, dict):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
         for value in obj.values():
             _force_load_include_files(value, _seen)
     elif isinstance(obj, (list, tuple)):
+        if id(obj) in _seen:
+            return
+        _seen.add(id(obj))
         for item in obj:
             _force_load_include_files(item, _seen)
 

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -151,8 +151,8 @@ class ConfigBundleCreator:
 
     def __init__(self, config: dict[str, Any]) -> None:
         self._config = config
-        self._config_dir = CORE.config_dir
-        self._config_path = CORE.config_path
+        self._config_dir = Path(CORE.config_dir).resolve()
+        self._config_path = Path(CORE.config_path).resolve()
         self._files: list[BundleFile] = []
         self._seen_paths: set[Path] = set()
         self._secrets_paths: set[Path] = set()
@@ -267,12 +267,18 @@ class ConfigBundleCreator:
         """
         with yaml_util.track_yaml_loads() as loaded_files:
             try:
-                yaml_util.load_yaml(self._config_path)
+                data = yaml_util.load_yaml(self._config_path)
             except EsphomeError:
                 _LOGGER.debug(
                     "Bundle: re-loading YAML for include discovery failed, "
                     "proceeding with partial file list"
                 )
+            else:
+                # Nested !include produces a deferred IncludeFile that is
+                # normally resolved during the substitution pass. Force-load
+                # them here so the track_yaml_loads listener fires and the
+                # referenced files end up in the bundle.
+                _force_load_include_files(data)
 
         for fpath in loaded_files:
             if fpath == self._config_path.resolve():
@@ -606,6 +612,44 @@ def _add_bytes_to_tar(tar: tarfile.TarFile, name: str, data: bytes) -> None:
     info.gid = 0
     info.mode = 0o644
     tar.addfile(info, io.BytesIO(data))
+
+
+def _force_load_include_files(obj: Any, _seen: set[int] | None = None) -> None:
+    """Recursively resolve any ``IncludeFile`` instances in a YAML tree.
+
+    Nested ``!include`` returns a deferred ``IncludeFile`` that is only
+    resolved during the substitution pass. During bundle discovery we need
+    the referenced files to actually load so the ``track_yaml_loads``
+    listener fires for them.
+
+    ``IncludeFile`` instances with unresolved substitution variables in the
+    filename cannot be loaded — we skip and warn about those.
+    """
+    if _seen is None:
+        _seen = set()
+    if id(obj) in _seen:
+        return
+    _seen.add(id(obj))
+
+    if isinstance(obj, yaml_util.IncludeFile):
+        if obj.has_unresolved_expressions():
+            _LOGGER.warning(
+                "Bundle: cannot resolve !include with substitutions in path: %s",
+                obj.file,
+            )
+            return
+        try:
+            loaded = obj.load()
+        except EsphomeError as err:
+            _LOGGER.warning("Bundle: failed to load !include %s: %s", obj.file, err)
+            return
+        _force_load_include_files(loaded, _seen)
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            _force_load_include_files(value, _seen)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            _force_load_include_files(item, _seen)
 
 
 def _resolve_include_path(include_path: Any) -> Path | None:

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -273,11 +273,11 @@ class ConfigBundleCreator:
         Secrets files are tracked separately so we can filter them to
         only include the keys this config actually references.
         """
-        # NOTE: this must be a *fresh* parse. _force_load_include_files()
-        # relies on every IncludeFile being newly constructed (with an unset
-        # _content cache) so that .load() actually invokes the loader and the
-        # track_yaml_loads listener fires. Reusing an already-parsed tree
-        # would silently reintroduce the original bug.
+        # Must be a fresh parse: IncludeFile.load() caches its result in
+        # _content, and we discover files by listening for loader calls. On
+        # an already-parsed tree the cache is populated, .load() returns
+        # without calling the loader, the listener never fires, and the
+        # referenced files would be silently dropped from the bundle.
         with yaml_util.track_yaml_loads() as loaded_files:
             try:
                 data = yaml_util.load_yaml(self._config_path)

--- a/esphome/bundle.py
+++ b/esphome/bundle.py
@@ -258,12 +258,41 @@ class ConfigBundleCreator:
     def _discover_yaml_includes(self) -> None:
         """Discover YAML files loaded during config parsing.
 
-        We track files by wrapping _load_yaml_internal. The config has already
-        been loaded at this point (bundle is a POST_CONFIG_ACTION), so we
-        re-load just to discover the file list.
+        Prefers the authoritative list captured during the real config load
+        (``CORE.data["_loaded_yaml_files"]``), which reflects substitution
+        choices — e.g. a conditional ``${p1 if sel == 1 else p2}`` only
+        actually loads one of the two referenced files.
+
+        Falls back to a re-parse + force-load of deferred ``IncludeFile``
+        nodes when the real list is unavailable (e.g. programmatic callers
+        or tests that construct a ``ConfigBundleCreator`` directly).
 
         Secrets files are tracked separately so we can filter them to
         only include the keys this config actually references.
+        """
+        loaded_files = CORE.data.get("_loaded_yaml_files")
+        if loaded_files is None:
+            loaded_files = self._reparse_for_include_discovery()
+
+        config_resolved = self._config_path.resolve()
+        for fpath in loaded_files:
+            fpath = Path(fpath).resolve()
+            if fpath == config_resolved:
+                continue  # Already added as config
+            if fpath.name in const.SECRETS_FILES:
+                self._secrets_paths.add(fpath)
+            self._add_file(fpath)
+
+    def _reparse_for_include_discovery(self) -> list[Path]:
+        """Fallback include discovery by re-parsing YAML without substitutions.
+
+        This is used when no authoritative file list was captured during the
+        real config load. Nested ``!include`` returns a deferred
+        ``IncludeFile`` that is normally resolved during the substitution
+        pass, so we force-load every ``IncludeFile`` to make the tracker
+        fire for nested includes. Over-inclusion is possible here because
+        substitution-dependent branches cannot be resolved without running
+        the substitution pass.
         """
         with yaml_util.track_yaml_loads() as loaded_files:
             try:
@@ -274,18 +303,8 @@ class ConfigBundleCreator:
                     "proceeding with partial file list"
                 )
             else:
-                # Nested !include produces a deferred IncludeFile that is
-                # normally resolved during the substitution pass. Force-load
-                # them here so the track_yaml_loads listener fires and the
-                # referenced files end up in the bundle.
                 _force_load_include_files(data)
-
-        for fpath in loaded_files:
-            if fpath == self._config_path.resolve():
-                continue  # Already added as config
-            if fpath.name in const.SECRETS_FILES:
-                self._secrets_paths.add(fpath)
-            self._add_file(fpath)
+        return loaded_files
 
     def _discover_component_files(self) -> None:
         """Walk the validated config for file references.

--- a/tests/unit_tests/fixtures/bundle/bundle_test.yaml
+++ b/tests/unit_tests/fixtures/bundle/bundle_test.yaml
@@ -11,9 +11,9 @@ esp32:
 logger:
   <<: !include common/base.yaml
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
+# Plain nested !include — deferred as an IncludeFile until the substitution
+# pass. The bundle must force-resolve it to pick up common/wifi.yaml.
+wifi: !include common/wifi.yaml
 
 api:
 

--- a/tests/unit_tests/fixtures/bundle/common/wifi.yaml
+++ b/tests/unit_tests/fixtures/bundle/common/wifi.yaml
@@ -1,0 +1,2 @@
+ssid: !secret wifi_ssid
+password: !secret wifi_password

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -21,6 +21,7 @@ from esphome.bundle import (
     _add_bytes_to_tar,
     _default_target_dir,
     _find_used_secret_keys,
+    _force_load_include_files,
     extract_bundle,
     is_bundle_path,
     prepare_bundle_for_compile,
@@ -935,8 +936,6 @@ def test_discover_files_nested_include_load_failure(
 
 def test_force_load_handles_cyclic_containers() -> None:
     """Cyclic dict/list references don't cause infinite recursion."""
-    from esphome.bundle import _force_load_include_files
-
     cyclic_dict: dict[str, Any] = {}
     cyclic_dict["self"] = cyclic_dict
 

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -1093,6 +1093,35 @@ def test_discover_files_fixture_config(fixture_path: Path, tmp_path: Path) -> No
     assert "common/wifi.yaml" in paths
 
 
+def test_discover_files_uses_loaded_yaml_files(tmp_path: Path) -> None:
+    """When CORE.data has _loaded_yaml_files, it is used verbatim.
+
+    This is the authoritative list captured during the real config load
+    (with substitutions applied). It avoids re-parsing and over-including
+    files referenced only by substitution-dependent branches.
+    """
+    config_dir = _setup_config_dir(
+        tmp_path,
+        files={
+            "selected.yaml": "ssid: a\n",
+            "not_selected.yaml": "ssid: b\n",
+        },
+    )
+    CORE.data["_loaded_yaml_files"] = [
+        (config_dir / "test.yaml").resolve(),
+        (config_dir / "selected.yaml").resolve(),
+    ]
+    try:
+        creator = ConfigBundleCreator({})
+        paths = {f.path for f in creator.discover_files()}
+    finally:
+        del CORE.data["_loaded_yaml_files"]
+
+    assert "test.yaml" in paths
+    assert "selected.yaml" in paths
+    assert "not_selected.yaml" not in paths
+
+
 # ---------------------------------------------------------------------------
 # ConfigBundleCreator - create_bundle
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import shutil
 import tarfile
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -932,6 +933,34 @@ def test_discover_files_nested_include_load_failure(
         "failed to load !include" in r.message and "missing.yaml" in r.message
         for r in caplog.records
     )
+
+
+def test_force_load_skips_duplicate_include_file() -> None:
+    """The same IncludeFile referenced twice is only loaded once."""
+
+    class _StubInclude:
+        """Mimics yaml_util.IncludeFile minimally for _force_load testing."""
+
+        def __init__(self) -> None:
+            self.file = Path("dup.yaml")
+            self.parent_file = Path("root.yaml")
+            self.load_calls = 0
+
+        def has_unresolved_expressions(self) -> bool:
+            return False
+
+        def load(self) -> dict[str, Any]:
+            self.load_calls += 1
+            return {}
+
+    stub = _StubInclude()
+    # Same instance appears twice — second visit must hit the _seen guard.
+    tree = {"a": stub, "b": [stub]}
+
+    with patch("esphome.bundle.yaml_util.IncludeFile", _StubInclude):
+        _force_load_include_files(tree)
+
+    assert stub.load_calls == 1
 
 
 def test_force_load_handles_cyclic_containers() -> None:

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -1093,35 +1093,6 @@ def test_discover_files_fixture_config(fixture_path: Path, tmp_path: Path) -> No
     assert "common/wifi.yaml" in paths
 
 
-def test_discover_files_uses_loaded_yaml_files(tmp_path: Path) -> None:
-    """When CORE.data has _loaded_yaml_files, it is used verbatim.
-
-    This is the authoritative list captured during the real config load
-    (with substitutions applied). It avoids re-parsing and over-including
-    files referenced only by substitution-dependent branches.
-    """
-    config_dir = _setup_config_dir(
-        tmp_path,
-        files={
-            "selected.yaml": "ssid: a\n",
-            "not_selected.yaml": "ssid: b\n",
-        },
-    )
-    CORE.data["_loaded_yaml_files"] = [
-        (config_dir / "test.yaml").resolve(),
-        (config_dir / "selected.yaml").resolve(),
-    ]
-    try:
-        creator = ConfigBundleCreator({})
-        paths = {f.path for f in creator.discover_files()}
-    finally:
-        del CORE.data["_loaded_yaml_files"]
-
-    assert "test.yaml" in paths
-    assert "selected.yaml" in paths
-    assert "not_selected.yaml" not in paths
-
-
 # ---------------------------------------------------------------------------
 # ConfigBundleCreator - create_bundle
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -913,6 +913,41 @@ def test_discover_files_nested_include_unresolved_substitution(
     assert "test.yaml" in paths
 
 
+def test_discover_files_nested_include_load_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A nested !include pointing at a missing file is logged and skipped."""
+    config_dir = _setup_config_dir(tmp_path)
+    (config_dir / "test.yaml").write_text(
+        "esphome:\n  name: test\nwifi: !include missing.yaml\n"
+    )
+
+    creator = ConfigBundleCreator({})
+    files = creator.discover_files()
+
+    paths = [f.path for f in files]
+    assert "test.yaml" in paths
+    assert any(
+        "failed to load !include" in r.message and "missing.yaml" in r.message
+        for r in caplog.records
+    )
+
+
+def test_force_load_handles_cyclic_containers() -> None:
+    """Cyclic dict/list references don't cause infinite recursion."""
+    from esphome.bundle import _force_load_include_files
+
+    cyclic_dict: dict[str, Any] = {}
+    cyclic_dict["self"] = cyclic_dict
+
+    cyclic_list: list[Any] = []
+    cyclic_list.append(cyclic_list)
+
+    # Should return without recursing forever
+    _force_load_include_files(cyclic_dict)
+    _force_load_include_files(cyclic_list)
+
+
 def test_discover_files_yaml_reload_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+import shutil
 import tarfile
 from typing import Any
 
@@ -1056,6 +1057,40 @@ def test_discover_files_walk_tuple_values(tmp_path: Path) -> None:
 
     paths = [f.path for f in files]
     assert "a.pem" in paths
+
+
+# ---------------------------------------------------------------------------
+# ConfigBundleCreator - fixture-based end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_discover_files_fixture_config(fixture_path: Path, tmp_path: Path) -> None:
+    """Use the real ``fixtures/bundle/`` tree as an end-to-end reproducer.
+
+    The fixture config uses ``wifi: !include common/wifi.yaml`` — a plain
+    nested !include that is returned as a deferred ``IncludeFile`` and only
+    resolved during the substitution pass. Before this fix, bundle discovery
+    never ran substitutions, so ``common/wifi.yaml`` was silently missing
+    from the bundle.
+    """
+    # Copy the fixture tree into a tmp dir so the test doesn't rely on the
+    # source repo being writable and so we can set CORE.config_path freely.
+    src = fixture_path / "bundle"
+    dst = tmp_path / "bundle"
+    shutil.copytree(src, dst)
+
+    CORE.config_path = dst / "bundle_test.yaml"
+
+    creator = ConfigBundleCreator({})
+    files = creator.discover_files()
+    paths = {f.path for f in files}
+
+    # Root and top-level !secret-referenced files
+    assert "bundle_test.yaml" in paths
+    assert "secrets.yaml" in paths
+    # The nested !include — this is what regressed when IncludeFile became
+    # deferred (PR #12213).
+    assert "common/wifi.yaml" in paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/test_bundle.py
+++ b/tests/unit_tests/test_bundle.py
@@ -485,7 +485,7 @@ def test_read_bundle_manifest_minimal(tmp_path: Path) -> None:
 
     result = read_bundle_manifest(bundle_path)
     assert result.esphome_version == "unknown"
-    assert result.files == []
+    assert not result.files
     assert result.has_secrets is False
 
 
@@ -860,6 +860,56 @@ def test_discover_files_skips_missing_directory(tmp_path: Path) -> None:
 
     # Only the config file
     assert len(files) == 1
+
+
+def test_discover_files_nested_include(tmp_path: Path) -> None:
+    """Nested !include files (e.g. wifi: !include wifi.yaml) are bundled."""
+    config_dir = _setup_config_dir(tmp_path)
+    (config_dir / "test.yaml").write_text(
+        "esphome:\n  name: test\nwifi: !include wifi.yaml\n"
+    )
+    (config_dir / "wifi.yaml").write_text('ssid: "a"\npassword: "b"\n')
+
+    creator = ConfigBundleCreator({})
+    files = creator.discover_files()
+
+    paths = [f.path for f in files]
+    assert "test.yaml" in paths
+    assert "wifi.yaml" in paths
+
+
+def test_discover_files_deeply_nested_include(tmp_path: Path) -> None:
+    """Chains of !include (a includes b includes c) are fully resolved."""
+    config_dir = _setup_config_dir(tmp_path)
+    (config_dir / "test.yaml").write_text(
+        "esphome:\n  name: test\nwifi: !include level1.yaml\n"
+    )
+    (config_dir / "level1.yaml").write_text("nested: !include level2.yaml\n")
+    (config_dir / "level2.yaml").write_text('value: "leaf"\n')
+
+    creator = ConfigBundleCreator({})
+    files = creator.discover_files()
+
+    paths = [f.path for f in files]
+    assert "level1.yaml" in paths
+    assert "level2.yaml" in paths
+
+
+def test_discover_files_nested_include_unresolved_substitution(
+    tmp_path: Path,
+) -> None:
+    """!include with substitution vars in path cannot be resolved; skipped gracefully."""
+    config_dir = _setup_config_dir(tmp_path)
+    (config_dir / "test.yaml").write_text(
+        "esphome:\n  name: test\nwifi: !include ${platform}.yaml\n"
+    )
+
+    creator = ConfigBundleCreator({})
+    # Should not raise
+    files = creator.discover_files()
+
+    paths = [f.path for f in files]
+    assert "test.yaml" in paths
 
 
 def test_discover_files_yaml_reload_failure(


### PR DESCRIPTION
# What does this implement/fix?

Fixes missing files in config bundles when YAML uses nested `!include`.

PR #12213 made `!include` return a deferred `IncludeFile` (so substitutions can appear in include paths). Only the top-level `!include` is eagerly resolved — nested `!include` (e.g. `wifi: !include wifi.yaml`) stays as an unresolved `IncludeFile` until the substitution pass.

The bundle's file discovery (`bundle._discover_yaml_includes`) re-parsed YAML under `track_yaml_loads()` but never ran substitutions, so nested includes never triggered the load listener and their files were silently missing from the bundle. Users reported this on the Home Assistant community forum.

This PR:

- Recursively walks the re-parsed YAML and force-loads every deferred `IncludeFile` (`_force_load_include_files()`), so the tracker fires for nested includes. Entries with unresolved substitution variables in the path are skipped with a warning.
- Deliberately includes **all** reachable `!include` files, not just branches selected by the local substitutions. Bundles are meant to be compiled on a different system where command-line substitution overrides may select a different branch — e.g. `!include network/${eth_model}/config.yaml` must ship every candidate so the remote build can pick any one.
- Resolves `config_dir`/`config_path` in `ConfigBundleCreator.__init__` so macOS `/var` → `/private/var` symlinks don't cause files to be incorrectly flagged as "outside config directory".
- Adds unit tests covering nested `!include`, `IncludeFile` chains, and unresolved-substitution paths.
- Adds a fixture-based regression test using `tests/unit_tests/fixtures/bundle/` with a plain nested `!include` that reproduces the original bug against un-fixed code.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported at https://community.home-assistant.io/t/esphome-2026-4-0-beta-packages-config-bundle-for-remote-compilation/1004350/2

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal bug fix)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Fix is platform-independent — it's in the Python bundle creation code.)

## Example entry for `config.yaml`:

```yaml
# Before this fix, bundling this config would silently drop wifi.yaml
esphome:
  name: test
  platform: ESP8266
  board: nodemcuv2

wifi: !include wifi.yaml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).