### PR TITLE
[mipi_rgb] Add definitions for sunton displays

### DIFF
--- a/esphome/components/mipi_rgb/models/sunton.py
+++ b/esphome/components/mipi_rgb/models/sunton.py
@@ -1,0 +1,51 @@
+from esphome.components.mipi import DriverChip
+from esphome.config_validation import UNDEFINED
+
+# fmt: off
+sunton = DriverChip(
+    "SUNTON_8048S070",
+    swap_xy=UNDEFINED,
+    initsequence=(),
+    width=800,
+    height=480,
+    pclk_frequency="12.5MHz",
+    de_pin=41,
+    hsync_pin=39,
+    vsync_pin=40,
+    pclk_pin=42,
+    hsync_pulse_width=30,
+    hsync_back_porch=16,
+    hsync_front_porch=210,
+    vsync_pulse_width=13,
+    vsync_back_porch=10,
+    vsync_front_porch=22,
+    data_pins={
+        "red": [14, 21, 47, 48, 45],
+        "green": [9, 46, 3, 8, 16, 1],
+        "blue": [15, 7, 6, 5, 4],
+    },
+)
+
+sunton.extend(
+    "SUNTON_8048S050",
+    swap_xy=UNDEFINED,
+    initsequence=(),
+    width=800,
+    height=480,
+    pclk_frequency="16MHz",
+    de_pin=40,
+    hsync_pin=39,
+    vsync_pin=41,
+    pclk_pin=42,
+    hsync_back_porch=8,
+    hsync_front_porch=8,
+    hsync_pulse_width=4,
+    vsync_back_porch=8,
+    vsync_front_porch=8,
+    vsync_pulse_width=4,
+    data_pins={
+        "red": [45, 48, 47, 21, 14],
+        "green": [5, 6, 7, 15, 16, 4],
+        "blue": [8, 3, 46, 9, 1],
+    },
+)

--- a/esphome/components/mipi_rgb/models/sunton.py
+++ b/esphome/components/mipi_rgb/models/sunton.py
@@ -3,7 +3,7 @@ from esphome.config_validation import UNDEFINED
 
 # fmt: off
 sunton = DriverChip(
-    "SUNTON_8048S070",
+    "ESP32-8048S070",
     swap_xy=UNDEFINED,
     initsequence=(),
     width=800,
@@ -27,7 +27,7 @@ sunton = DriverChip(
 )
 
 sunton.extend(
-    "SUNTON_8048S050",
+    "ESP32-8048S050",
     swap_xy=UNDEFINED,
     initsequence=(),
     width=800,


### PR DESCRIPTION
# What does this implement/fix?

Add models for the 5" and 7" Sunton displays. Those models are a standard RPI display (i.e. no init sequence needed); added default pin definitions.

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6485

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

7 inch model:
```yaml
# Example config.yaml
display:
  - platform: mipi_rgb
    model: SUNTON_8048S70
    id: screen
    show_test_card: true
```
5 inch model:
```yaml
# Example config.yaml
display:
  - platform: mipi_rgb
    model: SUNTON_8048S50
    id: screen
    show_test_card: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
