### PR TITLE
[bl0906] Disable loop when idle and introduce BL0906Stage enum

### DIFF
--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -8,20 +8,6 @@ namespace bl0906 {
 
 static const char *const TAG = "bl0906";
 
-// Stage values for the read state machine. After CHANNEL_6 the state machine jumps
-// to the two sentinel stages below, then to IDLE_STAGE which marks the cycle as
-// complete and disables the loop.
-static constexpr uint8_t TEMP_STAGE = 0;  // chip temperature
-static constexpr uint8_t CHANNEL_1 = 1;   // per-phase current + power + energy
-static constexpr uint8_t CHANNEL_2 = 2;
-static constexpr uint8_t CHANNEL_3 = 3;
-static constexpr uint8_t CHANNEL_4 = 4;
-static constexpr uint8_t CHANNEL_5 = 5;
-static constexpr uint8_t CHANNEL_6 = 6;
-static constexpr uint8_t FREQ_STAGE = UINT8_MAX - 2;   // frequency + voltage
-static constexpr uint8_t POWER_STAGE = UINT8_MAX - 1;  // total power + total energy
-static constexpr uint8_t IDLE_STAGE = UINT8_MAX;       // cycle complete
-
 constexpr uint32_t to_uint32_t(ube24_t input) { return input.h << 16 | input.m << 8 | input.l; }
 
 constexpr int32_t to_int32_t(sbe24_t input) {
@@ -37,46 +23,46 @@ void BL0906::loop() {
   while (this->available())
     this->flush();
 
-  if (this->current_stage_ == IDLE_STAGE) {
+  if (this->current_stage_ == STAGE_IDLE) {
     // Woken up between cycles to drain the action queue. Go back to sleep.
     this->handle_actions_();
     this->disable_loop();
     return;
   }
 
-  if (this->current_stage_ == TEMP_STAGE) {
+  if (this->current_stage_ == STAGE_TEMP) {
     // Temperature
     this->read_data_(BL0906_TEMPERATURE, BL0906_TREF, this->temperature_sensor_);
-  } else if (this->current_stage_ == CHANNEL_1) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_1) {
     this->read_data_(BL0906_I_1_RMS, BL0906_IREF, this->current_1_sensor_);
     this->read_data_(BL0906_WATT_1, BL0906_PREF, this->power_1_sensor_);
     this->read_data_(BL0906_CF_1_CNT, BL0906_EREF, this->energy_1_sensor_);
-  } else if (this->current_stage_ == CHANNEL_2) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_2) {
     this->read_data_(BL0906_I_2_RMS, BL0906_IREF, this->current_2_sensor_);
     this->read_data_(BL0906_WATT_2, BL0906_PREF, this->power_2_sensor_);
     this->read_data_(BL0906_CF_2_CNT, BL0906_EREF, this->energy_2_sensor_);
-  } else if (this->current_stage_ == CHANNEL_3) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_3) {
     this->read_data_(BL0906_I_3_RMS, BL0906_IREF, this->current_3_sensor_);
     this->read_data_(BL0906_WATT_3, BL0906_PREF, this->power_3_sensor_);
     this->read_data_(BL0906_CF_3_CNT, BL0906_EREF, this->energy_3_sensor_);
-  } else if (this->current_stage_ == CHANNEL_4) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_4) {
     this->read_data_(BL0906_I_4_RMS, BL0906_IREF, this->current_4_sensor_);
     this->read_data_(BL0906_WATT_4, BL0906_PREF, this->power_4_sensor_);
     this->read_data_(BL0906_CF_4_CNT, BL0906_EREF, this->energy_4_sensor_);
-  } else if (this->current_stage_ == CHANNEL_5) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_5) {
     this->read_data_(BL0906_I_5_RMS, BL0906_IREF, this->current_5_sensor_);
     this->read_data_(BL0906_WATT_5, BL0906_PREF, this->power_5_sensor_);
     this->read_data_(BL0906_CF_5_CNT, BL0906_EREF, this->energy_5_sensor_);
-  } else if (this->current_stage_ == CHANNEL_6) {
+  } else if (this->current_stage_ == STAGE_CHANNEL_6) {
     this->read_data_(BL0906_I_6_RMS, BL0906_IREF, this->current_6_sensor_);
     this->read_data_(BL0906_WATT_6, BL0906_PREF, this->power_6_sensor_);
     this->read_data_(BL0906_CF_6_CNT, BL0906_EREF, this->energy_6_sensor_);
-  } else if (this->current_stage_ == FREQ_STAGE) {
+  } else if (this->current_stage_ == STAGE_FREQ) {
     // Frequency
     this->read_data_(BL0906_FREQUENCY, BL0906_FREF, frequency_sensor_);
     // Voltage
     this->read_data_(BL0906_V_RMS, BL0906_UREF, voltage_sensor_);
-  } else if (this->current_stage_ == POWER_STAGE) {
+  } else if (this->current_stage_ == STAGE_POWER) {
     // Total power
     this->read_data_(BL0906_WATT_SUM, BL0906_WATT, this->total_power_sensor_);
     // Total Energy
@@ -88,19 +74,19 @@ void BL0906::loop() {
 
 void BL0906::advance_stage_() {
   switch (this->current_stage_) {
-    case CHANNEL_6:
-      this->current_stage_ = FREQ_STAGE;
+    case STAGE_CHANNEL_6:
+      this->current_stage_ = STAGE_FREQ;
       break;
-    case FREQ_STAGE:
-      this->current_stage_ = POWER_STAGE;
+    case STAGE_FREQ:
+      this->current_stage_ = STAGE_POWER;
       break;
-    case POWER_STAGE:
+    case STAGE_POWER:
       // Cycle complete; sleep until the next update().
-      this->current_stage_ = IDLE_STAGE;
+      this->current_stage_ = STAGE_IDLE;
       this->disable_loop();
       break;
     default:
-      this->current_stage_++;
+      this->current_stage_ = static_cast<BL0906Stage>(this->current_stage_ + 1);
       break;
   }
 }
@@ -121,7 +107,7 @@ void BL0906::setup() {
 }
 
 void BL0906::update() {
-  this->current_stage_ = TEMP_STAGE;
+  this->current_stage_ = STAGE_TEMP;
   this->enable_loop();
 }
 

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -61,7 +61,7 @@ void BL0906::loop() {
     // Frequency
     this->read_data_(BL0906_FREQUENCY, BL0906_FREF, this->frequency_sensor_);
     // Voltage
-    this->read_data_(BL0906_V_RMS, BL0906_UREF, voltage_sensor_);
+    this->read_data_(BL0906_V_RMS, BL0906_UREF, this->voltage_sensor_);
   } else if (this->current_stage_ == STAGE_POWER) {
     // Total power
     this->read_data_(BL0906_WATT_SUM, BL0906_WATT, this->total_power_sensor_);

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -8,6 +8,20 @@ namespace bl0906 {
 
 static const char *const TAG = "bl0906";
 
+// Stage values for the read state machine. After CHANNEL_6 the state machine jumps
+// to the two sentinel stages below, then to IDLE_STAGE which marks the cycle as
+// complete and disables the loop.
+static constexpr uint8_t TEMP_STAGE = 0;  // chip temperature
+static constexpr uint8_t CHANNEL_1 = 1;   // per-phase current + power + energy
+static constexpr uint8_t CHANNEL_2 = 2;
+static constexpr uint8_t CHANNEL_3 = 3;
+static constexpr uint8_t CHANNEL_4 = 4;
+static constexpr uint8_t CHANNEL_5 = 5;
+static constexpr uint8_t CHANNEL_6 = 6;
+static constexpr uint8_t FREQ_STAGE = UINT8_MAX - 2;   // frequency + voltage
+static constexpr uint8_t POWER_STAGE = UINT8_MAX - 1;  // total power + total energy
+static constexpr uint8_t IDLE_STAGE = UINT8_MAX;       // cycle complete
+
 constexpr uint32_t to_uint32_t(ube24_t input) { return input.h << 16 | input.m << 8 | input.l; }
 
 constexpr int32_t to_int32_t(sbe24_t input) {
@@ -20,56 +34,75 @@ constexpr uint8_t bl0906_checksum(const uint8_t address, const DataPacket *data)
 }
 
 void BL0906::loop() {
-  if (this->current_channel_ == UINT8_MAX) {
-    return;
-  }
-
   while (this->available())
     this->flush();
 
-  if (this->current_channel_ == 0) {
+  if (this->current_stage_ == IDLE_STAGE) {
+    // Woken up between cycles to drain the action queue. Go back to sleep.
+    this->handle_actions_();
+    this->disable_loop();
+    return;
+  }
+
+  if (this->current_stage_ == TEMP_STAGE) {
     // Temperature
     this->read_data_(BL0906_TEMPERATURE, BL0906_TREF, this->temperature_sensor_);
-  } else if (this->current_channel_ == 1) {
+  } else if (this->current_stage_ == CHANNEL_1) {
     this->read_data_(BL0906_I_1_RMS, BL0906_IREF, this->current_1_sensor_);
     this->read_data_(BL0906_WATT_1, BL0906_PREF, this->power_1_sensor_);
     this->read_data_(BL0906_CF_1_CNT, BL0906_EREF, this->energy_1_sensor_);
-  } else if (this->current_channel_ == 2) {
+  } else if (this->current_stage_ == CHANNEL_2) {
     this->read_data_(BL0906_I_2_RMS, BL0906_IREF, this->current_2_sensor_);
     this->read_data_(BL0906_WATT_2, BL0906_PREF, this->power_2_sensor_);
     this->read_data_(BL0906_CF_2_CNT, BL0906_EREF, this->energy_2_sensor_);
-  } else if (this->current_channel_ == 3) {
+  } else if (this->current_stage_ == CHANNEL_3) {
     this->read_data_(BL0906_I_3_RMS, BL0906_IREF, this->current_3_sensor_);
     this->read_data_(BL0906_WATT_3, BL0906_PREF, this->power_3_sensor_);
     this->read_data_(BL0906_CF_3_CNT, BL0906_EREF, this->energy_3_sensor_);
-  } else if (this->current_channel_ == 4) {
+  } else if (this->current_stage_ == CHANNEL_4) {
     this->read_data_(BL0906_I_4_RMS, BL0906_IREF, this->current_4_sensor_);
     this->read_data_(BL0906_WATT_4, BL0906_PREF, this->power_4_sensor_);
     this->read_data_(BL0906_CF_4_CNT, BL0906_EREF, this->energy_4_sensor_);
-  } else if (this->current_channel_ == 5) {
+  } else if (this->current_stage_ == CHANNEL_5) {
     this->read_data_(BL0906_I_5_RMS, BL0906_IREF, this->current_5_sensor_);
     this->read_data_(BL0906_WATT_5, BL0906_PREF, this->power_5_sensor_);
     this->read_data_(BL0906_CF_5_CNT, BL0906_EREF, this->energy_5_sensor_);
-  } else if (this->current_channel_ == 6) {
+  } else if (this->current_stage_ == CHANNEL_6) {
     this->read_data_(BL0906_I_6_RMS, BL0906_IREF, this->current_6_sensor_);
     this->read_data_(BL0906_WATT_6, BL0906_PREF, this->power_6_sensor_);
     this->read_data_(BL0906_CF_6_CNT, BL0906_EREF, this->energy_6_sensor_);
-  } else if (this->current_channel_ == UINT8_MAX - 2) {
+  } else if (this->current_stage_ == FREQ_STAGE) {
     // Frequency
     this->read_data_(BL0906_FREQUENCY, BL0906_FREF, frequency_sensor_);
     // Voltage
     this->read_data_(BL0906_V_RMS, BL0906_UREF, voltage_sensor_);
-  } else if (this->current_channel_ == UINT8_MAX - 1) {
+  } else if (this->current_stage_ == POWER_STAGE) {
     // Total power
     this->read_data_(BL0906_WATT_SUM, BL0906_WATT, this->total_power_sensor_);
     // Total Energy
     this->read_data_(BL0906_CF_SUM_CNT, BL0906_CF, this->total_energy_sensor_);
-  } else {
-    this->current_channel_ = UINT8_MAX - 2;  // Go to frequency and voltage
-    return;
   }
-  this->current_channel_++;
+  this->advance_stage_();
   this->handle_actions_();
+}
+
+void BL0906::advance_stage_() {
+  switch (this->current_stage_) {
+    case CHANNEL_6:
+      this->current_stage_ = FREQ_STAGE;
+      break;
+    case FREQ_STAGE:
+      this->current_stage_ = POWER_STAGE;
+      break;
+    case POWER_STAGE:
+      // Cycle complete; sleep until the next update().
+      this->current_stage_ = IDLE_STAGE;
+      this->disable_loop();
+      break;
+    default:
+      this->current_stage_++;
+      break;
+  }
 }
 
 void BL0906::setup() {
@@ -87,10 +120,15 @@ void BL0906::setup() {
   this->write_array(USR_WRPROT_ONLYREAD, sizeof(USR_WRPROT_ONLYREAD));
 }
 
-void BL0906::update() { this->current_channel_ = 0; }
+void BL0906::update() {
+  this->current_stage_ = TEMP_STAGE;
+  this->enable_loop();
+}
 
 size_t BL0906::enqueue_action_(ActionCallbackFuncPtr function) {
   this->action_queue_.push_back(function);
+  // Ensure the queue is serviced even if the read cycle has already completed.
+  this->enable_loop();
   return this->action_queue_.size();
 }
 

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -104,6 +104,9 @@ void BL0906::setup() {
   this->bias_correction_(BL0906_RMSOS_6, 0.01200, 0);  // Calibration current_6
 
   this->write_array(USR_WRPROT_ONLYREAD, sizeof(USR_WRPROT_ONLYREAD));
+
+  // Loop stays idle until the first update() or enqueued action.
+  this->disable_loop();
 }
 
 void BL0906::update() {

--- a/esphome/components/bl0906/bl0906.cpp
+++ b/esphome/components/bl0906/bl0906.cpp
@@ -59,7 +59,7 @@ void BL0906::loop() {
     this->read_data_(BL0906_CF_6_CNT, BL0906_EREF, this->energy_6_sensor_);
   } else if (this->current_stage_ == STAGE_FREQ) {
     // Frequency
-    this->read_data_(BL0906_FREQUENCY, BL0906_FREF, frequency_sensor_);
+    this->read_data_(BL0906_FREQUENCY, BL0906_FREF, this->frequency_sensor_);
     // Voltage
     this->read_data_(BL0906_V_RMS, BL0906_UREF, voltage_sensor_);
   } else if (this->current_stage_ == STAGE_POWER) {

--- a/esphome/components/bl0906/bl0906.h
+++ b/esphome/components/bl0906/bl0906.h
@@ -95,7 +95,7 @@ class BL0906 : public PollingComponent, public uart::UARTDevice {
 
   void bias_correction_(uint8_t address, float measurements, float correction);
 
-  BL0906Stage current_stage_{STAGE_TEMP};
+  BL0906Stage current_stage_{STAGE_IDLE};
   void advance_stage_();
   size_t enqueue_action_(ActionCallbackFuncPtr function);
   void handle_actions_();

--- a/esphome/components/bl0906/bl0906.h
+++ b/esphome/components/bl0906/bl0906.h
@@ -79,7 +79,8 @@ class BL0906 : public PollingComponent, public uart::UARTDevice {
 
   void bias_correction_(uint8_t address, float measurements, float correction);
 
-  uint8_t current_channel_{0};
+  uint8_t current_stage_{0};
+  void advance_stage_();
   size_t enqueue_action_(ActionCallbackFuncPtr function);
   void handle_actions_();
 

--- a/esphome/components/bl0906/bl0906.h
+++ b/esphome/components/bl0906/bl0906.h
@@ -12,6 +12,22 @@
 namespace esphome {
 namespace bl0906 {
 
+// Stage values for the read state machine. After STAGE_CHANNEL_6 the state machine
+// jumps to the two sentinel stages below, then to STAGE_IDLE which marks the cycle
+// as complete and disables the loop.
+enum BL0906Stage : uint8_t {
+  STAGE_TEMP = 0,       // chip temperature
+  STAGE_CHANNEL_1 = 1,  // per-phase current + power + energy
+  STAGE_CHANNEL_2 = 2,
+  STAGE_CHANNEL_3 = 3,
+  STAGE_CHANNEL_4 = 4,
+  STAGE_CHANNEL_5 = 5,
+  STAGE_CHANNEL_6 = 6,
+  STAGE_FREQ = UINT8_MAX - 2,   // frequency + voltage
+  STAGE_POWER = UINT8_MAX - 1,  // total power + total energy
+  STAGE_IDLE = UINT8_MAX,       // cycle complete
+};
+
 struct DataPacket {  // NOLINT(altera-struct-pack-align)
   uint8_t l{0};
   uint8_t m{0};
@@ -79,7 +95,7 @@ class BL0906 : public PollingComponent, public uart::UARTDevice {
 
   void bias_correction_(uint8_t address, float measurements, float correction);
 
-  uint8_t current_stage_{0};
+  BL0906Stage current_stage_{STAGE_TEMP};
   void advance_stage_();
   size_t enqueue_action_(ActionCallbackFuncPtr function);
   void handle_actions_();


### PR DESCRIPTION
# What does this implement/fix?

Reworks the BL0906 read state machine so the component stops burning loop ticks when it has nothing to do.

- Adds a `BL0906Stage` enum (unscoped, `uint8_t` underlying) covering temperature, per-channel, frequency/voltage, total power/energy, and idle stages — replacing the scattered `uint8_t` sentinels (`0`, `UINT8_MAX - 2`, `UINT8_MAX - 1`, `UINT8_MAX`).
- Renames `current_channel_` → `current_stage_` and retypes it to `BL0906Stage` (initial value `STAGE_IDLE`).
- `loop()` now disables itself once a full read cycle (`STAGE_POWER`) completes; `update()` re-enables it and restarts from `STAGE_TEMP`.
- `enqueue_action_()` also re-enables the loop so reset-energy actions fired between poll cycles are still serviced; the idle-stage branch in `loop()` drains the action queue and goes back to sleep.
- Removes a wasted loop tick between channel 6 and the frequency stage by transitioning directly in `advance_stage_()`.
- `setup()` ends by calling `disable_loop()` so the component stays quiet until the first `update()` (or enqueued action).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
uart:
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 19200

sensor:
  - platform: bl0906
    update_interval: 10s
    voltage:
      name: Voltage
    frequency:
      name: Frequency
    temperature:
      name: Chip Temperature
    channel_1:
      current:
        name: Channel 1 Current
      power:
        name: Channel 1 Power
      energy:
        name: Channel 1 Energy
    total_power:
      name: Total Power
    total_energy:
      name: Total Energy
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).