### PR TITLE
[zwave_proxy] Inline loop() hot-path fast-paths for response_handler_ and process_uart_

### DIFF
--- a/esphome/components/zwave_proxy/zwave_proxy.cpp
+++ b/esphome/components/zwave_proxy/zwave_proxy.cpp
@@ -101,8 +101,10 @@ void ZWaveProxy::loop() {
   this->status_clear_warning();
 }
 
-void ZWaveProxy::process_uart_() {
-  while (this->available()) {
+void ZWaveProxy::process_uart_slow_() {
+  // Caller (inline process_uart_) has already confirmed available() > 0, so use do/while to
+  // drain bytes — available() is still checked at the tail, but not redundantly on entry.
+  do {
     uint8_t byte;
     if (!this->read_byte(&byte)) {
       this->status_set_warning(LOG_STR("UART read failed"));
@@ -137,7 +139,7 @@ void ZWaveProxy::process_uart_() {
         this->api_connection_->send_message(this->outgoing_proto_msg_);
       }
     }
-  }
+  } while (this->available());
 }
 
 void ZWaveProxy::dump_config() {
@@ -414,7 +416,7 @@ void ZWaveProxy::parse_start_(uint8_t byte) {
   }
 }
 
-bool ZWaveProxy::response_handler_() {
+bool ZWaveProxy::response_handler_slow_() {
   switch (this->parsing_state_) {
     case ZWAVE_PARSING_STATE_SEND_ACK:
       this->last_response_ = ZWAVE_FRAME_TYPE_ACK;

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -38,6 +38,13 @@ enum ZWaveParsingState : uint8_t {
   ZWAVE_PARSING_STATE_READ_BL_MENU,
 };
 
+// response_handler_()'s inline fast-path relies on SEND_ACK/CAN/NAK being contiguous in this
+// enum so a single range check (state - SEND_ACK < 3) is equivalent to three equality checks.
+static_assert(ZWAVE_PARSING_STATE_SEND_CAN == ZWAVE_PARSING_STATE_SEND_ACK + 1,
+              "SEND_CAN must immediately follow SEND_ACK for response_handler_ fast-path");
+static_assert(ZWAVE_PARSING_STATE_SEND_NAK == ZWAVE_PARSING_STATE_SEND_ACK + 2,
+              "SEND_NAK must immediately follow SEND_CAN for response_handler_ fast-path");
+
 enum ZWaveProxyFeature : uint32_t {
   FEATURE_ZWAVE_PROXY_ENABLED = 1 << 0,
 };
@@ -93,7 +100,10 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
     }
     this->process_uart_slow_();
   }
-  void process_uart_slow_();  // Drain all available UART data
+  // Precondition: caller must guarantee available() > 0 before invoking (see inline
+  // process_uart_ above). The slow path uses do/while and would otherwise set a spurious UART
+  // warning on entry if called with no bytes pending.
+  void process_uart_slow_();
 
   // Pre-allocated message - always ready to send
   api::ZWaveProxyFrame outgoing_proto_msg_;

--- a/esphome/components/zwave_proxy/zwave_proxy.h
+++ b/esphome/components/zwave_proxy/zwave_proxy.h
@@ -72,8 +72,28 @@ class ZWaveProxy : public uart::UARTDevice, public Component {
   void send_simple_command_(uint8_t command_id);
   bool parse_byte_(uint8_t byte);  // Returns true if frame parsing was completed (a frame is ready in the buffer)
   void parse_start_(uint8_t byte);
-  bool response_handler_();
-  void process_uart_();  // Process all available UART data
+  // Inline fast-path: most calls happen with parsing_state_ outside the SEND_* range, so skip the
+  // out-of-line call entirely in the hot path (e.g. every loop() tick) and only pay for the real
+  // work when a response is actually pending. ESPHOME_ALWAYS_INLINE is required because with -Os
+  // gcc otherwise clones the wrapper into a shared $isra$ outline and keeps the call8.
+  ESPHOME_ALWAYS_INLINE bool response_handler_() {
+    if (this->parsing_state_ < ZWAVE_PARSING_STATE_SEND_ACK || this->parsing_state_ > ZWAVE_PARSING_STATE_SEND_NAK) {
+      return false;
+    }
+    return this->response_handler_slow_();
+  }
+  bool response_handler_slow_();
+  // Inline fast-path: UART::available() is cheap (ring-buffer head/tail compare on most backends).
+  // On an idle loop tick we want to skip the call to process_uart_ entirely. When bytes are
+  // pending we fall into the slow path, which drains the UART with a do/while so available() is
+  // only checked once per byte — no redundant re-check on entry.
+  ESPHOME_ALWAYS_INLINE void process_uart_() {
+    if (!this->available()) {
+      return;
+    }
+    this->process_uart_slow_();
+  }
+  void process_uart_slow_();  // Drain all available UART data
 
   // Pre-allocated message - always ready to send
   api::ZWaveProxyFrame outgoing_proto_msg_;


### PR DESCRIPTION
# What does this implement/fix?

Reduces per-tick work in `ZWaveProxy::loop()` by inlining fast-path guards for `response_handler_()` and `process_uart_()` into the header, and moving the real work into `_slow_` helpers in the .cpp.

On idle loop ticks (the overwhelmingly common case — no UART bytes pending, no response queued, no connection edge), the two `call8`/return pairs and one nested virtual call disappear from the hot path.

### `response_handler_`
Most loop ticks have `parsing_state_` outside the three `SEND_*` states. The inline wrapper does a cheap range check (`state - SEND_ACK < 3U`) and returns immediately; the slow path (switch + UART write + log) stays out of line.

### `process_uart_`
Most ticks have no UART bytes pending. The inline wrapper does `if (!this->available()) return;`, skipping the outer function call frame entirely. When bytes *are* pending, the slow path drains the UART with a `do/while` since the caller already confirmed `available() > 0` — no redundant entry check.

### Why `ESPHOME_ALWAYS_INLINE` is required
With `-Os` (ESP-IDF default), GCC otherwise clones the wrapper into a shared `$isra$` outline and keeps the `call8`. Forcing the inline is necessary to actually remove the call from the caller.

### Measured impact (ESP32-S3, `-Os`)
Idle-tick out-of-line calls in `ZWaveProxy::loop()`:

| Before | After |
|---|---|
| `response_handler_` | *(inlined, short-circuited)* |
| `api_is_connected` | `api_is_connected` |
| virtual `parent_->is_connected` | virtual `parent_->is_connected` |
| `process_uart_` → nested virtual `available()` | `UARTDevice::available` (lifted to caller) |
| **4 call8 + 1 nested callx8** | **2 call8 + 1 callx8** |

### On-device impact (ESP32-S3, `runtime_stats`, 60 s idle window)

Combined with [#15888](https://github.com/esphome/esphome/pull/15888) (inline `api_is_connected()`), measured on the same device before/after both PRs:

| Metric | Before | After | Δ |
|---|---|---|---|
| `zwave_proxy` avg per tick | 0.014 ms | 0.009 ms | **−36%** |
| `zwave_proxy` total / minute | 54.1 ms | 33.8 ms | −20.3 ms |
| `zwave_proxy` max per tick | 4.66 ms | 3.67 ms | −21% |
| `main_loop` active_total | 209.0 ms | 199.6 ms | −9.4 ms |

The 36% per-tick reduction is the dominant effect of the two PRs combined at ~62 Hz on a device with a subscribed Home Assistant client and no UART traffic (the expected steady state).

No functional change — semantics of `response_handler_()` and `process_uart_()` are identical. Same three call sites in the .cpp (`loop()`, `can_proceed()`, `parse_byte_`) continue to work unchanged; they now hit the inline wrapper.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal refactor only. Existing zwave_proxy configs work unchanged:
uart:
  id: zwave_uart
  tx_pin: GPIO17
  rx_pin: GPIO16
  baud_rate: 115200

zwave_proxy:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
