### PR TITLE
[core] Collapse adjacent USE_HOST ifdef blocks in Application

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -489,9 +489,6 @@ class Application {
 #ifdef USE_HOST
   std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
 #endif
-#ifdef USE_HOST
-  int wake_socket_fd_{-1};  // Shared wake notification socket for waking main loop from tasks
-#endif
 
   // StringRef members (8 bytes each: pointer + size)
   StringRef name_;
@@ -507,7 +504,8 @@ class Application {
 #endif
 
 #ifdef USE_HOST
-  int max_fd_{-1};  // Highest file descriptor number for select()
+  int max_fd_{-1};          // Highest file descriptor number for select()
+  int wake_socket_fd_{-1};  // Shared wake notification socket for waking main loop from tasks
 #endif
 
   // 2-byte members (grouped together for alignment)
@@ -524,9 +522,7 @@ class Application {
 
 #ifdef USE_HOST
   bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
-#endif
 
-#ifdef USE_HOST
   // Variable-sized members (not needed with fast select — is_socket_ready_ reads rcvevent directly)
   fd_set read_fds_{};       // Working fd_set: populated by select()
   fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes


### PR DESCRIPTION
# What does this implement/fix?

Collapse adjacent `#ifdef USE_HOST` blocks in `esphome/core/application.h` that were split unnecessarily into separate guards:

- Merge `wake_socket_fd_` into the existing `USE_HOST` block next to `max_fd_` (both are host-only ints used for select() / wake notification).
- Merge the `socket_fds_changed_` bool block with the following `fd_set read_fds_` / `base_read_fds_` block — both were already gated on `USE_HOST` back-to-back.

No behavioral change; member order and placement relative to surrounding size-class groups are preserved.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host

## Example entry for `config.yaml`:

```yaml
# No user-visible change; host-platform only.
esphome:
  name: host-test

host:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).