### PR TITLE
[scheduler][core] Lock-free fast-path on ESPHOME_THREAD_MULTI_NO_ATOMICS via __atomic builtins

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -235,11 +235,11 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
   }
   target->push_back(item);
   if (target == &this->to_add_) {
-    this->to_add_count_increment_();
+    this->to_add_count_increment_locked_();
   }
 #ifndef ESPHOME_THREAD_SINGLE
   else {
-    this->defer_count_increment_();
+    this->defer_count_increment_locked_();
   }
 #endif
 }
@@ -452,7 +452,7 @@ void Scheduler::full_cleanup_removed_items_() {
   this->items_.erase(this->items_.begin() + write, this->items_.end());
   // Rebuild the heap structure since items are no longer in heap order
   std::make_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
-  this->to_remove_clear_();
+  this->to_remove_clear_locked_();
 }
 
 #ifndef ESPHOME_THREAD_SINGLE
@@ -501,7 +501,7 @@ void HOT Scheduler::process_defer_queue_slow_path_(uint32_t &now) {
 
   this->lock_.lock();
   // Reset counter and snapshot queue end under lock
-  this->defer_count_clear_();
+  this->defer_count_clear_locked_();
   size_t defer_queue_end = this->defer_queue_.size();
   if (this->defer_queue_front_ >= defer_queue_end) {
     this->lock_.unlock();
@@ -621,7 +621,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
       LockGuard guard{this->lock_};
       if (is_item_removed_locked_(item)) {
         this->recycle_item_main_loop_(this->pop_raw_locked_());
-        this->to_remove_decrement_();
+        this->to_remove_decrement_locked_();
         continue;
       }
     }
@@ -630,7 +630,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
     if (is_item_removed_(item)) {
       LockGuard guard{this->lock_};
       this->recycle_item_main_loop_(this->pop_raw_locked_());
-      this->to_remove_decrement_();
+      this->to_remove_decrement_locked_();
       continue;
     }
 #endif
@@ -658,7 +658,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
 
     if (this->is_item_removed_locked_(executed_item)) {
       // We were removed/cancelled in the function call, recycle and continue
-      this->to_remove_decrement_();
+      this->to_remove_decrement_locked_();
       this->recycle_item_main_loop_(executed_item);
       continue;
     }
@@ -721,7 +721,7 @@ void HOT Scheduler::process_to_add_slow_path_() {
     std::push_heap(this->items_.begin(), this->items_.end(), SchedulerItem::cmp);
   }
   this->to_add_.clear();
-  this->to_add_count_clear_();
+  this->to_add_count_clear_locked_();
 }
 bool HOT Scheduler::cleanup_slow_path_() {
   // We must hold the lock for the entire cleanup operation because:
@@ -737,7 +737,7 @@ bool HOT Scheduler::cleanup_slow_path_() {
     SchedulerItem *item = this->items_[0];
     if (!this->is_item_removed_locked_(item))
       break;
-    this->to_remove_decrement_();
+    this->to_remove_decrement_locked_();
     this->recycle_item_main_loop_(this->pop_raw_locked_());
   }
   return !this->items_.empty();
@@ -825,7 +825,7 @@ bool HOT Scheduler::cancel_item_locked_(Component *component, NameType name_type
     size_t heap_cancelled = this->mark_matching_items_removed_locked_(this->items_, component, name_type, static_name,
                                                                       hash_or_id, type, match_retry, find_first);
     total_cancelled += heap_cancelled;
-    this->to_remove_add_(heap_cancelled);
+    this->to_remove_add_locked_(heap_cancelled);
     if (find_first && total_cancelled > 0)
       return true;
   }

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -550,16 +550,15 @@ class Scheduler {
   }
 
   // Increment to_add_count_ (no-op on single-threaded platforms).
-  // On NO_ATOMICS the caller must hold lock_ to serialise the load-modify-store
-  // against other writers; the __atomic_store_n makes the write visible to
-  // concurrent readers in the C++ memory model.
+  // On NO_ATOMICS the caller must hold lock_ to serialise RMW against
+  // other writers; reader fast-path uses __atomic_load_n.
   void to_add_count_increment_locked_() {
 #ifdef ESPHOME_THREAD_SINGLE
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-  __atomic_store_n(&this->to_add_count_, __atomic_load_n(&this->to_add_count_, __ATOMIC_RELAXED) + 1, __ATOMIC_RELAXED);
+  this->to_add_count_++;
 #endif
   }
 
@@ -570,7 +569,7 @@ class Scheduler {
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.store(0, std::memory_order_relaxed);
 #else
-  __atomic_store_n(&this->to_add_count_, 0, __ATOMIC_RELAXED);
+  this->to_add_count_ = 0;
 #endif
   }
 
@@ -602,7 +601,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-    __atomic_store_n(&this->defer_count_, __atomic_load_n(&this->defer_count_, __ATOMIC_RELAXED) + 1, __ATOMIC_RELAXED);
+    this->defer_count_++;
 #endif
   }
 
