### PR TITLE
[scheduler] Snapshot cross-thread counters once per Scheduler::call()

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -534,13 +534,29 @@ void HOT Scheduler::process_defer_queue_slow_path_(uint32_t &now) {
 #endif /* not ESPHOME_THREAD_SINGLE */
 
 uint32_t HOT Scheduler::call(uint32_t now) {
+  // Snapshot the skip-work counters once up front so the gates below don't
+  // each re-lock on NO_ATOMICS. See snapshot_counters_ for per-platform cost.
+  uint32_t snap_add;
+  uint32_t snap_remove;
 #ifndef ESPHOME_THREAD_SINGLE
-  this->process_defer_queue_(now);
-#endif /* not ESPHOME_THREAD_SINGLE */
+  uint32_t snap_defer;
+  this->snapshot_counters_(snap_defer, snap_add, snap_remove);
+
+  if (snap_defer > 0) {
+    this->process_defer_queue_slow_path_(now);
+    // Defer callbacks may set_timeout/set_interval/cancel_*, mutating the
+    // other two counters. Re-snapshot.
+    this->snapshot_counters_(snap_defer, snap_add, snap_remove);
+  }
+#else
+  this->snapshot_counters_(snap_add, snap_remove);
+#endif
 
   // Extend the caller's 32-bit timestamp to 64-bit for scheduler operations
   const auto now_64 = this->millis_64_from_(now);
-  this->process_to_add();
+
+  if (snap_add > 0)
+    this->process_to_add_slow_path_();
 
   // Track if any items were added to to_add_ during callbacks
   bool has_added_items = false;
@@ -582,13 +598,9 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // Cleanup removed items before processing
-  // First try to clean items from the top of the heap (fast path)
-  this->cleanup_();
-
-  // If we still have too many cancelled items, do a full cleanup
-  // This only happens if cancelled items are stuck in the middle/bottom of the heap
-  if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) {
+  // cleanup_slow_path_ returns the post-cleanup to_remove_ value (read
+  // under lock), so the MAX gate uses the fresh count for free.
+  if (snap_remove > 0 && this->cleanup_slow_path_() >= MAX_LOGICALLY_DELETED_ITEMS) {
     this->full_cleanup_removed_items_();
   }
   // IMPORTANT: This loop uses index-based access (items_[0]), NOT iterators.
@@ -723,7 +735,7 @@ void HOT Scheduler::process_to_add_slow_path_() {
   this->to_add_.clear();
   this->to_add_count_clear_();
 }
-bool HOT Scheduler::cleanup_slow_path_() {
+uint32_t HOT Scheduler::cleanup_slow_path_() {
   // We must hold the lock for the entire cleanup operation because:
   // 1. We're modifying items_ (via pop_raw_locked_) which requires exclusive access
   // 2. We're decrementing to_remove_ which is also modified by other threads
@@ -740,7 +752,7 @@ bool HOT Scheduler::cleanup_slow_path_() {
     this->to_remove_decrement_();
     this->recycle_item_main_loop_(this->pop_raw_locked_());
   }
-  return !this->items_.empty();
+  return this->to_remove_count_();
 }
 Scheduler::SchedulerItem *HOT Scheduler::pop_raw_locked_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -598,10 +598,14 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // cleanup_slow_path_ returns the post-cleanup to_remove_ value (read
-  // under lock), so the MAX gate uses the fresh count for free.
-  if (snap_remove > 0 && this->cleanup_slow_path_() >= MAX_LOGICALLY_DELETED_ITEMS) {
-    this->full_cleanup_removed_items_();
+  // Cleanup removed items from the top of the heap, then escalate to a full
+  // walk if there are still too many cancelled items stuck in the middle.
+  // to_remove_count_ is a cheap plain read (atomic relaxed load on ATOMICS,
+  // direct field read on NO_ATOMICS/SINGLE).
+  if (snap_remove > 0) {
+    this->cleanup_slow_path_();
+    if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS)
+      this->full_cleanup_removed_items_();
   }
   // IMPORTANT: This loop uses index-based access (items_[0]), NOT iterators.
   // This is intentional — fired intervals are pushed back into items_ via
@@ -735,7 +739,7 @@ void HOT Scheduler::process_to_add_slow_path_() {
   this->to_add_.clear();
   this->to_add_count_clear_();
 }
-uint32_t HOT Scheduler::cleanup_slow_path_() {
+bool HOT Scheduler::cleanup_slow_path_() {
   // We must hold the lock for the entire cleanup operation because:
   // 1. We're modifying items_ (via pop_raw_locked_) which requires exclusive access
   // 2. We're decrementing to_remove_ which is also modified by other threads
@@ -752,7 +756,7 @@ uint32_t HOT Scheduler::cleanup_slow_path_() {
     this->to_remove_decrement_();
     this->recycle_item_main_loop_(this->pop_raw_locked_());
   }
-  return this->to_remove_count_();
+  return !this->items_.empty();
 }
 Scheduler::SchedulerItem *HOT Scheduler::pop_raw_locked_() {
   std::pop_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -476,7 +476,7 @@ void Scheduler::compact_defer_queue_locked_() {
   // (saves ~156 bytes flash). Erasing from the end is O(1) - no shifting needed.
   this->defer_queue_.erase(this->defer_queue_.begin() + remaining, this->defer_queue_.end());
 }
-void HOT Scheduler::process_defer_queue_slow_path_(uint32_t &now) {
+void HOT Scheduler::process_defer_queue_(uint32_t &now) {
   // Process defer queue to guarantee FIFO execution order for deferred items.
   // Previously, defer() used the heap which gave undefined order for equal timestamps,
   // causing race conditions on multi-core systems (ESP32, BK7200).
@@ -543,7 +543,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   this->snapshot_counters_(snap_defer, snap_add, snap_remove);
 
   if (snap_defer > 0) {
-    this->process_defer_queue_slow_path_(now);
+    this->process_defer_queue_(now);
     // Defer callbacks may set_timeout/set_interval/cancel_*, mutating the
     // other two counters. Re-snapshot.
     this->snapshot_counters_(snap_defer, snap_add, snap_remove);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -312,10 +312,11 @@ class Scheduler {
   inline bool ESPHOME_ALWAYS_INLINE HOT cleanup_() {
     if (this->to_remove_empty_())
       return !this->items_.empty();
-    return this->cleanup_slow_path_();
+    this->cleanup_slow_path_();
+    return !this->items_.empty();
   }
-  // Slow path for cleanup_() when there are items to remove - defined in scheduler.cpp
-  bool cleanup_slow_path_();
+  // Slow path for cleanup_() - returns the post-cleanup to_remove_ count.
+  uint32_t cleanup_slow_path_();
   // Slow path for process_to_add() when there are items to merge - defined in scheduler.cpp
   void process_to_add_slow_path_();
   // Remove and return the front item from the heap as a raw pointer.
@@ -446,7 +447,29 @@ class Scheduler {
   // IMPORTANT: Caller must hold the scheduler lock before calling this function.
   // IMPORTANT: Must not be inlined - rare path, outlined to keep it out of the hot instruction cache lines.
   void __attribute__((noinline)) compact_defer_queue_locked_();
-#endif /* not ESPHOME_THREAD_SINGLE */
+
+  // Snapshot skip-work counters for Scheduler::call(). NO_ATOMICS: one lock
+  // for all three reads. ATOMICS: three relaxed loads, free.
+  inline void ESPHOME_ALWAYS_INLINE HOT snapshot_counters_(uint32_t &defer, uint32_t &add, uint32_t &remove) {
+#ifdef ESPHOME_THREAD_MULTI_NO_ATOMICS
+    LockGuard guard{this->lock_};
+    defer = this->defer_count_;
+    add = this->to_add_count_;
+    remove = this->to_remove_;
+#else /* ESPHOME_THREAD_MULTI_ATOMICS */
+    defer = this->defer_count_.load(std::memory_order_relaxed);
+    add = this->to_add_count_.load(std::memory_order_relaxed);
+    remove = this->to_remove_.load(std::memory_order_relaxed);
+#endif
+  }
+#else  /* ESPHOME_THREAD_SINGLE */
+  // SINGLE form — two direct reads, no defer queue. Lets call() use the
+  // same snap_add / snap_remove gates on every platform.
+  inline void ESPHOME_ALWAYS_INLINE HOT snapshot_counters_(uint32_t &add, uint32_t &remove) {
+    add = static_cast<uint32_t>(this->to_add_.size());
+    remove = this->to_remove_;
+  }
+#endif /* ESPHOME_THREAD_SINGLE */
 
   // Helper to check if item is marked for removal (platform-specific)
   // Returns true if item should be skipped, handles platform-specific synchronization

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -312,11 +312,10 @@ class Scheduler {
   inline bool ESPHOME_ALWAYS_INLINE HOT cleanup_() {
     if (this->to_remove_empty_())
       return !this->items_.empty();
-    this->cleanup_slow_path_();
-    return !this->items_.empty();
+    return this->cleanup_slow_path_();
   }
-  // Slow path for cleanup_() - returns the post-cleanup to_remove_ count.
-  uint32_t cleanup_slow_path_();
+  // Slow path for cleanup_() when there are items to remove - defined in scheduler.cpp
+  bool cleanup_slow_path_();
   // Slow path for process_to_add() when there are items to merge - defined in scheduler.cpp
   void process_to_add_slow_path_();
   // Remove and return the front item from the heap as a raw pointer.

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -414,17 +414,9 @@ class Scheduler {
 #ifndef ESPHOME_THREAD_SINGLE
   // Process defer queue for FIFO execution of deferred items.
   // IMPORTANT: This method should only be called from the main thread (loop task).
-  // Inlined: the fast path (nothing deferred) is just an atomic load check.
-  inline void ESPHOME_ALWAYS_INLINE HOT process_defer_queue_(uint32_t &now) {
-    // Fast path: nothing to process, avoid lock entirely.
-    // Worst case is a one-loop-iteration delay before newly deferred items are processed.
-    if (this->defer_empty_())
-      return;
-    this->process_defer_queue_slow_path_(now);
-  }
-
-  // Slow path for process_defer_queue_() - defined in scheduler.cpp
-  void process_defer_queue_slow_path_(uint32_t &now);
+  // The fast path (nothing deferred) is handled by Scheduler::call()'s snapshot
+  // gate; this is only invoked when the snapshot saw defer_count_ > 0.
+  void process_defer_queue_(uint32_t &now);
 
   // Helper to cleanup defer_queue_ after processing.
   // Keeps the common clear() path inline, outlines the rare compaction to keep


### PR DESCRIPTION
# What does this implement/fix?

On `ESPHOME_THREAD_MULTI_NO_ATOMICS` (BK72xx — ARMv5TE, no LDREX/STREX, `std::atomic` RMW unavailable) the per-helper `*_empty_()` fast paths fall back to "always take the lock". So `Scheduler::call()` paid three separate FreeRTOS mutex round-trips per iteration — `process_defer_queue_` / `process_to_add` / `cleanup_` — even on idle ticks with nothing to do. At ~3100 iter/min, ~8 µs per uncontended mutex, that's **~75 ms/min** of main-loop overhead on idle configs. Matches the measured BK72xx-vs-RTL87xx gap (`sched=125 ms/min` vs `sched=19 ms/min`).

Take the lock once at the top of `Scheduler::call()` and snapshot all three counters together:
- **NO_ATOMICS**: one `LockGuard`, three plain reads.
- **ATOMICS**: three relaxed atomic loads (free, same memory order as the existing per-helper fast paths).
- **SINGLE**: two direct reads (`to_add_.size()`, `to_remove_`); no defer queue exists.

The skip-work gates downstream branch on the snapshot and call the slow paths directly, bypassing the `*_empty_()` lock.

Notes:
- After `process_defer_queue_slow_path_` runs, re-snapshot: defer callbacks can call `set_timeout` / `set_interval` / `cancel_*`, mutating the other two counters.
- `cleanup_slow_path_()` now returns the post-cleanup `to_remove_` count (read under lock, free), so the `MAX_LOGICALLY_DELETED_ITEMS` gate uses the fresh value without a redundant fetch.
- No new lock-free `uint32_t` reads on NO_ATOMICS — everything on that platform still reads under `lock_`.
- Wrapper helpers `process_to_add() / cleanup_() / process_defer_queue_()` unchanged for their other callers.

Discovered while profiling main-loop overhead on NiceMCU XH-WB3S (BK7238) and CB3S (BK7231N) alongside [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360). Complements #15943.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while testing [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360). Complements #15943.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Verified using runtime_stats on BK7238/BK7231N.
esphome:
  name: wb3s-bk7238-test

bk72xx:
  board: xh-wb3s

runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).