### PR TITLE
[logger] Add optional CRLF line endings (crlf_line_endings)

### DIFF
--- a/esphome/components/logger/__init__.py
+++ b/esphome/components/logger/__init__.py
@@ -107,6 +107,7 @@ CONF_RUNTIME_TAG_LEVELS = "runtime_tag_levels"
 CONF_TASK_LOG_BUFFER_SIZE = "task_log_buffer_size"
 CONF_WAIT_FOR_CDC = "wait_for_cdc"
 CONF_EARLY_MESSAGE = "early_message"
+CONF_CRLF_LINE_ENDINGS = "crlf_line_endings"
 
 UART_SELECTION_ESP32 = {
     VARIANT_ESP32: [UART0, UART1, UART2],
@@ -325,6 +326,7 @@ CONFIG_SCHEMA = cv.All(
             cv.SplitDefault(CONF_EARLY_MESSAGE, nrf52=False): cv.All(
                 cv.only_on(PLATFORM_NRF52), cv.boolean
             ),
+            cv.Optional(CONF_CRLF_LINE_ENDINGS, default=False): cv.boolean,
         }
     ).extend(cv.COMPONENT_SCHEMA),
     validate_local_no_higher_than_global,
@@ -350,6 +352,8 @@ async def to_code(config: ConfigType) -> None:
     if task_log_buffer_size > 0:
         cg.add_define("USE_ESPHOME_TASK_LOG_BUFFER")
         cg.add_define("ESPHOME_TASK_LOG_BUFFER_SIZE", task_log_buffer_size)
