### PR TITLE
[core] Move host socket-select wake mechanism into wake.h/wake.cpp

### DIFF
--- a/esphome/components/socket/bsd_sockets_impl.cpp
+++ b/esphome/components/socket/bsd_sockets_impl.cpp
@@ -6,6 +6,9 @@
 
 #include <cstring>
 #include "esphome/core/application.h"
+#ifdef USE_HOST
+#include "esphome/core/wake.h"
+#endif
 
 namespace esphome::socket {
 
@@ -16,7 +19,7 @@ BSDSocketImpl::BSDSocketImpl(int fd, bool monitor_loop) {
 #ifdef USE_LWIP_FAST_SELECT
   this->cached_sock_ = hook_fd_for_fast_select(this->fd_);
 #else
-  this->loop_monitored_ = App.register_socket_fd(this->fd_);
+  this->loop_monitored_ = wake_register_fd(this->fd_);
 #endif
 }
 
@@ -36,7 +39,7 @@ int BSDSocketImpl::close() {
   this->cached_sock_ = nullptr;
 #else
   if (this->loop_monitored_) {
-    App.unregister_socket_fd(this->fd_);
+    wake_unregister_fd(this->fd_);
   }
 #endif
   int ret = ::close(this->fd_);

--- a/esphome/components/socket/lwip_sockets_impl.cpp
+++ b/esphome/components/socket/lwip_sockets_impl.cpp
@@ -6,6 +6,9 @@
 
 #include <cstring>
 #include "esphome/core/application.h"
+#ifdef USE_HOST
+#include "esphome/core/wake.h"
+#endif
 
 namespace esphome::socket {
 
@@ -16,7 +19,7 @@ LwIPSocketImpl::LwIPSocketImpl(int fd, bool monitor_loop) {
 #ifdef USE_LWIP_FAST_SELECT
   this->cached_sock_ = hook_fd_for_fast_select(this->fd_);
 #else
-  this->loop_monitored_ = App.register_socket_fd(this->fd_);
+  this->loop_monitored_ = wake_register_fd(this->fd_);
 #endif
 }
 
@@ -36,7 +39,7 @@ int LwIPSocketImpl::close() {
   this->cached_sock_ = nullptr;
 #else
   if (this->loop_monitored_) {
-    App.unregister_socket_fd(this->fd_);
+    wake_unregister_fd(this->fd_);
   }
 #endif
   int ret = lwip_close(this->fd_);

--- a/esphome/components/socket/socket.cpp
+++ b/esphome/components/socket/socket.cpp
@@ -5,13 +5,16 @@
 #include <string>
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
+#ifdef USE_HOST
+#include "esphome/core/wake.h"
+#endif
 
 namespace esphome::socket {
 
 #ifdef USE_HOST
 // Shared ready() implementation for fd-based socket implementations (BSD and LWIP sockets).
-// Checks if the Application's select() loop has marked this fd as ready.
-bool socket_ready_fd(int fd, bool loop_monitored) { return !loop_monitored || App.is_socket_ready_(fd); }
+// Checks if the host wake select() loop has marked this fd as ready.
+bool socket_ready_fd(int fd, bool loop_monitored) { return !loop_monitored || wake_fd_ready(fd); }
 #endif
 
 // Platform-specific inet_ntop wrappers

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -28,10 +28,6 @@
 #include "esphome/components/socket/socket.h"
 #endif
 
-#ifdef USE_HOST
-#include <cerrno>
-#endif
-
 namespace esphome {
 
 static const char *const TAG = "app";
@@ -133,8 +129,8 @@ void Application::setup() {
   esphome_main_task_handle = xTaskGetCurrentTaskHandle();
 #endif
 #ifdef USE_HOST
-  // Set up wake socket for waking main loop from tasks (platforms without fast select only)
-  this->setup_wake_loop_threadsafe_();
+  // Set up wake socket for waking main loop from tasks (host platform select() loop).
+  wake_setup();
 #endif
 
   // Ensure all active looping components are in LOOP state.
@@ -510,105 +506,6 @@ void Application::enable_pending_loops_() {
   }
 }
 
-#ifdef USE_HOST
-bool Application::register_socket_fd(int fd) {
-  // WARNING: This function is NOT thread-safe and must only be called from the main loop
-  // It modifies socket_fds_ and related variables without locking
-  if (fd < 0)
-    return false;
-
-  if (fd >= FD_SETSIZE) {
-    ESP_LOGE(TAG, "fd %d exceeds FD_SETSIZE %d", fd, FD_SETSIZE);
-    return false;
-  }
-
-  this->socket_fds_.push_back(fd);
-  this->socket_fds_changed_ = true;
-  if (fd > this->max_fd_) {
-    this->max_fd_ = fd;
-  }
-
-  return true;
-}
-
-void Application::unregister_socket_fd(int fd) {
-  // WARNING: This function is NOT thread-safe and must only be called from the main loop
-  // It modifies socket_fds_ and related variables without locking
-  if (fd < 0)
-    return;
-
-  for (size_t i = 0; i < this->socket_fds_.size(); i++) {
-    if (this->socket_fds_[i] != fd)
-      continue;
-
-    // Swap with last element and pop - O(1) removal since order doesn't matter.
-    if (i < this->socket_fds_.size() - 1)
-      this->socket_fds_[i] = this->socket_fds_.back();
-    this->socket_fds_.pop_back();
-    this->socket_fds_changed_ = true;
-    // Only recalculate max_fd if we removed the current max
-    if (fd == this->max_fd_) {
-      this->max_fd_ = -1;
-      for (int sock_fd : this->socket_fds_) {
-        if (sock_fd > this->max_fd_)
-          this->max_fd_ = sock_fd;
-      }
-    }
-    return;
-  }
-}
-
-#endif
-
-// Only the select() fallback path remains in the .cpp — all other paths are inlined in application.h
-#ifdef USE_HOST
-void Application::yield_with_select_(uint32_t delay_ms) {
-  // Fallback select() path (host platform and any future platforms without fast select).
-  if (!this->socket_fds_.empty()) [[likely]] {
-    // Update fd_set if socket list has changed
-    if (this->socket_fds_changed_) [[unlikely]] {
-      FD_ZERO(&this->base_read_fds_);
-      // fd bounds are validated in register_socket_fd()
-      for (int fd : this->socket_fds_) {
-        FD_SET(fd, &this->base_read_fds_);
-      }
-      this->socket_fds_changed_ = false;
-    }
-
-    // Copy base fd_set before each select
-    this->read_fds_ = this->base_read_fds_;
-
-    // Convert delay_ms to timeval
-    struct timeval tv;
-    tv.tv_sec = delay_ms / 1000;
-    tv.tv_usec = (delay_ms - tv.tv_sec * 1000) * 1000;
-
-    // Call select with timeout
-    int ret = ::select(this->max_fd_ + 1, &this->read_fds_, nullptr, nullptr, &tv);
-
-    // Process select() result:
-    // ret > 0: socket(s) have data ready - normal and expected
-    // ret == 0: timeout occurred - normal and expected
-    if (ret >= 0) [[likely]] {
-      // Yield if zero timeout since select(0) only polls without yielding
-      if (delay_ms == 0) [[unlikely]] {
-        yield();
-      }
-      return;
-    }
-    // ret < 0: error (EINTR is normal, anything else is unexpected)
-    const int err = errno;
-    if (err == EINTR) {
-      return;
-    }
-    // select() error - log and fall through to delay()
-    ESP_LOGW(TAG, "select() failed with errno %d", err);
-  }
-  // No sockets registered or select() failed - use regular delay
-  delay(delay_ms);
-}
-#endif  // USE_HOST
-
 // App storage — asm label shares the linker symbol with "extern Application App".
 // char[] is trivially destructible, so no __cxa_atexit or destructor chain is emitted.
 // Constructed via placement new in the generated setup().
@@ -627,66 +524,6 @@ alignas(Application) char app_storage[sizeof(Application)] asm(
     ESPHOME_STRINGIFY_(__USER_LABEL_PREFIX__) "_ZN7esphome3AppE");
 #undef ESPHOME_STRINGIFY_
 #undef ESPHOME_STRINGIFY_IMPL_
-
-// Host platform wake_loop_threadsafe() and setup — needs wake_socket_fd_
-// ESP32/LibreTiny/ESP8266/RP2040 implementations are in wake.cpp
-#ifdef USE_HOST
-
-void Application::setup_wake_loop_threadsafe_() {
-  // Create UDP socket for wake notifications
-  this->wake_socket_fd_ = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-  if (this->wake_socket_fd_ < 0) {
-    ESP_LOGW(TAG, "Wake socket create failed: %d", errno);
-    return;
-  }
-
-  // Bind to loopback with auto-assigned port
-  struct sockaddr_in addr = {};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  addr.sin_port = 0;  // Auto-assign port
-
-  if (::bind(this->wake_socket_fd_, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
-    ESP_LOGW(TAG, "Wake socket bind failed: %d", errno);
-    ::close(this->wake_socket_fd_);
-    this->wake_socket_fd_ = -1;
-    return;
-  }
-
-  // Get the assigned address and connect to it
-  // Connecting a UDP socket allows using send() instead of sendto() for better performance
-  struct sockaddr_in wake_addr;
-  socklen_t len = sizeof(wake_addr);
-  if (::getsockname(this->wake_socket_fd_, (struct sockaddr *) &wake_addr, &len) < 0) {
-    ESP_LOGW(TAG, "Wake socket address failed: %d", errno);
-    ::close(this->wake_socket_fd_);
-    this->wake_socket_fd_ = -1;
-    return;
-  }
-
-  // Connect to self (loopback) - allows using send() instead of sendto()
-  // After connect(), no need to store wake_addr - the socket remembers it
-  if (::connect(this->wake_socket_fd_, (struct sockaddr *) &wake_addr, sizeof(wake_addr)) < 0) {
-    ESP_LOGW(TAG, "Wake socket connect failed: %d", errno);
-    ::close(this->wake_socket_fd_);
-    this->wake_socket_fd_ = -1;
-    return;
-  }
-
-  // Set non-blocking mode
-  int flags = ::fcntl(this->wake_socket_fd_, F_GETFL, 0);
-  ::fcntl(this->wake_socket_fd_, F_SETFL, flags | O_NONBLOCK);
-
-  // Register with application's select() loop
-  if (!this->register_socket_fd(this->wake_socket_fd_)) {
-    ESP_LOGW(TAG, "Wake socket register failed");
-    ::close(this->wake_socket_fd_);
-    this->wake_socket_fd_ = -1;
-    return;
-  }
-}
-
-#endif  // USE_HOST
 
 void Application::get_build_time_string(std::span<char, BUILD_TIME_STR_SIZE> buffer) {
   ESPHOME_strncpy_P(buffer.data(), ESPHOME_BUILD_TIME_STR, buffer.size());

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -27,26 +27,11 @@
 #ifdef USE_LWIP_FAST_SELECT
 #include "esphome/core/lwip_fast_select.h"
 #endif
-#ifdef USE_HOST
-#include <sys/select.h>
-#include <sys/socket.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#endif
 #ifdef USE_RUNTIME_STATS
 #include "esphome/components/runtime_stats/runtime_stats.h"
 #endif
 #include "esphome/core/wake.h"
 #include "esphome/core/entity_includes.h"
-
-namespace esphome::socket {
-#ifdef USE_HOST
-/// Shared ready() helper for fd-based socket implementations.
-bool socket_ready_fd(int fd, bool loop_monitored);  // NOLINT(readability-redundant-declaration)
-#endif
-}  // namespace esphome::socket
 
 #ifdef USE_RUNTIME_STATS
 namespace esphome::runtime_stats {
@@ -343,18 +328,6 @@ class Application {
 
   Scheduler scheduler;
 
-#ifdef USE_HOST
-  /// Register/unregister a socket file descriptor with the host select() fallback loop.
-  /// USE_LWIP_FAST_SELECT builds do not use this API — sockets hook the lwIP netconn
-  /// event_callback directly (see socket.h hook_fd_for_fast_select) and rely on FreeRTOS
-  /// task notifications for wake-up.
-  /// NOTE: File descriptors >= FD_SETSIZE (typically 10 on ESP) will be rejected with an error.
-  /// WARNING: These functions are NOT thread-safe. They must only be called from the main loop.
-  /// @return true if registration was successful, false if fd exceeds limits
-  bool register_socket_fd(int fd);
-  void unregister_socket_fd(int fd);
-#endif
-
   /// Wake the main event loop from another thread or callback.
   /// @see esphome::wake_loop_threadsafe() in wake.h for platform details.
   void wake_loop_threadsafe() { esphome::wake_loop_threadsafe(); }
@@ -372,21 +345,11 @@ class Application {
 
  protected:
   friend Component;
-#ifdef USE_HOST
-  friend bool socket::socket_ready_fd(int fd, bool loop_monitored);
-#endif
 #ifdef USE_RUNTIME_STATS
   friend class runtime_stats::RuntimeStatsCollector;
 #endif
   friend void ::setup();
   friend void ::original_setup();
-#ifdef USE_HOST
-  friend void wake_loop_threadsafe();  // Host platform accesses wake_socket_fd_
-#endif
-
-#ifdef USE_HOST
-  bool is_socket_ready_(int fd) const { return FD_ISSET(fd, &this->read_fds_); }
-#endif
 
   /// Walk all registered components looking for any whose component_state_
   /// has the given flag set. Used by Component::status_clear_*_slow_path_()
@@ -460,18 +423,9 @@ class Application {
   void service_status_led_slow_(uint32_t time);
 #endif
 
-  /// Perform a delay while also monitoring socket file descriptors for readiness
-#ifdef USE_HOST
-  // select() fallback path is too complex to inline (host platform)
-  void yield_with_select_(uint32_t delay_ms);
-#else
+  /// Sleep for up to delay_ms, returning early if a wake event arrives.
+  /// Thin wrapper over the platform wake primitive in wake.h.
   inline void ESPHOME_ALWAYS_INLINE yield_with_select_(uint32_t delay_ms);
-#endif
-
-#ifdef USE_HOST
-  void setup_wake_loop_threadsafe_();       // Create wake notification socket
-  inline void drain_wake_notifications_();  // Read pending wake notifications in main loop (hot path - inlined)
-#endif
 
   // === Member variables ordered by size to minimize padding ===
 
@@ -496,9 +450,6 @@ class Application {
   //   and active_end_ is incremented
   // - This eliminates branch mispredictions from flag checking in the hot loop
   FixedVector<Component *> looping_components_{};
-#ifdef USE_HOST
-  std::vector<int> socket_fds_;  // Vector of all monitored socket file descriptors
-#endif
 
   // StringRef members (8 bytes each: pointer + size)
   StringRef name_;
@@ -513,11 +464,6 @@ class Application {
   uint32_t last_status_led_service_{0};
 #endif
 
-#ifdef USE_HOST
-  int max_fd_{-1};          // Highest file descriptor number for select()
-  int wake_socket_fd_{-1};  // Shared wake notification socket for waking main loop from tasks
-#endif
-
   // 2-byte members (grouped together for alignment)
   uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress
   uint16_t loop_interval_{16};                                     // Loop interval in ms (max 65535ms = 65.5 seconds)
@@ -529,14 +475,6 @@ class Application {
   bool name_add_mac_suffix_;
   bool in_loop_{false};
   volatile bool has_pending_enable_loop_requests_{false};
-
-#ifdef USE_HOST
-  bool socket_fds_changed_{false};  // Flag to rebuild base_read_fds_ when socket_fds_ changes
-
-  // Variable-sized members (not needed with fast select — is_socket_ready_ reads rcvevent directly)
-  fd_set read_fds_{};       // Working fd_set: populated by select()
-  fd_set base_read_fds_{};  // Cached fd_set rebuilt only when socket_fds_ changes
-#endif
 
   // StaticVectors (largest members - contain actual array data inline)
   StaticVector<Component *, ESPHOME_COMPONENT_COUNT> components_{};
@@ -565,30 +503,6 @@ class Application {
 /// Global storage of Application pointer - only one Application can exist.
 extern Application App;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-#ifdef USE_HOST
-// Inline implementations for hot-path functions
-// drain_wake_notifications_() is called on every loop iteration
-
-// Small buffer for draining wake notification bytes (1 byte sent per wake)
-// Size allows draining multiple notifications per recvfrom() without wasting stack
-static constexpr size_t WAKE_NOTIFY_DRAIN_BUFFER_SIZE = 16;
-
-inline void Application::drain_wake_notifications_() {
-  // Called from main loop to drain any pending wake notifications
-  // Must check is_socket_ready_() to avoid blocking on empty socket
-  if (this->wake_socket_fd_ >= 0 && this->is_socket_ready_(this->wake_socket_fd_)) {
-    char buffer[WAKE_NOTIFY_DRAIN_BUFFER_SIZE];
-    // Drain all pending notifications with non-blocking reads
-    // Multiple wake events may have triggered multiple writes, so drain until EWOULDBLOCK
-    // We control both ends of this loopback socket (always write 1 byte per wake),
-    // so no error checking needed - any errors indicate catastrophic system failure
-    while (::recvfrom(this->wake_socket_fd_, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
-      // Just draining, no action needed - wake has already occurred
-    }
-  }
-}
-#endif  // USE_HOST
-
 // Phase A: drain wake notifications and run the scheduler. Invoked on every
 // Application::loop() tick regardless of whether a component phase runs, so
 // scheduler items fire at their requested cadence even when the caller has
@@ -598,8 +512,8 @@ inline void Application::drain_wake_notifications_() {
 // per-item feeds inside scheduler.call() without an extra millis().
 inline uint32_t ESPHOME_ALWAYS_INLINE Application::scheduler_tick_(uint32_t now) {
 #ifdef USE_HOST
-  // Drain wake notifications first to clear socket for next wake
-  this->drain_wake_notifications_();
+  // Drain wake notifications first to clear socket for next wake.
+  wake_drain_notifications();
 #endif
   return this->scheduler.call(now);
 }
@@ -757,11 +671,11 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   }
 }
 
-// Inline yield_with_select_ for all paths except the select() fallback
-#ifndef USE_HOST
+// All platforms route loop yields through the platform wake primitive.
+// On host this drains the loopback wake socket via select(); on FreeRTOS
+// targets it uses task notifications; on ESP8266/RP2040 it uses esp_delay/WFE.
 inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay_ms) {
   esphome::internal::wakeable_delay(delay_ms);
 }
-#endif  // !USE_HOST
 
 }  // namespace esphome

--- a/esphome/core/wake.cpp
+++ b/esphome/core/wake.cpp
@@ -1,13 +1,20 @@
 #include "esphome/core/wake.h"
 #include "esphome/core/hal.h"
+#include "esphome/core/log.h"
 
 #ifdef USE_ESP8266
 #include <coredecls.h>
 #endif
 
 #ifdef USE_HOST
-#include "esphome/core/application.h"
+#include <arpa/inet.h>
+#include <cerrno>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/socket.h>
+#include <unistd.h>
+#include <vector>
 #endif
 
 namespace esphome {
@@ -82,17 +89,188 @@ void wakeable_delay(uint32_t ms) {
 }  // namespace internal
 #endif  // USE_RP2040
 
-// === Host (UDP loopback socket) ===
+// === Host (UDP loopback socket + select() based fd watcher) ===
 #ifdef USE_HOST
+
+static const char *const TAG = "wake";
+
+namespace internal {
+// File-scope state — referenced inline by wake_drain_notifications() and
+// wake_fd_ready() in wake.h, and by the bodies in this file.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+int g_wake_socket_fd = -1;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+fd_set g_read_fds{};
+}  // namespace internal
+
+namespace {
+// File-local state owned entirely by the select() loop.
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+std::vector<int> s_socket_fds;
+int s_max_fd = -1;
+bool s_socket_fds_changed = false;
+fd_set s_base_read_fds{};
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+}  // namespace
+
+bool wake_register_fd(int fd) {
+  // WARNING: not thread-safe — must be called only from the main loop.
+  if (fd < 0)
+    return false;
+
+  if (fd >= FD_SETSIZE) {
+    ESP_LOGE(TAG, "fd %d exceeds FD_SETSIZE %d", fd, FD_SETSIZE);
+    return false;
+  }
+
+  s_socket_fds.push_back(fd);
+  s_socket_fds_changed = true;
+  if (fd > s_max_fd) {
+    s_max_fd = fd;
+  }
+
+  return true;
+}
+
+void wake_unregister_fd(int fd) {
+  // WARNING: not thread-safe — must be called only from the main loop.
+  if (fd < 0)
+    return;
+
+  for (size_t i = 0; i < s_socket_fds.size(); i++) {
+    if (s_socket_fds[i] != fd)
+      continue;
+
+    // Swap with last element and pop — O(1) removal since order doesn't matter.
+    if (i < s_socket_fds.size() - 1)
+      s_socket_fds[i] = s_socket_fds.back();
+    s_socket_fds.pop_back();
+    s_socket_fds_changed = true;
+    // Only recalculate max_fd if we removed the current max.
+    if (fd == s_max_fd) {
+      s_max_fd = -1;
+      for (int sock_fd : s_socket_fds) {
+        if (sock_fd > s_max_fd)
+          s_max_fd = sock_fd;
+      }
+    }
+    return;
+  }
+}
+
+namespace internal {
+void wakeable_delay(uint32_t ms) {
+  // Fallback select() path for the host platform (and any future platform
+  // without fast select). select() is the host equivalent of FreeRTOS task
+  // notify / esp_delay / WFE used on the embedded targets.
+  if (!s_socket_fds.empty()) [[likely]] {
+    // Update fd_set if socket list has changed.
+    if (s_socket_fds_changed) [[unlikely]] {
+      FD_ZERO(&s_base_read_fds);
+      // fd bounds are validated in wake_register_fd().
+      for (int fd : s_socket_fds) {
+        FD_SET(fd, &s_base_read_fds);
+      }
+      s_socket_fds_changed = false;
+    }
+
+    // Copy base fd_set before each select.
+    g_read_fds = s_base_read_fds;
+
+    // Convert ms to timeval.
+    struct timeval tv;
+    tv.tv_sec = ms / 1000;
+    tv.tv_usec = (ms - tv.tv_sec * 1000) * 1000;
+
+    // Call select with timeout.
+    int ret = ::select(s_max_fd + 1, &g_read_fds, nullptr, nullptr, &tv);
+
+    // Process select() result:
+    // ret > 0: socket(s) have data ready - normal and expected
+    // ret == 0: timeout occurred - normal and expected
+    if (ret >= 0) [[likely]] {
+      // Yield if zero timeout since select(0) only polls without yielding.
+      if (ms == 0) [[unlikely]] {
+        yield();
+      }
+      return;
+    }
+    // ret < 0: error (EINTR is normal, anything else is unexpected).
+    const int err = errno;
+    if (err == EINTR) {
+      return;
+    }
+    // select() error - log and fall through to delay().
+    ESP_LOGW(TAG, "select() failed with errno %d", err);
+  }
+  // No sockets registered or select() failed - use regular delay.
+  delay(ms);
+}
+}  // namespace internal
+
 void wake_loop_threadsafe() {
   // Set flag before sending so the consumer's gate check on the next loop()
   // entry observes the wake regardless of select() scheduling.
   wake_request_set();
-  if (App.wake_socket_fd_ >= 0) {
+  if (internal::g_wake_socket_fd >= 0) {
     const char dummy = 1;
-    ::send(App.wake_socket_fd_, &dummy, 1, 0);
+    ::send(internal::g_wake_socket_fd, &dummy, 1, 0);
   }
 }
-#endif
+
+void wake_setup() {
+  // Create UDP socket for wake notifications.
+  internal::g_wake_socket_fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (internal::g_wake_socket_fd < 0) {
+    ESP_LOGW(TAG, "Wake socket create failed: %d", errno);
+    return;
+  }
+
+  // Bind to loopback with auto-assigned port.
+  struct sockaddr_in addr = {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = 0;  // Auto-assign port
+
+  if (::bind(internal::g_wake_socket_fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+    ESP_LOGW(TAG, "Wake socket bind failed: %d", errno);
+    ::close(internal::g_wake_socket_fd);
+    internal::g_wake_socket_fd = -1;
+    return;
+  }
+
+  // Get the assigned address and connect to it.
+  // Connecting a UDP socket allows using send() instead of sendto() for better performance.
+  struct sockaddr_in wake_addr;
+  socklen_t len = sizeof(wake_addr);
+  if (::getsockname(internal::g_wake_socket_fd, (struct sockaddr *) &wake_addr, &len) < 0) {
+    ESP_LOGW(TAG, "Wake socket address failed: %d", errno);
+    ::close(internal::g_wake_socket_fd);
+    internal::g_wake_socket_fd = -1;
+    return;
+  }
+
+  // Connect to self (loopback) — allows using send() instead of sendto().
+  // After connect(), no need to store wake_addr — the socket remembers it.
+  if (::connect(internal::g_wake_socket_fd, (struct sockaddr *) &wake_addr, sizeof(wake_addr)) < 0) {
+    ESP_LOGW(TAG, "Wake socket connect failed: %d", errno);
+    ::close(internal::g_wake_socket_fd);
+    internal::g_wake_socket_fd = -1;
+    return;
+  }
+
+  // Set non-blocking mode.
+  int flags = ::fcntl(internal::g_wake_socket_fd, F_GETFL, 0);
+  ::fcntl(internal::g_wake_socket_fd, F_SETFL, flags | O_NONBLOCK);
+
+  // Register with the select() loop.
+  if (!wake_register_fd(internal::g_wake_socket_fd)) {
+    ESP_LOGW(TAG, "Wake socket register failed");
+    ::close(internal::g_wake_socket_fd);
+    internal::g_wake_socket_fd = -1;
+    return;
+  }
+}
+#endif  // USE_HOST
 
 }  // namespace esphome

--- a/esphome/core/wake.h
+++ b/esphome/core/wake.h
@@ -21,6 +21,11 @@
 #include <pico/time.h>
 #endif
 
+#ifdef USE_HOST
+#include <sys/select.h>
+#include <sys/socket.h>
+#endif
+
 namespace esphome {
 
 // === Wake flag for ESP8266/RP2040 ===
@@ -170,6 +175,21 @@ void wakeable_delay(uint32_t ms);
 #ifdef USE_HOST
 /// Host: wakes select() via UDP loopback socket. Defined in wake.cpp.
 void wake_loop_threadsafe();
+
+/// Register a socket file descriptor with the host select() loop. Not
+/// thread-safe — main loop only. Returns false if fd is invalid or
+/// >= FD_SETSIZE.
+bool wake_register_fd(int fd);
+
+/// Unregister a socket file descriptor. Not thread-safe — main loop only.
+void wake_unregister_fd(int fd);
+
+/// One-time setup of the loopback wake socket. Called from Application::setup().
+void wake_setup();
+
+// wake_fd_ready() and wake_drain_notifications() are defined inline at the
+// bottom of this file — they need internal::g_read_fds / g_wake_socket_fd in
+// scope, which depend on USE_HOST-only includes pulled in above.
 #else
 /// Zephyr is currently the only platform without a wake mechanism.
 /// wake_loop_threadsafe() is a no-op and wakeable_delay() falls back to delay().
@@ -180,6 +200,10 @@ inline void wake_loop_threadsafe() {}
 inline void wake_loop_any_context() { wake_loop_threadsafe(); }
 
 namespace internal {
+#ifdef USE_HOST
+/// Host wakeable_delay uses select() over the registered fds — defined in wake.cpp.
+void wakeable_delay(uint32_t ms);
+#else
 inline void ESPHOME_ALWAYS_INLINE wakeable_delay(uint32_t ms) {
   if (ms == 0) [[unlikely]] {
     yield();
@@ -187,8 +211,40 @@ inline void ESPHOME_ALWAYS_INLINE wakeable_delay(uint32_t ms) {
   }
   delay(ms);
 }
+#endif
 }  // namespace internal
 
 #endif
+
+#ifdef USE_HOST
+namespace internal {
+// File-scope state owned by wake.cpp. Accessed inline by wake_drain_notifications()
+// and wake_fd_ready() so the hot path stays in the header.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern int g_wake_socket_fd;
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern fd_set g_read_fds;
+}  // namespace internal
+
+inline bool wake_fd_ready(int fd) { return FD_ISSET(fd, &internal::g_read_fds); }
+
+// Small buffer for draining wake notification bytes (1 byte sent per wake).
+// Sized to drain multiple notifications per recvfrom() without wasting stack.
+inline constexpr size_t WAKE_NOTIFY_DRAIN_BUFFER_SIZE = 16;
+
+inline void wake_drain_notifications() {
+  // Called from main loop to drain any pending wake notifications.
+  // Must check wake_fd_ready() to avoid blocking on empty socket.
+  if (internal::g_wake_socket_fd >= 0 && wake_fd_ready(internal::g_wake_socket_fd)) {
+    char buffer[WAKE_NOTIFY_DRAIN_BUFFER_SIZE];
+    // Drain all pending notifications with non-blocking reads. Multiple wake events
+    // may have triggered multiple writes, so drain until EWOULDBLOCK. We control
+    // both ends of this loopback socket (always 1 byte per wake), so no error
+    // checking — any error indicates catastrophic system failure.
+    while (::recvfrom(internal::g_wake_socket_fd, buffer, sizeof(buffer), 0, nullptr, nullptr) > 0) {
+    }
+  }
+}
+#endif  // USE_HOST
 
 }  // namespace esphome

--- a/esphome/core/wake.h
+++ b/esphome/core/wake.h
@@ -226,13 +226,13 @@ extern int g_wake_socket_fd;
 extern fd_set g_read_fds;
 }  // namespace internal
 
-inline bool wake_fd_ready(int fd) { return FD_ISSET(fd, &internal::g_read_fds); }
+inline bool ESPHOME_ALWAYS_INLINE wake_fd_ready(int fd) { return FD_ISSET(fd, &internal::g_read_fds); }
 
 // Small buffer for draining wake notification bytes (1 byte sent per wake).
 // Sized to drain multiple notifications per recvfrom() without wasting stack.
 inline constexpr size_t WAKE_NOTIFY_DRAIN_BUFFER_SIZE = 16;
 
-inline void wake_drain_notifications() {
+inline void ESPHOME_ALWAYS_INLINE wake_drain_notifications() {
   // Called from main loop to drain any pending wake notifications.
   // Must check wake_fd_ready() to avoid blocking on empty socket.
   if (internal::g_wake_socket_fd >= 0 && wake_fd_ready(internal::g_wake_socket_fd)) {


### PR DESCRIPTION
# What does this implement/fix?

Consolidates the host platform's wake plumbing into `wake.h`/`wake.cpp`, which already owned the FreeRTOS / ESP8266 / RP2040 wake primitives. Previously the host wake mechanism was split: `wake.cpp` had `wake_loop_threadsafe()` (which had to `friend` into `Application` to reach `wake_socket_fd_`), while `application.{h,cpp}` owned the fd registry, the select() loop, the wake-socket lifecycle, and the readiness query.

After this change:

- New host-only API in `wake.h`: `wake_register_fd`, `wake_unregister_fd`, `wake_fd_ready`, `wake_setup`, `wake_drain_notifications`.
- `internal::wakeable_delay` for host now performs `select()` over the registered fds — the same role `xTaskNotifyTake` plays on ESP32, `esp_delay` on ESP8266, and `__wfe` + alarm on RP2040.
- `Application` drops the host-specific `socket_fds_`, `max_fd_`, `wake_socket_fd_`, `socket_fds_changed_`, `read_fds_`, `base_read_fds_` members, the host include block (`<sys/select.h>`, `<sys/socket.h>`, etc.), and the `friend void wake_loop_threadsafe()` / `friend bool socket::socket_ready_fd(...)` declarations.
- `yield_with_select_()` collapses to a single inline definition for all platforms that delegates to `wakeable_delay()`.
- Socket factories (`bsd_sockets_impl.cpp`, `lwip_sockets_impl.cpp`) and `socket::socket_ready_fd()` now call the `wake.h` API directly instead of going through `App`.

Net diff: +263 / -269 lines. No behavior change — same select() loop, same wake socket, same fd lifecycle, just relocated into the file that already owns the per-platform wake abstraction.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible config change. Internal core refactor only.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).