### PR TITLE
[mitsubishi_cn105] add support for half-degree temperature setpoint

### DIFF
--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
@@ -352,7 +352,7 @@ void MitsubishiCN105::set_target_temperature(float target_temperature) {
     ESP_LOGD(TAG, "Setting temperature out-of-range: %.1f", target_temperature);
     return;
   }
-  this->status_.target_temperature = std::round(target_temperature);
+  this->status_.target_temperature = target_temperature;
   this->pending_updates_.set(UpdateFlag::TEMPERATURE);
 }
 
@@ -387,9 +387,9 @@ void MitsubishiCN105::apply_settings_() {
   if (this->pending_updates_.has(UpdateFlag::TEMPERATURE)) {
     payload[1] |= 0x04;
     if (this->use_temperature_encoding_b_) {
-      payload[14] = static_cast<uint8_t>(this->status_.target_temperature * 2.0f + 128.0f);
+      payload[14] = static_cast<uint8_t>(std::round(this->status_.target_temperature * 2.0f) + 128.0f);
     } else {
-      payload[5] = static_cast<uint8_t>(TARGET_TEMPERATURE_ENC_A_OFFSET - this->status_.target_temperature);
+      payload[5] = static_cast<uint8_t>(TARGET_TEMPERATURE_ENC_A_OFFSET - std::round(this->status_.target_temperature));
     }
   }
 

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
@@ -352,7 +352,7 @@ void MitsubishiCN105::set_target_temperature(float target_temperature) {
     ESP_LOGD(TAG, "Setting temperature out-of-range: %.1f", target_temperature);
     return;
   }
-  this->status_.target_temperature = target_temperature;
+  this->status_.target_temperature = std::round(target_temperature * 2.0f) / 2.0f;
   this->pending_updates_.set(UpdateFlag::TEMPERATURE);
 }
 
@@ -387,7 +387,7 @@ void MitsubishiCN105::apply_settings_() {
   if (this->pending_updates_.has(UpdateFlag::TEMPERATURE)) {
     payload[1] |= 0x04;
     if (this->use_temperature_encoding_b_) {
-      payload[14] = static_cast<uint8_t>(std::round(this->status_.target_temperature * 2.0f) + 128.0f);
+      payload[14] = static_cast<uint8_t>(std::round(this->status_.target_temperature * 2.0f) + 128);
     } else {
       payload[5] = static_cast<uint8_t>(TARGET_TEMPERATURE_ENC_A_OFFSET - std::round(this->status_.target_temperature));
     }

--- a/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
+++ b/esphome/components/mitsubishi_cn105/mitsubishi_cn105.cpp
@@ -352,7 +352,7 @@ void MitsubishiCN105::set_target_temperature(float target_temperature) {
     ESP_LOGD(TAG, "Setting temperature out-of-range: %.1f", target_temperature);
     return;
   }
-  this->status_.target_temperature = std::round(target_temperature * 2.0f) / 2.0f;
+  this->status_.target_temperature = target_temperature;
   this->pending_updates_.set(UpdateFlag::TEMPERATURE);
 }
 

--- a/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
+++ b/tests/components/mitsubishi_cn105/climate/mitsubishi_cn105_tests.cpp
@@ -341,6 +341,17 @@ TEST(MitsubishiCN105Tests, ApplySettingsTemperatureEncodedB) {
                                                   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB4, 0x00, 0xC5));
 }
 
+TEST(MitsubishiCN105Tests, ApplySettingsHalfDegreeTemperatureEncodedB) {
+  auto ctx = TestContext{};
+
+  ctx.sut.use_temperature_encoding_b_ = true;
+  ctx.sut.set_target_temperature(26.5f);
+  ctx.sut.apply_settings();
+
+  EXPECT_THAT(ctx.uart.tx, ::testing::ElementsAre(0xFC, 0x41, 0x01, 0x30, 0x10, 0x01, 0x04, 0x00, 0x00, 0x00, 0x00,
+                                                  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB5, 0x00, 0xC4));
+}
+
 TEST(MitsubishiCN105Tests, ApplyModeCool) {
   auto ctx = TestContext{};
 


### PR DESCRIPTION
# What does this implement/fix?

Add support for half-degree temperature setpoint (e.g. 26.5°C).

Detached from https://github.com/esphome/esphome/pull/15488.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
climate:
  - platform: mitsubishi_cn105
    ...
    visual:
      temperature_step:
        target_temperature: 0.5
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

