### PR TITLE
[time] Fix RTC is_valid() rejecting valid times after day_of_year cleanup

### DIFF
--- a/esphome/components/bm8563/bm8563.cpp
+++ b/esphome/components/bm8563/bm8563.cpp
@@ -63,7 +63,7 @@ void BM8563::read_time() {
            rtc_time.day_of_week, rtc_time.hour, rtc_time.minute, rtc_time.second);
 
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid()) {
+  if (!rtc_time.is_valid(true, false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/bm8563/bm8563.cpp
+++ b/esphome/components/bm8563/bm8563.cpp
@@ -63,7 +63,7 @@ void BM8563::read_time() {
            rtc_time.day_of_week, rtc_time.hour, rtc_time.minute, rtc_time.second);
 
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid(true, false)) {
+  if (!rtc_time.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -44,7 +44,7 @@ void DS1307Component::read_time() {
       .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid()) {
+  if (!rtc_time.is_valid(true, false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/ds1307/ds1307.cpp
+++ b/esphome/components/ds1307/ds1307.cpp
@@ -44,7 +44,7 @@ void DS1307Component::read_time() {
       .year = uint16_t(ds1307_.reg.year + 10u * ds1307_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid(true, false)) {
+  if (!rtc_time.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/pcf85063/pcf85063.cpp
+++ b/esphome/components/pcf85063/pcf85063.cpp
@@ -44,7 +44,7 @@ void PCF85063Component::read_time() {
       .year = uint16_t(pcf85063_.reg.year + 10u * pcf85063_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid(true, false)) {
+  if (!rtc_time.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/pcf85063/pcf85063.cpp
+++ b/esphome/components/pcf85063/pcf85063.cpp
@@ -44,7 +44,7 @@ void PCF85063Component::read_time() {
       .year = uint16_t(pcf85063_.reg.year + 10u * pcf85063_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid()) {
+  if (!rtc_time.is_valid(true, false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/pcf8563/pcf8563.cpp
+++ b/esphome/components/pcf8563/pcf8563.cpp
@@ -44,7 +44,7 @@ void PCF8563Component::read_time() {
       .year = uint16_t(pcf8563_.reg.year + 10u * pcf8563_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid()) {
+  if (!rtc_time.is_valid(true, false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/pcf8563/pcf8563.cpp
+++ b/esphome/components/pcf8563/pcf8563.cpp
@@ -44,7 +44,7 @@ void PCF8563Component::read_time() {
       .year = uint16_t(pcf8563_.reg.year + 10u * pcf8563_.reg.year_10 + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid(true, false)) {
+  if (!rtc_time.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/rx8130/rx8130.cpp
+++ b/esphome/components/rx8130/rx8130.cpp
@@ -81,7 +81,7 @@ void RX8130Component::read_time() {
       .year = static_cast<uint16_t>(bcd2dec(date[6]) + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid(true, false)) {
+  if (!rtc_time.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/components/rx8130/rx8130.cpp
+++ b/esphome/components/rx8130/rx8130.cpp
@@ -81,7 +81,7 @@ void RX8130Component::read_time() {
       .year = static_cast<uint16_t>(bcd2dec(date[6]) + 2000),
   };
   rtc_time.recalc_timestamp_utc(false);
-  if (!rtc_time.is_valid()) {
+  if (!rtc_time.is_valid(true, false)) {
     ESP_LOGE(TAG, "Invalid RTC time, not syncing to system clock.");
     return;
   }

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -76,7 +76,7 @@ struct ESPTime {
   /// @copydoc strftime(const std::string &format)
   std::string strftime(const char *format);
 
-  /// Check if this ESPTime is valid (all fields in range and year is greater than or equal to 2019)
+  /// Check if this ESPTime is valid (year >= 2019 and the requested fields are in range).
   /// @param check_day_of_week validate day_of_week (not always available when constructing from date/time fields)
   /// @param check_day_of_year validate day_of_year (not always available when constructing from date/time fields)
   bool is_valid(bool check_day_of_week = true, bool check_day_of_year = true) const {

--- a/esphome/core/time.h
+++ b/esphome/core/time.h
@@ -77,7 +77,11 @@ struct ESPTime {
   std::string strftime(const char *format);
 
   /// Check if this ESPTime is valid (all fields in range and year is greater than or equal to 2019)
-  bool is_valid() const { return this->year >= 2019 && this->fields_in_range(); }
+  /// @param check_day_of_week validate day_of_week (not always available when constructing from date/time fields)
+  /// @param check_day_of_year validate day_of_year (not always available when constructing from date/time fields)
+  bool is_valid(bool check_day_of_week = true, bool check_day_of_year = true) const {
+    return this->year >= 2019 && this->fields_in_range(check_day_of_week, check_day_of_year);
+  }
 
   /// Check if time fields are in range.
   /// @param check_day_of_week validate day_of_week (not always available when constructing from date/time fields)

--- a/tests/components/time/is_valid.cpp
+++ b/tests/components/time/is_valid.cpp
@@ -1,0 +1,72 @@
+// Regression tests for ESPTime::is_valid() optional checks.
+//
+// The RTC components (ds1307, bm8563, pcf85063, pcf8563, rx8130) read date/time
+// fields from hardware but do not populate day_of_year. They call
+// recalc_timestamp_utc(false) -- which skips day_of_year -- and then is_valid().
+// These tests ensure the is_valid() overload can skip day_of_year validation so
+// RTCs don't log "Invalid RTC time, not syncing to system clock." for valid times.
+
+#include <gtest/gtest.h>
+#include "esphome/core/time.h"
+
+namespace esphome::testing {
+
+// Build an ESPTime that mirrors what the RTC components construct: all fields
+// populated from hardware except day_of_year (left zero-initialized).
+static ESPTime make_rtc_like_time() {
+  ESPTime t{};
+  t.second = 30;
+  t.minute = 15;
+  t.hour = 12;
+  t.day_of_week = 4;  // thursday
+  t.day_of_month = 15;
+  t.month = 4;
+  t.year = 2026;
+  // day_of_year intentionally left at 0 -- RTCs don't compute it.
+  return t;
+}
+
+TEST(ESPTimeIsValid, DefaultRejectsZeroDayOfYear) {
+  // Default is_valid() checks day_of_year; zero-init is out of range.
+  ESPTime t = make_rtc_like_time();
+  EXPECT_FALSE(t.is_valid());
+}
+
+TEST(ESPTimeIsValid, SkipDayOfYearAcceptsRTCLikeTime) {
+  // RTC code path: skip day_of_year validation.
+  ESPTime t = make_rtc_like_time();
+  EXPECT_TRUE(t.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false));
+}
+
+TEST(ESPTimeIsValid, SkipDayOfYearStillRejectsOutOfRangeFields) {
+  ESPTime t = make_rtc_like_time();
+  t.hour = 25;
+  EXPECT_FALSE(t.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false));
+}
+
+TEST(ESPTimeIsValid, SkipDayOfYearStillRejectsYearBefore2019) {
+  ESPTime t = make_rtc_like_time();
+  t.year = 2000;
+  EXPECT_FALSE(t.is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false));
+}
+
+TEST(ESPTimeIsValid, SkipBothDayChecksAcceptsGPSLikeTime) {
+  // GPS path (gps_time.cpp) populates neither day_of_week nor day_of_year.
+  ESPTime t{};
+  t.second = 30;
+  t.minute = 15;
+  t.hour = 12;
+  t.day_of_month = 15;
+  t.month = 4;
+  t.year = 2026;
+  EXPECT_TRUE(t.is_valid(/*check_day_of_week=*/false, /*check_day_of_year=*/false));
+  EXPECT_FALSE(t.is_valid());  // default still rejects
+}
+
+TEST(ESPTimeIsValid, FullyPopulatedAcceptsWithDefaults) {
+  ESPTime t = make_rtc_like_time();
+  t.day_of_year = 105;
+  EXPECT_TRUE(t.is_valid());
+}
+
+}  // namespace esphome::testing


### PR DESCRIPTION
# What does this implement/fix?

After #15129 removed the dummy `day_of_year` / `day_of_week` placeholders from the RTC `read_time()` paths, the designated initializers leave `day_of_year` zero-initialized. `recalc_timestamp_utc(false)` correctly skips the `day_of_year` check (via #15128's `fields_in_range(false, use_day_of_year)`), but the subsequent `rtc_time.is_valid()` call still required `day_of_year > 0`, so every read is rejected with `Invalid RTC time, not syncing to system clock.`.

This regression affects users of `ds1307`, `bm8563`, `pcf85063`, `pcf8563`, and `rx8130` on 2026.4.0 / dev.

Reported on Discord: https://ptb.discord.com/channels/429907082951524364/1494022129803464874

**Fix:** extend `ESPTime::is_valid()` with the same optional `check_day_of_week` / `check_day_of_year` parameters as `fields_in_range()`, and update the RTC components to call `is_valid(/*check_day_of_week=*/true, /*check_day_of_year=*/false)` since they populate `day_of_week` from hardware but do not compute `day_of_year`.

Audited other `ESPTime::is_valid()` callers: all operate on `ESPTime`s produced by `RealTimeClock::now()`/`utcnow()` (via `from_c_tm`), which populates every field including `day_of_year`, so no other call sites are affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- regression from #15129 / #15128

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
i2c:
  sda: 21
  scl: 22

time:
  - platform: ds1307
    id: rtc_time
  - platform: homeassistant
    on_time_sync:
      then:
        ds1307.write_time:
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).