### PR TITLE
[modbus] Add accept_truncated_frames option for devices that drop trailing CRC

### DIFF
--- a/esphome/components/modbus/__init__.py
+++ b/esphome/components/modbus/__init__.py
@@ -22,6 +22,7 @@ CONF_MODBUS_ID = "modbus_id"
 CONF_SEND_WAIT_TIME = "send_wait_time"
 CONF_TURNAROUND_TIME = "turnaround_time"
 CONF_LONG_RX_BUFFER_DELAY = "long_rx_buffer_delay"
+CONF_ACCEPT_TRUNCATED_FRAMES = "accept_truncated_frames"
 
 ModbusRole = modbus_ns.enum("ModbusRole")
 MODBUS_ROLES = {
@@ -45,6 +46,7 @@ CONFIG_SCHEMA = (
                 CONF_LONG_RX_BUFFER_DELAY
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
+            cv.Optional(CONF_ACCEPT_TRUNCATED_FRAMES, default=False): cv.boolean,
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -67,6 +69,7 @@ async def to_code(config):
     cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
     cg.add(var.set_turnaround_time(config[CONF_TURNAROUND_TIME]))
     cg.add(var.set_disable_crc(config[CONF_DISABLE_CRC]))
+    cg.add(var.set_accept_truncated_frames(config[CONF_ACCEPT_TRUNCATED_FRAMES]))
     if (long_rx := config.get(CONF_LONG_RX_BUFFER_DELAY)) is not None:
         cg.add(var.set_long_rx_buffer_delay(long_rx))
 

--- a/esphome/components/modbus/__init__.py
+++ b/esphome/components/modbus/__init__.py
@@ -21,6 +21,7 @@ CONF_ROLE = "role"
 CONF_MODBUS_ID = "modbus_id"
 CONF_SEND_WAIT_TIME = "send_wait_time"
 CONF_TURNAROUND_TIME = "turnaround_time"
+CONF_LONG_RX_BUFFER_DELAY = "long_rx_buffer_delay"
 
 ModbusRole = modbus_ns.enum("ModbusRole")
 MODBUS_ROLES = {
@@ -39,6 +40,9 @@ CONFIG_SCHEMA = (
             ): cv.positive_time_period_milliseconds,
             cv.Optional(
                 CONF_TURNAROUND_TIME, default="100ms"
+            ): cv.positive_time_period_milliseconds,
+            cv.Optional(
+                CONF_LONG_RX_BUFFER_DELAY
             ): cv.positive_time_period_milliseconds,
             cv.Optional(CONF_DISABLE_CRC, default=False): cv.boolean,
         }
@@ -63,6 +67,8 @@ async def to_code(config):
     cg.add(var.set_send_wait_time(config[CONF_SEND_WAIT_TIME]))
     cg.add(var.set_turnaround_time(config[CONF_TURNAROUND_TIME]))
     cg.add(var.set_disable_crc(config[CONF_DISABLE_CRC]))
+    if (long_rx := config.get(CONF_LONG_RX_BUFFER_DELAY)) is not None:
+        cg.add(var.set_long_rx_buffer_delay(long_rx))
 
 
 def modbus_device_schema(default_address):

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -108,30 +108,70 @@ void Modbus::receive_and_parse_modbus_bytes_() {
                   millis() - this->last_send_);
       }
 
-      // If the bytes in the rx buffer do not parse, clear out the buffer
-      if (!this->parse_modbus_byte_(buf[i])) {
-        this->clear_rx_buffer_(LOG_STR("parse failed"), true);
-      }
+      // parse_modbus_byte_ is responsible for resynchronising the buffer on CRC failure, so it
+      // always returns true and we never clear the buffer here.
+      this->parse_modbus_byte_(buf[i]);
       this->last_modbus_byte_ = millis();
     }
   }
 }
 
 bool Modbus::parse_modbus_byte_(uint8_t byte) {
-  size_t at = this->rx_buffer_.size();
+  // Append the new byte and try to parse a frame from the front of rx_buffer_.
+  // We resynchronise past any leading junk so the parser can recover from e.g. stale bytes
+  // from a late-arriving previous response, or direction-switch noise from some RS485
+  // transceiver modules, without waiting for the receive timeout.
+  //
+  // Two resync mechanisms cooperate:
+  //
+  // 1. CLIENT fast-path: while a response is pending (waiting_for_response_ != 0), any byte at
+  //    the front of rx_buffer_ that doesn't match the expected device address is dropped
+  //    immediately. This avoids the trap where junk byte 1 looks like a function code and
+  //    junk byte 2 looks like a large payload length, causing the parser to swallow the real
+  //    frame as "payload" without ever reaching a CRC check.
+  //
+  // 2. BAD_FRAME drop-one-byte retry: if try_parse_rx_buffer_ reaches a CRC check and it
+  //    fails, we drop byte 0 and retry. This handles junk that happens to begin with the
+  //    expected address by coincidence.
   this->rx_buffer_.push_back(byte);
-  const uint8_t *raw = &this->rx_buffer_[0];
+  while (!this->rx_buffer_.empty()) {
+    if (this->role == ModbusRole::CLIENT) {
+      // No request pending — any byte arriving in the buffer is unsolicited noise
+      // (typically the trailing byte of RS485 direction-switch on some transceivers).
+      // Dropping here avoids the "timeout after partial response" warning that would
+      // otherwise fire when the stray byte sits in the buffer until frame_delay expires.
+      if (this->waiting_for_response_ == 0) {
+        ESP_LOGV(TAG, "Resync: dropping 0x%02X (no request pending)", this->rx_buffer_[0]);
+        this->rx_buffer_.erase(this->rx_buffer_.begin());
+        continue;
+      }
+      // Request pending — drop bytes that don't match the awaited device address.
+      if (this->rx_buffer_[0] != this->waiting_for_response_) {
+        ESP_LOGV(TAG, "Resync: dropping 0x%02X (waiting for address 0x%02X)", this->rx_buffer_[0],
+                 this->waiting_for_response_);
+        this->rx_buffer_.erase(this->rx_buffer_.begin());
+        continue;
+      }
+    }
+    const ParseResult result = this->try_parse_rx_buffer_();
+    if (result == ParseResult::NEEDS_MORE_BYTES || result == ParseResult::FRAME_PROCESSED) {
+      return true;
+    }
+    // BAD_FRAME: drop the first byte and retry parsing from the new front.
+    ESP_LOGV(TAG, "Resync: dropping byte 0x%02X after CRC fail, %zu bytes remain", this->rx_buffer_[0],
+             this->rx_buffer_.size() - 1);
+    this->rx_buffer_.erase(this->rx_buffer_.begin());
+  }
+  return true;
+}
 
