### PR TITLE
[modbus] Resynchronise rx buffer past leading junk bytes

### DIFF
--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -108,30 +108,70 @@ void Modbus::receive_and_parse_modbus_bytes_() {
                   millis() - this->last_send_);
       }
 
-      // If the bytes in the rx buffer do not parse, clear out the buffer
-      if (!this->parse_modbus_byte_(buf[i])) {
-        this->clear_rx_buffer_(LOG_STR("parse failed"), true);
-      }
+      // parse_modbus_byte_ is responsible for resynchronising the buffer on CRC failure, so it
+      // always returns true and we never clear the buffer here.
+      this->parse_modbus_byte_(buf[i]);
       this->last_modbus_byte_ = millis();
     }
   }
 }
 
 bool Modbus::parse_modbus_byte_(uint8_t byte) {
-  size_t at = this->rx_buffer_.size();
+  // Append the new byte and try to parse a frame from the front of rx_buffer_.
+  // We resynchronise past any leading junk so the parser can recover from e.g. stale bytes
+  // from a late-arriving previous response, or direction-switch noise from some RS485
+  // transceiver modules, without waiting for the receive timeout.
+  //
+  // Two resync mechanisms cooperate:
+  //
+  // 1. CLIENT fast-path: while a response is pending (waiting_for_response_ != 0), any byte at
+  //    the front of rx_buffer_ that doesn't match the expected device address is dropped
+  //    immediately. This avoids the trap where junk byte 1 looks like a function code and
+  //    junk byte 2 looks like a large payload length, causing the parser to swallow the real
+  //    frame as "payload" without ever reaching a CRC check.
+  //
+  // 2. BAD_FRAME drop-one-byte retry: if try_parse_rx_buffer_ reaches a CRC check and it
+  //    fails, we drop byte 0 and retry. This handles junk that happens to begin with the
+  //    expected address by coincidence.
   this->rx_buffer_.push_back(byte);
-  const uint8_t *raw = &this->rx_buffer_[0];
+  while (!this->rx_buffer_.empty()) {
+    if (this->role == ModbusRole::CLIENT) {
+      // No request pending — any byte arriving in the buffer is unsolicited noise
+      // (typically the trailing byte of RS485 direction-switch on some transceivers).
+      // Dropping here avoids the "timeout after partial response" warning that would
+      // otherwise fire when the stray byte sits in the buffer until frame_delay expires.
+      if (this->waiting_for_response_ == 0) {
+        ESP_LOGV(TAG, "Resync: dropping 0x%02X (no request pending)", this->rx_buffer_[0]);
+        this->rx_buffer_.erase(this->rx_buffer_.begin());
+        continue;
+      }
+      // Request pending — drop bytes that don't match the awaited device address.
+      if (this->rx_buffer_[0] != this->waiting_for_response_) {
+        ESP_LOGV(TAG, "Resync: dropping 0x%02X (waiting for address 0x%02X)", this->rx_buffer_[0],
+                 this->waiting_for_response_);
+        this->rx_buffer_.erase(this->rx_buffer_.begin());
+        continue;
+      }
+    }
+    const ParseResult result = this->try_parse_rx_buffer_();
+    if (result == ParseResult::NEEDS_MORE_BYTES || result == ParseResult::FRAME_PROCESSED) {
+      return true;
+    }
+    // BAD_FRAME: drop the first byte and retry parsing from the new front.
+    ESP_LOGV(TAG, "Resync: dropping byte 0x%02X after CRC fail, %zu bytes remain", this->rx_buffer_[0],
+             this->rx_buffer_.size() - 1);
+    this->rx_buffer_.erase(this->rx_buffer_.begin());
+  }
+  return true;
+}
 
