### PR TITLE
[core] Expose App.wake_loop_isrsafe() on ESP8266

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -342,7 +342,7 @@ class Application {
   static void IRAM_ATTR wake_loop_isrsafe(BaseType_t *px) { esphome::wake_loop_isrsafe(px); }
 #elif defined(USE_ESP8266)
   /// Wake from ISR (ESP8266). No task_woken arg — no FreeRTOS. Caller must be IRAM_ATTR.
-  static void ESPHOME_ALWAYS_INLINE wake_loop_isrsafe() { esphome::wake_loop_isrsafe(); }
+  static void IRAM_ATTR ESPHOME_ALWAYS_INLINE wake_loop_isrsafe() { esphome::wake_loop_isrsafe(); }
 #endif
 
   /// Wake from any context (ISR, thread, callback).

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -340,6 +340,9 @@ class Application {
 #if defined(USE_ESP32) || defined(USE_LIBRETINY)
   /// Wake from ISR (ESP32 and LibreTiny).
   static void IRAM_ATTR wake_loop_isrsafe(BaseType_t *px) { esphome::wake_loop_isrsafe(px); }
+#elif defined(USE_ESP8266)
+  /// Wake from ISR (ESP8266). No task_woken arg — no FreeRTOS. Caller must be IRAM_ATTR.
+  static void ESPHOME_ALWAYS_INLINE wake_loop_isrsafe() { esphome::wake_loop_isrsafe(); }
 #endif
 
   /// Wake from any context (ISR, thread, callback).

--- a/esphome/core/wake.h
+++ b/esphome/core/wake.h
@@ -77,6 +77,9 @@ void wake_loop_any_context();
 /// Non-ISR: always inline.
 inline void wake_loop_threadsafe() { wake_loop_impl(); }
 
+/// ISR-safe: no task_woken arg because ESP8266 has no FreeRTOS. Caller must be IRAM_ATTR.
+inline void ESPHOME_ALWAYS_INLINE wake_loop_isrsafe() { wake_loop_impl(); }
+
 namespace internal {
 inline void wakeable_delay(uint32_t ms) {
   if (ms == 0) {


### PR DESCRIPTION
# What does this implement/fix?

Exposes `App.wake_loop_isrsafe()` on ESP8266 so IRAM ISR callbacks can wake the main loop using the same API name already available on ESP32/LibreTiny.

ESP8266 has no FreeRTOS, so the signature takes no `task_woken` arg (unlike the ESP32 version). Inlines to `wake_loop_impl()` — sets `g_main_loop_woke` and calls `esp_schedule()`, matching the existing `wake_loop_threadsafe()` fast path. The caller must be `IRAM_ATTR`, which is already required for any ESP8266 ISR that can fire during flash writes, so inlining places the body in IRAM automatically.

Motivation: external components (e.g. ratgdo's SoftwareSerial `onReceive` hook) currently use `App.wake_loop_threadsafe()` from ISR context. That still works but the naming is misleading. This lets them switch to `wake_loop_isrsafe()` for consistency with the ESP32 path.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal C++ API)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable — internal C++ API addition. Used from external
# components like:
#
#   inline void IRAM_ATTR my_isr() { App.wake_loop_isrsafe(); }
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).