### PR TITLE
[wifi] Avoid BDK 3.0.78 wifi_event_sta_disconnected_t collision on BK72xx

### DIFF
--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -12,7 +12,12 @@
 
 #ifdef USE_BK72XX
 extern "C" {
+// BDK 3.0.78 (required for BK7238) redeclares wifi_event_sta_disconnected_t,
+// which LibreTiny's Arduino WiFi API already defines. ESPHome doesn't use the
+// BDK version, so rename it across this include to avoid the collision.
+#define wifi_event_sta_disconnected_t bdk_wifi_event_sta_disconnected_t
 #include <wlan_ui_pub.h>
+#undef wifi_event_sta_disconnected_t
 }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

LibreTiny's [PR #360](https://github.com/libretiny-eu/libretiny/pull/360) adds BK7238 support and requires BDK 3.0.78. When compiling `esphome/components/wifi/wifi_component_libretiny.cpp` with that BDK, the build fails:

```
.../framework-beken-bdk/beken378/func/include/wlan_defs_pub.h:341:3: error:
  conflicting declaration 'typedef struct wifi_event_sta_disconnected_t wifi_event_sta_disconnected_t'
.../libretiny/cores/common/arduino/libraries/api/WiFi/WiFiEvents.h:33:3: note:
  previous declaration as 'typedef struct wifi_event_sta_disconnected_t wifi_event_sta_disconnected_t'
```

BDK 3.0.78 added a new `wifi_event_sta_disconnected_t` typedef in `wlan_defs_pub.h` that collides with the identically named typedef already defined by LibreTiny's Arduino WiFi API (`WiFiEvents.h`). Both headers end up transitively included by `wifi_component_libretiny.cpp`.

ESPHome only uses `bk_wlan_get_link_status` from this header and never references the conflicting type. The fix renames BDK's version with a local `#define` across the include so both headers coexist. The rename is a no-op on BDK 3.0.33 (BK7231T/N) because that version does not declare the typedef, so existing BK7231T/N builds are unaffected.

Tested by compiling and running on a NiceMCU XH-WB3S (BK7238) board using the LibreTiny `feature/bk7238` branch with BDK 3.0.78, as described in [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Unblocks BK7238 support once [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360) lands.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# NiceMCU XH-WB3S (BK7238) using libretiny-eu/libretiny#360
esphome:
  name: wb3s-bk7238-test
  platformio_options:
    custom_versions.beken-bdk: 3.0.78

bk72xx:
  board: xh-wb3s
  family: BK7231N  # ESPHome does not yet know BK7238; works at runtime
  framework:
    version: 0.0.0
    source: https://github.com/libretiny-eu/libretiny#feature/bk7238

logger:
api:
ota:
  - platform: esphome
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).