### PR TITLE
[ili9xxx] Fix crash when display buffer allocation fails

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -225,7 +225,7 @@ void ILI9XXXDisplay::update() {
     this->do_update_();
   } while (this->need_update_);
   this->prossing_update_ = false;
-  if (this->buffer_ != nullptr) {
+  if (!this->is_failed()) {
     this->display_();
   }
 }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -225,7 +225,7 @@ void ILI9XXXDisplay::update() {
     this->do_update_();
   } while (this->need_update_);
   this->prossing_update_ = false;
-  if (this->check_buffer_()) {
+  if (this->buffer_ != nullptr) {
     this->display_();
   }
 }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -215,6 +215,9 @@ void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
 }
 
 void ILI9XXXDisplay::update() {
+  if (this->is_failed()) {
+    return;
+  }
   if (this->prossing_update_) {
     this->need_update_ = true;
     return;

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -225,7 +225,7 @@ void ILI9XXXDisplay::update() {
     this->do_update_();
   } while (this->need_update_);
   this->prossing_update_ = false;
-  if (this->buffer_ != nullptr) {
+  if (this->check_buffer_()) {
     this->display_();
   }
 }

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -215,9 +215,6 @@ void HOT ILI9XXXDisplay::draw_absolute_pixel_internal(int x, int y, Color color)
 }
 
 void ILI9XXXDisplay::update() {
-  if (this->is_failed()) {
-    return;
-  }
   if (this->prossing_update_) {
     this->need_update_ = true;
     return;
@@ -228,7 +225,9 @@ void ILI9XXXDisplay::update() {
     this->do_update_();
   } while (this->need_update_);
   this->prossing_update_ = false;
-  this->display_();
+  if (this->buffer_ != nullptr) {
+    this->display_();
+  }
 }
 
 void ILI9XXXDisplay::display_() {


### PR DESCRIPTION
# What does this implement/fix?

Fix a null pointer dereference crash in the deprecated `ili9xxx` component when display buffer allocation fails. The buffer allocation is lazy (happens on first draw via `check_buffer_()`), so when it fails mid-`update()` the component is marked as failed but `display_()` still runs and dereferences the null buffer pointer.

The fix checks for null buffer after `do_update_()` returns and before calling `display_()`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15767

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A - bugfix only, no config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).