-  // Byte 0: modbus address (match all)
-  if (at == 0)
-    return true;
-  // Byte 1: function code
-  if (at == 1)
-    return true;
-  // Byte 2: Size (with modbus rtu function code 4/3)
-  // See also https://en.wikipedia.org/wiki/Modbus
-  if (at == 2)
-    return true;
+Modbus::ParseResult Modbus::try_parse_rx_buffer_() {
+  const size_t size = this->rx_buffer_.size();
+  // Byte 0: modbus address, byte 1: function code, byte 2: size (for read registers).
+  if (size < 3) {
+    return ParseResult::NEEDS_MORE_BYTES;
+  }
+  const uint8_t *raw = this->rx_buffer_.data();
 
   uint8_t address = raw[0];
   uint8_t function_code = raw[1];
@@ -149,15 +189,17 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
     // installed, but wait, there is the CRC, and if we get a hit there is a good
     // chance that this is a complete message ... admittedly there is a small chance is
     // isn't but that is quite small given the purpose of the CRC in the first place
-
-    data_len = at - 2;
     data_offset = 1;
+    data_len = size - data_offset - 2;
 
     uint16_t computed_crc = crc16(raw, data_offset + data_len);
     uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
 
-    if (computed_crc != remote_crc)
-      return true;
+    if (computed_crc != remote_crc) {
+      // For user-defined functions the frame length is discovered by searching for a matching CRC;
+      // keep accumulating bytes until either the CRC matches or the frame-delay timeout fires.
+      return ParseResult::NEEDS_MORE_BYTES;
+    }
 
     ESP_LOGD(TAG, "User-defined function %02X found", function_code);
 
@@ -172,8 +214,8 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
         data_offset = 2;
         data_len = 4;
       } else if (function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
-        if (at < 6) {
-          return true;
+        if (size < 7) {
+          return ParseResult::NEEDS_MORE_BYTES;
         }
         data_offset = 2;
         // starting address (2 bytes) + quantity of registers (2 bytes) + byte count itself (1 byte) + actual byte count
@@ -197,15 +239,11 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
       data_len = 1;
     }
 
-    // Byte data_offset..data_offset+data_len-1: Data
-    if (at < data_offset + data_len)
-      return true;
+    // Need header + data + 2 CRC bytes before we can validate.
+    if (size < static_cast<size_t>(data_offset) + data_len + 2) {
+      return ParseResult::NEEDS_MORE_BYTES;
+    }
 
-    // Byte 3+data_len: CRC_LO (over all bytes)
-    if (at == data_offset + data_len)
-      return true;
-
-    // Byte data_offset+len+1: CRC_HI (over all bytes)
     uint16_t computed_crc = crc16(raw, data_offset + data_len);
     uint16_t remote_crc = uint16_t(raw[data_offset + data_len]) | (uint16_t(raw[data_offset + data_len + 1]) << 8);
     if (computed_crc != remote_crc) {
@@ -216,14 +254,17 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
 #endif
         ESP_LOGVV(TAG, "  (%02X != %02X)  %s", computed_crc, remote_crc,
                   format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
+        // Fall through: user has opted into accepting mismatched frames, publish the data.
       } else {
-        ESP_LOGW(TAG, "CRC check failed %" PRIu32 "ms after last send", millis() - this->last_send_);
+        // Demoted to VERBOSE because resync will typically fire on every poll on a lossy bus
+        // and we don't want to flood the log. The hex dump stays at VERY_VERBOSE.
+        ESP_LOGV(TAG, "CRC check failed %" PRIu32 "ms after last send", millis() - this->last_send_);
 #if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERY_VERBOSE
         char hex_buf[format_hex_pretty_size(MODBUS_MAX_LOG_BYTES)];
 #endif
         ESP_LOGVV(TAG, "  (%02X != %02X) %s", computed_crc, remote_crc,
                   format_hex_pretty_to(hex_buf, this->rx_buffer_.data(), this->rx_buffer_.size()));
-        return false;
+        return ParseResult::BAD_FRAME;
       }
     }
   }