+    if config[CONF_CRLF_LINE_ENDINGS]:
+        cg.add_define("USE_LOGGER_CRLF_LINE_ENDINGS")
     log = cg.new_Pvariable(
         config[CONF_ID],
         baud_rate,

--- a/esphome/components/logger/log_buffer.h
+++ b/esphome/components/logger/log_buffer.h
@@ -40,13 +40,24 @@ struct LogBuffer {
   // Must be called after notify_listeners_() since listeners need null-terminated strings.
   // Console output uses length-based writes (buf.pos), so null terminator is not needed.
   void terminate_with_newline() {
-    if (this->pos < this->size) {
+#ifdef USE_LOGGER_CRLF_LINE_ENDINGS
+    if (this->remaining_() >= 2) {
+      this->data[this->pos++] = '\r';
+      this->data[this->pos++] = '\n';
+    } else if (this->size > 1) {
+      this->data[this->size - 1] = '\n';
+      this->data[this->size - 2] = '\r';
+      this->pos = this->size;
+    }
+#else
+    if (this->remaining_() >= 1) {
       this->data[this->pos++] = '\n';
     } else if (this->size > 0) {
       // Buffer was full - replace last char with newline to ensure it's visible
       this->data[this->size - 1] = '\n';
       this->pos = this->size;
     }
+#endif
   }
   void HOT write_header(uint8_t level, const char *tag, int line, const char *thread_name) {
     // Early return if insufficient space - intentionally don't update pos to prevent partial writes
@@ -101,16 +112,19 @@ struct LogBuffer {
 
     this->pos = p - this->data;
   }
-  void HOT format_body(const char *format, va_list args) {
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+#define VSNPRINTF vsnprintf_P
+#define FORMAT_TYPE PGM_P
+#else
+#define VSNPRINTF vsnprintf
+#define FORMAT_TYPE const char *
+#endif
+
+  void HOT format_body(FORMAT_TYPE format, va_list args) {
     this->format_vsnprintf_(format, args);
     this->finalize_();
   }
-#ifdef USE_STORE_LOG_STR_IN_FLASH
-  void HOT format_body_P(PGM_P format, va_list args) {
-    this->format_vsnprintf_P_(format, args);
-    this->finalize_();
-  }
-#endif
+
   void write_body(const char *text, uint16_t text_length) {
     const uint16_t available = this->remaining_();
     const uint16_t copy_len = (text_length < available) ? text_length : available;
@@ -122,18 +136,19 @@ struct LogBuffer {
   }
 
  private:
-  bool full_() const { return this->pos >= this->size; }
-  uint16_t remaining_() const { return this->size - this->pos; }
+  bool full_() const { return this->pos + ANSI_RESET_LEN >= this->size; }
+  uint16_t remaining_() const { return full_() ? 0 : this->size - this->pos - ANSI_RESET_LEN; }
   char *current_() { return this->data + this->pos; }
   void finalize_() {
     this->write_ansi_reset_();
     // Null terminate
-    this->data[this->full_() ? this->size - 1 : this->pos] = '\0';
+    const bool full = this->pos >= this->size;
+    this->data[full ? this->size - 1 : this->pos] = '\0';
   }
   // Write ANSI reset sequence inline ("\033[0m") - avoids write_() call overhead
   static constexpr uint16_t ANSI_RESET_LEN = 4;  // "\033[0m"
   void write_ansi_reset_() {
-    if (this->remaining_() >= ANSI_RESET_LEN) {
+    if (this->size - this->pos >= ANSI_RESET_LEN) {
       char *p = this->current_();
       *p++ = '\033';
       *p++ = '[';
@@ -142,29 +157,64 @@ struct LogBuffer {
       this->pos += ANSI_RESET_LEN;
     }
   }
-  void strip_trailing_newlines_() {
-    while (this->pos > 0 && this->data[this->pos - 1] == '\n')
-      this->pos--;
-  }
-  void process_vsnprintf_result_(int ret) {
-    if (ret < 0)
-      return;
-    const uint16_t rem = this->remaining_();
-    this->pos += (ret >= rem) ? (rem - 1) : static_cast<uint16_t>(ret);
-    this->strip_trailing_newlines_();
-  }
-  void format_vsnprintf_(const char *format, va_list args) {
+  void format_vsnprintf_(FORMAT_TYPE format, va_list args) {
     if (this->full_())
       return;
-    this->process_vsnprintf_result_(vsnprintf(this->current_(), this->remaining_(), format, args));
-  }
-#ifdef USE_STORE_LOG_STR_IN_FLASH
-  void format_vsnprintf_P_(PGM_P format, va_list args) {
-    if (this->full_())
-      return;
-    this->process_vsnprintf_result_(vsnprintf_P(this->current_(), this->remaining_(), format, args));
-  }
+    // Reserve space for the ANSI reset sequence written by finalize_() after this returns.
+    const uint16_t budget = this->remaining_();
+    if (budget <= 1)
+      return;  // buffer full because there is no space even for null terminator
+    int vsnprintf_result = VSNPRINTF(this->current_(), budget, format, args);
+    const bool error = vsnprintf_result < 0;
+    if (error) {
+      return;  // error in vsnprintf, don't update pos or try to process result
+    }
+    const bool cropped = vsnprintf_result >= budget;
+    uint16_t offset = cropped ? (budget - 1) : static_cast<uint16_t>(vsnprintf_result);
+    if (offset <= 0) {
+      return;  // nothing to append to the buffer; only null terminator
+    }
+    // discard trailing LF (and a preceding CR, so a manually-included trailing "\r\n" is also stripped)
+    while (offset > 0 && this->data[this->pos + offset - 1] == '\n') {
+      offset--;
+#ifdef USE_LOGGER_CRLF_LINE_ENDINGS
+      if (offset > 0 && this->data[this->pos + offset - 1] == '\r')
+        offset--;
 #endif
+    }
+#ifdef USE_LOGGER_CRLF_LINE_ENDINGS
+    // inplace expansion of LF characters into CR+LF; count_chars is capped so that
+    // count_chars + count_lf_chars never exceeds `budget`, discarding trailing chars rather than overflowing the
+    // buffer (this also means we never split a CR+LF pair, since we stop before consuming the LF that wouldn't fit)
+    uint16_t count_lf_chars = 0;
+    uint16_t count_chars = 0;
+    while (count_chars < offset) {
+      const uint16_t i = this->pos + count_chars;
+      const bool is_lone_lf = this->data[i] == '\n' && (i == 0 || this->data[i - 1] != '\r');
+      const uint16_t width_if_consumed = count_chars + count_lf_chars + 1 + (is_lone_lf ? 1 : 0);
+      if (width_if_consumed > budget)
+        break;  // would overflow the reserved space - stop here and discard the rest
+      count_chars++;
+      if (is_lone_lf)
+        count_lf_chars++;
+    }
+    if (count_lf_chars > 0) {
+      uint16_t src = this->pos + count_chars;
+      uint16_t dst = src + count_lf_chars;
+      while (src > this->pos) {
+        const char c = this->data[--src];
+        this->data[--dst] = c;
+        if (c == '\n' && (src == 0 || this->data[src - 1] != '\r')) {
+          this->data[--dst] = '\r';
+        }
+      }
+    }
+    offset = count_chars + count_lf_chars;
+#endif
+    this->pos += offset;
+  }
+#undef VSNPRINTF
+#undef FORMAT_TYPE
   // Extract one decimal digit via subtraction (no division - important for ESP8266)
   static inline void ESPHOME_ALWAYS_INLINE write_digit(char *&p, int &value, int divisor) {
     char d = '0';

--- a/esphome/components/logger/logger.h
+++ b/esphome/components/logger/logger.h
@@ -201,8 +201,11 @@ class Logger final : public Component {
 
   void log_vprintf_(uint8_t level, const char *tag, int line, const char *format, va_list args);  // NOLINT
 #ifdef USE_STORE_LOG_STR_IN_FLASH
+#define PREPARE_FORMAT(format) (reinterpret_cast<PGM_P>(format))
   void log_vprintf_(uint8_t level, const char *tag, int line, const __FlashStringHelper *format,
                     va_list args);  // NOLINT
+#else
+#define PREPARE_FORMAT(format) (format)
 #endif
 
  protected:
@@ -237,23 +240,15 @@ class Logger final : public Component {
 #endif
 
   // Format a log message with printf-style arguments and write it to a buffer with header, footer, and null terminator
+  // Template handles both const char* (RAM) and __FlashStringHelper* (flash) format strings
   // thread_name: name of the calling thread/task, or nullptr for main task (callers already know which task they're on)
-  inline void HOT format_log_to_buffer_with_terminator_(uint8_t level, const char *tag, int line, const char *format,
+  template<typename FormatType>
+  inline void HOT format_log_to_buffer_with_terminator_(uint8_t level, const char *tag, int line, FormatType format,
                                                         va_list args, LogBuffer &buf, const char *thread_name) {
     buf.write_header(level, tag, line, thread_name);
-    buf.format_body(format, args);
+    buf.format_body(PREPARE_FORMAT(format), args);
   }
-
-#ifdef USE_STORE_LOG_STR_IN_FLASH
-  // Format a log message with flash string format and write it to a buffer with header, footer, and null terminator
-  // ESP8266-only (single-task), thread_name is always nullptr
-  inline void HOT format_log_to_buffer_with_terminator_P_(uint8_t level, const char *tag, int line,
-                                                          const __FlashStringHelper *format, va_list args,
-                                                          LogBuffer &buf) {
-    buf.write_header(level, tag, line, nullptr);
-    buf.format_body_P(reinterpret_cast<PGM_P>(format), args);
-  }
-#endif
+#undef PREPARE_FORMAT
 
   // Helper to notify log callbacks
   inline void HOT notify_listeners_(uint8_t level, const char *tag, const LogBuffer &buf) {
@@ -283,14 +278,7 @@ class Logger final : public Component {
                                                   FormatType format, va_list args, const char *thread_name) {
     RecursionGuard guard(recursion_guard);
     LogBuffer buf{this->tx_buffer_, ESPHOME_LOGGER_TX_BUFFER_SIZE};
-#ifdef USE_STORE_LOG_STR_IN_FLASH
-    if constexpr (std::is_same_v<FormatType, const __FlashStringHelper *>) {
-      this->format_log_to_buffer_with_terminator_P_(level, tag, line, format, args, buf);
-    } else
-#endif
-    {
-      this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, buf, thread_name);
-    }
+    { this->format_log_to_buffer_with_terminator_(level, tag, line, format, args, buf, thread_name); }
     this->notify_listeners_(level, tag, buf);
     this->write_log_buffer_to_console_(buf);
   }
@@ -361,6 +349,9 @@ class Logger final : public Component {
   bool main_task_recursion_guard_{false};
 #ifdef USE_LIBRETINY
   bool non_main_task_recursion_guard_{false};  // Shared guard for all non-main tasks on LibreTiny
+#endif
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  bool global_recursion_guard_{false};  // Simple global recursion guard for single-task platforms
 #endif
 #else
   bool global_recursion_guard_{false};                    // Simple global recursion guard for single-task platforms

--- a/tests/components/logger/log_buffer.cpp
+++ b/tests/components/logger/log_buffer.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+#include "esphome/components/logger/log_buffer.h"
+#include "esphome/components/logger/logger.h"
+#include <cstdarg>
+#include <cstring>
+#include <memory>
+#include <string>
+
+namespace esphome::logger::testing {
+
+#ifdef USE_LOGGER_CRLF_LINE_ENDINGS
+#define LINE_ENDING "\r\n"
+#else
+#define LINE_ENDING "\n"
+#endif
+
+#define LF "\n"
+#define ANSI_RESET "\x1B[0m"
+#define HEADER "\x1B[1;31m[E][TestTag:042]\x1B[1;31m[TestThread]\x1B[1;31m: "
+
+static void reset_flash_format_call_flag_if_applicable() {
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  vsnprintf_P_called = false;
+#endif
+}
+
+static bool was_flash_format_called_if_applicable() {
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  return vsnprintf_P_called;
+#else
+  return true;
+#endif
+}
+
+template<typename FormatType>
+void write_to_log_buffer(uint8_t level, const char *tag, int line, LogBuffer &buf, const char *thread_name,
+                         FormatType format, ...) {
+  va_list arg;
+  va_start(arg, format);
+  buf.write_header(level, tag, line, thread_name);
+  buf.format_body(format, arg);
+  va_end(arg);
+  buf.terminate_with_newline();
+}
+
+static void write_fixed_test_message(LogBuffer &buf, const char *msg) {
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+  write_to_log_buffer(1, "TestTag", 42, buf, "TestThread", (PGM_P) msg);
+#else
+  write_to_log_buffer(1, "TestTag", 42, buf, "TestThread", msg);
+#endif
+}
+
+LogBuffer create_test_log_buffer(uint16_t internal_size) {
+  // Intentionally leaked: the buffer must outlive this function and is only used for the duration of the test.
+  auto tx_buffer = std::make_unique<char[]>(internal_size + 1);  // +1 for null terminator
+  LogBuffer buf{tx_buffer.release(), internal_size};
+  return buf;
+}
+
+static constexpr const char *TEST_GENERATION_PARAMS[] = {"a" LINE_ENDING "aa", "b\r\nbb", "ccc"};
+
+class LogBufferTest : public ::testing::TestWithParam<const char *> {};
+
+TEST_P(LogBufferTest, TestDifferentStrings) {
+  // given
+  reset_flash_format_call_flag_if_applicable();
+  auto buf = create_test_log_buffer(1000);
+  const auto *msg = GetParam();
+
+  // when
+  write_fixed_test_message(buf, msg);
+
+  // then
+  auto expected_msg = std::string(HEADER) + std::string(msg) + std::string(ANSI_RESET LINE_ENDING);
+  EXPECT_EQ(buf.pos, expected_msg.length());
+  EXPECT_EQ(std::string(buf.data, buf.pos), expected_msg);
+  EXPECT_TRUE(was_flash_format_called_if_applicable());
+}
+
+TEST(LogBufferTest, HeaderDoesNotFit) {
+  // given
+  reset_flash_format_call_flag_if_applicable();
+  auto buf = create_test_log_buffer(50);
+  const auto *msg = "Test 1234" LINE_ENDING "haha";
+
+  // when
+  write_fixed_test_message(buf, msg);
+
+  // then
+  auto expected_msg = std::string(msg) + std::string(ANSI_RESET) + std::string(LINE_ENDING);
+  EXPECT_EQ(buf.pos, expected_msg.length());
+  EXPECT_EQ(std::string(buf.data, buf.pos), expected_msg);
+  EXPECT_TRUE(was_flash_format_called_if_applicable());
+}
+
+TEST(LogBufferTest, ManyNewlines) {
+  // given
+  reset_flash_format_call_flag_if_applicable();
+  // Buffer large enough to hold the fully CRLF-expanded message with no truncation.
+  auto buf = create_test_log_buffer(128 + 30);
+#define NINE_LFS LF LF LF LF LF LF LF LF LF
+#define NINE_LINE_ENDINGS \
+  LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING LINE_ENDING
+  // The source message always contains raw "\n" - CRLF expansion (if enabled) happens inside format_body().
+  const auto *msg = "asdfasdfasdfasdfasdfasdfasdfasdfa1dfasdfasdfas2fasddfasdfas3fasd" NINE_LFS "haha";
+
+  // when
+  write_fixed_test_message(buf, msg);
+
+  // then
+  auto expected_msg =
+      std::string(HEADER "asdfasdfasdfasdfasdfasdfasdfasdfa1dfasdfasdfas2fasddfasdfas3fasd" NINE_LINE_ENDINGS
+                         "haha\x1B[0m" LINE_ENDING);
+  EXPECT_EQ(buf.pos, expected_msg.length());
+  EXPECT_EQ(std::string(buf.data, buf.pos), expected_msg);
+  EXPECT_TRUE(was_flash_format_called_if_applicable());
+}
+
+//"string with " LF " and " LF "ending with " LF
+
+// Regression test: an undersized buffer with many embedded newlines must not overflow past `size`,
+// even though CRLF expansion needs extra bytes beyond what vsnprintf wrote.
+TEST(LogBufferTest, ManyNewlinesTruncatedWhenBufferTooSmall) {
+  reset_flash_format_call_flag_if_applicable();
+  auto buf = create_test_log_buffer(128 + 5);  // deliberately too small to fit all 9 expanded newlines
+  const auto *msg = "asdfasdfasdfasdfasdfasdfasdfasdfa1dfasdfasdfas2fasddfasdfas3fasd" NINE_LFS "haha";
+
+  write_fixed_test_message(buf, msg);
+
+  EXPECT_LE(buf.pos, buf.size);
+  EXPECT_TRUE(was_flash_format_called_if_applicable());
+}
+
+// Regression test: when the header doesn't fit (pos stays 0) and the message body consists solely of
+// newlines longer than the buffer, the trailing-newline-discard loop must not read before `data[0]`.
+TEST(LogBufferTest, AllNewlinesWithoutHeaderDoesNotUnderflow) {
+  reset_flash_format_call_flag_if_applicable();
+  auto buf = create_test_log_buffer(10);                  // too small for the header -> pos stays 0
+  const auto *msg = LF LF LF LF LF LF LF LF LF LF LF LF;  // more LFs than the buffer can hold
+
+  write_fixed_test_message(buf, msg);
+
+  EXPECT_LE(buf.pos, buf.size);
+  EXPECT_TRUE(was_flash_format_called_if_applicable());
+}
+
+INSTANTIATE_TEST_SUITE_P(MyTest, LogBufferTest, ::testing::ValuesIn(TEST_GENERATION_PARAMS));
+
+}  // namespace esphome::logger::testing

--- a/tests/components/logger/logger.cpp
+++ b/tests/components/logger/logger.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+#include "esphome/components/logger/logger.h"
+#include <cstdarg>
+#include <string>
+
+namespace esphome::logger::testing {
+
+void start_stdout_capture() { ::testing::internal::CaptureStdout(); }
+
+std::string stop_stdout_capture() { return ::testing::internal::GetCapturedStdout(); }
+
+template<typename FormatType>
+void test_esp_log_printf(uint8_t level, const char *tag, int line, Logger &logger, const char *thread_name,
+                         FormatType format, ...) {
+  va_list arg;
+  va_start(arg, format);
+  logger.log_vprintf_(level, tag, line, format, arg);
+  va_end(arg);
+}
+
+#ifdef USE_LOGGER_CRLF_LINE_ENDINGS
+
+TEST(LoggerTest, LoggerTestWithCrlf) {
+  auto *log = new logger::Logger(115200);  // NOLINT
+  start_stdout_capture();
+  test_esp_log_printf(1, "TestTag", 42, *log, "TestThread", "Test %d\nhaha", 1234);
+  const std::string captured_output = stop_stdout_capture();
+  EXPECT_NE(captured_output.find("[E][TestTag:042]"), std::string::npos);
+  EXPECT_NE(captured_output.find("Test 1234\r\nhaha"), std::string::npos);
+}
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+TEST(LoggerTest, LoggerTestWithCrlfInFlash) {
+  vsnprintf_P_called = false;
+  auto *log = new logger::Logger(115200);  // NOLINT
+  start_stdout_capture();
+  test_esp_log_printf(1, "TestTag2", 42, *log, "TestThread2", (__FlashStringHelper *) "Test2 %d\nhaha", 1234);
+  const std::string captured_flash_output = stop_stdout_capture();
+  EXPECT_NE(captured_flash_output.find("[E][TestTag2:042]"), std::string::npos);
+  EXPECT_NE(captured_flash_output.find("Test2 1234\r\nhaha"), std::string::npos);
+  EXPECT_TRUE(vsnprintf_P_called);
+}
+#endif
+#else
+TEST(LogBufferTest, LoggerTestWithLf) {
+  auto *log = new logger::Logger(115200);  // NOLINT
+  start_stdout_capture();
+  test_esp_log_printf(1, "TestTag", 42, *log, "TestThread", "Test %d\nhaha", 1234);
+  const std::string captured_output = stop_stdout_capture();
+  EXPECT_NE(captured_output.find("[E][TestTag:042]"), std::string::npos);
+  EXPECT_NE(captured_output.find("Test 1234\nhaha"), std::string::npos);
+}
+#ifdef USE_STORE_LOG_STR_IN_FLASH
+TEST(LoggerTest, LoggerTestWithLfInFlash) {
+  vsnprintf_P_called = false;
+  auto *log = new logger::Logger(115200);  // NOLINT
+  start_stdout_capture();
+  test_esp_log_printf(1, "TestTag2", 42, *log, "TestThread2", (__FlashStringHelper *) "Test2 %d\nhaha", 1234);
+  const std::string captured_flash_output = stop_stdout_capture();
+  EXPECT_NE(captured_flash_output.find("[E][TestTag2:042]"), std::string::npos);
+  EXPECT_NE(captured_flash_output.find("Test2 1234\nhaha"), std::string::npos);
+  EXPECT_TRUE(vsnprintf_P_called);
+}
+#endif
+#endif
+
+}  // namespace esphome::logger::testing

--- a/tests/components/logger/test-crlf_line_endings.esp32_idf.yaml
+++ b/tests/components/logger/test-crlf_line_endings.esp32_idf.yaml
@@ -1,0 +1,5 @@
+<<: !include common-default_uart.yaml
+
+logger:
+  id: logger_id
+  crlf_line_endings: true


### PR DESCRIPTION
Some terminals do not properly handle LF-only output, resulting in misaligned ("staircase") logs.

# What does this implement/fix?

Add optional CRLF line endings to improve compatibility with such environments.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature:**

- [esphome/discussions/3624](https://github.com/orgs/esphome/discussions/3624)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation :**

- esphome/esphome-docs#6482

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
logger:
  crlf_line_endings: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
