### PR TITLE
[io_expanders] Self-heal interrupt-driven expanders when INT stays asserted across the read

### DIFF
--- a/esphome/components/mcp23016/mcp23016.cpp
+++ b/esphome/components/mcp23016/mcp23016.cpp
@@ -37,7 +37,10 @@ void IRAM_ATTR MCP23016::gpio_intr(MCP23016 *arg) { arg->enable_loop_soon_any_co
 void MCP23016::loop() {
   // Invalidate cache at the start of each loop
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();
   }
 }

--- a/esphome/components/mcp23xxx_base/mcp23xxx_base.h
+++ b/esphome/components/mcp23xxx_base/mcp23xxx_base.h
@@ -21,7 +21,10 @@ template<uint8_t N> class MCP23XXXBase : public Component, public gpio_expander:
 
   void loop() override {
     this->reset_pin_cache_();
-    if (this->interrupt_pin_ != nullptr) {
+    // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+    // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
+    // stale state forever; keep looping until the line is released so we self-heal.
+    if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
       this->disable_loop();
     }
   }

--- a/esphome/components/pca6416a/pca6416a.cpp
+++ b/esphome/components/pca6416a/pca6416a.cpp
@@ -62,7 +62,10 @@ void IRAM_ATTR PCA6416AComponent::gpio_intr(PCA6416AComponent *arg) { arg->enabl
 void PCA6416AComponent::loop() {
   // Invalidate cache at the start of each loop
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();
   }
 }

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -50,13 +50,11 @@ void IRAM_ATTR PCA9554Component::gpio_intr(PCA9554Component *arg) { arg->enable_
 void PCA9554Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
-    // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
-    // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
-    // stale state forever; keep looping until the line is released so we self-heal.
-    if (this->interrupt_pin_->digital_read()) {
-      this->disable_loop();
-    }
+  // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
+    this->disable_loop();
   }
 }
 

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -50,8 +50,8 @@ void IRAM_ATTR PCA9554Component::gpio_intr(PCA9554Component *arg) { arg->enable_
 void PCA9554Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
-  // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
-  // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
   // stale state forever; keep looping until the line is released so we self-heal.
   if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();

--- a/esphome/components/pca9554/pca9554.cpp
+++ b/esphome/components/pca9554/pca9554.cpp
@@ -51,8 +51,12 @@ void PCA9554Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
   if (this->interrupt_pin_ != nullptr) {
-    // Interrupt-driven: disable loop until next interrupt fires
-    this->disable_loop();
+    // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
+    // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+    // stale state forever; keep looping until the line is released so we self-heal.
+    if (this->interrupt_pin_->digital_read()) {
+      this->disable_loop();
+    }
   }
 }
 

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -31,8 +31,8 @@ void IRAM_ATTR PCF8574Component::gpio_intr(PCF8574Component *arg) { arg->enable_
 void PCF8574Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
-  // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
-  // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
   // stale state forever; keep looping until the line is released so we self-heal.
   if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -32,8 +32,12 @@ void PCF8574Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
   if (this->interrupt_pin_ != nullptr) {
-    // Interrupt-driven: disable loop until next interrupt fires
-    this->disable_loop();
+    // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
+    // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+    // stale state forever; keep looping until the line is released so we self-heal.
+    if (this->interrupt_pin_->digital_read()) {
+      this->disable_loop();
+    }
   }
 }
 void PCF8574Component::dump_config() {

--- a/esphome/components/pcf8574/pcf8574.cpp
+++ b/esphome/components/pcf8574/pcf8574.cpp
@@ -31,13 +31,11 @@ void IRAM_ATTR PCF8574Component::gpio_intr(PCF8574Component *arg) { arg->enable_
 void PCF8574Component::loop() {
   // Invalidate the cache so the next digital_read() triggers a fresh I2C read
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
-    // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
-    // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
-    // stale state forever; keep looping until the line is released so we self-heal.
-    if (this->interrupt_pin_->digital_read()) {
-      this->disable_loop();
-    }
+  // Only disable the loop once INT# has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT# asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
+    this->disable_loop();
   }
 }
 void PCF8574Component::dump_config() {

--- a/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
+++ b/esphome/components/pi4ioe5v6408/pi4ioe5v6408.cpp
@@ -82,7 +82,10 @@ void PI4IOE5V6408Component::pin_mode(uint8_t pin, gpio::Flags flags) {
 
 void PI4IOE5V6408Component::loop() {
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();
   }
 }

--- a/esphome/components/tca9555/tca9555.cpp
+++ b/esphome/components/tca9555/tca9555.cpp
@@ -57,7 +57,10 @@ void TCA9555Component::pin_mode(uint8_t pin, gpio::Flags flags) {
 }
 void TCA9555Component::loop() {
   this->reset_pin_cache_();
-  if (this->interrupt_pin_ != nullptr) {
+  // Only disable the loop once INT has actually gone HIGH. Input transitions that straddle the
+  // I2C read leave INT asserted without re-firing a falling edge, which would strand us with
+  // stale state forever; keep looping until the line is released so we self-heal.
+  if (this->interrupt_pin_ != nullptr && this->interrupt_pin_->digital_read()) {
     this->disable_loop();
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Fixes a stuck-LOW failure mode in every interrupt-capable IO expander added in the 2026.4 cycle. When an input transition straddles the I²C read that is supposed to release `INT`, the chip keeps the line asserted without re-firing a falling edge, so the driver never reads again and loses all subsequent input events until reboot.

Pattern is identical across components:
1. ISR (falling edge) → `enable_loop_soon_any_context()`.
2. Main `loop()` invalidates the cache and unconditionally calls `disable_loop()`.
3. Binary sensors then read, which clears `INT` — usually.
4. If any pin transitioned mid-read, the chip does **not** release `INT`. The line stays LOW, no new falling edge can fire (it's already LOW), and the component is wedged.

The fix is one-liner per component: only call `disable_loop()` after confirming `interrupt_pin_->digital_read()` is HIGH. If it's still LOW, the loop runs again next tick, invalidates, and re-reads until the line releases. Self-heal converges in 1–2 extra ticks plus one or two extra I²C reads per recovered race — negligible on any of these buses.

Components covered (all merged into 2026.4.0):

| Component(s) | PR |
|---|---|
| `pcf8574` (PCF8574 / PCF8575) | #15444 |
| `pca9554` (PCA9554 / 9555 / 9538 / 9537) | #15444 |
| `mcp23xxx_base` (MCP23008 / 17 / 18, MCP23S08 / S17) | #15445 |
| `pi4ioe5v6408` | #15445 |
| `tca9555` | #15613 |
| `pca6416a` | #15614 |
| `mcp23016` | #15616 |

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Developer breaking change
- [ ] Undocumented C++ API change
- [ ] Code quality improvements
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15903

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for ``config.yaml``:

```yaml
# The bug reproduces on any interrupt-driven expander config where inputs
# can transition frequently. Minimal repro from issue #15903:
i2c:
  sda: 14
  scl: 15
  frequency: 100kHz

pcf8574:
  - id: wejscia
    address: 0x20
    pcf8575: true
    interrupt_pin: GPIO4

binary_sensor:
  - platform: gpio
    id: sw
    pin:
      pcf8574: wejscia
      number: 0
      mode: { input: true }
      inverted: true
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under ``tests/`` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

## Rationale for why the straddle-read specifically

PCF8575 (NXP): *"The INT output is reset by a read operation of the PCF8575."* The reset occurs at read-completion time. If any input transitions during the read, the chip latches the new state but does not release `INT`.

At 100 kHz I²C, the 2-byte read window is ≈285 µs. With enough input activity that window eventually aligns with a physical transition. Over ~1–2 days of normal duty cycle this deterministically shows up as the driver going silent — which is exactly what @th0m4sek reports in #15903 ("stops after a day and 20 hours").

MCP23xxx, PI4IOE5V6408, TCA9555, PCA6416A and MCP23016 each have their own interrupt latch but all share the same architectural property: `INT` is open-drain, asserted on change, released by a read, and the driver here uses the same falling-edge + `disable_loop()` pattern. The straddle-read vulnerability is structural, not chip-specific, so the one-liner fix is applied uniformly.

## Why check `INT` at the end instead of at the start, or re-reading in `loop()` directly

Two alternatives considered:

1. Do the hardware read from `loop()` itself and verify `INT` in the same tick.
2. Leave the lazy-read model (binary sensors trigger the I²C read) and just gate `disable_loop()` on `INT == HIGH`.

(2) is what this PR does: smaller diff, no changes to `read_cache_valid_` handling, no extra I²C read on the happy path. The cost is one extra loop iteration to confirm HIGH after a clean event; on the rare straddle-recovery path it's still bounded to a handful of ticks and a couple of extra reads. No reliability difference between the two, only diff size.