### PR TITLE
[mipi_spi] Add Sunton ESP32-2424S012

### DIFF
--- a/esphome/components/mipi_spi/models/cyd.py
+++ b/esphome/components/mipi_spi/models/cyd.py
@@ -1,4 +1,6 @@
-from .ili import ILI9341, ILI9342, ST7789V
+from esphome.const import CONF_IGNORE_STRAPPING_WARNING, CONF_NUMBER
+
+from .ili import GC9A01A, ILI9341, ILI9342, ST7789V
 
 ILI9341.extend(
     # ESP32-2432S028 CYD board with Micro USB, has ILI9341 controller
@@ -42,4 +44,11 @@ ILI9342.extend(
         (0xE0, 0x00, 0x0C, 0x11, 0x04, 0x11, 0x08, 0x37, 0x89, 0x4C, 0x06, 0x0C, 0x0A, 0x2E, 0x34, 0x0F),  # Positive Gamma Correction
         (0xE1, 0x00, 0x0B, 0x11, 0x05, 0x13, 0x09, 0x33, 0x67, 0x48, 0x07, 0x0E, 0x0B, 0x23, 0x33, 0x0F),  # Negative Gamma Correction
     )
+)
+
+GC9A01A.extend(
+    "ESP32-2424S012",
+    invert_colors=True,
+    cs_pin=10,
+    dc_pin={CONF_NUMBER: 2, CONF_IGNORE_STRAPPING_WARNING: True},
 )

--- a/esphome/components/mipi_spi/models/ili.py
+++ b/esphome/components/mipi_spi/models/ili.py
@@ -555,7 +555,7 @@ ST7789V = DriverChip(
         ),
     ),
 )
-DriverChip(
+GC9A01A = DriverChip(
     "GC9A01A",
     mirror_x=True,
     width=240,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6479

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
display:
  - platform: mipi_spi
    enable_pin: 3 # backlight
    id: display_id
    model: esp32-2424s012
    rotation: 90
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
