### PR TITLE
[libretiny] Inline xTaskGetTickCount() for millis() fast path

### DIFF
--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -19,8 +19,9 @@ void HOT yield() { ::yield(); }
 // Skip the Arduino core's ::millis() wrapper so the public esphome::millis() is
 // inlinable at its call sites and matches MillisInternal::get()'s fast path.
 // IRAM_ATTR is kept because components (e.g. rotary_encoder) call millis() from
-// ISR handlers; xTaskGetTickCountFromISR() is used in ISR context to satisfy the
-// FreeRTOS API contract.
+// ISR handlers. On RTL87xx / LN882x, millis() dispatches to xTaskGetTickCountFromISR()
+// in ISR context to satisfy the FreeRTOS API contract; on BK72xx it intentionally
+// matches the Arduino core's wiring.c and always uses xTaskGetTickCount().
 //
 // RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is already in
 // milliseconds. BK72xx runs at 500 Hz — multiply by portTICK_PERIOD_MS (== 2) to
@@ -32,7 +33,7 @@ uint32_t IRAM_ATTR HOT millis() {
 }
 #elif defined(USE_BK72XX)
 uint32_t IRAM_ATTR HOT millis() {
-  // BK72xx's Arduino millis() does not dispatch on ISR context; match that.
+  static_assert(configTICK_RATE_HZ == 500, "BK72xx millis() fast path assumes 500 Hz FreeRTOS tick");
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
 }
 #else

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -16,19 +16,15 @@ void loop();
 namespace esphome {
 
 void HOT yield() { ::yield(); }
-// Skip the Arduino core's ::millis() wrapper so the public esphome::millis() is
-// inlinable at its call sites and matches MillisInternal::get()'s fast path.
+// Inline the tick read so esphome::millis() matches MillisInternal::get()'s fast
+// path instead of going through the Arduino core's out-of-line ::millis() wrapper.
 //
-// RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is already in
-// milliseconds. IRAM_ATTR is kept on those families because components (e.g.
-// rotary_encoder) call millis() from ISR handlers, and in ISR context millis()
-// dispatches to xTaskGetTickCountFromISR() to satisfy the FreeRTOS API contract.
+// RTL87xx / LN882x (1 kHz): xTaskGetTickCount() is already ms. IRAM_ATTR + ISR
+// dispatch are needed because ISR handlers (e.g. rotary_encoder) call millis().
 //
-// BK72xx runs FreeRTOS at 500 Hz — multiply by portTICK_PERIOD_MS (== 2) to convert
-// ticks to milliseconds, matching the Arduino core's wiring.c. IRAM_ATTR is a no-op
-// on BK72xx (see hal.h): the SDK masks FIQ + IRQ at the CPU around every flash
-// operation, so no ISR runs while flash is stalled and IRAM placement is unnecessary.
-// BK72xx therefore also skips the ISR dispatch, matching the Arduino core.
+// BK72xx (500 Hz): ticks * portTICK_PERIOD_MS (== 2). IRAM_ATTR and ISR dispatch
+// are both unnecessary — the SDK masks FIQ + IRQ during flash writes (see hal.h),
+// so no ISR runs while flash is stalled.
 #if defined(USE_RTL87XX) || defined(USE_LN882X)
 uint32_t IRAM_ATTR HOT millis() {
   static_assert(configTICK_RATE_HZ == 1000, "millis() fast path requires 1 kHz FreeRTOS tick");

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -16,8 +16,29 @@ void loop();
 namespace esphome {
 
 void HOT yield() { ::yield(); }
+// Skip the Arduino core's ::millis() wrapper so the public esphome::millis() is
+// inlinable at its call sites and matches MillisInternal::get()'s fast path.
+// IRAM_ATTR is kept because components (e.g. rotary_encoder) call millis() from
+// ISR handlers; xTaskGetTickCountFromISR() is used in ISR context to satisfy the
+// FreeRTOS API contract.
+//
+// RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is already in
+// milliseconds. BK72xx runs at 500 Hz — multiply by portTICK_PERIOD_MS (== 2) to
+// convert ticks to milliseconds, matching the Arduino core's wiring.c.
+#if defined(USE_RTL87XX) || defined(USE_LN882X)
+uint32_t IRAM_ATTR HOT millis() {
+  static_assert(configTICK_RATE_HZ == 1000, "millis() fast path requires 1 kHz FreeRTOS tick");
+  return in_isr_context() ? xTaskGetTickCountFromISR() : xTaskGetTickCount();
+}
+#elif defined(USE_BK72XX)
+uint32_t IRAM_ATTR HOT millis() {
+  // BK72xx's Arduino millis() does not dispatch on ISR context; match that.
+  return xTaskGetTickCount() * portTICK_PERIOD_MS;
+}
+#else
 uint32_t IRAM_ATTR HOT millis() { return ::millis(); }
-uint64_t millis_64() { return Millis64Impl::compute(::millis()); }
+#endif
+uint64_t millis_64() { return Millis64Impl::compute(millis()); }
 uint32_t IRAM_ATTR HOT micros() { return ::micros(); }
 void HOT delay(uint32_t ms) { ::delay(ms); }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) { ::delayMicroseconds(us); }

--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -18,21 +18,24 @@ namespace esphome {
 void HOT yield() { ::yield(); }
 // Skip the Arduino core's ::millis() wrapper so the public esphome::millis() is
 // inlinable at its call sites and matches MillisInternal::get()'s fast path.
-// IRAM_ATTR is kept because components (e.g. rotary_encoder) call millis() from
-// ISR handlers. On RTL87xx / LN882x, millis() dispatches to xTaskGetTickCountFromISR()
-// in ISR context to satisfy the FreeRTOS API contract; on BK72xx it intentionally
-// matches the Arduino core's wiring.c and always uses xTaskGetTickCount().
 //
 // RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is already in
-// milliseconds. BK72xx runs at 500 Hz — multiply by portTICK_PERIOD_MS (== 2) to
-// convert ticks to milliseconds, matching the Arduino core's wiring.c.
+// milliseconds. IRAM_ATTR is kept on those families because components (e.g.
+// rotary_encoder) call millis() from ISR handlers, and in ISR context millis()
+// dispatches to xTaskGetTickCountFromISR() to satisfy the FreeRTOS API contract.
+//
+// BK72xx runs FreeRTOS at 500 Hz — multiply by portTICK_PERIOD_MS (== 2) to convert
+// ticks to milliseconds, matching the Arduino core's wiring.c. IRAM_ATTR is a no-op
+// on BK72xx (see hal.h): the SDK masks FIQ + IRQ at the CPU around every flash
+// operation, so no ISR runs while flash is stalled and IRAM placement is unnecessary.
+// BK72xx therefore also skips the ISR dispatch, matching the Arduino core.
 #if defined(USE_RTL87XX) || defined(USE_LN882X)
 uint32_t IRAM_ATTR HOT millis() {
   static_assert(configTICK_RATE_HZ == 1000, "millis() fast path requires 1 kHz FreeRTOS tick");
   return in_isr_context() ? xTaskGetTickCountFromISR() : xTaskGetTickCount();
 }
 #elif defined(USE_BK72XX)
-uint32_t IRAM_ATTR HOT millis() {
+uint32_t HOT millis() {
   static_assert(configTICK_RATE_HZ == 500, "BK72xx millis() fast path assumes 500 Hz FreeRTOS tick");
   return xTaskGetTickCount() * portTICK_PERIOD_MS;
 }

--- a/esphome/core/millis_internal.h
+++ b/esphome/core/millis_internal.h
@@ -42,8 +42,13 @@ class MillisInternal {
     return xTaskGetTickCount();
 #elif defined(USE_BK72XX)
     // BK72xx runs FreeRTOS at 500 Hz; scale ticks by portTICK_PERIOD_MS (== 2).
-    // Inlined here because esphome::millis() on BK72xx has no-op IRAM_ATTR but
-    // is still out-of-line, so calling it would cost a real function call.
+    // Inlined here because esphome::millis() on BK72xx is out-of-line (its
+    // IRAM_ATTR is a no-op — see hal.h — because the BK72xx SDK wraps flash
+    // operations in GLOBAL_INT_DISABLE() which masks FIQ + IRQ at the CPU for
+    // the duration of every write, so no ISR runs while flash is stalled and
+    // IRAM placement / FromISR dispatch are both unnecessary). Calling the
+    // out-of-line esphome::millis() would still cost a real function call,
+    // which this inlined path avoids.
     static_assert(configTICK_RATE_HZ == 500, "BK72xx MillisInternal assumes 500 Hz FreeRTOS tick");
     return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #else

--- a/esphome/core/millis_internal.h
+++ b/esphome/core/millis_internal.h
@@ -36,19 +36,13 @@ class MillisInternal {
 #if defined(USE_ESP32) && CONFIG_FREERTOS_HZ == 1000
     return xTaskGetTickCount();
 #elif defined(USE_LIBRETINY) && (defined(USE_RTL87XX) || defined(USE_LN882X))
-    // RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is
-    // already in milliseconds.
+    // 1 kHz: xTaskGetTickCount() is already ms.
     static_assert(configTICK_RATE_HZ == 1000, "MillisInternal fast path requires 1 kHz FreeRTOS tick");
     return xTaskGetTickCount();
 #elif defined(USE_BK72XX)
-    // BK72xx runs FreeRTOS at 500 Hz; scale ticks by portTICK_PERIOD_MS (== 2).
-    // Inlined here because esphome::millis() on BK72xx is out-of-line (its
-    // IRAM_ATTR is a no-op — see hal.h — because the BK72xx SDK wraps flash
-    // operations in GLOBAL_INT_DISABLE() which masks FIQ + IRQ at the CPU for
-    // the duration of every write, so no ISR runs while flash is stalled and
-    // IRAM placement / FromISR dispatch are both unnecessary). Calling the
-    // out-of-line esphome::millis() would still cost a real function call,
-    // which this inlined path avoids.
+    // 500 Hz: scale by portTICK_PERIOD_MS (== 2). Inlined to avoid the
+    // out-of-line call to esphome::millis() (IRAM_ATTR is a no-op on BK72xx —
+    // SDK masks FIQ + IRQ during flash writes, see hal.h).
     static_assert(configTICK_RATE_HZ == 500, "BK72xx MillisInternal assumes 500 Hz FreeRTOS tick");
     return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #else

--- a/esphome/core/millis_internal.h
+++ b/esphome/core/millis_internal.h
@@ -7,6 +7,9 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <sdkconfig.h>
+#elif defined(USE_LIBRETINY)
+#include <FreeRTOS.h>
+#include <task.h>
 #endif
 
 namespace esphome {
@@ -14,10 +17,11 @@ namespace esphome {
 // Friend-gated accessor for a fast millis() variant intended only for
 // known task-context callers on the main loop hot path (Application::loop()
 // and WarnIfComponentBlockingGuard::finish()). It skips the ISR-context
-// dispatch that the public esphome::millis() pays on ESP32.
+// dispatch that the public esphome::millis() pays on ESP32 and libretiny.
 //
-// MUST NOT be called from ISR context: on ESP32 it calls the non-FromISR
-// FreeRTOS API directly, which is undefined behavior in ISR context.
+// MUST NOT be called from ISR context: on ESP32 and libretiny it calls the
+// non-FromISR FreeRTOS API directly, which is undefined behavior in ISR
+// context.
 //
 // Adding new callers requires adding a friend declaration here — that
 // is the review point. Do not relax the access (e.g. by making get()
@@ -31,6 +35,17 @@ class MillisInternal {
   static ESPHOME_ALWAYS_INLINE uint32_t get() {
 #if defined(USE_ESP32) && CONFIG_FREERTOS_HZ == 1000
     return xTaskGetTickCount();
+#elif defined(USE_LIBRETINY) && (defined(USE_RTL87XX) || defined(USE_LN882X))
+    // RTL87xx and LN882x run FreeRTOS at 1 kHz, so xTaskGetTickCount() is
+    // already in milliseconds.
+    static_assert(configTICK_RATE_HZ == 1000, "MillisInternal fast path requires 1 kHz FreeRTOS tick");
+    return xTaskGetTickCount();
+#elif defined(USE_BK72XX)
+    // BK72xx runs FreeRTOS at 500 Hz; scale ticks by portTICK_PERIOD_MS (== 2).
+    // Inlined here because esphome::millis() on BK72xx has no-op IRAM_ATTR but
+    // is still out-of-line, so calling it would cost a real function call.
+    static_assert(configTICK_RATE_HZ == 500, "BK72xx MillisInternal assumes 500 Hz FreeRTOS tick");
+    return xTaskGetTickCount() * portTICK_PERIOD_MS;
 #else
     return millis();
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Libretiny redo of https://github.com/esphome/esphome/pull/15661, which did the same thing for ESP32.

Libretiny's Arduino core already implements `millis()` as `xTaskGetTickCount()` internally (RTL87xx / LN882x at 1 kHz) or `xTaskGetTickCount() * portTICK_PERIOD_MS` (BK72xx at 500 Hz). However, `esphome::millis()` still wraps `::millis()` and is out-of-line:

- On RTL87xx / LN882x, `IRAM_ATTR` expands to `__attribute__((noinline, section(...)))`, forcing a real function call.
- On BK72xx, `IRAM_ATTR` is a no-op, but `esphome::millis()` is still a regular out-of-line function (a call through the Arduino core's `::millis()` symbol).

So on every loop iteration, `Application::loop()` and `WarnIfComponentBlockingGuard::finish()` pay a function call to read the tick counter, even though the underlying operation is one or two instructions.

This PR:

1. Inlines the libretiny fast paths into `MillisInternal::get()` in `esphome/core/millis_internal.h`, so the hot-path callers (`Application::loop()`, `WarnIfComponentBlockingGuard::finish()`, `Application::setup()`, `feed_wdt()`, `teardown_components()`) get the tick read inlined. Branches added:
   - `USE_RTL87XX` / `USE_LN882X` → `xTaskGetTickCount()` (1 kHz ⇒ already ms)
   - `USE_BK72XX` → `xTaskGetTickCount() * portTICK_PERIOD_MS` (500 Hz ⇒ 2 ms/tick)
   - Each branch has a `static_assert` on `configTICK_RATE_HZ` so a future tick-rate change in the libretiny cores trips a build error.

2. Rewrites `esphome::millis()` in `esphome/components/libretiny/core.cpp` to call `xTaskGetTickCount()` directly instead of going through `::millis()`. This keeps the public API fast and stable even if the libretiny Arduino core changes its internal implementation, and guarantees that `esphome::millis()` and `MillisInternal::get()` always read the same clock.
   - RTL87xx / LN882x keep `IRAM_ATTR` and dispatch to `xTaskGetTickCountFromISR()` in ISR context (matching the Arduino core's `wiring.c` pattern) because components like `rotary_encoder` call `millis()` from ISR handlers, and the section attribute keeps it callable while flash is stalled.
   - BK72xx skips `IRAM_ATTR` (which is a no-op on that family anyway — see `hal.h`) and the ISR dispatch: the BK72xx SDK wraps flash operations in `GLOBAL_INT_DISABLE()`, which masks FIQ + IRQ at the CPU for the duration of every write, so no ISR can fire during a flash stall and IRAM placement / `xTaskGetTickCountFromISR()` dispatch are unnecessary.

3. Routes `millis_64()` through `millis()` rather than `::millis()` so the 64-bit extension is rooted in the same clock as the 32-bit fast path — scheduler rollover tracking stays consistent.

The same ISR-safety contract as on ESP32 applies: `MillisInternal::get()` must only be called from task context; the friend-gated access on the class enforces this at the source level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a (follow-up to #15661)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (internal optimization, no user-facing change)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal optimization only.
```

## Checklist:
  - [x] The code change is tested and works locally. (`script/test_build_components -c libretiny -t {bk72xx-ard,rtl87xx-ard,ln882x-ard} -e compile` all succeed. Flashed and running on real hardware: `bw15-device.yaml` (BW15 / RTL8720C — RTL87xx branch) and `cb3s-test.yaml` (CB3S / BK7231N — BK72xx branch).)
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
