### PR TITLE
[core] Fix DelayAction compile error with non-const reference args

### DIFF
--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -205,7 +205,9 @@ template<typename... Ts> class DelayAction : public Action<Ts...>, public Compon
     } else {
       // For delays with arguments, capture by value to preserve argument values
       // Arguments must be copied because original references may be invalid after delay
-      auto f = [this, x...]() { this->play_next_(x...); };
+      // `mutable` is required so captured copies of non-const reference args (e.g. std::string&)
+      // are passed as non-const lvalues to play_next_(const Ts&...) where Ts may be `T&`
+      auto f = [this, x...]() mutable { this->play_next_(x...); };
       App.scheduler.set_timer_common_(this, Scheduler::SchedulerItem::TIMEOUT, Scheduler::NameType::NUMERIC_ID_INTERNAL,
                                       nullptr, static_cast<uint32_t>(InternalSchedulerID::DELAY_ACTION),
                                       this->delay_.value(x...), std::move(f),

--- a/tests/components/http_request/http_request.yaml
+++ b/tests/components/http_request/http_request.yaml
@@ -45,6 +45,11 @@ esphome:
                   args:
                     - response->status_code
                     - body.c_str()
+              - delay: 1s
+              - logger.log:
+                  format: "After delay, body still: %s"
+                  args:
+                    - body.c_str()
 
 http_request:
   useragent: esphome/tagreader


### PR DESCRIPTION
# What does this implement/fix?

Fixes a compilation error introduced in 2026.4.0 when a `delay` action is used inside a trigger whose argument list contains a non-const lvalue reference (for example `http_request`'s `on_response` trigger, which is `Trigger<std::shared_ptr<HttpContainer>, std::string &>`).

PR #14968 replaced `std::bind` with a lambda in `DelayAction::play_complex`. Because the lambda is not `mutable`, its captured copies are const-qualified. When one of the automation parameter types is a non-const reference `T&`, `const Ts&...` collapses back to `T&`, and passing a const-qualified capture to `play_next_(const Ts&...)` fails:

```
error: binding reference of type 'std::string&' to 'const std::string' discards qualifiers
  auto f = [this, x...]() { this->play_next_(x...); };
```

`std::bind` handled this automatically because its internal storage exposes the stored args as non-const lvalues. The minimal fix is to mark the lambda `mutable` so the captured values are non-const lvalues, which matches the previous `std::bind` behaviour.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15808

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32dev
  framework:
    type: esp-idf

http_request:

button:
  - platform: template
    id: test
    on_press:
      then:
        - http_request.get:
            url: http://127.0.0.1
            capture_response: true
            on_response:
              then:
                - delay: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).