### PR TITLE
[api][serial_proxy] Expose the port ID in serial proxy info

### DIFF
--- a/esphome/components/api/api.proto
+++ b/esphome/components/api/api.proto
@@ -217,6 +217,7 @@ enum SerialProxyPortType {
 message SerialProxyInfo {
   string name = 1;                    // Human-readable port name
   SerialProxyPortType port_type = 2;  // Port type (RS232, RS485)
+  string id = 3;                      // Port ID
 }
 
 // DeviceInfoResponse max_data_length values:

--- a/esphome/components/api/api_connection.cpp
+++ b/esphome/components/api/api_connection.cpp
@@ -1801,6 +1801,7 @@ bool APIConnection::send_device_info_response_() {
     auto &info = resp.serial_proxies[serial_proxy_index++];
     info.name = StringRef(proxy->get_name());
     info.port_type = proxy->get_port_type();
+    info.id = StringRef(proxy->get_id());
   }
 #endif
 #ifdef USE_API_NOISE

--- a/esphome/components/api/api_pb2.cpp
+++ b/esphome/components/api/api_pb2.cpp
@@ -82,12 +82,14 @@ uint8_t *SerialProxyInfo::encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PAR
   uint8_t *__restrict__ pos = buffer.get_pos();
   ProtoEncode::encode_string(pos PROTO_ENCODE_DEBUG_ARG, 1, this->name);
   ProtoEncode::encode_uint32(pos PROTO_ENCODE_DEBUG_ARG, 2, static_cast<uint32_t>(this->port_type));
+  ProtoEncode::encode_string(pos PROTO_ENCODE_DEBUG_ARG, 3, this->id);
   return pos;
 }
 uint32_t SerialProxyInfo::calculate_size() const {
   uint32_t size = 0;
   size += ProtoSize::calc_length(1, this->name.size());
   size += this->port_type ? 2 : 0;
+  size += ProtoSize::calc_length(1, this->id.size());
   return size;
 }
 #endif

--- a/esphome/components/api/api_pb2.h
+++ b/esphome/components/api/api_pb2.h
@@ -506,6 +506,7 @@ class SerialProxyInfo final : public ProtoMessage {
  public:
   StringRef name{};
   enums::SerialProxyPortType port_type{};
+  StringRef id{};
   uint8_t *encode(ProtoWriteBuffer &buffer PROTO_ENCODE_DEBUG_PARAM) const;
   uint32_t calculate_size() const;
 #ifdef HAS_PROTO_MESSAGE_DUMP

--- a/esphome/components/api/api_pb2_dump.cpp
+++ b/esphome/components/api/api_pb2_dump.cpp
@@ -885,6 +885,7 @@ const char *SerialProxyInfo::dump_to(DumpBuffer &out) const {
   MessageDumpHelper helper(out, ESPHOME_PSTR("SerialProxyInfo"));
   dump_field(out, ESPHOME_PSTR("name"), this->name);
   dump_field(out, ESPHOME_PSTR("port_type"), static_cast<enums::SerialProxyPortType>(this->port_type));
+  dump_field(out, ESPHOME_PSTR("id"), this->id);
   return out.c_str();
 }
 #endif

--- a/esphome/components/serial_proxy/__init__.py
+++ b/esphome/components/serial_proxy/__init__.py
@@ -85,6 +85,7 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     cg.add(cg.App.register_serial_proxy(var))
     cg.add(var.set_name(config[CONF_NAME]))
+    cg.add(var.set_id(str(config[CONF_ID])))
     cg.add(var.set_port_type(config[CONF_PORT_TYPE]))
     cg.add_define("USE_SERIAL_PROXY")
 

--- a/esphome/components/serial_proxy/serial_proxy.h
+++ b/esphome/components/serial_proxy/serial_proxy.h
@@ -60,6 +60,12 @@ class SerialProxy : public uart::UARTDevice, public Component {
   /// Get the human-readable port name
   const char *get_name() const { return this->name_; }
 
+  /// Set the YAML component ID (string literal in flash)
+  void set_id(const char *id) { this->id_ = id; }
+
+  /// Get the YAML component ID
+  const char *get_id() const { return this->id_; }
+
   /// Set the port type (from YAML configuration)
   void set_port_type(api::enums::SerialProxyPortType port_type) { this->port_type_ = port_type; }
 
@@ -119,6 +125,9 @@ class SerialProxy : public uart::UARTDevice, public Component {
 
   /// Human-readable port name (points to a string literal in flash)
   const char *name_{nullptr};
+
+  /// YAML component ID (points to a string literal in flash)
+  const char *id_{nullptr};
 
   /// Port type
   api::enums::SerialProxyPortType port_type_{};


### PR DESCRIPTION
# What does this implement/fix?
Expose the `id` of the serial proxy config entry through the ESPHome API.

This will allow us to use it for Home Assistant Core uniqueness purposes as part of the serial port "serial number". Without it, we would rely on the YAML order of the serial proxies or the port name, neither of which are particularly stable.

See https://github.com/home-assistant/core/pull/168660 for context.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
