### PR TITLE
[lvgl] Fix angles for arc

### DIFF
--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -78,7 +78,7 @@ class ArcType(NumberType):
                 prop = str(prop)
                 if prop.endswith("_angle"):
                     await w.set_property(
-                        "bg_" + prop, config.get(prop), processor=validator
+                        "bg_" + prop, await validator.process(config.get(prop))
                     )
                 else:
                     await w.set_property(prop, config, processor=validator)

--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -78,7 +78,7 @@ class ArcType(NumberType):
                 prop = str(prop)
                 if prop.endswith("_angle"):
                     await w.set_property(
-                        "bg_" + prop, config[prop], processor=validator
+                        "bg_" + prop, config.get(prop), processor=validator
                     )
                 else:
                     await w.set_property(prop, config, processor=validator)

--- a/esphome/components/lvgl/widgets/arc.py
+++ b/esphome/components/lvgl/widgets/arc.py
@@ -77,8 +77,11 @@ class ArcType(NumberType):
                 # start_angle and end_angle are mapped to bg_start_angle and bg_end_angle
                 prop = str(prop)
                 if prop.endswith("_angle"):
-                    prop = "bg_" + prop
-                await w.set_property(prop, config, processor=validator)
+                    await w.set_property(
+                        "bg_" + prop, config[prop], processor=validator
+                    )
+                else:
+                    await w.set_property(prop, config, processor=validator)
         if CONF_ADJUSTABLE in config:
             if not config[CONF_ADJUSTABLE]:
                 lv_obj.remove_style(w.obj, nullptr, LV_PART.KNOB)


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

When using `start_angle` and `end_angle` on arc, the values were not being set.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15853 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] host

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
