### PR TITLE
[ota] Make set_auth_password() lambda-callable via empty-password opt-in

### DIFF
--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -150,12 +150,14 @@ async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_port(config[CONF_PORT]))
 
-    # Always compile the auth path so set_auth_password() is callable from lambda
-    # (e.g. to rotate the password at runtime). A runtime-empty password_ is treated
-    # as "no password" by the server.
-    cg.add_define("USE_OTA_PASSWORD")
-    if config.get(CONF_PASSWORD):
-        cg.add(var.set_auth_password(config[CONF_PASSWORD]))
+    # Compile the auth path whenever `password:` is present in YAML, even if empty.
+    # An empty password opts in to the auth code path so set_auth_password() can be
+    # called at runtime (e.g. to rotate the password from a lambda). When `password:`
+    # is omitted entirely, the auth path is excluded to save flash on small devices.
+    if CONF_PASSWORD in config:
+        cg.add_define("USE_OTA_PASSWORD")
+        if config[CONF_PASSWORD]:
+            cg.add(var.set_auth_password(config[CONF_PASSWORD]))
     cg.add_define("USE_OTA_VERSION", config[CONF_VERSION])
     # Build flag so lwip_fast_select.c (a .c file that can't include defines.h) sees it.
     cg.add_build_flag("-DUSE_OTA_PLATFORM_ESPHOME")

--- a/esphome/components/esphome/ota/__init__.py
+++ b/esphome/components/esphome/ota/__init__.py
@@ -150,10 +150,12 @@ async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     cg.add(var.set_port(config[CONF_PORT]))
 
-    # Password could be set to an empty string and we can assume that means no password
+    # Always compile the auth path so set_auth_password() is callable from lambda
+    # (e.g. to rotate the password at runtime). A runtime-empty password_ is treated
+    # as "no password" by the server.
+    cg.add_define("USE_OTA_PASSWORD")
     if config.get(CONF_PASSWORD):
         cg.add(var.set_auth_password(config[CONF_PASSWORD]))
-        cg.add_define("USE_OTA_PASSWORD")
     cg.add_define("USE_OTA_VERSION", config[CONF_VERSION])
     # Build flag so lwip_fast_select.c (a .c file that can't include defines.h) sees it.
     cg.add_build_flag("-DUSE_OTA_PLATFORM_ESPHOME")

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -28,6 +28,14 @@ class ESPHomeOTAComponent final : public ota::OTAComponent {
   };
 #ifdef USE_OTA_PASSWORD
   void set_auth_password(const std::string &password) { password_ = password; }
+#else
+  // Stub so lambdas referencing set_auth_password() produce a clear error instead of
+  // a cryptic "no member" diagnostic. Only fires if the stub is actually instantiated.
+  template<bool B = false> void set_auth_password(const std::string & /*password*/) {
+    static_assert(B, "set_auth_password() requires the OTA auth path to be compiled. "
+                     "Add 'password: \"\"' (empty string) to your 'ota: - platform: esphome' "
+                     "config to enable runtime password rotation.");
+  }
 #endif  // USE_OTA_PASSWORD
 
   /// Manually set the port OTA should listen on

--- a/esphome/components/esphome/ota/ota_esphome.h
+++ b/esphome/components/esphome/ota/ota_esphome.h
@@ -31,7 +31,7 @@ class ESPHomeOTAComponent final : public ota::OTAComponent {
 #else
   // Stub so lambdas referencing set_auth_password() produce a clear error instead of
   // a cryptic "no member" diagnostic. Only fires if the stub is actually instantiated.
-  template<bool B = false> void set_auth_password(const std::string & /*password*/) {
+  template<bool B = false> void set_auth_password(const std::string &) {
     static_assert(B, "set_auth_password() requires the OTA auth path to be compiled. "
                      "Add 'password: \"\"' (empty string) to your 'ota: - platform: esphome' "
                      "config to enable runtime password rotation.");

--- a/tests/components/ota/test-empty_password.esp8266-ard.yaml
+++ b/tests/components/ota/test-empty_password.esp8266-ard.yaml
@@ -6,6 +6,7 @@ ota:
   - platform: esphome
     id: my_ota
     port: 3287
+    password: ""
 
 esphome:
   on_boot:

--- a/tests/components/ota/test-no_password.esp8266-ard.yaml
+++ b/tests/components/ota/test-no_password.esp8266-ard.yaml
@@ -1,0 +1,13 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+ota:
+  - platform: esphome
+    id: my_ota
+    port: 3287
+
+esphome:
+  on_boot:
+    then:
+      - lambda: id(my_ota).set_auth_password("runtime_password");


### PR DESCRIPTION
# What does this implement/fix?

`set_auth_password()` is gated behind `USE_OTA_PASSWORD`, which is only defined
when the YAML has a non-empty `password:`. The [Removing a Password](https://esphome.io/components/ota/esphome/#removing-a-password)
docs tell users to call `id(my_ota).set_auth_password("")` at runtime — but as
soon as they also remove the YAML `password:`, the setter disappears from the
compiled class and their lambda fails with:

```
error: 'class esphome::ESPHomeOTAComponent' has no member named 'set_auth_password'
```

## Approach

Rather than always compiling the auth path (which would add ~1-2 KB of flash
to every ESP8266 build regardless of whether the user wants runtime password
rotation), this PR lets the user opt in by declaring `password: ""` in YAML:

- `USE_OTA_PASSWORD` is now defined whenever the `password:` key is present in
  YAML, including when it's an empty string. Users who want runtime password
  rotation add `password: ""` to compile in the auth path.
- When `password:` is omitted entirely, the auth path is excluded as before,
  so devices that don't need OTA passwords pay zero flash cost.
- A templated `set_auth_password()` stub is added in the no-auth build that
  fires a `static_assert` if a lambda actually calls it, telling the user
  exactly what to do:

  ```
  set_auth_password() requires the OTA auth path to be compiled.
  Add 'password: ""' (empty string) to your 'ota: - platform: esphome'
  config to enable runtime password rotation.
  ```

  The assert is SFINAE-protected on a template parameter so it only fires on
  actual instantiation — builds without a lambda call are unaffected.

A runtime-empty `password_` is already treated by the server as "no password"
(see `ota_esphome.cpp:218`), so the over-the-wire behavior with an empty YAML
password is the same as having no password at all.

Note: this fixes only the compile-error half of #15899. The protocol desync
that happens when a server runs with runtime-empty `password_` while the client
is compiled with one is a separate protocol-level issue and isn't addressed
here.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes #15899

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
ota:
  - platform: esphome
    id: my_ota
    password: ""  # opt in to runtime password rotation

esphome:
  on_boot:
    then:
      - lambda: id(my_ota).set_auth_password("runtime_password");
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).