### PR TITLE
Refactor SEN6X component for improved sensor management and commands

### DIFF
--- a/esphome/components/sen6x/sen6x.cpp
+++ b/esphome/components/sen6x/sen6x.cpp
@@ -7,29 +7,58 @@ namespace esphome::sen6x {
 
 static const char *const TAG = "sen6x";
 
-static constexpr uint8_t POLL_RETRIES = 24;     // 24 attempts
-static constexpr uint32_t I2C_READ_DELAY = 20;  // 20 ms to wait for I2C read to complete
-static constexpr uint32_t POLL_INTERVAL = 50;   // 50 ms between poll attempts
-// Single numeric timeout ID — the chain is sequential so only one is active at a time.
+static constexpr uint8_t  POLL_RETRIES = 24;
+static constexpr uint32_t I2C_READ_DELAY = 20;
+static constexpr uint32_t POLL_INTERVAL = 50;
 static constexpr uint32_t TIMEOUT_POLL = 1;
+static constexpr uint32_t INIT_TIME = 100;
+static constexpr uint32_t STARTUP_TIME = 1100;
+static constexpr uint32_t WARMUP_TIME = 60000;
+
+// I2C Commands
 static constexpr uint16_t SEN6X_CMD_GET_DATA_READY_STATUS = 0x0202;
 static constexpr uint16_t SEN6X_CMD_GET_FIRMWARE_VERSION = 0xD100;
 static constexpr uint16_t SEN6X_CMD_GET_PRODUCT_NAME = 0xD014;
 static constexpr uint16_t SEN6X_CMD_GET_SERIAL_NUMBER = 0xD033;
+static constexpr uint16_t SEN6X_CMD_READ_DEVICE_STATUS = 0xD206;
+static constexpr uint16_t SEN6X_CMD_READ_AND_CLEAR_DEVICE_STATUS = 0xD210;
+static constexpr uint16_t SEN6X_CMD_START_MEASUREMENTS = 0x0021;
+static constexpr uint16_t SEN6X_CMD_STOP_MEASUREMENTS = 0x0104;
+static constexpr uint16_t SEN6X_CMD_RESET = 0xD304;
+static constexpr uint16_t SEN6X_CMD_READ_NUMBER_CONCENTRATION = 0x0316;
 
-static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT = 0x0300;  // SEN66 only!
+// Specific commands for continuous measurements by model
+static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN66 = 0x0300;
 static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN62 = 0x04A3;
 static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN63C = 0x0471;
 static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN65 = 0x0446;
 static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN68 = 0x0467;
 static constexpr uint16_t SEN6X_CMD_READ_MEASUREMENT_SEN69C = 0x04B5;
 
-static constexpr uint16_t SEN6X_CMD_START_MEASUREMENTS = 0x0021;
-static constexpr uint16_t SEN6X_CMD_RESET = 0xD304;
+// Tuning and parameters
+static constexpr uint16_t SEN6X_CMD_SET_TEMPERATURE_OFFSET = 0x60B2;
+static constexpr uint16_t SEN6X_CMD_SET_TEMPERATURE_ACCELERATION = 0x6100;
+static constexpr uint16_t SEN6X_CMD_START_FAN_CLEANING = 0x5607;
+static constexpr uint16_t SEN6X_CMD_ACTIVATE_SHT_HEATER = 0x6765;
+static constexpr uint16_t SEN6X_CMD_GET_SHT_HEATER_MEASUREMENTS = 0x6790;
+static constexpr uint16_t SEN6X_CMD_GET_VOC_ALGORITHM_TUNING_PARAMETERS = 0x60D0;
+static constexpr uint16_t SEN6X_CMD_SET_VOC_ALGORITHM_TUNING_PARAMETERS = 0x60D0;
+static constexpr uint16_t SEN6X_CMD_GET_NOX_ALGORITHM_TUNING_PARAMETERS = 0x60E1;
+static constexpr uint16_t SEN6X_CMD_SET_NOX_ALGORITHM_TUNING_PARAMETERS = 0x60E1;
+
+// CO2, Pressure e Altitude
+static constexpr uint16_t SEN6X_CMD_SET_PERFORM_FORCED_CO2_RECALIBRATION = 0x6707;
+static constexpr uint16_t SEN6X_CMD_SET_PERFORM_CO2_SENSOR_FACTORY_RESET = 0x6754;
+static constexpr uint16_t SEN6X_CMD_GET_CO2_SENSOR_AUTOMATIC_SELF_CALIBRATION = 0x6711;
+static constexpr uint16_t SEN6X_CMD_SET_CO2_SENSOR_AUTOMATIC_SELF_CALIBRATION = 0x6711;
+static constexpr uint16_t SEN6X_CMD_GET_AMBIENT_PRESSURE = 0x6720;
+static constexpr uint16_t SEN6X_CMD_SET_AMBIENT_PRESSURE = 0x6720;
+static constexpr uint16_t SEN6X_CMD_GET_SENSOR_ALTITUDE = 0x6736;
+static constexpr uint16_t SEN6X_CMD_SET_SENSOR_ALTITUDE = 0x6736;
+
+
 
 static inline void set_read_command_and_words(SEN6XComponent::Sen6xType type, uint16_t &read_cmd, uint8_t &read_words) {
-  read_cmd = SEN6X_CMD_READ_MEASUREMENT;
-  read_words = 9;
   switch (type) {
     case SEN6XComponent::SEN62:
       read_cmd = SEN6X_CMD_READ_MEASUREMENT_SEN62;
@@ -44,7 +73,7 @@ static inline void set_read_command_and_words(SEN6XComponent::Sen6xType type, ui
       read_words = 8;
       break;
     case SEN6XComponent::SEN66:
-      read_cmd = SEN6X_CMD_READ_MEASUREMENT;
+      read_cmd = SEN6X_CMD_READ_MEASUREMENT_SEN66;
       read_words = 9;
       break;
     case SEN6XComponent::SEN68:
@@ -55,103 +84,136 @@ static inline void set_read_command_and_words(SEN6XComponent::Sen6xType type, ui
       read_cmd = SEN6X_CMD_READ_MEASUREMENT_SEN69C;
       read_words = 10;
       break;
-    default:
-      break;
+    case SEN6XComponent::UNKNOWN:
+      read_cmd = SEN6X_CMD_READ_MEASUREMENT_SEN66;
+      read_words = 9;
+      break;			
   }
 }
 
-void SEN6XComponent::setup() {
-  ESP_LOGCONFIG(TAG, "Setting up sen6x...");
+SEN6XComponent::Sen6xType SEN6XComponent::infer_type_from_product_name_(const std::string &product_name) {
+  // Use a simple mapping to match product strings to types.
+  // We check if the product name contains the model string to handle potential suffixes.
+  if (product_name.find("SEN62") != std::string::npos) return SEN62;
+  if (product_name.find("SEN63C") != std::string::npos) return SEN63C;
+  if (product_name.find("SEN65") != std::string::npos) return SEN65;
+  if (product_name.find("SEN66") != std::string::npos) return SEN66;
+  if (product_name.find("SEN68") != std::string::npos) return SEN68;
+  if (product_name.find("SEN69C") != std::string::npos) return SEN69C;
+  // Log a warning if the product name was read but doesn't match known models
+  if (!product_name.empty()) {
+    ESP_LOGW(TAG, "Product name '%s' does not match any known SEN6x type", product_name.c_str());
+  }
+  return UNKNOWN;
+}
 
-  // the sensor needs 100 ms to enter the idle state
+void SEN6XComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up SEN6X...");
+
+  // The sensor needs ~100ms after power-up to enter IDLE state and accept commands
   this->set_timeout(100, [this]() {
     // Reset the sensor to ensure a clean state regardless of prior commands or power issues
     if (!this->write_command(SEN6X_CMD_RESET)) {
-      ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-      this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
+      ESP_LOGE(TAG, "Failed to send reset command!");
+      this->mark_failed();
       return;
     }
 
-    // After reset the sensor needs 100 ms to become ready
+    // After a soft reset, the sensor needs another 100ms to become responsive
     this->set_timeout(100, [this]() {
-      // Step 1: Read serial number (~25ms with I2C delay)
-      uint16_t raw_serial_number[16];
-      if (!this->get_register(SEN6X_CMD_GET_SERIAL_NUMBER, raw_serial_number, 16, 20)) {
-        ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-        this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
+      this->state_ = STARTING;
+
+      // Step 1: Read serial number
+      uint16_t raw_serial[16];
+      if (!this->get_register(SEN6X_CMD_GET_SERIAL_NUMBER, raw_serial, 16, I2C_READ_DELAY)) {
+        ESP_LOGE(TAG, "Failed to read serial number!");
+        this->mark_failed();
         return;
       }
-      this->serial_number_ = SEN6XComponent::sensirion_convert_to_string_in_place(raw_serial_number, 16);
+      this->serial_number_ = SEN6XComponent::sensirion_convert_to_string_in_place(raw_serial, 16);
       ESP_LOGI(TAG, "Serial number: %s", this->serial_number_.c_str());
 
-      // Step 2: Read product name in next loop iteration
+      // Step 2: Read product name and validate sensor compatibility
       this->set_timeout(0, [this]() {
-        uint16_t raw_product_name[16];
-        if (!this->get_register(SEN6X_CMD_GET_PRODUCT_NAME, raw_product_name, 16, 20)) {
-          ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-          this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
+        uint16_t raw_name[16];
+        if (!this->get_register(SEN6X_CMD_GET_PRODUCT_NAME, raw_name, 16, I2C_READ_DELAY)) {
+          ESP_LOGE(TAG, "Failed to read product name!");
+          this->mark_failed();
           return;
         }
 
-        this->product_name_ = SEN6XComponent::sensirion_convert_to_string_in_place(raw_product_name, 16);
+        this->product_name_ = SEN6XComponent::sensirion_convert_to_string_in_place(raw_name, 16);
+        Sen6xType inferred = this->infer_type_from_product_name_(this->product_name_);
 
-        Sen6xType inferred_type = this->infer_type_from_product_name_(this->product_name_);
+        // Handle type detection and mismatch
         if (this->sen6x_type_ == UNKNOWN) {
-          this->sen6x_type_ = inferred_type;
-          if (inferred_type == UNKNOWN) {
-            ESP_LOGE(TAG, "Unknown product '%s'", this->product_name_.c_str());
+          if (inferred == UNKNOWN) {
+            ESP_LOGE(TAG, "Unsupported product detected: '%s'", this->product_name_.c_str());
             this->mark_failed();
             return;
           }
-          ESP_LOGD(TAG, "Type inferred from product: %s", this->product_name_.c_str());
-        } else if (this->sen6x_type_ != inferred_type && inferred_type != UNKNOWN) {
-          ESP_LOGW(TAG, "Configured type (used) mismatches product '%s'", this->product_name_.c_str());
+          this->sen6x_type_ = inferred;
+          ESP_LOGD(TAG, "Type inferred from product name: %s", this->product_name_.c_str());
+        } else if (inferred != UNKNOWN && this->sen6x_type_ != inferred) {
+          ESP_LOGW(TAG, "Manual type configuration mismatches detected product '%s'", this->product_name_.c_str());
         }
         ESP_LOGI(TAG, "Product: %s", this->product_name_.c_str());
 
-        // Validate configured sensors against detected type and disable unsupported ones
+        // Define capabilities based on detected/configured type
         const bool has_voc_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
                                   this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
-        const bool has_co2 = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
-        const bool has_hcho = (this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+        const bool has_co2     = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
+        const bool has_hcho    = (this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+        const bool has_nc      = (this->sen6x_type_ != SEN69C); // SEN69C is the only one lacking NC in the series
+
+        // Disable unsupported sensors and log errors
         if (this->voc_sensor_ && !has_voc_nox) {
-          ESP_LOGE(TAG, "VOC requires SEN65, SEN66, SEN68, or SEN69C");
+          ESP_LOGE(TAG, "VOC sensor not supported by %s - disabling", this->product_name_.c_str());
           this->voc_sensor_ = nullptr;
         }
         if (this->nox_sensor_ && !has_voc_nox) {
-          ESP_LOGE(TAG, "NOx requires SEN65, SEN66, SEN68, or SEN69C");
+          ESP_LOGE(TAG, "NOx sensor not supported by %s - disabling", this->product_name_.c_str());
           this->nox_sensor_ = nullptr;
         }
         if (this->co2_sensor_ && !has_co2) {
-          ESP_LOGE(TAG, "CO2 requires SEN63C, SEN66, or SEN69C");
+          ESP_LOGE(TAG, "CO2 sensor not supported by %s - disabling", this->product_name_.c_str());
           this->co2_sensor_ = nullptr;
         }
         if (this->hcho_sensor_ && !has_hcho) {
-          ESP_LOGE(TAG, "Formaldehyde requires SEN68 or SEN69C");
+          ESP_LOGE(TAG, "HCHO sensor not supported by %s - disabling", this->product_name_.c_str());
           this->hcho_sensor_ = nullptr;
         }
+        if (!has_nc && (this->pm_nc_0_5_sensor_ || this->pm_nc_1_0_sensor_ || this->pm_nc_2_5_sensor_)) {
+          ESP_LOGE(TAG, "NC sensors not supported by %s - disabling", this->product_name_.c_str());
+          this->pm_nc_0_5_sensor_ = this->pm_nc_1_0_sensor_ = this->pm_nc_2_5_sensor_ = nullptr;
+          this->pm_nc_4_0_sensor_ = this->pm_nc_10_0_sensor_ = nullptr;
+        }
 
-        // Step 3: Read firmware version and start measurements in next loop iteration
+        // Step 3: Read firmware and start continuous measurement
         this->set_timeout(0, [this]() {
-          uint16_t raw_firmware_version = 0;
-          if (!this->get_register(SEN6X_CMD_GET_FIRMWARE_VERSION, raw_firmware_version, 20)) {
-            ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-            this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
+          uint16_t raw_fw = 0;
+          if (!this->get_register(SEN6X_CMD_GET_FIRMWARE_VERSION, raw_fw, I2C_READ_DELAY)) {
+            ESP_LOGE(TAG, "Failed to read firmware version!");
+            this->mark_failed();
             return;
           }
-          this->firmware_version_major_ = (raw_firmware_version >> 8) & 0xFF;
-          this->firmware_version_minor_ = raw_firmware_version & 0xFF;
+          this->firmware_version_major_ = (raw_fw >> 8) & 0xFF;
+          this->firmware_version_minor_ = raw_fw & 0xFF;
           ESP_LOGI(TAG, "Firmware: %u.%u", this->firmware_version_major_, this->firmware_version_minor_);
 
           if (!this->write_command(SEN6X_CMD_START_MEASUREMENTS)) {
-            ESP_LOGE(TAG, ESP_LOG_MSG_COMM_FAIL);
-            this->mark_failed(LOG_STR(ESP_LOG_MSG_COMM_FAIL));
+            ESP_LOGE(TAG, "Failed to start continuous measurements!");
+            this->mark_failed();
             return;
           }
 
-          this->set_timeout(60000, [this]() { this->startup_complete_ = true; });
-          this->initialized_ = true;
-          ESP_LOGD(TAG, "Initialized");
+          this->state_ = WARMING_UP;
+          ESP_LOGD(TAG, "Sensor warming up...");
+
+          this->set_timeout(WARMUP_TIME, [this]() {
+            this->state_ = MEASURING;
+            ESP_LOGD(TAG, "Sensor initialized and measuring");
+          });
         });
       });
     });
@@ -159,244 +221,794 @@ void SEN6XComponent::setup() {
 }
 
 void SEN6XComponent::dump_config() {
-  ESP_LOGCONFIG(TAG,
-                "sen6x:\n"
-                "  Product: %s\n"
-                "  Serial: %s\n"
-                "  Firmware: %u.%u\n"
-                "  Address: 0x%02X",
-                this->product_name_.c_str(), this->serial_number_.c_str(), this->firmware_version_major_,
-                this->firmware_version_minor_, this->address_);
+  // Header
+  ESP_LOGCONFIG(TAG, "SEN6X:");
+  ESP_LOGCONFIG(TAG, "  Address: 0x%02X", this->address_);
+  ESP_LOGCONFIG(TAG, "  Product: %s", this->product_name_.c_str());
+  ESP_LOGCONFIG(TAG, "  Serial: %s", this->serial_number_.c_str());
+  ESP_LOGCONFIG(TAG, "  Firmware: %u.%u", this->firmware_version_major_, this->firmware_version_minor_);
+
   LOG_UPDATE_INTERVAL(this);
-  LOG_SENSOR("  ", "PM  1.0", this->pm_1_0_sensor_);
-  LOG_SENSOR("  ", "PM  2.5", this->pm_2_5_sensor_);
-  LOG_SENSOR("  ", "PM  4.0", this->pm_4_0_sensor_);
+
+  // Mass Concentration
+  LOG_SENSOR("  ", "PM 1.0", this->pm_1_0_sensor_);
+  LOG_SENSOR("  ", "PM 2.5", this->pm_2_5_sensor_);
+  LOG_SENSOR("  ", "PM 4.0", this->pm_4_0_sensor_);
   LOG_SENSOR("  ", "PM 10.0", this->pm_10_0_sensor_);
+
+  // Number Concentration
+  LOG_SENSOR("  ", "NC 0.5", this->pm_nc_0_5_sensor_);
+  LOG_SENSOR("  ", "NC 1.0", this->pm_nc_1_0_sensor_);
+  LOG_SENSOR("  ", "NC 2.5", this->pm_nc_2_5_sensor_);
+  LOG_SENSOR("  ", "NC 4.0", this->pm_nc_4_0_sensor_);
+  LOG_SENSOR("  ", "NC 10.0", this->pm_nc_10_0_sensor_);
+
+  // Gases & Environment
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_SENSOR("  ", "Humidity", this->humidity_sensor_);
-  LOG_SENSOR("  ", "VOC", this->voc_sensor_);
-  LOG_SENSOR("  ", "NOx", this->nox_sensor_);
-  LOG_SENSOR("  ", "HCHO", this->hcho_sensor_);
+  LOG_SENSOR("  ", "VOC Index", this->voc_sensor_);
+  LOG_SENSOR("  ", "NOx Index", this->nox_sensor_);
   LOG_SENSOR("  ", "CO2", this->co2_sensor_);
+  LOG_SENSOR("  ", "HCHO", this->hcho_sensor_);
 }
 
 void SEN6XComponent::update() {
-  if (!this->initialized_) {
+  // Skip update if the sensor is still initializing
+  if (this->state_ == STARTING) {
     return;
   }
 
-  // Cancel any in-flight polling from a previous update() cycle.
+  // Ensure any in-flight polling chain from a previous update cycle is stopped
   this->cancel_timeout(TIMEOUT_POLL);
 
+  // If the sensor is in IDLE, there's no data to fetch
+  if (this->is_idle_()) {
+    ESP_LOGV(TAG, "Skipping update: sensor is in IDLE state");
+    return;
+  }
+
+  // Set the specific read command and word count based on the detected SEN6x model
   set_read_command_and_words(this->sen6x_type_, this->read_cmd_, this->read_words_);
 
-  // Polling uses chained timeouts to guarantee each I2C operation completes
-  // before the next begins. The flow is:
-  //
-  //   poll_data_ready_()
-  //     -> write_command (data ready status)
-  //     -> timeout I2C_READ_DELAY
-  //       -> read_data (check ready flag)
-  //       -> if not ready: timeout POLL_INTERVAL -> poll_data_ready_() (retry)
-  //       -> if ready: read_measurements_()
-  //                      -> write_command (read measurement)
-  //                      -> timeout I2C_READ_DELAY
-  //                        -> parse_and_publish_measurements_()
-  //
-  // All timeouts share a single ID (TIMEOUT_POLL) since only one is active
-  // at a time. cancel_timeout in update() stops any in-flight chain.
+  // Start the asynchronous polling chain using sequential timeouts.
+  // Logic flow:
+  //   poll_data_ready_() -> check flag -> if ready -> read_measurements_() -> parse/publish
+  // All steps use I2C_READ_DELAY to ensure the sensor has time to process requests.
+
   this->poll_retries_remaining_ = POLL_RETRIES;
-  this->poll_data_ready_();
+
+  if (this->is_measuring_()) {
+    ESP_LOGV(TAG, "Starting data readout cycle...");
+    this->poll_data_ready_();
+  }
 }
+
 
 void SEN6XComponent::poll_data_ready_() {
   if (this->poll_retries_remaining_ == 0) {
-    this->status_set_warning();
-    ESP_LOGD(TAG, "Data not ready");
+    ESP_LOGW(TAG, "Data ready polling failed: maximum retries reached");
     return;
   }
-  ESP_LOGV(TAG, "Data ready polling attempt %u",
-           static_cast<unsigned>(POLL_RETRIES - this->poll_retries_remaining_ + 1));
+
+  ESP_LOGV(TAG, "Polling data ready (attempt %u/%u)...",
+           static_cast<unsigned>(POLL_RETRIES - this->poll_retries_remaining_ + 1),
+           static_cast<unsigned>(POLL_RETRIES));
+
   this->poll_retries_remaining_--;
 
+  // Step 1: Send the request for the Data Ready status
   if (!this->write_command(SEN6X_CMD_GET_DATA_READY_STATUS)) {
-    this->status_set_warning();
-    ESP_LOGD(TAG, "write data ready status error (%d)", this->last_error_);
+    ESP_LOGE(TAG, "Failed to write Data Ready status command! (Error: %d)", this->last_error_);
     return;
   }
 
+  // Step 2: Wait for the sensor to process the request, then read the result
   this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() {
-    uint16_t raw_read_status;
-    if (!this->read_data(&raw_read_status, 1)) {
-      this->status_set_warning();
-      ESP_LOGD(TAG, "read data ready status error (%d)", this->last_error_);
+    uint16_t status_reg;
+    if (!this->read_data(&status_reg, 1)) {
+      ESP_LOGE(TAG, "Failed to read Data Ready register! (Error: %d)", this->last_error_);
       return;
     }
 
-    if ((raw_read_status & 0x0001) == 0) {
-      // Not ready yet; schedule next attempt after POLL_INTERVAL.
+    // Check the LSB (bit 0): 1 = Data Ready, 0 = Busy
+    if ((status_reg & 0x0001) == 0) {
+      // Data not ready yet; schedule the next polling attempt
       this->set_timeout(TIMEOUT_POLL, POLL_INTERVAL, [this]() { this->poll_data_ready_(); });
       return;
     }
 
+    // Data is available, proceed to read measurements
+    ESP_LOGV(TAG, "Data is ready, proceeding to readout");
     this->read_measurements_();
   });
 }
 
 void SEN6XComponent::read_measurements_() {
+  // Step 1: Request the measurement data from the sensor.
+  // The specific command (read_cmd_) was already determined in the update() cycle
+  // based on the detected sensor type.
   if (!this->write_command(this->read_cmd_)) {
-    this->status_set_warning();
-    ESP_LOGD(TAG, "Read measurement failed (%d)", this->last_error_);
+    ESP_LOGE(TAG, "Failed to send read measurement command! (Error: %d)", this->last_error_);
     return;
   }
-
-  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() { this->parse_and_publish_measurements_(); });
+  // Step 2: Wait for the sensor to prepare the data buffer (I2C_READ_DELAY).
+  // Then proceed to parse and publish the values to the ESPHome frontend.
+  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() {
+    this->parse_and_publish_measurements_();
+  });
 }
 
 void SEN6XComponent::parse_and_publish_measurements_() {
-  uint16_t measurements[10];
+  uint16_t m[10];
 
-  if (!this->read_data(measurements, this->read_words_)) {
-    this->status_set_warning();
-    ESP_LOGD(TAG, "Read data failed (%d)", this->last_error_);
+  // Check if we are in a valid state to process data
+  if (!this->is_measuring_()) {
+    ESP_LOGD(TAG, "Sensor is not in measuring state, ignoring data");
     return;
   }
-  int8_t voc_index = -1;
-  int8_t nox_index = -1;
-  int8_t hcho_index = -1;
-  int8_t co2_index = -1;
-  bool co2_uint16 = false;
+
+  // Read the raw data words from the I2C bus
+  if (!this->read_data(m, this->read_words_)) {
+    ESP_LOGE(TAG, "Failed to read measurement data! (Error: %d)", this->last_error_);
+    return;
+  }
+
+  // Helper lambda to handle Sensirion's NAN/Invalid values
+  // auto check_nan = [](uint16_t value, uint16_t invalid_marker) -> float {
+    // return (value == invalid_marker) ? NAN : NAN; // Placeholder logic
+  // };
+
+  // --- Core Measurements (PM, Temp, Hum) ---
+  // PM values are unsigned, 0xFFFF is the invalid marker
+  float pm1 = (m[0] == 0xFFFF) ? NAN : m[0] / 10.0f;
+  float pm2_5 = (m[1] == 0xFFFF) ? NAN : m[1] / 10.0f;
+  float pm4 = (m[2] == 0xFFFF) ? NAN : m[2] / 10.0f;
+  float pm10 = (m[3] == 0xFFFF) ? NAN : m[3] / 10.0f;
+
+  // Temperature and Humidity are signed int16, 0x7FFF is the invalid marker
+  float hum = (m[4] == 0x7FFF) ? NAN : static_cast<int16_t>(m[4]) / 100.0f;
+  float temp = (m[5] == 0x7FFF) ? NAN : static_cast<int16_t>(m[5]) / 200.0f;
+
+  // --- Dynamic Index Mapping based on model ---
+  int8_t voc_idx = -1, nox_idx = -1, hcho_idx = -1, co2_idx = -1;
+  bool co2_is_u16 = false;
+
   switch (this->sen6x_type_) {
-    case SEN62:
-      break;
-    case SEN63C:
-      co2_index = 6;
-      break;
-    case SEN65:
-      voc_index = 6;
-      nox_index = 7;
-      break;
-    case SEN66:
-      voc_index = 6;
-      nox_index = 7;
-      co2_index = 8;
-      co2_uint16 = true;
-      break;
-    case SEN68:
-      voc_index = 6;
-      nox_index = 7;
-      hcho_index = 8;
-      break;
-    case SEN69C:
-      voc_index = 6;
-      nox_index = 7;
-      hcho_index = 8;
-      co2_index = 9;
-      break;
-    default:
-      break;
+    case SEN63C: co2_idx = 6; break;
+    case SEN65:  voc_idx = 6; nox_idx = 7; break;
+    case SEN66:  voc_idx = 6; nox_idx = 7; co2_idx = 8; co2_is_u16 = true; break;
+    case SEN68:  voc_idx = 6; nox_idx = 7; hcho_idx = 8; break;
+    case SEN69C: voc_idx = 6; nox_idx = 7; hcho_idx = 8; co2_idx = 9; break;
+    default: break;
   }
 
-  float pm_1_0 = measurements[0] / 10.0f;
-  if (measurements[0] == 0xFFFF)
-    pm_1_0 = NAN;
-  float pm_2_5 = measurements[1] / 10.0f;
-  if (measurements[1] == 0xFFFF)
-    pm_2_5 = NAN;
-  float pm_4_0 = measurements[2] / 10.0f;
-  if (measurements[2] == 0xFFFF)
-    pm_4_0 = NAN;
-  float pm_10_0 = measurements[3] / 10.0f;
-  if (measurements[3] == 0xFFFF)
-    pm_10_0 = NAN;
-  float humidity = static_cast<int16_t>(measurements[4]) / 100.0f;
-  if (measurements[4] == 0x7FFF)
-    humidity = NAN;
-  float temperature = static_cast<int16_t>(measurements[5]) / 200.0f;
-  if (measurements[5] == 0x7FFF)
-    temperature = NAN;
+  // --- Gas Index Measurements ---
+  // VOC/NOx are only valid after warmup (state == MEASURING)
+  float voc = NAN, nox = NAN, hcho = NAN, co2 = NAN;
 
-  float voc = NAN;
-  float nox = NAN;
-  float hcho = NAN;
-  float co2 = NAN;
-
-  if (voc_index >= 0) {
-    voc = static_cast<int16_t>(measurements[voc_index]) / 10.0f;
-    if (measurements[voc_index] == 0x7FFF)
-      voc = NAN;
-  }
-  if (nox_index >= 0) {
-    nox = static_cast<int16_t>(measurements[nox_index]) / 10.0f;
-    if (measurements[nox_index] == 0x7FFF)
-      nox = NAN;
+  if (this->state_ == MEASURING) {
+    if (voc_idx >= 0) voc = (m[voc_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[voc_idx]) / 10.0f;
+    if (nox_idx >= 0) nox = (m[nox_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[nox_idx]) / 10.0f;
   }
 
-  if (hcho_index >= 0) {
-    const uint16_t hcho_raw = measurements[hcho_index];
-    hcho = hcho_raw / 10.0f;
-    if (hcho_raw == 0xFFFF)
-      hcho = NAN;
+  if (hcho_idx >= 0) hcho = (m[hcho_idx] == 0xFFFF) ? NAN : m[hcho_idx] / 10.0f;
+
+  if (co2_idx >= 0) {
+    if (co2_is_u16) co2 = (m[co2_idx] == 0xFFFF) ? NAN : m[co2_idx];
+    else co2 = (m[co2_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[co2_idx]);
   }
 
-  if (co2_index >= 0) {
-    if (co2_uint16) {
-      const uint16_t co2_raw = measurements[co2_index];
-      co2 = static_cast<float>(co2_raw);
-      if (co2_raw == 0xFFFF)
-        co2 = NAN;
-    } else {
-      const int16_t co2_raw = static_cast<int16_t>(measurements[co2_index]);
-      co2 = static_cast<float>(co2_raw);
-      if (co2_raw == 0x7FFF)
-        co2 = NAN;
-    }
-  }
+  // --- Publish States ---
+  if (this->pm_1_0_sensor_) this->pm_1_0_sensor_->publish_state(pm1);
+  if (this->pm_2_5_sensor_) this->pm_2_5_sensor_->publish_state(pm2_5);
+  if (this->pm_4_0_sensor_) this->pm_4_0_sensor_->publish_state(pm4);
+  if (this->pm_10_0_sensor_) this->pm_10_0_sensor_->publish_state(pm10);
+  if (this->temperature_sensor_) this->temperature_sensor_->publish_state(temp);
+  if (this->humidity_sensor_) this->humidity_sensor_->publish_state(hum);
+  if (this->voc_sensor_) this->voc_sensor_->publish_state(voc);
+  if (this->nox_sensor_) this->nox_sensor_->publish_state(nox);
+  if (this->hcho_sensor_) this->hcho_sensor_->publish_state(hcho);
+  if (this->co2_sensor_) this->co2_sensor_->publish_state(co2);
 
-  if (!this->startup_complete_) {
-    ESP_LOGD(TAG, "Startup delay, ignoring values");
-    this->status_clear_warning();
+  // --- Handle Number Concentration (NC) ---
+  const bool has_nc_configured = (this->pm_nc_0_5_sensor_ || this->pm_nc_1_0_sensor_ || this->pm_nc_2_5_sensor_);
+  const bool can_read_nc = (this->sen6x_type_ != SEN69C); // SEN69C usually doesn't provide NC via 0x0316
+
+  if (has_nc_configured && can_read_nc) {
+    this->read_number_concentration_();
+  }
+}
+
+void SEN6XComponent::read_number_concentration_() {
+  // Step 1: Request Number Concentration data from the sensor
+  // This command is specific to models that support particle counting (NC)
+  if (!this->write_command(SEN6X_CMD_READ_NUMBER_CONCENTRATION)) {
+    ESP_LOGE(TAG, "Failed to send read number concentration command! (Error: %d)", this->last_error_);
+    return;
+  }
+  // Step 2: Wait for the sensor to prepare the data buffer
+  // Then proceed to parse and publish the NC values
+  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() {
+    this->parse_and_publish_number_concentration_();
+  });
+}
+
+void SEN6XComponent::parse_and_publish_number_concentration_() {
+  uint16_t m[5]; // NC 0.5, 1.0, 2.5, 4.0, 10.0
+
+  // Read the 5 data words for Number Concentration
+  if (!this->read_data(m, 5)) {
+    ESP_LOGE(TAG, "Failed to read number concentration data! (Error: %d)", this->last_error_);
     return;
   }
 
-  if (this->pm_1_0_sensor_ != nullptr)
-    this->pm_1_0_sensor_->publish_state(pm_1_0);
-  if (this->pm_2_5_sensor_ != nullptr)
-    this->pm_2_5_sensor_->publish_state(pm_2_5);
-  if (this->pm_4_0_sensor_ != nullptr)
-    this->pm_4_0_sensor_->publish_state(pm_4_0);
-  if (this->pm_10_0_sensor_ != nullptr)
-    this->pm_10_0_sensor_->publish_state(pm_10_0);
-  if (this->temperature_sensor_ != nullptr)
-    this->temperature_sensor_->publish_state(temperature);
-  if (this->humidity_sensor_ != nullptr)
-    this->humidity_sensor_->publish_state(humidity);
-  if (this->voc_sensor_ != nullptr)
-    this->voc_sensor_->publish_state(voc);
-  if (this->nox_sensor_ != nullptr)
-    this->nox_sensor_->publish_state(nox);
-  if (this->hcho_sensor_ != nullptr)
-    this->hcho_sensor_->publish_state(hcho);
-  if (this->co2_sensor_ != nullptr)
-    this->co2_sensor_->publish_state(co2);
+  // Parse values: Sensirion uses 0xFFFF as an invalid/missing data marker.
+  // Valid values must be divided by 10.0 to get the correct concentration.
+  float nc0_5  = (m[0] == 0xFFFF) ? NAN : m[0] / 10.0f;
+  float nc1_0  = (m[1] == 0xFFFF) ? NAN : m[1] / 10.0f;
+  float nc2_5  = (m[2] == 0xFFFF) ? NAN : m[2] / 10.0f;
+  float nc4_0  = (m[3] == 0xFFFF) ? NAN : m[3] / 10.0f;
+  float nc10_0 = (m[4] == 0xFFFF) ? NAN : m[4] / 10.0f;
 
+  // Publish states to ESPHome sensors if they are configured
+  if (this->pm_nc_0_5_sensor_)  this->pm_nc_0_5_sensor_->publish_state(nc0_5);
+  if (this->pm_nc_1_0_sensor_)  this->pm_nc_1_0_sensor_->publish_state(nc1_0);
+  if (this->pm_nc_2_5_sensor_)  this->pm_nc_2_5_sensor_->publish_state(nc2_5);
+  if (this->pm_nc_4_0_sensor_)  this->pm_nc_4_0_sensor_->publish_state(nc4_0);
+  if (this->pm_nc_10_0_sensor_) this->pm_nc_10_0_sensor_->publish_state(nc10_0);
+
+  // Success: ensure any transient communication warnings are cleared
   this->status_clear_warning();
 }
 
-SEN6XComponent::Sen6xType SEN6XComponent::infer_type_from_product_name_(const std::string &product_name) {
-  if (product_name == "SEN62")
-    return SEN62;
-  if (product_name == "SEN63C")
-    return SEN63C;
-  if (product_name == "SEN65")
-    return SEN65;
-  if (product_name == "SEN66")
-    return SEN66;
-  if (product_name == "SEN68")
-    return SEN68;
-  if (product_name == "SEN69C")
-    return SEN69C;
-  return UNKNOWN;
+void SEN6XComponent::stop_measurement() {
+  // Prevent stopping if the sensor is already IDLE or not yet fully initialized
+  if (!this->is_measuring_()) {
+    ESP_LOGW(TAG, "Cannot stop measurement: sensor is not in a measuring state");
+    return;
+  }
+
+  // Attempt to send the I2C stop command
+  if (!this->write_command(SEN6X_CMD_STOP_MEASUREMENTS)) {
+    ESP_LOGE(TAG, "Failed to stop measurement!");
+    return;
+  }
+
+  // Immediately cancel any pending polling or state transition timeouts
+  this->cancel_timeout(TIMEOUT_POLL);
+  this->state_ = IDLE;
+
+  ESP_LOGI(TAG, "Measurement stopped");
+}
+
+void SEN6XComponent::start_continuous_measurement() {
+  // Only allow starting if the sensor is explicitly in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot start measurement: sensor is already active");
+    return;
+  }
+
+  // Attempt to send the I2C start command
+  if (!this->write_command(SEN6X_CMD_START_MEASUREMENTS)) {
+    ESP_LOGE(TAG, "Failed to start continuous measurement!");
+    return;
+  }
+
+  // Ensure any previous polling chain is cleared before starting a new one
+  this->cancel_timeout(TIMEOUT_POLL);
+
+  // Sequence: Wait for command processing -> WARMING_UP -> MEASURING
+  this->set_timeout(TIMEOUT_POLL, STARTUP_TIME, [this]() {
+    this->state_ = WARMING_UP;
+    ESP_LOGD(TAG, "Sensor is warming up...");
+
+    this->set_timeout(TIMEOUT_POLL, WARMUP_TIME, [this]() {
+      this->state_ = MEASURING;
+      ESP_LOGD(TAG, "Sensor is now in full measuring mode");
+    });
+  });
+
+  ESP_LOGI(TAG, "Continuous measurement started");
+}
+
+bool SEN6XComponent::get_data_ready() {
+  // Check if the sensor is in a valid state to produce data
+  if (!this->is_measuring_()) {
+    ESP_LOGW(TAG, "Cannot check Data Ready: sensor is not measuring");
+    return false;
+  }
+
+  uint16_t status_reg;
+  // Use get_register to handle the write command, delay, and read sequence
+  if (!this->get_register(SEN6X_CMD_GET_DATA_READY_STATUS, status_reg, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read Data Ready status!");
+    return false;
+  }
+
+  // Bit 0: 1 indicates data is ready to be read, 0 indicates busy
+  return (status_reg & 0x0001) != 0;
+}
+
+void SEN6XComponent::device_reset() {
+  ESP_LOGI(TAG, "Initiating soft reset...");
+
+  // Cancel any active polling or state transition timers before resetting
+  this->cancel_timeout(TIMEOUT_POLL);
+
+  if (!this->write_command(SEN6X_CMD_RESET)) {
+    ESP_LOGE(TAG, "Failed to send reset command!");
+    return;
+  }
+
+  this->state_ = STARTING;
+
+  // After reset, the sensor needs time to reboot (INIT_TIME)
+  this->set_timeout(TIMEOUT_POLL, INIT_TIME, [this]() {
+    ESP_LOGD(TAG, "Sensor rebooted, restarting measurements...");
+
+    if (!this->write_command(SEN6X_CMD_START_MEASUREMENTS)) {
+      ESP_LOGE(TAG, "Failed to restart measurements after reset!");
+      this->mark_failed();
+      return;
+    }
+
+    this->state_ = WARMING_UP;
+    ESP_LOGD(TAG, "Sensor is warming up...");
+
+    // Wait for the algorithm to stabilize (WARMUP_TIME)
+    this->set_timeout(TIMEOUT_POLL, WARMUP_TIME, [this]() {
+      this->state_ = MEASURING;
+      ESP_LOGD(TAG, "Sensor is now measuring");
+    });
+  });
+}
+
+uint32_t SEN6XComponent::get_device_status(bool clear_after_read) {
+  // Select the appropriate command based on the clear_after_read flag
+  uint16_t cmd = clear_after_read ? SEN6X_CMD_READ_AND_CLEAR_DEVICE_STATUS : SEN6X_CMD_READ_DEVICE_STATUS;
+  uint16_t raw_status[2];
+
+  // Read the two 16-bit words that compose the 32-bit status register
+  if (!this->get_register(cmd, raw_status, 2, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read device status register!");
+    return 0;
+  }
+
+  // Combine the two words into a single 32-bit unsigned integer
+  uint32_t status = (static_cast<uint32_t>(raw_status[0]) << 16) | raw_status[1];
+
+  ESP_LOGD(TAG, "Device Status Register: 0x%08X", status);
+  return status;
+}
+
+void SEN6XComponent::set_temperature_offset(float offset_c) {
+  // Sensirion expects the offset in degrees Celsius multiplied by 200.
+  // We cast to int16_t first to handle potential negative offsets correctly
+  // before storing in the uint16_t register format.
+  int16_t offset_val = static_cast<int16_t>(offset_c * 200.0f);
+
+  // Attempt to write the offset to the sensor's non-volatile memory or shadow register
+  if (!this->write_command(SEN6X_CMD_SET_TEMPERATURE_OFFSET, static_cast<uint16_t>(offset_val))) {
+    ESP_LOGE(TAG, "Failed to set temperature offset!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Temperature offset successfully set to %.2f °C", offset_c);
+}
+
+void SEN6XComponent::set_temperature_acceleration(uint16_t profile) {
+  // This setting can only be changed when the sensor is not actively measuring
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot set temperature acceleration: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Valid profiles: 0 (Default), 1 (Slow), 2 (Fast)
+  if (profile > 2) {
+    ESP_LOGE(TAG, "Invalid temperature acceleration profile: %u (allowed: 0, 1, 2)", profile);
+    return;
+  }
+
+  // Attempt to write the profile to the sensor register
+  if (!this->write_command(SEN6X_CMD_SET_TEMPERATURE_ACCELERATION, profile)) {
+    ESP_LOGE(TAG, "Failed to set temperature acceleration profile!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Temperature acceleration profile successfully set to: %u", profile);
+}
+
+void SEN6XComponent::set_ambient_pressure(uint16_t pressure_hpa) {
+  // Ambient pressure compensation is only effective during active measurements
+  if (!this->is_measuring_()) {
+    ESP_LOGW(TAG, "Cannot set ambient pressure: sensor is not in a measuring state");
+    return;
+  }
+
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support pressure compensation
+  const bool supports_pressure = (this->sen6x_type_ == SEN63C ||
+                                  this->sen6x_type_ == SEN66 ||
+                                  this->sen6x_type_ == SEN69C);
+
+  if (!supports_pressure) {
+    ESP_LOGW(TAG, "Ambient pressure compensation is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // Attempt to write the pressure value (in hPa) to the sensor
+  if (!this->write_command(SEN6X_CMD_SET_AMBIENT_PRESSURE, pressure_hpa)) {
+    ESP_LOGE(TAG, "Failed to set ambient pressure!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Ambient pressure compensation set to: %u hPa", pressure_hpa);
+}
+
+uint16_t SEN6XComponent::get_ambient_pressure() {
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support pressure readings
+  const bool supports_pressure = (this->sen6x_type_ == SEN63C ||
+                                  this->sen6x_type_ == SEN66 ||
+                                  this->sen6x_type_ == SEN69C);
+
+  if (!supports_pressure) {
+    ESP_LOGW(TAG, "Ambient pressure reading is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return 0;
+  }
+
+  uint16_t pressure_hpa = 0;
+  // Request the current ambient pressure compensation value from the sensor
+  if (!this->get_register(SEN6X_CMD_GET_AMBIENT_PRESSURE, pressure_hpa, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read ambient pressure!");
+    return 0;
+  }
+
+  ESP_LOGD(TAG, "Sensor reported ambient pressure: %u hPa", pressure_hpa);
+  return pressure_hpa;
+}
+
+void SEN6XComponent::set_sensor_altitude(uint16_t altitude_meters) {
+  // Sensor altitude can only be configured while the sensor is in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot set altitude: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support altitude compensation
+  const bool supports_altitude = (this->sen6x_type_ == SEN63C ||
+                                  this->sen6x_type_ == SEN66 ||
+                                  this->sen6x_type_ == SEN69C);
+
+  if (!supports_altitude) {
+    ESP_LOGW(TAG, "Altitude compensation is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // Attempt to write the altitude (in meters) to the sensor register
+  if (!this->write_command(SEN6X_CMD_SET_SENSOR_ALTITUDE, altitude_meters)) {
+    ESP_LOGE(TAG, "Failed to set sensor altitude!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Sensor altitude compensation set to: %u meters", altitude_meters);
+}
+
+uint16_t SEN6XComponent::get_sensor_altitude() {
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support altitude compensation
+  const bool supports_altitude = (this->sen6x_type_ == SEN63C ||
+                                  this->sen6x_type_ == SEN66 ||
+                                  this->sen6x_type_ == SEN69C);
+
+  if (!supports_altitude) {
+    ESP_LOGW(TAG, "Altitude reading is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return 0;
+  }
+
+  uint16_t altitude = 0;
+  // Request the current altitude compensation value (in meters) from the sensor
+  if (!this->get_register(SEN6X_CMD_GET_SENSOR_ALTITUDE, altitude, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read sensor altitude!");
+    return 0;
+  }
+
+  ESP_LOGD(TAG, "Sensor reported altitude: %u m", altitude);
+  return altitude;
+}
+
+void SEN6XComponent::start_fan_cleaning() {
+  // Fan cleaning is a high-speed burst that must be triggered in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot start fan cleaning: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Attempt to send the fan cleaning command (accelerates fan to maximum speed)
+  if (!this->write_command(SEN6X_CMD_START_FAN_CLEANING)) {
+    ESP_LOGE(TAG, "Failed to start fan cleaning!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Fan cleaning process started successfully");
+}
+
+void SEN6XComponent::activate_sht_heater() {
+  // The heater is used to remove condensation and must be activated in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot activate SHT heater: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Attempt to send the command to activate the internal SHT heater
+  if (!this->write_command(SEN6X_CMD_ACTIVATE_SHT_HEATER)) {
+    ESP_LOGE(TAG, "Failed to activate SHT heater!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "SHT heater successfully activated");
+}
+
+bool SEN6XComponent::get_sht_heater_measurements(float &temp, float &hum) {
+  // SHT Heater measurements can only be retrieved while the sensor is in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot read SHT heater measurements: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return false;
+  }
+
+  uint16_t data[3]; // Response format: [0]=Temperature, [1]=Humidity, [2]=Dummy/Reserved
+
+  // Request the specific heater-influenced RHT data from the sensor
+  if (!this->get_register(SEN6X_CMD_GET_SHT_HEATER_MEASUREMENTS, data, 3, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read SHT heater measurements!");
+    return false;
+  }
+
+  // Parse values with Sensirion's 0x7FFF invalid data marker check
+  // Temperature: ticks / 200.0, Humidity: ticks / 100.0
+  temp = (data[0] == 0x7FFF) ? NAN : static_cast<int16_t>(data[0]) / 200.0f;
+  hum  = (data[1] == 0x7FFF) ? NAN : static_cast<int16_t>(data[1]) / 100.0f;
+
+  ESP_LOGV(TAG, "SHT heater diagnostics: T=%.2f °C, RH=%.2f %%", temp, hum);
+  return true;
+}
+
+void SEN6XComponent::set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max) {
+  // Tuning parameters for the gas engine must be configured in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot set VOC tuning: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Only models equipped with a VOC sensor support algorithm tuning
+  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+
+  if (!supports_voc) {
+    ESP_LOGW(TAG, "VOC algorithm tuning is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // Prepare the 4-word data packet for the Sensirion Gas Index Algorithm
+  uint16_t data[4] = {index_offset, learning_time, gain, gate_max};
+
+  if (!this->write_command(SEN6X_CMD_SET_VOC_ALGORITHM_TUNING_PARAMETERS, data, 4)) {
+    ESP_LOGE(TAG, "Failed to set VOC algorithm tuning parameters!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "VOC tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
+           index_offset, learning_time, gain, gate_max);
+}
+
+void SEN6XComponent::set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max) {
+  // NOx algorithm parameters can only be updated while the sensor is in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot set NOx tuning: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Only models equipped with a NOx sensor support algorithm tuning
+  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+
+  if (!supports_nox) {
+    ESP_LOGW(TAG, "NOx algorithm tuning is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // Pack the 4 tuning words for the Sensirion NOx Index Algorithm
+  uint16_t data[4] = {index_offset, learning_time, gain, gate_max};
+
+  if (!this->write_command(SEN6X_CMD_SET_NOX_ALGORITHM_TUNING_PARAMETERS, data, 4)) {
+    ESP_LOGE(TAG, "Failed to set NOx algorithm tuning parameters!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "NOx tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
+           index_offset, learning_time, gain, gate_max);
+}
+
+bool SEN6XComponent::get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max) {
+  // Tuning parameters can only be retrieved while the sensor is in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot get VOC tuning: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return false;
+  }
+
+  // Only models with gas sensors (VOC/NOx) support these parameters
+  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+
+  if (!supports_voc) {
+    ESP_LOGW(TAG, "VOC tuning is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return false;
+  }
+
+  uint16_t data[4];
+  // Request the 4-word tuning packet from the sensor
+  if (!this->get_register(SEN6X_CMD_GET_VOC_ALGORITHM_TUNING_PARAMETERS, data, 4, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read VOC algorithm tuning parameters!");
+    return false;
+  }
+
+  index_offset  = data[0];
+  learning_time = data[1];
+  gain          = data[2];
+  gate_max      = data[3];
+
+  ESP_LOGI(TAG, "VOC tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
+           index_offset, learning_time, gain, gate_max);
+  return true;
+}
+
+bool SEN6XComponent::get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max) {
+  // Tuning parameters can only be retrieved while the sensor is in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot get NOx tuning: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return false;
+  }
+
+  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+
+  if (!supports_nox) {
+    ESP_LOGW(TAG, "NOx tuning is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return false;
+  }
+
+  uint16_t data[4];
+  // Request the 4-word tuning packet from the sensor
+  if (!this->get_register(SEN6X_CMD_GET_NOX_ALGORITHM_TUNING_PARAMETERS, data, 4, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read NOx algorithm tuning parameters!");
+    return false;
+  }
+
+  index_offset  = data[0];
+  learning_time = data[1];
+  gain          = data[2];
+  gate_max      = data[3];
+
+  ESP_LOGI(TAG, "NOx tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
+           index_offset, learning_time, gain, gate_max);
+  return true;
+}
+
+void SEN6XComponent::set_co2_automatic_self_calibration(bool enable) {
+  // Check if the current model supports CO2 sensor features (ASC)
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
+                             this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN69C);
+
+  if (!supports_co2) {
+    ESP_LOGW(TAG, "CO2 Automatic Self Calibration is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // Convert boolean to the 16-bit value expected by the sensor (1=ON, 0=OFF)
+  uint16_t value = enable ? 0x0001 : 0x0000;
+
+  // Attempt to write the ASC setting to the sensor's non-volatile memory
+  if (!this->write_command(SEN6X_CMD_SET_CO2_SENSOR_AUTOMATIC_SELF_CALIBRATION, value)) {
+    ESP_LOGE(TAG, "Failed to set CO2 Automatic Self Calibration!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "CO2 Automatic Self Calibration successfully set to: %s", enable ? "ENABLED" : "DISABLED");
+}
+
+bool SEN6XComponent::get_co2_automatic_self_calibration() {
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support ASC
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
+                             this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN69C);
+
+  if (!supports_co2) {
+    ESP_LOGW(TAG, "CO2 Automatic Self Calibration reading is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return false;
+  }
+
+  uint16_t value = 0;
+  // Request the current ASC status (1 = Enabled, 0 = Disabled)
+  if (!this->get_register(SEN6X_CMD_GET_CO2_SENSOR_AUTOMATIC_SELF_CALIBRATION, value, I2C_READ_DELAY)) {
+    ESP_LOGE(TAG, "Failed to read CO2 Automatic Self Calibration status!");
+    return false;
+  }
+
+  ESP_LOGD(TAG, "CO2 Automatic Self Calibration status: %s", (value == 0x0001) ? "ENABLED" : "DISABLED");
+  return (value == 0x0001);
+}
+
+void SEN6XComponent::perform_forced_co2_recalibration(uint16_t co2_ppm) {
+  // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support FRC
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
+                             this->sen6x_type_ == SEN66 ||
+                             this->sen6x_type_ == SEN69C);
+
+  if (!supports_co2) {
+    ESP_LOGW(TAG, "Forced CO2 Recalibration is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // FRC requires the sensor to be actively measuring for at least several minutes
+  if (!this->is_measuring_()) {
+    ESP_LOGW(TAG, "Cannot perform FRC: sensor must be in MEASURING state (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Attempt to send the reference CO2 concentration (in ppm)
+  if (!this->write_command(SEN6X_CMD_SET_PERFORM_FORCED_CO2_RECALIBRATION, co2_ppm)) {
+    ESP_LOGE(TAG, "Failed to perform Forced CO2 Recalibration!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "Forced CO2 Recalibration successful at %u ppm", co2_ppm);
+}
+
+void SEN6XComponent::perform_co2_sensor_factory_reset() {
+  // CO2 factory reset is only applicable to specific CO2-enabled models
+  const bool supports_co2_reset = (this->sen6x_type_ == SEN66 ||
+                                   this->sen6x_type_ == SEN69C);
+
+  if (!supports_co2_reset) {
+    ESP_LOGW(TAG, "CO2 factory reset is not supported on this model (%s)",
+             this->product_name_.c_str());
+    return;
+  }
+
+  // It is recommended to perform NVM (Non-Volatile Memory) operations in IDLE state
+  if (!this->is_idle_()) {
+    ESP_LOGW(TAG, "Cannot perform CO2 factory reset: sensor is not IDLE (current: %s)",
+             this->get_state().c_str());
+    return;
+  }
+
+  // Attempt to send the factory reset command for the CO2 sub-module
+  if (!this->write_command(SEN6X_CMD_SET_PERFORM_CO2_SENSOR_FACTORY_RESET)) {
+    ESP_LOGE(TAG, "Failed to perform CO2 factory reset!");
+    return;
+  }
+
+  ESP_LOGI(TAG, "CO2 factory reset successfully executed");
 }
 
 }  // namespace esphome::sen6x
+

--- a/esphome/components/sen6x/sen6x.cpp
+++ b/esphome/components/sen6x/sen6x.cpp
@@ -7,7 +7,7 @@ namespace esphome::sen6x {
 
 static const char *const TAG = "sen6x";
 
-static constexpr uint8_t  POLL_RETRIES = 24;
+static constexpr uint8_t POLL_RETRIES = 24;
 static constexpr uint32_t I2C_READ_DELAY = 20;
 static constexpr uint32_t POLL_INTERVAL = 50;
 static constexpr uint32_t TIMEOUT_POLL = 1;
@@ -56,8 +56,6 @@ static constexpr uint16_t SEN6X_CMD_SET_AMBIENT_PRESSURE = 0x6720;
 static constexpr uint16_t SEN6X_CMD_GET_SENSOR_ALTITUDE = 0x6736;
 static constexpr uint16_t SEN6X_CMD_SET_SENSOR_ALTITUDE = 0x6736;
 
-
-
 static inline void set_read_command_and_words(SEN6XComponent::Sen6xType type, uint16_t &read_cmd, uint8_t &read_words) {
   switch (type) {
     case SEN6XComponent::SEN62:
@@ -87,19 +85,25 @@ static inline void set_read_command_and_words(SEN6XComponent::Sen6xType type, ui
     case SEN6XComponent::UNKNOWN:
       read_cmd = SEN6X_CMD_READ_MEASUREMENT_SEN66;
       read_words = 9;
-      break;			
+      break;
   }
 }
 
 SEN6XComponent::Sen6xType SEN6XComponent::infer_type_from_product_name_(const std::string &product_name) {
   // Use a simple mapping to match product strings to types.
   // We check if the product name contains the model string to handle potential suffixes.
-  if (product_name.find("SEN62") != std::string::npos) return SEN62;
-  if (product_name.find("SEN63C") != std::string::npos) return SEN63C;
-  if (product_name.find("SEN65") != std::string::npos) return SEN65;
-  if (product_name.find("SEN66") != std::string::npos) return SEN66;
-  if (product_name.find("SEN68") != std::string::npos) return SEN68;
-  if (product_name.find("SEN69C") != std::string::npos) return SEN69C;
+  if (product_name.find("SEN62") != std::string::npos)
+    return SEN62;
+  if (product_name.find("SEN63C") != std::string::npos)
+    return SEN63C;
+  if (product_name.find("SEN65") != std::string::npos)
+    return SEN65;
+  if (product_name.find("SEN66") != std::string::npos)
+    return SEN66;
+  if (product_name.find("SEN68") != std::string::npos)
+    return SEN68;
+  if (product_name.find("SEN69C") != std::string::npos)
+    return SEN69C;
   // Log a warning if the product name was read but doesn't match known models
   if (!product_name.empty()) {
     ESP_LOGW(TAG, "Product name '%s' does not match any known SEN6x type", product_name.c_str());
@@ -162,9 +166,9 @@ void SEN6XComponent::setup() {
         // Define capabilities based on detected/configured type
         const bool has_voc_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
                                   this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
-        const bool has_co2     = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
-        const bool has_hcho    = (this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
-        const bool has_nc      = (this->sen6x_type_ != SEN69C); // SEN69C is the only one lacking NC in the series
+        const bool has_co2 = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
+        const bool has_hcho = (this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+        const bool has_nc = (this->sen6x_type_ != SEN69C);  // SEN69C is the only one lacking NC in the series
 
         // Disable unsupported sensors and log errors
         if (this->voc_sensor_ && !has_voc_nox) {
@@ -283,7 +287,6 @@ void SEN6XComponent::update() {
   }
 }
 
-
 void SEN6XComponent::poll_data_ready_() {
   if (this->poll_retries_remaining_ == 0) {
     ESP_LOGW(TAG, "Data ready polling failed: maximum retries reached");
@@ -333,9 +336,7 @@ void SEN6XComponent::read_measurements_() {
   }
   // Step 2: Wait for the sensor to prepare the data buffer (I2C_READ_DELAY).
   // Then proceed to parse and publish the values to the ESPHome frontend.
-  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() {
-    this->parse_and_publish_measurements_();
-  });
+  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() { this->parse_and_publish_measurements_(); });
 }
 
 void SEN6XComponent::parse_and_publish_measurements_() {
@@ -355,7 +356,7 @@ void SEN6XComponent::parse_and_publish_measurements_() {
 
   // Helper lambda to handle Sensirion's NAN/Invalid values
   // auto check_nan = [](uint16_t value, uint16_t invalid_marker) -> float {
-    // return (value == invalid_marker) ? NAN : NAN; // Placeholder logic
+  // return (value == invalid_marker) ? NAN : NAN; // Placeholder logic
   // };
 
   // --- Core Measurements (PM, Temp, Hum) ---
@@ -374,12 +375,32 @@ void SEN6XComponent::parse_and_publish_measurements_() {
   bool co2_is_u16 = false;
 
   switch (this->sen6x_type_) {
-    case SEN63C: co2_idx = 6; break;
-    case SEN65:  voc_idx = 6; nox_idx = 7; break;
-    case SEN66:  voc_idx = 6; nox_idx = 7; co2_idx = 8; co2_is_u16 = true; break;
-    case SEN68:  voc_idx = 6; nox_idx = 7; hcho_idx = 8; break;
-    case SEN69C: voc_idx = 6; nox_idx = 7; hcho_idx = 8; co2_idx = 9; break;
-    default: break;
+    case SEN63C:
+      co2_idx = 6;
+      break;
+    case SEN65:
+      voc_idx = 6;
+      nox_idx = 7;
+      break;
+    case SEN66:
+      voc_idx = 6;
+      nox_idx = 7;
+      co2_idx = 8;
+      co2_is_u16 = true;
+      break;
+    case SEN68:
+      voc_idx = 6;
+      nox_idx = 7;
+      hcho_idx = 8;
+      break;
+    case SEN69C:
+      voc_idx = 6;
+      nox_idx = 7;
+      hcho_idx = 8;
+      co2_idx = 9;
+      break;
+    default:
+      break;
   }
 
   // --- Gas Index Measurements ---
@@ -387,32 +408,47 @@ void SEN6XComponent::parse_and_publish_measurements_() {
   float voc = NAN, nox = NAN, hcho = NAN, co2 = NAN;
 
   if (this->state_ == MEASURING) {
-    if (voc_idx >= 0) voc = (m[voc_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[voc_idx]) / 10.0f;
-    if (nox_idx >= 0) nox = (m[nox_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[nox_idx]) / 10.0f;
+    if (voc_idx >= 0)
+      voc = (m[voc_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[voc_idx]) / 10.0f;
+    if (nox_idx >= 0)
+      nox = (m[nox_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[nox_idx]) / 10.0f;
   }
 
-  if (hcho_idx >= 0) hcho = (m[hcho_idx] == 0xFFFF) ? NAN : m[hcho_idx] / 10.0f;
+  if (hcho_idx >= 0)
+    hcho = (m[hcho_idx] == 0xFFFF) ? NAN : m[hcho_idx] / 10.0f;
 
   if (co2_idx >= 0) {
-    if (co2_is_u16) co2 = (m[co2_idx] == 0xFFFF) ? NAN : m[co2_idx];
-    else co2 = (m[co2_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[co2_idx]);
+    if (co2_is_u16)
+      co2 = (m[co2_idx] == 0xFFFF) ? NAN : m[co2_idx];
+    else
+      co2 = (m[co2_idx] == 0x7FFF) ? NAN : static_cast<int16_t>(m[co2_idx]);
   }
 
   // --- Publish States ---
-  if (this->pm_1_0_sensor_) this->pm_1_0_sensor_->publish_state(pm1);
-  if (this->pm_2_5_sensor_) this->pm_2_5_sensor_->publish_state(pm2_5);
-  if (this->pm_4_0_sensor_) this->pm_4_0_sensor_->publish_state(pm4);
-  if (this->pm_10_0_sensor_) this->pm_10_0_sensor_->publish_state(pm10);
-  if (this->temperature_sensor_) this->temperature_sensor_->publish_state(temp);
-  if (this->humidity_sensor_) this->humidity_sensor_->publish_state(hum);
-  if (this->voc_sensor_) this->voc_sensor_->publish_state(voc);
-  if (this->nox_sensor_) this->nox_sensor_->publish_state(nox);
-  if (this->hcho_sensor_) this->hcho_sensor_->publish_state(hcho);
-  if (this->co2_sensor_) this->co2_sensor_->publish_state(co2);
+  if (this->pm_1_0_sensor_)
+    this->pm_1_0_sensor_->publish_state(pm1);
+  if (this->pm_2_5_sensor_)
+    this->pm_2_5_sensor_->publish_state(pm2_5);
+  if (this->pm_4_0_sensor_)
+    this->pm_4_0_sensor_->publish_state(pm4);
+  if (this->pm_10_0_sensor_)
+    this->pm_10_0_sensor_->publish_state(pm10);
+  if (this->temperature_sensor_)
+    this->temperature_sensor_->publish_state(temp);
+  if (this->humidity_sensor_)
+    this->humidity_sensor_->publish_state(hum);
+  if (this->voc_sensor_)
+    this->voc_sensor_->publish_state(voc);
+  if (this->nox_sensor_)
+    this->nox_sensor_->publish_state(nox);
+  if (this->hcho_sensor_)
+    this->hcho_sensor_->publish_state(hcho);
+  if (this->co2_sensor_)
+    this->co2_sensor_->publish_state(co2);
 
   // --- Handle Number Concentration (NC) ---
   const bool has_nc_configured = (this->pm_nc_0_5_sensor_ || this->pm_nc_1_0_sensor_ || this->pm_nc_2_5_sensor_);
-  const bool can_read_nc = (this->sen6x_type_ != SEN69C); // SEN69C usually doesn't provide NC via 0x0316
+  const bool can_read_nc = (this->sen6x_type_ != SEN69C);  // SEN69C usually doesn't provide NC via 0x0316
 
   if (has_nc_configured && can_read_nc) {
     this->read_number_concentration_();
@@ -428,13 +464,11 @@ void SEN6XComponent::read_number_concentration_() {
   }
   // Step 2: Wait for the sensor to prepare the data buffer
   // Then proceed to parse and publish the NC values
-  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() {
-    this->parse_and_publish_number_concentration_();
-  });
+  this->set_timeout(TIMEOUT_POLL, I2C_READ_DELAY, [this]() { this->parse_and_publish_number_concentration_(); });
 }
 
 void SEN6XComponent::parse_and_publish_number_concentration_() {
-  uint16_t m[5]; // NC 0.5, 1.0, 2.5, 4.0, 10.0
+  uint16_t m[5];  // NC 0.5, 1.0, 2.5, 4.0, 10.0
 
   // Read the 5 data words for Number Concentration
   if (!this->read_data(m, 5)) {
@@ -444,18 +478,23 @@ void SEN6XComponent::parse_and_publish_number_concentration_() {
 
   // Parse values: Sensirion uses 0xFFFF as an invalid/missing data marker.
   // Valid values must be divided by 10.0 to get the correct concentration.
-  float nc0_5  = (m[0] == 0xFFFF) ? NAN : m[0] / 10.0f;
-  float nc1_0  = (m[1] == 0xFFFF) ? NAN : m[1] / 10.0f;
-  float nc2_5  = (m[2] == 0xFFFF) ? NAN : m[2] / 10.0f;
-  float nc4_0  = (m[3] == 0xFFFF) ? NAN : m[3] / 10.0f;
+  float nc0_5 = (m[0] == 0xFFFF) ? NAN : m[0] / 10.0f;
+  float nc1_0 = (m[1] == 0xFFFF) ? NAN : m[1] / 10.0f;
+  float nc2_5 = (m[2] == 0xFFFF) ? NAN : m[2] / 10.0f;
+  float nc4_0 = (m[3] == 0xFFFF) ? NAN : m[3] / 10.0f;
   float nc10_0 = (m[4] == 0xFFFF) ? NAN : m[4] / 10.0f;
 
   // Publish states to ESPHome sensors if they are configured
-  if (this->pm_nc_0_5_sensor_)  this->pm_nc_0_5_sensor_->publish_state(nc0_5);
-  if (this->pm_nc_1_0_sensor_)  this->pm_nc_1_0_sensor_->publish_state(nc1_0);
-  if (this->pm_nc_2_5_sensor_)  this->pm_nc_2_5_sensor_->publish_state(nc2_5);
-  if (this->pm_nc_4_0_sensor_)  this->pm_nc_4_0_sensor_->publish_state(nc4_0);
-  if (this->pm_nc_10_0_sensor_) this->pm_nc_10_0_sensor_->publish_state(nc10_0);
+  if (this->pm_nc_0_5_sensor_)
+    this->pm_nc_0_5_sensor_->publish_state(nc0_5);
+  if (this->pm_nc_1_0_sensor_)
+    this->pm_nc_1_0_sensor_->publish_state(nc1_0);
+  if (this->pm_nc_2_5_sensor_)
+    this->pm_nc_2_5_sensor_->publish_state(nc2_5);
+  if (this->pm_nc_4_0_sensor_)
+    this->pm_nc_4_0_sensor_->publish_state(nc4_0);
+  if (this->pm_nc_10_0_sensor_)
+    this->pm_nc_10_0_sensor_->publish_state(nc10_0);
 
   // Success: ensure any transient communication warnings are cleared
   this->status_clear_warning();
@@ -599,8 +638,7 @@ void SEN6XComponent::set_temperature_offset(float offset_c) {
 void SEN6XComponent::set_temperature_acceleration(uint16_t profile) {
   // This setting can only be changed when the sensor is not actively measuring
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot set temperature acceleration: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot set temperature acceleration: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
@@ -627,13 +665,11 @@ void SEN6XComponent::set_ambient_pressure(uint16_t pressure_hpa) {
   }
 
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support pressure compensation
-  const bool supports_pressure = (this->sen6x_type_ == SEN63C ||
-                                  this->sen6x_type_ == SEN66 ||
-                                  this->sen6x_type_ == SEN69C);
+  const bool supports_pressure =
+      (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_pressure) {
-    ESP_LOGW(TAG, "Ambient pressure compensation is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "Ambient pressure compensation is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
@@ -648,13 +684,11 @@ void SEN6XComponent::set_ambient_pressure(uint16_t pressure_hpa) {
 
 uint16_t SEN6XComponent::get_ambient_pressure() {
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support pressure readings
-  const bool supports_pressure = (this->sen6x_type_ == SEN63C ||
-                                  this->sen6x_type_ == SEN66 ||
-                                  this->sen6x_type_ == SEN69C);
+  const bool supports_pressure =
+      (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_pressure) {
-    ESP_LOGW(TAG, "Ambient pressure reading is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "Ambient pressure reading is not supported on this model (%s)", this->product_name_.c_str());
     return 0;
   }
 
@@ -672,19 +706,16 @@ uint16_t SEN6XComponent::get_ambient_pressure() {
 void SEN6XComponent::set_sensor_altitude(uint16_t altitude_meters) {
   // Sensor altitude can only be configured while the sensor is in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot set altitude: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot set altitude: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support altitude compensation
-  const bool supports_altitude = (this->sen6x_type_ == SEN63C ||
-                                  this->sen6x_type_ == SEN66 ||
-                                  this->sen6x_type_ == SEN69C);
+  const bool supports_altitude =
+      (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_altitude) {
-    ESP_LOGW(TAG, "Altitude compensation is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "Altitude compensation is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
@@ -699,13 +730,11 @@ void SEN6XComponent::set_sensor_altitude(uint16_t altitude_meters) {
 
 uint16_t SEN6XComponent::get_sensor_altitude() {
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support altitude compensation
-  const bool supports_altitude = (this->sen6x_type_ == SEN63C ||
-                                  this->sen6x_type_ == SEN66 ||
-                                  this->sen6x_type_ == SEN69C);
+  const bool supports_altitude =
+      (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_altitude) {
-    ESP_LOGW(TAG, "Altitude reading is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "Altitude reading is not supported on this model (%s)", this->product_name_.c_str());
     return 0;
   }
 
@@ -723,8 +752,7 @@ uint16_t SEN6XComponent::get_sensor_altitude() {
 void SEN6XComponent::start_fan_cleaning() {
   // Fan cleaning is a high-speed burst that must be triggered in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot start fan cleaning: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot start fan cleaning: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
@@ -740,8 +768,7 @@ void SEN6XComponent::start_fan_cleaning() {
 void SEN6XComponent::activate_sht_heater() {
   // The heater is used to remove condensation and must be activated in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot activate SHT heater: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot activate SHT heater: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
@@ -757,12 +784,11 @@ void SEN6XComponent::activate_sht_heater() {
 bool SEN6XComponent::get_sht_heater_measurements(float &temp, float &hum) {
   // SHT Heater measurements can only be retrieved while the sensor is in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot read SHT heater measurements: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot read SHT heater measurements: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return false;
   }
 
-  uint16_t data[3]; // Response format: [0]=Temperature, [1]=Humidity, [2]=Dummy/Reserved
+  uint16_t data[3];  // Response format: [0]=Temperature, [1]=Humidity, [2]=Dummy/Reserved
 
   // Request the specific heater-influenced RHT data from the sensor
   if (!this->get_register(SEN6X_CMD_GET_SHT_HEATER_MEASUREMENTS, data, 3, I2C_READ_DELAY)) {
@@ -773,27 +799,26 @@ bool SEN6XComponent::get_sht_heater_measurements(float &temp, float &hum) {
   // Parse values with Sensirion's 0x7FFF invalid data marker check
   // Temperature: ticks / 200.0, Humidity: ticks / 100.0
   temp = (data[0] == 0x7FFF) ? NAN : static_cast<int16_t>(data[0]) / 200.0f;
-  hum  = (data[1] == 0x7FFF) ? NAN : static_cast<int16_t>(data[1]) / 100.0f;
+  hum = (data[1] == 0x7FFF) ? NAN : static_cast<int16_t>(data[1]) / 100.0f;
 
   ESP_LOGV(TAG, "SHT heater diagnostics: T=%.2f °C, RH=%.2f %%", temp, hum);
   return true;
 }
 
-void SEN6XComponent::set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max) {
+void SEN6XComponent::set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain,
+                                                         uint16_t gate_max) {
   // Tuning parameters for the gas engine must be configured in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot set VOC tuning: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot set VOC tuning: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
   // Only models equipped with a VOC sensor support algorithm tuning
-  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN68 ||
+                             this->sen6x_type_ == SEN69C);
 
   if (!supports_voc) {
-    ESP_LOGW(TAG, "VOC algorithm tuning is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "VOC algorithm tuning is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
@@ -805,25 +830,24 @@ void SEN6XComponent::set_voc_algorithm_tuning_parameters(uint16_t index_offset, 
     return;
   }
 
-  ESP_LOGI(TAG, "VOC tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
-           index_offset, learning_time, gain, gate_max);
+  ESP_LOGI(TAG, "VOC tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m", index_offset,
+           learning_time, gain, gate_max);
 }
 
-void SEN6XComponent::set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max) {
+void SEN6XComponent::set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain,
+                                                         uint16_t gate_max) {
   // NOx algorithm parameters can only be updated while the sensor is in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot set NOx tuning: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot set NOx tuning: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
   // Only models equipped with a NOx sensor support algorithm tuning
-  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN68 ||
+                             this->sen6x_type_ == SEN69C);
 
   if (!supports_nox) {
-    ESP_LOGW(TAG, "NOx algorithm tuning is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "NOx algorithm tuning is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
@@ -835,25 +859,24 @@ void SEN6XComponent::set_nox_algorithm_tuning_parameters(uint16_t index_offset, 
     return;
   }
 
-  ESP_LOGI(TAG, "NOx tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
-           index_offset, learning_time, gain, gate_max);
+  ESP_LOGI(TAG, "NOx tuning successfully set: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m", index_offset,
+           learning_time, gain, gate_max);
 }
 
-bool SEN6XComponent::get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max) {
+bool SEN6XComponent::get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time,
+                                                         uint16_t &gain, uint16_t &gate_max) {
   // Tuning parameters can only be retrieved while the sensor is in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot get VOC tuning: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot get VOC tuning: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return false;
   }
 
   // Only models with gas sensors (VOC/NOx) support these parameters
-  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+  const bool supports_voc = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN68 ||
+                             this->sen6x_type_ == SEN69C);
 
   if (!supports_voc) {
-    ESP_LOGW(TAG, "VOC tuning is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "VOC tuning is not supported on this model (%s)", this->product_name_.c_str());
     return false;
   }
 
@@ -864,30 +887,29 @@ bool SEN6XComponent::get_voc_algorithm_tuning_parameters(uint16_t &index_offset,
     return false;
   }
 
-  index_offset  = data[0];
+  index_offset = data[0];
   learning_time = data[1];
-  gain          = data[2];
-  gate_max      = data[3];
+  gain = data[2];
+  gate_max = data[3];
 
-  ESP_LOGI(TAG, "VOC tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
-           index_offset, learning_time, gain, gate_max);
+  ESP_LOGI(TAG, "VOC tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m", index_offset, learning_time,
+           gain, gate_max);
   return true;
 }
 
-bool SEN6XComponent::get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max) {
+bool SEN6XComponent::get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time,
+                                                         uint16_t &gain, uint16_t &gate_max) {
   // Tuning parameters can only be retrieved while the sensor is in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot get NOx tuning: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot get NOx tuning: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return false;
   }
 
-  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN68 || this->sen6x_type_ == SEN69C);
+  const bool supports_nox = (this->sen6x_type_ == SEN65 || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN68 ||
+                             this->sen6x_type_ == SEN69C);
 
   if (!supports_nox) {
-    ESP_LOGW(TAG, "NOx tuning is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "NOx tuning is not supported on this model (%s)", this->product_name_.c_str());
     return false;
   }
 
@@ -898,25 +920,22 @@ bool SEN6XComponent::get_nox_algorithm_tuning_parameters(uint16_t &index_offset,
     return false;
   }
 
-  index_offset  = data[0];
+  index_offset = data[0];
   learning_time = data[1];
-  gain          = data[2];
-  gate_max      = data[3];
+  gain = data[2];
+  gate_max = data[3];
 
-  ESP_LOGI(TAG, "NOx tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m",
-           index_offset, learning_time, gain, gate_max);
+  ESP_LOGI(TAG, "NOx tuning parameters read: Offset=%u, Learning=%u h, Gain=%u, Gate=%u m", index_offset, learning_time,
+           gain, gate_max);
   return true;
 }
 
 void SEN6XComponent::set_co2_automatic_self_calibration(bool enable) {
   // Check if the current model supports CO2 sensor features (ASC)
-  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
-                             this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN69C);
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_co2) {
-    ESP_LOGW(TAG, "CO2 Automatic Self Calibration is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "CO2 Automatic Self Calibration is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
@@ -934,9 +953,7 @@ void SEN6XComponent::set_co2_automatic_self_calibration(bool enable) {
 
 bool SEN6XComponent::get_co2_automatic_self_calibration() {
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support ASC
-  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
-                             this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN69C);
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_co2) {
     ESP_LOGW(TAG, "CO2 Automatic Self Calibration reading is not supported on this model (%s)",
@@ -957,20 +974,16 @@ bool SEN6XComponent::get_co2_automatic_self_calibration() {
 
 void SEN6XComponent::perform_forced_co2_recalibration(uint16_t co2_ppm) {
   // Only models with CO2 sensors (SEN63C, SEN66, SEN69C) support FRC
-  const bool supports_co2 = (this->sen6x_type_ == SEN63C ||
-                             this->sen6x_type_ == SEN66 ||
-                             this->sen6x_type_ == SEN69C);
+  const bool supports_co2 = (this->sen6x_type_ == SEN63C || this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_co2) {
-    ESP_LOGW(TAG, "Forced CO2 Recalibration is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "Forced CO2 Recalibration is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
   // FRC requires the sensor to be actively measuring for at least several minutes
   if (!this->is_measuring_()) {
-    ESP_LOGW(TAG, "Cannot perform FRC: sensor must be in MEASURING state (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot perform FRC: sensor must be in MEASURING state (current: %s)", this->get_state().c_str());
     return;
   }
 
@@ -985,19 +998,16 @@ void SEN6XComponent::perform_forced_co2_recalibration(uint16_t co2_ppm) {
 
 void SEN6XComponent::perform_co2_sensor_factory_reset() {
   // CO2 factory reset is only applicable to specific CO2-enabled models
-  const bool supports_co2_reset = (this->sen6x_type_ == SEN66 ||
-                                   this->sen6x_type_ == SEN69C);
+  const bool supports_co2_reset = (this->sen6x_type_ == SEN66 || this->sen6x_type_ == SEN69C);
 
   if (!supports_co2_reset) {
-    ESP_LOGW(TAG, "CO2 factory reset is not supported on this model (%s)",
-             this->product_name_.c_str());
+    ESP_LOGW(TAG, "CO2 factory reset is not supported on this model (%s)", this->product_name_.c_str());
     return;
   }
 
   // It is recommended to perform NVM (Non-Volatile Memory) operations in IDLE state
   if (!this->is_idle_()) {
-    ESP_LOGW(TAG, "Cannot perform CO2 factory reset: sensor is not IDLE (current: %s)",
-             this->get_state().c_str());
+    ESP_LOGW(TAG, "Cannot perform CO2 factory reset: sensor is not IDLE (current: %s)", this->get_state().c_str());
     return;
   }
 
@@ -1011,4 +1021,3 @@ void SEN6XComponent::perform_co2_sensor_factory_reset() {
 }
 
 }  // namespace esphome::sen6x
-

--- a/esphome/components/sen6x/sen6x.h
+++ b/esphome/components/sen6x/sen6x.h
@@ -48,7 +48,7 @@ class SEN6XComponent : public PollingComponent, public sensirion_common::Sensiri
 
   // Temperature & Compensation
   void set_temperature_offset(float offset_c);
-  void set_temperature_acceleration(uint16_t profile); // 0: default, 1: slow, 2: fast
+  void set_temperature_acceleration(uint16_t profile);  // 0: default, 1: slow, 2: fast
   void set_ambient_pressure(uint16_t pressure_hpa);
   uint16_t get_ambient_pressure();
   void set_sensor_altitude(uint16_t altitude_meters);
@@ -58,16 +58,20 @@ class SEN6XComponent : public PollingComponent, public sensirion_common::Sensiri
   std::string get_product_name() const { return this->product_name_; }
   std::string get_serial_number() const { return this->serial_number_; }
   std::string get_firmware_version() const {
-    return std::to_string(this->firmware_version_major_) + "." +
-           std::to_string(this->firmware_version_minor_);
+    return std::to_string(this->firmware_version_major_) + "." + std::to_string(this->firmware_version_minor_);
   }
   std::string get_state() const {
     switch (this->state_) {
-      case STARTING: return "STARTING";
-      case WARMING_UP: return "WARMING_UP";
-      case MEASURING: return "MEASURING";
-      case IDLE: return "IDLE";
-      default: return "";
+      case STARTING:
+        return "STARTING";
+      case WARMING_UP:
+        return "WARMING_UP";
+      case MEASURING:
+        return "MEASURING";
+      case IDLE:
+        return "IDLE";
+      default:
+        return "";
     }
   }
 
@@ -77,10 +81,14 @@ class SEN6XComponent : public PollingComponent, public sensirion_common::Sensiri
   bool get_sht_heater_measurements(float &temp, float &hum);
 
   // Tuning Parameters (VOC & NOx)
-  void set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
-  void set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
-  bool get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
-  bool get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
+  void set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain,
+                                           uint16_t gate_max);
+  void set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain,
+                                           uint16_t gate_max);
+  bool get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain,
+                                           uint16_t &gate_max);
+  bool get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain,
+                                           uint16_t &gate_max);
 
   // CO2 Calibration
   void set_co2_automatic_self_calibration(bool enable);

--- a/esphome/components/sen6x/sen6x.h
+++ b/esphome/components/sen6x/sen6x.h
@@ -3,14 +3,23 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/sensirion_common/i2c_sensirion.h"
+#include <string>
 
 namespace esphome::sen6x {
 
 class SEN6XComponent : public PollingComponent, public sensirion_common::SensirionI2CDevice {
+  // Mass Concentration Sensors
   SUB_SENSOR(pm_1_0)
   SUB_SENSOR(pm_2_5)
   SUB_SENSOR(pm_4_0)
   SUB_SENSOR(pm_10_0)
+  // Number Concentration Sensors
+  SUB_SENSOR(pm_nc_0_5)
+  SUB_SENSOR(pm_nc_1_0)
+  SUB_SENSOR(pm_nc_2_5)
+  SUB_SENSOR(pm_nc_4_0)
+  SUB_SENSOR(pm_nc_10_0)
+  // Environment & Gas Sensors
   SUB_SENSOR(temperature)
   SUB_SENSOR(humidity)
   SUB_SENSOR(voc)
@@ -19,31 +28,89 @@ class SEN6XComponent : public PollingComponent, public sensirion_common::Sensiri
   SUB_SENSOR(hcho)
 
  public:
+  enum Sen6xType { SEN62, SEN63C, SEN65, SEN66, SEN68, SEN69C, UNKNOWN };
+  enum State { STARTING, WARMING_UP, MEASURING, IDLE };
+
   float get_setup_priority() const override { return setup_priority::DATA; }
   void setup() override;
   void dump_config() override;
   void update() override;
 
-  enum Sen6xType { SEN62, SEN63C, SEN65, SEN66, SEN68, SEN69C, UNKNOWN };
+  // Configuration
+  void set_type(const std::string &type) { this->sen6x_type_ = this->infer_type_from_product_name_(type); }
 
-  void set_type(const std::string &type) { sen6x_type_ = infer_type_from_product_name_(type); }
+  // Measurement Control
+  void stop_measurement();
+  void start_continuous_measurement();
+  bool get_data_ready();
+  void device_reset();
+  uint32_t get_device_status(bool clear_after_read = false);
+
+  // Temperature & Compensation
+  void set_temperature_offset(float offset_c);
+  void set_temperature_acceleration(uint16_t profile); // 0: default, 1: slow, 2: fast
+  void set_ambient_pressure(uint16_t pressure_hpa);
+  uint16_t get_ambient_pressure();
+  void set_sensor_altitude(uint16_t altitude_meters);
+  uint16_t get_sensor_altitude();
+
+  // Device Info Getters
+  std::string get_product_name() const { return this->product_name_; }
+  std::string get_serial_number() const { return this->serial_number_; }
+  std::string get_firmware_version() const {
+    return std::to_string(this->firmware_version_major_) + "." +
+           std::to_string(this->firmware_version_minor_);
+  }
+  std::string get_state() const {
+    switch (this->state_) {
+      case STARTING: return "STARTING";
+      case WARMING_UP: return "WARMING_UP";
+      case MEASURING: return "MEASURING";
+      case IDLE: return "IDLE";
+      default: return "";
+    }
+  }
+
+  // Maintenance & Advanced Features
+  void start_fan_cleaning();
+  void activate_sht_heater();
+  bool get_sht_heater_measurements(float &temp, float &hum);
+
+  // Tuning Parameters (VOC & NOx)
+  void set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
+  void set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
+  bool get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
+  bool get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
+
+  // CO2 Calibration
+  void set_co2_automatic_self_calibration(bool enable);
+  bool get_co2_automatic_self_calibration();
+  void perform_forced_co2_recalibration(uint16_t co2_ppm);
+  void perform_co2_sensor_factory_reset();
 
  protected:
+  Sen6xType sen6x_type_{UNKNOWN};
+  State state_{STARTING};
+
+  bool is_idle_() const { return this->state_ == IDLE; }
+  bool is_measuring_() const { return this->state_ == WARMING_UP || this->state_ == MEASURING; }
+
+  std::string product_name_;
+  std::string serial_number_;
+  uint8_t firmware_version_major_{0};
+  uint8_t firmware_version_minor_{0};
+
+  uint16_t read_cmd_{0};
+  uint8_t poll_retries_remaining_{0};
+  uint8_t read_words_{0};
+
+  // Internal Logic
   Sen6xType infer_type_from_product_name_(const std::string &product_name);
   void poll_data_ready_();
   void read_measurements_();
   void parse_and_publish_measurements_();
-
-  bool initialized_{false};
-  std::string product_name_;
-  Sen6xType sen6x_type_{UNKNOWN};
-  std::string serial_number_;
-  uint16_t read_cmd_{0};
-  uint8_t firmware_version_major_{0};
-  uint8_t firmware_version_minor_{0};
-  uint8_t poll_retries_remaining_{0};
-  uint8_t read_words_{0};
-  bool startup_complete_{false};
+  void read_number_concentration_();
+  void parse_and_publish_number_concentration_();
 };
 
 }  // namespace esphome::sen6x

--- a/esphome/components/sen6x/sensor.py
+++ b/esphome/components/sen6x/sensor.py
@@ -177,6 +177,7 @@ SENSOR_MAP = {
     CONF_FORMALDEHYDE: "set_hcho_sensor",
 }
 
+
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
@@ -189,4 +190,3 @@ async def to_code(config):
         if cfg := config.get(key):
             sens = await sensor.new_sensor(cfg)
             cg.add(getattr(var, func_name)(sens))
-

--- a/esphome/components/sen6x/sensor.py
+++ b/esphome/components/sen6x/sensor.py
@@ -37,6 +37,14 @@ CODEOWNERS = ["@martgras", "@mebner86", "@mikelawrence", "@tuct"]
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["sensirion_common"]
 
+CONF_PM_NC_0_5 = "pm_nc_0_5"
+CONF_PM_NC_1_0 = "pm_nc_1_0"
+CONF_PM_NC_2_5 = "pm_nc_2_5"
+CONF_PM_NC_4_0 = "pm_nc_4_0"
+CONF_PM_NC_10_0 = "pm_nc_10_0"
+
+ICON_BLUR = "mdi:blur"
+
 sen6x_ns = cg.esphome_ns.namespace("sen6x")
 SEN6XComponent = sen6x_ns.class_(
     "SEN6XComponent", cg.PollingComponent, sensirion_common.SensirionI2CDevice
@@ -48,6 +56,36 @@ CONFIG_SCHEMA = (
             cv.GenerateID(): cv.declare_id(SEN6XComponent),
             cv.Optional(CONF_TYPE): cv.one_of(
                 "SEN62", "SEN63C", "SEN65", "SEN66", "SEN68", "SEN69C", upper=True
+            ),
+            cv.Optional(CONF_PM_NC_0_5): sensor.sensor_schema(
+                unit_of_measurement="particles/cm³",
+                icon=ICON_BLUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_NC_1_0): sensor.sensor_schema(
+                unit_of_measurement="particles/cm³",
+                icon=ICON_BLUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_NC_2_5): sensor.sensor_schema(
+                unit_of_measurement="particles/cm³",
+                icon=ICON_BLUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_NC_4_0): sensor.sensor_schema(
+                unit_of_measurement="particles/cm³",
+                icon=ICON_BLUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_PM_NC_10_0): sensor.sensor_schema(
+                unit_of_measurement="particles/cm³",
+                icon=ICON_BLUR,
+                accuracy_decimals=1,
+                state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_PM_1_0): sensor.sensor_schema(
                 unit_of_measurement=UNIT_MICROGRAMS_PER_CUBIC_METER,
@@ -126,6 +164,11 @@ SENSOR_MAP = {
     CONF_PM_2_5: "set_pm_2_5_sensor",
     CONF_PM_4_0: "set_pm_4_0_sensor",
     CONF_PM_10_0: "set_pm_10_0_sensor",
+    CONF_PM_NC_0_5: "set_pm_nc_0_5_sensor",
+    CONF_PM_NC_1_0: "set_pm_nc_1_0_sensor",
+    CONF_PM_NC_2_5: "set_pm_nc_2_5_sensor",
+    CONF_PM_NC_4_0: "set_pm_nc_4_0_sensor",
+    CONF_PM_NC_10_0: "set_pm_nc_10_0_sensor",
     CONF_TEMPERATURE: "set_temperature_sensor",
     CONF_HUMIDITY: "set_humidity_sensor",
     CONF_VOC: "set_voc_sensor",
@@ -133,7 +176,6 @@ SENSOR_MAP = {
     CONF_CO2: "set_co2_sensor",
     CONF_FORMALDEHYDE: "set_hcho_sensor",
 }
-
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -147,3 +189,4 @@ async def to_code(config):
         if cfg := config.get(key):
             sens = await sensor.new_sensor(cfg)
             cg.add(getattr(var, func_name)(sens))
+


### PR DESCRIPTION
Refactor and extend the SEN6X component: add many I2C command constants, explicit timing constants, and per-model read commands. Replace the simple init flow with a stateful startup sequence (STARTING, WARMING_UP, MEASURING, IDLE), perform sensor reset on setup, read serial/product/firmware, infer model type, and disable unsupported sensors automatically. Rework polling/read chain to use chained timeouts with improved logging and error handling; parse measurements with dynamic index mapping per model and add separate number-concentration read/parse flow. Add numerous control and helper APIs (start/stop measurements, device reset, read/get device status, ambient pressure/altitude, fan cleaning, SHT heater, VOC/NOx tuning, CO2 ASC, etc.) and tidy dump_config output and sensor labels. Overall changes improve robustness, model compatibility, and expose runtime configuration controls.

# What does this implement/fix?

Initially, I needed to access the measured values of particle number concentrations for the various PM sizes from 0.5 to 10. Therefore, based on the datasheet (https://sensirion.com/media/documents/FAFC548D/693FBB15/PS_DS_SEN6x.pdf), I integrated these five new sensors.

Then, while working on it, I exposed the available functions of the sensor according to the documentation, extending the sensor already available in ESPHome to cover all the device's functionalities.

I also expose the sensor's status itself (IDLE or MEASURING).


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Features: 
    Added Number Concentration Sensors (pm_nc_0_5, pm_nc_1_0, pm_nc_2_5, pm_nc_4_0, pm_nc_10_0)

    Exposed to lambda the following:

      **// Measurement Control**
      void stop_measurement();
      void start_continuous_measurement();
      bool get_data_ready();
      void device_reset();
      uint32_t get_device_status(bool clear_after_read = false);
    
      **// Temperature & Compensation**
      void set_temperature_offset(float offset_c);
      void set_temperature_acceleration(uint16_t profile);
      void set_ambient_pressure(uint16_t pressure_hpa);
      uint16_t get_ambient_pressure();
      void set_sensor_altitude(uint16_t altitude_meters);
      uint16_t get_sensor_altitude();
    
      **// Device Info Getters**
      std::string get_product_name();
      std::string get_serial_number();
      std::string get_firmware_version();
      std::string get_state();
    
      **// Maintenance & Advanced Features**
      void start_fan_cleaning();
      void activate_sht_heater();
      bool get_sht_heater_measurements(float &temp, float &hum);
    
      **// Tuning Parameters (VOC & NOx)**
      void set_voc_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
      void set_nox_algorithm_tuning_parameters(uint16_t index_offset, uint16_t learning_time, uint16_t gain, uint16_t gate_max);
      bool get_voc_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
      bool get_nox_algorithm_tuning_parameters(uint16_t &index_offset, uint16_t &learning_time, uint16_t &gain, uint16_t &gate_max);
    
      **// CO2 Calibration**
      void set_co2_automatic_self_calibration(bool enable);
      bool get_co2_automatic_self_calibration();
      void perform_forced_co2_recalibration(uint16_t co2_ppm);
      void perform_co2_sensor_factory_reset();

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

  - platform: sen6x
    id: sen66
    type: SEN66
    i2c_id: bus_int
    address: 0x6B
    update_interval: 5s
    
    pm_nc_0_5:
      id: sen66_pm_nc005
      name: PM <0.5µm
      filters:
        - or:
          - delta: 1
      on_value:
        then:
        - if:
            condition:
              lambda: 'return !isnan(x);'
            then:
              - lvgl.label.update:
                  id: card_pm05_value
                  text:
                    format: "%.0f"
                    args: [x]
                    if_nan: "--"
              - lvgl.led.update:
                  id: card_pm05_led
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
