### PR TITLE
[api] Fall back to plaintext for logger connections

### DIFF
--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -93,13 +93,17 @@ async def async_run_logs(
                     config, raw_line, backtrace_state=backtrace_state
                 )
 
-    # Safe to fall back to plaintext here: the log stream is strictly
-    # one-way from device to client, and this code never accepts commands
-    # or acts on any message the device sends. The worst an on-path
-    # attacker can do is show fabricated log lines, which is why
-    # aioesphomeapi logs a warning that the device's identity cannot be
-    # verified. Never mirror this opt-in for any connection that sends
-    # data to the device or uses Home Assistant actions.
+    # Safe to fall back to plaintext here only for this diagnostics use
+    # case: the stream is one-way from device to client, and this code
+    # never accepts commands or acts on any message the device sends.
+    # An on-path attacker could still both inject fabricated log lines
+    # and passively read the device's log output (and any state data
+    # delivered when subscribe_states is enabled), so this does lose
+    # confidentiality as well as authentication/integrity. That tradeoff
+    # is acceptable for operator-visible logs, which aioesphomeapi also
+    # warns may come from an unverified device. Never mirror this opt-in
+    # for any connection that sends data to the device or uses Home
+    # Assistant actions.
     stop = await async_run(
         cli,
         on_log,

--- a/esphome/components/api/client.py
+++ b/esphome/components/api/client.py
@@ -93,7 +93,20 @@ async def async_run_logs(
                     config, raw_line, backtrace_state=backtrace_state
                 )
 
-    stop = await async_run(cli, on_log, name=name, subscribe_states=subscribe_states)
+    # Safe to fall back to plaintext here: the log stream is strictly
+    # one-way from device to client, and this code never accepts commands
+    # or acts on any message the device sends. The worst an on-path
+    # attacker can do is show fabricated log lines, which is why
+    # aioesphomeapi logs a warning that the device's identity cannot be
+    # verified. Never mirror this opt-in for any connection that sends
+    # data to the device or uses Home Assistant actions.
+    stop = await async_run(
+        cli,
+        on_log,
+        name=name,
+        subscribe_states=subscribe_states,
+        allow_plaintext_fallback=True,
+    )
     try:
         await asyncio.Event().wait()
     finally:


### PR DESCRIPTION
# What does this implement/fix?

When a device is re-flashed with firmware that no longer has the API encryption key, `esphome logs` currently fails the Noise handshake with EncryptionPlaintextAPIError and retries forever; opt in to the new aioesphomeapi `allow_plaintext_fallback` flag so the logger connection downgrades to plaintext (with a warning from aioesphomeapi) instead of looping. The log stream is strictly one-way from device to client, this code never accepts commands or acts on any message the device sends, and we do not mirror this opt-in anywhere that sends data to the device or exposes Home Assistant actions.

This is especially common via the dashboard: when a user adopts or creates a device the dashboard auto-adds an encryption key to the YAML, but the dashboard still lets them skip the flash step. The device keeps running plaintext firmware while the YAML now has a key, so logs look broken until they re-flash; with this change logs keep working and the warning tells them what happened.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

api:
  encryption:
    key: rXyWAtLMjwJ4zYkWAIKI05dCHtuTDXnvDnBADo/bnIQ=
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).