### PR TITLE
[deep_sleep] Fix sleep_duration codegen type to uint32_t

### DIFF
--- a/esphome/components/deep_sleep/__init__.py
+++ b/esphome/components/deep_sleep/__init__.py
@@ -417,7 +417,7 @@ async def deep_sleep_enter_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
     if CONF_SLEEP_DURATION in config:
-        template_ = await cg.templatable(config[CONF_SLEEP_DURATION], args, cg.int32)
+        template_ = await cg.templatable(config[CONF_SLEEP_DURATION], args, cg.uint32)
         cg.add(var.set_sleep_duration(template_))
 
     if CONF_UNTIL in config:

--- a/tests/components/deep_sleep/common.yaml
+++ b/tests/components/deep_sleep/common.yaml
@@ -4,3 +4,9 @@ esphome:
       - deep_sleep.prevent
       - delay: 1s
       - deep_sleep.allow
+      - if:
+          condition:
+            lambda: 'return false;'
+          then:
+            - deep_sleep.enter:
+                sleep_duration: 60min


### PR DESCRIPTION
# What does this implement/fix?

Fix a codegen type mismatch in the `deep_sleep.enter` action. The Python codegen was emitting the `sleep_duration` templatable wrapper with an `int32_t` return type, but the C++ field declared by `TEMPLATABLE_VALUE(uint32_t, sleep_duration)` (in `deep_sleep_component.h`) is `uint32_t`.

With the new 4-byte `TemplatableFn` storage added in #15545, this type mismatch now falls through to the deprecated casting-trampoline overload in `esphome/core/automation.h`, producing a build warning:

```
warning: 'esphome::TemplatableFn<T, X>::TemplatableFn(F) ... is deprecated:
Lambda return type does not match TemplatableFn<T> — use the correct type in codegen [-Wdeprecated-declarations]
```

The warning was triggered for any configured `sleep_duration:` under `deep_sleep.enter`, regardless of whether the value was a substitution, a literal time period, or a lambda — substitutions in the reporter's config just made it more prominent.

Fix: change `cg.int32` to `cg.uint32` in `deep_sleep_enter_to_code` so the generated lambda's return type matches the C++ field, selecting the direct function-pointer constructor and eliminating the trampoline (and the warning).

A component test was added so a future mismatch would be caught by CI: none of the existing `tests/components/deep_sleep/*.yaml` files exercised `deep_sleep.enter` with `sleep_duration:`, which is how this drifted unnoticed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15963

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
substitutions:
  dozetime: "60min"

deep_sleep:
  id: sleep_mode

esphome:
  on_boot:
    then:
      - if:
          condition:
            lambda: 'return false;'
          then:
            - deep_sleep.enter:
                id: sleep_mode
                sleep_duration: \${dozetime}
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).