### PR TITLE
[core] Raise WDT_FEED_INTERVAL_MS to 2000ms on BK72xx

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -219,11 +219,19 @@ class Application {
   /// loops and scheduler items still feed after every op, so any op exceeding
   /// this threshold triggers a real feed naturally.
   /// Safety margins vs. platform watchdog timeouts:
-  ///   - ESP32 task WDT default (5 s): ~16x
-  ///   - ESP8266 soft WDT (~1.6 s):    ~5x  <-- floor case; any future change
-  ///                                             must keep comfortable margin here
-  ///   - ESP8266 HW WDT (~6 s):        ~20x
+  ///   - ESP32 task WDT default (5 s):  ~16x
+  ///   - ESP8266 soft WDT (~1.6 s):     ~5x  <-- floor case; any future change
+  ///                                              must keep comfortable margin here
+  ///   - ESP8266 HW WDT (~6 s):         ~20x
+  ///   - BK72xx HW WDT (10 s):          ~5x  <-- platform override below
+#ifdef USE_BK72XX
+  // BDK busy-waits 200us per WDT reload (sctrl_dpll_delay200us). LibreTiny
+  // sets HW WDT to 10s; 2000ms keeps ~5x margin. See wdt_ctrl WCMD_RELOAD_PERIOD:
+  // https://github.com/libretiny-eu/framework-beken-bdk/blob/44800e7451ea30fbcbd3bb6e905315de59349fee/beken378/driver/wdt/wdt.c#L75-L87
+  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 2000;
+#else
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
+#endif
 
   /// Feed the task watchdog. Cold entry — callers without a millis()
   /// timestamp in hand. Out of line to keep call sites tiny.


### PR DESCRIPTION
# What does this implement/fix?

BK72xx silicon requires a ~200 µs busy-wait (`sctrl_dpll_delay200us()`) between two watchdog register key writes on every reload. The busy-wait lives in BDK's [`beken378/driver/wdt/wdt.c` — `WCMD_RELOAD_PERIOD` case, line 80](https://github.com/libretiny-eu/framework-beken-bdk/blob/44800e7451ea30fbcbd3bb6e905315de59349fee/beken378/driver/wdt/wdt.c#L75-L87) and cannot be worked around at the SDK level — it's a hardware requirement for the two-key reload sequence. Each `arch_feed_wdt()` therefore costs ~300 µs on BK7231T/N/BK7238.

LibreTiny initialises the BK72xx HW watchdog at 10000 ms (`lt_wdt_enable(10000L)` in `libretiny/core.cpp`), but ESPHome's generic `WDT_FEED_INTERVAL_MS` of 300 ms was sized for ESP8266's 1.6 s soft watchdog — leaving BK72xx over-servicing the watchdog ~33× per timeout window and paying ~60 ms/min of main-loop overhead to no benefit.

Raise the interval to 2000 ms on BK72xx only, which keeps a **5× safety margin** on the 10 s HW WDT (the same ratio that motivated the generic 300 ms value against ESP8266's 1.6 s soft WDT) while cutting feed frequency ~6×. Component loops and scheduler items still call `feed_wdt_with_time()` after every op, so any operation longer than the threshold still triggers a real feed naturally.

## Measurements

Measured using a local `runtime_stats` debug patch (included below) that splits the `before` bucket into `sched` vs. `wdt` sub-slices and counts how often the slow-path `arch_feed_wdt()` actually fires.

### NiceMCU XH-WB3S (BK7238)

Tested alongside [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360).

**Before (`WDT_FEED_INTERVAL_MS = 300`):**
```
main_loop: iters=3329, active_avg=0.110ms, active_max=4.80ms, active_total=367.1ms, overhead_total=193.6ms
main_loop_overhead_section: before=132.9ms, tail=11.6ms, inter_component=49.0ms
main_loop_before_breakdown: sched=71.6ms, wdt=61.3ms, residual=0.0ms
wdt_slow_path: hits=196 (5.9% of iters, avg=312.68us/hit)
```

**After (`WDT_FEED_INTERVAL_MS = 2000`):**
```
main_loop: iters=3329, active_avg=0.095ms, active_max=4.32ms, active_total=315.0ms, overhead_total=151.2ms
main_loop_overhead_section: before=89.8ms, tail=11.0ms, inter_component=50.5ms
main_loop_before_breakdown: sched=73.4ms, wdt=16.3ms, residual=0.0ms
wdt_slow_path: hits=30 (0.9% of iters, avg=544.77us/hit)
```

- `wdt` bucket: **61.3 ms → 16.3 ms/min** (−45 ms)
- `wdt_slow_path` hits: **196 → 30/min** (6.5× reduction)
- `overhead_total`: **193.6 ms → 151.2 ms/min** (−42 ms)
- `active_total`: **367 ms → 315 ms/min** (−52 ms)

### CB3S (BK7231N)

Confirmed the fix behaves identically on BK7231N (same BDK code path). Post-fix measurement:

```
main_loop: iters=3108, active_avg=1.365ms, active_max=3690.04ms, active_total=4243.2ms, overhead_total=266.2ms
main_loop_overhead_section: before=135.2ms, tail=19.5ms, inter_component=111.6ms
main_loop_before_breakdown: sched=121.3ms, wdt=13.9ms, residual=0.0ms
wdt_slow_path: hits=28 (0.9% of iters, avg=497.21us/hit)
```

- `wdt_slow_path` hits: **28/min (0.9% of iters)** — matches the BK7238 post-fix rate, confirming the 2000 ms interval gates both chips identically.
- `wdt` bucket: **13.9 ms/min** (comparable to BK7238's 16.3 ms/min; variance dominated by iteration count and status_led coincidence).

### BW15 (RTL8720CF) — comparison, not modified by this PR

For reference, the RTL87xx port runs the same ESPHome feed loop at the unchanged 300 ms interval and pays **~20 µs per feed** — an order of magnitude cheaper than BK72xx. This confirms the cost is a BK72xx-specific hardware issue, not something that would justify changing the generic interval:

```
main_loop: iters=3385, active_avg=0.750ms, active_max=2295.51ms, active_total=2537.2ms, overhead_total=56.4ms
main_loop_overhead_section: before=23.1ms, tail=3.3ms, inter_component=29.9ms
main_loop_before_breakdown: sched=19.3ms, wdt=3.9ms, residual=0.0ms
wdt_slow_path: hits=188 (5.6% of iters, avg=20.65us/hit)
```

- RTL87xx `wdt` bucket: **3.9 ms/min at 188 hits** (vs. BK7238 pre-fix: **61.3 ms/min at 196 hits**).
- Per-hit cost: **20.65 µs on RTL87xx** vs. **312.68 µs on BK7238** — directly attributable to the 200 µs BDK busy-wait that RTL doesn't have.

The hit-count × avg confirms the feed interval was the binding constraint on BK72xx (not real op duration). Other platforms (ESP32/ESP8266/RP2040/RTL87xx/LN882x) are unaffected — they retain the existing 300 ms value.

## Debug patch used for the measurement

For reviewers who want to reproduce the breakdown locally (not part of this PR — kept as a separate debug patch):

```diff
diff --git a/esphome/components/runtime_stats/runtime_stats.cpp b/esphome/components/runtime_stats/runtime_stats.cpp
--- a/esphome/components/runtime_stats/runtime_stats.cpp
+++ b/esphome/components/runtime_stats/runtime_stats.cpp
@@ -81,6 +81,19 @@ void RuntimeStatsCollector::log_stats_() {
     ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms",
              static_cast<double>(before) / 1000.0, static_cast<double>(tail) / 1000.0,
              static_cast<double>(inter) / 1000.0);
+    uint64_t sched = this->period_before_sched_time_us_;
+    uint64_t wdt = this->period_before_wdt_time_us_;
+    uint64_t before_residual = before > sched + wdt ? before - sched - wdt : 0;
+    ESP_LOGI(TAG, "  main_loop_before_breakdown: sched=%.1fms, wdt=%.1fms, residual=%.1fms",
+             static_cast<double>(sched) / 1000.0, static_cast<double>(wdt) / 1000.0,
+             static_cast<double>(before_residual) / 1000.0);
+    uint32_t wdt_slow_hits = App.wdt_slow_count_;
+    App.wdt_slow_count_ = 0;
+    ESP_LOGI(TAG, "  wdt_slow_path: hits=%" PRIu32 " (%.1f%% of iters, avg=%.2fus/hit)", wdt_slow_hits,
+             this->period_active_count_ > 0
+                 ? 100.0 * static_cast<double>(wdt_slow_hits) / static_cast<double>(this->period_active_count_)
+                 : 0.0,
+             wdt_slow_hits > 0 ? static_cast<double>(wdt) / static_cast<double>(wdt_slow_hits) : 0.0);
   }
 
   // Log total stats since boot (only for active components - idle ones haven't changed)
@@ -116,6 +129,12 @@ void RuntimeStatsCollector::log_stats_() {
     ESP_LOGI(TAG, "  main_loop_overhead_section: before=%.1fms, tail=%.1fms, inter_component=%.1fms",
              static_cast<double>(before) / 1000.0, static_cast<double>(tail) / 1000.0,
              static_cast<double>(inter) / 1000.0);
+    uint64_t sched = this->total_before_sched_time_us_;
+    uint64_t wdt = this->total_before_wdt_time_us_;
+    uint64_t before_residual = before > sched + wdt ? before - sched - wdt : 0;
+    ESP_LOGI(TAG, "  main_loop_before_breakdown: sched=%.1fms, wdt=%.1fms, residual=%.1fms",
+             static_cast<double>(sched) / 1000.0, static_cast<double>(wdt) / 1000.0,
+             static_cast<double>(before_residual) / 1000.0);
   }
 
   // Reset period stats
@@ -126,6 +145,8 @@ void RuntimeStatsCollector::log_stats_() {
   this->period_active_time_us_ = 0;
   this->period_active_max_us_ = 0;
   this->period_before_time_us_ = 0;
+  this->period_before_sched_time_us_ = 0;
+  this->period_before_wdt_time_us_ = 0;
   this->period_tail_time_us_ = 0;
 }
diff --git a/esphome/components/runtime_stats/runtime_stats.h b/esphome/components/runtime_stats/runtime_stats.h
--- a/esphome/components/runtime_stats/runtime_stats.h
+++ b/esphome/components/runtime_stats/runtime_stats.h
@@ -49,7 +49,8 @@ class RuntimeStatsCollector {
   // which captures per-iteration inter-component bookkeeping (set_current_component,
   // WarnIfComponentBlockingGuard construction/destruction, feed_wdt_with_time calls,
   // the for-loop itself).
-  void record_loop_active(uint32_t active_us, uint32_t before_us, uint32_t tail_us) {
+  void record_loop_active(uint32_t active_us, uint32_t before_us, uint32_t sched_us, uint32_t wdt_us,
+                          uint32_t tail_us) {
     this->period_active_count_++;
     this->period_active_time_us_ += active_us;
     if (active_us > this->period_active_max_us_)
@@ -61,6 +62,10 @@ class RuntimeStatsCollector {
 
     this->period_before_time_us_ += before_us;
     this->total_before_time_us_ += before_us;
+    this->period_before_sched_time_us_ += sched_us;
+    this->total_before_sched_time_us_ += sched_us;
+    this->period_before_wdt_time_us_ += wdt_us;
+    this->total_before_wdt_time_us_ += wdt_us;
     this->period_tail_time_us_ += tail_us;
     this->total_tail_time_us_ += tail_us;
   }
@@ -88,6 +93,12 @@ class RuntimeStatsCollector {
   // Split of overhead sections — accumulated per iteration.
   uint64_t period_before_time_us_{0};
   uint64_t total_before_time_us_{0};
+  // Sub-split of `before` into scheduler_tick_ vs. post-scheduler feed_wdt_with_time
+  // vs. residual (MillisInternal::get + measurement jitter + preemption).
+  uint64_t period_before_sched_time_us_{0};
+  uint64_t total_before_sched_time_us_{0};
+  uint64_t period_before_wdt_time_us_{0};
+  uint64_t total_before_wdt_time_us_{0};
   uint64_t period_tail_time_us_{0};
   uint64_t total_tail_time_us_{0};
 };
diff --git a/esphome/core/application.cpp b/esphome/core/application.cpp
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -217,6 +217,9 @@ void HOT Application::feed_wdt_slow_(uint32_t time) {
   // confirmed the WDT_FEED_INTERVAL_MS rate limit was exceeded.
   arch_feed_wdt();
   this->last_wdt_feed_ = time;
+#ifdef USE_RUNTIME_STATS
+  this->wdt_slow_count_++;
+#endif
 }
diff --git a/esphome/core/application.h b/esphome/core/application.h
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -463,6 +463,11 @@ class Application {
   // millis() of most recent status_led dispatch; rate-limits independently of last_wdt_feed_
   uint32_t last_status_led_service_{0};
 #endif
+#ifdef USE_RUNTIME_STATS
+  // Count of feed_wdt_slow_() invocations since last runtime_stats log. Lets
+  // stats output report how often the slow path (arch_feed_wdt) actually runs.
+  uint32_t wdt_slow_count_{0};
+#endif
 
   // 2-byte members (grouped together for alignment)
   uint16_t dump_config_at_{std::numeric_limits<uint16_t>::max()};  // Index into components_ for dump_config progress
@@ -561,6 +566,12 @@ inline void ESPHOME_ALWAYS_INLINE __attribute__((optimize("O2"))) Application::l
   // so the gate check and WDT feed both reflect actual elapsed time after
   // scheduler dispatch, without an extra millis() call.
   uint32_t now = this->scheduler_tick_(MillisInternal::get());
+#ifdef USE_RUNTIME_STATS
+  // Capture immediately after scheduler_tick_ returns so the post-scheduler
+  // feed_wdt_with_time slice can be separated from the scheduler slice in
+  // the `before` bucket.
+  uint32_t loop_after_sched_us = micros();
+#endif
   // Guarantee one WDT feed per tick even when the scheduler had nothing to
   // dispatch and the component phase is gated out — covers configs with no
   // looping components and no scheduler work (setup() has its own
@@ -632,10 +643,22 @@ inline void ESPHOME_ALWAYS_INLINE __attribute__((optimize("O2"))) Application::l
     uint32_t loop_before_overhead_us = loop_before_wall_us > loop_before_scheduled_us
                                            ? loop_before_wall_us - static_cast<uint32_t>(loop_before_scheduled_us)
                                            : 0;
+    // Sub-split of the `before` bucket. `sched_us` covers MillisInternal::get()
+    // plus scheduler_tick_ (everything before the post-scheduler feed_wdt_with_time),
+    // with scheduled-component time subtracted out so it reflects scheduler
+    // infrastructure overhead only. `wdt_us` covers the post-scheduler
+    // feed_wdt_with_time() call (including any status_led dispatch when the
+    // STATUS_LED_DISPATCH_INTERVAL_MS gate also elapses on the same call).
+    uint32_t loop_before_sched_wall_us = loop_after_sched_us - loop_active_start_us;
+    uint32_t loop_before_sched_us = loop_before_sched_wall_us > loop_before_scheduled_us
+                                        ? loop_before_sched_wall_us - static_cast<uint32_t>(loop_before_scheduled_us)
+                                        : 0;
+    uint32_t loop_before_wdt_us = loop_before_end_us - loop_after_sched_us;
     // tail_us is only defined when Phase B ran; 0 on Phase A-only ticks so the
     // stats bucket keeps its "component-phase trailing overhead" meaning.
     uint32_t loop_tail_us = do_component_phase ? (loop_now_us - loop_tail_start_us) : 0;
-    global_runtime_stats->record_loop_active(loop_now_us - loop_active_start_us, loop_before_overhead_us, loop_tail_us);
+    global_runtime_stats->record_loop_active(loop_now_us - loop_active_start_us, loop_before_overhead_us,
+                                             loop_before_sched_us, loop_before_wdt_us, loop_tail_us);
     global_runtime_stats->process_pending_stats(now);
   }
 #endif
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while testing [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360) (BK7238 support) on a NiceMCU XH-WB3S. Additionally verified on CB3S (BK7231N); RTL87xx (BW15) compared for reference.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Verified using runtime_stats on BK7238 and BK7231N builds.
esphome:
  name: wb3s-bk7238-test

bk72xx:
  board: xh-wb3s  # or cb3s for BK7231N

runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).