### PR TITLE
[core] Feed WDT unconditionally in main loop to fix empty-config panic

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -402,7 +402,7 @@ class Application {
   void enable_component_loop_(Component *component);
   void enable_pending_loops_();
   void activate_looping_component_(uint16_t index);
-  inline void ESPHOME_ALWAYS_INLINE before_loop_tasks_(uint32_t loop_start_time);
+  inline uint32_t ESPHOME_ALWAYS_INLINE before_loop_tasks_(uint32_t loop_start_time);
   inline void ESPHOME_ALWAYS_INLINE after_loop_tasks_() { this->in_loop_ = false; }
 
   /// Process dump_config output one component per loop iteration.
@@ -546,18 +546,15 @@ inline void Application::drain_wake_notifications_() {
 }
 #endif  // USE_HOST
 
-inline void ESPHOME_ALWAYS_INLINE Application::before_loop_tasks_(uint32_t loop_start_time) {
+inline uint32_t ESPHOME_ALWAYS_INLINE Application::before_loop_tasks_(uint32_t loop_start_time) {
 #ifdef USE_HOST
   // Drain wake notifications first to clear socket for next wake
   this->drain_wake_notifications_();
 #endif
 
-  // Process scheduled tasks. Scheduler::call now feeds the watchdog itself
-  // after each scheduled item that actually runs, so we no longer need an
-  // unconditional feed here — when Scheduler::call has no work to do, the
-  // only elapsed time is a sleep wake + a few instructions, and when it does
-  // have work, it fed the wdt as it went.
-  this->scheduler.call(loop_start_time);
+  // Scheduler::call feeds the WDT per item and returns the timestamp of the
+  // last fired item, or the input unchanged when nothing ran.
+  uint32_t last_op_end_time = this->scheduler.call(loop_start_time);
 
   // Process any pending enable_loop requests from ISRs
   // This must be done before marking in_loop_ = true to avoid race conditions
@@ -575,6 +572,7 @@ inline void ESPHOME_ALWAYS_INLINE Application::before_loop_tasks_(uint32_t loop_
 
   // Mark that we're in the loop for safe reentrant modifications
   this->in_loop_ = true;
+  return last_op_end_time;
 }
 
 inline void ESPHOME_ALWAYS_INLINE Application::loop() {
@@ -592,7 +590,13 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // Get the initial loop time at the start
   uint32_t last_op_end_time = millis();
 
-  this->before_loop_tasks_(last_op_end_time);
+  // Returned timestamp keeps us monotonic with last_wdt_feed_ (advanced by
+  // the scheduler's per-item feeds) without an extra millis() call.
+  last_op_end_time = this->before_loop_tasks_(last_op_end_time);
+  // Guarantee a WDT touch every tick — covers configs with no looping
+  // components and no scheduler work, where the per-item / per-component
+  // feeds never fire. Rate-limited inline fast path, ~free when unneeded.
+  this->feed_wdt_with_time(last_op_end_time);
 #ifdef USE_RUNTIME_STATS
   uint32_t loop_before_end_us = micros();
   uint64_t loop_before_scheduled_us = ComponentRuntimeStats::global_recorded_us - loop_recorded_snap;

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -533,7 +533,7 @@ void HOT Scheduler::process_defer_queue_slow_path_(uint32_t &now) {
 }
 #endif /* not ESPHOME_THREAD_SINGLE */
 
-void HOT Scheduler::call(uint32_t now) {
+uint32_t HOT Scheduler::call(uint32_t now) {
 #ifndef ESPHOME_THREAD_SINGLE
   this->process_defer_queue_(now);
 #endif /* not ESPHOME_THREAD_SINGLE */
@@ -703,6 +703,9 @@ void HOT Scheduler::call(uint32_t now) {
     this->debug_verify_no_leak_();
   }
 #endif
+  // execute_item_() advances `now` as items fire; return it so the caller
+  // stays monotonic with last_wdt_feed_.
+  return now;
 }
 void HOT Scheduler::process_to_add_slow_path_() {
   LockGuard guard{this->lock_};

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -129,7 +129,8 @@ class Scheduler {
 
   // Execute all scheduled items that are ready
   // @param now Fresh timestamp from millis() - must not be stale/cached
-  void call(uint32_t now);
+  // @return Timestamp of the last item that ran, or `now` unchanged if none ran.
+  uint32_t call(uint32_t now);
 
   // Move items from to_add_ into the main heap.
   // IMPORTANT: This method should only be called from the main thread (loop task).


### PR DESCRIPTION
# What does this implement/fix?

Minimal backport-oriented fix for the task watchdog firing in 2026.4.0 when the main loop has **no looping components** and **no scheduled items** on a given tick.

Example reproducer (reported on Discord: https://ptb.discord.com/channels/429907082951524364/1494921330632691753):

```yaml
esphome:
  name: esp-ili9341-test
esp32:
  variant: esp32
  framework:
    type: esp-idf
logger:
  level: debug
```

Log:
```
E (11036) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (11036) task_wdt:  - loopTask (CPU 1)
```

## Why

Since 2026.4.0, `Application::before_loop_tasks_()` no longer unconditionally feeds the WDT — `Scheduler::call()` feeds it per executed item, and component loops feed it after each `component->loop()`. When **neither** fires on a tick (zero active looping components, no scheduled item due), `yield_with_select_()` sleeps for up to `loop_interval_` with nothing ever reaching `arch_feed_wdt()`, so the loopTask starves the task WDT and panics.

This also triggers on configs where every looping component has called `disable_loop()` and no scheduler work is pending.

## What

Adds one `this->feed_wdt_with_time(last_op_end_time);` call right after `before_loop_tasks_()` in `Application::loop()`. `feed_wdt_with_time()` is an `ALWAYS_INLINE` rate-limited fast path (load + sub + branch, 3 ms floor) — essentially free when the floor has not elapsed, but guarantees the loopTask touches the WDT at least once per tick regardless of component or scheduler state.

To keep the timestamp argument monotonic with `last_wdt_feed_` (which `Scheduler::execute_item_()` advances via `feed_wdt_with_time(guard.finish())` as items fire), `Scheduler::call()` now returns its internal `now` — already advanced by `now = this->execute_item_(item, now);` — which is forwarded through `before_loop_tasks_()`. No extra `millis()` call is needed; when no items run the returned value equals the input.

This restores the pre-2026.4.0 WDT-per-tick behavior (`before_loop_tasks_()` used to call `this->feed_wdt(loop_start_time);` unconditionally after `scheduler.call()`) without reverting the per-item / per-component WDT feeds introduced in 2026.4.0.

## Relationship to #15792 and backport notes

#15792 is the full structural fix (decouples component-loop cadence from scheduler wake timing) and also happens to close this WDT window as a side effect. This PR is the **minimal** change that fixes only the WDT starvation, intended as a clean candidate to backport into 2026.4.1.

Backport dependency chain for 2026.4.1 (cherry-pick in this order — verified):

1. #15658 (`da9fbb8044` — "Fix app_state_ status bits clobbered for non-looping components") — adds `any_component_has_status_flag_`, which 15656's diff context depends on
2. #15656 (`506edaadd5` — "Inline feed_wdt hot path with out-of-line slow path") — introduces `feed_wdt_with_time()`, which this PR calls
3. This PR — cherry-picks with a **trivial context-only conflict** in `Application::loop()`

**Conflict resolution for step 3:** this PR's diff was generated on top of dev, which also contains #15743 ("runtime_stats: Track main loop active time and report overhead"). #15743 added a new `#ifdef USE_RUNTIME_STATS` block inside `Application::loop()` around `before_loop_tasks_()`, which is in this PR's diff context but not on 2026.4.0. Since #15743 is not a candidate for backport, the cherry-pick will conflict on that block. Resolve by keeping only the functional change:

```cpp
// Returned timestamp keeps us monotonic with last_wdt_feed_ (advanced by
// the scheduler's per-item feeds) without an extra millis() call.
last_op_end_time = this->before_loop_tasks_(last_op_end_time);
// Guarantee a WDT touch every tick — covers configs with no looping
// components and no scheduler work, where the per-item / per-component
// feeds never fire. Rate-limited inline fast path, ~free when unneeded.
this->feed_wdt_with_time(last_op_end_time);
```

Drop the `#ifdef USE_RUNTIME_STATS { uint32_t loop_before_end_us = ...; uint64_t loop_before_scheduled_us = ...; } #endif` block from the incoming diff — it references `loop_active_start_us` / `loop_recorded_snap` which don't exist on 2026.4.0. The rest of the PR (scheduler return value, `before_loop_tasks_()` signature change) applies clean.

(For reference: cherry-picking #15658 → #15656 → #15743 → this PR applies with zero conflicts, confirming the conflict is purely #15743's context.)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Fixes Discord report: https://ptb.discord.com/channels/429907082951524364/1494921330632691753
- Related community thread: https://community.home-assistant.io/t/version-2026-4-0-breaks-my-light-switch/1004760
- Alternate (full) fix: #15792

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Minimal reproducer — before this PR, loopTask WDT triggers within ~11 s
esphome:
  name: esp-ili9341-test

esp32:
  variant: esp32
  framework:
    type: esp-idf

logger:
  level: debug
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).