### PR TITLE
[wifi] Guard retry_phase_to_log_string with log level check to fix warning

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -327,8 +327,8 @@ static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
     return LOG_STR("RESTARTING");
   return LOG_STR("UNKNOWN");
 }
-
 #endif  // ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
+
 bool WiFiComponent::went_through_explicit_hidden_phase_() const {
   // If first configured network is marked hidden, we went through EXPLICIT_HIDDEN phase
   // This means those networks were already tried and should be skipped in RETRY_HIDDEN

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -308,6 +308,7 @@ bool CompactString::operator==(const StringRef &other) const {
 /// │  - Roaming fail (RECONNECTING on other AP): counter preserved        │
 /// └──────────────────────────────────────────────────────────────────────┘
 
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
 // Use if-chain instead of switch to avoid jump table in RODATA (wastes RAM on ESP8266)
 static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
   if (phase == WiFiRetryPhase::INITIAL_CONNECT)
@@ -327,6 +328,7 @@ static const LogString *retry_phase_to_log_string(WiFiRetryPhase phase) {
   return LOG_STR("UNKNOWN");
 }
 
+#endif  // ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_INFO
 bool WiFiComponent::went_through_explicit_hidden_phase_() const {
   // If first configured network is marked hidden, we went through EXPLICIT_HIDDEN phase
   // This means those networks were already tried and should be skipped in RETRY_HIDDEN


### PR DESCRIPTION
# What does this implement/fix?

The static function  is only referenced inside  and  macros. When the log level is set to  or higher, those macros are compiled out entirely, leaving the function with no call sites and triggering a  compiler warning.

Fix: wrap the function definition in a  guard — the same pattern used elsewhere in the codebase — so it is only compiled when at least one of its call sites is active.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Test Environment

- [x] ESP32 IDF
- [x] BK72xx

## Checklist:
  - [x] The code change is tested and works locally.