### PR TITLE
[qmc5883l] Move per-update log line from DEBUG to VERBOSE

### DIFF
--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -100,7 +100,7 @@ void QMC5883LComponent::update() {
   // ROL_PNT in setup and reading 7 bytes starting at the status register.
   // If status and all three axes are desired, using ROL_PNT saves you 3 bytes.
   // But simply not reading status saves you 4 bytes always and is much simpler.
-  if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_DEBUG) {
+  if (ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE) {
     err = this->read_register(QMC5883L_REGISTER_STATUS, &status, 1);
     if (err != i2c::ERROR_OK) {
       char buf[32];
@@ -165,7 +165,7 @@ void QMC5883LComponent::update() {
     temp = int16_t(raw_temp) * 0.01f;
   }
 
-  ESP_LOGD(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f° temperature=%0.01f°C status=%u", x, y, z, heading,
+  ESP_LOGV(TAG, "Got x=%0.02fµT y=%0.02fµT z=%0.02fµT heading=%0.01f° temperature=%0.01f°C status=%u", x, y, z, heading,
            temp, status);
 
   if (this->x_sensor_ != nullptr)


### PR DESCRIPTION
## What does this implement/fix?

Move the per-reading log line and associated status register I2C read from DEBUG to VERBOSE level.

When polled at high rates (up to 200Hz with `drdy_pin`), each `ESP_LOGD` call produces ~95 bytes of UART output taking ~8ms at 115200 baud. At 200Hz this exceeds the UART throughput.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).