### PR TITLE
[esp32] Downgrade unneeded `ignore_pin_validation_error` to a warning

### DIFF
--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -172,10 +172,16 @@ def validate_gpio_pin(pin):
             exc,
         )
     else:
-        # Throw an exception if used for a pin that would not have resulted
-        # in a validation error anyway!
+        # `ignore_pin_validation_error` is meant to suppress an actual validation
+        # error (strapping/SPI flash/USB-JTAG/etc.). If the pin has no such error,
+        # the option is a no-op -- warn so the user can clean it up, but don't
+        # block the build.
         if ignore_pin_validation_warning:
-            raise cv.Invalid(f"GPIO{pin[CONF_NUMBER]} is not a reserved pin")
+            _LOGGER.warning(
+                "GPIO%d has no validation errors to ignore; "
+                "remove `ignore_pin_validation_error: true` from this pin.",
+                pin[CONF_NUMBER],
+            )
 
     return pin
 

--- a/esphome/components/esp32/gpio.py
+++ b/esphome/components/esp32/gpio.py
@@ -172,10 +172,10 @@ def validate_gpio_pin(pin):
             exc,
         )
     else:
-        # `ignore_pin_validation_error` is meant to suppress an actual validation
-        # error (strapping/SPI flash/USB-JTAG/etc.). If the pin has no such error,
-        # the option is a no-op -- warn so the user can clean it up, but don't
-        # block the build.
+        # `ignore_pin_validation_error` only suppresses an error raised by the
+        # variant's pin_validation above (e.g. SPI flash/PSRAM pins, invalid pin
+        # numbers). If that didn't raise, the option is a no-op -- warn so the
+        # user can clean it up, but don't block the build.
         if ignore_pin_validation_warning:
             _LOGGER.warning(
                 "GPIO%d has no validation errors to ignore; "

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import pytest
 
-from esphome.components.esp32 import VARIANTS
+from esphome.components.esp32 import VARIANT_ESP32, VARIANTS
 from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS, KEY_VARIANT
 from esphome.components.esp32.gpio import validate_gpio_pin
 import esphome.config_validation as cv
@@ -161,8 +161,6 @@ def test_ignore_pin_validation_error_on_clean_pin_warns(
 ) -> None:
     """A pin that passes validation but sets `ignore_pin_validation_error: true`
     should log a warning nudging the user to remove the flag, and not raise."""
-    from esphome.components.esp32 import VARIANT_ESP32
-
     set_core_config(
         PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
     )
@@ -181,8 +179,6 @@ def test_ignore_pin_validation_error_on_dirty_pin_suppresses(
 ) -> None:
     """A pin that fails validation with `ignore_pin_validation_error: true` should
     log the suppression warning and not raise (existing behavior)."""
-    from esphome.components.esp32 import VARIANT_ESP32
-
     set_core_config(
         PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
     )
@@ -200,8 +196,6 @@ def test_dirty_pin_without_ignore_flag_raises(
     set_core_config: SetCoreConfigCallable,
 ) -> None:
     """A pin that fails validation without the ignore flag should still raise."""
-    from esphome.components.esp32 import VARIANT_ESP32
-
     set_core_config(
         PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
     )
@@ -216,8 +210,6 @@ def test_clean_pin_without_ignore_flag_does_not_warn(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A clean pin without the ignore flag should pass silently."""
-    from esphome.components.esp32 import VARIANT_ESP32
-
     set_core_config(
         PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
     )

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -9,9 +9,15 @@ from typing import Any
 import pytest
 
 from esphome.components.esp32 import VARIANTS
-from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS
+from esphome.components.esp32.const import KEY_ESP32, KEY_SDKCONFIG_OPTIONS, KEY_VARIANT
+from esphome.components.esp32.gpio import validate_gpio_pin
 import esphome.config_validation as cv
-from esphome.const import CONF_ESPHOME, PlatformFramework
+from esphome.const import (
+    CONF_ESPHOME,
+    CONF_IGNORE_PIN_VALIDATION_ERROR,
+    CONF_NUMBER,
+    PlatformFramework,
+)
 from esphome.core import CORE
 from tests.component_tests.types import SetCoreConfigCallable
 
@@ -147,6 +153,81 @@ def test_execute_from_psram_p4_sdkconfig(
     assert sdkconfig.get("CONFIG_SPIRAM_XIP_FROM_PSRAM") is True
     assert "CONFIG_SPIRAM_FETCH_INSTRUCTIONS" not in sdkconfig
     assert "CONFIG_SPIRAM_RODATA" not in sdkconfig
+
+
+def test_ignore_pin_validation_error_on_clean_pin_warns(
+    set_core_config: SetCoreConfigCallable,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A pin that passes validation but sets `ignore_pin_validation_error: true`
+    should log a warning nudging the user to remove the flag, and not raise."""
+    from esphome.components.esp32 import VARIANT_ESP32
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
+    )
+
+    pin = {CONF_NUMBER: 4, CONF_IGNORE_PIN_VALIDATION_ERROR: True}
+    with caplog.at_level("WARNING"):
+        result = validate_gpio_pin(pin)
+
+    assert result[CONF_NUMBER] == 4
+    assert "GPIO4 has no validation errors to ignore" in caplog.text
+
+
+def test_ignore_pin_validation_error_on_dirty_pin_suppresses(
+    set_core_config: SetCoreConfigCallable,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A pin that fails validation with `ignore_pin_validation_error: true` should
+    log the suppression warning and not raise (existing behavior)."""
+    from esphome.components.esp32 import VARIANT_ESP32
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
+    )
+
+    # GPIO6 is a flash pin on ESP32 -> pin_validation raises cv.Invalid
+    pin = {CONF_NUMBER: 6, CONF_IGNORE_PIN_VALIDATION_ERROR: True}
+    with caplog.at_level("WARNING"):
+        result = validate_gpio_pin(pin)
+
+    assert result[CONF_NUMBER] == 6
+    assert "Ignoring validation error on pin 6" in caplog.text
+
+
+def test_dirty_pin_without_ignore_flag_raises(
+    set_core_config: SetCoreConfigCallable,
+) -> None:
+    """A pin that fails validation without the ignore flag should still raise."""
+    from esphome.components.esp32 import VARIANT_ESP32
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
+    )
+
+    pin = {CONF_NUMBER: 6, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
+    with pytest.raises(cv.Invalid, match="flash interface"):
+        validate_gpio_pin(pin)
+
+
+def test_clean_pin_without_ignore_flag_does_not_warn(
+    set_core_config: SetCoreConfigCallable,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A clean pin without the ignore flag should pass silently."""
+    from esphome.components.esp32 import VARIANT_ESP32
+
+    set_core_config(
+        PlatformFramework.ESP32_IDF, platform_data={KEY_VARIANT: VARIANT_ESP32}
+    )
+
+    pin = {CONF_NUMBER: 4, CONF_IGNORE_PIN_VALIDATION_ERROR: False}
+    with caplog.at_level("WARNING"):
+        result = validate_gpio_pin(pin)
+
+    assert result[CONF_NUMBER] == 4
+    assert "has no validation errors to ignore" not in caplog.text
 
 
 def test_execute_from_psram_disabled_sdkconfig(


### PR DESCRIPTION
# What does this implement/fix?

Setting `ignore_pin_validation_error: true` on a pin that has **no** validation issue currently fails the build with the confusing message:

```
GPIO0 is not a reserved pin
```

The wording reads backwards (it sounds like the pin needs to be reserved), and the failure mode hits users who defensively add the flag — for example, when sharing a wakeup pin with another component, or when copying configs between boards. The check was added in #5615 to discourage sprinkling the flag everywhere, but the cost is a hard build failure for what is effectively a no-op annotation.

This PR downgrades the hard error to a `_LOGGER.warning` that names the flag and tells the user to remove it. The build proceeds; the user still gets a clear nudge to clean their config.

Before:

```
GPIO0 is not a reserved pin.
```

After (warning, no build failure):

```
GPIO0 has no validation errors to ignore; remove `ignore_pin_validation_error: true` from this pin.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15810

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
deep_sleep:
  wakeup_pin:
    number: GPIO0           # any non-restricted pin
    ignore_pin_validation_error: true
  wakeup_pin_mode: IGNORE
```

Previously: build fails with \"GPIO0 is not a reserved pin\".
Now: build succeeds with a warning telling the user to remove the flag.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).