### PR TITLE
[time] Handle Windows EINVAL when validating POSIX TZ strings

### DIFF
--- a/esphome/components/time/__init__.py
+++ b/esphome/components/time/__init__.py
@@ -1,3 +1,4 @@
+import errno
 from importlib import resources
 import logging
 
@@ -74,6 +75,12 @@ def _load_tzdata(iana_key: str) -> bytes | None:
         return (resources.files(package) / resource).read_bytes()
     except (FileNotFoundError, ModuleNotFoundError, IsADirectoryError):
         return None
+    except OSError as e:
+        # Windows raises EINVAL for paths with NTFS-illegal chars (e.g. '<'/'>'
+        # in POSIX TZ strings like "<+08>-8" that validate_tz feeds back here).
+        if e.errno == errno.EINVAL:
+            return None
+        raise
 
 
 def _extract_tz_string(tzfile: bytes) -> str:

--- a/tests/unit_tests/components/test_time.py
+++ b/tests/unit_tests/components/test_time.py
@@ -1,6 +1,11 @@
 """Tests for time component cron expression parsing."""
 
-from esphome.components.time import _parse_cron_part
+import errno
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from esphome.components.time import _load_tzdata, _parse_cron_part, validate_tz
 
 
 def test_star_slash_seconds() -> None:
@@ -78,3 +83,63 @@ def test_range() -> None:
 
 def test_single_value() -> None:
     assert _parse_cron_part("30", 0, 59, {}) == {30}
+
+
+def _mock_resources_with_error(error: Exception) -> MagicMock:
+    """Return a mock of importlib.resources.files where read_bytes raises error."""
+    leaf = MagicMock()
+    leaf.read_bytes.side_effect = error
+    package = MagicMock()
+    package.__truediv__.return_value = leaf
+    return MagicMock(return_value=package)
+
+
+def test_load_tzdata_returns_none_on_windows_einval() -> None:
+    """On Windows, opening a tzdata path with NTFS-illegal chars raises OSError(EINVAL).
+
+    Regression test for crash when the system TZ resolves to a POSIX string like
+    "<+08>-8" (Asia/Shanghai, IST, etc.) and is fed back into _load_tzdata by
+    validate_tz to check whether it is also a valid IANA key.
+    """
+    err = OSError(errno.EINVAL, "Invalid argument")
+    with patch(
+        "esphome.components.time.resources.files",
+        _mock_resources_with_error(err),
+    ):
+        assert _load_tzdata("<+08>-8") is None
+
+
+def test_load_tzdata_propagates_unexpected_oserror() -> None:
+    """Unrelated OSErrors (e.g. PermissionError) must not be swallowed."""
+    with (
+        patch(
+            "esphome.components.time.resources.files",
+            _mock_resources_with_error(
+                PermissionError(errno.EACCES, "Permission denied")
+            ),
+        ),
+        pytest.raises(PermissionError),
+    ):
+        _load_tzdata("Some/Zone")
+
+
+def test_load_tzdata_returns_none_on_file_not_found() -> None:
+    """Existing behavior: missing tz file returns None rather than raising."""
+    with patch(
+        "esphome.components.time.resources.files",
+        _mock_resources_with_error(FileNotFoundError()),
+    ):
+        assert _load_tzdata("Not/A/Zone") is None
+
+
+def test_validate_tz_accepts_posix_string_when_read_bytes_raises_einval() -> None:
+    """validate_tz must not crash when _load_tzdata hits the Windows EINVAL path.
+
+    Simulates the Windows case where the auto-detected POSIX TZ string is fed
+    back through _load_tzdata and the underlying read_bytes raises errno 22.
+    """
+    with patch(
+        "esphome.components.time.resources.files",
+        _mock_resources_with_error(OSError(errno.EINVAL, "Invalid argument")),
+    ):
+        assert validate_tz("<+08>-8") == "<+08>-8"


### PR DESCRIPTION
# What does this implement/fix?

On Windows, `esphome run` crashes with `OSError: [Errno 22] Invalid argument` during config validation whenever the system timezone's POSIX TZ string contains characters illegal in NTFS paths (`<` or `>`). Affected zones include anything whose abbreviation is not a plain 3-letter name — e.g. Asia/Shanghai (`<+08>-8`), most South American zones (`<-03>3`), IST (`<+0530>-5:30`).

Root cause: `validate_tz()` always feeds its input back through `_load_tzdata()` to test whether the value is also a valid IANA key. On Linux/macOS that raises `FileNotFoundError` (an `OSError` subclass already caught). On Windows NTFS, opening `tzdata\zoneinfo\<+08>-8` raises a *plain* `OSError(errno=22)` — not caught by the previous except, so it escapes.

Traceback excerpt from the user report:
```
File "esphome/components/time/__init__.py", line 284, in validate_tz
    tzfile = _load_tzdata(value)
File "esphome/components/time/__init__.py", line 74, in _load_tzdata
    return (resources.files(package) / resource).read_bytes()
OSError: [Errno 22] Invalid argument: '...\\tzdata\\zoneinfo\\<+08>-8'
```

The fix is surgical: keep the existing `FileNotFoundError` / `IsADirectoryError` / `ModuleNotFoundError` handling, and additionally swallow `OSError` only when `errno == EINVAL`. Other `OSError` subclasses (`PermissionError`, disk errors, etc.) continue to propagate so real problems are not masked.

`detect_tz()` itself is unaffected — it loads the valid IANA key (e.g. `Asia/Shanghai`), which contains no illegal chars, and then returns the POSIX string extracted from the tzdata footer. The POSIX string is what the C++ runtime actually uses on-device; ESPHome never ships IANA names to firmware.

Workaround for users on an affected Windows system: setting `time.timezone` explicitly to any valid IANA name bypasses `detect_tz()` and the round-trip, avoiding the crash.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/esphome-desktop#57

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Pure Python config-validation fix — no firmware build path is exercised. Verified via unit tests.)

## Example entry for `config.yaml`:

```yaml
# Reproduces the crash on Windows when the system timezone is, e.g., Asia/Shanghai:
time:
  - platform: sntp
    id: sntp_time
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).