### PR TITLE
[internal_temperature] Fix internal Temperature discrepancy on BK7231T

### DIFF
--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -21,7 +21,7 @@ void InternalTemperatureSensor::update() {
 #if defined(USE_LIBRETINY_VARIANT_BK7231N)
   temperature = raw * -0.38f + 156.0f;
 #elif defined(USE_LIBRETINY_VARIANT_BK7231T)
-  temperature = raw * 0.04f;
+  temperature = raw * 0.12f;
 #else   // USE_LIBRETINY_VARIANT
   temperature = raw * 0.128f;
 #endif  // USE_LIBRETINY_VARIANT

--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -21,7 +21,7 @@ void InternalTemperatureSensor::update() {
 #if defined(USE_LIBRETINY_VARIANT_BK7231N)
   temperature = raw * -0.38f + 156.0f;
 #elif defined(USE_LIBRETINY_VARIANT_BK7231T)
-  temperature = raw * 0.12f;
+  temperature = raw * 0.128f;
 #else   // USE_LIBRETINY_VARIANT
   temperature = raw * 0.128f;
 #endif  // USE_LIBRETINY_VARIANT

--- a/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
+++ b/esphome/components/internal_temperature/internal_temperature_bk72xx.cpp
@@ -20,8 +20,6 @@ void InternalTemperatureSensor::update() {
   success = (result == 0);
 #if defined(USE_LIBRETINY_VARIANT_BK7231N)
   temperature = raw * -0.38f + 156.0f;
-#elif defined(USE_LIBRETINY_VARIANT_BK7231T)
-  temperature = raw * 0.128f;
 #else   // USE_LIBRETINY_VARIANT
   temperature = raw * 0.128f;
 #endif  // USE_LIBRETINY_VARIANT


### PR DESCRIPTION
# What does this implement/fix?

This fixes the internal temperature discrepancy on BK7231T

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**
https://github.com/esphome/esphome/issues/14442
- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
