### PR TITLE
[dsmr] Small refactoring: Move `Aes128GcmDecryptorImpl` type inside `esphome::dsmr` namespace.

### DIFF
--- a/esphome/components/dsmr/dsmr.h
+++ b/esphome/components/dsmr/dsmr.h
@@ -18,21 +18,26 @@
 
 #if __has_include(<psa/crypto.h>)
 #include <dsmr_parser/decryption/aes128gcm_tfpsa.h>
-using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmTfPsa;
 #elif __has_include(<mbedtls/gcm.h>)
 #if __has_include(<mbedtls/esp_config.h>)
 #include <mbedtls/esp_config.h>
 #endif
 #include <dsmr_parser/decryption/aes128gcm_mbedtls.h>
-using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmMbedTls;
 #elif __has_include(<bearssl/bearssl.h>)
 #include <dsmr_parser/decryption/aes128gcm_bearssl.h>
-using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmBearSsl;
 #else
 #error "The platform doesn't provide a compatible encryption library for dsmr_parser"
 #endif
 
 namespace esphome::dsmr {
+
+#if __has_include(<psa/crypto.h>)
+using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmTfPsa;
+#elif __has_include(<mbedtls/gcm.h>)
+using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmMbedTls;
+#else
+using Aes128GcmDecryptorImpl = dsmr_parser::Aes128GcmBearSsl;
+#endif
 
 using namespace dsmr_parser::fields;
 


### PR DESCRIPTION
# What does this implement/fix?

* It is a very small refactoring: don't expose `Aes128GcmDecryptorImpl` type into a global namespace. It can collide with some other existing definitions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not needed. This is just a small refactoring that doesn't affect the functionality.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
