### PR TITLE
[qmc5883l] Use GPIO interrupt when DRDY pin is configured

### DIFF
--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -1,4 +1,5 @@
 #include "qmc5883l.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <cmath>
@@ -70,6 +71,10 @@ void QMC5883LComponent::setup() {
     this->error_code_ = COMMUNICATION_FAILED;
     this->mark_failed();
     return;
+  }
+
+  if (!this->drdy_use_isr_ && this->get_update_interval() < App.get_loop_interval()) {
+    this->high_freq_.start();
   }
 }
 

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -92,6 +92,10 @@ void QMC5883LComponent::dump_config() {
   LOG_SENSOR("  ", "Heading", this->heading_sensor_);
   LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
   LOG_PIN("  DRDY Pin: ", this->drdy_pin_);
+  if (this->drdy_pin_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  DRDY mode: %s",
+                  this->drdy_use_isr_ ? LOG_STR_LITERAL("interrupt") : LOG_STR_LITERAL("polling"));
+  }
 }
 
 void QMC5883LComponent::update() {

--- a/esphome/components/qmc5883l/qmc5883l.cpp
+++ b/esphome/components/qmc5883l/qmc5883l.cpp
@@ -1,5 +1,4 @@
 #include "qmc5883l.h"
-#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 #include <cmath>
@@ -24,6 +23,8 @@ static const uint8_t QMC5883L_REGISTER_CONTROL_1 = 0x09;
 static const uint8_t QMC5883L_REGISTER_CONTROL_2 = 0x0A;
 static const uint8_t QMC5883L_REGISTER_PERIOD = 0x0B;
 
+void IRAM_ATTR QMC5883LComponent::gpio_intr(QMC5883LComponent *arg) { arg->enable_loop_soon_any_context(); }
+
 void QMC5883LComponent::setup() {
   // Soft Reset
   if (!this->write_byte(QMC5883L_REGISTER_CONTROL_2, 1 << 7)) {
@@ -35,6 +36,12 @@ void QMC5883LComponent::setup() {
 
   if (this->drdy_pin_) {
     this->drdy_pin_->setup();
+    if (this->drdy_pin_->is_internal()) {
+      static_cast<InternalGPIOPin *>(this->drdy_pin_)
+          ->attach_interrupt(&QMC5883LComponent::gpio_intr, this, gpio::INTERRUPT_RISING_EDGE);
+      this->drdy_use_isr_ = true;
+      this->stop_poller();
+    }
   }
 
   uint8_t control_1 = 0;
@@ -64,10 +71,6 @@ void QMC5883LComponent::setup() {
     this->mark_failed();
     return;
   }
-
-  if (this->get_update_interval() < App.get_loop_interval()) {
-    high_freq_.start();
-  }
 }
 
 void QMC5883LComponent::dump_config() {
@@ -87,13 +90,25 @@ void QMC5883LComponent::dump_config() {
 }
 
 void QMC5883LComponent::update() {
-  i2c::ErrorCode err;
-  uint8_t status = false;
-
-  // If DRDY pin is configured and the data is not ready return.
+  // If DRDY is on an external expander we keep the polling path and early-return
+  // if data is not ready yet. Internal DRDY pins take the ISR path via loop().
   if (this->drdy_pin_ && !this->drdy_pin_->digital_read()) {
     return;
   }
+  this->read_sensor_();
+}
+
+void QMC5883LComponent::loop() {
+  this->disable_loop();
+  if (!this->drdy_use_isr_ || !this->drdy_pin_->digital_read()) {
+    return;
+  }
+  this->read_sensor_();
+}
+
+void QMC5883LComponent::read_sensor_() {
+  i2c::ErrorCode err;
+  uint8_t status = false;
 
   // Status byte gets cleared when data is read, so we have to read this first.
   // If status and two axes are desired, it's possible to save one byte of traffic by enabling

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -32,6 +32,7 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   void setup() override;
   void dump_config() override;
   void update() override;
+  void loop() override;
 
   void set_drdy_pin(GPIOPin *pin) { drdy_pin_ = pin; }
   void set_datarate(QMC5883LDatarate datarate) { datarate_ = datarate; }
@@ -44,6 +45,9 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   void set_temperature_sensor(sensor::Sensor *temperature_sensor) { temperature_sensor_ = temperature_sensor; }
 
  protected:
+  static void IRAM_ATTR gpio_intr(QMC5883LComponent *arg);
+  void read_sensor_();
+
   QMC5883LDatarate datarate_{QMC5883L_DATARATE_10_HZ};
   QMC5883LRange range_{QMC5883L_RANGE_200_UT};
   QMC5883LOversampling oversampling_{QMC5883L_SAMPLING_512};
@@ -53,12 +57,12 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
   sensor::Sensor *heading_sensor_{nullptr};
   sensor::Sensor *temperature_sensor_{nullptr};
   GPIOPin *drdy_pin_{nullptr};
+  bool drdy_use_isr_{false};
   enum ErrorCode {
     NONE = 0,
     COMMUNICATION_FAILED,
   } error_code_;
   i2c::ErrorCode read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len = 1);
-  HighFrequencyLoopRequester high_freq_;
 };
 
 }  // namespace qmc5883l

--- a/esphome/components/qmc5883l/qmc5883l.h
+++ b/esphome/components/qmc5883l/qmc5883l.h
@@ -63,6 +63,7 @@ class QMC5883LComponent : public PollingComponent, public i2c::I2CDevice {
     COMMUNICATION_FAILED,
   } error_code_;
   i2c::ErrorCode read_bytes_16_le_(uint8_t a_register, uint16_t *data, uint8_t len = 1);
+  HighFrequencyLoopRequester high_freq_;
 };
 
 }  // namespace qmc5883l


### PR DESCRIPTION
# What does this implement/fix?

Drive qmc5883l reads from a DRDY GPIO interrupt instead of polling on the `update_interval` cadence when the DRDY pin is internal. Same pattern as #15627.

- ISR calls `enable_loop_soon_any_context()`
- `loop()` calls `disable_loop()` immediately, checks pin level, reads sensor if high
- On setup, if `drdy_pin` is an internal GPIO: attach rising-edge ISR and call `stop_poller()` so `update()` no longer fires
- If `drdy_pin` is on an expander (non-internal): keep the existing polling path, early-return from `update()` when pin is low
- If no `drdy_pin`: unchanged (PollingComponent with no DRDY short-circuit)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes required
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).