### PR TITLE
[lvgl] Guard lv_image_set_src wrapper with LV_USE_IMAGE

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -78,15 +78,15 @@ inline void lv_style_set_text_font(lv_style_t *style, const font::Font *font) {
 #if defined(USE_LVGL_IMAGE) && defined(USE_IMAGE)
 #if LV_USE_IMAGE
 // Shortcut / overload, so that the source of an image widget can easily be updated from within a lambda.
-inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { lv_image_set_src(obj, image->get_lv_image_dsc()); }
+inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { ::lv_image_set_src(obj, image->get_lv_image_dsc()); }
 #endif  // LV_USE_IMAGE
 
 inline void lv_obj_set_style_bitmap_mask_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
+  ::lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
 }
 
 inline void lv_obj_set_style_bg_image_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
+  ::lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
 }
 #endif  // USE_LVGL_IMAGE
 #ifdef USE_LVGL_ANIMIMG

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -78,14 +78,14 @@ inline void lv_style_set_text_font(lv_style_t *style, const font::Font *font) {
 #if defined(USE_LVGL_IMAGE) && defined(USE_IMAGE)
 // Shortcut / overload, so that the source of an image can easily be updated
 // from within a lambda.
-inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { lv_image_set_src(obj, image->get_lv_image_dsc()); }
+inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { ::lv_image_set_src(obj, image->get_lv_image_dsc()); }
 
 inline void lv_obj_set_style_bitmap_mask_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
+  ::lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
 }
 
 inline void lv_obj_set_style_bg_image_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
+  ::lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
 }
 #endif  // USE_LVGL_IMAGE
 #ifdef USE_LVGL_ANIMIMG

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -78,15 +78,15 @@ inline void lv_style_set_text_font(lv_style_t *style, const font::Font *font) {
 #if defined(USE_LVGL_IMAGE) && defined(USE_IMAGE)
 #if LV_USE_IMAGE
 // Shortcut / overload, so that the source of an image widget can easily be updated from within a lambda.
-inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { ::lv_image_set_src(obj, image->get_lv_image_dsc()); }
+inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { lv_image_set_src(obj, image->get_lv_image_dsc()); }
 #endif  // LV_USE_IMAGE
 
 inline void lv_obj_set_style_bitmap_mask_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  ::lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
+  lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);
 }
 
 inline void lv_obj_set_style_bg_image_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
-  ::lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
+  lv_obj_set_style_bg_image_src(obj, image->get_lv_image_dsc(), selector);
 }
 #endif  // USE_LVGL_IMAGE
 #ifdef USE_LVGL_ANIMIMG

--- a/esphome/components/lvgl/lvgl_esphome.h
+++ b/esphome/components/lvgl/lvgl_esphome.h
@@ -76,9 +76,10 @@ inline void lv_style_set_text_font(lv_style_t *style, const font::Font *font) {
 }
 #endif
 #if defined(USE_LVGL_IMAGE) && defined(USE_IMAGE)
-// Shortcut / overload, so that the source of an image can easily be updated
-// from within a lambda.
+#if LV_USE_IMAGE
+// Shortcut / overload, so that the source of an image widget can easily be updated from within a lambda.
 inline void lv_image_set_src(lv_obj_t *obj, image::Image *image) { ::lv_image_set_src(obj, image->get_lv_image_dsc()); }
+#endif  // LV_USE_IMAGE
 
 inline void lv_obj_set_style_bitmap_mask_src(lv_obj_t *obj, image::Image *image, lv_style_selector_t selector) {
   ::lv_obj_set_style_bitmap_mask_src(obj, image->get_lv_image_dsc(), selector);


### PR DESCRIPTION
# What does this implement/fix?

The `lv_image_set_src` convenience wrapper in `lvgl_esphome.h` is guarded by `USE_LVGL_IMAGE`, which is defined whenever ESPHome images are used with LVGL (including for style properties like `bg_image_src`). However, the LVGL function it calls (`lv_image_set_src`) only exists when `LV_USE_IMAGE` is enabled — i.e., when the LVGL image **widget** is used.

When `LV_USE_IMAGE` is 0 (no image widget, just image styles), the wrapper tries to call a function that doesn't exist. The only candidate the compiler finds is the wrapper itself, causing:
```
error: cannot convert 'lv_image_dsc_t*' to 'esphome::image::Image*'
```

The fix adds `#if LV_USE_IMAGE` around the `lv_image_set_src` wrapper, matching the same guard LVGL uses in `lv_image.h`. The style wrappers (`lv_obj_set_style_bg_image_src`, `lv_obj_set_style_bitmap_mask_src`) are unaffected — they call LVGL core functions that are always available.

**Reproducer:** any config using `bg_image_src` (image style) without an explicit LVGL `image:` widget, combined with something that defines `USE_LVGL_IMAGE` (e.g. a `qrcode` widget via auto-generated hello_world page).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15768

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduces the error without the fix (USE_LVGL_IMAGE defined, LV_USE_IMAGE=0):
image:
  - file: mdi:lightbulb
    id: buttonimg
    resize: 32x32
    type: RGB565

lvgl:
  widgets:
    - button:
        bg_image_src: buttonimg
    # qrcode pulls in USE_LVGL_IMAGE via get_uses() -> CONF_IMAGE
    - qrcode:
        text: "https://esphome.io"
        size: 100
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).