### PR TITLE
[substitutions] Fix `substitutions: !include file.yaml` regression

### DIFF
--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -516,7 +516,14 @@ def do_packages_pass(
     if CONF_PACKAGES not in config:
         return config
 
-    substitutions = UserDict(config.pop(CONF_SUBSTITUTIONS, {}))
+    raw_substitutions = config.pop(CONF_SUBSTITUTIONS, {})
+    if isinstance(raw_substitutions, yaml_util.IncludeFile):
+        # Resolve `substitutions: !include file.yaml` before feeding into UserDict.
+        with cv.prepend_path(CONF_SUBSTITUTIONS):
+            raw_substitutions, _ = resolve_include(
+                raw_substitutions, [], ContextVars(), strict_undefined=False
+            )
+    substitutions = UserDict(raw_substitutions)
     processor = _PackageProcessor(
         substitutions, command_line_substitutions, skip_update
     )

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -517,11 +517,20 @@ def do_packages_pass(
         return config
 
     raw_substitutions = config.pop(CONF_SUBSTITUTIONS, {})
-    if isinstance(raw_substitutions, yaml_util.IncludeFile):
-        # Resolve `substitutions: !include file.yaml` before feeding into UserDict.
-        with cv.prepend_path(CONF_SUBSTITUTIONS):
+    with cv.prepend_path(CONF_SUBSTITUTIONS):
+        if isinstance(raw_substitutions, yaml_util.IncludeFile):
+            # Resolve `substitutions: !include file.yaml` before feeding into UserDict.
+            # Seed with command-line substitutions so `!include ${var}.yaml` can
+            # reference CLI-provided vars in the filename.
             raw_substitutions, _ = resolve_include(
-                raw_substitutions, [], ContextVars(), strict_undefined=False
+                raw_substitutions,
+                [],
+                ContextVars(command_line_substitutions or {}),
+                strict_undefined=False,
+            )
+        if not isinstance(raw_substitutions, dict):
+            raise cv.Invalid(
+                f"Substitutions must be a key to value mapping, got {type(raw_substitutions)}"
             )
     substitutions = UserDict(raw_substitutions)
     processor = _PackageProcessor(

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -10,6 +10,7 @@ from esphome.components.substitutions import (
     ContextVars,
     push_context,
     resolve_include,
+    resolve_substitutions_block,
     substitute,
 )
 from esphome.components.substitutions.jinja import has_jinja
@@ -516,23 +517,12 @@ def do_packages_pass(
     if CONF_PACKAGES not in config:
         return config
 
-    raw_substitutions = config.pop(CONF_SUBSTITUTIONS, {})
     with cv.prepend_path(CONF_SUBSTITUTIONS):
-        if isinstance(raw_substitutions, yaml_util.IncludeFile):
-            # Resolve `substitutions: !include file.yaml` before feeding into UserDict.
-            # Seed with command-line substitutions so `!include ${var}.yaml` can
-            # reference CLI-provided vars in the filename.
-            raw_substitutions, _ = resolve_include(
-                raw_substitutions,
-                [],
-                ContextVars(command_line_substitutions or {}),
-                strict_undefined=False,
+        substitutions = UserDict(
+            resolve_substitutions_block(
+                config.pop(CONF_SUBSTITUTIONS, {}), command_line_substitutions
             )
-        if not isinstance(raw_substitutions, dict):
-            raise cv.Invalid(
-                f"Substitutions must be a key to value mapping, got {type(raw_substitutions)}"
-            )
-    substitutions = UserDict(raw_substitutions)
+        )
     processor = _PackageProcessor(
         substitutions, command_line_substitutions, skip_update
     )

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -431,8 +431,13 @@ def do_substitution_pass(
     with cv.prepend_path(CONF_SUBSTITUTIONS):
         if isinstance(substitutions, IncludeFile):
             # Resolve `substitutions: !include file.yaml` before validating the shape.
+            # Seed with command-line substitutions so `!include ${var}.yaml` can
+            # reference CLI-provided vars in the filename.
             substitutions, _ = resolve_include(
-                substitutions, [], ContextVars(), strict_undefined=False
+                substitutions,
+                [],
+                ContextVars(command_line_substitutions or {}),
+                strict_undefined=False,
             )
         if not isinstance(substitutions, dict):
             raise cv.Invalid(

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -414,6 +414,31 @@ def _warn_unresolved_variables(errors: ErrList) -> None:
         )
 
 
+def resolve_substitutions_block(
+    substitutions: Any,
+    command_line_substitutions: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Resolve a deferred ``substitutions: !include file.yaml`` and validate the shape.
+
+    The caller is responsible for wrapping the call in
+    ``cv.prepend_path(CONF_SUBSTITUTIONS)`` for error reporting.
+    ``command_line_substitutions`` seeds the filename context so
+    ``substitutions: !include ${var}.yaml`` can reference CLI-provided vars.
+    """
+    if isinstance(substitutions, IncludeFile):
+        substitutions, _ = resolve_include(
+            substitutions,
+            [],
+            ContextVars(command_line_substitutions or {}),
+            strict_undefined=False,
+        )
+    if not isinstance(substitutions, dict):
+        raise cv.Invalid(
+            f"Substitutions must be a key to value mapping, got {type(substitutions)}"
+        )
+    return substitutions
+
+
 def do_substitution_pass(
     config: OrderedDict, command_line_substitutions: dict[str, Any] | None = None
 ) -> OrderedDict:
@@ -429,20 +454,9 @@ def do_substitution_pass(
     # Use merge_dicts_ordered to preserve OrderedDict type for move_to_end()
     substitutions = config.pop(CONF_SUBSTITUTIONS, {})
     with cv.prepend_path(CONF_SUBSTITUTIONS):
-        if isinstance(substitutions, IncludeFile):
-            # Resolve `substitutions: !include file.yaml` before validating the shape.
-            # Seed with command-line substitutions so `!include ${var}.yaml` can
-            # reference CLI-provided vars in the filename.
-            substitutions, _ = resolve_include(
-                substitutions,
-                [],
-                ContextVars(command_line_substitutions or {}),
-                strict_undefined=False,
-            )
-        if not isinstance(substitutions, dict):
-            raise cv.Invalid(
-                f"Substitutions must be a key to value mapping, got {type(substitutions)}"
-            )
+        substitutions = resolve_substitutions_block(
+            substitutions, command_line_substitutions
+        )
         substitutions = merge_dicts_ordered(
             substitutions, command_line_substitutions or {}
         )

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -429,6 +429,11 @@ def do_substitution_pass(
     # Use merge_dicts_ordered to preserve OrderedDict type for move_to_end()
     substitutions = config.pop(CONF_SUBSTITUTIONS, {})
     with cv.prepend_path(CONF_SUBSTITUTIONS):
+        if isinstance(substitutions, IncludeFile):
+            # Resolve `substitutions: !include file.yaml` before validating the shape.
+            substitutions, _ = resolve_include(
+                substitutions, [], ContextVars(), strict_undefined=False
+            )
         if not isinstance(substitutions, dict):
             raise cv.Invalid(
                 f"Substitutions must be a key to value mapping, got {type(substitutions)}"

--- a/esphome/components/substitutions/__init__.py
+++ b/esphome/components/substitutions/__init__.py
@@ -426,6 +426,9 @@ def resolve_substitutions_block(
     ``substitutions: !include ${var}.yaml`` can reference CLI-provided vars.
     """
     if isinstance(substitutions, IncludeFile):
+        # Single-shot resolution — matches ``_walk_packages`` for the
+        # ``packages: !include`` entry point.  Chained includes (an include that
+        # itself loads another ``!include`` at the top level) are not supported.
         substitutions, _ = resolve_include(
             substitutions,
             [],

--- a/tests/unit_tests/fixtures/substitutions/15-substitutions_as_include.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/15-substitutions_as_include.approved.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wifi_password: sub_password
+wifi:
+  ssid: main_ssid
+  password: sub_password

--- a/tests/unit_tests/fixtures/substitutions/15-substitutions_as_include.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/15-substitutions_as_include.input.yaml
@@ -1,0 +1,5 @@
+substitutions: !include 15-substitutions_inc.yaml
+
+wifi:
+  ssid: main_ssid
+  password: $wifi_password

--- a/tests/unit_tests/fixtures/substitutions/15-substitutions_inc.yaml
+++ b/tests/unit_tests/fixtures/substitutions/15-substitutions_inc.yaml
@@ -1,0 +1,1 @@
+wifi_password: sub_password

--- a/tests/unit_tests/fixtures/substitutions/16-substitutions_as_include_with_packages.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/16-substitutions_as_include_with_packages.approved.yaml
@@ -1,0 +1,5 @@
+substitutions:
+  wifi_password: sub_password
+wifi:
+  ssid: main_ssid
+  password: sub_password

--- a/tests/unit_tests/fixtures/substitutions/16-substitutions_as_include_with_packages.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/16-substitutions_as_include_with_packages.input.yaml
@@ -1,0 +1,9 @@
+substitutions: !include 15-substitutions_inc.yaml
+
+packages:
+  wifi_pkg:
+    wifi:
+      password: $wifi_password
+
+wifi:
+  ssid: main_ssid

--- a/tests/unit_tests/fixtures/substitutions/17-substitutions_include_cli_var.approved.yaml
+++ b/tests/unit_tests/fixtures/substitutions/17-substitutions_include_cli_var.approved.yaml
@@ -1,0 +1,6 @@
+substitutions:
+  subs_file: 15-substitutions_inc
+  wifi_password: sub_password
+wifi:
+  ssid: main_ssid
+  password: sub_password

--- a/tests/unit_tests/fixtures/substitutions/17-substitutions_include_cli_var.input.yaml
+++ b/tests/unit_tests/fixtures/substitutions/17-substitutions_include_cli_var.input.yaml
@@ -1,0 +1,8 @@
+command_line_substitutions:
+  subs_file: 15-substitutions_inc
+
+substitutions: !include ${subs_file}.yaml
+
+wifi:
+  ssid: main_ssid
+  password: $wifi_password

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -675,6 +675,57 @@ def test_include_filename_substitution_undefined_var(tmp_path: Path) -> None:
         substitutions.do_substitution_pass(config)
 
 
+def test_do_substitution_pass_included_substitutions_must_be_mapping(
+    tmp_path: Path,
+) -> None:
+    """`substitutions: !include list.yaml` where the file holds a list raises cv.Invalid.
+
+    Locks in the shape check that runs after the deferred IncludeFile has been
+    resolved.
+    """
+    parent = tmp_path / "main.yaml"
+    parent.write_text("")
+
+    def loader(path: Path):
+        return ["not", "a", "mapping"]
+
+    include = yaml_util.IncludeFile(parent, "subs.yaml", None, loader)
+    config = OrderedDict({CONF_SUBSTITUTIONS: include})
+
+    with pytest.raises(
+        cv.Invalid, match="Substitutions must be a key to value mapping"
+    ):
+        substitutions.do_substitution_pass(config)
+
+
+def test_do_packages_pass_included_substitutions_must_be_mapping(
+    tmp_path: Path,
+) -> None:
+    """`substitutions: !include list.yaml` alongside `packages:` raises cv.Invalid.
+
+    Without the shape check, ``UserDict(...)`` would surface a low-level
+    ``TypeError``; the explicit ``cv.Invalid`` points at the substitutions path.
+    """
+    parent = tmp_path / "main.yaml"
+    parent.write_text("")
+
+    def loader(path: Path):
+        return ["not", "a", "mapping"]
+
+    include = yaml_util.IncludeFile(parent, "subs.yaml", None, loader)
+    config = OrderedDict(
+        {
+            CONF_SUBSTITUTIONS: include,
+            "packages": {"noop": {"wifi": {"ssid": "main"}}},
+        }
+    )
+
+    with pytest.raises(
+        cv.Invalid, match="Substitutions must be a key to value mapping"
+    ):
+        do_packages_pass(config)
+
+
 def test_resolve_package_undefined_var_in_include_filename(tmp_path: Path) -> None:
     """An undefined substitution in a package include filename raises cv.Invalid.
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a regression from #14918 where `substitutions: !include file.yaml` stopped
working because the substitution engine now leaves `!include` as a deferred
`IncludeFile` marker. Both entry points that read `config[CONF_SUBSTITUTIONS]`
choked on it:

- `do_substitution_pass` rejected with
  `Substitutions must be a key to value mapping, got <class 'esphome.helpers.IncludeFile'>`.
- `do_packages_pass` crashed in `UserDict(config.pop(CONF_SUBSTITUTIONS, {}))`
  when both `packages:` and `substitutions: !include` were present.

The fix mirrors the symmetric `packages: !include mypackages.yaml` fix from
#15677 — resolve the `IncludeFile` before the shape check. The
resolve + shape-validation logic is extracted into a shared
`resolve_substitutions_block()` helper in the substitutions module and called
from both passes.

While there:

- The include filename context is seeded from `command_line_substitutions`, so
  `substitutions: !include ${var}.yaml` honors CLI-provided vars the way the
  `packages: !include` path already does.
- `do_packages_pass` raises a clean `cv.Invalid` under `CONF_SUBSTITUTIONS` when
  the resolved include isn't a mapping, instead of surfacing a low-level
  `TypeError` from `UserDict()`.

Fixture-based regression tests added under `tests/unit_tests/fixtures/substitutions/`:

1. `substitutions: !include file.yaml` on its own (fixture 15)
2. `substitutions: !include file.yaml` combined with `packages:` (fixture 16)
3. `substitutions: !include ${cli_var}.yaml` — CLI-templated filename (fixture 17)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15848

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(YAML-level fix — platform-independent. Verified with the ESP8266 minimal repro
from the issue and the nested merge-key workspace layout it describes.)

## Example entry for `config.yaml`:

```yaml
# mydevice.yaml
substitutions: !include components/substitutions.yaml

esphome:
  name: test-device

esp8266:
  board: d1_mini
```

```yaml
# components/substitutions.yaml
<<: !include ../../EHSFONTS/mdi_glyph_substitutions.yaml
user_var: my_value
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).