### PR TITLE
[core] raise WDT_FEED_INTERVAL_MS from 3 ms to 300 ms

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -211,11 +211,16 @@ void Application::process_dump_config_() {
 
 void Application::feed_wdt() {
   // Cold entry: callers without a millis() timestamp in hand. Fetches the
-  // time and takes the same rate-limit path as feed_wdt_with_time().
+  // time and takes the same rate-limit paths as feed_wdt_with_time().
   uint32_t now = millis();
   if (now - this->last_wdt_feed_ > WDT_FEED_INTERVAL_MS) {
     this->feed_wdt_slow_(now);
   }
+#ifdef USE_STATUS_LED
+  if (now - this->last_status_led_service_ > STATUS_LED_DISPATCH_INTERVAL_MS) {
+    this->service_status_led_slow_(now);
+  }
+#endif
 }
 
 void HOT Application::feed_wdt_slow_(uint32_t time) {
@@ -223,26 +228,35 @@ void HOT Application::feed_wdt_slow_(uint32_t time) {
   // confirmed the WDT_FEED_INTERVAL_MS rate limit was exceeded.
   arch_feed_wdt();
   this->last_wdt_feed_ = time;
-#ifdef USE_STATUS_LED
-  if (status_led::global_status_led != nullptr) {
-    auto *sl = status_led::global_status_led;
-    uint8_t sl_state = sl->get_component_state() & COMPONENT_STATE_MASK;
-    if (sl_state == COMPONENT_STATE_LOOP_DONE) {
-      // status_led only transitions to LOOP_DONE from inside its own loop() (after the
-      // first idle-path dispatch), so its pin is already initialized by pre_setup() and
-      // its setup() has already run. Re-dispatch only if an error or warning bit has been
-      // set since; otherwise skip entirely.
-      if ((this->app_state_ & STATUS_LED_MASK) == 0)
-        return;
-      sl->enable_loop();
-    } else if (sl_state != COMPONENT_STATE_LOOP) {
-      // CONSTRUCTION/SETUP/FAILED: not our job — App::setup() drives the lifecycle.
-      return;
-    }
-    sl->loop();
-  }
-#endif
 }
+
+#ifdef USE_STATUS_LED
+void HOT Application::service_status_led_slow_(uint32_t time) {
+  // Callers (feed_wdt(), feed_wdt_with_time()) have already confirmed the
+  // STATUS_LED_DISPATCH_INTERVAL_MS rate limit was exceeded. Rate-limited
+  // separately from arch_feed_wdt() so the LED blink pattern stays readable
+  // (status_led error blink period is 250 ms) while HAL watchdog pokes can
+  // still run at the much coarser WDT_FEED_INTERVAL_MS cadence.
+  this->last_status_led_service_ = time;
+  if (status_led::global_status_led == nullptr)
+    return;
+  auto *sl = status_led::global_status_led;
+  uint8_t sl_state = sl->get_component_state() & COMPONENT_STATE_MASK;
+  if (sl_state == COMPONENT_STATE_LOOP_DONE) {
+    // status_led only transitions to LOOP_DONE from inside its own loop() (after the
+    // first idle-path dispatch), so its pin is already initialized by pre_setup() and
+    // its setup() has already run. Re-dispatch only if an error or warning bit has been
+    // set since; otherwise skip entirely.
+    if ((this->app_state_ & STATUS_LED_MASK) == 0)
+      return;
+    sl->enable_loop();
+  } else if (sl_state != COMPONENT_STATE_LOOP) {
+    // CONSTRUCTION/SETUP/FAILED: not our job — App::setup() drives the lifecycle.
+    return;
+  }
+  sl->loop();
+}
+#endif
 
 bool Application::any_component_has_status_flag_(uint8_t flag) const {
   // Walk all components (not just looping ones) so non-looping components'

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -229,10 +229,17 @@ class Application {
 
   void schedule_dump_config() { this->dump_config_at_ = 0; }
 
-  /// Minimum interval between real arch_feed_wdt() calls. Chosen to keep the
-  /// rate of HAL pokes low while still being small enough that any plausible
-  /// watchdog timeout (seconds) has orders of magnitude of safety margin.
-  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 3;
+  /// Minimum interval between real arch_feed_wdt() calls. Sized so the outer
+  /// feed in Application::loop() is effectively rate-limited across both the
+  /// normal ~62 Hz cadence and worst-case wake-storm scenarios (e.g. external
+  /// stacks like OpenThread posting frequent wake notifications). Component
+  /// loops and scheduler items still feed after every op, so any op exceeding
+  /// this threshold triggers a real feed naturally.
+  /// Safety margins vs. platform watchdog timeouts:
+  ///   - ESP32 task WDT default (5 s): ~16x
+  ///   - ESP8266 soft WDT (~1.6 s):    ~5x
+  ///   - ESP8266 HW WDT (~6 s):        ~20x
+  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
 
   /// Feed the task watchdog. Cold entry — callers without a millis()
   /// timestamp in hand. Out of line to keep call sites tiny.

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -262,7 +262,7 @@ class Application {
   /// When USE_STATUS_LED is compiled in, also gates a separate (shorter)
   /// interval for dispatching status_led so the LED blink pattern stays
   /// readable even though arch_feed_wdt pokes are now rate-limited at
-  /// 300 ms. The two rate limits are independent so raising
+  /// WDT_FEED_INTERVAL_MS. The two rate limits are independent so raising
   /// WDT_FEED_INTERVAL_MS does not distort the LED cadence.
   void ESPHOME_ALWAYS_INLINE feed_wdt_with_time(uint32_t time) {
     if (static_cast<uint32_t>(time - this->last_wdt_feed_) > WDT_FEED_INTERVAL_MS) [[unlikely]] {

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -237,7 +237,8 @@ class Application {
   /// this threshold triggers a real feed naturally.
   /// Safety margins vs. platform watchdog timeouts:
   ///   - ESP32 task WDT default (5 s): ~16x
-  ///   - ESP8266 soft WDT (~1.6 s):    ~5x
+  ///   - ESP8266 soft WDT (~1.6 s):    ~5x  <-- floor case; any future change
+  ///                                             must keep comfortable margin here
   ///   - ESP8266 HW WDT (~6 s):        ~20x
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
 
@@ -245,14 +246,33 @@ class Application {
   /// timestamp in hand. Out of line to keep call sites tiny.
   void feed_wdt();
 
+#ifdef USE_STATUS_LED
+  /// Dispatch interval for the status LED update. Deliberately shorter than
+  /// WDT_FEED_INTERVAL_MS because the status LED error blink has a 250 ms
+  /// period (status_led.cpp:ERROR_PERIOD_MS) and a 150 ms on-window; the
+  /// dispatch cadence must be short enough to render that blink without
+  /// aliasing. Sampling every 100 ms yields an on/off observation inside
+  /// every error period with headroom for the 250 ms warning on-window.
+  static constexpr uint32_t STATUS_LED_DISPATCH_INTERVAL_MS = 100;
+#endif
+
   /// Feed the task watchdog, hot entry. Callers that already have a
   /// millis() timestamp pay only a load + sub + branch on the common
-  /// (no-op) path. The actual arch feed + status LED update live in
-  /// feed_wdt_slow_.
+  /// (no-op) path. The actual arch feed lives in feed_wdt_slow_.
+  /// When USE_STATUS_LED is compiled in, also gates a separate (shorter)
+  /// interval for dispatching status_led so the LED blink pattern stays
+  /// readable even though arch_feed_wdt pokes are now rate-limited at
+  /// 300 ms. The two rate limits are independent so raising
+  /// WDT_FEED_INTERVAL_MS does not distort the LED cadence.
   void ESPHOME_ALWAYS_INLINE feed_wdt_with_time(uint32_t time) {
     if (static_cast<uint32_t>(time - this->last_wdt_feed_) > WDT_FEED_INTERVAL_MS) [[unlikely]] {
       this->feed_wdt_slow_(time);
     }
+#ifdef USE_STATUS_LED
+    if (static_cast<uint32_t>(time - this->last_status_led_service_) > STATUS_LED_DISPATCH_INTERVAL_MS) [[unlikely]] {
+      this->service_status_led_slow_(time);
+    }
+#endif
   }
 
   void reboot();
@@ -417,10 +437,20 @@ class Application {
   /// Caller must ensure dump_config_at_ < components_.size().
   void __attribute__((noinline)) process_dump_config_();
 
-  /// Slow path for feed_wdt(): actually calls arch_feed_wdt(), updates
-  /// last_wdt_feed_, and re-dispatches the status LED. Out of line so the
-  /// inline wrapper stays tiny.
+  /// Slow path for feed_wdt(): actually calls arch_feed_wdt() and updates
+  /// last_wdt_feed_. Out of line so the inline wrapper stays tiny. Does NOT
+  /// touch status_led — that's gated separately via service_status_led_slow_
+  /// because the two rate limits have very different safe ranges (~ seconds
+  /// for WDT, < 250 ms for LED blink rendering).
   void feed_wdt_slow_(uint32_t time);
+
+#ifdef USE_STATUS_LED
+  /// Slow path for the status_led dispatch rate limit. Runs the status_led
+  /// component's loop() based on its state (LOOP / LOOP_DONE with status
+  /// bits set), and updates last_status_led_service_. Out of line to keep
+  /// the feed_wdt_with_time hot path a couple of load+branch sequences.
+  void service_status_led_slow_(uint32_t time);
+#endif
 
   /// Perform a delay while also monitoring socket file descriptors for readiness
 #ifdef USE_HOST
@@ -475,6 +505,10 @@ class Application {
   uint32_t last_loop_{0};
   uint32_t loop_component_start_time_{0};
   uint32_t last_wdt_feed_{0};  // millis() of most recent arch_feed_wdt(); rate-limits feed_wdt() hot path
+#ifdef USE_STATUS_LED
+  // millis() of most recent status_led dispatch; rate-limits independently of last_wdt_feed_
+  uint32_t last_status_led_service_{0};
+#endif
 
 #ifdef USE_HOST
   int max_fd_{-1};  // Highest file descriptor number for select()


### PR DESCRIPTION
# What does this implement/fix?

Raises `WDT_FEED_INTERVAL_MS` from **3 ms** to **300 ms**, and decouples the status LED dispatch from the WDT feed rate limit so the LED blink cadence stays readable after the bump.

## The bug, shown on a real device

Reported by @rwrozelle on #15792 while testing raised `loop_interval_` for power saving with OpenThread: a 60 s runtime_stats window showed **360,651 main-loop iterations** (~6000 Hz) and:

```
main_loop: iters=360651, active_avg=0.006ms, active_max=7.31ms, active_total=2073.1ms, overhead_total=2006.2ms
main_loop_overhead_section: before=1557.9ms, tail=448.0ms, inter_component=0.3ms
```

2 s of overhead inside a 60 s window — **26 % of CPU** — was being burned inside `arch_feed_wdt()`. The main loop was iterating thousands of times per second doing almost nothing, and the 3 ms rate limit on the outer WDT feed ensured the slow path (`esp_task_wdt_reset()` on ESP32, spinlock-guarded) fired on essentially every iteration.

## Why the 3 ms limit was stale

The `> 3` rate-limit check has been in ESPHome since the **April 2019 C++ port** (`6682c43d` "Merge C++ into python codebase"). In that original version the "feed" was dramatically cheaper than it is today:

```cpp
// 2019 code:
if (now - LAST_FEED > 3) {
#ifdef ARDUINO_ARCH_ESP8266
    ESP.wdtFeed();   // sub-µs soft-WDT counter reset
#endif
#ifdef ARDUINO_ARCH_ESP32
    yield();         // cooperative yield to FreeRTOS — no task-WDT involvement
#endif
```

On ESP32-Arduino it was literally `yield()` — essentially free. In **September 2021** PR #2303 switched ESP32 to ESP-IDF and the feed became `arch_feed_wdt()` → `esp_task_wdt_reset()`, which walks a task list under a spinlock and costs **~10–12 µs** per call (worse with BT/WiFi active). The 3 ms threshold was carried forward unchanged through that transition and never revisited, despite the feed operation becoming roughly **1000× more expensive**.

## Why it is safe to raise now

The watchdog is fed after every long-running operation via the per-op feed sites added in recent PRs — raising the idle-tick rate limit changes no behavior around real work:

- **After every scheduled item** — #15656 moved the feed inside `Scheduler::execute_item_`, so each callback is followed by a feed.
- **After every component `loop()`** — `Application::loop()` already feeds after each component iteration.
- **Unconditionally at the top of every loop tick** — #15830 made this unconditional so empty configs still feed.

Any operation exceeding 300 ms naturally clears the rate-limit gate on the feed call that immediately follows it. The only behavior change is that *idle ticks* no longer each pay a HAL watchdog poke.

Safety margins vs. platform watchdog timeouts remain comfortable:
- ESP32 task WDT default (5 s): **~16x**
- ESP8266 soft WDT (~1.6 s): **~5x** — floor case
- ESP8266 HW WDT (~6 s): **~20x**

## Status LED kept readable

`Application::feed_wdt_slow_()` previously also re-dispatched `status_led::global_status_led`, so rate-limiting the HAL feed at 300 ms would also cap the LED update cadence. That distorts the error-blink pattern (`ERROR_PERIOD_MS = 250 ms` with a 150 ms on-window in `status_led.cpp`): at a 300 ms dispatch interval the LED can be sampled entirely inside or entirely outside the on-window, turning a readable blink into an aliased one.

Split into two independent rate limits:

| Constant | Value | Purpose |
|---|---|---|
| `WDT_FEED_INTERVAL_MS` | 300 ms | `arch_feed_wdt()` rate limit |
| `STATUS_LED_DISPATCH_INTERVAL_MS` | 100 ms | `status_led::loop()` dispatch |

`feed_wdt_with_time()` now has two independent gate checks (a load + sub + branch each); the fast path on both misses remains cheap. `feed_wdt_slow_()` no longer touches status_led; the dispatch lives in a new `service_status_led_slow_()` compiled in only when `USE_STATUS_LED` is set. Devices without a status LED see zero behavior change and no new state.

## Cross-platform validation

Diagnostic instrumentation (sub-split of the `before` runtime_stats bucket + `wdt_slow_count_` counter) on five devices, 60 s sample window each:

| Device | Platform | main_loop iters | wdt_slow hits | hit rate | wdt total |
|---|---|---|---|---|---|
| gatetrigger32 | ESP32 (no BT) | 3752 | 197 | 5.3 % | 6.3 ms |
| bw15-device | RTL87xx | 3383 | 188 | 5.6 % | 4.6 ms |
| cb3s-test | BK72xx | 3101 | 183 | 5.9 % | 17.4 ms |
| winefrige | ESP8266 | 4876 | 196 | 4.0 % | 8.0 ms |
| BT proxy | ESP32 IDF + BT | 4341 | 196 | 4.5 % | 21.6 ms |

Hit counts cluster tightly at 183–197 per 60 s ≈ 3 Hz = `60000 ms / 300 ms` across four platform families — the rate limit is what governs feed cadence now, nothing else.

Before-and-after on the BT proxy (same device, same workload):

| metric | 3 ms interval | 300 ms interval | delta |
|---|---|---|---|
| `wdt_slow_path` hits | 4065 (95.3 %) | 196 (4.5 %) | **−95 %** |
| `wdt` bucket total | 46.5 ms | 21.6 ms | **−54 %** |
| `before` bucket total | 114.6 ms | 87.5 ms | **−24 %** |

Under the wake-storm scenario that motivated this PR, the feed rate drops from thousands of Hz to ~3 Hz, reclaiming the 26 % CPU burn without changing the correctness properties of the watchdog.

No WDT panics on any of the five devices during validation.

## Scope — deliberately minimal; future work

This PR only changes two constants (`WDT_FEED_INTERVAL_MS`, new `STATUS_LED_DISPATCH_INTERVAL_MS`) and splits the status-LED dispatch out of `feed_wdt_slow_`. It does **not** expose either interval as configuration, touch the platform watchdog timeouts, or change the sleep-bound logic in `Application::loop()`. Scope is kept tight so the change is easy to validate on-device and easy to revert if a platform surprises us.

Natural follow-ups, intentionally deferred:

- **Make `WDT_FEED_INTERVAL_MS` configurable** — e.g. a run time config for sleep or maybe YAML knob under `esphome:` so power-managed configs can trade WDT safety margin for even longer idle sleeps. Raising further than 300 ms should be opt-in.
- **Let `Application::loop()` sleep beyond `loop_interval_`** when there are no looping components — the suggestion on #15792. Now that idle-tick WDT feeds are ~free and fire at ~3 Hz instead of ~kHz, a much longer sleep bound is viable on platforms with `wake_loop_threadsafe()` support. This needs its own PR because the `loop_interval_` gate is user-visible behavior and merits separate review.
- **Platform-specific tuning** — 300 ms is a conservative value chosen to keep the ESP8266 soft-WDT floor comfortable (~5×). Platforms with longer HW WDT timeouts could raise it further.

Keeping this PR to "the threshold is 1000× too low for how expensive the feed has become" lets each of the above land independently with its own validation and discussion.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Addresses the watchdog churn symptom reported by @rwrozelle on #15792 under raised `loop_interval_`.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (on-device 60 s runtime_stats comparison above)
- [x] ESP8266 (on-device 60 s runtime_stats comparison above)
- [ ] RP2040/RP2350
- [x] BK72xx (on-device 60 s runtime_stats comparison above)
- [x] RTL87xx (on-device 60 s runtime_stats comparison above)
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change required — the adjustment is internal to the main-loop
# watchdog-feed rate limiter. Effect is immediate on flash.
esphome:
  name: any-device
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

No automated tests are added in this PR — the change is a rate-limit constant and a status-LED dispatch split whose real-world effects show up only on-device. Validation is on-device across five devices (ESP32 IDF + BT, ESP32 no-BT, ESP8266, BK72xx, RTL87xx) documented in the PR body; a 60 s runtime_stats window on each confirmed the feed hit rate drops from ~95 % of iterations to ~5 %. An automated test for this would need host-side fakes for `arch_feed_wdt` and a fake high-resolution clock, which would be more machinery than the change is worth.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).


