### PR TITLE
[one_wire] Show discovered devices as INFO message

### DIFF
--- a/esphome/components/one_wire/one_wire_bus.cpp
+++ b/esphome/components/one_wire/one_wire_bus.cpp
@@ -85,10 +85,10 @@ void OneWireBus::dump_devices_(const char *tag) {
   if (this->devices_.empty()) {
     ESP_LOGW(tag, "  Found no devices!");
   } else {
-    ESP_LOGCONFIG(tag, "  Found devices:");
+    ESP_LOGI(tag, "  Found devices:");
     char hex_buf[17];  // uint64_t = 16 hex chars + null
     for (auto &address : this->devices_) {
-      ESP_LOGCONFIG(tag, "    0x%s (%s)", format_hex_to(hex_buf, address), LOG_STR_ARG(get_model_str(address & 0xff)));
+      ESP_LOGI(tag, "    0x%s (%s)", format_hex_to(hex_buf, address), LOG_STR_ARG(get_model_str(address & 0xff)));
     }
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Currently need to recompile with logging level DEBUG to see discovered devices on the bus. 
Much convinient is to log them as INFO message, as f.e. i2c component does. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [X] Other

**Related issue or feature (if applicable):**

- fixes 

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