@@ -610,7 +609,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.store(0, std::memory_order_relaxed);
 #else
-    __atomic_store_n(&this->defer_count_, 0, __ATOMIC_RELAXED);
+    this->defer_count_ = 0;
 #endif
   }
 
@@ -639,30 +638,24 @@ class Scheduler {
   void to_remove_add_locked_(uint32_t count) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_add(count, std::memory_order_relaxed);
-#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-    __atomic_store_n(&this->to_remove_, __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) + count, __ATOMIC_RELAXED);
 #else
-  this->to_remove_ += count;
+    this->to_remove_ += count;
 #endif
   }
 
   void to_remove_decrement_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_sub(1, std::memory_order_relaxed);
-#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-    __atomic_store_n(&this->to_remove_, __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) - 1, __ATOMIC_RELAXED);
 #else
-  this->to_remove_--;
+    this->to_remove_--;
 #endif
   }
 
   void to_remove_clear_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.store(0, std::memory_order_relaxed);
-#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-    __atomic_store_n(&this->to_remove_, 0, __ATOMIC_RELAXED);
 #else
-  this->to_remove_ = 0;
+    this->to_remove_ = 0;
 #endif
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -525,40 +525,41 @@ class Scheduler {
 
 #ifndef ESPHOME_THREAD_SINGLE
   // Fast-path counter for process_to_add() to skip taking the lock when there
-  // is nothing to add. std::atomic on ATOMICS; volatile uint32_t on NO_ATOMICS
-  // (aligned 32-bit reads are atomic on ARMv5TE — BK72xx — and volatile
-  // prevents the compiler caching/eliding the read). On NO_ATOMICS, callers
-  // must hold lock_ for any RMW mutation. Not needed on SINGLE.
+  // is nothing to add. std::atomic on ATOMICS; plain uint32_t on NO_ATOMICS
+  // (BK72xx — ARMv5TE single-core, lacks LDREX/STREX so std::atomic RMW would
+  // require libatomic). Reads use __atomic_load_n(__ATOMIC_RELAXED) on
+  // NO_ATOMICS — compiles to a plain LDR (aligned 32-bit load is naturally
+  // atomic on ARMv5TE) but expresses the concurrent-access intent in the C++
+  // memory model. Writes live behind *_locked_ helpers and must hold lock_.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> to_add_count_{0};
 #else
-  volatile uint32_t to_add_count_{0};
+  uint32_t to_add_count_{0};
 #endif
 #endif /* ESPHOME_THREAD_SINGLE */
 
   // Fast-path helper for process_to_add() to decide if it can skip the lock.
-  // - SINGLE: direct container check (no concurrent writers).
-  // - ATOMICS: lock-free load of to_add_count_.
-  // - NO_ATOMICS: volatile read. A stale 0 is benign — next call() iteration
-  //   observes the update; RMW mutation is still under lock_.
   bool to_add_empty_() const {
 #ifdef ESPHOME_THREAD_SINGLE
     return this->to_add_.empty();
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     return this->to_add_count_.load(std::memory_order_relaxed) == 0;
 #else
-  return this->to_add_count_ == 0;
+  return __atomic_load_n(&this->to_add_count_, __ATOMIC_RELAXED) == 0;
 #endif
   }
 
-  // Increment to_add_count_ (no-op on single-threaded platforms)
+  // Increment to_add_count_ (no-op on single-threaded platforms).
+  // On NO_ATOMICS the caller must hold lock_ to serialise the load-modify-store
+  // against other writers; the __atomic_store_n makes the write visible to
+  // concurrent readers in the C++ memory model.
   void to_add_count_increment_locked_() {
 #ifdef ESPHOME_THREAD_SINGLE
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-  this->to_add_count_++;
+  __atomic_store_n(&this->to_add_count_, __atomic_load_n(&this->to_add_count_, __ATOMIC_RELAXED) + 1, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -569,7 +570,7 @@ class Scheduler {
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.store(0, std::memory_order_relaxed);
 #else
-  this->to_add_count_ = 0;
+  __atomic_store_n(&this->to_add_count_, 0, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -581,11 +582,11 @@ class Scheduler {
   size_t defer_queue_front_{0};               // Index of first valid item in defer_queue_ (tracks consumed items)
 
   // Fast-path counter for process_defer_queue_() to skip lock when nothing to
-  // process. See to_add_count_ above for the volatile rationale on NO_ATOMICS.
+  // process. See to_add_count_ above for the NO_ATOMICS rationale.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> defer_count_{0};
 #else
-  volatile uint32_t defer_count_{0};
+  uint32_t defer_count_{0};
 #endif
 
   bool defer_empty_() const {
@@ -593,7 +594,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     return this->defer_count_.load(std::memory_order_relaxed) == 0;
 #else
-    return this->defer_count_ == 0;
+    return __atomic_load_n(&this->defer_count_, __ATOMIC_RELAXED) == 0;
 #endif
   }
 
@@ -601,7 +602,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-    this->defer_count_++;
+    __atomic_store_n(&this->defer_count_, __atomic_load_n(&this->defer_count_, __ATOMIC_RELAXED) + 1, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -609,61 +610,69 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.store(0, std::memory_order_relaxed);
 #else
-    this->defer_count_ = 0;
+    __atomic_store_n(&this->defer_count_, 0, __ATOMIC_RELAXED);
 #endif
   }
 
 #endif /* ESPHOME_THREAD_SINGLE */
 
   // Counter for items marked for removal. Incremented cross-thread in
-  // cancel_item_locked_(). See to_add_count_ above for the volatile rationale
-  // on NO_ATOMICS.
+  // cancel_item_locked_(). See to_add_count_ above for the NO_ATOMICS
+  // rationale.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> to_remove_{0};
-#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-  volatile uint32_t to_remove_{0};
 #else
-uint32_t to_remove_{0};
+  uint32_t to_remove_{0};
 #endif
 
   // Lock-free check if there are items to remove (for fast-path in cleanup_)
   bool to_remove_empty_() const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     return this->to_remove_.load(std::memory_order_relaxed) == 0;
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    return __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) == 0;
 #else
-    return this->to_remove_ == 0;
+  return this->to_remove_ == 0;
 #endif
   }
 
   void to_remove_add_locked_(uint32_t count) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_add(count, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) + count, __ATOMIC_RELAXED);
 #else
-    this->to_remove_ += count;
+  this->to_remove_ += count;
 #endif
   }
 
   void to_remove_decrement_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_sub(1, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) - 1, __ATOMIC_RELAXED);
 #else
-    this->to_remove_--;
+  this->to_remove_--;
 #endif
   }
 
   void to_remove_clear_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.store(0, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, 0, __ATOMIC_RELAXED);
 #else
