### PR TITLE
[core] Default PollingComponent() to not run when codegen is bypassed

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -601,7 +601,7 @@ class Component {
  */
 class PollingComponent : public Component {
  public:
-  PollingComponent() : PollingComponent(1) {}
+  PollingComponent() : PollingComponent(SCHEDULER_DONT_RUN) {}
 
   /** Initialize this polling component with the given update interval in ms.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -601,7 +601,7 @@ class Component {
  */
 class PollingComponent : public Component {
  public:
-  PollingComponent() : PollingComponent(SCHEDULER_DONT_RUN) {}
+  PollingComponent() : PollingComponent(1) {}
 
   /** Initialize this polling component with the given update interval in ms.
    *

--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -601,7 +601,7 @@ class Component {
  */
 class PollingComponent : public Component {
  public:
-  PollingComponent() : PollingComponent(0) {}
+  PollingComponent() : PollingComponent(SCHEDULER_DONT_RUN) {}
 
   /** Initialize this polling component with the given update interval in ms.
    *


### PR DESCRIPTION
# What does this implement/fix?

**Chained on top of #15831.** Changes the default-constructed `PollingComponent()` interval from `1` to `SCHEDULER_DONT_RUN` (`UINT32_MAX`).

This is the intentional breaking change that #15831 split off. #15831 encodes the current runtime-coerce behavior at compile time (`1`) as a pure no-op, safe for backport. This PR then changes the actual semantics to "don't run."

## Why

The default-constructor value is only observed when an external component bypasses codegen — writes `PollingComponent()` directly in C++ and never calls `set_update_interval()`. See #15831 for the full scope discussion.

Neither `0` nor `1` is a good default for that case:

- `0` spins the loop at 1ms after runtime coercion (#15799), starving the watchdog.
- `1` polls every 1ms, which is not meaningfully different — no author who forgot to set an interval actually wants 1000 updates per second.

If an author bypasses codegen *and* forgets to set an interval, the right behavior is to not poll at all. The scheduler already treats `SCHEDULER_DONT_RUN` as disabled (`scheduler.cpp:137`, `component.cpp:446`), and `LOG_UPDATE_INTERVAL` already prints `Update Interval: never` for this value. So the component fails loudly and obviously (no updates, clearly logged) rather than subtly (spinning at 1ms, masking other symptoms).

## Why this is a developer breaking change

Before #15516 the inefficient scheduler meant `interval=0` was informally throttled into pseudo-`loop()` behavior, so external components that relied on the no-arg constructor got "some" polling. After #15799 / #15831 they still got 1ms polling. This PR changes that to no polling — external components relying on the default to produce *any* updates will stop updating until they pass an explicit interval or call `set_update_interval()`.

This affects only external components that:
1. Bypass ESPHome codegen, AND
2. Call `PollingComponent()` with no argument, AND
3. Never call `set_update_interval()` afterwards

Known example: https://github.com/psvanstrom/esphome-p1reader/pull/110 (which already switched to `PollingComponent(10)` independently).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- chained on #15831
- follow-up to #15799
- discussion: https://github.com/esphome/esphome/pull/15799#issuecomment-4273310330

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