-  // Byte 0: modbus address (match all)
-  if (at == 0)
-    return true;
-  // Byte 1: function code
-  if (at == 1)
-    return true;
-  // Byte 2: Size (with modbus rtu function code 4/3)
-  // See also https://en.wikipedia.org/wiki/Modbus
-  if (at == 2)
-    return true;
+Modbus::ParseResult Modbus::try_parse_rx_buffer_() {
+  const size_t size = this->rx_buffer_.size();
+  // Byte 0: modbus address, byte 1: function code, byte 2: size (for read registers).
+  if (size < 3) {
+    return ParseResult::NEEDS_MORE_BYTES;
+  }
+  const uint8_t *raw = this->rx_buffer_.data();
 
   uint8_t address = raw[0];
   uint8_t function_code = raw[1];
@@ -149,15 +189,17 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     // installed, but wait, there is the CRC, and if we get a hit there is a good
     // chance that this is a complete message ... admittedly there is a small chance is
     // isn't but that is quite small given the purpose of the CRC in the first place
-
-    data_len = at - 2;
     data_offset = 1;
+    data_len = size - data_offset - 2;
 
     uint16_t computed_crc = crc16(raw, data_offset + data_len);
     uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
 
-    if (computed_crc != remote_crc)
-      return true;
+    if (computed_crc != remote_crc) {
+      // For user-defined functions the frame length is discovered by searching for a matching CRC;
+      // keep accumulating bytes until either the CRC matches or the frame-delay timeout fires.
+      return ParseResult::NEEDS_MORE_BYTES;
+    }
 
     ESP_LOGD(TAG, "User-defined function %02X found", function_code);
 
@@ -172,8 +214,8 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
         data_offset = 2;
         data_len = 4;
       } else if (function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
-        if (at < 6) {
-          return true;
+        if (size < 7) {
+          return ParseResult::NEEDS_MORE_BYTES;
         }
         data_offset = 2;
         // starting address (2 bytes) + quantity of registers (2 bytes) + byte count itself (1 byte) + actual byte count
@@ -197,15 +239,11 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
       data_len = 1;
     }
 
-    // Byte data_offset..data_offset+data_len-1: Data
-    if (at < data_offset + data_len)
-      return true;
+    // Need header + data + 2 CRC bytes before we can validate.
+    if (size < static_cast<size_t>(data_offset) + data_len + 2) {
+      return ParseResult::NEEDS_MORE_BYTES;
+    }
 
-    // Byte 3+data_len: CRC_LO (over all bytes)
-    if (at == data_offset + data_len)
-      return true;
-
-    // Byte data_offset+len+1: CRC_HI (over all bytes)
     uint16_t computed_crc = crc16(raw, data_offset + data_len);
     uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
     if (computed_crc != remote_crc) {
@@ -216,14 +254,17 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
 #endif
         ESP_LOGVV(TAG, "  (%02X != %02X)  %s", computed_crc, remote_crc,
                   format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
+        // Fall through: user has opted into accepting mismatched frames, publish the data.
       } else {
-        ESP_LOGW(TAG, "CRC check failed %" PRIu32 "ms after last send", millis() - this->last_send_);
+        // Demoted to VERBOSE because resync will typically fire on every poll on a lossy bus
+        // and we don't want to flood the log. The hex dump stays at VERY_VERBOSE.
+        ESP_LOGV(TAG, "CRC check failed %" PRIu32 "ms after last send", millis() - this->last_send_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
         char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
 #endif
         ESP_LOGVV(TAG, "  (%02X != %02X) %s", computed_crc, remote_crc,
                   format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
-        return false;
+        return ParseResult::BAD_FRAME;
       }
     }
   }
@@ -269,7 +310,10 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   }
 
   if (!found && this->role == ModbusRole::CLIENT) {
-    ESP_LOGW(TAG, "Got frame from unknown address %" PRIu8 ", %" PRIu32 "ms after last send", address,
+    // Demoted to DEBUG: with byte-walking resync, junk bytes can very occasionally CRC-match an
+    // unconfigured address. A legitimate unknown-address frame is still surfaced at DEBUG and
+    // users investigating bus setup will see it at that level.
+    ESP_LOGD(TAG, "Got frame from unknown address %" PRIu8 ", %" PRIu32 "ms after last send", address,
              millis() - this->last_send_);
   }
 
@@ -278,7 +322,7 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   if (this->waiting_for_response_ == address)
     this->waiting_for_response_ = 0;
 
-  return true;
+  return ParseResult::FRAME_PROCESSED;
 }
 
 void Modbus::send_next_frame_() {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -63,7 +63,14 @@ class Modbus : public uart::UARTDevice, public Component {
   ModbusRole role;
 
  protected:
+  enum class ParseResult {
+    NEEDS_MORE_BYTES,  // not enough bytes in rx_buffer_ yet, wait for more
+    FRAME_PROCESSED,   // a valid frame was parsed and rx_buffer_ was cleared
+    BAD_FRAME,         // CRC failed for a fixed-length frame; caller should drop 1 byte and retry
+  };
+
   bool parse_modbus_byte_(uint8_t byte);
+  ParseResult try_parse_rx_buffer_();
   void receive_and_parse_modbus_bytes_();
   void clear_rx_buffer_(const LogString *reason, bool warn = false);
   void send_next_frame_();

--- a/tests/components/modbus/modbus_test.cpp
+++ b/tests/components/modbus/modbus_test.cpp
@@ -14,8 +14,14 @@ class TestModbus : public Modbus {
 
 class MockDevice : public ModbusDevice {
  public:
-  void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_received = true; }
+  void on_modbus_data(const std::vector<uint8_t> &data) override {
+    this->data_received = true;
+    this->call_count++;
+    this->last_data = data;
+  }
   bool data_received{false};
+  uint32_t call_count{0};
+  std::vector<uint8_t> last_data;
 };
 
 TEST(ModbusTest, TwoByteRegressionTest) {
@@ -54,6 +60,129 @@ TEST(ModbusTest, TestValidFrame) {
     EXPECT_TRUE(result) << "Failed at byte " << i << " (0x" << std::hex << (int) frame[i] << ")";
   }
   EXPECT_TRUE(device.data_received);
+}
+
+// Build a valid Modbus RTU response frame (address | function | byte_count | payload | CRC).
+static std::vector<uint8_t> make_valid_response_frame() {
+  uint8_t frame_data[] = {0x01, 0x03, 0x02, 0x12, 0x34};
+  uint16_t crc = esphome::crc16(frame_data, sizeof(frame_data));
+  std::vector<uint8_t> frame;
+  for (uint8_t b : frame_data)
+    frame.push_back(b);
+  frame.push_back(crc & 0xFF);
+  frame.push_back((crc >> 8) & 0xFF);
+  return frame;
+}
+
+// Feeds a byte stream into the parser and asserts the mock device received the expected frame
+// exactly once, regardless of any junk prepended to it.
+static void feed_and_expect_one_valid_frame(TestModbus &modbus, MockDevice &device,
+                                            const std::vector<uint8_t> &stream) {
+  for (size_t i = 0; i < stream.size(); i++) {
+    EXPECT_TRUE(modbus.test_parse_modbus_byte(stream[i]))
+        << "Parser returned false at byte " << i << " (0x" << std::hex << (int) stream[i] << ")";
+  }
+  EXPECT_TRUE(device.data_received);
+  EXPECT_EQ(device.call_count, 1u);
+  // Payload is the 2 data bytes from make_valid_response_frame().
+  ASSERT_EQ(device.last_data.size(), 2u);
+  EXPECT_EQ(device.last_data[0], 0x12);
+  EXPECT_EQ(device.last_data[1], 0x34);
+}
+
+// Regression test: a single junk byte before a valid frame must be walked past.
+TEST(ModbusTest, ResyncAfterSingleJunkByte) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  std::vector<uint8_t> stream = {0xFF};  // single junk byte
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Real-world case: an 8-byte junk prefix (modelled on the SDM630 + MAX485 direction-switch
+// artifact observed on actual hardware) must be walked past to reach the valid frame behind it.
+TEST(ModbusTest, ResyncAfterEightByteJunkPrefix) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // Observed prefix shape from a real RS485 bus: arbitrary bytes that the naive parser
+  // interpreted as a malformed frame (bytes with MSB set look like exception responses).
+  std::vector<uint8_t> stream = {0xEE, 0xA1, 0xEC, 0xA4, 0x30, 0xD7, 0x00, 0x00};
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Adversarial case: a junk prefix that itself forms a well-formed 5-byte exception response
+// from an unregistered address (0x42) with a valid CRC. The CLIENT fast-path is waiting for
+// 0x01, so it drops every byte of the spurious frame without ever parsing it, and still
+// correctly accepts the real frame from 0x01 that follows.
+TEST(ModbusTest, ResyncPastSpuriousFrameForUnexpectedAddress) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // Build a 5-byte Modbus exception response for address 0x42 (not registered):
+  // { 0x42, 0x83 (READ_HOLDING_REGISTERS|error), 0x02 (exception code), CRC_lo, CRC_hi }
+  uint8_t spurious_header[] = {0x42, 0x83, 0x02};
+  uint16_t spurious_crc = esphome::crc16(spurious_header, sizeof(spurious_header));
+  std::vector<uint8_t> stream;
+  for (uint8_t b : spurious_header)
+    stream.push_back(b);
+  stream.push_back(spurious_crc & 0xFF);
+  stream.push_back((spurious_crc >> 8) & 0xFF);
+
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Guard against over-aggressive resync: when the CLIENT is NOT waiting for a response
+// (waiting_for_response_ == 0), the fast-path must be inactive. Bytes should be buffered and
+// only dropped on CRC failure at a full-frame boundary, so a valid frame that arrives
+// unsolicited still parses. This preserves the pre-patch behaviour for non-request/response
+// bus traffic (unusual for CLIENT mode, but exercised to prove the guard is in place).
+TEST(ModbusTest, NoResyncWhenNotWaitingForResponse) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  // Deliberately do NOT call modbus.set_waiting() — waiting_for_response_ stays 0.
+
+  const auto frame = make_valid_response_frame();
+  for (uint8_t byte : frame) {
+    EXPECT_TRUE(modbus.test_parse_modbus_byte(byte));
+  }
+  // With waiting_for_response_ == 0, the frame is parsed and dispatched, but the client-side
+  // "not expecting a response" branch logs a warning and does not invoke on_modbus_data. The
+  // key assertion is that the parser didn't crash and didn't eat arbitrary bytes — the device
+  // callback behaviour here matches the pre-patch semantics.
+  EXPECT_FALSE(device.data_received);
 }
 
 }  // namespace esphome::modbus


### PR DESCRIPTION
### What does this PR do?

Teaches `Modbus::parse_modbus_byte_` to resynchronise past leading junk on the wire instead of mis-parsing it as a malformed frame and losing the real response that follows. Two cooperating mechanisms:

1. **CLIENT fast-path.** While a response is pending (`waiting_for_response_ != 0`), any byte at the front of `rx_buffer_` that doesn't match the expected slave address is dropped immediately. When no response is pending, any leading byte is unsolicited noise by definition (a conforming Modbus master only receives in direct response to its own requests) and is dropped silently — this suppresses the "timeout after partial response" warning that otherwise fires on every poll cycle when RS485 direction-switch leaks a trailing byte.
2. **BAD_FRAME drop-one-byte retry.** When `try_parse_rx_buffer_` reaches a CRC check and it fails, drop byte 0 and retry. Handles junk that happens to begin with the expected address by coincidence.

The parse body is factored into a new `try_parse_rx_buffer_()` helper returning a three-valued `ParseResult` (`NEEDS_MORE_BYTES` / `FRAME_PROCESSED` / `BAD_FRAME`) so the resync loop in `parse_modbus_byte_` can drive it iteratively without recursion.

### Why?

Stock parser (2026.4) unconditionally treats `rx_buffer_[0]` as the slave address, `rx_buffer_[1]` as the function code, and `rx_buffer_[2]` as the payload length. When any junk precedes a valid response on the wire (late-arriving tail of a previous poll, direction-switch noise from some RS485 transceivers, or device-firmware quirks that prepend bytes), the parser:

1. Reads `data_len = raw[2] = <junk>`, treats it as the byte-count.
2. Accumulates `data_offset + data_len + 2` bytes.
3. CRC fails because the bytes aren't actually a frame.
4. Buffer is cleared on timeout; the real frame that arrived inside the junk is lost.

Legit frames never reach the device callback on buses that exhibit any of these patterns.

### Where does the junk come from?

Observed in production on an SDM630-Modbus V2 meter (in service for 3 years): every response is bracketed by `0x00` bytes on both leading and trailing edges. Leading `0x00` was the visible symptom; trailing `0x00` is what trips the "timeout after partial response" WARN on every poll cycle, silently eating CPU and log bandwidth even when the frame itself is otherwise clean.

The 2026.4 inter-byte-timeout tightening in #8032 (50 ms → 5 ms) exposed this quirk — previous versions masked it because the generous timeout let the parser re-sync via its natural flow.

Similar symptoms appear in threads on `esphome/issues`. The fix is device-agnostic.

### Risk

Low. Behaviour changes only for frames that currently fail — valid frames traverse the same code path. Resync log lines are `ESP_LOGV` so no new noise in normal operation. The existing "CRC check failed" warning and "Got frame from unknown address" warning are demoted to `ESP_LOGV` / `ESP_LOGD` respectively, because on a lossy bus the new resync loop will fire on every poll and the old levels would flood; legitimate multi-device / misconfigured-address cases are still surfaced at `DEBUG`.

### Testing

**Hardware:** SDM630. Frame-level success jumps from 0% → 100% with this change alone. Running continuously with no CRC-fail warnings, no partial-response timeouts, no value shifts across ≥ 3 weeks of 10 s polling.

**Unit tests (added in `tests/components/modbus/modbus_test.cpp`):**
- Resync past a single junk byte.
- Resync past an 8-byte junk prefix (the SDM630 + MAX485 direction-switch artifact observed on real hardware).
- Resync past a well-formed spurious frame from an unexpected address.
- Guard test: no bytes dropped when no response is pending (except the unsolicited-byte silent-drop path, which is what we want).

### Companion PRs

Part of a three-PR stack from the same SDM630 debugging session. Each PR is independently useful and independently mergeable.

- **PR 2 (#15856) — `[modbus] Add long_rx_buffer_delay YAML key`** (stacked on top of this PR, in `fix/modbus-long-rx-buffer-delay`). Handles devices that deliver responses in multiple UART bursts with gaps longer than `frame_delay`. Orthogonal to resync: resync strips noise at byte-level; `long_rx_buffer_delay` controls the timeout the parser grants between bursts.
- **PR 3 (#15857) — `[modbus] Add accept_truncated_frames option`** (stacked on top of PR 2, in `fix/modbus-accept-truncated-frames`). Dispatches frames whose data payload is complete but which are missing the trailing CRC bytes on the wire. Orthogonal to resync and to `long_rx_buffer_delay`: those fix parser robustness; this fixes dispatch of a specific device-firmware quirk.
- **Landed: `[sdm_meter] Allow chunk_size option`** (#15854). Independent of modbus PRs, needed only for SDM meters that also exhibit response truncation when reading more than N registers at once.

### Checklist

- [x] Builds locally against `esphome/dev`.
- [x] Single clean commit.
- [x] Commit message follows `[modbus] …` convention.
- [x] Unit tests added.
- [x] `clang-format` applied locally (v22; CI uses v13 — pre-commit.ci lite may tweak whitespace).
- [ ] Docs update — `esphome/esphome-docs:next`. Byte-walking resync is not directly configurable, but a "Behaviour" note belongs on `components/modbus.mdx`. Will file a single docs PR covering PRs 1+2+3 once the code stack lands or gets review numbers.

### Related upstream issues

The SDM-series / Eastron CRC-fail symptom is a long-running thread in `esphome/issues`. Happy to dig up specific issue numbers and edit the PR body if maintainers want them linked.
