### PR TITLE
[core] Compute get_config_version_hash at compile time

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -702,7 +702,10 @@ void Application::get_comment_string(std::span<char, ESPHOME_COMMENT_SIZE_MAX> b
 
 uint32_t Application::get_config_hash() { return ESPHOME_CONFIG_HASH; }
 
-uint32_t Application::get_config_version_hash() { return fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION); }
+uint32_t Application::get_config_version_hash() {
+  constexpr uint32_t HASH = fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION);
+  return HASH;
+}
 
 time_t Application::get_build_time() { return ESPHOME_BUILD_TIME; }
 


### PR DESCRIPTION
# What does this implement/fix?

`Application::get_config_version_hash()` previously called `fnv1a_hash_extend(ESPHOME_CONFIG_HASH, ESPHOME_VERSION)` at runtime on every call. Both inputs are known at codegen time (codegen `#define`s) and `fnv1a_hash_extend` is already `constexpr`, so the result can be folded at compile time.

Force compile-time evaluation by assigning the result to a `constexpr` local. The generated code is now a single 32-bit load of a precomputed constant — no string scan, no multiplies, no XORs at runtime.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible change; internal compile-time folding.
esphome:
  name: my-device

esp32:
  board: esp32dev
  framework:
    type: esp-idf

wifi:
  ssid: "foo"
  password: "bar"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).