### PR TITLE
[core] feed_wdt wraps feed_wdt_with_time

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -212,16 +212,8 @@ void Application::process_dump_config_() {
 
 void Application::feed_wdt() {
   // Cold entry: callers without a millis() timestamp in hand. Fetches the
-  // time and takes the same rate-limit paths as feed_wdt_with_time().
-  uint32_t now = MillisInternal::get();
-  if (now - this->last_wdt_feed_ > WDT_FEED_INTERVAL_MS) {
-    this->feed_wdt_slow_(now);
-  }
-#ifdef USE_STATUS_LED
-  if (now - this->last_status_led_service_ > STATUS_LED_DISPATCH_INTERVAL_MS) {
-    this->service_status_led_slow_(now);
-  }
-#endif
+  // time and defers to the hot path.
+  this->feed_wdt_with_time(MillisInternal::get());
 }
 
 void HOT Application::feed_wdt_slow_(uint32_t time) {


### PR DESCRIPTION
# What does this implement/fix?

`Application::feed_wdt()` duplicated the body of `feed_wdt_with_time()`. Since `feed_wdt_with_time()` is `ESPHOME_ALWAYS_INLINE`, the cold-entry path can simply forward to it without changing generated code.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# No configuration changes; internal refactor only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).