### PR TITLE
[ld2412] Fix flaky integration test race condition

### DIFF
--- a/tests/integration/test_uart_mock_ld2412.py
+++ b/tests/integration/test_uart_mock_ld2412.py
@@ -325,9 +325,13 @@ async def test_uart_mock_ld2412_engineering_truncated(
         ],
     )
 
-    # Signal when we see Phase 3 recovery values (gate_0_move=50)
+    # Signal when we see ALL Phase 3 recovery values to avoid race where some
+    # arrive after the waiter fires but before we index into the lists
     recovery_received = collector.add_waiter(
-        lambda: pytest.approx(50.0) in collector.sensor_states["gate_0_move_energy"]
+        lambda: (
+            pytest.approx(50.0) in collector.sensor_states["gate_0_move_energy"]
+            and pytest.approx(42.0) in collector.sensor_states["light"]
+        )
     )
 
     async with (


### PR DESCRIPTION
# What does this implement/fix?

Fixes a flaky race in `test_uart_mock_ld2412_engineering_truncated`. The recovery waiter fired as soon as `gate_0_move_energy=50` arrived, but the test then immediately asserted `pytest.approx(42.0) in collector.sensor_states["light"]`. The `light=42` update arrives in a subsequent state response, so on a slow CI run the assertion ran before that state was collected and the test failed with:

```
assert 42.0 ± 4.2e-05 in [87.0, 87.0]
```

Same race pattern and fix as #15299 for ld2410: gate the waiter on **all** recovery values that will be asserted, so the waiter only fires once every value the test indexes has been received.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).