### PR TITLE
[wifi] Fix stale wifi.connected after state transition

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -1579,6 +1579,8 @@ void WiFiComponent::check_connecting_finished(uint32_t now) {
 #endif
 
     this->state_ = WIFI_COMPONENT_STATE_STA_CONNECTED;
+    // Refresh is_connected() cache; loop()'s refresh ran before this transition.
+    this->update_connected_state_();
     this->num_retried_ = 0;
     this->print_connect_params_();
 

--- a/esphome/components/wifi/wifi_component_esp8266.cpp
+++ b/esphome/components/wifi/wifi_component_esp8266.cpp
@@ -951,6 +951,8 @@ void WiFiComponent::process_pending_callbacks_() {
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
   if (this->pending_.disconnect) {
     this->pending_.disconnect = false;
+    // Refresh is_connected() cache here, not in the SDK callback (sys context).
+    this->update_connected_state_();
     this->notify_disconnect_state_listeners_();
   }
 #endif

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -804,6 +804,8 @@ void WiFiComponent::wifi_process_event_(IDFWiFiEvent *data) {
     s_sta_connected = false;
     s_sta_connecting = false;
     error_from_callback_ = true;
+    // Refresh is_connected() cache; error_from_callback_ makes it false.
+    this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     this->notify_disconnect_state_listeners_();
 #endif

--- a/esphome/components/wifi/wifi_component_libretiny.cpp
+++ b/esphome/components/wifi/wifi_component_libretiny.cpp
@@ -530,6 +530,8 @@ void WiFiComponent::wifi_process_event_(LTWiFiEvent *event) {
         this->error_from_callback_ = true;
       }
 
+      // Refresh is_connected() cache; sta_state_/error_from_callback_ make it false.
+      this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
       this->notify_disconnect_state_listeners_();
 #endif

--- a/esphome/components/wifi/wifi_component_pico_w.cpp
+++ b/esphome/components/wifi/wifi_component_pico_w.cpp
@@ -342,6 +342,8 @@ bool WiFiComponent::wifi_loop_() {
     s_sta_was_connected = false;
     s_sta_had_ip = false;
     ESP_LOGV(TAG, "Disconnected");
+    // Refresh is_connected() cache; driver link status reports disconnected.
+    this->update_connected_state_();
 #ifdef USE_WIFI_CONNECT_STATE_LISTENERS
     this->notify_disconnect_state_listeners_();
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Fixes `wifi.connected` returning `false` inside connect state listener automations such as `wifi_info` text sensors' `on_value` trigger (and in lambdas that run in the same loop iteration as the transition). This regressed after #14463 introduced a cached `connected_` flag for `is_connected()`.

**Root cause:**

1. `wifi_loop_()` processes events and calls `update_connected_state_()` — at this point `state_` is still `STA_CONNECTING`, so the cache is set to `false`.
2. `check_connecting_finished()` then transitions `state_` to `STA_CONNECTED` and calls `notify_connect_state_listeners_()`.
3. Listeners fire `publish_state` on their text sensors, which runs the user's `on_value` automation.
4. The automation checks `wifi.connected` → `is_connected()` returns the stale cached `connected_ == false` → the `else` branch runs (turning LEDs off instead of on).

Symmetric staleness exists on disconnect paths — a lambda or listener automation running between the disconnect event and the next loop iteration would observe `connected_ == true`.

Before the caching change in #14463, `is_connected()` re-evaluated state directly, so the earlier fix in #13733 worked as intended.

**Fix:**

Refresh the cache at each state-transition site so the invariant *"`is_connected()` reflects the current edge"* holds immediately, not one loop iteration later. This is the right layer for the invariant: the cache is owned by the state machine, so it is refreshed where the state machine transitions.

- `check_connecting_finished()`: refresh after `state_ = STA_CONNECTED`.
- ESP-IDF / LibreTiny disconnect event handlers: refresh after setting `error_from_callback_` (these handlers run on the main loop, drained from the event queue).
- ESP8266 `process_pending_callbacks_()` disconnect path: refresh before notify. The SDK callback itself runs in system context (~2KB stack) and cannot safely call `update_connected_state_()` (it makes SDK calls), so the refresh is deferred to the main-loop processor via the existing `pending_.disconnect` flag.
- Pico W `wifi_loop_()` disconnect branch: refresh after the driver poll observes disconnect.

The refreshes are intentionally outside the `USE_WIFI_CONNECT_STATE_LISTENERS` guard wherever safe so that lambdas and conditions observe the new state too — not just listener automations. On ESP8266 it remains gated because the only main-loop deferral path on that platform is itself gated by that macro.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15959

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no documentation changes needed)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# blue_led now correctly turns on when WiFi connects
wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

text_sensor:
  - platform: wifi_info
    ssid:
      name: "WiFi SSID"
      on_value:
        - if:
            condition:
              wifi.connected:
            then:
              - switch.turn_on: blue_led   # Now works again
            else:
              - switch.turn_off: blue_led
              - switch.turn_off: red_led

switch:
  - platform: gpio
    pin: GPIO2
    id: blue_led
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
