### PR TITLE
[core] coerce set_interval(0) / update_interval: 0ms to 1ms

### DIFF
--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -954,9 +954,12 @@ def update_interval(value):
     if result.total_milliseconds == 0:
         _LOGGER.warning(
             "update_interval of 0ms is not supported — coercing to 1ms. "
-            "This was historically (mis)used as a pseudo-loop() mechanism; "
-            "use a real loop() override with HighFrequencyLoopRequester for "
-            "run-every-loop behaviour."
+            "A literal 0ms schedule would spin the main loop (the scheduled "
+            "item would always be due, so the scheduler would never yield "
+            "back) and trigger a watchdog reset. Set update_interval to a "
+            "non-zero value such as 1ms or higher. (Custom C++ components "
+            "that need true run-every-loop behaviour should override loop() "
+            "with HighFrequencyLoopRequester instead.)"
         )
         return TimePeriodMilliseconds(milliseconds=1)
     return result

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -953,7 +953,7 @@ def update_interval(value):
     # true run-every-loop behaviour.
     if result.total_milliseconds == 0:
         _LOGGER.warning(
-            "update_interval of 0ms is not supported — coercing to 1ms. "
+            "update_interval of 0ms is not supported - coercing to 1ms. "
             "A literal 0ms schedule would spin the main loop (the scheduled "
             "item would always be due, so the scheduler would never yield "
             "back) and trigger a watchdog reset. Set update_interval to a "

--- a/esphome/config_validation.py
+++ b/esphome/config_validation.py
@@ -943,7 +943,23 @@ def time_period_in_minutes_(value):
 def update_interval(value):
     if value == "never":
         return TimePeriodMilliseconds(milliseconds=SCHEDULER_DONT_RUN)
-    return positive_time_period_milliseconds(value)
+    result = positive_time_period_milliseconds(value)
+    # 0ms was historically (mis)used as a pseudo-loop() mechanism for
+    # PollingComponents. Under the hood it calls set_interval(0), which
+    # causes Scheduler::call() to spin (WDT reset in the field). Coerce
+    # to 1ms so existing configs keep working at ~1kHz instead of
+    # spinning. Don't hard-fail so configs don't break on upgrade;
+    # authors should migrate to HighFrequencyLoopRequester (C++) for
+    # true run-every-loop behaviour.
+    if result.total_milliseconds == 0:
+        _LOGGER.warning(
+            "update_interval of 0ms is not supported — coercing to 1ms. "
+            "This was historically (mis)used as a pseudo-loop() mechanism; "
+            "use a real loop() override with HighFrequencyLoopRequester for "
+            "run-every-loop behaviour."
+        )
+        return TimePeriodMilliseconds(milliseconds=1)
+    return result
 
 
 time_period = Any(time_period_str_unit, time_period_str_colon, time_period_dict)

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -152,7 +152,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // the intended mechanism for running fast in the main loop. Zero-delay
   // timeouts (defer) remain legitimate one-shots and are not affected.
   if (type == SchedulerItem::INTERVAL && delay == 0) [[unlikely]] {
-    ESP_LOGW(TAG, "[%s] set_interval(0) would spin main loop — coercing to 1ms (use HighFrequencyLoopRequester)",
+    ESP_LOGW(TAG, "[%s] set_interval(0) would spin main loop - coercing to 1ms (use HighFrequencyLoopRequester)",
              component ? LOG_STR_ARG(component->get_component_log_str()) : LOG_STR_LITERAL("?"));
     delay = 1;
   }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -152,7 +152,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // the intended mechanism for running fast in the main loop. Zero-delay
   // timeouts (defer) remain legitimate one-shots and are not affected.
   if (type == SchedulerItem::INTERVAL && delay == 0) [[unlikely]] {
-    ESP_LOGW(TAG, "[%s] set_interval(0) is misuse — coercing to 1ms. Use HighFrequencyLoopRequester instead.",
+    ESP_LOGW(TAG, "[%s] set_interval(0) would spin main loop — coercing to 1ms (use HighFrequencyLoopRequester)",
              component ? LOG_STR_ARG(component->get_component_log_str()) : LOG_STR_LITERAL("?"));
     delay = 1;
   }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -152,7 +152,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   // the intended mechanism for running fast in the main loop. Zero-delay
   // timeouts (defer) remain legitimate one-shots and are not affected.
   if (type == SchedulerItem::INTERVAL && delay == 0) [[unlikely]] {
-    ESP_LOGW(TAG, "[%s] set_interval(0) would spin main loop - coercing to 1ms (use HighFrequencyLoopRequester)",
+    ESP_LOGE(TAG, "[%s] set_interval(0) would spin main loop - coercing to 1ms (use HighFrequencyLoopRequester)",
              component ? LOG_STR_ARG(component->get_component_log_str()) : LOG_STR_LITERAL("?"));
     delay = 1;
   }

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -144,6 +144,19 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     return;
   }
 
+  // An interval of 0 means "fire every tick forever," which is misuse: the
+  // item would always be due, causing Scheduler::call() to spin and starve
+  // the main loop (WDT reset in the field). Coerce to 1ms so existing code
+  // using update_interval=0ms as a pseudo-loop() continues to work at ~1kHz,
+  // and warn so authors can migrate to HighFrequencyLoopRequester which is
+  // the intended mechanism for running fast in the main loop. Zero-delay
+  // timeouts (defer) remain legitimate one-shots and are not affected.
+  if (type == SchedulerItem::INTERVAL && delay == 0) [[unlikely]] {
+    ESP_LOGW(TAG, "[%s] set_interval(0) is misuse — coercing to 1ms. Use HighFrequencyLoopRequester instead.",
+             component ? LOG_STR_ARG(component->get_component_log_str()) : LOG_STR_LITERAL("?"));
+    delay = 1;
+  }
+
   // Take lock early to protect scheduler_item_pool_ access and retry-cancelled check
   LockGuard guard{this->lock_};
 

--- a/tests/integration/fixtures/scheduler_interval_zero_coerced.yaml
+++ b/tests/integration/fixtures/scheduler_interval_zero_coerced.yaml
@@ -16,7 +16,7 @@ interval:
   # Scheduler::set_timer_common_ coercion (not the Python cv.update_interval
   # path, since interval: doesn't call cv.update_interval — it's an intervals
   # component schema, not a PollingComponent's update_interval).
-  # Expected: scheduler coerces to 1ms at registration, emits ESP_LOGW,
+  # Expected: scheduler coerces to 1ms at registration, emits ESP_LOGE,
   # fires at ~1kHz instead of spinning.
   - interval: 0ms
     then:

--- a/tests/integration/fixtures/scheduler_interval_zero_coerced.yaml
+++ b/tests/integration/fixtures/scheduler_interval_zero_coerced.yaml
@@ -1,0 +1,27 @@
+esphome:
+  name: sched-interval-zero
+
+host:
+api:
+logger:
+  level: DEBUG
+
+globals:
+  - id: fire_count
+    type: int
+    initial_value: "0"
+
+interval:
+  # Deliberately configure 0ms — this path goes through the C++
+  # Scheduler::set_timer_common_ coercion (not the Python cv.update_interval
+  # path, since interval: doesn't call cv.update_interval — it's an intervals
+  # component schema, not a PollingComponent's update_interval).
+  # Expected: scheduler coerces to 1ms at registration, emits ESP_LOGW,
+  # fires at ~1kHz instead of spinning.
+  - interval: 0ms
+    then:
+      - lambda: |-
+          id(fire_count) += 1;
+          if (id(fire_count) == 50) {
+            ESP_LOGI("test", "ZERO_INTERVAL_50_FIRES_REACHED");
+          }

--- a/tests/integration/test_scheduler_interval_zero_coerced.py
+++ b/tests/integration/test_scheduler_interval_zero_coerced.py
@@ -1,0 +1,67 @@
+"""Test that Scheduler::set_timer_common_ coerces interval=0 to 1ms.
+
+Regression test for the scheduler busy-loop when interval=0 was passed
+literally. Without the coercion, Scheduler::call() would spin forever
+because the item's next_execution == now_64 after re-scheduling, failing
+the loop's `> now_64` break condition. The device would fail to yield
+back to the main loop and trigger a WDT reset.
+
+With the coercion, interval=0 becomes interval=1 and the scheduler
+fires at ~1kHz (bounded by the loop), the main loop continues to run,
+and the device stays responsive to API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_scheduler_interval_zero_coerced(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """interval=0ms must be coerced to 1ms and not starve the main loop."""
+    loop = asyncio.get_running_loop()
+    reached_50: asyncio.Future[None] = loop.create_future()
+    coerce_warning: asyncio.Future[None] = loop.create_future()
+
+    def on_log_line(line: str) -> None:
+        if "ZERO_INTERVAL_50_FIRES_REACHED" in line and not reached_50.done():
+            reached_50.set_result(None)
+        if "would spin main loop" in line and not coerce_warning.done():
+            coerce_warning.set_result(None)
+
+    async with (
+        run_compiled(yaml_config, line_callback=on_log_line),
+        api_client_connected() as client,
+    ):
+        # The API-client connection itself is evidence that the main loop
+        # is not starved — if set_interval(0) were spinning we could not
+        # get here at all.
+        device_info = await client.device_info()
+        assert device_info is not None
+        assert device_info.name == "sched-interval-zero"
+
+        # Coerce warning must fire at registration
+        try:
+            await asyncio.wait_for(coerce_warning, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Expected coerce warning 'would spin main loop' not seen")
+
+        # The coerced 1ms interval should fire 50 times quickly — this
+        # confirms the callback actually runs (not just registered) and the
+        # scheduler yields back to the main loop each time.
+        try:
+            await asyncio.wait_for(reached_50, timeout=5.0)
+        except TimeoutError:
+            pytest.fail(
+                "Coerced interval=0→1ms did not reach 50 fires within 5s, "
+                "which would indicate either the coercion failed or the "
+                "main loop is still being starved."
+            )

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -24,6 +24,7 @@ from esphome.const import (
     PLATFORM_LN882X,
     PLATFORM_RP2040,
     PLATFORM_RTL87XX,
+    SCHEDULER_DONT_RUN,
 )
 from esphome.core import CORE, HexInt, Lambda
 
@@ -789,6 +790,6 @@ def test_update_interval__preserves_nonzero_values() -> None:
 
 
 def test_update_interval__never_passes_through() -> None:
-    """update_interval: never must still map to SCHEDULER_DONT_RUN (0xFFFFFFFF)."""
+    """update_interval: never must still map to SCHEDULER_DONT_RUN."""
     result = config_validation.update_interval("never")
-    assert result.total_milliseconds == 0xFFFFFFFF
+    assert result.total_milliseconds == SCHEDULER_DONT_RUN

--- a/tests/unit_tests/test_config_validation.py
+++ b/tests/unit_tests/test_config_validation.py
@@ -765,3 +765,30 @@ def test_percentage_validators__raw_number_above_one_without_percent_sign(
         config_validation.unbounded_percentage(value)
     with pytest.raises(Invalid, match="percent sign"):
         config_validation.unbounded_possibly_negative_percentage(value)
+
+
+def test_update_interval__coerces_zero_to_one_ms(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """update_interval: 0ms must be coerced to 1ms (not rejected) because a
+    literal 0ms schedule causes Scheduler::call() to spin. Coercion keeps
+    existing configs compiling on upgrade while emitting a user-facing
+    warning that directs them to set a non-zero value."""
+    with caplog.at_level("WARNING"):
+        result = config_validation.update_interval("0ms")
+    assert result.total_milliseconds == 1
+    assert "update_interval of 0ms is not supported" in caplog.text
+    assert "1ms" in caplog.text
+
+
+def test_update_interval__preserves_nonzero_values() -> None:
+    """Non-zero update_interval values must pass through unchanged."""
+    assert config_validation.update_interval("1ms").total_milliseconds == 1
+    assert config_validation.update_interval("50ms").total_milliseconds == 50
+    assert config_validation.update_interval("60s").total_milliseconds == 60000
+
+
+def test_update_interval__never_passes_through() -> None:
+    """update_interval: never must still map to SCHEDULER_DONT_RUN (0xFFFFFFFF)."""
+    result = config_validation.update_interval("never")
+    assert result.total_milliseconds == 0xFFFFFFFF


### PR DESCRIPTION
# What does this implement/fix?

`update_interval: 0ms` on a PollingComponent translates to `set_interval(0, ...)` under the hood, which has historically been (mis)used as a pseudo-`loop()` mechanism. It worked only because the old scheduler was inefficient enough that it couldn't actually fire every tick — natural throttling made the misuse survivable.

#15516 optimised the scheduler enough that it can now honour `interval=0` literally, and that turns the old tolerated misuse into a real spin + WDT reset in the field.

## Why exactly `interval=0` spins (and `interval≥1` doesn't)

`Scheduler::call()` captures `now_64` **once at entry** and uses it as the dispatch deadline for this pass:

```cpp
const auto now_64 = this->millis_64_from_(now);            // scheduler.cpp:542

while (!this->items_.empty()) {
  SchedulerItem *item = this->items_[0];
  if (item->get_next_execution() > now_64) break;           // scheduler.cpp:603 — gate
  // ...run callback...
  now = this->execute_item_(item, now);
  // reschedule interval using call-start now_64, not post-callback time
  executed_item->set_next_execution(now_64 + executed_item->interval);   // scheduler.cpp:667
  // push back into heap, peek next items_[0]
}
```

For any `interval ≥ 1`:
- After the callback, `next_execution = now_64 + interval > now_64`
- Next loop iteration: gate is `next_execution > now_64` → true → **break** → control returns to the main loop

For `interval = 0`:
- After the callback, `next_execution = now_64 + 0 = now_64`
- Next loop iteration: gate is `now_64 > now_64` → **false** → no break → item is dispatched again → spin forever
- The main loop never runs; scheduler chews the watchdog to death

This also means that for legitimate intervals, if a callback takes longer than the interval (e.g. callback = 150ms, interval = 100ms), the scheduler does **not** try to catch up by firing multiple times in one `call()`. The item's new `next_execution` is `now_64 + 100` which is still `> now_64` (since `now_64` was captured at call-entry), the loop breaks, and the main loop runs. The item naturally drifts slower than requested — much better than starving the main loop.

`interval=0` is the unique case where that "yields back to main loop" invariant breaks.

## Fix: coerce `interval=0` to `1ms` at both layers

Now that we can deliver on what's being asked for, we can't allow it. Two-layer coercion:

- **Scheduler (`set_timer_common_` in `scheduler.cpp`)**: coerce `delay == 0` to `1` when `type == INTERVAL`. `ESP_LOGE` points authors at `HighFrequencyLoopRequester` (the intended mechanism for run-every-loop behaviour). Timeouts are unaffected — `defer()` / `set_timeout(0)` are legitimate one-shots.
- **Config validation (`cv.update_interval` in `config_validation.py`)**: same coercion at YAML validation time with a `_LOGGER.warning`, so users see it at validate time rather than only at runtime. Deliberately NOT a hard validation failure — existing configs must keep compiling on upgrade.

The net effect: code that writes `set_interval(0)` or YAML configs using `update_interval: 0ms` continue to work — at ~1kHz instead of spinning the main loop.

### Why coerce rather than revert #15516 or hard-fail validation

There are three possible ways to address this:

1. **Revert #15516.** The pre-#15516 reschedule path (`to_add_` round-trip) was slow enough to incidentally throttle `interval=0`. But that perf cost is paid on *every* fired interval on *every* `scheduler.call()` — i.e., every main-loop tick on every ESPHome device ever. Sacrificing a real perf win on the hot path to accommodate a misuse pattern is the wrong trade. Plus, reverting wouldn't give users the behaviour they thought they were asking for either — it'd just throttle back to the pre-#15516 rate, which was never "fire every tick."
2. **Hard-fail validation.** Breaks existing configs on upgrade for no reliability benefit — the coerced 1ms value runs identically to what #15516 would have silently produced anyway. External components and direct C++ callers wouldn't be caught by Python validation, so the runtime coercion is needed regardless.
3. **Coerce at creation time (this PR).** Zero runtime cost on the hot path (the check is at registration, not dispatch, and `[[unlikely]]`-marked). Existing configs keep compiling and running. The `ESP_LOGE` tells the user exactly what happened and points them at the correct mechanism. Follows the same pattern already established in `set_retry_common_` for an equivalent class of misuse.

### Why "detect misuse + coerce + log" is the right shape

`Scheduler::set_retry_common_` already follows exactly this pattern for a similar class of misuse:

```cpp
if (backoff_increase_factor < 0.0001) {
  ESP_LOGE(TAG, "set_retry: backoff_factor %0.1f too small, using 1.0: %s", backoff_increase_factor,
           (name_type == NameType::STATIC_STRING && static_name) ? static_name : "");
  backoff_increase_factor = 1;
}
```

A zero (or near-zero) backoff factor would drive `current_interval *= 0.0` to zero forever — breaking the exponential-backoff intent in a nonsense way. Rather than rejecting the call or hard-failing validation, the code logs an error and coerces to a sane default. This keeps existing configs compiling on upgrade and makes the failure mode obvious in logs.

`set_interval(0)` is the same class of misuse (user asks for something that can't be reliably delivered) so this PR uses the same shape: `ESP_LOGE` + coerce to `1ms`.

### Why `set_retry` didn't have this spin problem

Retries ride the **TIMEOUT path**, not INTERVAL. TIMEOUTs are one-shot on every platform (scheduler.cpp:682): they fire, get recycled, and do not re-arm themselves. The retry handler creates a *fresh* TIMEOUT from inside the callback via `set_timer_common_`, which lands in a staging queue that is **not** processed until after the current `scheduler.call()` while-loop exits:

- On multi-threaded platforms, `delay=0 && TIMEOUT` lands in `defer_queue_` (scheduler.cpp:200-202). `process_defer_queue_slow_path_` snapshots `defer_queue_end = defer_queue_.size()` at entry (scheduler.cpp:505) and only iterates up to that snapshot — items added during processing are left for the next tick.
- On single-threaded platforms, it lands in `to_add_`, which is processed at the start/end of `call()` (scheduler.cpp:543, 689) but not during the while-loop.

The queue differs by platform, but the important invariant — "fired TIMEOUT does not re-arm itself; a retry is a fresh TIMEOUT that waits for the next tick" — holds for both. That's the property INTERVAL lacks (scheduler.cpp:678-679 pushes fired intervals back into `items_` during the same while-loop iteration via `push_heap`), which is why `set_interval(0)` is the unique unprotected case.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes https://github.com/esphome/esphome/issues/15795
- fixes https://github.com/esphome/esphome/issues/15795
- Surfaced by scheduler optimisation in #15516 (which made the spin actually possible in the field).
- Also preconditions #15792 (main-loop / scheduler decoupling) — that PR removes the `delay_time / 2` floor, which would make the spin even more aggressive on any raised `loop_interval_`. Landing this first keeps existing `update_interval: 0ms` configs safe before #15792 lands.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (real-device WDT crash reproduction reported by user with `update_interval: 0ms`)
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host

## Example entry for `config.yaml`:

```yaml
# Before this PR: this crashed with WDT reset on ESP32 IDF after the
# scheduler optimisation in #15516.
# After this PR: emits a config-validation warning and runs at 1ms.
sensor:
  - platform: template
    name: "Whatever"
    update_interval: 0ms
    lambda: |-
      return 42.0;
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
