### PR TITLE
[lvgl] Fix crash with snow on rotated display

### DIFF
--- a/esphome/components/lvgl/lvgl_esphome.cpp
+++ b/esphome/components/lvgl/lvgl_esphome.cpp
@@ -642,26 +642,28 @@ void LvglComponent::write_random_() {
   int iterations = 6 - lv_display_get_inactive_time(this->disp_) / 60000;
   if (iterations <= 0)
     iterations = 1;
+  int16_t width = lv_display_get_horizontal_resolution(this->disp_);
+  int16_t height = lv_display_get_vertical_resolution(this->disp_);
   while (iterations-- != 0) {
-    int32_t col = random_uint32() % this->width_;
+    int32_t col = random_uint32() % width;
     col = col / this->draw_rounding * this->draw_rounding;
-    int32_t row = random_uint32() % this->height_;
+    int32_t row = random_uint32() % height;
     row = row / this->draw_rounding * this->draw_rounding;
     // size will be between 8 and 32, and a multiple of draw_rounding
     int32_t size = (random_uint32() % 25 + 8) / this->draw_rounding * this->draw_rounding;
-    lv_area_t area{col, row, col + size - 1, row + size - 1};
+    lv_area_t area{.x1 = col, .y1 = row, .x2 = col + size - 1, .y2 = row + size - 1};
     // clip to display bounds just in case
-    if (area.x2 >= this->width_)
-      area.x2 = this->width_ - 1;
-    if (area.y2 >= this->height_)
-      area.y2 = this->height_ - 1;
+    if (area.x2 >= width)
+      area.x2 = width - 1;
+    if (area.y2 >= height)
+      area.y2 = height - 1;
 
     // line_len can't exceed 1024, and minimum buffer size is 2048, so this won't overflow the buffer
     size_t line_len = lv_area_get_width(&area) * lv_area_get_height(&area) / 2;
     for (size_t i = 0; i != line_len; i++) {
-      ((uint32_t *) (this->draw_buf_))[i] = random_uint32();
+      reinterpret_cast<uint32_t *>(this->draw_buf_)[i] = random_uint32();
     }
-    this->draw_buffer_(&area, (lv_color_data *) this->draw_buf_);
+    this->draw_buffer_(&area, reinterpret_cast<lv_color_data *>(this->draw_buf_));
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When writing random snow and LVGL is using software rotation, must use rotated size to avoid out-of-bounds writes causing crash.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://discord.com/channels/429907082951524364/1494601565099659274

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
