### PR TITLE
[core] Replace strnlen in buf_append_str for Zephyr compatibility

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1117,7 +1117,10 @@ inline size_t buf_append_str(char *buf, size_t size, size_t pos, const char *str
     return size;
   }
   size_t remaining = size - pos - 1;  // reserve space for null terminator
-  size_t len = strnlen(str, remaining);
+  size_t len = 0;
+  while (len < remaining && str[len] != '\0') {
+    len++;
+  }
   memcpy(buf + pos, str, len);
   pos += len;
   buf[pos] = '\0';


### PR DESCRIPTION
# What does this implement/fix?

Extracted from #15885 to fix CI. Zephyr's libc does not provide `strnlen`, which broke the Zephyr build after #15738 introduced `buf_append_str` in `esphome/core/helpers.h`.

Replaces the `strnlen` call with an explicit bounded loop so the helper compiles on all supported toolchains (including Zephyr/nRF52840).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15738
- Extracted from #15885

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-visible configuration change.
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).