### PR TITLE
[core] Default PollingComponent() to 1ms when codegen is bypassed

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -601,7 +601,7 @@ class Component {
  */
 class PollingComponent : public Component {
  public:
-  PollingComponent() : PollingComponent(SCHEDULER_DONT_RUN) {}
+  PollingComponent() : PollingComponent(1) {}
 
   /** Initialize this polling component with the given update interval in ms.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -601,7 +601,7 @@ class Component {
  */
 class PollingComponent : public Component {
  public:
-  PollingComponent() : PollingComponent(0) {}
+  PollingComponent() : PollingComponent(SCHEDULER_DONT_RUN) {}
 
   /** Initialize this polling component with the given update interval in ms.
    *


### PR DESCRIPTION
# What does this implement/fix?

Changes the default-constructed `PollingComponent()` interval from `0` to `1`.

## Scope

**This PR only affects external components that bypass ESPHome codegen.** In-tree components and anything using the standard codegen path are unaffected — `cg.register_component()` / `cg.register_polling_component()` always calls `set_update_interval()` with an explicit value, so the default-constructor value is never observed.

The default is only hit when a component author writes C++ like:

```cpp
class MyComponent : public PollingComponent, public uart::UARTDevice {
 public:
  MyComponent(uart::UARTComponent *parent) : PollingComponent(), uart::UARTDevice(parent) {}
  // ...and never calls set_update_interval()
};
```

This pattern appears in hand-rolled external components that register themselves without going through ESPHome's Python codegen (e.g. https://github.com/psvanstrom/esphome-p1reader/pull/110).

## Why change it

Prompted by post-merge discussion on #15799:

- https://github.com/esphome/esphome/pull/15799#issuecomment-4273310330 — @cadwal raised that the default itself was a bad value even with the runtime coerce in place.
- https://github.com/esphome/esphome/pull/15799#issuecomment-4273331083 — my initial reply noting codegen always sets it.
- https://github.com/esphome/esphome/pull/15799#issuecomment-4273412089 — @cadwal's follow-up that this assumes the component was written/composed correctly, which external components may not be.

Before #15516 the old scheduler was inefficient enough that `interval=0` was informally throttled into pseudo-`loop()` behavior — external components using this pattern "just worked." After #15516 it became a hard spin + WDT reset. #15799 landed a runtime coercion `0 → 1ms` so those components stopped crashing.

This PR pushes that `1` up to compile time: encode the default as `1` rather than rely on the runtime coercion to fix it up. It removes one inconsistency (compile-time sentinel vs. runtime-observed value) and makes the behavior local to the constructor rather than spooky action from the scheduler.

## Behavior change

Zero observable change relative to 2026.4.1 for any component — external or in-tree. External components that relied on the no-arg constructor already run at 1ms after the coerce; they continue to run at 1ms. In-tree components never hit this path.

Whether `1ms` is the right long-term default for bypass-codegen authors (vs. "never" / removing the no-arg constructor entirely) is a separate discussion for a future intentional breaking change — see #15832.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- follow-up to https://github.com/esphome/esphome/pull/15799
- followed up by #15832 (breaking change to `SCHEDULER_DONT_RUN`)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
