### PR TITLE
[sdm_meter] Allow splitting bulk register read into chunks

### DIFF
--- a/esphome/components/sdm_meter/sdm_meter.cpp
+++ b/esphome/components/sdm_meter/sdm_meter.cpp
@@ -9,14 +9,70 @@ namespace sdm_meter {
 static const char *const TAG = "sdm_meter";
 
 static const uint8_t MODBUS_CMD_READ_IN_REGISTERS = 0x04;
-static const uint8_t MODBUS_REGISTER_COUNT = 80;  // 74 x 16-bit registers
+static const uint16_t MODBUS_REGISTER_COUNT = 80;  // 40 x FP32 registers (0x00..0x4F)
+
+void SDMMeter::loop() {
+  // If update() was unable to send we retry until we can send.
+  if (!this->waiting_to_update_)
+    return;
+  this->update();
+}
+
+void SDMMeter::update() {
+  // The bus might be slow, or there might be other devices, or other components might be talking to our device.
+  if (!this->ready_for_immediate_send()) {
+    this->waiting_to_update_ = true;
+    return;
+  }
+  this->waiting_to_update_ = false;
+
+  if (this->polling_) {
+    ESP_LOGW(TAG, "Previous poll incomplete (stuck at chunk 0x%04X) - restarting", this->next_chunk_start_);
+  }
+  this->polling_ = true;
+  this->next_chunk_start_ = 0;
+  this->chunk_buffer_.assign(MODBUS_REGISTER_COUNT * 2, 0);
+  const uint16_t first_count = (this->chunk_size_ < MODBUS_REGISTER_COUNT) ? this->chunk_size_ : MODBUS_REGISTER_COUNT;
+  this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, first_count);
+}
 
 void SDMMeter::on_modbus_data(const std::vector<uint8_t> &data) {
-  if (data.size() < MODBUS_REGISTER_COUNT * 2) {
-    ESP_LOGW(TAG, "Invalid size for SDMMeter!");
+  if (!this->polling_) {
+    ESP_LOGW(TAG, "Received modbus data while not polling - ignoring");
     return;
   }
 
+  const uint16_t pending_count = ((MODBUS_REGISTER_COUNT - this->next_chunk_start_) < this->chunk_size_)
+                                     ? (MODBUS_REGISTER_COUNT - this->next_chunk_start_)
+                                     : this->chunk_size_;
+  const size_t expected = static_cast<size_t>(pending_count) * 2;
+  if (data.size() != expected) {
+    ESP_LOGW(TAG, "Chunk size mismatch at register 0x%04X: got %u expected %u - aborting this poll",
+             this->next_chunk_start_, static_cast<unsigned>(data.size()), static_cast<unsigned>(expected));
+    this->polling_ = false;
+    return;
+  }
+
+  const size_t offset = static_cast<size_t>(this->next_chunk_start_) * 2;
+  std::copy(data.begin(), data.end(), this->chunk_buffer_.begin() + offset);
+
+  this->next_chunk_start_ += this->chunk_size_;
+
+  // Compute size of next chunk, clamped so we don't over-read past MODBUS_REGISTER_COUNT.
+  const uint16_t remaining =
+      (this->next_chunk_start_ < MODBUS_REGISTER_COUNT) ? (MODBUS_REGISTER_COUNT - this->next_chunk_start_) : 0;
+  const uint16_t this_count = (remaining < this->chunk_size_) ? remaining : this->chunk_size_;
+
+  if (this_count > 0) {
+    this->send(MODBUS_CMD_READ_IN_REGISTERS, this->next_chunk_start_, this_count);
+    return;
+  }
+
+  this->polling_ = false;
+  this->publish_all_(this->chunk_buffer_);
+}
+
+void SDMMeter::publish_all_(const std::vector<uint8_t> &data) {
   auto sdm_meter_get_float = [&](size_t i) -> float {
     uint32_t temp = encode_uint32(data[i], data[i + 1], data[i + 2], data[i + 3]);
     float f;
@@ -83,12 +139,13 @@ void SDMMeter::on_modbus_data(const std::vector<uint8_t> &data) {
     this->export_reactive_energy_sensor_->publish_state(export_reactive_energy);
 }
 
-void SDMMeter::update() { this->send(MODBUS_CMD_READ_IN_REGISTERS, 0, MODBUS_REGISTER_COUNT); }
 void SDMMeter::dump_config() {
+  const uint16_t chunks = (MODBUS_REGISTER_COUNT + this->chunk_size_ - 1) / this->chunk_size_;
   ESP_LOGCONFIG(TAG,
                 "SDM Meter:\n"
-                "  Address: 0x%02X",
-                this->address_);
+                "  Address: 0x%02X\n"
+                "  Chunk size: %u registers (%u request%s per poll)",
+                this->address_, this->chunk_size_, chunks, chunks == 1 ? "" : "s");
   for (uint8_t i = 0; i < 3; i++) {
     auto phase = this->phases_[i];
     if (!phase.setup)

--- a/esphome/components/sdm_meter/sdm_meter.h
+++ b/esphome/components/sdm_meter/sdm_meter.h
@@ -54,6 +54,10 @@ class SDMMeter : public PollingComponent, public modbus::ModbusDevice {
     this->export_reactive_energy_sensor_ = export_reactive_energy_sensor;
   }
 
+  void set_chunk_size(uint8_t chunk_size) { this->chunk_size_ = chunk_size; }
+
+  void loop() override;
+
   void update() override;
 
   void on_modbus_data(const std::vector<uint8_t> &data) override;
@@ -61,6 +65,8 @@ class SDMMeter : public PollingComponent, public modbus::ModbusDevice {
   void dump_config() override;
 
  protected:
+  void publish_all_(const std::vector<uint8_t> &data);
+
   struct SDMPhase {
     bool setup{false};
     sensor::Sensor *voltage_sensor_{nullptr};
@@ -77,6 +83,12 @@ class SDMMeter : public PollingComponent, public modbus::ModbusDevice {
   sensor::Sensor *export_active_energy_sensor_{nullptr};
   sensor::Sensor *import_reactive_energy_sensor_{nullptr};
   sensor::Sensor *export_reactive_energy_sensor_{nullptr};
+
+  std::vector<uint8_t> chunk_buffer_;
+  uint16_t next_chunk_start_{0};
+  uint8_t chunk_size_{80};
+  bool polling_{false};
+  bool waiting_to_update_{false};
 };
 
 }  // namespace sdm_meter

--- a/esphome/components/sdm_meter/sensor.py
+++ b/esphome/components/sdm_meter/sensor.py
@@ -42,6 +42,8 @@ from esphome.const import (
     UNIT_WATT,
 )
 
+CONF_CHUNK_SIZE = "chunk_size"
+
 AUTO_LOAD = ["modbus"]
 CODEOWNERS = ["@polyfaces", "@jesserockz"]
 
@@ -138,6 +140,7 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=2,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
+            cv.Optional(CONF_CHUNK_SIZE, default=80): cv.int_range(min=1, max=80),
         }
     )
     .extend(cv.polling_component_schema("10s"))
@@ -149,6 +152,8 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await modbus.register_modbus_device(var, config)
+
+    cg.add(var.set_chunk_size(config[CONF_CHUNK_SIZE]))
 
     if CONF_TOTAL_POWER in config:
         sens = await sensor.new_sensor(config[CONF_TOTAL_POWER])

--- a/tests/components/sdm_meter/common.yaml
+++ b/tests/components/sdm_meter/common.yaml
@@ -1,6 +1,7 @@
 sensor:
   - platform: sdm_meter
     modbus_id: modbus_bus
+    chunk_size: 16
     phase_a:
       current:
         name: Phase A Current


### PR DESCRIPTION
### What does this PR do?

Adds an optional `chunk_size:` YAML key to the `sdm_meter` platform. When set, the component splits the 80-register `FC04` bulk read into smaller N-register requests, accumulates them in memory, and publishes sensors only after all chunks arrive.

Default is `80` — identical to the existing single-request behaviour. Users who hit the meter-firmware quirks described below opt in with e.g. `chunk_size: 16`.

Also adopts the `ready_for_immediate_send()` guard pattern from `growatt_solar`, so `update()` defers the poll cycle to the next `loop()` tick when the modbus bus is busy instead of stepping on an in-flight transaction.

### Why?

Some SDM meter firmwares (reproducibly on an SDM630-Modbus V2 ) have two independent quirks that the existing single-request path cannot work around:

1. **Response truncation.** The meter transmits the data payload correctly but stops before the 2 trailing CRC bytes — or, with larger reads (>16 registers), also truncates data bytes. Observed ceiling is around 119 bytes on the wire; the missing tail arrives as the leading bytes of the *next* poll, corrupting every subsequent cycle.
2. **Small-read semantics change.** For reads of ≤4 registers, the same meter returns phantom/wrong values on registers `0x00–0x07`. Splitting into e.g. `count=1` requests doesn't work either.

Splitting the read into 16-register chunks (32-byte payload, 37-byte response) sits under the truncation ceiling *and* above the small-read semantic-change threshold, so values decode correctly.

### Default-path backward compatibility

With `chunk_size` unset (the default, `80`), the behaviour is byte-for-byte identical to before:
- `update()` calls `send(FC04, 0, 80)` once.
- `on_modbus_data` receives 160 bytes, validates length, and publishes — same control flow as the pre-patch code, just routed through the chunk accumulator which is a no-op on a single chunk.

No user of a well-behaved SDM meter needs to change anything.

### Scope — standalone, not bundled

This PR is intentionally small and self-contained. It only touches `sdm_meter` (one component, one sensor platform; CODEOWNERS are @polyfaces and @jesserockz)

On the SDM630 firmware I tested, three additional quirks outside this component also needed to be handled — response truncation, inter-burst gaps, and missing trailing CRC bytes. Those are fixed in the `modbus` component on a separate fork branch and will be proposed as their own independent PRs *later*, once community testing against other modbus integrations (shelly_dimmer, sungrow_solar, growatt_solar, and so on) has exercised them on non-SDM hardware.

This PR does **not** depend on those: `chunk_size` is strictly additive and useful in isolation for any meter that has a smaller TX ceiling than the full 160-byte response, regardless of CRC behaviour.

### API

```yaml
sensor:
  - platform: sdm_meter
    chunk_size: 16          # NEW — optional, default 80
    phase_a:
      voltage:
        name: "SDM630 Phase A Voltage"
      # ... existing options unchanged
```

Range: `1 ≤ chunk_size ≤ 80`.

### Implementation notes

- State added: `chunk_buffer_` (160-byte accumulator), `next_chunk_start_`, `chunk_size_`, `polling_`, `waiting_to_update_`.
- `polling_` guards against overlapping polls: if `update()` fires while a previous cycle is in flight, the old cycle aborts (`ESP_LOGW`) and restarts. Should not happen with reasonable `update_interval` + `send_wait_time`, but defensive.
- Chunk-size mismatch in `on_modbus_data` → poll aborted, no partial publish (prevents mixing fresh values in some registers with stale values in others).
- `loop()` override is minimal: early-returns unless `waiting_to_update_` is set. No measurable overhead on the hot path.

### Testing

- Hardware: SDM630-Modbus V2 + ESP32 + MAX485, `chunk_size: 16`, alongside the three companion modbus fork-branch changes. Running continuously since 2026-04-17 on an always-on node. All 27 sensors (V/I/P/S/Q/PF/angle per phase + total power + frequency + 4 energy counters) publish every 30 s. Zero CRC-fail warnings, zero partial-response timeouts, zero value shifts.
- Stock path: compiled with `chunk_size` unset (default 80), same YAML against a clean ESPHome `dev`, compiles identically to the pre-patch component. No behaviour diff without the opt-in.
- Integration test YAML at `tests/components/sdm_meter/common.yaml` updated to set `chunk_size: 16` so CI exercises the new option.

### Docs

Companion docs PR: esphome/esphome-docs#6484 — adds the `chunk_size` bullet under "Configuration variables" on `src/content/docs/components/sensor/sdm_meter.mdx`.

### Checklist

- [x] Builds locally against `esphome/dev` with `esphome compile`.
- [x] Preserves stock behaviour with `chunk_size` unset (default 80).
- [x] Integration test YAML exercises the new key.
- [x] Commit message follows `[sdm_meter] …` convention.
- [x] Docs PR filed: esphome/esphome-docs#6484.
- [ ] `script/clang-format` / `script/clang-tidy` / `script/ci-custom.py` — clang-format applied locally with v22 (ESPHome CI uses v13, minor whitespace fixes may autofix). Other scripts I'll re-run via Docker (`ghcr.io/esphome/esphome-lint`) if CI flags anything.
