### PR TITLE
[ci] Auto-close PRs opened from a fork's default branch

### DIFF
--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -1,0 +1,71 @@
+name: Close PR From Fork Default Branch
+
+on:
+  # pull_request_target is required so we have permission to comment and close PRs from forks.
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close:
+    name: Close PR opened from fork's default branch
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+      && github.event.pull_request.head.ref == github.event.repository.default_branch
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const author = context.payload.pull_request.user.login;
+            const defaultBranch = context.payload.repository.default_branch;
+            const headRepo = context.payload.pull_request.head.repo.full_name;
+
+            const body = [
+              `Hi @${author}, thanks for opening a pull request! :tada:`,
+              ``,
+              `It looks like this PR was opened from the \`${defaultBranch}\` branch of your fork (\`${headRepo}\`), which is the same name as this repository's default branch. Working directly on \`${defaultBranch}\` in your fork causes a few problems:`,
+              ``,
+              `- Your fork's \`${defaultBranch}\` branch will permanently diverge from \`esphome/esphome:${defaultBranch}\`, making it hard to keep your fork up to date.`,
+              `- Any additional commits you push to \`${defaultBranch}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
+              `- Maintainers can't push fixes to your branch.`,
+              ``,
+              `Please re-open this as a new PR from a dedicated feature branch. The usual flow looks like:`,
+              ``,
+              `\`\`\`bash`,
+              `# Make sure your fork's ${defaultBranch} is up to date with upstream`,
+              `git remote add upstream https://github.com/${owner}/${repo}.git  # if you haven't already`,
+              `git fetch upstream`,
+              `git checkout ${defaultBranch}`,
+              `git reset --hard upstream/${defaultBranch}`,
+              `git push --force-with-lease origin ${defaultBranch}`,
+              ``,
+              `# Create a new branch for your change and cherry-pick / re-apply your commits there`,
+              `git checkout -b my-feature-branch upstream/${defaultBranch}`,
+              `# ...re-apply your changes, then:`,
+              `git push origin my-feature-branch`,
+              `\`\`\``,
+              ``,
+              `Then open a new pull request from \`my-feature-branch\` into \`${owner}/${repo}:${defaultBranch}\`.`,
+              ``,
+              `Closing this PR for now — sorry for the friction, and thanks again for contributing! :heart:`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: prNumber,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner,
+              repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });

--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -33,7 +33,7 @@ jobs:
               ``,
               `- Your fork's \`${defaultBranch}\` branch will permanently diverge from \`esphome/esphome:${defaultBranch}\`, making it hard to keep your fork up to date.`,
               `- Any additional commits you push to \`${defaultBranch}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
-              `- Maintainers can't push fixes to your branch.`,
+              `- Pushing maintainer fixes to your branch is awkward, since it means committing directly to your fork's default branch.`,
               ``,
               `Please re-open this as a new PR from a dedicated feature branch. The usual flow looks like:`,
               ``,

--- a/.github/workflows/close-pr-from-fork-default-branch.yml
+++ b/.github/workflows/close-pr-from-fork-default-branch.yml
@@ -34,6 +34,7 @@ jobs:
               `- Your fork's \`${defaultBranch}\` branch will permanently diverge from \`esphome/esphome:${defaultBranch}\`, making it hard to keep your fork up to date.`,
               `- Any additional commits you push to \`${defaultBranch}\` will be added to this PR, so you can't easily work on multiple changes at once.`,
               `- Pushing maintainer fixes to your branch is awkward, since it means committing directly to your fork's default branch.`,
+              `- It makes local collaboration painful — \`${defaultBranch}\` in a checkout becomes ambiguous between upstream and your fork, and maintainers end up with naming collisions when fetching your branch.`,
               ``,
               `Please re-open this as a new PR from a dedicated feature branch. The usual flow looks like:`,
               ``,


### PR DESCRIPTION
# What does this implement/fix?

Adds a GitHub Actions workflow that automatically closes pull requests opened from a fork's default branch (i.e. the PR's head branch has the same name as the upstream default branch, currently `dev`) and posts a friendly comment explaining the problem and how to move the work to a feature branch.

**Scope:** only affects *newly opened* (or reopened) PRs. Existing open PRs from a fork's `dev` branch are **not** touched — no back-fill, no retroactive closing.

Working directly on the fork's default branch causes several recurring issues for contributors:

- Their fork's default branch permanently diverges from `esphome/esphome:dev`, making it hard to keep their fork in sync.
- Any additional commits pushed to `dev` end up tacked onto the open PR, so they can't easily work on multiple changes at once.
- Pushing maintainer fixes to the branch is awkward, since it means committing directly to the contributor's fork default branch.
- Local collaboration becomes painful — `dev` in a checkout is ambiguous between upstream and the contributor's fork, and maintainers end up with naming collisions when fetching the branch.

The workflow:

- Triggers on `pull_request_target` for `opened` and `reopened` only — existing open PRs are left alone.
- Runs only when the PR is from a fork **and** `head.ref == repository.default_branch`, so internal branches are untouched even if named `dev`.
- Uses `pull_request_target` for write access, but only runs `actions/github-script` with no checkout of PR code — no untrusted code executes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# N/A - this is a CI workflow change
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).