### PR TITLE
[sensor] Add alternate calibration format for ntc

### DIFF
--- a/esphome/components/const/__init__.py
+++ b/esphome/components/const/__init__.py
@@ -2,11 +2,12 @@
 
 CODEOWNERS = ["@esphome/core"]
 
-CONF_BYTE_ORDER = "byte_order"
-CONF_CLIMATE_ID = "climate_id"
 BYTE_ORDER_LITTLE = "little_endian"
 BYTE_ORDER_BIG = "big_endian"
 
+CONF_B_CONSTANT = "b_constant"
+CONF_BYTE_ORDER = "byte_order"
+CONF_CLIMATE_ID = "climate_id"
 CONF_COLOR_DEPTH = "color_depth"
 CONF_CRC_ENABLE = "crc_enable"
 CONF_DATA_BITS = "data_bits"

--- a/esphome/components/lc709203f/sensor.py
+++ b/esphome/components/lc709203f/sensor.py
@@ -1,5 +1,6 @@
 import esphome.codegen as cg
 from esphome.components import i2c, sensor
+from esphome.components.const import CONF_B_CONSTANT
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_BATTERY_LEVEL,
@@ -21,8 +22,6 @@ from esphome.const import (
 DEPENDENCIES = ["i2c"]
 
 lc709203f_ns = cg.esphome_ns.namespace("lc709203f")
-
-CONF_B_CONSTANT = "b_constant"
 
 LC709203FBatteryVoltage = lc709203f_ns.enum("LC709203FBatteryVoltage")
 BATTERY_VOLTAGE_OPTIONS = {

--- a/esphome/components/ntc/sensor.py
+++ b/esphome/components/ntc/sensor.py
@@ -2,6 +2,7 @@ from math import log
 
 import esphome.codegen as cg
 from esphome.components import sensor
+from esphome.components.const import CONF_B_CONSTANT
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_CALIBRATION,
@@ -18,7 +19,6 @@ from esphome.const import (
 ntc_ns = cg.esphome_ns.namespace("ntc")
 NTC = ntc_ns.class_("NTC", cg.Component, sensor.Sensor)
 
-CONF_B_CONSTANT = "b_constant"
 CONF_A = "a"
 CONF_B = "b"
 CONF_C = "c"

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -32,6 +32,8 @@ from esphome.const import (
     CONF_OPTIMISTIC,
     CONF_PERIOD,
     CONF_QUANTILE,
+    CONF_REFERENCE_RESISTANCE,
+    CONF_REFERENCE_TEMPERATURE,
     CONF_SEND_EVERY,
     CONF_SEND_FIRST_AT,
     CONF_STATE_CLASS,
@@ -1044,6 +1046,7 @@ def validate_ntc_calibration_parameter(value):
 CONF_A = "a"
 CONF_B = "b"
 CONF_C = "c"
+CONF_B_CONSTANT = "b_constant"
 ZERO_POINT = 273.15
 
 
@@ -1079,16 +1082,37 @@ def ntc_get_abc(value):
     return a, b, c
 
 
+def ntc_calc_b_constant(value):
+    beta = value[CONF_B_CONSTANT]
+    t0 = value[CONF_REFERENCE_TEMPERATURE] + ZERO_POINT
+    r0 = value[CONF_REFERENCE_RESISTANCE]
+
+    a = (1 / t0) - (1 / beta) * math.log(r0)
+    b = 1 / beta
+    c = 0
+    return a, b, c
+
+
 def ntc_process_calibration(value):
     if isinstance(value, dict):
-        value = cv.Schema(
-            {
-                cv.Required(CONF_A): cv.float_,
-                cv.Required(CONF_B): cv.float_,
-                cv.Required(CONF_C): cv.float_,
-            }
-        )(value)
-        a, b, c = ntc_get_abc(value)
+        if CONF_B_CONSTANT in value:
+            value = cv.Schema(
+                {
+                    cv.Required(CONF_B_CONSTANT): cv.float_,
+                    cv.Required(CONF_REFERENCE_TEMPERATURE): cv.temperature,
+                    cv.Required(CONF_REFERENCE_RESISTANCE): cv.resistance,
+                }
+            )(value)
+            a, b, c = ntc_calc_b_constant(value)
+        else:
+            value = cv.Schema(
+                {
+                    cv.Required(CONF_A): cv.float_,
+                    cv.Required(CONF_B): cv.float_,
+                    cv.Required(CONF_C): cv.float_,
+                }
+            )(value)
+            a, b, c = ntc_get_abc(value)
     elif isinstance(value, list):
         if len(value) != 3:
             raise cv.Invalid(
@@ -1098,7 +1122,7 @@ def ntc_process_calibration(value):
         a, b, c = ntc_calc_steinhart_hart(value)
     else:
         raise cv.Invalid(
-            f"Calibration parameter accepts either a list for steinhart-hart calibration, or mapping for b-constant calibration, not {type(value)}"
+            f"Calibration parameter accepts either a list for steinhart-hart calibration, or mapping for b-constant or precomputed (a, b, c) calibration, not {type(value)}"
         )
     _LOGGER.info("Coefficient: a:%s, b:%s, c:%s", a, b, c)
     return {

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -1098,9 +1098,16 @@ def ntc_process_calibration(value):
         if CONF_B_CONSTANT in value:
             value = cv.Schema(
                 {
-                    cv.Required(CONF_B_CONSTANT): cv.float_,
-                    cv.Required(CONF_REFERENCE_TEMPERATURE): cv.temperature,
-                    cv.Required(CONF_REFERENCE_RESISTANCE): cv.resistance,
+                    cv.Required(CONF_B_CONSTANT): cv.All(
+                        cv.float_, cv.Range(min=0, min_included=False)
+                    ),
+                    cv.Required(CONF_REFERENCE_TEMPERATURE): cv.All(
+                        cv.temperature,
+                        cv.Range(min=-ZERO_POINT, min_included=False),
+                    ),
+                    cv.Required(CONF_REFERENCE_RESISTANCE): cv.All(
+                        cv.resistance, cv.Range(min=0, min_included=False)
+                    ),
                 }
             )(value)
             a, b, c = ntc_calc_b_constant(value)

--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -4,6 +4,7 @@ import math
 from esphome import automation
 import esphome.codegen as cg
 from esphome.components import mqtt, web_server, zigbee
+from esphome.components.const import CONF_B_CONSTANT
 import esphome.config_validation as cv
 from esphome.const import (
     CONF_ABOVE,
@@ -1046,7 +1047,6 @@ def validate_ntc_calibration_parameter(value):
 CONF_A = "a"
 CONF_B = "b"
 CONF_C = "c"
-CONF_B_CONSTANT = "b_constant"
 ZERO_POINT = 273.15
 
 

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -202,6 +202,11 @@ sensor:
           value: last
       - timeout:
           timeout: 1d
+      - to_ntc_temperature:
+          calibration:
+            b_constant: 3950
+            reference_temperature: 25.0°C
+            reference_resistance: 10kOhm
       - to_ntc_resistance:
           calibration:
             - 10.0kOhm -> 25°C
@@ -270,8 +275,6 @@ cover:
     stop_action:
       - logger.log: stop_action
     optimistic: true
-    on_open:
-      - logger.log: "Cover on_open (deprecated)"
     on_opened:
       - logger.log: "Cover fully opened"
     on_closed:


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The to_ntc_temperature filter did not allow the alternate calibration format accepted by the ntc sensor platform.

Also remove a deprecated trigger from the test file.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6509

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
