### PR TITLE
[mipi_dsi] Add Seeed reTerminal d1001 display

### DIFF
--- a/esphome/components/lvgl/hello_world.yaml
+++ b/esphome/components/lvgl/hello_world.yaml
@@ -89,10 +89,12 @@
                       id: hello_world_label_
                       text: "Hello World!"
                       align: center
-            - obj:
+            - container:
                 id: hello_world_qrcode_
                 outline_width: 0
                 border_width: 0
+                height: 100
+                width: 100
                 hidden: !lambda |-
                     return lv_obj_get_width(lv_screen_active()) < 300 && lv_obj_get_height(lv_screen_active()) < 400;
                 widgets:

--- a/esphome/components/lvgl/hello_world.yaml
+++ b/esphome/components/lvgl/hello_world.yaml
@@ -89,12 +89,10 @@
                       id: hello_world_label_
                       text: "Hello World!"
                       align: center
-            - container:
+            - obj:
                 id: hello_world_qrcode_
                 outline_width: 0
                 border_width: 0
-                height: 100
-                width: 100
                 hidden: !lambda |-
                     return lv_obj_get_width(lv_screen_active()) < 300 && lv_obj_get_height(lv_screen_active()) < 400;
                 widgets:

--- a/esphome/components/mipi_dsi/models/seeed.py
+++ b/esphome/components/mipi_dsi/models/seeed.py
@@ -1,0 +1,29 @@
+from esphome.components.mipi import DriverChip
+import esphome.config_validation as cv
+
+# Standalone display
+# Product page: https://www.seeedstudio.com/reTerminal-D1001-p-6729.html
+DriverChip(
+    "SEEED-RETERMINAL-D1001",
+    height=1280,
+    width=800,
+    hsync_back_porch=20,
+    hsync_pulse_width=20,
+    hsync_front_porch=40,
+    vsync_back_porch=12,
+    vsync_pulse_width=4,
+    vsync_front_porch=30,
+    pclk_frequency="80MHz",
+    lane_bit_rate="1.5Gbps",
+    swap_xy=cv.UNDEFINED,
+    color_order="RGB",
+    enable_pin=[{"xl9535": None, "number": 0}, {"xl9535": None, "number": 7}],
+    reset_pin={"xl9535": None, "number": 2},
+    initsequence=(
+        (0xE0, 0x00),
+        (0xE1, 0x93),
+        (0xE2, 0x65),
+        (0xE3, 0xF8),
+        (0x80, 0x01),
+    ),
+)

--- a/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
+++ b/tests/component_tests/mipi_dsi/test_mipi_dsi_config.py
@@ -7,6 +7,11 @@ import pytest
 
 from esphome import config_validation as cv
 from esphome.components.esp32 import KEY_BOARD, VARIANT_ESP32P4
+
+# Importing xl9535 registers its pin schema with pins.PIN_SCHEMA_REGISTRY so that
+# models (e.g. SEEED-RETERMINAL-D1001) that reference xl9535-backed pins in their
+# defaults can be validated by the mipi_dsi CONFIG_SCHEMA in this test.
+import esphome.components.xl9535  # noqa: F401
 from esphome.const import (
     CONF_DIMENSIONS,
     CONF_HEIGHT,


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

* Add DSI display driver for the Seeed reTerminal D1001 display. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6494

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
