### PR TITLE
[ci] Scope local pylint pre-commit hook to esphome/

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
         entry: python3 script/run-in-env.py pylint
         language: system
         types: [python]
+        files: ^esphome/.+\.py$
       - id: clang-tidy-hash
         name: Update clang-tidy hash
         entry: python script/clang_tidy_hash.py --update-if-changed


### PR DESCRIPTION
# What does this implement/fix?

The CI `pylint` job runs `pylint esphome` — esphome/ only. The local pre-commit hook had no `files:` restriction, so it also linted `tests/`, flagging pre-existing `protected-access` usage and `too-many-public-methods` in `tests/unit_tests/test_core.py` that CI never sees. That blocked local commits on warnings CI doesn't gate on.

This adds `files: ^esphome/.+\.py$` to the local pylint pre-commit hook so its scope matches the CI job exactly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# n/a — build tooling change only
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
