### PR TITLE
[ili9xxx] Guard against null buffer in display_() when allocation fails

### DIFF
--- a/esphome/components/ili9xxx/ili9xxx_defines.h
+++ b/esphome/components/ili9xxx/ili9xxx_defines.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 namespace esphome {
 namespace ili9xxx {
 

--- a/esphome/components/ili9xxx/ili9xxx_display.cpp
+++ b/esphome/components/ili9xxx/ili9xxx_display.cpp
@@ -229,6 +229,10 @@ void ILI9XXXDisplay::update() {
 }
 
 void ILI9XXXDisplay::display_() {
+  // buffer may be null if allocation failed
+  if (this->buffer_ == nullptr) {
+    return;
+  }
   // check if something was displayed
   if ((this->x_high_ < this->x_low_) || (this->y_high_ < this->y_low_)) {
     return;


### PR DESCRIPTION
# What does this implement/fix?

`ILI9XXXDisplay::display_()` dereferences `this->buffer_` without checking if it is null. If `alloc_buffer_()` fails to allocate (e.g. low heap during setup on memory-constrained devices like the ESP32-S3-Box-3), `mark_failed()` is called but `buffer_` stays null. A subsequent call to `update()` — for example from an `UpdateComponentAction` triggered by a template switch's initial state publish during `setup()` — still calls `display_()`, which then crashes accessing `this->buffer_[...]`.

Running out of memory should mark the component as failed, not crash the device. This adds a one-line guard at the top of `display_()` to return early if the buffer is null.

Stack trace from a field crash:

```
0x4200e4af: esphome::ili9xxx::ILI9XXXDisplay::display_() at ili9xxx_display.cpp:276
0x4200e5d2: esphome::ili9xxx::ILI9XXXDisplay::update() at ili9xxx_display.cpp:228
0x4201f201: esphome::UpdateComponentAction<>::play() at base_automation.h:523
...
0x42015e2b: esphome::template_::TemplateSwitch::setup() at template_switch.cpp:49
0x420eb3cd: esphome::Component::call_setup() at component.cpp:207
0x4201c8fd: esphome::Application::setup() at application.cpp:82
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15767

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; this is a runtime safety fix.
display:
  - platform: ili9xxx
    model: ili9341
    cs_pin: 5
    dc_pin: 4
    reset_pin: 22
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).