### PR TITLE
[core] Dedupe yield() fast path in wakeable_delay and always-inline

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -754,18 +754,6 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
 // Inline yield_with_select_ for all paths except the select() fallback
 #ifndef USE_HOST
 inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay_ms) {
-#ifdef USE_LWIP_FAST_SELECT
-  // Fast path (ESP32/LibreTiny): FreeRTOS task notifications posted by the lwip
-  // event_callback wrapper (see lwip_fast_select.c) are the single source of truth for
-  // socket wake-ups. Every NETCONN_EVT_RCVPLUS posts an xTaskNotifyGive, so any notification
-  // that lands between wakes keeps the counter non-zero (next ulTaskNotifyTake returns
-  // immediately) or wakes a blocked Take directly. Additional wake sources:
-  // wake_loop_threadsafe() from background tasks, and the delay_ms timeout.
-  if (delay_ms == 0) [[unlikely]] {
-    yield();
-    return;
-  }
-#endif
   esphome::internal::wakeable_delay(delay_ms);
 }
 #endif  // !USE_HOST

--- a/esphome/core/wake.cpp
+++ b/esphome/core/wake.cpp
@@ -58,7 +58,7 @@ static int64_t alarm_callback_(alarm_id_t id, void *user_data) {
 
 namespace internal {
 void wakeable_delay(uint32_t ms) {
-  if (ms == 0) {
+  if (ms == 0) [[unlikely]] {
     yield();
     return;
   }

--- a/esphome/core/wake.h
+++ b/esphome/core/wake.h
@@ -96,8 +96,14 @@ inline void wake_loop_threadsafe() {
 }
 
 namespace internal {
-inline void wakeable_delay(uint32_t ms) {
-  if (ms == 0) {
+inline void ESPHOME_ALWAYS_INLINE wakeable_delay(uint32_t ms) {
+  // Fast path (with USE_LWIP_FAST_SELECT): FreeRTOS task notifications posted by the lwip
+  // event_callback wrapper (see lwip_fast_select.c) are the single source of truth for
+  // socket wake-ups. Every NETCONN_EVT_RCVPLUS posts an xTaskNotifyGive, so any notification
+  // that lands between wakes keeps the counter non-zero (next ulTaskNotifyTake returns
+  // immediately) or wakes a blocked Take directly. Additional wake sources:
+  // wake_loop_threadsafe() from background tasks, and the ms timeout.
+  if (ms == 0) [[unlikely]] {
     yield();
     return;
   }
@@ -127,8 +133,8 @@ inline void wake_loop_threadsafe() { wake_loop_impl(); }
 inline void ESPHOME_ALWAYS_INLINE wake_loop_isrsafe() { wake_loop_impl(); }
 
 namespace internal {
-inline void wakeable_delay(uint32_t ms) {
-  if (ms == 0) {
+inline void ESPHOME_ALWAYS_INLINE wakeable_delay(uint32_t ms) {
+  if (ms == 0) [[unlikely]] {
     delay(0);
     return;
   }
@@ -174,8 +180,8 @@ inline void wake_loop_threadsafe() {}
 inline void wake_loop_any_context() { wake_loop_threadsafe(); }
 
 namespace internal {
-inline void wakeable_delay(uint32_t ms) {
-  if (ms == 0) {
+inline void ESPHOME_ALWAYS_INLINE wakeable_delay(uint32_t ms) {
+  if (ms == 0) [[unlikely]] {
     yield();
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Two small cleanups in the wake/yield path:

1. **Remove duplicate `if (delay_ms == 0) yield()` fast path** in `Application::yield_with_select_()` (`esphome/core/application.h`). Every `wakeable_delay()` implementation (ESP32/LibreTiny, ESP8266, RP2040, Host/Zephyr) already handles `ms == 0` with `yield()`/`delay(0)` at the top of the function, so the guard in the caller was redundant.

2. **Move the USE_LWIP_FAST_SELECT fast-path explanation inside `wakeable_delay()`** (ESP32/LibreTiny FreeRTOS path in `esphome/core/wake.h`), where the behavior it describes actually lives.

3. **Mark all inline `wakeable_delay()` overloads `ESPHOME_ALWAYS_INLINE`** so removing the outer fast path doesn't cost inlining, and add `[[unlikely]]` to the `ms == 0` branch (including the RP2040 out-of-line version in `wake.cpp`) — the 0 case is the rare one.

No behavioral change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host

## Example entry for `config.yaml`:

```yaml
# No user-visible change; internal refactor of the wake/yield helpers.
esphome:
  name: my-device

esp32:
  board: esp32dev
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).