### PR TITLE
[bme680_bsec] [bme68x_bsec2] Mark the two BSEC variants as mutually exclusive

### DIFF
--- a/esphome/components/bme680_bsec/__init__.py
+++ b/esphome/components/bme680_bsec/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_ID, CONF_SAMPLE_RATE, CONF_TEMPERATURE_OFFSET, Fr
 CODEOWNERS = ["@trvrnrth"]
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["sensor", "text_sensor"]
+CONFLICTS_WITH = ["bme68x_bsec2"]
 MULTI_CONF = True
 
 CONF_BME680_BSEC_ID = "bme680_bsec_id"

--- a/esphome/components/bme68x_bsec2/__init__.py
+++ b/esphome/components/bme68x_bsec2/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
 )
 
 CODEOWNERS = ["@neffs", "@kbx81"]
+CONFLICTS_WITH = ["bme680_bsec"]
 
 DOMAIN = "bme68x_bsec2"
 


### PR DESCRIPTION
# What does this implement/fix?

Declare mutual `CONFLICTS_WITH` between `bme680_bsec` and `bme68x_bsec2` so that a config using both is rejected at validation time with a clear error instead of a late-stage linker failure.

`bme680_bsec` pulls in the BSEC v1 library, which exposes the single-instance BSEC API (`bsec_init`, `bsec_set_configuration`, `bsec_update_subscription`, …). `bme68x_bsec2` pulls in the BSEC v2 library, which replaces those with multi-instance equivalents (`bsec_init_m`, `bsec_set_configuration_m`, `bsec_update_subscription_m`, …). The two libraries ship as drop-in replacements for each other — trying to link both into one firmware leaves the `*_m` symbols unresolved:

```
ld: bme68x_bsec2.cpp.o: undefined reference to `bsec_set_configuration_m'
ld: bme68x_bsec2.cpp.o: undefined reference to `bsec_update_subscription_m'
ld: bme68x_bsec2.cpp.o: undefined reference to `bsec_sensor_control_m'
ld: bme68x_bsec2.cpp.o: undefined reference to `bsec_init_m'
… (8 total)
```

This currently surfaces in CI whenever `test_build_components` groups `bme680_bsec` together with `bme68x_bsec2_i2c`. End users hitting the same combination get no useful diagnostic — just a cryptic linker error at the end of a long build. Since `bme68x_bsec2_i2c` already `AUTO_LOAD`s `bme68x_bsec2`, putting the declaration on the base `bme68x_bsec2` component covers any future bus-specific variants automatically.

Validated locally:

```
$ esphome config /tmp/both.yaml
Failed config

bme680_bsec: [source /tmp/both.yaml:12]
  Component bme680_bsec cannot be used together with component bme68x_bsec2.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# This now fails at config-validation time with a clear message
# instead of at link time with undefined-reference errors:
bme680_bsec:

bme68x_bsec2_i2c:
  address: 0x77
  model: bme680
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).