### PR TITLE
[core] Use MAC_ADDRESS_BUFFER_SIZE constant instead of duplicated literal

### DIFF
--- a/esphome/components/esp32_ble/ble.cpp
+++ b/esphome/components/esp32_ble/ble.cpp
@@ -257,11 +257,9 @@ bool ESP32BLE::ble_setup_() {
 
   if (this->name_ != nullptr) {
     if (App.is_name_add_mac_suffix_enabled()) {
-      // MAC address length: 12 hex chars + null terminator
-      constexpr size_t mac_address_len = 13;
       // MAC address suffix length (last 6 characters of 12-char MAC address string)
       constexpr size_t mac_address_suffix_len = 6;
-      char mac_addr[mac_address_len];
+      char mac_addr[MAC_ADDRESS_BUFFER_SIZE];
       get_mac_address_into_buffer(mac_addr);
       const char *mac_suffix_ptr = mac_addr + mac_address_suffix_len;
       make_name_with_suffix_to(name_buffer, sizeof(name_buffer), this->name_, strlen(this->name_), '-', mac_suffix_ptr,

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -82,11 +82,9 @@ class Application {
   void pre_setup(char *name, size_t name_len, char *friendly_name, size_t friendly_name_len) {
     arch_init();
     this->name_add_mac_suffix_ = true;
-    // MAC address length: 12 hex chars + null terminator
-    constexpr size_t mac_address_len = 13;
     // MAC address suffix length (last 6 characters of 12-char MAC address string)
     constexpr size_t mac_address_suffix_len = 6;
-    char mac_addr[mac_address_len];
+    char mac_addr[MAC_ADDRESS_BUFFER_SIZE];
     get_mac_address_into_buffer(mac_addr);
     // Overwrite the placeholder suffix in the mutable static buffers with actual MAC
     // name is always non-empty (validated by validate_hostname in Python config)


### PR DESCRIPTION
# What does this implement/fix?

Replace the locally-defined `constexpr size_t mac_address_len = 13` literal (with the comment "12 hex chars + null terminator") in two places with the shared `MAC_ADDRESS_BUFFER_SIZE` constant from `esphome/core/helpers.h`, which is already defined as `MAC_ADDRESS_SIZE * 2 + 1` (= 13).

This removes a duplicated magic number and ties the local buffer size to the same constant used by `get_mac_address_into_buffer()`'s `std::span<char, MAC_ADDRESS_BUFFER_SIZE>` parameter, enforcing the size match at the type level.

Touched files:
- `esphome/core/application.h` — `Application::pre_setup()` (ESPHOME_NAME_ADD_MAC_SUFFIX path)
- `esphome/components/esp32_ble/ble.cpp` — `ESP32BLE::ble_setup_()` name-with-MAC path

No behavioral change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration change; purely an internal constant rename.
esphome:
  name: my-device
  name_add_mac_suffix: true

esp32:
  board: esp32dev
  framework:
    type: esp-idf

esp32_ble:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).