-    this->to_remove_ = 0;
+  this->to_remove_ = 0;
 #endif
   }
 
   uint32_t to_remove_count_() const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     return this->to_remove_.load(std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    return __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED);
 #else
-    return this->to_remove_;
+  return this->to_remove_;
 #endif
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -552,7 +552,7 @@ class Scheduler {
   }
 
   // Increment to_add_count_ (no-op on single-threaded platforms)
-  void to_add_count_increment_() {
+  void to_add_count_increment_locked_() {
 #ifdef ESPHOME_THREAD_SINGLE
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
@@ -563,7 +563,7 @@ class Scheduler {
   }
 
   // Reset to_add_count_ (no-op on single-threaded platforms)
-  void to_add_count_clear_() {
+  void to_add_count_clear_locked_() {
 #ifdef ESPHOME_THREAD_SINGLE
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
@@ -597,7 +597,7 @@ class Scheduler {
 #endif
   }
 
-  void defer_count_increment_() {
+  void defer_count_increment_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.fetch_add(1, std::memory_order_relaxed);
 #else
@@ -605,7 +605,7 @@ class Scheduler {
 #endif
   }
 
-  void defer_count_clear_() {
+  void defer_count_clear_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.store(0, std::memory_order_relaxed);
 #else
@@ -635,7 +635,7 @@ uint32_t to_remove_{0};
 #endif
   }
 
-  void to_remove_add_(uint32_t count) {
+  void to_remove_add_locked_(uint32_t count) {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_add(count, std::memory_order_relaxed);
 #else
@@ -643,7 +643,7 @@ uint32_t to_remove_{0};
 #endif
   }
 
-  void to_remove_decrement_() {
+  void to_remove_decrement_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.fetch_sub(1, std::memory_order_relaxed);
 #else
@@ -651,7 +651,7 @@ uint32_t to_remove_{0};
 #endif
   }
 
-  void to_remove_clear_() {
+  void to_remove_clear_locked_() {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->to_remove_.store(0, std::memory_order_relaxed);
 #else

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -524,30 +524,30 @@ class Scheduler {
   std::vector<SchedulerItem *> to_add_;
 
 #ifndef ESPHOME_THREAD_SINGLE
-  // Fast-path counter for process_to_add() to skip taking the lock when there is
-  // nothing to add. Uses std::atomic on platforms that support it, plain uint32_t
-  // otherwise. On non-atomic platforms, callers must hold the scheduler lock when
-  // mutating this counter. Not needed on single-threaded platforms where we can
-  // check to_add_.empty() directly.
+  // Fast-path counter for process_to_add() to skip taking the lock when there
+  // is nothing to add. std::atomic on ATOMICS; volatile uint32_t on NO_ATOMICS
+  // (aligned 32-bit reads are atomic on ARMv5TE — BK72xx — and volatile
+  // prevents the compiler caching/eliding the read). On NO_ATOMICS, callers
+  // must hold lock_ for any RMW mutation. Not needed on SINGLE.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> to_add_count_{0};
 #else
-  uint32_t to_add_count_{0};
+  volatile uint32_t to_add_count_{0};
 #endif
 #endif /* ESPHOME_THREAD_SINGLE */
 
-  // Fast-path helper for process_to_add() to decide if it can try the lock-free path.
-  // - On ESPHOME_THREAD_SINGLE: direct container check is safe (no concurrent writers).
-  // - On ESPHOME_THREAD_MULTI_ATOMICS: performs a lock-free check via to_add_count_.
-  // - On ESPHOME_THREAD_MULTI_NO_ATOMICS: always returns false to force the caller
-  //   down the locked path; this is NOT a lock-free emptiness check on that platform.
+  // Fast-path helper for process_to_add() to decide if it can skip the lock.
+  // - SINGLE: direct container check (no concurrent writers).
+  // - ATOMICS: lock-free load of to_add_count_.
+  // - NO_ATOMICS: volatile read. A stale 0 is benign — next call() iteration
+  //   observes the update; RMW mutation is still under lock_.
   bool to_add_empty_() const {
 #ifdef ESPHOME_THREAD_SINGLE
     return this->to_add_.empty();
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     return this->to_add_count_.load(std::memory_order_relaxed) == 0;
 #else
-  return false;
+  return this->to_add_count_ == 0;
 #endif
   }
 
@@ -580,20 +580,20 @@ class Scheduler {
   std::vector<SchedulerItem *> defer_queue_;  // FIFO queue for defer() calls
   size_t defer_queue_front_{0};               // Index of first valid item in defer_queue_ (tracks consumed items)
 
-  // Fast-path counter for process_defer_queue_() to skip lock when nothing to process.
+  // Fast-path counter for process_defer_queue_() to skip lock when nothing to
+  // process. See to_add_count_ above for the volatile rationale on NO_ATOMICS.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> defer_count_{0};
 #else
-  uint32_t defer_count_{0};
+  volatile uint32_t defer_count_{0};
 #endif
 
   bool defer_empty_() const {
     // defer_queue_ only exists on multi-threaded platforms, so no ESPHOME_THREAD_SINGLE path
-    // ESPHOME_THREAD_MULTI_NO_ATOMICS: always take the lock
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     return this->defer_count_.load(std::memory_order_relaxed) == 0;
 #else
-    return false;
+    return this->defer_count_ == 0;
 #endif
   }
 
@@ -615,23 +615,23 @@ class Scheduler {
 
 #endif /* ESPHOME_THREAD_SINGLE */
 
-  // Counter for items marked for removal. Incremented cross-thread in cancel_item_locked_().
-  // On ESPHOME_THREAD_MULTI_ATOMICS this is read without a lock in the cleanup_() fast path;
-  // on ESPHOME_THREAD_MULTI_NO_ATOMICS the fast path is disabled so cleanup_() always takes the lock.
+  // Counter for items marked for removal. Incremented cross-thread in
+  // cancel_item_locked_(). See to_add_count_ above for the volatile rationale
+  // on NO_ATOMICS.
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
   std::atomic<uint32_t> to_remove_{0};
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+  volatile uint32_t to_remove_{0};
 #else
-  uint32_t to_remove_{0};
+uint32_t to_remove_{0};
 #endif
 
   // Lock-free check if there are items to remove (for fast-path in cleanup_)
   bool to_remove_empty_() const {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     return this->to_remove_.load(std::memory_order_relaxed) == 0;
-#elif defined(ESPHOME_THREAD_SINGLE)
-    return this->to_remove_ == 0;
 #else
-  return false;  // Always take the lock path
+    return this->to_remove_ == 0;
 #endif
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -626,7 +626,7 @@ class Scheduler {
 
   // Lock-free check if there are items to remove (for fast-path in cleanup_)
   bool to_remove_empty_() const {
-#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+#if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     return this->to_remove_.load(std::memory_order_relaxed) == 0;
 #elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
     return __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED) == 0;
@@ -660,7 +660,7 @@ class Scheduler {
   }
 
   uint32_t to_remove_count_() const {
-#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+#if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     return this->to_remove_.load(std::memory_order_relaxed);
 #elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
     return __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED);

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -550,26 +550,28 @@ class Scheduler {
   }
 
   // Increment to_add_count_ (no-op on single-threaded platforms).
-  // On NO_ATOMICS the caller must hold lock_ to serialise RMW against
-  // other writers; reader fast-path uses __atomic_load_n.
+  // On NO_ATOMICS the caller must hold lock_; the atomic store pairs with
+  // the reader's __atomic_load_n in to_add_empty_(). The input-value read is
+  // plain — safe because only writers (serialised by lock_) modify the
+  // counter, and concurrent readers only atomic-load (no conflicting write).
   void to_add_count_increment_locked_() {
-#ifdef ESPHOME_THREAD_SINGLE
+#if defined(ESPHOME_THREAD_SINGLE)
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-  this->to_add_count_++;
+  __atomic_store_n(&this->to_add_count_, this->to_add_count_ + 1, __ATOMIC_RELAXED);
 #endif
   }
 
   // Reset to_add_count_ (no-op on single-threaded platforms)
   void to_add_count_clear_locked_() {
-#ifdef ESPHOME_THREAD_SINGLE
+#if defined(ESPHOME_THREAD_SINGLE)
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.store(0, std::memory_order_relaxed);
 #else
-  this->to_add_count_ = 0;
+  __atomic_store_n(&this->to_add_count_, 0, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -601,7 +603,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-    this->defer_count_++;
+    __atomic_store_n(&this->defer_count_, this->defer_count_ + 1, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -609,7 +611,7 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.store(0, std::memory_order_relaxed);
 #else
-    this->defer_count_ = 0;
+    __atomic_store_n(&this->defer_count_, 0, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -636,26 +638,32 @@ class Scheduler {
   }
 
   void to_remove_add_locked_(uint32_t count) {
-#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+#if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_remove_.fetch_add(count, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, this->to_remove_ + count, __ATOMIC_RELAXED);
 #else
-    this->to_remove_ += count;
+  this->to_remove_ += count;
 #endif
   }
 
   void to_remove_decrement_locked_() {
-#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+#if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_remove_.fetch_sub(1, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, this->to_remove_ - 1, __ATOMIC_RELAXED);
 #else
-    this->to_remove_--;
+  this->to_remove_--;
 #endif
   }
 
   void to_remove_clear_locked_() {
-#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+#if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_remove_.store(0, std::memory_order_relaxed);
+#elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
+    __atomic_store_n(&this->to_remove_, 0, __ATOMIC_RELAXED);
 #else
-    this->to_remove_ = 0;
+  this->to_remove_ = 0;
 #endif
   }
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -550,17 +550,18 @@ class Scheduler {
   }
 
   // Increment to_add_count_ (no-op on single-threaded platforms).
-  // On NO_ATOMICS the caller must hold lock_; the atomic store pairs with
-  // the reader's __atomic_load_n in to_add_empty_(). The input-value read is
-  // plain — safe because only writers (serialised by lock_) modify the
-  // counter, and concurrent readers only atomic-load (no conflicting write).
+  // On NO_ATOMICS the caller must hold lock_; both load and store go through
+  // __atomic_*_n with __ATOMIC_RELAXED to keep every access to the counter
+  // explicitly atomic in the C++ memory model (same ARMv5TE codegen as
+  // plain LDR+STR).
   void to_add_count_increment_locked_() {
 #if defined(ESPHOME_THREAD_SINGLE)
     // No counter needed — to_add_empty_() checks the vector directly
 #elif defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_add_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-  __atomic_store_n(&this->to_add_count_, this->to_add_count_ + 1, __ATOMIC_RELAXED);
+  uint32_t v = __atomic_load_n(&this->to_add_count_, __ATOMIC_RELAXED);
+  __atomic_store_n(&this->to_add_count_, v + 1, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -603,7 +604,8 @@ class Scheduler {
 #ifdef ESPHOME_THREAD_MULTI_ATOMICS
     this->defer_count_.fetch_add(1, std::memory_order_relaxed);
 #else
-    __atomic_store_n(&this->defer_count_, this->defer_count_ + 1, __ATOMIC_RELAXED);
+    uint32_t v = __atomic_load_n(&this->defer_count_, __ATOMIC_RELAXED);
+    __atomic_store_n(&this->defer_count_, v + 1, __ATOMIC_RELAXED);
 #endif
   }
 
@@ -641,7 +643,8 @@ class Scheduler {
 #if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_remove_.fetch_add(count, std::memory_order_relaxed);
 #elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-    __atomic_store_n(&this->to_remove_, this->to_remove_ + count, __ATOMIC_RELAXED);
+    uint32_t v = __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED);
+    __atomic_store_n(&this->to_remove_, v + count, __ATOMIC_RELAXED);
 #else
   this->to_remove_ += count;
 #endif
@@ -651,7 +654,8 @@ class Scheduler {
 #if defined(ESPHOME_THREAD_MULTI_ATOMICS)
     this->to_remove_.fetch_sub(1, std::memory_order_relaxed);
 #elif defined(ESPHOME_THREAD_MULTI_NO_ATOMICS)
-    __atomic_store_n(&this->to_remove_, this->to_remove_ - 1, __ATOMIC_RELAXED);
+    uint32_t v = __atomic_load_n(&this->to_remove_, __ATOMIC_RELAXED);
+    __atomic_store_n(&this->to_remove_, v - 1, __ATOMIC_RELAXED);
 #else
   this->to_remove_--;
 #endif

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -72,12 +72,8 @@ uint64_t Millis64Impl::compute(uint32_t now) {
   // Without atomics, this implementation uses locks more aggressively:
   // 1. Always locks when near the rollover boundary (within 10 seconds)
   // 2. Always locks when detecting a large backwards jump
-  // 3. Updates without lock in normal forward progression.
-  // Concurrent reads/writes use __atomic_load_n / __atomic_store_n with
-  // __ATOMIC_RELAXED so the cross-thread accesses are well-defined in the
-  // C++ memory model. On ARMv5TE these compile to plain LDR/STR. Writers
-  // holding `lock` use plain assignments; the lock serialises them against
-  // other writers.
+  // 3. Updates without lock in normal forward progression (accepting minor races)
+  // This is less efficient but necessary without atomic operations.
   uint16_t major = __atomic_load_n(&millis_major, __ATOMIC_RELAXED);
   uint32_t last = __atomic_load_n(&last_millis, __ATOMIC_RELAXED);
 
@@ -105,10 +101,9 @@ uint64_t Millis64Impl::compute(uint32_t now) {
     // Update last_millis while holding lock
     last_millis = now;
   } else if (now > last) {
-    // Normal case: Not near rollover and time moved forward. Publish the new
-    // low word without taking the lock. A concurrent writer under lock may
-    // overwrite this with a slightly-different value, which can produce a
-    // few microseconds of backwards time movement — acceptable because:
+    // Normal case: Not near rollover and time moved forward
+    // Update without lock. While this may cause minor races (microseconds of
+    // backwards time movement), they're acceptable because:
     // 1. The scheduler operates at millisecond resolution, not microsecond
     // 2. We've already prevented the critical rollover race condition
     // 3. Any backwards movement is orders of magnitude smaller than scheduler delays

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -92,14 +92,14 @@ uint64_t Millis64Impl::compute(uint32_t now) {
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)
-      millis_major++;
+      __atomic_store_n(&millis_major, static_cast<uint16_t>(millis_major + 1), __ATOMIC_RELAXED);
       major++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
       ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */
     }
     // Update last_millis while holding lock
-    last_millis = now;
+    __atomic_store_n(&last_millis, now, __ATOMIC_RELAXED);
   } else if (now > last) {
     // Normal case: Not near rollover and time moved forward
     // Update without lock. While this may cause minor races (microseconds of

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -72,10 +72,14 @@ uint64_t Millis64Impl::compute(uint32_t now) {
   // Without atomics, this implementation uses locks more aggressively:
   // 1. Always locks when near the rollover boundary (within 10 seconds)
   // 2. Always locks when detecting a large backwards jump
-  // 3. Updates without lock in normal forward progression (accepting minor races)
-  // This is less efficient but necessary without atomic operations.
-  uint16_t major = millis_major;
-  uint32_t last = last_millis;
+  // 3. Updates without lock in normal forward progression.
+  // Concurrent reads/writes use __atomic_load_n / __atomic_store_n with
+  // __ATOMIC_RELAXED so the cross-thread accesses are well-defined in the
+  // C++ memory model. On ARMv5TE these compile to plain LDR/STR. Writers
+  // holding `lock` use plain assignments; the lock serialises them against
+  // other writers.
+  uint16_t major = __atomic_load_n(&millis_major, __ATOMIC_RELAXED);
+  uint32_t last = __atomic_load_n(&last_millis, __ATOMIC_RELAXED);
 
   // Define a safe window around the rollover point (10 seconds)
   // This covers any reasonable scheduler delays or thread preemption
@@ -101,13 +105,14 @@ uint64_t Millis64Impl::compute(uint32_t now) {
     // Update last_millis while holding lock
     last_millis = now;
   } else if (now > last) {
-    // Normal case: Not near rollover and time moved forward
-    // Update without lock. While this may cause minor races (microseconds of
-    // backwards time movement), they're acceptable because:
+    // Normal case: Not near rollover and time moved forward. Publish the new
+    // low word without taking the lock. A concurrent writer under lock may
+    // overwrite this with a slightly-different value, which can produce a
+    // few microseconds of backwards time movement — acceptable because:
     // 1. The scheduler operates at millisecond resolution, not microsecond
     // 2. We've already prevented the critical rollover race condition
     // 3. Any backwards movement is orders of magnitude smaller than scheduler delays
-    last_millis = now;
+    __atomic_store_n(&last_millis, now, __ATOMIC_RELAXED);
   }
   // If now <= last and we're not near rollover, don't update
   // This minimizes backwards time movement

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -87,8 +87,13 @@ uint64_t Millis64Impl::compute(uint32_t now) {
   if (near_rollover || (now < last && (last - now) > HALF_MAX_UINT32)) {
     // Near rollover or detected a rollover - need lock for safety
     LockGuard guard{lock};
-    // Re-read with lock held
-    last = last_millis;
+    // Re-read both values with lock held. last_millis can be updated
+    // unlocked from the forward-progression branch below, so use an atomic
+    // load. millis_major can only be updated under this lock, but another
+    // thread may have completed a rollover between our unlocked loads above
+    // and the lock acquisition — reload or we'd return a stale high word.
+    last = __atomic_load_n(&last_millis, __ATOMIC_RELAXED);
+    major = __atomic_load_n(&millis_major, __ATOMIC_RELAXED);
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
       // True rollover detected (happens every ~49.7 days)

--- a/esphome/core/time_64.cpp
+++ b/esphome/core/time_64.cpp
@@ -96,9 +96,11 @@ uint64_t Millis64Impl::compute(uint32_t now) {
     major = __atomic_load_n(&millis_major, __ATOMIC_RELAXED);
 
     if (now < last && (last - now) > HALF_MAX_UINT32) {
-      // True rollover detected (happens every ~49.7 days)
-      __atomic_store_n(&millis_major, static_cast<uint16_t>(millis_major + 1), __ATOMIC_RELAXED);
+      // True rollover detected (happens every ~49.7 days).
+      // Use the already-loaded `major` local; avoids a second read of the
+      // global (equivalent under the held lock).
       major++;
+      __atomic_store_n(&millis_major, major, __ATOMIC_RELAXED);
 #ifdef ESPHOME_DEBUG_SCHEDULER
       ESP_LOGD(TAG, "Detected true 32-bit rollover at %" PRIu32 "ms (was %" PRIu32 ")", now, last);
 #endif /* ESPHOME_DEBUG_SCHEDULER */


### PR DESCRIPTION
# What does this implement/fix?

The `_empty_()` helpers (`to_add_empty_`, `defer_empty_`, `to_remove_empty_`) forced the lock path on `ESPHOME_THREAD_MULTI_NO_ATOMICS` by hardcoding `return false`. That made `Scheduler::call()` pay a FreeRTOS mutex round-trip for each of `process_defer_queue_` / `process_to_add` / `cleanup_` on every idle tick — three uncontended `xSemaphoreTake`/`xSemaphoreGive` pairs just to confirm "nothing to do".

On the only NO_ATOMICS target (BK72xx — ARMv5TE, single-core, no LDREX/STREX so `std::atomic` RMW would require libatomic), aligned 32-bit load/store is atomic at the hardware level. Switch the three scheduler skip-work counters and the Millis64 rollover state to use GCC atomic builtins at `__ATOMIC_RELAXED`:

- **Readers** (unlocked fast path): `__atomic_load_n(&counter, __ATOMIC_RELAXED)` — compiles to a plain LDR.
- **Writers** (under `lock_`): explicit two-step `__atomic_load_n` into a local, then `__atomic_store_n` of the incremented value. Compiles to a plain LDR + STR pair.

Every access to the counters is now explicitly atomic in the C++ memory model. On ARMv5TE the codegen is identical to the previous plain-access version — no libatomic dependency.

Also rename the seven counter RMW mutators with a `_locked_` suffix to match the existing convention (`pop_raw_locked_`, `is_item_removed_locked_`, `cancel_item_locked_`, etc.) and make the caller-holds-lock contract explicit at every call site.

`time_64.cpp` gets the same treatment for `millis_major` / `last_millis`. Bonus: incidental correctness fix where the unlocked `major` load could be stale by the time the lock was acquired, producing a ~49.7-day backwards time jump if another thread handled a rollover in the window.

## Stale fast-path read: realistic exposure on BK72xx

Readers don't hold `lock_`, so a stale read is formally possible. On single-core BK72xx this isn't cache coherency — only preemption of a writer mid-critical-section can expose it, and only if a non-main FreeRTOS task writes to the scheduler. Who actually does that?

- **Main-loop writers** (every component's `set_timeout` / `set_interval` / `cancel_*`, all `update()` / `loop()` paths, entity state callbacks → MQTT publish defers): never race with the reader — it's the same task.
- **ESP32-only tasks** (`esp32_camera`, `i2s_audio`, `micro_wake_word`, `usb_cdc_acm`, `esp32_ble*`): not compiled for BK72xx.
- **LibreTiny WiFi events**: route through the Arduino event dispatcher, which calls `wake_loop_threadsafe()` and lets the main loop handle them — no direct scheduler write.
- **MQTT RX callbacks**: the only real cross-thread producer on BK72xx. `AsyncMqttClient` (via `AsyncTCP`) runs `_onData` on a dedicated FreeRTOS service task; `mqtt_client.cpp:657` calls `defer(...)` from that task to hop the callback back to the main loop. Takes `lock_`, bumps `defer_count_`.

Even in the MQTT case, the stale-read worst case is **one extra main-loop iteration of latency (≤~20 ms at 3100 iter/min)**. And `defer()` as called there does not invoke `wake_loop_threadsafe()` — the deferred callback already has no latency guarantee, it fires whenever the main loop next ticks naturally (up to `loop_interval_` / ~16 ms idle). Our stale-read penalty fits entirely inside the slack that contract already has.

**Outcomes catalogued:**
- *Stale-zero* (counter actually nonzero): slow path skipped this tick, item stays in its vector, picked up on next `Scheduler::call()`. No loss.
- *Stale-nonzero* (counter actually zero): take the lock, find nothing, release. One wasted mutex — exactly the pre-PR cost. Self-healing.
- *Torn read*: impossible. Aligned 32-bit LDR + `__ATOMIC_RELAXED` rules it out.
- *Cancelled item mid-cleanup*: if `cleanup_` was skipped on a stale-zero tick, the main while-loop's per-item `is_item_removed_locked_` (already under lock) catches the cancellation at pop time — nothing spurious fires.

Without MQTT configured, the race window has no producer at all on BK72xx.

## Measurements

NiceMCU XH-WB3S (BK7238), `runtime_stats` breakdown patch (not part of this PR) splits `before` into `sched` + `wdt`.

**Baseline (upstream `dev`):**
```
main_loop: iters=3329, active_total=367.1ms, overhead_total=193.6ms
main_loop_overhead_section: before=132.9ms, tail=11.6ms, inter_component=49.0ms
main_loop_before_breakdown: sched=71.6ms, wdt=61.3ms, residual=0.0ms
```

**With #15943 (BK72xx WDT interval 300ms → 2000ms):**
```
main_loop: iters=3329, active_total=315.0ms, overhead_total=151.2ms
main_loop_overhead_section: before=89.8ms, tail=11.0ms, inter_component=50.5ms
main_loop_before_breakdown: sched=73.4ms, wdt=16.3ms, residual=0.0ms
```

**With #15943 + this PR:**
```
main_loop: iters=3333, active_total=340.7ms, overhead_total=161.4ms
main_loop_overhead_section: before=57.1ms, tail=16.0ms, inter_component=88.2ms
main_loop_before_breakdown: sched=42.1ms, wdt=15.1ms, residual=0.0ms
```

This PR's contribution (scheduler only, comparing to WDT-only baseline):
- `sched` bucket: **73.4 ms → 42.1 ms/min** (-31 ms, −42%). Matches ~3 µs/mutex × 3 mutexes × ~3300 iter/min.
- `before` bucket: **89.8 ms → 57.1 ms/min** (-33 ms, −36%).

Combined with #15943:
- `before`: **132.9 ms → 57.1 ms/min** (-76 ms, −57%)
- `overhead_total`: **193.6 ms → 161.4 ms/min** (-32 ms)

`inter_component` is now the dominant bucket (88.2 ms/min = ~6.6 µs/iter × 4 components), representing per-component bookkeeping (`set_current_component`, `WarnIfComponentBlockingGuard` ctor/dtor, per-component `feed_wdt_with_time`) — that's outside this PR's scope.

## Files touched

- `esphome/core/scheduler.h` — counter fields (plain `uint32_t` on NO_ATOMICS), `_empty_()` helpers, RMW mutators renamed with `_locked_` suffix, all writer paths use `__atomic_load_n` + `__atomic_store_n`.
- `esphome/core/time_64.cpp` — unlocked and under-lock reads/writes of `millis_major` and `last_millis` on NO_ATOMICS, and `major` is reloaded under lock to fix the staleness bug.

`ATOMICS` and `SINGLE` paths are unchanged.

Discovered while profiling main-loop overhead on NiceMCU XH-WB3S (BK7238) and CB3S (BK7231N) alongside [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360). Complements #15943.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while testing [libretiny-eu/libretiny#360](https://github.com/libretiny-eu/libretiny/pull/360). Complements #15943.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Verified using runtime_stats on BK7238/BK7231N.
esphome:
  name: wb3s-bk7238-test

bk72xx:
  board: xh-wb3s

runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).