### PR TITLE
[api_protobuf] Support compound `ifdef` conditions in proto generator

### DIFF
--- a/script/api_protobuf/api_protobuf.py
+++ b/script/api_protobuf/api_protobuf.py
@@ -65,11 +65,31 @@ _enum_max_values: dict[str, int] = {}
 _message_desc_map: dict[str, Any] = {}
 
 
+def _make_ifdef_line(condition: str) -> str:
+    """Return the correct preprocessor open-guard line for a condition string.
+
+    Simple identifiers use ``#ifdef IDENTIFIER``.
+    Compound expressions (containing ``||`` or ``&&``) use
+    ``#if defined(A) || defined(B)`` so that the preprocessor
+    evaluates them correctly.
+    """
+    if any(op in condition for op in ("||", "&&", "!")):
+        # Replace each bare identifier token with defined(token)
+        expr = re.sub(r"\b([A-Za-z_]\w*)\b", r"defined(\1)", condition)
+        return f"#if {expr}"
+    return f"#ifdef {condition}"
+
+
 def indent_list(text: str, padding: str = "  ") -> list[str]:
     """Indent each line of the given text with the specified padding."""
     lines = []
     for line in text.splitlines():
-        if line == "" or line.startswith("#ifdef") or line.startswith("#endif"):
+        if (
+            line == ""
+            or line.startswith("#ifdef")
+            or line.startswith("#if ")
+            or line.startswith("#endif")
+        ):
             p = ""
         else:
             p = padding
@@ -82,7 +102,7 @@ def indent(text: str, padding: str = "  ") -> str:
 
 
 def wrap_with_ifdef(content: str | list[str], ifdef: str | None) -> list[str]:
-    """Wrap content with #ifdef directives if ifdef is provided.
+    """Wrap content with #ifdef / #if directives if ifdef is provided.
 
     Args:
         content: Single string or list of strings to wrap
@@ -96,7 +116,7 @@ def wrap_with_ifdef(content: str | list[str], ifdef: str | None) -> list[str]:
             return [content]
         return content
 
-    result = [f"#ifdef {ifdef}"]
+    result = [_make_ifdef_line(ifdef)]
     if isinstance(content, str):
         result.append(content)
     else:
@@ -3021,7 +3041,7 @@ def build_service_message_type(
     if source in (SOURCE_BOTH, SOURCE_CLIENT):
         # Only add ifdef when we're actually generating content
         if ifdef is not None:
-            hout += f"#ifdef {ifdef}\n"
+            hout += _make_ifdef_line(ifdef) + "\n"
         # Generate receive handler and switch case
         func = f"on_{snake}"
         has_fields = any(not field.options.deprecated for field in mt.field)
@@ -3302,8 +3322,8 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
                 content += "#endif\n"
                 dump_cpp += "#endif\n"
             if enum_ifdef is not None:
-                content += f"#ifdef {enum_ifdef}\n"
-                dump_cpp += f"#ifdef {enum_ifdef}\n"
+                content += _make_ifdef_line(enum_ifdef) + "\n"
+                dump_cpp += _make_ifdef_line(enum_ifdef) + "\n"
             current_ifdef = enum_ifdef
 
         content += s
@@ -3378,9 +3398,9 @@ static void dump_bytes_field(DumpBuffer &out, const char *field_name, const uint
                 if dump_cpp:
                     dump_cpp += "#endif\n"
             if msg_ifdef is not None:
-                content += f"#ifdef {msg_ifdef}\n"
-                cpp += f"#ifdef {msg_ifdef}\n"
-                dump_cpp += f"#ifdef {msg_ifdef}\n"
+                content += _make_ifdef_line(msg_ifdef) + "\n"
+                cpp += _make_ifdef_line(msg_ifdef) + "\n"
+                dump_cpp += _make_ifdef_line(msg_ifdef) + "\n"
             current_ifdef = msg_ifdef
 
         content += s
@@ -3529,7 +3549,7 @@ static const char *const TAG = "api.service";
         for id_ in sorted(ids):
             _, ifdef, case_label = RECEIVE_CASES[id_]
             if ifdef:
-                result += f"#ifdef {ifdef}\n"
+                result += _make_ifdef_line(ifdef) + "\n"
             result += f"    case {case_label}:  {comment}\n"
             if ifdef:
                 result += "#endif\n"
@@ -3572,7 +3592,7 @@ static const char *const TAG = "api.service";
     out += "  switch (msg_type) {\n"
     for i, (case, ifdef, case_label) in cases:
         if ifdef is not None:
-            out += f"#ifdef {ifdef}\n"
+            out += _make_ifdef_line(ifdef) + "\n"
 
         c = f"    case {case_label}: {{\n"
         c += indent(case, "      ") + "\n"


### PR DESCRIPTION
# What does this implement/fix?

The `api_protobuf.py` code generator previously emitted `#ifdef X` for all `(ifdef)` proto option values. This is invalid C preprocessor syntax for compound conditions like `"USE_A || USE_B"` — `#ifdef` only accepts a single token.

Adds a `_make_ifdef_line()` helper that detects `||`/`&&`/`!` operators and emits `#if defined(A) || defined(B)` for compound expressions, while keeping simple `#ifdef X` for single identifiers. All 7 direct emission sites are updated to use the helper, and `indent_list()` is extended to also suppress indentation for `#if ` lines (matching the existing `#ifdef`/`#endif` behavior).

This change is useful for #15556 which uses some common messages for both IR and RF.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a — prerequisite for upcoming `radio_frequency` component which uses compound `(ifdef) = "USE_IR_RF || USE_RADIO_FREQUENCY"` on shared protobuf messages. See #15556

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a (internal tooling only)

## Test Environment

- [x] ESP32 IDF

## Example entry for `config.yaml`:

```yaml
# No config change — this is a code generator improvement.
# Proto messages can now use compound ifdef conditions:
#
# message SharedMessage {
#   option (ifdef) = "USE_IR_RF || USE_RADIO_FREQUENCY";
#   ...
# }
#
# Which correctly generates:
#   #if defined(USE_IR_RF) || defined(USE_RADIO_FREQUENCY)
# instead of the invalid:
#   #ifdef USE_IR_RF || USE_RADIO_FREQUENCY
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).