### PR TITLE
Exclude illegal `LF` char from OBIS info value output & make it plaintext as well as manufacturer

### DIFF
--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -105,9 +105,13 @@ std::vector<ObisInfo> SmlFile::get_obis_info() {
 std::string bytes_repr(const BytesView &buffer) {
   std::string repr;
   for (auto const value : buffer) {
+    unsigned int num_val = static_cast<unsigned int>(value);
+    if (num_val == 10) { // 10 = "LF" -> Exclude illegal ASCII char (DZG DVS74 outputs it at start of "1-0:96.50.1")
+      continue;
+    }
     // max 3: 2 hex digits + null
     char hex_buf[3];
-    snprintf(hex_buf, sizeof(hex_buf), "%02x", static_cast<unsigned int>(value));
+    snprintf(hex_buf, sizeof(hex_buf), "%02x", num_val);
     repr += hex_buf;
   }
   return repr;

--- a/esphome/components/sml/sml_parser.cpp
+++ b/esphome/components/sml/sml_parser.cpp
@@ -106,7 +106,7 @@ std::string bytes_repr(const BytesView &buffer) {
   std::string repr;
   for (auto const value : buffer) {
     unsigned int num_val = static_cast<unsigned int>(value);
-    if (num_val == 10) { // 10 = "LF" -> Exclude illegal ASCII char (DZG DVS74 outputs it at start of "1-0:96.50.1")
+    if (num_val == 10) {  // 10 = "LF" -> Exclude illegal ASCII char (DZG DVS74 outputs it at start of "1-0:96.50.1")
       continue;
     }
     // max 3: 2 hex digits + null


### PR DESCRIPTION
# What does this implement/fix?

Fixes OBIS info output for `1-0:96.1.0` of DZG DVS74 meters (and potentially others, too) which otherwise contains illegal `LF` ASCII char.

## Note to maintainers
Instead of leaving users to wrack their brains, this PR aims to add the hex decoding part for the meter's device ID.
Though, it's "partly optional" in the sense of "I'd rather see my `LF` fix merged than being rejected because of this 'bonus feature'" as even only the former would tremendously help users.

Nonetheless, moving the decoding to this component **_might_** come at the cost of possibly breaking those user scenarios which already decode the hex value themselves, e.g., via `lambda` in `text_sensor`'s filters.
**_But_** & I'm perfectly honest with you guys here: I'd expect those users to contribute their "decoder logic", if necessarily different from this one, back to this component's source code as it ultimately enables users incapable of doing so to gain plaintext output, hence easier component usage for their meters.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15772
- fixes esphome/issues#5106

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- TBD: esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
text_sensor:
  - format: text
    name: "Device ID"
    obis_code: "1-0:96.1.0"
    platform: sml
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
