### PR TITLE
[core] Inline api_is_connected() for hot-path callers

### DIFF
--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -1,5 +1,4 @@
 #include "esphome/core/util.h"
-#include "esphome/core/defines.h"
 #include "esphome/core/application.h"
 #include "esphome/core/version.h"
 #include "esphome/core/log.h"

--- a/esphome/core/util.cpp
+++ b/esphome/core/util.cpp
@@ -4,24 +4,11 @@
 #include "esphome/core/version.h"
 #include "esphome/core/log.h"
 
-#ifdef USE_API
-#include "esphome/components/api/api_server.h"
-#endif
-
 #ifdef USE_MQTT
 #include "esphome/components/mqtt/mqtt_client.h"
 #endif
 
 namespace esphome {
-
-bool api_is_connected() {
-#ifdef USE_API
-  if (api::global_api_server != nullptr) {
-    return api::global_api_server->is_connected();
-  }
-#endif
-  return false;
-}
 
 bool mqtt_is_connected() {
 #ifdef USE_MQTT

--- a/esphome/core/util.h
+++ b/esphome/core/util.h
@@ -1,10 +1,28 @@
 #pragma once
 
 #include <string>
+
+#include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
+
+#ifdef USE_API
+#include "esphome/components/api/api_server.h"
+#endif
+
 namespace esphome {
 
-/// Return whether the node has at least one client connected to the native API
-bool api_is_connected();
+/// Return whether the node has at least one client connected to the native API.
+///
+/// Inline so that hot-path callers (e.g. component loop() ticks that check connectivity every
+/// iteration) can skip the call8/return pair. With USE_API disabled this trivially returns false
+/// and collapses at compile time.
+#ifdef USE_API
+ESPHOME_ALWAYS_INLINE inline bool api_is_connected() {
+  return api::global_api_server != nullptr && api::global_api_server->is_connected();
+}
+#else
+ESPHOME_ALWAYS_INLINE inline bool api_is_connected() { return false; }
+#endif
 
 /// Return whether the node has an active connection to an MQTT broker
 bool mqtt_is_connected();


### PR DESCRIPTION
# What does this implement/fix?

Moves `api_is_connected()` from `util.cpp` to `util.h` as `ESPHOME_ALWAYS_INLINE`. The body is trivial — a null check on `global_api_server` plus `APIServer::is_connected()` (which is just `!clients_.empty()`) — so the out-of-line `call8` was pure overhead for any component that checks connectivity every loop tick.

Callers like `zwave_proxy::loop()` and `serial_proxy::loop()` currently pay a call frame on every iteration just to check one pointer and one vector emptiness. Inlining eliminates that entirely.

### Measured impact (ESP32-S3, `-Os`)

Before (one `call8` + return + stack frame per tick):
```asm
call8 api_is_connected
beqz  a10, disconnect_handling
```

After (5 inline Xtensa instructions, no call):
```asm
l32r   a8, global_api_server    ; load pointer to pointer
l32i.n a8, a8, 0                ; deref → APIServer*
beqz.n a8, skip                 ; null? skip
l32i.n a9, a8, 56               ; clients_._M_start
l32i.n a8, a8, 60               ; clients_._M_finish
bne    a9, a8, connected        ; non-empty? connected
```

### On-device impact (ESP32-S3, `runtime_stats`, 60 s idle window)

Combined with [#15887](https://github.com/esphome/esphome/pull/15887) (inline fast-paths in `ZWaveProxy::loop()`), measured on the same device before/after both PRs:

| Metric | Before | After | Δ |
|---|---|---|---|
| `zwave_proxy` avg per tick | 0.014 ms | 0.009 ms | **−36%** |
| `zwave_proxy` total / minute | 54.1 ms | 33.8 ms | −20.3 ms |
| `zwave_proxy` max per tick | 4.66 ms | 3.67 ms | −21% |
| `main_loop` active_total | 209.0 ms | 199.6 ms | −9.4 ms |

The 36% per-tick reduction is the dominant effect of the two PRs combined at ~62 Hz on a device with a subscribed Home Assistant client and no UART traffic (the expected steady state). This PR contributes by removing one of the four out-of-line `call8`s per tick; #15887 removes the other two.

### Includes

`util.h` now pulls in `api_server.h` under `USE_API`. Only 25 `.cpp` files include `util.h`, and all of them are on builds where USE_API is also set in practice (wifi, safe_mode, nextion, web_server, tuya, api itself, etc.), so the additional transitive include is essentially free on the platforms that matter. With USE_API disabled the inline function collapses to `return false` at compile time and folds away entirely.

No public API change — `api_is_connected()` remains a free function in the `esphome::` namespace with the same signature and semantics.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal refactor only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
