### PR TITLE
[core] Chunk generated setup() into per-component IIFE lambdas

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -569,6 +569,7 @@ def wrap_to_code(name, comp):
 
     @functools.wraps(comp.to_code)
     async def wrapped(conf):
+        cg.add(cg.ComponentMarker(name))
         cg.add(cg.LineComment(f"{name}:"))
         if comp.config_schema is not None:
             conf_str = yaml_util.dump(conf)

--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -13,6 +13,7 @@ from esphome.cpp_generator import (  # noqa: F401
     ComponentMarker,
     Expression,
     FlashStringLiteral,
+    IIFEUnsafeStatement,
     LineComment,
     LogStringLiteral,
     MockObj,

--- a/esphome/codegen.py
+++ b/esphome/codegen.py
@@ -10,6 +10,7 @@
 # pylint: disable=unused-import
 from esphome.cpp_generator import (  # noqa: F401
     ArrayInitializer,
+    ComponentMarker,
     Expression,
     FlashStringLiteral,
     LineComment,

--- a/esphome/components/safe_mode/__init__.py
+++ b/esphome/components/safe_mode/__init__.py
@@ -87,7 +87,10 @@ async def to_code(config):
             config[CONF_REBOOT_TIMEOUT],
             config[CONF_BOOT_IS_GOOD_AFTER],
         )
-        cg.add(RawExpression(f"if ({condition}) return"))
+        # Wrap in IIFEUnsafeStatement so cpp_main_section emits this
+        # component's block flat rather than inside an IIFE lambda —
+        # the `return` must exit setup() itself, not just the lambda.
+        cg.add(cg.IIFEUnsafeStatement(RawExpression(f"if ({condition}) return")))
 
     CORE.data[CONF_SAFE_MODE] = {}
     CORE.data[CONF_SAFE_MODE][KEY_PAST_SAFE_MODE] = True

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1052,13 +1052,16 @@ class EsphomeCore:
 
         # Split main_statements at ComponentMarker sentinels into a prefix
         # (statements emitted before any component) plus per-component groups.
+        # Each group's first entry is its marker comment, kept separate so
+        # it can bracket the IIFE rather than be buried inside it.
         prefix: list[str] = []
-        components: list[list[str]] = []
+        components: list[tuple[str, list[str]]] = []
         current = prefix
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
-                current = [str(exp).rstrip()]
-                components.append(current)
+                body: list[str] = []
+                components.append((str(exp).rstrip(), body))
+                current = body
                 continue
             current.append(str(statement(exp)).rstrip())
 
@@ -1066,13 +1069,19 @@ class EsphomeCore:
         if not components:
             return "\n".join(prefix) + "\n\n"
 
-        # Each component's block is wrapped in a noinline IIFE lambda so its
-        # stack frame is released on return, bounding peak stack during
-        # setup(). Large blocks are sub-split to cap single heavy components
-        # (e.g. sensor platforms with many filter registrations).
+        # Each component's block is wrapped in IIFE lambdas so its stack
+        # frame is released on return, bounding peak stack during setup().
+        # Large blocks are sub-split to cap single heavy components (e.g.
+        # sensor platforms with many filter registrations). The marker
+        # comment brackets the IIFE on both sides so the generated
+        # main.cpp is easy to scan by component.
         pieces = list(prefix)
-        for block in components:
-            pieces.extend(_wrap_in_iifes(block, max_statements=50))
+        for marker, body in components:
+            wrapped = _wrap_in_iifes(body, max_statements=50)
+            pieces.append(marker)
+            pieces.extend(wrapped)
+            if any("[]()" in line for line in wrapped):
+                pieces.append(marker)
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -616,6 +616,12 @@ def _wrap_in_iifes(lines: list[str], max_statements: int | None) -> list[str]:
     out: list[str] = []
     chunk: list[str] = []
     depth: int = 0
+    # Once depth goes negative we stop trusting the brace count and
+    # keep everything remaining in one final IIFE. A later ``{`` could
+    # arithmetically bring depth back to 0, but by that point the brace
+    # tracking is already unreliable — re-enabling mid-stream splits
+    # could land between a declaration and its use.
+    poisoned: bool = False
 
     def flush() -> None:
         if not chunk:
@@ -631,11 +637,16 @@ def _wrap_in_iifes(lines: list[str], max_statements: int | None) -> list[str]:
     for line in lines:
         chunk.append(line)
         # Count { and } per line so inline control flow (e.g. `if (cond) {`)
-        # and balanced inline lambdas are tracked correctly. If depth ever
-        # goes negative (unbalanced input) we never return to 0 and the
-        # rest falls through into a single final IIFE — safe fallback.
+        # and balanced inline lambdas are tracked correctly.
         depth += line.count("{") - line.count("}")
-        if max_statements is not None and depth == 0 and len(chunk) >= max_statements:
+        if depth < 0:
+            poisoned = True
+        if (
+            not poisoned
+            and max_statements is not None
+            and depth == 0
+            and len(chunk) >= max_statements
+        ):
             flush()
     flush()
     return out

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -531,6 +531,14 @@ class Library:
         return self
 
 
+# Cap on the number of statements in a single IIFE chunk when a
+# component's to_code body is sub-split. Picks a frame-size sweet spot
+# on esp32-s3 — large enough that most components fit in one chunk and
+# small enough that heavy sensor platforms (many filter registrations)
+# don't produce a chunk with a very large spill frame.
+IIFE_MAX_STATEMENTS = 50
+
+
 def _emits_bare_local(exp: "Statement") -> bool:
     """True if ``exp`` emits a scope brace or bare-raw construct that may
     declare a function-local whose lifetime extends past the current
@@ -1134,7 +1142,7 @@ class EsphomeCore:
                 # declarations must stay in one IIFE so the declarations
                 # remain visible to subsequent uses. ``max_statements=None``
                 # disables sub-splitting for the group.
-                cap = None if group_no_split[0] else 50
+                cap = None if group_no_split[0] else IIFE_MAX_STATEMENTS
                 pieces.extend(_wrap_in_iifes(body, max_statements=cap))
         return "\n".join(pieces) + "\n\n"
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -565,11 +565,18 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
 
     for line in lines:
         chunk.append(line)
-        stripped = line.strip()
-        if stripped == "{":
-            depth += 1
-        elif stripped == "}":
-            depth -= 1
+        # Track brace depth by counting ``{`` and ``}`` characters per line
+        # rather than matching whole-line tokens. Today the only codegen
+        # that emits scope braces as separate statements is
+        # ``cg.with_local_variable()`` (standalone ``{`` / ``}`` lines),
+        # but counting is robust against future codegen that emits inline
+        # control-flow like ``if (cond) {`` or ``} else {`` on a single
+        # line. Multi-line statements (inline lambdas) carry balanced
+        # braces within one list entry so they contribute no net depth.
+        # Braces inside string literals would throw the count off, but
+        # esphome's generated main.cpp does not currently emit strings
+        # that contain unbalanced braces in main_statements.
+        depth += line.count("{") - line.count("}")
         if depth == 0 and len(chunk) >= max_statements:
             flush()
     flush()
@@ -1069,13 +1076,17 @@ class EsphomeCore:
         if not components:
             return "\n".join(prefix) + "\n\n"
 
-        # Each component's block is wrapped in IIFE lambdas so its stack
-        # frame is released on return, bounding peak stack during setup().
-        # Large blocks are sub-split to cap single heavy components (e.g.
-        # sensor platforms with many filter registrations). "begin X" and
-        # "end X" marker comments bracket the IIFE so the generated
-        # main.cpp is easy to scan by component; a comment-only component
-        # gets a single "begin X" marker (no IIFE, no end marker).
+        # Each component's block is wrapped in an IIFE lambda that
+        # introduces a nested scope, shortening the lifetimes of
+        # temporaries so GCC can bound peak setup-time stack usage.
+        # The IIFE has no noinline attribute, so the compiler is free
+        # to inline the block when that produces smaller code without
+        # regressing peak stack. Large blocks are sub-split to cap
+        # single heavy components (e.g. sensor platforms with many
+        # filter registrations). "begin X" and "end X" marker comments
+        # bracket the IIFE so the generated main.cpp is easy to scan by
+        # component; a comment-only component gets a single "begin X"
+        # marker (no IIFE, no end marker).
         pieces = list(prefix)
         for name, body in components:
             wrapped = _wrap_in_iifes(body, max_statements=50)

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 import logging
 import math
 import os
@@ -537,6 +538,24 @@ class Library:
 # small enough that heavy sensor platforms (many filter registrations)
 # don't produce a chunk with a very large spill frame.
 IIFE_MAX_STATEMENTS = 50
+
+
+@dataclass
+class _ComponentGroup:
+    """A contiguous run of statements emitted by one component's to_code."""
+
+    lines: list[str] = field(default_factory=list)
+    # True when the group contains a statement that must affect setup()'s
+    # own control flow (e.g. safe_mode's `return`). Emit the group flat,
+    # bypassing IIFE wrapping entirely.
+    unsafe: bool = False
+    # True when the group contains a statement that may declare a
+    # function-local whose lifetime extends past the current statement
+    # (scope-brace RawStatement, direct RawExpression, typed
+    # AssignmentExpression). Wrap the group in a single IIFE without
+    # sub-splitting so the declaration and any later references stay
+    # in the same lambda.
+    no_split: bool = False
 
 
 def _emits_bare_local(exp: "Statement") -> bool:
@@ -1124,43 +1143,32 @@ class EsphomeCore:
         #   sub-split so the declaration and any later references stay
         #   together.
         prefix: list[str] = []
-        # Flags are stored as 1-element lists so they can be mutated by
-        # reference after the tuple has been pushed into ``components``
-        # (assignment to a local ``unsafe_flag`` inside the loop would
-        # rebind the local without updating the stored tuple entry).
-        # A small dataclass would read cleaner but the pattern is
-        # localized to this one property.
-        components: list[tuple[list[str], list[bool], list[bool]]] = []
+        components: list[_ComponentGroup] = []
         current: list[str] = prefix
-        unsafe_flag: list[bool] = [False]  # unused for prefix
-        no_split_flag: list[bool] = [False]  # unused for prefix
+        group: _ComponentGroup | None = None
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
-                current = []
-                unsafe_flag = [False]
-                no_split_flag = [False]
-                components.append((current, unsafe_flag, no_split_flag))
+                group = _ComponentGroup()
+                components.append(group)
+                current = group.lines
                 continue
-            if isinstance(exp, IIFEUnsafeStatement):
-                unsafe_flag[0] = True
-            if _emits_bare_local(exp):
-                no_split_flag[0] = True
+            if group is not None:
+                if isinstance(exp, IIFEUnsafeStatement):
+                    group.unsafe = True
+                if _emits_bare_local(exp):
+                    group.no_split = True
             current.append(str(statement(exp)).rstrip())
 
         if not components:
             return "\n".join(prefix) + "\n\n"
 
         pieces: list[str] = list(prefix)
-        for body, group_unsafe, group_no_split in components:
-            if group_unsafe[0]:
-                pieces.extend(body)
+        for g in components:
+            if g.unsafe:
+                pieces.extend(g.lines)
             else:
-                # A group containing raw scope braces or bare-local
-                # declarations must stay in one IIFE so the declarations
-                # remain visible to subsequent uses. ``max_statements=None``
-                # disables sub-splitting for the group.
-                cap = None if group_no_split[0] else IIFE_MAX_STATEMENTS
-                pieces.extend(_wrap_in_iifes(body, max_statements=cap))
+                cap = None if g.no_split else IIFE_MAX_STATEMENTS
+                pieces.extend(_wrap_in_iifes(g.lines, max_statements=cap))
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -1052,15 +1052,15 @@ class EsphomeCore:
 
         # Split main_statements at ComponentMarker sentinels into a prefix
         # (statements emitted before any component) plus per-component groups.
-        # Each group's first entry is its marker comment, kept separate so
-        # it can bracket the IIFE rather than be buried inside it.
+        # Each group carries its component name so cpp_main_section can emit
+        # begin/end marker comments bracketing the IIFE.
         prefix: list[str] = []
         components: list[tuple[str, list[str]]] = []
         current = prefix
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
                 body: list[str] = []
-                components.append((str(exp).rstrip(), body))
+                components.append((exp.name, body))
                 current = body
                 continue
             current.append(str(statement(exp)).rstrip())
@@ -1072,16 +1072,18 @@ class EsphomeCore:
         # Each component's block is wrapped in IIFE lambdas so its stack
         # frame is released on return, bounding peak stack during setup().
         # Large blocks are sub-split to cap single heavy components (e.g.
-        # sensor platforms with many filter registrations). The marker
-        # comment brackets the IIFE on both sides so the generated
-        # main.cpp is easy to scan by component.
+        # sensor platforms with many filter registrations). "begin X" and
+        # "end X" marker comments bracket the IIFE so the generated
+        # main.cpp is easy to scan by component; a comment-only component
+        # gets a single "begin X" marker (no IIFE, no end marker).
         pieces = list(prefix)
-        for marker, body in components:
+        for name, body in components:
             wrapped = _wrap_in_iifes(body, max_statements=50)
-            pieces.append(marker)
+            has_iife = any("[]()" in line for line in wrapped)
+            pieces.append(f"// === begin {name} ===")
             pieces.extend(wrapped)
-            if any("[]()" in line for line in wrapped):
-                pieces.append(marker)
+            if has_iife:
+                pieces.append(f"// === end {name} ===")
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -531,6 +531,39 @@ class Library:
         return self
 
 
+def _wrap_in_noinline_iifes(lines: list[str], max_statements: int) -> list[str]:
+    """Wrap ``lines`` in one or more ``[]() [[gnu::noinline]] { ... }();`` IIFEs.
+
+    Splits into IIFEs of up to ``max_statements`` entries each. Never splits
+    inside a brace-balanced block (e.g. the ``{`` / ``}`` pair that
+    ``cg.with_local_variable()`` emits around a scoped local), so an IIFE
+    may exceed ``max_statements`` when a block straddles the boundary.
+    """
+    out: list[str] = []
+    chunk: list[str] = []
+    depth = 0
+
+    def flush() -> None:
+        if not chunk:
+            return
+        out.append("[]() [[gnu::noinline]] {")
+        out.extend(chunk)
+        out.append("}();")
+        chunk.clear()
+
+    for line in lines:
+        chunk.append(line)
+        stripped = line.strip()
+        if stripped == "{":
+            depth += 1
+        elif stripped == "}":
+            depth -= 1
+        if depth == 0 and len(chunk) >= max_statements:
+            flush()
+    flush()
+    return out
+
+
 # pylint: disable=too-many-public-methods
 class EsphomeCore:
     def __init__(self):
@@ -1003,14 +1036,32 @@ class EsphomeCore:
 
     @property
     def cpp_main_section(self):
-        from esphome.cpp_generator import statement
+        from esphome.cpp_generator import ComponentMarker, statement
 
-        main_code = []
+        # Split main_statements at ComponentMarker sentinels into a prefix
+        # (statements emitted before any component) plus per-component groups.
+        prefix: list[str] = []
+        components: list[list[str]] = []
+        current = prefix
         for exp in self.main_statements:
-            text = str(statement(exp))
-            text = text.rstrip()
-            main_code.append(text)
-        return "\n".join(main_code) + "\n\n"
+            if isinstance(exp, ComponentMarker):
+                current = [str(exp).rstrip()]
+                components.append(current)
+                continue
+            current.append(str(statement(exp)).rstrip())
+
+        # No components → flat output (host build, tests).
+        if not components:
+            return "\n".join(prefix) + "\n\n"
+
+        # Each component's block is wrapped in a noinline IIFE lambda so its
+        # stack frame is released on return, bounding peak stack during
+        # setup(). Large blocks are sub-split to cap single heavy components
+        # (e.g. sensor platforms with many filter registrations).
+        pieces = list(prefix)
+        for block in components:
+            pieces.extend(_wrap_in_noinline_iifes(block, max_statements=50))
+        return "\n".join(pieces) + "\n\n"
 
     @property
     def cpp_global_section(self):

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -532,21 +532,13 @@ class Library:
 
 
 def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
-    """Wrap ``lines`` in one or more ``[]() {...}();`` IIFEs.
+    """Wrap ``lines`` in ``[]() {...}();`` IIFEs of up to ``max_statements``
+    each. Never splits inside a brace-balanced block (e.g. the ``{`` / ``}``
+    pair from ``cg.with_local_variable()``), so an IIFE may exceed the cap
+    when a block straddles it. Comment-only chunks pass through verbatim.
 
-    Splits into IIFEs of up to ``max_statements`` entries each. Never splits
-    inside a brace-balanced block (e.g. the ``{`` / ``}`` pair that
-    ``cg.with_local_variable()`` emits around a scoped local), so an IIFE
-    may exceed ``max_statements`` when a block straddles the boundary.
-    A comment-only chunk is emitted verbatim with no IIFE, since wrapping
-    pure comments in a no-op lambda is clutter.
-
-    The IIFEs intentionally have no ``noinline`` attribute: GCC's ``-Os``
-    inliner makes good decisions about which chunks to keep as functions
-    and which to re-inline, and forcing all chunks to stay as functions
-    costs flash without measurably improving peak stack on configs where
-    the scope structure is itself sufficient to bound live-range lifetimes.
-    """
+    No ``noinline`` attribute — GCC's inliner re-folds small chunks freely,
+    keeping flash small without regressing peak stack."""
     out: list[str] = []
     chunk: list[str] = []
     depth = 0
@@ -564,23 +556,10 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
 
     for line in lines:
         chunk.append(line)
-        # Track brace depth by counting ``{`` and ``}`` characters per line
-        # rather than matching whole-line tokens. The current codegen only
-        # emits scope braces via ``cg.with_local_variable()`` (standalone
-        # ``{`` / ``}`` lines), but counting is robust against future
-        # codegen emitting inline control flow like ``if (cond) {`` or
-        # ``} else {``. Multi-line statements (e.g. inline lambdas) carry
-        # balanced braces within one list entry and contribute no net
-        # depth. Braces inside string literals would throw the count off;
-        # esphome's generated main.cpp does not currently emit such
-        # strings in main_statements.
-        #
-        # If depth ever goes negative (unmatched ``}`` before ``{``), we
-        # never return to depth 0 for the remainder of the input, so no
-        # further flushes fire and the rest of the chunk falls through
-        # into a single IIFE at the final ``flush()``. This is the
-        # intended safe-harbor behavior — negative depth signals a
-        # violated assumption about the input, not a normal branch.
+        # Count { and } per line so inline control flow (e.g. `if (cond) {`)
+        # and balanced inline lambdas are tracked correctly. If depth ever
+        # goes negative (unbalanced input) we never return to 0 and the
+        # rest falls through into a single final IIFE — safe fallback.
         depth += line.count("{") - line.count("}")
         if depth == 0 and len(chunk) >= max_statements:
             flush()
@@ -1062,15 +1041,10 @@ class EsphomeCore:
     def cpp_main_section(self):
         from esphome.cpp_generator import ComponentMarker, statement
 
-        # Split main_statements at ComponentMarker sentinels into a prefix
-        # (statements emitted before any component) plus per-component
-        # groups. Each group is wrapped in an IIFE lambda so GCC can
-        # shorten temporary lifetimes and bound peak setup-time stack;
-        # large groups are sub-split to cap single heavy components
-        # (e.g. sensor platforms with many filter registrations). The
-        # IIFEs have no noinline attribute, so the compiler is free to
-        # inline the block when that produces smaller code without
-        # regressing peak stack.
+        # Split main_statements at ComponentMarker sentinels and wrap each
+        # component's group in an IIFE, sub-splitting at 50 statements so
+        # a single heavy component (e.g. a sensor platform with many
+        # filter registrations) can't blow the peak chunk frame.
         prefix: list[str] = []
         components: list[list[str]] = []
         current = prefix

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -538,6 +538,8 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
     inside a brace-balanced block (e.g. the ``{`` / ``}`` pair that
     ``cg.with_local_variable()`` emits around a scoped local), so an IIFE
     may exceed ``max_statements`` when a block straddles the boundary.
+    A comment-only chunk is emitted verbatim with no IIFE, since wrapping
+    pure comments in a no-op lambda is clutter.
 
     The IIFEs intentionally have no ``noinline`` attribute: GCC's ``-Os``
     inliner makes good decisions about which chunks to keep as functions
@@ -552,9 +554,6 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
     def flush() -> None:
         if not chunk:
             return
-        # If the chunk is comments-only (e.g. a component that emits a
-        # header marker and config dump but no C++ statements), emit them
-        # verbatim without wrapping — an empty IIFE is pure clutter.
         if all(line.lstrip().startswith("//") for line in chunk):
             out.extend(chunk)
         else:
@@ -566,16 +565,22 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
     for line in lines:
         chunk.append(line)
         # Track brace depth by counting ``{`` and ``}`` characters per line
-        # rather than matching whole-line tokens. Today the only codegen
-        # that emits scope braces as separate statements is
-        # ``cg.with_local_variable()`` (standalone ``{`` / ``}`` lines),
-        # but counting is robust against future codegen that emits inline
-        # control-flow like ``if (cond) {`` or ``} else {`` on a single
-        # line. Multi-line statements (inline lambdas) carry balanced
-        # braces within one list entry so they contribute no net depth.
-        # Braces inside string literals would throw the count off, but
-        # esphome's generated main.cpp does not currently emit strings
-        # that contain unbalanced braces in main_statements.
+        # rather than matching whole-line tokens. The current codegen only
+        # emits scope braces via ``cg.with_local_variable()`` (standalone
+        # ``{`` / ``}`` lines), but counting is robust against future
+        # codegen emitting inline control flow like ``if (cond) {`` or
+        # ``} else {``. Multi-line statements (e.g. inline lambdas) carry
+        # balanced braces within one list entry and contribute no net
+        # depth. Braces inside string literals would throw the count off;
+        # esphome's generated main.cpp does not currently emit such
+        # strings in main_statements.
+        #
+        # If depth ever goes negative (unmatched ``}`` before ``{``), we
+        # never return to depth 0 for the remainder of the input, so no
+        # further flushes fire and the rest of the chunk falls through
+        # into a single IIFE at the final ``flush()``. This is the
+        # intended safe-harbor behavior — negative depth signals a
+        # violated assumption about the input, not a normal branch.
         depth += line.count("{") - line.count("}")
         if depth == 0 and len(chunk) >= max_statements:
             flush()
@@ -1058,43 +1063,30 @@ class EsphomeCore:
         from esphome.cpp_generator import ComponentMarker, statement
 
         # Split main_statements at ComponentMarker sentinels into a prefix
-        # (statements emitted before any component) plus per-component groups.
-        # Each group carries its component name so cpp_main_section can emit
-        # begin/end marker comments bracketing the IIFE.
+        # (statements emitted before any component) plus per-component
+        # groups. Each group is wrapped in an IIFE lambda so GCC can
+        # shorten temporary lifetimes and bound peak setup-time stack;
+        # large groups are sub-split to cap single heavy components
+        # (e.g. sensor platforms with many filter registrations). The
+        # IIFEs have no noinline attribute, so the compiler is free to
+        # inline the block when that produces smaller code without
+        # regressing peak stack.
         prefix: list[str] = []
-        components: list[tuple[str, list[str]]] = []
+        components: list[list[str]] = []
         current = prefix
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
-                body: list[str] = []
-                components.append((exp.name, body))
-                current = body
+                current = []
+                components.append(current)
                 continue
             current.append(str(statement(exp)).rstrip())
 
-        # No components → flat output (host build, tests).
         if not components:
             return "\n".join(prefix) + "\n\n"
 
-        # Each component's block is wrapped in an IIFE lambda that
-        # introduces a nested scope, shortening the lifetimes of
-        # temporaries so GCC can bound peak setup-time stack usage.
-        # The IIFE has no noinline attribute, so the compiler is free
-        # to inline the block when that produces smaller code without
-        # regressing peak stack. Large blocks are sub-split to cap
-        # single heavy components (e.g. sensor platforms with many
-        # filter registrations). "begin X" and "end X" marker comments
-        # bracket the IIFE so the generated main.cpp is easy to scan by
-        # component; a comment-only component gets a single "begin X"
-        # marker (no IIFE, no end marker).
         pieces = list(prefix)
-        for name, body in components:
-            wrapped = _wrap_in_iifes(body, max_statements=50)
-            has_iife = any("[]()" in line for line in wrapped)
-            pieces.append(f"// === begin {name} ===")
-            pieces.extend(wrapped)
-            if has_iife:
-                pieces.append(f"// === end {name} ===")
+        for body in components:
+            pieces.extend(_wrap_in_iifes(body, max_statements=50))
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -541,7 +541,7 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
     keeping flash small without regressing peak stack."""
     out: list[str] = []
     chunk: list[str] = []
-    depth = 0
+    depth: int = 0
 
     def flush() -> None:
         if not chunk:
@@ -1038,29 +1038,43 @@ class EsphomeCore:
         self.data[KEY_CONTROLLER_REGISTRY_COUNT] = controller_count + 1
 
     @property
-    def cpp_main_section(self):
-        from esphome.cpp_generator import ComponentMarker, statement
+    def cpp_main_section(self) -> str:
+        from esphome.cpp_generator import (
+            ComponentMarker,
+            IIFEUnsafeStatement,
+            statement,
+        )
 
         # Split main_statements at ComponentMarker sentinels and wrap each
         # component's group in an IIFE, sub-splitting at 50 statements so
         # a single heavy component (e.g. a sensor platform with many
         # filter registrations) can't blow the peak chunk frame.
+        # Components that contain an IIFEUnsafeStatement (e.g. safe_mode's
+        # setup-scope `return`) are emitted flat so the statement affects
+        # setup()'s control flow, not the lambda's.
         prefix: list[str] = []
-        components: list[list[str]] = []
-        current = prefix
+        components: list[tuple[list[str], list[bool]]] = []
+        current: list[str] = prefix
+        unsafe_flag: list[bool] = [False]  # unused for prefix
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
                 current = []
-                components.append(current)
+                unsafe_flag = [False]
+                components.append((current, unsafe_flag))
                 continue
+            if isinstance(exp, IIFEUnsafeStatement):
+                unsafe_flag[0] = True
             current.append(str(statement(exp)).rstrip())
 
         if not components:
             return "\n".join(prefix) + "\n\n"
 
-        pieces = list(prefix)
-        for body in components:
-            pieces.extend(_wrap_in_iifes(body, max_statements=50))
+        pieces: list[str] = list(prefix)
+        for body, group_unsafe in components:
+            if group_unsafe[0]:
+                pieces.extend(body)
+            else:
+                pieces.extend(_wrap_in_iifes(body, max_statements=50))
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -531,18 +531,19 @@ class Library:
         return self
 
 
-def _wrap_in_noinline_iifes(lines: list[str], max_statements: int) -> list[str]:
-    """Wrap ``lines`` in one or more ``[]() __attribute__((noinline)) {...}();`` IIFEs.
+def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
+    """Wrap ``lines`` in one or more ``[]() {...}();`` IIFEs.
 
     Splits into IIFEs of up to ``max_statements`` entries each. Never splits
     inside a brace-balanced block (e.g. the ``{`` / ``}`` pair that
     ``cg.with_local_variable()`` emits around a scoped local), so an IIFE
     may exceed ``max_statements`` when a block straddles the boundary.
 
-    GCC note: ``__attribute__((noinline))`` between the lambda parameter
-    list and body binds to ``operator()``. The C++ standard-attribute
-    spelling ``[[gnu::noinline]]`` in that position binds to the return
-    type instead and produces ``-Wattributes`` warnings.
+    The IIFEs intentionally have no ``noinline`` attribute: GCC's ``-Os``
+    inliner makes good decisions about which chunks to keep as functions
+    and which to re-inline, and forcing all chunks to stay as functions
+    costs flash without measurably improving peak stack on configs where
+    the scope structure is itself sufficient to bound live-range lifetimes.
     """
     out: list[str] = []
     chunk: list[str] = []
@@ -551,7 +552,7 @@ def _wrap_in_noinline_iifes(lines: list[str], max_statements: int) -> list[str]:
     def flush() -> None:
         if not chunk:
             return
-        out.append("[]() __attribute__((noinline)) {")
+        out.append("[]() {")
         out.extend(chunk)
         out.append("}();")
         chunk.clear()
@@ -1065,7 +1066,7 @@ class EsphomeCore:
         # (e.g. sensor platforms with many filter registrations).
         pieces = list(prefix)
         for block in components:
-            pieces.extend(_wrap_in_noinline_iifes(block, max_statements=50))
+            pieces.extend(_wrap_in_iifes(block, max_statements=50))
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -544,7 +544,14 @@ def _emits_bare_local(exp: "Statement") -> bool:
     declare a function-local whose lifetime extends past the current
     statement. Components that emit any such statement must not be
     sub-split — later references within the same ``to_code`` would land
-    in a different IIFE and fail to compile."""
+    in a different IIFE and fail to compile.
+
+    The detection is intentionally safety-biased: false negatives cause
+    silent broken C++, false positives just keep a component in one
+    slightly larger IIFE. Any ``cg.add(RawExpression(...))`` disables
+    sub-splitting for its group regardless of whether the raw text
+    actually references a local, because the chunker can't introspect
+    arbitrary raw text."""
     from esphome.cpp_generator import (
         AssignmentExpression,
         ExpressionStatement,
@@ -561,7 +568,11 @@ def _emits_bare_local(exp: "Statement") -> bool:
     # `time::ParsedTimezone tz{}` or `tz.field = ...`. CORE.add wraps
     # a passed Expression in an ExpressionStatement; when the inner is
     # a RawExpression the author is emitting uninterpreted text that
-    # may reference a local declared elsewhere in the same block.
+    # may reference a local declared elsewhere in the same block. A
+    # RawExpression passed as a CallExpression argument does NOT land
+    # here (its ExpressionStatement's .expression is the CallExpression),
+    # so value-pass patterns like `var.set_program(RawExpression("&foo"))`
+    # continue to sub-split normally.
     if isinstance(exp, ExpressionStatement) and isinstance(
         exp.expression, RawExpression
     ):
@@ -1113,6 +1124,12 @@ class EsphomeCore:
         #   sub-split so the declaration and any later references stay
         #   together.
         prefix: list[str] = []
+        # Flags are stored as 1-element lists so they can be mutated by
+        # reference after the tuple has been pushed into ``components``
+        # (assignment to a local ``unsafe_flag`` inside the loop would
+        # rebind the local without updating the stored tuple entry).
+        # A small dataclass would read cleaner but the pattern is
+        # localized to this one property.
         components: list[tuple[list[str], list[bool], list[bool]]] = []
         current: list[str] = prefix
         unsafe_flag: list[bool] = [False]  # unused for prefix

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -552,9 +552,15 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
     def flush() -> None:
         if not chunk:
             return
-        out.append("[]() {")
-        out.extend(chunk)
-        out.append("}();")
+        # If the chunk is comments-only (e.g. a component that emits a
+        # header marker and config dump but no C++ statements), emit them
+        # verbatim without wrapping — an empty IIFE is pure clutter.
+        if all(line.lstrip().startswith("//") for line in chunk):
+            out.extend(chunk)
+        else:
+            out.append("[]() {")
+            out.extend(chunk)
+            out.append("}();")
         chunk.clear()
 
     for line in lines:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -531,11 +531,47 @@ class Library:
         return self
 
 
-def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
+def _emits_bare_local(exp: "Statement") -> bool:
+    """True if ``exp`` emits a scope brace or bare-raw construct that may
+    declare a function-local whose lifetime extends past the current
+    statement. Components that emit any such statement must not be
+    sub-split — later references within the same ``to_code`` would land
+    in a different IIFE and fail to compile."""
+    from esphome.cpp_generator import (
+        AssignmentExpression,
+        ExpressionStatement,
+        RawExpression,
+        RawStatement,
+    )
+
+    # Scope braces from cg.with_local_variable() or inline scope blocks
+    # (e.g. time's tz pattern). Content-aware so RawStatements emitted
+    # for "call();  // comment" (entity_helpers) don't false-positive.
+    if isinstance(exp, RawStatement) and str(exp).strip() in ("{", "}"):
+        return True
+    # cg.add(RawExpression(...)) — bare raw text, e.g.
+    # `time::ParsedTimezone tz{}` or `tz.field = ...`. CORE.add wraps
+    # a passed Expression in an ExpressionStatement; when the inner is
+    # a RawExpression the author is emitting uninterpreted text that
+    # may reference a local declared elsewhere in the same block.
+    if isinstance(exp, ExpressionStatement) and isinstance(
+        exp.expression, RawExpression
+    ):
+        return True
+    # cg.variable(id, rhs) — emits ``Type id = rhs;`` as a function-local.
+    return (
+        isinstance(exp, ExpressionStatement)
+        and isinstance(exp.expression, AssignmentExpression)
+        and exp.expression.type is not None
+    )
+
+
+def _wrap_in_iifes(lines: list[str], max_statements: int | None) -> list[str]:
     """Wrap ``lines`` in ``[]() {...}();`` IIFEs of up to ``max_statements``
-    each. Never splits inside a brace-balanced block (e.g. the ``{`` / ``}``
-    pair from ``cg.with_local_variable()``), so an IIFE may exceed the cap
-    when a block straddles it. Comment-only chunks pass through verbatim.
+    each, or in a single IIFE when ``max_statements`` is ``None``. Never
+    splits inside a brace-balanced block (e.g. the ``{`` / ``}`` pair from
+    ``cg.with_local_variable()``), so an IIFE may exceed the cap when a
+    block straddles it. Comment-only chunks pass through verbatim.
 
     No ``noinline`` attribute — GCC's inliner re-folds small chunks freely,
     keeping flash small without regressing peak stack."""
@@ -561,7 +597,7 @@ def _wrap_in_iifes(lines: list[str], max_statements: int) -> list[str]:
         # goes negative (unbalanced input) we never return to 0 and the
         # rest falls through into a single final IIFE — safe fallback.
         depth += line.count("{") - line.count("}")
-        if depth == 0 and len(chunk) >= max_statements:
+        if max_statements is not None and depth == 0 and len(chunk) >= max_statements:
             flush()
     flush()
     return out
@@ -1049,32 +1085,57 @@ class EsphomeCore:
         # component's group in an IIFE, sub-splitting at 50 statements so
         # a single heavy component (e.g. a sensor platform with many
         # filter registrations) can't blow the peak chunk frame.
-        # Components that contain an IIFEUnsafeStatement (e.g. safe_mode's
-        # setup-scope `return`) are emitted flat so the statement affects
-        # setup()'s control flow, not the lambda's.
+        #
+        # Two escape hatches control whether a component's group is safe
+        # to sub-split:
+        #
+        # - IIFEUnsafeStatement (e.g. safe_mode's setup-scope `return`):
+        #   the whole group must stay at setup() scope so the statement
+        #   affects setup()'s control flow, not the lambda's. Emit flat.
+        #
+        # - Any statement that may declare a function-local: a bare
+        #   ``{`` / ``}`` RawStatement (from ``cg.with_local_variable``,
+        #   time's inline tz block, etc.), a direct ``RawExpression``
+        #   passed to ``cg.add`` (raw bare-local or field-assignment
+        #   emission like ``time::ParsedTimezone tz`` followed by
+        #   ``tz.field = ...``), or a typed ``AssignmentExpression``
+        #   (``cg.variable`` emitting ``Type id = rhs;``). Each signals
+        #   "this group's body may contain bare names whose scope is the
+        #   enclosing IIFE"; wrap the whole group in one IIFE with no
+        #   sub-split so the declaration and any later references stay
+        #   together.
         prefix: list[str] = []
-        components: list[tuple[list[str], list[bool]]] = []
+        components: list[tuple[list[str], list[bool], list[bool]]] = []
         current: list[str] = prefix
         unsafe_flag: list[bool] = [False]  # unused for prefix
+        no_split_flag: list[bool] = [False]  # unused for prefix
         for exp in self.main_statements:
             if isinstance(exp, ComponentMarker):
                 current = []
                 unsafe_flag = [False]
-                components.append((current, unsafe_flag))
+                no_split_flag = [False]
+                components.append((current, unsafe_flag, no_split_flag))
                 continue
             if isinstance(exp, IIFEUnsafeStatement):
                 unsafe_flag[0] = True
+            if _emits_bare_local(exp):
+                no_split_flag[0] = True
             current.append(str(statement(exp)).rstrip())
 
         if not components:
             return "\n".join(prefix) + "\n\n"
 
         pieces: list[str] = list(prefix)
-        for body, group_unsafe in components:
+        for body, group_unsafe, group_no_split in components:
             if group_unsafe[0]:
                 pieces.extend(body)
             else:
-                pieces.extend(_wrap_in_iifes(body, max_statements=50))
+                # A group containing raw scope braces or bare-local
+                # declarations must stay in one IIFE so the declarations
+                # remain visible to subsequent uses. ``max_statements=None``
+                # disables sub-splitting for the group.
+                cap = None if group_no_split[0] else 50
+                pieces.extend(_wrap_in_iifes(body, max_statements=cap))
         return "\n".join(pieces) + "\n\n"
 
     @property

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -532,12 +532,17 @@ class Library:
 
 
 def _wrap_in_noinline_iifes(lines: list[str], max_statements: int) -> list[str]:
-    """Wrap ``lines`` in one or more ``[]() [[gnu::noinline]] { ... }();`` IIFEs.
+    """Wrap ``lines`` in one or more ``[]() __attribute__((noinline)) {...}();`` IIFEs.
 
     Splits into IIFEs of up to ``max_statements`` entries each. Never splits
     inside a brace-balanced block (e.g. the ``{`` / ``}`` pair that
     ``cg.with_local_variable()`` emits around a scoped local), so an IIFE
     may exceed ``max_statements`` when a block straddles the boundary.
+
+    GCC note: ``__attribute__((noinline))`` between the lambda parameter
+    list and body binds to ``operator()``. The C++ standard-attribute
+    spelling ``[[gnu::noinline]]`` in that position binds to the return
+    type instead and produces ``-Wattributes`` warnings.
     """
     out: list[str] = []
     chunk: list[str] = []
@@ -546,7 +551,7 @@ def _wrap_in_noinline_iifes(lines: list[str], max_statements: int) -> list[str]:
     def flush() -> None:
         if not chunk:
             return
-        out.append("[]() [[gnu::noinline]] {")
+        out.append("[]() __attribute__((noinline)) {")
         out.extend(chunk)
         out.append("}();")
         chunk.clear()

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -435,23 +435,14 @@ class LineComment(Statement):
 
 
 class ComponentMarker(Statement):
-    """Sentinel marker recorded in main_statements when a component's
-    ``to_code`` begins emitting code. ``cpp_main_section`` consumes
-    these as chunking boundaries: the statements between two markers
-    form a group that gets wrapped in an IIFE so GCC can shorten
-    temporary lifetimes and bound peak setup-time stack usage.
+    """Chunking-boundary sentinel. ``cpp_main_section`` wraps the
+    statements between two markers in an IIFE to shorten temporary
+    lifetimes and bound peak setup-time stack. Emits no C++ output.
 
-    The marker produces no C++ output of its own; its ``__str__`` is
-    only used for debugging (e.g. ``repr`` of ``main_statements``).
-    The component name is retained so tooling can inspect grouping if
-    needed, but the generated ``main.cpp`` carries no per-component
-    labels — partitioning is best-effort anyway because
-    ``CORE.flush_tasks`` can interleave coroutines on each ``await``
-    (e.g. ``cg.get_variable``) and re-schedule by priority, which
-    means a component's later statements can land between a different
-    component's earlier statements. This is semantically safe because
-    every statement either uses placement new into static storage or
-    mutates a global already declared at file scope."""
+    Grouping is best-effort: ``flush_tasks`` can interleave coroutines
+    on ``await``, so a component's later statements may land in another
+    component's chunk. Safe because every statement either placement-
+    news into static storage or mutates a file-scope global."""
 
     __slots__ = ("name",)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -477,7 +477,13 @@ def progmem_array(id_, rhs) -> "MockObj":
     rhs = safe_exp(rhs)
     obj = MockObj(id_, ".")
     assignment = ProgmemAssignmentExpression(id_.type, id_, rhs)
-    CORE.add(assignment)
+    # Emit at file scope, not inside setup(). setup() is split into
+    # per-component IIFE lambdas; a function-local static declared in one
+    # lambda is not visible to statements in sibling lambdas that
+    # reference the same shared table (e.g. two lights sharing a gamma
+    # lookup). File-scope static constexpr is semantically identical for
+    # read-only lookup tables.
+    CORE.add_global(assignment)
     CORE.register_variable(id_, obj)
     return obj
 
@@ -486,7 +492,7 @@ def static_const_array(id_, rhs) -> "MockObj":
     rhs = safe_exp(rhs)
     obj = MockObj(id_, ".")
     assignment = StaticConstAssignmentExpression(id_.type, id_, rhs)
-    CORE.add(assignment)
+    CORE.add_global(assignment)
     CORE.register_variable(id_, obj)
     return obj
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -436,9 +436,8 @@ class LineComment(Statement):
 
 class ComponentMarker(Statement):
     """Sentinel marker recorded in main_statements when a component's
-    to_code begins emitting code. Used by cpp_main_section to split
-    setup() output into per-component chunks, so each component's
-    stack frame is released on return."""
+    to_code begins emitting code. ``cpp_main_section`` consumes these
+    to bracket each component's IIFE with begin/end comment markers."""
 
     __slots__ = ("name",)
 
@@ -446,7 +445,7 @@ class ComponentMarker(Statement):
         self.name = name
 
     def __str__(self):
-        return f"// === {self.name} ==="
+        return f"// === begin {self.name} ==="
 
 
 class ProgmemAssignmentExpression(AssignmentExpression):

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -460,8 +460,12 @@ class ComponentMarker(Statement):
 
     Grouping is best-effort: ``flush_tasks`` can interleave coroutines
     on ``await``, so a component's later statements may land in another
-    component's chunk. Safe because every statement either placement-
-    news into static storage or mutates a file-scope global."""
+    component's chunk. This is safe for the dominant codegen patterns
+    (placement-new into static storage, assignment to a file-scope
+    global); patterns that depend on function-local state within the
+    IIFE scope (cg.variable, with_local_variable, raw bare locals)
+    are kept together by the bare-local detection in cpp_main_section
+    so they aren't split across sibling lambdas."""
 
     __slots__ = ("name",)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -436,13 +436,22 @@ class LineComment(Statement):
 
 class ComponentMarker(Statement):
     """Sentinel marker recorded in main_statements when a component's
-    to_code begins emitting code. ``cpp_main_section`` consumes these
-    to bracket each component's generated block with begin/end comment
-    markers and to wrap it in an IIFE scope. The IIFE introduces a
-    nested scope so GCC can shorten temporary lifetimes and help reduce
-    peak setup-time stack usage; the lambda has no ``noinline``
-    attribute, so the compiler may still inline the block when that
-    produces smaller code without regressing peak stack."""
+    ``to_code`` begins emitting code. ``cpp_main_section`` consumes
+    these as chunking boundaries: the statements between two markers
+    form a group that gets wrapped in an IIFE so GCC can shorten
+    temporary lifetimes and bound peak setup-time stack usage.
+
+    The marker produces no C++ output of its own; its ``__str__`` is
+    only used for debugging (e.g. ``repr`` of ``main_statements``).
+    The component name is retained so tooling can inspect grouping if
+    needed, but the generated ``main.cpp`` carries no per-component
+    labels — partitioning is best-effort anyway because
+    ``CORE.flush_tasks`` can interleave coroutines on each ``await``
+    (e.g. ``cg.get_variable``) and re-schedule by priority, which
+    means a component's later statements can land between a different
+    component's earlier statements. This is semantically safe because
+    every statement placement-news into static storage or mutates a
+    global already declared at file scope."""
 
     __slots__ = ("name",)
 
@@ -450,7 +459,7 @@ class ComponentMarker(Statement):
         self.name = name
 
     def __str__(self):
-        return f"// === begin {self.name} ==="
+        return f"// component-marker: {self.name}"
 
 
 class ProgmemAssignmentExpression(AssignmentExpression):

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -534,9 +534,14 @@ def literal(name: str) -> "MockObj":
 
 
 def variable(
-    id_: ID, rhs: SafeExpType, type_: "MockObj" = None, register=True
+    id_: ID, rhs: SafeExpType, type_: "MockObj" = None, register: bool = True
 ) -> "MockObj":
     """Declare a new variable, not pointer type, in the code generation.
+
+    Emits a function-local declaration ``Type id = rhs;`` inside setup().
+    ``cpp_main_section`` detects typed ``AssignmentExpression`` and
+    disables sub-chunking for the component's group, so later references
+    to the local within the same ``to_code`` stay visible.
 
     :param id_: The ID used to declare the variable.
     :param rhs: The expression to place on the right hand side of the assignment.

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -450,8 +450,8 @@ class ComponentMarker(Statement):
     (e.g. ``cg.get_variable``) and re-schedule by priority, which
     means a component's later statements can land between a different
     component's earlier statements. This is semantically safe because
-    every statement placement-news into static storage or mutates a
-    global already declared at file scope."""
+    every statement either uses placement new into static storage or
+    mutates a global already declared at file scope."""
 
     __slots__ = ("name",)
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -434,6 +434,25 @@ class LineComment(Statement):
         return "\n".join(parts)
 
 
+class IIFEUnsafeStatement(Statement):
+    """Statement that must not be placed inside an IIFE lambda when
+    ``cpp_main_section`` chunks ``setup()``. Causes the containing
+    component's block to be emitted flat (no IIFE), so constructs that
+    rely on exiting ``setup()`` directly — e.g. safe_mode's
+    ``if (should_enter_safe_mode(...)) return;`` — still work.
+
+    Accepts either a ``Statement`` or a bare ``Expression``; bare
+    expressions are wrapped so they terminate with a semicolon."""
+
+    __slots__ = ("inner",)
+
+    def __init__(self, inner: Expression | Statement) -> None:
+        self.inner = inner
+
+    def __str__(self) -> str:
+        return str(statement(self.inner))
+
+
 class ComponentMarker(Statement):
     """Chunking-boundary sentinel. ``cpp_main_section`` wraps the
     statements between two markers in an IIFE to shorten temporary
@@ -446,10 +465,10 @@ class ComponentMarker(Statement):
 
     __slots__ = ("name",)
 
-    def __init__(self, name: str):
+    def __init__(self, name: str) -> None:
         self.name = name
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"// component-marker: {self.name}"
 
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -434,6 +434,21 @@ class LineComment(Statement):
         return "\n".join(parts)
 
 
+class ComponentMarker(Statement):
+    """Sentinel marker recorded in main_statements when a component's
+    to_code begins emitting code. Used by cpp_main_section to split
+    setup() output into per-component chunks, so each component's
+    stack frame is released on return."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self):
+        return f"// === {self.name} ==="
+
+
 class ProgmemAssignmentExpression(AssignmentExpression):
     __slots__ = ()
 

--- a/esphome/cpp_generator.py
+++ b/esphome/cpp_generator.py
@@ -437,7 +437,12 @@ class LineComment(Statement):
 class ComponentMarker(Statement):
     """Sentinel marker recorded in main_statements when a component's
     to_code begins emitting code. ``cpp_main_section`` consumes these
-    to bracket each component's IIFE with begin/end comment markers."""
+    to bracket each component's generated block with begin/end comment
+    markers and to wrap it in an IIFE scope. The IIFE introduces a
+    nested scope so GCC can shorten temporary lifetimes and help reduce
+    peak setup-time stack usage; the lambda has no ``noinline``
+    attribute, so the compiler may still inline the block when that
+    produces smaller code without regressing peak stack."""
 
     __slots__ = ("name",)
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -877,7 +877,7 @@ def test_wrap_in_noinline_iifes_empty_input() -> None:
 def test_wrap_in_noinline_iifes_fewer_lines_than_limit() -> None:
     lines = ["a();", "b();", "c();"]
     assert core._wrap_in_noinline_iifes(lines, max_statements=10) == [
-        "[]() [[gnu::noinline]] {",
+        "[]() __attribute__((noinline)) {",
         "a();",
         "b();",
         "c();",
@@ -896,13 +896,13 @@ def test_wrap_in_noinline_iifes_never_splits_inside_braces() -> None:
     # max=2 would naively split after "{" but brace guard keeps block whole.
     lines = ["a();", "{", "inner();", "}", "b();"]
     assert core._wrap_in_noinline_iifes(lines, max_statements=2) == [
-        "[]() [[gnu::noinline]] {",
+        "[]() __attribute__((noinline)) {",
         "a();",
         "{",
         "inner();",
         "}",
         "}();",
-        "[]() [[gnu::noinline]] {",
+        "[]() __attribute__((noinline)) {",
         "b();",
         "}();",
     ]
@@ -911,14 +911,14 @@ def test_wrap_in_noinline_iifes_never_splits_inside_braces() -> None:
 def test_wrap_in_noinline_iifes_nested_braces() -> None:
     lines = ["{", "{", "deep();", "}", "}", "after();"]
     assert core._wrap_in_noinline_iifes(lines, max_statements=1) == [
-        "[]() [[gnu::noinline]] {",
+        "[]() __attribute__((noinline)) {",
         "{",
         "{",
         "deep();",
         "}",
         "}",
         "}();",
-        "[]() [[gnu::noinline]] {",
+        "[]() __attribute__((noinline)) {",
         "after();",
         "}();",
     ]
@@ -929,7 +929,7 @@ def test_wrap_in_noinline_iifes_unbalanced_braces_fall_through() -> None:
     # a single IIFE with all lines rather than splitting mid-flight.
     lines = ["a();", "}", "b();"]
     result = core._wrap_in_noinline_iifes(lines, max_statements=1)
-    assert result[0] == "[]() [[gnu::noinline]] {"
+    assert result[0] == "[]() __attribute__((noinline)) {"
     assert result[-1] == "}();"
     assert [line for line in result if line in lines] == lines
 
@@ -952,7 +952,7 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
         RawStatement("new_wifi();"),
     ]
     out = target.cpp_main_section
-    assert out.count("[]() [[gnu::noinline]] {") == 2
+    assert out.count("[]() __attribute__((noinline)) {") == 2
     assert out.count("}();") == 2
     assert "// === logger ===" in out
     assert "// === wifi ===" in out
@@ -966,4 +966,4 @@ def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:
         RawStatement("body();"),
     ]
     out = target.cpp_main_section
-    assert out.index("prefix();") < out.index("[]() [[gnu::noinline]] {")
+    assert out.index("prefix();") < out.index("[]() __attribute__((noinline)) {")

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -870,14 +870,14 @@ class TestEsphomeCore:
         assert "Wire" in target.platformio_libraries
 
 
-def test_wrap_in_noinline_iifes_empty_input() -> None:
-    assert not core._wrap_in_noinline_iifes([], max_statements=10)
+def test_wrap_in_iifes_empty_input() -> None:
+    assert not core._wrap_in_iifes([], max_statements=10)
 
 
-def test_wrap_in_noinline_iifes_fewer_lines_than_limit() -> None:
+def test_wrap_in_iifes_fewer_lines_than_limit() -> None:
     lines = ["a();", "b();", "c();"]
-    assert core._wrap_in_noinline_iifes(lines, max_statements=10) == [
-        "[]() __attribute__((noinline)) {",
+    assert core._wrap_in_iifes(lines, max_statements=10) == [
+        "[]() {",
         "a();",
         "b();",
         "c();",
@@ -885,51 +885,51 @@ def test_wrap_in_noinline_iifes_fewer_lines_than_limit() -> None:
     ]
 
 
-def test_wrap_in_noinline_iifes_splits_at_max_statements() -> None:
+def test_wrap_in_iifes_splits_at_max_statements() -> None:
     lines = [f"s{i}();" for i in range(5)]
-    result = core._wrap_in_noinline_iifes(lines, max_statements=2)
+    result = core._wrap_in_iifes(lines, max_statements=2)
     # With max=2 and 5 lines: chunks of 2, 2, 1 → 3 IIFEs.
     assert sum(1 for line in result if line.startswith("[]()")) == 3
 
 
-def test_wrap_in_noinline_iifes_never_splits_inside_braces() -> None:
+def test_wrap_in_iifes_never_splits_inside_braces() -> None:
     # max=2 would naively split after "{" but brace guard keeps block whole.
     lines = ["a();", "{", "inner();", "}", "b();"]
-    assert core._wrap_in_noinline_iifes(lines, max_statements=2) == [
-        "[]() __attribute__((noinline)) {",
+    assert core._wrap_in_iifes(lines, max_statements=2) == [
+        "[]() {",
         "a();",
         "{",
         "inner();",
         "}",
         "}();",
-        "[]() __attribute__((noinline)) {",
+        "[]() {",
         "b();",
         "}();",
     ]
 
 
-def test_wrap_in_noinline_iifes_nested_braces() -> None:
+def test_wrap_in_iifes_nested_braces() -> None:
     lines = ["{", "{", "deep();", "}", "}", "after();"]
-    assert core._wrap_in_noinline_iifes(lines, max_statements=1) == [
-        "[]() __attribute__((noinline)) {",
+    assert core._wrap_in_iifes(lines, max_statements=1) == [
+        "[]() {",
         "{",
         "{",
         "deep();",
         "}",
         "}",
         "}();",
-        "[]() __attribute__((noinline)) {",
+        "[]() {",
         "after();",
         "}();",
     ]
 
 
-def test_wrap_in_noinline_iifes_unbalanced_braces_fall_through() -> None:
+def test_wrap_in_iifes_unbalanced_braces_fall_through() -> None:
     # Pathological input where "}" appears before "{": don't crash; emit
     # a single IIFE with all lines rather than splitting mid-flight.
     lines = ["a();", "}", "b();"]
-    result = core._wrap_in_noinline_iifes(lines, max_statements=1)
-    assert result[0] == "[]() __attribute__((noinline)) {"
+    result = core._wrap_in_iifes(lines, max_statements=1)
+    assert result[0] == "[]() {"
     assert result[-1] == "}();"
     assert [line for line in result if line in lines] == lines
 
@@ -952,7 +952,7 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
         RawStatement("new_wifi();"),
     ]
     out = target.cpp_main_section
-    assert out.count("[]() __attribute__((noinline)) {") == 2
+    assert out.count("[]() {") == 2
     assert out.count("}();") == 2
     assert "// === logger ===" in out
     assert "// === wifi ===" in out
@@ -966,4 +966,4 @@ def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:
         RawStatement("body();"),
     ]
     out = target.cpp_main_section
-    assert out.index("prefix();") < out.index("[]() __attribute__((noinline)) {")
+    assert out.index("prefix();") < out.index("[]() {")

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1020,13 +1020,19 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
     assert "component-marker" not in out
 
 
+_CHUNK_COUNT = 3  # number of sub-chunks to force when testing splitting
+# Statement count that produces exactly _CHUNK_COUNT IIFEs when sub-split
+# at IIFE_MAX_STATEMENTS (full chunks at the cap, no partial).
+_STATEMENTS_OVER_CAP = core.IIFE_MAX_STATEMENTS * _CHUNK_COUNT
+
+
 def test_cpp_main_section_scope_brace_raw_disables_sub_split() -> None:
     # A group containing scope-brace RawStatements (e.g. `{` / `}` from
     # with_local_variable) must stay in one IIFE regardless of size so
     # the scope bounds and any locals between them stay together.
     target = core.EsphomeCore()
     stmts: list = [ComponentMarker("wifi"), RawStatement("{")]
-    stmts.extend(RawStatement(f"s{i}();") for i in range(100))
+    stmts.extend(RawStatement(f"s{i}();") for i in range(_STATEMENTS_OVER_CAP))
     stmts.append(RawStatement("}"))
     target.main_statements = stmts
     out = target.cpp_main_section
@@ -1040,11 +1046,12 @@ def test_cpp_main_section_inline_comment_raw_still_sub_splits() -> None:
     # content-aware check only triggers on bare `{` / `}`.
     target = core.EsphomeCore()
     stmts: list = [ComponentMarker("sensor")]
-    stmts.extend(RawStatement(f"s{i}();  // flags") for i in range(120))
+    stmts.extend(
+        RawStatement(f"s{i}();  // flags") for i in range(_STATEMENTS_OVER_CAP)
+    )
     target.main_statements = stmts
     out = target.cpp_main_section
-    # 120 statements / 50-cap = 3 sub-chunks expected.
-    assert out.count("[]() {") == 3
+    assert out.count("[]() {") == _CHUNK_COUNT
 
 
 def test_cpp_main_section_raw_expression_disables_sub_split() -> None:
@@ -1057,7 +1064,8 @@ def test_cpp_main_section_raw_expression_disables_sub_split() -> None:
         ExpressionStatement(RawExpression("time::ParsedTimezone tz{}")),
     ]
     stmts.extend(
-        ExpressionStatement(RawExpression(f"tz.field_{i} = {i}")) for i in range(100)
+        ExpressionStatement(RawExpression(f"tz.field_{i} = {i}"))
+        for i in range(_STATEMENTS_OVER_CAP)
     )
     target.main_statements = stmts
     out = target.cpp_main_section
@@ -1069,21 +1077,18 @@ def test_cpp_main_section_raw_expression_as_call_arg_still_sub_splits() -> None:
     # `var.set_program(RawExpression("&foo"))`) produces
     # `ExpressionStatement(CallExpression(..., RawExpression))` — the
     # outer expression is a CallExpression, not a RawExpression, so
-    # the group is still sub-splittable. Exercise this with actual
-    # CallExpression-wrapping-RawExpression statements filling the
-    # group past the 50-statement cap.
+    # the group is still sub-splittable.
     target = core.EsphomeCore()
     stmts: list = [ComponentMarker("rp2040_pio_led_strip")]
     stmts.extend(
         ExpressionStatement(
             CallExpression(MockObj(f"var_{i}.set_program"), RawExpression("&foo"))
         )
-        for i in range(120)
+        for i in range(_STATEMENTS_OVER_CAP)
     )
     target.main_statements = stmts
     out = target.cpp_main_section
-    # 120 statements / 50-cap -> 3 sub-chunks.
-    assert out.count("[]() {") == 3
+    assert out.count("[]() {") == _CHUNK_COUNT
 
 
 def test_cpp_main_section_typed_assignment_disables_sub_split() -> None:
@@ -1096,7 +1101,7 @@ def test_cpp_main_section_typed_assignment_disables_sub_split() -> None:
         AssignmentExpression(MockObj("int"), "", MockObj("x"), MockObj("42"))
     )
     stmts: list = [ComponentMarker("custom"), typed_assign]
-    stmts.extend(RawStatement(f"use_x_{i}();") for i in range(100))
+    stmts.extend(RawStatement(f"use_x_{i}();") for i in range(_STATEMENTS_OVER_CAP))
     target.main_statements = stmts
     out = target.cpp_main_section
     assert out.count("[]() {") == 1

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -9,6 +9,7 @@ from strategies import mac_addr_strings
 from esphome import const, core
 from esphome.cpp_generator import (
     AssignmentExpression,
+    CallExpression,
     ComponentMarker,
     ExpressionStatement,
     IIFEUnsafeStatement,
@@ -1068,15 +1069,20 @@ def test_cpp_main_section_raw_expression_as_call_arg_still_sub_splits() -> None:
     # `var.set_program(RawExpression("&foo"))`) produces
     # `ExpressionStatement(CallExpression(..., RawExpression))` — the
     # outer expression is a CallExpression, not a RawExpression, so
-    # the group is still sub-splittable.
+    # the group is still sub-splittable. Exercise this with actual
+    # CallExpression-wrapping-RawExpression statements filling the
+    # group past the 50-statement cap.
     target = core.EsphomeCore()
     stmts: list = [ComponentMarker("rp2040_pio_led_strip")]
-    # Emit >50 plain statements with one being an ExpressionStatement
-    # wrapping a non-RawExpression inner (RawStatement for simplicity
-    # here — the real codegen wraps a CallExpression).
-    stmts.extend(RawStatement(f"s{i}();") for i in range(120))
+    stmts.extend(
+        ExpressionStatement(
+            CallExpression(MockObj(f"var_{i}.set_program"), RawExpression("&foo"))
+        )
+        for i in range(120)
+    )
     target.main_statements = stmts
     out = target.cpp_main_section
+    # 120 statements / 50-cap -> 3 sub-chunks.
     assert out.count("[]() {") == 3
 
 

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -7,6 +7,7 @@ import pytest
 from strategies import mac_addr_strings
 
 from esphome import const, core
+from esphome.cpp_generator import ComponentMarker, RawStatement
 
 
 class TestHexInt:
@@ -867,3 +868,102 @@ class TestEsphomeCore:
             mock_enable.assert_called_once_with("Wire")
 
         assert "Wire" in target.platformio_libraries
+
+
+def test_wrap_in_noinline_iifes_empty_input() -> None:
+    assert not core._wrap_in_noinline_iifes([], max_statements=10)
+
+
+def test_wrap_in_noinline_iifes_fewer_lines_than_limit() -> None:
+    lines = ["a();", "b();", "c();"]
+    assert core._wrap_in_noinline_iifes(lines, max_statements=10) == [
+        "[]() [[gnu::noinline]] {",
+        "a();",
+        "b();",
+        "c();",
+        "}();",
+    ]
+
+
+def test_wrap_in_noinline_iifes_splits_at_max_statements() -> None:
+    lines = [f"s{i}();" for i in range(5)]
+    result = core._wrap_in_noinline_iifes(lines, max_statements=2)
+    # With max=2 and 5 lines: chunks of 2, 2, 1 → 3 IIFEs.
+    assert sum(1 for line in result if line.startswith("[]()")) == 3
+
+
+def test_wrap_in_noinline_iifes_never_splits_inside_braces() -> None:
+    # max=2 would naively split after "{" but brace guard keeps block whole.
+    lines = ["a();", "{", "inner();", "}", "b();"]
+    assert core._wrap_in_noinline_iifes(lines, max_statements=2) == [
+        "[]() [[gnu::noinline]] {",
+        "a();",
+        "{",
+        "inner();",
+        "}",
+        "}();",
+        "[]() [[gnu::noinline]] {",
+        "b();",
+        "}();",
+    ]
+
+
+def test_wrap_in_noinline_iifes_nested_braces() -> None:
+    lines = ["{", "{", "deep();", "}", "}", "after();"]
+    assert core._wrap_in_noinline_iifes(lines, max_statements=1) == [
+        "[]() [[gnu::noinline]] {",
+        "{",
+        "{",
+        "deep();",
+        "}",
+        "}",
+        "}();",
+        "[]() [[gnu::noinline]] {",
+        "after();",
+        "}();",
+    ]
+
+
+def test_wrap_in_noinline_iifes_unbalanced_braces_fall_through() -> None:
+    # Pathological input where "}" appears before "{": don't crash; emit
+    # a single IIFE with all lines rather than splitting mid-flight.
+    lines = ["a();", "}", "b();"]
+    result = core._wrap_in_noinline_iifes(lines, max_statements=1)
+    assert result[0] == "[]() [[gnu::noinline]] {"
+    assert result[-1] == "}();"
+    assert [line for line in result if line in lines] == lines
+
+
+def test_cpp_main_section_no_components_emits_flat() -> None:
+    target = core.EsphomeCore()
+    target.main_statements = [RawStatement("a();"), RawStatement("b();")]
+    out = target.cpp_main_section
+    assert "[[gnu::noinline]]" not in out
+    assert "a();" in out
+    assert "b();" in out
+
+
+def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
+    target = core.EsphomeCore()
+    target.main_statements = [
+        ComponentMarker("logger"),
+        RawStatement("new_logger();"),
+        ComponentMarker("wifi"),
+        RawStatement("new_wifi();"),
+    ]
+    out = target.cpp_main_section
+    assert out.count("[]() [[gnu::noinline]] {") == 2
+    assert out.count("}();") == 2
+    assert "// === logger ===" in out
+    assert "// === wifi ===" in out
+
+
+def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:
+    target = core.EsphomeCore()
+    target.main_statements = [
+        RawStatement("prefix();"),
+        ComponentMarker("c"),
+        RawStatement("body();"),
+    ]
+    out = target.cpp_main_section
+    assert out.index("prefix();") < out.index("[]() [[gnu::noinline]] {")

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -7,7 +7,12 @@ import pytest
 from strategies import mac_addr_strings
 
 from esphome import const, core
-from esphome.cpp_generator import ComponentMarker, RawStatement
+from esphome.cpp_generator import (
+    ComponentMarker,
+    IIFEUnsafeStatement,
+    RawExpression,
+    RawStatement,
+)
 
 
 class TestHexInt:
@@ -1009,6 +1014,31 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
     assert out.count("}();") == 2
     # ComponentMarker produces no output of its own.
     assert "component-marker" not in out
+
+
+def test_cpp_main_section_iife_unsafe_statement_emits_component_flat() -> None:
+    # A component that emits IIFEUnsafeStatement (e.g. safe_mode with
+    # `if (...) return;`) must be emitted flat — a `return` inside an
+    # IIFE would only exit the lambda, not setup().
+    target = core.EsphomeCore()
+    target.main_statements = [
+        ComponentMarker("logger"),
+        RawStatement("new_logger();"),
+        ComponentMarker("safe_mode"),
+        RawStatement("new_safe_mode();"),
+        IIFEUnsafeStatement(RawExpression("if (entering) return")),
+        ComponentMarker("sensor"),
+        RawStatement("new_sensor();"),
+    ]
+    out = target.cpp_main_section
+    # logger and sensor wrapped; safe_mode flat.
+    assert out.count("[]() {") == 2
+    # safe_mode's statements appear at top level, not indented in a lambda.
+    assert "new_safe_mode();" in out
+    assert "if (entering) return;" in out
+    # The IIFEUnsafeStatement wrapper picks up the trailing semicolon
+    # via statement() when inner is a bare Expression.
+    assert "if (entering) return\n" not in out
 
 
 def test_cpp_main_section_comment_only_component_omits_iife() -> None:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -937,7 +937,7 @@ def test_wrap_in_iifes_unbalanced_braces_fall_through() -> None:
 def test_wrap_in_iifes_skips_comment_only_chunks() -> None:
     # Components that emit only a ComponentMarker + config dump (no C++
     # statements) should not be wrapped in an empty IIFE.
-    lines = ["// === sha256 ===", "// sha256:", "//   {}"]
+    lines = ["// === begin sha256 ===", "// sha256:", "//   {}"]
     assert core._wrap_in_iifes(lines, max_statements=50) == lines
 
 
@@ -961,14 +961,16 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
     out = target.cpp_main_section
     assert out.count("[]() {") == 2
     assert out.count("}();") == 2
-    # Each component's marker brackets its IIFE (once before, once after).
-    assert out.count("// === logger ===") == 2
-    assert out.count("// === wifi ===") == 2
+    # Each component's IIFE is bracketed by a begin/end marker pair.
+    assert "// === begin logger ===" in out
+    assert "// === end logger ===" in out
+    assert "// === begin wifi ===" in out
+    assert "// === end wifi ===" in out
 
 
 def test_cpp_main_section_comment_only_component_emits_single_marker() -> None:
     # A component that emits no C++ statements (only a ComponentMarker)
-    # should not grow a useless trailing duplicate marker.
+    # gets only a begin marker — no IIFE, so no end marker.
     target = core.EsphomeCore()
     target.main_statements = [
         ComponentMarker("sha256"),
@@ -976,8 +978,10 @@ def test_cpp_main_section_comment_only_component_emits_single_marker() -> None:
         RawStatement("new_wifi();"),
     ]
     out = target.cpp_main_section
-    assert out.count("// === sha256 ===") == 1
-    assert out.count("// === wifi ===") == 2  # wifi has an IIFE
+    assert "// === begin sha256 ===" in out
+    assert "// === end sha256 ===" not in out
+    assert "// === begin wifi ===" in out
+    assert "// === end wifi ===" in out
 
 
 def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -8,8 +8,11 @@ from strategies import mac_addr_strings
 
 from esphome import const, core
 from esphome.cpp_generator import (
+    AssignmentExpression,
     ComponentMarker,
+    ExpressionStatement,
     IIFEUnsafeStatement,
+    MockObj,
     RawExpression,
     RawStatement,
 )
@@ -1014,6 +1017,83 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
     assert out.count("}();") == 2
     # ComponentMarker produces no output of its own.
     assert "component-marker" not in out
+
+
+def test_cpp_main_section_scope_brace_raw_disables_sub_split() -> None:
+    # A group containing scope-brace RawStatements (e.g. `{` / `}` from
+    # with_local_variable) must stay in one IIFE regardless of size so
+    # the scope bounds and any locals between them stay together.
+    target = core.EsphomeCore()
+    stmts: list = [ComponentMarker("wifi"), RawStatement("{")]
+    stmts.extend(RawStatement(f"s{i}();") for i in range(100))
+    stmts.append(RawStatement("}"))
+    target.main_statements = stmts
+    out = target.cpp_main_section
+    assert out.count("[]() {") == 1
+    assert out.count("}();") == 1
+
+
+def test_cpp_main_section_inline_comment_raw_still_sub_splits() -> None:
+    # entity_helpers emits `call();  // flags` as RawStatement for inline
+    # comments. Those shouldn't flag the group as scope-using — the
+    # content-aware check only triggers on bare `{` / `}`.
+    target = core.EsphomeCore()
+    stmts: list = [ComponentMarker("sensor")]
+    stmts.extend(RawStatement(f"s{i}();  // flags") for i in range(120))
+    target.main_statements = stmts
+    out = target.cpp_main_section
+    # 120 statements / 50-cap = 3 sub-chunks expected.
+    assert out.count("[]() {") == 3
+
+
+def test_cpp_main_section_raw_expression_disables_sub_split() -> None:
+    # cg.add(RawExpression(...)) — e.g. `time::ParsedTimezone tz` followed
+    # by `tz.field = ...` — is raw bare text that may reference a local
+    # declared elsewhere in the same group. Keep the group in one IIFE.
+    target = core.EsphomeCore()
+    stmts: list = [
+        ComponentMarker("time"),
+        ExpressionStatement(RawExpression("time::ParsedTimezone tz{}")),
+    ]
+    stmts.extend(
+        ExpressionStatement(RawExpression(f"tz.field_{i} = {i}")) for i in range(100)
+    )
+    target.main_statements = stmts
+    out = target.cpp_main_section
+    assert out.count("[]() {") == 1
+
+
+def test_cpp_main_section_raw_expression_as_call_arg_still_sub_splits() -> None:
+    # RawExpression passed as an argument to a method call (e.g.
+    # `var.set_program(RawExpression("&foo"))`) produces
+    # `ExpressionStatement(CallExpression(..., RawExpression))` — the
+    # outer expression is a CallExpression, not a RawExpression, so
+    # the group is still sub-splittable.
+    target = core.EsphomeCore()
+    stmts: list = [ComponentMarker("rp2040_pio_led_strip")]
+    # Emit >50 plain statements with one being an ExpressionStatement
+    # wrapping a non-RawExpression inner (RawStatement for simplicity
+    # here — the real codegen wraps a CallExpression).
+    stmts.extend(RawStatement(f"s{i}();") for i in range(120))
+    target.main_statements = stmts
+    out = target.cpp_main_section
+    assert out.count("[]() {") == 3
+
+
+def test_cpp_main_section_typed_assignment_disables_sub_split() -> None:
+    # cg.variable(id, rhs) emits `Type id = rhs;` via
+    # ExpressionStatement(AssignmentExpression(type=..., ...)). That's a
+    # function-local whose name must stay visible across all uses in
+    # the component — no sub-split.
+    target = core.EsphomeCore()
+    typed_assign = ExpressionStatement(
+        AssignmentExpression(MockObj("int"), "", MockObj("x"), MockObj("42"))
+    )
+    stmts: list = [ComponentMarker("custom"), typed_assign]
+    stmts.extend(RawStatement(f"use_x_{i}();") for i in range(100))
+    target.main_statements = stmts
+    out = target.cpp_main_section
+    assert out.count("[]() {") == 1
 
 
 def test_cpp_main_section_iife_unsafe_statement_emits_component_flat() -> None:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -934,6 +934,40 @@ def test_wrap_in_iifes_unbalanced_braces_fall_through() -> None:
     assert [line for line in result if line in lines] == lines
 
 
+def test_wrap_in_iifes_never_splits_inline_brace_lines() -> None:
+    # Defensive: if codegen ever emits control flow with braces on the
+    # same line (if/else/for), the depth tracker should keep the whole
+    # scoped block together even with aggressive max_statements.
+    lines = [
+        "before();",
+        "if (cond) {",
+        "then_branch();",
+        "} else {",
+        "for (;;) {",
+        "loop_body();",
+        "}",
+        "}",
+        "after();",
+    ]
+    assert core._wrap_in_iifes(lines, max_statements=1) == [
+        "[]() {",
+        "before();",
+        "}();",
+        "[]() {",
+        "if (cond) {",
+        "then_branch();",
+        "} else {",
+        "for (;;) {",
+        "loop_body();",
+        "}",
+        "}",
+        "}();",
+        "[]() {",
+        "after();",
+        "}();",
+    ]
+
+
 def test_wrap_in_iifes_skips_comment_only_chunks() -> None:
     # Components that emit only a ComponentMarker + config dump (no C++
     # statements) should not be wrapped in an empty IIFE.

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -1107,6 +1107,24 @@ def test_cpp_main_section_typed_assignment_disables_sub_split() -> None:
     assert out.count("[]() {") == 1
 
 
+def test_cpp_main_section_iife_unsafe_wins_over_no_split() -> None:
+    # A group that triggers BOTH flags (IIFEUnsafeStatement present AND
+    # a bare-local emission) must still be emitted flat — the unsafe
+    # flag wins because a `return` inside any IIFE, even a single big
+    # one, only exits the lambda.
+    target = core.EsphomeCore()
+    target.main_statements = [
+        ComponentMarker("safe_mode_with_local"),
+        RawStatement("{"),  # would trigger no_split
+        RawStatement("new_foo();"),
+        RawStatement("}"),
+        IIFEUnsafeStatement(RawExpression("if (cond) return")),
+    ]
+    out = target.cpp_main_section
+    assert "[]() {" not in out
+    assert "if (cond) return;" in out
+
+
 def test_cpp_main_section_iife_unsafe_statement_emits_component_flat() -> None:
     # A component that emits IIFEUnsafeStatement (e.g. safe_mode with
     # `if (...) return;`) must be emitted flat — a `return` inside an

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -934,6 +934,13 @@ def test_wrap_in_iifes_unbalanced_braces_fall_through() -> None:
     assert [line for line in result if line in lines] == lines
 
 
+def test_wrap_in_iifes_skips_comment_only_chunks() -> None:
+    # Components that emit only a ComponentMarker + config dump (no C++
+    # statements) should not be wrapped in an empty IIFE.
+    lines = ["// === sha256 ===", "// sha256:", "//   {}"]
+    assert core._wrap_in_iifes(lines, max_statements=50) == lines
+
+
 def test_cpp_main_section_no_components_emits_flat() -> None:
     target = core.EsphomeCore()
     target.main_statements = [RawStatement("a();"), RawStatement("b();")]

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -943,6 +943,20 @@ def test_wrap_in_iifes_unbalanced_braces_fall_through() -> None:
     assert [line for line in result if line in lines] == lines
 
 
+def test_wrap_in_iifes_negative_depth_stays_poisoned() -> None:
+    # Once depth goes negative the brace tracker is unreliable; a later
+    # arithmetic return to depth 0 must not re-enable splitting. Here
+    # "}" drives depth to -1 immediately, then "{" later brings depth
+    # back to 0 arithmetically. With max=1 every statement would flush
+    # if splitting were still enabled — assert everything emits as one
+    # IIFE because the poisoned flag stayed set.
+    lines = ["}", "a();", "{", "b();", "}", "c();"]
+    result = core._wrap_in_iifes(lines, max_statements=1)
+    assert sum(1 for line in result if line == "[]() {") == 1
+    assert result[0] == "[]() {"
+    assert result[-1] == "}();"
+
+
 def test_wrap_in_iifes_never_splits_inline_brace_lines() -> None:
     # Defensive: if codegen ever emits control flow with braces on the
     # same line (if/else/for), the depth tracker should keep the whole

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -871,7 +871,7 @@ class TestEsphomeCore:
 
 
 def test_wrap_in_iifes_empty_input() -> None:
-    assert not core._wrap_in_iifes([], max_statements=10)
+    assert core._wrap_in_iifes([], max_statements=10) == []
 
 
 def test_wrap_in_iifes_fewer_lines_than_limit() -> None:
@@ -969,9 +969,20 @@ def test_wrap_in_iifes_never_splits_inline_brace_lines() -> None:
 
 
 def test_wrap_in_iifes_skips_comment_only_chunks() -> None:
-    # Components that emit only a ComponentMarker + config dump (no C++
-    # statements) should not be wrapped in an empty IIFE.
-    lines = ["// === begin sha256 ===", "// sha256:", "//   {}"]
+    # A chunk with no C++ statements (only comments, e.g. a component's
+    # config dump) should be emitted verbatim without a no-op IIFE.
+    lines = ["// sha256:", "//   {}"]
+    assert core._wrap_in_iifes(lines, max_statements=50) == lines
+
+
+def test_wrap_in_iifes_ignores_iife_pattern_in_comment() -> None:
+    # A comment whose text mentions "[]()" (e.g. a YAML dump of a
+    # lambda) must not fool the comment-only detector into wrapping.
+    lines = [
+        "// on_value:",
+        "//   - !lambda |-",
+        "//       return []() { return 5; };",
+    ]
     assert core._wrap_in_iifes(lines, max_statements=50) == lines
 
 
@@ -979,7 +990,7 @@ def test_cpp_main_section_no_components_emits_flat() -> None:
     target = core.EsphomeCore()
     target.main_statements = [RawStatement("a();"), RawStatement("b();")]
     out = target.cpp_main_section
-    assert "[[gnu::noinline]]" not in out
+    assert "[]() {" not in out
     assert "a();" in out
     assert "b();" in out
 
@@ -993,18 +1004,17 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
         RawStatement("new_wifi();"),
     ]
     out = target.cpp_main_section
+    # One IIFE per component that emits C++ statements.
     assert out.count("[]() {") == 2
     assert out.count("}();") == 2
-    # Each component's IIFE is bracketed by a begin/end marker pair.
-    assert "// === begin logger ===" in out
-    assert "// === end logger ===" in out
-    assert "// === begin wifi ===" in out
-    assert "// === end wifi ===" in out
+    # ComponentMarker produces no output of its own.
+    assert "component-marker" not in out
 
 
-def test_cpp_main_section_comment_only_component_emits_single_marker() -> None:
-    # A component that emits no C++ statements (only a ComponentMarker)
-    # gets only a begin marker — no IIFE, so no end marker.
+def test_cpp_main_section_comment_only_component_omits_iife() -> None:
+    # A component that emits only a ComponentMarker (no statements) adds
+    # nothing to the generated output. A neighboring component with
+    # actual code still gets its own IIFE.
     target = core.EsphomeCore()
     target.main_statements = [
         ComponentMarker("sha256"),
@@ -1012,10 +1022,8 @@ def test_cpp_main_section_comment_only_component_emits_single_marker() -> None:
         RawStatement("new_wifi();"),
     ]
     out = target.cpp_main_section
-    assert "// === begin sha256 ===" in out
-    assert "// === end sha256 ===" not in out
-    assert "// === begin wifi ===" in out
-    assert "// === end wifi ===" in out
+    assert out.count("[]() {") == 1
+    assert "new_wifi();" in out
 
 
 def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -961,8 +961,23 @@ def test_cpp_main_section_component_marker_wraps_in_iife() -> None:
     out = target.cpp_main_section
     assert out.count("[]() {") == 2
     assert out.count("}();") == 2
-    assert "// === logger ===" in out
-    assert "// === wifi ===" in out
+    # Each component's marker brackets its IIFE (once before, once after).
+    assert out.count("// === logger ===") == 2
+    assert out.count("// === wifi ===") == 2
+
+
+def test_cpp_main_section_comment_only_component_emits_single_marker() -> None:
+    # A component that emits no C++ statements (only a ComponentMarker)
+    # should not grow a useless trailing duplicate marker.
+    target = core.EsphomeCore()
+    target.main_statements = [
+        ComponentMarker("sha256"),
+        ComponentMarker("wifi"),
+        RawStatement("new_wifi();"),
+    ]
+    out = target.cpp_main_section
+    assert out.count("// === sha256 ===") == 1
+    assert out.count("// === wifi ===") == 2  # wifi has an IIFE
 
 
 def test_cpp_main_section_prefix_statements_stay_outside_iife() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Generated `setup()` is one monolithic function whose stack frame scales super-linearly with config size. On apollo-r-pro-1-eth (esp32-s3, ~6k-line main.cpp) the frame hits 1,264 B at `-Os`; larger configs like the 16k-line LVGL config in #15796 can overflow the 8 KB loop task stack *before* `safe_mode` gets a chance to increment its boot counter, leaving devices bootlooping with no recovery path.

## What changes

`cpp_main_section` now wraps each component's `to_code` output in a `[]() { ... }();` IIFE lambda. The block scope lets GCC shorten temporary lifetimes; the compiler is free to inline whichever chunks it wants. Groups larger than 50 statements are sub-split to cap peak chunk frame against individual heavy components (e.g. sensor platforms with many filter registrations).

The change is a codegen restructuring only — no runtime behavior changes on `loop()`, no user-visible config surface.

### Safety mechanisms for codegen patterns the IIFE wrapping could break

- `cg.progmem_array()` / `cg.static_const_array()` emit at file scope. Read-only lookup tables referenced across multiple component blocks can't live as function-locals of one IIFE.
- `cg.IIFEUnsafeStatement` (new) wraps statements that must affect `setup()`'s own control flow (e.g. `safe_mode`'s `if (should_enter_safe_mode(...)) return;`). Its containing component's group is emitted flat so `return` exits `setup()` itself, not just the lambda.
- Components that emit bare-local constructs — scope-brace `RawStatement` (`cg.with_local_variable`, time's `tz` block), direct `RawExpression` via `cg.add`, or typed `AssignmentExpression` (`cg.variable`) — get their group wrapped in a single IIFE with no sub-split, so a bare-named local and its uses stay in the same lambda. Detection is content-aware: inline-comment `RawStatement`s (`call();  // flags` from `entity_helpers`) and `RawExpression`-as-arg-to-a-CallExpression don't false-positive.

## Measurements

Peak setup stack and flash on three real configs, `-Os`:

| Config | Platform | main.cpp lines | Baseline peak | After peak | Flash Δ |
| --- | --- | ---: | ---: | ---: | ---: |
| apollo-r-pro-1-eth | esp32-s3 | 5,943 | 1,264 B | 320 B (**-75%**) | **-540 B** |
| esphome LVGL test | esp32 | 8,080 | 416 B | ~280 B (-33%) | ~-320 B |
| neargaragedoor | esp8266 | 1,619 | 176 B | 176 B (0%) | -32 B |

Apollo detail: `setup()` own frame 176 B, max non-inlined chunk frame 144 B.

The IIFEs have no `noinline` attribute. GCC's `-Os` inliner re-inlines smaller chunks freely and that's fine — what matters is the scope structure at codegen time, not a forced function boundary at link time. Forcing `noinline` costs +388 B flash on esp32-s3 / +1,104 B on esp8266 for only marginal additional peak-stack reduction on esp32 and *zero* benefit on esp8266.

A simpler alternative (`__attribute__((optimize("O2")))` on `setup()`) cuts apollo peak stack only to 688 B at a cost of +7,188 B flash.

## How the measurements were taken

For each config, compiled once on `upstream/dev` (baseline) and once with this branch. From each `firmware.elf`:

- **Stack frame of `setup()`**: ran `objdump -d` on the `_Z5setupv` symbol (`setup` on esp8266 due to C linkage) and decoded the prologue — `entry a1, N` on the Xtensa windowed ABI (esp32) or `addi a1, a1, -N` on the call0 ABI (esp8266).
- **Max chunk frame**: for every symbol matching `_ZZ5setupvENKUlvE.*_clEv`, decoded the same prologue and took the max. Chunk symbols only appear when GCC decides not to inline a chunk back into `setup()`; a chunk count of 20/100 means the compiler kept 20 as real functions and inlined the rest.
- **Peak stack during `setup()`**: `setup()` frame + max chunk frame, since a chunk's frame lives on top of `setup()`'s during its call. Does not account for further nesting into component constructors — that overhead exists in both baseline and after, and is *lower* after because `setup()`'s own frame is smaller.
- **Flash**: the `Flash:` line from the PlatformIO `compile` output.

Runtime impact on `loop()`: none — this change touches only the structure of `setup()`, which runs once at boot. Runtime cost of the extra function calls during that one-time setup is ~5 cycles each × ≤100 calls ≈ 2 μs on a 240 MHz core, below measurement noise compared to the real work setup() does (Wi-Fi/I2C init etc.).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- related to https://github.com/esphome/esphome/issues/15796

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# n/a — internal codegen change, no config surface
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
