### PR TITLE
[mipi_spi] Add Waveshare C6 LCD 1.47

### DIFF
--- a/esphome/components/mipi_spi/models/waveshare.py
+++ b/esphome/components/mipi_spi/models/waveshare.py
@@ -15,7 +15,7 @@ from esphome.components.mipi import (
 import esphome.config_validation as cv
 
 from .amoled import CO5300
-from .ili import ILI9488_A
+from .ili import ILI9488_A, ST7789V
 from .jc import AXS15231
 
 DriverChip(
@@ -242,4 +242,16 @@ ST7789P.extend(
             0x23,
         ),
     ),
+)
+
+ST7789V.extend(
+    "WAVESHARE-ESP32-C6-LCD-1.47",
+    width=172,
+    height=320,
+    offset_width=34,
+    invert_colors=True,
+    data_rate="40MHz",
+    reset_pin=21,
+    cs_pin=14,
+    dc_pin={"number": 15, "ignore_strapping_warning": True},
 )


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

Add the Waveshare C6 LCD 1.47 display board. 

https://www.waveshare.com/wiki/ESP32-C6-LCD-1.47


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1493968361795752037/1494275812113907783

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6474

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
