### PR TITLE
[ld2412] Fix null deref in set_basic_config when entities unconfigured

### DIFF
--- a/esphome/components/ld2412/ld2412.cpp
+++ b/esphome/components/ld2412/ld2412.cpp
@@ -777,32 +777,38 @@ void LD2412Component::get_distance_resolution_() { this->send_command_(CMD_QUERY
 void LD2412Component::query_light_control_() { this->send_command_(CMD_QUERY_LIGHT_CONTROL, nullptr, 0); }
 
 void LD2412Component::set_basic_config() {
+  uint8_t min_gate = 1;
+  uint8_t max_gate = TOTAL_GATES;
+  uint16_t timeout = DEFAULT_PRESENCE_TIMEOUT;
+  uint8_t out_pin_level = 0x01;
+
 #ifdef USE_NUMBER
-  if (!this->min_distance_gate_number_->has_state() || !this->max_distance_gate_number_->has_state() ||
-      !this->timeout_number_->has_state()) {
-    return;
+  if (this->min_distance_gate_number_ != nullptr) {
+    if (!this->min_distance_gate_number_->has_state())
+      return;
+    min_gate = static_cast<int>(this->min_distance_gate_number_->state);
+  }
+  if (this->max_distance_gate_number_ != nullptr) {
+    if (!this->max_distance_gate_number_->has_state())
+      return;
+    max_gate = static_cast<int>(this->max_distance_gate_number_->state) + 1;
+  }
+  if (this->timeout_number_ != nullptr) {
+    if (!this->timeout_number_->has_state())
+      return;
+    timeout = static_cast<int>(this->timeout_number_->state);
   }
 #endif
 #ifdef USE_SELECT
-  if (!this->out_pin_level_select_->has_state()) {
-    return;
+  if (this->out_pin_level_select_ != nullptr) {
+    if (!this->out_pin_level_select_->has_state())
+      return;
+    out_pin_level = find_uint8(OUT_PIN_LEVELS_BY_STR, this->out_pin_level_select_->current_option().c_str());
   }
 #endif
 
   uint8_t value[5] = {
-#ifdef USE_NUMBER
-      lowbyte(static_cast<int>(this->min_distance_gate_number_->state)),
-      lowbyte(static_cast<int>(this->max_distance_gate_number_->state) + 1),
-      lowbyte(static_cast<int>(this->timeout_number_->state)),
-      highbyte(static_cast<int>(this->timeout_number_->state)),
-#else
-      1,    TOTAL_GATES, DEFAULT_PRESENCE_TIMEOUT, 0,
-#endif
-#ifdef USE_SELECT
-      find_uint8(OUT_PIN_LEVELS_BY_STR, this->out_pin_level_select_->current_option().c_str()),
-#else
-      0x01,  // Default value if not using select
-#endif
+      lowbyte(min_gate), lowbyte(max_gate), lowbyte(timeout), highbyte(timeout), out_pin_level,
   };
   this->set_config_mode_(true);
   this->send_command_(CMD_BASIC_CONF, value, sizeof(value));


### PR DESCRIPTION
# What does this implement/fix?

Fixes a crash in `LD2412Component::set_basic_config()` when a user changes a number entity (e.g. `max_distance_gate`) from Home Assistant.

`USE_NUMBER` and `USE_SELECT` are global defines set whenever **any** number/select entity exists anywhere in the firmware — they are not per-instance flags. The LD2412 sub-entities (`min_distance_gate`, `max_distance_gate`, `timeout`, `out_pin_level`) are all `cv.Optional` in the Python schema, so the member pointers can be `nullptr` even while the macros are defined.

The previous code unconditionally called `has_state()` and `->state` on those pointers, which crashed (`LoadProhibited`) as soon as the user moved the slider — see the backtrace in the linked issue ending at `ld2412.cpp:787` / inlined `EntityBase::has_state()`.

This PR guards each pointer with an explicit `!= nullptr` check (matching the pattern already used elsewhere in this file at lines 459, 832, 837), and falls back to the same defaults that were used when the macros were not defined.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15890

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Reproduces the crash on `dev` (any number entity change → reboot).
# With this fix, changing the slider in HA updates the device normally.
uart:
  id: uartld
  tx_pin: GPIO17
  rx_pin: GPIO18
  baud_rate: 115200
  parity: NONE
  stop_bits: 1

ld2412:
  uart_id: uartld

number:
  - platform: ld2412
    timeout:
      name: Presence Timeout
    min_distance_gate:
      name: Minimum Distance Gate
    max_distance_gate:
      name: Maximum Distance Gate
# Note: no `select:` block — out_pin_level_select_ is nullptr, but
# USE_SELECT is still defined due to other selects elsewhere in the
# firmware (api, etc.), triggering the null deref before this fix.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).