### PR TITLE
[ac_dimmer] Zero-crossing interrupt type

### DIFF
--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -229,8 +229,15 @@ void AcDimmer::dump_config() {
                 "   Min Power: %.1f%%\n"
                 "   Init with half cycle: %s",
                 this->store_.min_power / 10.0f, YESNO(this->init_with_half_cycle_));
-  LOG_PIN("  Output Pin: ", this->gate_pin_);
-  LOG_PIN("  Zero-Cross Pin: ", this->zero_cross_pin_);
+  LOG_PIN("   Output Pin: ", this->gate_pin_);
+  LOG_PIN("   Zero-Cross Pin: ", this->zero_cross_pin_);
+  if (this->zero_cross_interrupt_type_ == gpio::INTERRUPT_RISING_EDGE) {
+    ESP_LOGCONFIG(TAG, "    Interrupt Type : rising");
+  } else if (this->zero_cross_interrupt_type_ == gpio::INTERRUPT_FALLING_EDGE) {
+    ESP_LOGCONFIG(TAG, "    Interrupt Type : falling");
+  } else {
+    ESP_LOGCONFIG(TAG, "    Interrupt Type : any");
+  }
   if (method_ == DIM_METHOD_LEADING_PULSE) {
     ESP_LOGCONFIG(TAG, "   Method: leading pulse");
   } else if (method_ == DIM_METHOD_LEADING) {
@@ -238,9 +245,8 @@ void AcDimmer::dump_config() {
   } else {
     ESP_LOGCONFIG(TAG, "   Method: trailing");
   }
-
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGV(TAG, "  Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
+  ESP_LOGV(TAG, "   Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
 }
 
 }  // namespace esphome::ac_dimmer

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -226,27 +226,27 @@ void AcDimmer::write_state(float state) {
 void AcDimmer::dump_config() {
   ESP_LOGCONFIG(TAG,
                 "AcDimmer:\n"
-                "   Min Power: %.1f%%\n"
-                "   Init with half cycle: %s",
+                "  Min Power: %.1f%%\n"
+                "  Init with half cycle: %s",
                 this->store_.min_power / 10.0f, YESNO(this->init_with_half_cycle_));
-  LOG_PIN("   Output Pin: ", this->gate_pin_);
-  LOG_PIN("   Zero-Cross Pin: ", this->zero_cross_pin_);
+  LOG_PIN("  Output Pin: ", this->gate_pin_);
+  LOG_PIN("  Zero-Cross Pin: ", this->zero_cross_pin_);
   if (this->zero_cross_interrupt_type_ == gpio::INTERRUPT_RISING_EDGE) {
-    ESP_LOGCONFIG(TAG, "    Interrupt Type : rising");
+    ESP_LOGCONFIG(TAG, "  Interrupt Type: rising");
   } else if (this->zero_cross_interrupt_type_ == gpio::INTERRUPT_FALLING_EDGE) {
-    ESP_LOGCONFIG(TAG, "    Interrupt Type : falling");
+    ESP_LOGCONFIG(TAG, "  Interrupt Type: falling");
   } else {
-    ESP_LOGCONFIG(TAG, "    Interrupt Type : any");
+    ESP_LOGCONFIG(TAG, "  Interrupt Type: any");
   }
   if (method_ == DIM_METHOD_LEADING_PULSE) {
-    ESP_LOGCONFIG(TAG, "   Method: leading pulse");
+    ESP_LOGCONFIG(TAG, "  Method: leading pulse");
   } else if (method_ == DIM_METHOD_LEADING) {
-    ESP_LOGCONFIG(TAG, "   Method: leading");
+    ESP_LOGCONFIG(TAG, "  Method: leading");
   } else {
-    ESP_LOGCONFIG(TAG, "   Method: trailing");
+    ESP_LOGCONFIG(TAG, "  Method: trailing");
   }
   LOG_FLOAT_OUTPUT(this);
-  ESP_LOGV(TAG, "   Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
+  ESP_LOGV(TAG, "  Estimated Frequency: %.3fHz", 1e6f / this->store_.cycle_time_us / 2);
 }
 
 }  // namespace esphome::ac_dimmer

--- a/esphome/components/ac_dimmer/ac_dimmer.cpp
+++ b/esphome/components/ac_dimmer/ac_dimmer.cpp
@@ -190,7 +190,7 @@ void AcDimmer::setup() {
     this->zero_cross_pin_->setup();
     this->store_.zero_cross_pin = this->zero_cross_pin_->to_isr();
     this->zero_cross_pin_->attach_interrupt(&AcDimmerDataStore::s_gpio_intr, &this->store_,
-                                            gpio::INTERRUPT_FALLING_EDGE);
+                                            this->zero_cross_interrupt_type_);
   }
 
 #ifdef USE_ESP8266

--- a/esphome/components/ac_dimmer/ac_dimmer.h
+++ b/esphome/components/ac_dimmer/ac_dimmer.h
@@ -48,6 +48,7 @@ class AcDimmer : public output::FloatOutput, public Component {
   void dump_config() override;
   void set_gate_pin(InternalGPIOPin *gate_pin) { gate_pin_ = gate_pin; }
   void set_zero_cross_pin(InternalGPIOPin *zero_cross_pin) { zero_cross_pin_ = zero_cross_pin; }
+  void set_zero_cross_interrupt_type(gpio::InterruptType type) { zero_cross_interrupt_type_ = type; }
   void set_init_with_half_cycle(bool init_with_half_cycle) { init_with_half_cycle_ = init_with_half_cycle; }
   void set_method(DimMethod method) { method_ = method; }
 
@@ -56,6 +57,7 @@ class AcDimmer : public output::FloatOutput, public Component {
 
   InternalGPIOPin *gate_pin_;
   InternalGPIOPin *zero_cross_pin_;
+  gpio::InterruptType zero_cross_interrupt_type_;
   AcDimmerDataStore store_;
   bool init_with_half_cycle_;
   DimMethod method_;

--- a/esphome/components/ac_dimmer/output.py
+++ b/esphome/components/ac_dimmer/output.py
@@ -7,6 +7,8 @@ from esphome.core import CORE
 
 CODEOWNERS = ["@glmnet"]
 
+gpio_ns = cg.esphome_ns.namespace("gpio")
+
 ac_dimmer_ns = cg.esphome_ns.namespace("ac_dimmer")
 AcDimmer = ac_dimmer_ns.class_("AcDimmer", output.FloatOutput, cg.Component)
 
@@ -17,15 +19,26 @@ DIM_METHODS = {
     "TRAILING": DimMethod.DIM_METHOD_TRAILING,
 }
 
+ZC_INTERRUPT_TYPES = {
+    "RISING": gpio_ns.INTERRUPT_RISING_EDGE,
+    "FALLING": gpio_ns.INTERRUPT_FALLING_EDGE,
+    "ANY": gpio_ns.INTERRUPT_ANY_EDGE,
+}
+
 CONF_GATE_PIN = "gate_pin"
 CONF_ZERO_CROSS_PIN = "zero_cross_pin"
 CONF_INIT_WITH_HALF_CYCLE = "init_with_half_cycle"
+CONF_ZERO_CROSS_INTERRUPT_TYPE = "zero_cross_interrupt_type"
+
 CONFIG_SCHEMA = cv.All(
     output.FLOAT_OUTPUT_SCHEMA.extend(
         {
             cv.Required(CONF_ID): cv.declare_id(AcDimmer),
             cv.Required(CONF_GATE_PIN): pins.internal_gpio_output_pin_schema,
             cv.Required(CONF_ZERO_CROSS_PIN): pins.internal_gpio_input_pin_schema,
+            cv.Optional(CONF_ZERO_CROSS_INTERRUPT_TYPE, default="FALLING"): cv.enum(
+                ZC_INTERRUPT_TYPES, upper=True, space="_"
+            ),
             cv.Optional(CONF_INIT_WITH_HALF_CYCLE, default=True): cv.boolean,
             cv.Optional(CONF_METHOD, default="leading pulse"): cv.enum(
                 DIM_METHODS, upper=True, space="_"
@@ -54,5 +67,6 @@ async def to_code(config):
     cg.add(var.set_gate_pin(pin))
     pin = await cg.gpio_pin_expression(config[CONF_ZERO_CROSS_PIN])
     cg.add(var.set_zero_cross_pin(pin))
+    cg.add(var.set_zero_cross_interrupt_type(config[CONF_ZERO_CROSS_INTERRUPT_TYPE]))
     cg.add(var.set_init_with_half_cycle(config[CONF_INIT_WITH_HALF_CYCLE]))
     cg.add(var.set_method(config[CONF_METHOD]))

--- a/tests/components/ac_dimmer/common.yaml
+++ b/tests/components/ac_dimmer/common.yaml
@@ -3,3 +3,4 @@ output:
     id: ac_dimmer_1
     gate_pin: ${gate_pin}
     zero_cross_pin: ${zero_cross_pin}
+    zero_cross_interrupt_type: ANY


### PR DESCRIPTION
# What does this implement/fix?

For the **AC Dimmer** component, this PR allows the interrupt type for the zero-crossing input to be user configurable. It defaults to `FALLING` which is the original behavior.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**
- None

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6490

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
output:
  - platform: ac_dimmer
    id: dimmer1
    gate_pin: GPIO16
    zero_cross_pin:
      number: GPIO20
      mode:
        input: true
      inverted: yes
    zero_cross_interrupt_type: ANY

light:
  - platform: monochromatic
    output: dimmer1
    name: Dimmable Light
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [X] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).