@@ -269,7 +310,10 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   }
 
   if (!found && this->role == ModbusRole::CLIENT) {
-    ESP_LOGW(TAG, "Got frame from unknown address %" PRIu8 ", %" PRIu32 "ms after last send", address,
+    // Demoted to DEBUG: with byte-walking resync, junk bytes can very occasionally CRC-match an
+    // unconfigured address. A legitimate unknown-address frame is still surfaced at DEBUG and
+    // users investigating bus setup will see it at that level.
+    ESP_LOGD(TAG, "Got frame from unknown address %" PRIu8 ", %" PRIu32 "ms after last send", address,
              millis() - this->last_send_);
   }
 
@@ -278,7 +322,7 @@ bool Modbus::parse_modbus_byte_(uint8_t byte) {
   if (this->waiting_for_response_ == address)
     this->waiting_for_response_ = 0;
 
-  return true;
+  return ParseResult::FRAME_PROCESSED;
 }
 
 void Modbus::send_next_frame_() {

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -68,7 +68,18 @@ void Modbus::loop() {
   // then the comparison is backwards (small negative which wraps to large positive) and will cause a false timeout
   // So in this component we don't use any cached timestamp values to avoid these annoying bugs
   if (millis() - this->last_modbus_byte_ > timeout) {
-    this->clear_rx_buffer_(LOG_STR("timeout after partial response"), true);
+    // Some devices (e.g. certain SDM630 firmwares) deliver a complete data payload on the wire
+    // but cut the transmission before the trailing CRC bytes. accept_truncated_frames opts into
+    // dispatching such a frame anyway, on the same timeout that would otherwise discard it.
+    // Only applies when: (a) user has opted in, (b) a response is pending, (c) buffer begins
+    // with the awaited address, and (d) enough bytes have arrived to cover the full declared
+    // data payload. CRC is simply not checked (analogous to disable_crc, but for the missing
+    // bytes case rather than the wrong bytes case).
+    if (this->accept_truncated_frames_ && this->waiting_for_response_ != 0 && this->try_accept_truncated_rx_buffer_()) {
+      // Frame dispatched; buffer cleared by the helper.
+    } else {
+      this->clear_rx_buffer_(LOG_STR("timeout after partial response"), true);
+    }
   }
 
   // If we're past the send_wait_time timeout and response buffer doesn't have the start of the expected response
@@ -339,6 +350,71 @@ Modbus::ParseResult Modbus::try_parse_rx_buffer_() {
   return ParseResult::FRAME_PROCESSED;
 }
 
+// Called from loop() when the inter-byte timeout has fired and accept_truncated_frames is enabled.
+// Mirrors the CLIENT-side payload-layout logic of try_parse_rx_buffer_ but skips the CRC check
+// entirely — the caller has established that no further bytes are arriving, so if the declared
+// payload has fully arrived we dispatch it regardless of whether the trailing CRC bytes made it
+// onto the wire. User-defined function codes are not supported: their frame length is discovered
+// by finding a matching CRC, which is meaningless once we've opted out of CRC.
+bool Modbus::try_accept_truncated_rx_buffer_() {
+  if (this->role != ModbusRole::CLIENT)
+    return false;
+
+  const size_t size = this->rx_buffer_.size();
+  if (size < 3)
+    return false;
+
+  const uint8_t *raw = this->rx_buffer_.data();
+  const uint8_t address = raw[0];
+  const uint8_t function_code = raw[1];
+
+  if (address != this->waiting_for_response_)
+    return false;
+
+  uint8_t data_offset = 3;
+  uint8_t data_len = raw[2];
+
+  if (function_code == ModbusFunctionCode::WRITE_SINGLE_COIL ||
+      function_code == ModbusFunctionCode::WRITE_SINGLE_REGISTER ||
+      function_code == ModbusFunctionCode::WRITE_MULTIPLE_COILS ||
+      function_code == ModbusFunctionCode::WRITE_MULTIPLE_REGISTERS) {
+    data_offset = 2;
+    data_len = 4;
+  } else if ((function_code & FUNCTION_CODE_EXCEPTION_MASK) == FUNCTION_CODE_EXCEPTION_MASK) {
+    data_offset = 2;
+    data_len = 1;
+  } else if (((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_1_INIT) &&
+              (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_1_END)) ||
+             ((function_code >= FUNCTION_CODE_USER_DEFINED_SPACE_2_INIT) &&
+              (function_code <= FUNCTION_CODE_USER_DEFINED_SPACE_2_END))) {
+    return false;
+  }
+
+  if (size < static_cast<size_t>(data_offset) + data_len)
+    return false;
+
+  ESP_LOGD(TAG,
+           "Accepting truncated frame (%zu bytes received, expected %u with CRC) from 0x%02X %" PRIu32
+           "ms after last send",
+           size, static_cast<unsigned>(data_offset + data_len + 2), address, millis() - this->last_send_);
+
+  std::vector<uint8_t> data(this->rx_buffer_.begin() + data_offset, this->rx_buffer_.begin() + data_offset + data_len);
+
+  for (auto *device : this->devices_) {
+    if (device->address_ == address) {
+      if ((function_code & FUNCTION_CODE_EXCEPTION_MASK) == FUNCTION_CODE_EXCEPTION_MASK) {
+        device->on_modbus_error(function_code & FUNCTION_CODE_MASK, raw[2]);
+      } else {
+        device->on_modbus_data(data);
+      }
+    }
+  }
+
+  this->clear_rx_buffer_(LOG_STR("truncated frame accepted"));
+  this->waiting_for_response_ = 0;
+  return true;
+}
+
 void Modbus::send_next_frame_() {
   if (this->tx_buffer_.empty())
     return;
@@ -376,16 +452,18 @@ void Modbus::send_next_frame_() {
 }
 
 void Modbus::dump_config() {
-  ESP_LOGCONFIG(
-      TAG,
-      "Modbus:\n"
-      "  Send Wait Time: %d ms\n"
-      "  Turnaround Time: %d ms\n"
-      "  Frame Delay: %d ms\n"
-      "  Long Rx Buffer Delay: %d ms%s\n"
-      "  CRC Disabled: %s",
-      this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_, this->long_rx_buffer_delay_ms_,
-      this->long_rx_buffer_delay_user_set_ ? " (user-set, applies unconditionally)" : "", YESNO(this->disable_crc_));
+  ESP_LOGCONFIG(TAG,
+                "Modbus:\n"
+                "  Send Wait Time: %d ms\n"
+                "  Turnaround Time: %d ms\n"
+                "  Frame Delay: %d ms\n"
+                "  Long Rx Buffer Delay: %d ms%s\n"
+                "  CRC Disabled: %s\n"
+                "  Accept Truncated Frames: %s",
+                this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_,
+                this->long_rx_buffer_delay_ms_,
+                this->long_rx_buffer_delay_user_set_ ? " (user-set, applies unconditionally)" : "",
+                YESNO(this->disable_crc_), YESNO(this->accept_truncated_frames_));
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
 }
 float Modbus::get_setup_priority() const {

--- a/esphome/components/modbus/modbus.cpp
+++ b/esphome/components/modbus/modbus.cpp
@@ -29,12 +29,20 @@ void Modbus::setup() {
   // When rx_full_threshold is configured (non-zero), the UART has a hardware FIFO with a
   // meaningful threshold (e.g., ESP32 native UART), so we can calculate a precise delay.
   // Otherwise (e.g., USB UART), use 50ms to handle data arriving in chunks.
+  //
+  // If the user explicitly set long_rx_buffer_delay via YAML, keep their value and skip the
+  // auto-calculation. A user-set value also unconditionally applies in loop() (see below),
+  // bypassing the rx_full_threshold size gate — this is the escape hatch for slow devices
+  // (e.g. some SDM-series power meters) whose responses arrive in multiple short bursts with
+  // per-burst gaps longer than the auto-derived delay.
   static constexpr uint16_t DEFAULT_LONG_RX_BUFFER_DELAY_MS = 50;
-  size_t rx_threshold = this->parent_->get_rx_full_threshold();
-  this->long_rx_buffer_delay_ms_ =
-      rx_threshold != uart::UARTComponent::RX_FULL_THRESHOLD_UNSET
-          ? (rx_threshold * MODBUS_BITS_PER_CHAR * MS_PER_SEC / this->parent_->get_baud_rate()) + 1
-          : DEFAULT_LONG_RX_BUFFER_DELAY_MS;
+  if (!this->long_rx_buffer_delay_user_set_) {
+    size_t rx_threshold = this->parent_->get_rx_full_threshold();
+    this->long_rx_buffer_delay_ms_ =
+        rx_threshold != uart::UARTComponent::RX_FULL_THRESHOLD_UNSET
+            ? (rx_threshold * MODBUS_BITS_PER_CHAR * MS_PER_SEC / this->parent_->get_baud_rate()) + 1
+            : DEFAULT_LONG_RX_BUFFER_DELAY_MS;
+  }
 }
 
 void Modbus::loop() {
@@ -43,11 +51,17 @@ void Modbus::loop() {
 
   // If the response frame is finished (including interframe delay) - we timeout.
   // The long_rx_buffer_delay accounts for long responses (larger than the UART rx_full_threshold) to avoid timeouts
-  // when the buffer is filling the back half of the response
-  const uint16_t timeout = std::max(
-      (uint16_t) this->frame_delay_ms_,
-      (uint16_t) (this->rx_buffer_.size() >= this->parent_->get_rx_full_threshold() ? this->long_rx_buffer_delay_ms_
-                                                                                    : 0));
+  // when the buffer is filling the back half of the response.
+  //
+  // When the user explicitly set long_rx_buffer_delay via YAML, it applies unconditionally
+  // (no rx_full_threshold gate). The gate is only a useful heuristic for the auto-derived
+  // value — users who know their device sends in short bursts with long gaps want the long
+  // delay to apply from the very first byte, not only once the buffer has already grown.
+  const uint16_t long_delay =
+      this->long_rx_buffer_delay_user_set_
+          ? this->long_rx_buffer_delay_ms_
+          : (this->rx_buffer_.size() >= this->parent_->get_rx_full_threshold() ? this->long_rx_buffer_delay_ms_ : 0);
+  const uint16_t timeout = std::max((uint16_t) this->frame_delay_ms_, long_delay);
   // We use millis() here and elsewhere instead of App.get_loop_component_start_time() to avoid stale timestamps
   // It's critical in all timestamp comparisons that the left timestamp comes before the right one in time
   // If we use a cached value in place of millis() and last_modbus_byte_ is updated inside our loop
@@ -362,15 +376,16 @@ void Modbus::send_next_frame_() {
 }
 
 void Modbus::dump_config() {
-  ESP_LOGCONFIG(TAG,
-                "Modbus:\n"
-                "  Send Wait Time: %d ms\n"
-                "  Turnaround Time: %d ms\n"
-                "  Frame Delay: %d ms\n"
-                "  Long Rx Buffer Delay: %d ms\n"
-                "  CRC Disabled: %s",
-                this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_,
-                this->long_rx_buffer_delay_ms_, YESNO(this->disable_crc_));
+  ESP_LOGCONFIG(
+      TAG,
+      "Modbus:\n"
+      "  Send Wait Time: %d ms\n"
+      "  Turnaround Time: %d ms\n"
+      "  Frame Delay: %d ms\n"
+      "  Long Rx Buffer Delay: %d ms%s\n"
+      "  CRC Disabled: %s",
+      this->send_wait_time_, this->turnaround_delay_ms_, this->frame_delay_ms_, this->long_rx_buffer_delay_ms_,
+      this->long_rx_buffer_delay_user_set_ ? " (user-set, applies unconditionally)" : "", YESNO(this->disable_crc_));
   LOG_PIN("  Flow Control Pin: ", this->flow_control_pin_);
 }
 float Modbus::get_setup_priority() const {

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -59,6 +59,10 @@ class Modbus : public uart::UARTDevice, public Component {
   void set_send_wait_time(uint16_t time_in_ms) { this->send_wait_time_ = time_in_ms; }
   void set_turnaround_time(uint16_t time_in_ms) { this->turnaround_delay_ms_ = time_in_ms; }
   void set_disable_crc(bool disable_crc) { this->disable_crc_ = disable_crc; }
+  void set_long_rx_buffer_delay(uint16_t time_in_ms) {
+    this->long_rx_buffer_delay_ms_ = time_in_ms;
+    this->long_rx_buffer_delay_user_set_ = true;
+  }
 
   ModbusRole role;
 
@@ -85,6 +89,7 @@ class Modbus : public uart::UARTDevice, public Component {
   uint16_t turnaround_delay_ms_{100};
   uint8_t waiting_for_response_{0};
   bool disable_crc_{false};
+  bool long_rx_buffer_delay_user_set_{false};
 
   GPIOPin *flow_control_pin_{nullptr};
 

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -63,7 +63,14 @@ class Modbus : public uart::UARTDevice, public Component {
   ModbusRole role;
 
  protected:
+  enum class ParseResult {
+    NEEDS_MORE_BYTES,  // not enough bytes in rx_buffer_ yet, wait for more
+    FRAME_PROCESSED,   // a valid frame was parsed and rx_buffer_ was cleared
+    BAD_FRAME,         // CRC failed for a fixed-length frame; caller should drop 1 byte and retry
+  };
+
   bool parse_modbus_byte_(uint8_t byte);
+  ParseResult try_parse_rx_buffer_();
   void receive_and_parse_modbus_bytes_();
   void clear_rx_buffer_(const LogString *reason, bool warn = false);
   void send_next_frame_();

--- a/esphome/components/modbus/modbus.h
+++ b/esphome/components/modbus/modbus.h
@@ -59,6 +59,7 @@ class Modbus : public uart::UARTDevice, public Component {
   void set_send_wait_time(uint16_t time_in_ms) { this->send_wait_time_ = time_in_ms; }
   void set_turnaround_time(uint16_t time_in_ms) { this->turnaround_delay_ms_ = time_in_ms; }
   void set_disable_crc(bool disable_crc) { this->disable_crc_ = disable_crc; }
+  void set_accept_truncated_frames(bool accept) { this->accept_truncated_frames_ = accept; }
   void set_long_rx_buffer_delay(uint16_t time_in_ms) {
     this->long_rx_buffer_delay_ms_ = time_in_ms;
     this->long_rx_buffer_delay_user_set_ = true;
@@ -75,6 +76,7 @@ class Modbus : public uart::UARTDevice, public Component {
 
   bool parse_modbus_byte_(uint8_t byte);
   ParseResult try_parse_rx_buffer_();
+  bool try_accept_truncated_rx_buffer_();
   void receive_and_parse_modbus_bytes_();
   void clear_rx_buffer_(const LogString *reason, bool warn = false);
   void send_next_frame_();
@@ -89,6 +91,7 @@ class Modbus : public uart::UARTDevice, public Component {
   uint16_t turnaround_delay_ms_{100};
   uint8_t waiting_for_response_{0};
   bool disable_crc_{false};
+  bool accept_truncated_frames_{false};
   bool long_rx_buffer_delay_user_set_{false};
 
   GPIOPin *flow_control_pin_{nullptr};

--- a/tests/components/modbus/modbus_test.cpp
+++ b/tests/components/modbus/modbus_test.cpp
@@ -14,8 +14,14 @@ class TestModbus : public Modbus {
 
 class MockDevice : public ModbusDevice {
  public:
-  void on_modbus_data(const std::vector<uint8_t> &data) override { this->data_received = true; }
+  void on_modbus_data(const std::vector<uint8_t> &data) override {
+    this->data_received = true;
+    this->call_count++;
+    this->last_data = data;
+  }
   bool data_received{false};
+  uint32_t call_count{0};
+  std::vector<uint8_t> last_data;
 };
 
 TEST(ModbusTest, TwoByteRegressionTest) {
@@ -54,6 +60,129 @@ TEST(ModbusTest, TestValidFrame) {
     EXPECT_TRUE(result) << "Failed at byte " << i << " (0x" << std::hex << (int) frame[i] << ")";
   }
   EXPECT_TRUE(device.data_received);
+}
+
+// Build a valid Modbus RTU response frame (address | function | byte_count | payload | CRC).
+static std::vector<uint8_t> make_valid_response_frame() {
+  uint8_t frame_data[] = {0x01, 0x03, 0x02, 0x12, 0x34};
+  uint16_t crc = esphome::crc16(frame_data, sizeof(frame_data));
+  std::vector<uint8_t> frame;
+  for (uint8_t b : frame_data)
+    frame.push_back(b);
+  frame.push_back(crc & 0xFF);
+  frame.push_back((crc >> 8) & 0xFF);
+  return frame;
+}
+
+// Feeds a byte stream into the parser and asserts the mock device received the expected frame
+// exactly once, regardless of any junk prepended to it.
+static void feed_and_expect_one_valid_frame(TestModbus &modbus, MockDevice &device,
+                                            const std::vector<uint8_t> &stream) {
+  for (size_t i = 0; i < stream.size(); i++) {
+    EXPECT_TRUE(modbus.test_parse_modbus_byte(stream[i]))
+        << "Parser returned false at byte " << i << " (0x" << std::hex << (int) stream[i] << ")";
+  }
+  EXPECT_TRUE(device.data_received);
+  EXPECT_EQ(device.call_count, 1u);
+  // Payload is the 2 data bytes from make_valid_response_frame().
+  ASSERT_EQ(device.last_data.size(), 2u);
+  EXPECT_EQ(device.last_data[0], 0x12);
+  EXPECT_EQ(device.last_data[1], 0x34);
+}
+
+// Regression test: a single junk byte before a valid frame must be walked past.
+TEST(ModbusTest, ResyncAfterSingleJunkByte) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  std::vector<uint8_t> stream = {0xFF};  // single junk byte
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Real-world case: an 8-byte junk prefix (modelled on the SDM630 + MAX485 direction-switch
+// artifact observed on actual hardware) must be walked past to reach the valid frame behind it.
+TEST(ModbusTest, ResyncAfterEightByteJunkPrefix) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // Observed prefix shape from a real RS485 bus: arbitrary bytes that the naive parser
+  // interpreted as a malformed frame (bytes with MSB set look like exception responses).
+  std::vector<uint8_t> stream = {0xEE, 0xA1, 0xEC, 0xA4, 0x30, 0xD7, 0x00, 0x00};
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Adversarial case: a junk prefix that itself forms a well-formed 5-byte exception response
+// from an unregistered address (0x42) with a valid CRC. The CLIENT fast-path is waiting for
+// 0x01, so it drops every byte of the spurious frame without ever parsing it, and still
+// correctly accepts the real frame from 0x01 that follows.
+TEST(ModbusTest, ResyncPastSpuriousFrameForUnexpectedAddress) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  modbus.set_waiting(0x01);
+
+  // Build a 5-byte Modbus exception response for address 0x42 (not registered):
+  // { 0x42, 0x83 (READ_HOLDING_REGISTERS|error), 0x02 (exception code), CRC_lo, CRC_hi }
+  uint8_t spurious_header[] = {0x42, 0x83, 0x02};
+  uint16_t spurious_crc = esphome::crc16(spurious_header, sizeof(spurious_header));
+  std::vector<uint8_t> stream;
+  for (uint8_t b : spurious_header)
+    stream.push_back(b);
+  stream.push_back(spurious_crc & 0xFF);
+  stream.push_back((spurious_crc >> 8) & 0xFF);
+
+  const auto frame = make_valid_response_frame();
+  stream.insert(stream.end(), frame.begin(), frame.end());
+
+  feed_and_expect_one_valid_frame(modbus, device, stream);
+}
+
+// Guard against over-aggressive resync: when the CLIENT is NOT waiting for a response
+// (waiting_for_response_ == 0), the fast-path must be inactive. Bytes should be buffered and
+// only dropped on CRC failure at a full-frame boundary, so a valid frame that arrives
+// unsolicited still parses. This preserves the pre-patch behaviour for non-request/response
+// bus traffic (unusual for CLIENT mode, but exercised to prove the guard is in place).
+TEST(ModbusTest, NoResyncWhenNotWaitingForResponse) {
+  TestModbus modbus;
+  modbus.set_role(ModbusRole::CLIENT);
+
+  MockDevice device;
+  device.set_parent(&modbus);
+  device.set_address(0x01);
+  modbus.register_device(&device);
+  // Deliberately do NOT call modbus.set_waiting() — waiting_for_response_ stays 0.
+
+  const auto frame = make_valid_response_frame();
+  for (uint8_t byte : frame) {
+    EXPECT_TRUE(modbus.test_parse_modbus_byte(byte));
+  }
+  // With waiting_for_response_ == 0, the frame is parsed and dispatched, but the client-side
+  // "not expecting a response" branch logs a warning and does not invoke on_modbus_data. The
+  // key assertion is that the parser didn't crash and didn't eat arbitrary bytes — the device
+  // callback behaviour here matches the pre-patch semantics.
+  EXPECT_FALSE(device.data_received);
 }
 
 }  // namespace esphome::modbus


### PR DESCRIPTION
### What does this PR do?

Adds an optional `accept_truncated_frames: bool` YAML key on the `modbus:` block (default `false`, identical off-path). When enabled, before `clear_rx_buffer_` fires on inter-byte timeout, a new helper `try_accept_truncated_rx_buffer_()` checks whether the intact *data payload* of a valid response has already arrived and only the trailing CRC bytes are missing. If so, the frame is dispatched to the device callback with CRC verification skipped; otherwise the existing drop-buffer behaviour runs unchanged.

Gating conditions (all must hold for acceptance):

1. CLIENT role, `waiting_for_response_ != 0`.
2. `rx_buffer_[0] == waiting_for_response_` (belt-and-braces; byte-walking resync from PR 1 already guarantees this).
3. Function code is **not** in the user-defined function code space — their frame length is discovered by matching CRC, which is meaningless without one.
4. `size >= data_offset + data_len` (full payload present — rejects if truly truncated with data bytes missing).

`data_offset` / `data_len` are derived with the same CLIENT-side logic as `try_parse_rx_buffer_` (read-response: offset 3, len from byte-count field; write-response: offset 2, len 4; exception: offset 2, len 1).

Edge case: `size == data_offset + data_len + 1` (one CRC byte present, one missing) — accept the payload, ignore the stray byte.

### Why?

Some Modbus RTU devices deliver a full response payload but stop transmitting before the 2 trailing CRC bytes. The parser sits in `NEEDS_MORE_BYTES` until `frame_delay` / `long_rx_buffer_delay` fires, then `clear_rx_buffer_` dumps the intact payload with a `timeout after partial response` warning. The data was on the wire; the device just didn't send the final 2 bytes.

`disable_crc` doesn't help: it fires only when a CRC has been collected and mismatches; it cannot recover when the CRC bytes are absent entirely.

Observed on an SDM630-Modbus V2 meter with 16-register bulk reads (37-byte expected, 35-byte delivered = `[addr][func][bytecount][32 data bytes]`). Reproducible across thousands of cycles.

### Orthogonal to `disable_crc`

- `disable_crc` = accept frames with CRC bytes *present but wrong value*.
- `accept_truncated_frames` = accept frames with CRC bytes *absent entirely*.

Both can be enabled independently. Naming kept deliberately distinct.

### Risk

Opt-in, off by default. When enabled, the only new behaviour is that frames meeting the 4 gating conditions above — which the stock parser currently discards — are dispatched to the device. Devices that opt into this option have already signed up to accept unverified payloads, same contract as `disable_crc`.

User-defined function codes (`0x41`–`0x48`, `0x64`–`0x6E`) are explicitly excluded from acceptance because their frame length is discovered by matching a CRC, which can't be done without one.

### YAML example

```yaml
modbus:
  id: modbus_hub
  flow_control_pin: 5
  accept_truncated_frames: true   # NEW — optional, default false
```

### Log-level choice

The acceptance log line is `ESP_LOGD`, not `ESP_LOGW`. When the option is enabled and the device is one that trips this path, the log fires on every poll cycle — `ESP_LOGW` would drown normal operation. Debug-level keeps the information available under verbose logging but silent at default levels. If reviewers prefer a different level (e.g. `ESP_LOGI` so users can see the option is active), happy to adjust.

### Depends on

**PR 1** (#15855, `[modbus] Resynchronise rx buffer past leading junk bytes`, in `fix/modbus-byte-walking-resync`) **and PR 2** (#15856, `[modbus] Add long_rx_buffer_delay YAML key for slow responders`, in `fix/modbus-long-rx-buffer-delay`).

GitHub will show PR 1's and PR 2's commits in this PR's diff since they share a branch stack — **reviewers should review only the top commit (`d896e1b`)** here; the other commits are being reviewed in #15855 and #15856 respectively.

Rationale for stacking: a device that truncates CRC usually also prepends noise (handled by PR 1) and needs a long inter-byte timeout (handled by PR 2), so the three are tested together in practice. They're technically independent and could merge in any order; filing separately makes each diff reviewable in isolation.

### Testing

**Hardware:** SDM630 with `accept_truncated_frames: true` + PR 1 + PR 2 + chunked `sdm_meter` reads (#15854). Running continuously since 2026-04-17. All 27 sensors (V/I/P/S/Q/PF/angle per phase + total power + frequency + 4 energy counters) publish every 10 s. Zero partial-response timeouts, zero value shifts, zero missed polls.

**No-op path:** compile-tested with the key omitted or set to `false`. `try_accept_truncated_rx_buffer_` is never called; `clear_rx_buffer_` path is byte-identical to pre-patch.

### Companion PRs

- **PR 1** (#15855, stacked below) — `[modbus] Resynchronise rx buffer past leading junk bytes`.
- **PR 2** (#15856, stacked below) — `[modbus] Add long_rx_buffer_delay YAML key for slow responders`.
- **Landed:** `[sdm_meter] Allow chunk_size option` (#15854). Independent of modbus PRs.

### Checklist

- [x] Builds locally against `esphome/dev`.
- [x] Opt-in, off by default (`accept_truncated_frames: false`).
- [x] Acceptance log at `ESP_LOGD` to avoid log flood.
- [x] Single commit (clang-format applied locally).
- [x] Commit message follows `[modbus] …` convention.
- [x] `dump_config` exposes the option.
- [ ] Docs update — combined with PR 1 / PR 2 docs on `esphome/esphome-docs:next`. Will file once code PRs have review numbers.

### Related upstream issues

Happy to link specific `esphome/issues` threads if maintainers want — will dig after filing.
