### PR TITLE
[core] Clean up stale includes and inline yield_with_select_ in application

### DIFF
--- a/esphome/components/libretiny/core.cpp
+++ b/esphome/components/libretiny/core.cpp
@@ -56,7 +56,7 @@ void arch_init() {
   //
   // Raise to priority 6: above WiFi/LwIP tasks (4-5) so they don't preempt the
   // main loop, but below the TCP/IP thread (7) so packet processing keeps priority.
-  // This is safe because ESPHome yields voluntarily via yield_with_select_() and
+  // This is safe because ESPHome yields voluntarily via wakeable_delay() and
   // the Arduino mainTask yield() after each loop() iteration.
   static constexpr UBaseType_t MAIN_TASK_PRIORITY = 6;
   static_assert(MAIN_TASK_PRIORITY < configMAX_PRIORITIES, "MAIN_TASK_PRIORITY must be less than configMAX_PRIORITIES");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -12,9 +12,6 @@
 #include <esp_ota_ops.h>
 #include <esp_bootloader_desc.h>
 #endif
-#ifdef USE_LWIP_FAST_SELECT
-#include "esphome/core/lwip_fast_select.h"
-#endif  // USE_LWIP_FAST_SELECT
 #include "esphome/core/version.h"
 #include "esphome/core/hal.h"
 #include <algorithm>
@@ -22,10 +19,6 @@
 
 #ifdef USE_STATUS_LED
 #include "esphome/components/status_led/status_led.h"
-#endif
-
-#if (defined(USE_ESP8266) || defined(USE_RP2040)) && defined(USE_SOCKET_IMPL_LWIP_TCP)
-#include "esphome/components/socket/socket.h"
 #endif
 
 namespace esphome {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -359,7 +359,7 @@ void Application::teardown_components(uint32_t timeout_ms) {
 
     // Give some time for I/O operations if components are still pending
     if (pending_count > 0) {
-      this->yield_with_select_(1);
+      esphome::internal::wakeable_delay(1);
     }
 
     // Update time for next iteration

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -420,10 +420,6 @@ class Application {
   void service_status_led_slow_(uint32_t time);
 #endif
 
-  /// Sleep for up to delay_ms, returning early if a wake event arrives.
-  /// Thin wrapper over the platform wake primitive in wake.h.
-  inline void ESPHOME_ALWAYS_INLINE yield_with_select_(uint32_t delay_ms);
-
   // === Member variables ordered by size to minimize padding ===
 
   // Pointer-sized members first
@@ -661,18 +657,14 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
     const uint32_t until_sched = this->scheduler.next_schedule_in(now).value_or(until_phase);
     delay_time = std::min(until_phase, until_sched);
   }
-  this->yield_with_select_(delay_time);
+  // All platforms route loop yields through the platform wake primitive.
+  // On host this drains the loopback wake socket via select(); on FreeRTOS
+  // targets it uses task notifications; on ESP8266/RP2040 it uses esp_delay/WFE.
+  esphome::internal::wakeable_delay(delay_time);
 
   if (this->dump_config_at_ < this->components_.size()) {
     this->process_dump_config_();
   }
-}
-
-// All platforms route loop yields through the platform wake primitive.
-// On host this drains the loopback wake socket via select(); on FreeRTOS
-// targets it uses task notifications; on ESP8266/RP2040 it uses esp_delay/WFE.
-inline void ESPHOME_ALWAYS_INLINE Application::yield_with_select_(uint32_t delay_ms) {
-  esphome::internal::wakeable_delay(delay_ms);
 }
 
 }  // namespace esphome

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -24,9 +24,6 @@
 #include "esphome/core/area.h"
 #endif
 
-#ifdef USE_LWIP_FAST_SELECT
-#include "esphome/core/lwip_fast_select.h"
-#endif
 #ifdef USE_RUNTIME_STATS
 #include "esphome/components/runtime_stats/runtime_stats.h"
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Pure cleanup in `esphome/core/application.{h,cpp}`; no behavior change.

1. **Remove stale `socket.h` include in `application.cpp`.** After #15931 moved the host socket-select wake mechanism (`register_socket_fd`, `unregister_socket_fd`, `yield_with_select_` impl) from `application.cpp` into `wake.h`/`wake.cpp`, nothing in `application.cpp` references socket symbols anymore.

2. **Remove dead `lwip_fast_select.h` includes in `application.cpp` and `application.h`.** Zero symbols from that header (`esphome_lwip_*`, `ESPHOME_LWIP_*`, `lwip_sock`) are referenced in either translation unit.

3. **Inline `Application::yield_with_select_()`.** It was a trivial one-line passthrough to `esphome::internal::wakeable_delay()`. Both call sites now call `wakeable_delay()` directly, and a stale comment referencing `yield_with_select_()` in `libretiny/core.cpp` is updated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# N/A — internal refactor, no user-facing configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).