### PR TITLE
[image] Fix byte order handling

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -28,7 +28,6 @@ from esphome.const import (
     CONF_URL,
 )
 from esphome.core import CORE, HexInt
-from esphome.final_validate import full_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -676,11 +675,16 @@ def _final_validate(config):
     :param config:
     :return:
     """
-    fv = full_config.get()
-    if "lvgl" in fv and not all(CONF_BYTE_ORDER in x for x in config):
+    if not all(CONF_BYTE_ORDER in x for x in config):
         config = config.copy()
         for c in config:
-            if not c.get(CONF_BYTE_ORDER):
+            if byte_order := c.get(CONF_BYTE_ORDER):
+                if byte_order == "BIG_ENDIAN":
+                    _LOGGER.warning(
+                        "The image '%s' is configured with big-endian byte order, little-endian is expected",
+                        c.get(CONF_FILE),
+                    )
+            else:
                 c[CONF_BYTE_ORDER] = "LITTLE_ENDIAN"
     return config
 

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -675,17 +675,16 @@ def _final_validate(config):
     :param config:
     :return:
     """
-    if not all(CONF_BYTE_ORDER in x for x in config):
-        config = config.copy()
-        for c in config:
-            if byte_order := c.get(CONF_BYTE_ORDER):
-                if byte_order == "BIG_ENDIAN":
-                    _LOGGER.warning(
-                        "The image '%s' is configured with big-endian byte order, little-endian is expected",
-                        c.get(CONF_FILE),
-                    )
-            else:
-                c[CONF_BYTE_ORDER] = "LITTLE_ENDIAN"
+    config = config.copy()
+    for c in config:
+        if byte_order := c.get(CONF_BYTE_ORDER):
+            if byte_order == "BIG_ENDIAN":
+                _LOGGER.warning(
+                    "The image '%s' is configured with big-endian byte order, little-endian is expected",
+                    c.get(CONF_FILE),
+                )
+        else:
+            c[CONF_BYTE_ORDER] = "LITTLE_ENDIAN"
     return config
 
 

--- a/esphome/components/image/image.cpp
+++ b/esphome/components/image/image.cpp
@@ -189,7 +189,7 @@ Color Image::get_rgb_pixel_(int x, int y) const {
 }
 Color Image::get_rgb565_pixel_(int x, int y) const {
   const uint8_t *pos = this->data_start_ + (x + y * this->width_) * this->bpp_ / 8;
-  uint16_t rgb565 = encode_uint16(progmem_read_byte(pos), progmem_read_byte(pos + 1));
+  uint16_t rgb565 = encode_uint16(progmem_read_byte(pos + 1), progmem_read_byte(pos));
   auto r = (rgb565 & 0xF800) >> 11;
   auto g = (rgb565 & 0x07E0) >> 5;
   auto b = rgb565 & 0x001F;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The default byte order for images changed from big to little-endian, but the image drawing code was not updated to match. Fix this and add a warning for explicitly configured big-endian.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1494532355203928185

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6477

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
