### PR TITLE
[image] Fix rodata bloat for multi-frame RGB565+alpha animations

### DIFF
--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -756,7 +756,7 @@ async def write_image(config, all_frames=False):
             for col in range(width):
                 encoder.encode(pixels[row * width + col])
             encoder.end_row()
-        encoder.end_image()
+    encoder.end_image()
 
     rhs = [HexInt(x) for x in encoder.data]
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)


### PR DESCRIPTION
# What does this implement/fix?

Fixes a rodata blow-up regression for multi-frame animations using `IMAGE_TYPE_RGB565` with an alpha channel.

## Root cause

Commit `17a562cc17` ("Rework RGB565 Alpha format to match LVGL9", introduced via the LVGL v9.5.0 migration #12312) refactored `ImageRGB565` so the alpha byte is no longer emitted inline per pixel but accumulated into a parallel `self.alpha` buffer and appended to `self.data` in a new `end_image()` hook. The pre-existing `write_image()` loop calls `end_image()` **inside the per-frame loop**:

```python
for frame_index in range(frame_count):
    image.seek(frame_index)
    pixels = encoder.convert(image.resize((width, height)), path).getdata()
    for row in range(height):
        for col in range(width):
            encoder.encode(pixels[row * width + col])
        encoder.end_row()
    encoder.end_image()   # <-- once per frame
```

Before `17a562cc17`, `end_image()` was a no-op in the base class so calling it per frame was harmless. After, it runs `self.data.extend(self.alpha)`, so for an N-frame animation the full alpha buffer is appended N times instead of once.

## Measured impact

Reproduced against the config in #15871 (100×100×12-frame RGB565+alpha GIF, ESP32 ESP-IDF):

| Build | Flash Data (`setup()::uint8_t_id_15`) |
|---|---:|
| 2026.3.3 | 360,000 B |
| 2026.4.0 | 1,679,488 B (**+1.26 MB**) |
| dev + this fix | 360,000 B |

Firmware total on the same config goes from 2,593,327 B back down to 1,275,983 B, restoring OTA-partition headroom for 4 MB devices.

Math, for the curious:
- `encoder = ImageRGB565(100, height=100 × 12=1200, ALPHA_CHANNEL, …)` → `self.alpha` sized `100 × 1200 = 120,000`
- Loop ran `end_image()` 12×, each appending 120,000 B → +1,440,000 B of zeros past the first frame

## Fix

Move `encoder.end_image()` out of the frame loop so it runs exactly once, matching the pre-`17a562cc17` byte layout. `self.alpha` was already sized for the full multi-frame range and is filled correctly across the nested loops (`self.alpha[self.index // 2] = a` walks the entire buffer); the only bug was extending `self.data` with it too many times.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

**Related issue or feature:**

- fixes https://github.com/esphome/esphome/issues/15871
- regression from https://github.com/esphome/esphome/pull/12312 (commit `17a562cc17`)

## Test Environment

- [x] ESP32 IDF (repro + verify)

## Example entry for `config.yaml`

```yaml
# Any multi-frame animation with RGB565 + alpha triggers the pre-fix bloat:
animation:
  - file: "some_multi_frame.gif"
    id: my_animation
    type: RGB565
    transparency: alpha_channel
```

## Checklist

- [x] The code change is tested and works locally.
- [ ] Tests have been added to verify that the new code works (under `tests/` folder).