### PR TITLE
[web_server_idf] Fix cross-thread race on SSE session state

### DIFF
--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -503,14 +503,16 @@ bool AsyncEventSource::loop() {
       this->has_pending_sessions_.store(false, std::memory_order_relaxed);
     }
     for (auto *rsp : incoming) {
+      // Already disconnected? Drop it; skip on_connect_/prime on a dead session.
+      if (rsp->fd_.load() == 0) {
+        delete rsp;  // NOLINT(cppcoreguidelines-owning-memory)
+        continue;
+      }
       this->sessions_.push_back(rsp);
       if (this->on_connect_) {
         this->on_connect_(rsp);
       }
-      // Already disconnected? Cleanup pass below will delete it.
-      if (rsp->fd_.load() != 0) {
-        rsp->prime_();
-      }
+      rsp->prime_();
     }
   }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -532,10 +532,12 @@ void AsyncEventSource::adopt_pending_sessions_main_loop_() {
       continue;
     }
     this->sessions_.push_back(rsp);
+    // Prime first so on_connect_ observes a session that has already sent its
+    // initial ping/config/sorting_groups, matching the pre-refactor ordering.
+    rsp->start_session_main_loop_();
     if (this->on_connect_) {
       this->on_connect_(rsp);
     }
-    rsp->start_session_main_loop_();
   }
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -493,26 +493,9 @@ void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
 }
 
 bool AsyncEventSource::loop() {
-  // Fast path: one atomic load per tick. Lock only on a real connect.
+  // Fast path: one atomic load per tick. Slow path is out-of-line on connect.
   if (this->has_pending_sessions_.load(std::memory_order_acquire)) {
-    std::vector<AsyncEventSourceResponse *> incoming;
-    {
-      LockGuard guard{this->pending_mutex_};
-      incoming.swap(this->pending_sessions_);
-      this->has_pending_sessions_.store(false, std::memory_order_relaxed);
-    }
-    for (auto *rsp : incoming) {
-      // Already disconnected? Drop it; skip on_connect_/prime on a dead session.
-      if (rsp->fd_.load() == 0) {
-        delete rsp;  // NOLINT(cppcoreguidelines-owning-memory)
-        continue;
-      }
-      this->sessions_.push_back(rsp);
-      if (this->on_connect_) {
-        this->on_connect_(rsp);
-      }
-      rsp->start_session_main_loop_();
-    }
+    this->adopt_pending_sessions_main_loop_();
   }
 
   // Clean up dead sessions safely
@@ -533,6 +516,27 @@ bool AsyncEventSource::loop() {
     }
   }
   return !this->sessions_.empty();
+}
+
+void AsyncEventSource::adopt_pending_sessions_main_loop_() {
+  std::vector<AsyncEventSourceResponse *> incoming;
+  {
+    LockGuard guard{this->pending_mutex_};
+    incoming.swap(this->pending_sessions_);
+    this->has_pending_sessions_.store(false, std::memory_order_relaxed);
+  }
+  for (auto *rsp : incoming) {
+    // Already disconnected? Drop it; skip on_connect_/session start on a dead session.
+    if (rsp->fd_.load() == 0) {
+      delete rsp;  // NOLINT(cppcoreguidelines-owning-memory)
+      continue;
+    }
+    this->sessions_.push_back(rsp);
+    if (this->on_connect_) {
+      this->on_connect_(rsp);
+    }
+    rsp->start_session_main_loop_();
+  }
 }
 
 void AsyncEventSource::try_send_nodefer(const char *message, const char *event, uint32_t id, uint32_t reconnect) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -482,27 +482,19 @@ AsyncEventSource::~AsyncEventSource() {
 }
 
 void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
-  // Runs on the httpd task. Do only the HTTP-level setup that needs the live httpd_req_t,
-  // then hand the session off to the main loop for adoption and priming. This keeps
-  // sessions_, event_buffer_, and deferred_queue_ mutated exclusively from the main loop.
+  // Httpd task: set up the live httpd_req_t and park the session; main loop does the rest.
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,clang-analyzer-cplusplus.NewDeleteLeaks)
   auto *rsp = new AsyncEventSourceResponse(request, this, this->web_server_);
   {
     LockGuard guard{this->pending_mutex_};
     this->pending_sessions_.push_back(rsp);
-    // Release-store so the main loop's acquire-load sees the push_back above.
     this->has_pending_sessions_.store(true, std::memory_order_release);
   }
-  // Wake up WebServer::loop() to adopt and prime this client.
-  // Safe from httpd task context via the pending_enable_loop_ flag.
   this->web_server_->enable_loop_soon_any_context();
 }
 
 bool AsyncEventSource::loop() {
-  // Adopt sessions handed off from the httpd task. Fast path: one atomic load per tick
-  // when nothing is pending. Only take the lock / touch the vector on a real connect.
-  // Swap under the lock and do the heavy work (on_connect_ callback, initial sends,
-  // entity iterator start) outside it so they cannot race with httpd handlers.
+  // Fast path: one atomic load per tick. Lock only on a real connect.
   if (this->has_pending_sessions_.load(std::memory_order_acquire)) {
     std::vector<AsyncEventSourceResponse *> incoming;
     {
@@ -515,8 +507,7 @@ bool AsyncEventSource::loop() {
       if (this->on_connect_) {
         this->on_connect_(rsp);
       }
-      // Skip priming if the client disconnected before we got here; the cleanup pass below
-      // will delete it.
+      // Already disconnected? Cleanup pass below will delete it.
       if (rsp->fd_.load() != 0) {
         rsp->prime_();
       }
@@ -567,9 +558,7 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
                                                    esphome::web_server_idf::AsyncEventSource *server,
                                                    esphome::web_server::WebServer *ws)
     : server_(server), web_server_(ws), entities_iterator_(ws, server) {
-  // Runs on the httpd task. Only touch state tied to the live httpd_req_t here; the
-  // main loop will call prime_() later to do the initial sends and start the iterator.
-  // Writing to event_buffer_ / deferred_queue_ from this task would race with the main loop.
+  // Httpd task only. prime_() on the main loop handles event_buffer_ / iterator setup.
   httpd_req_t *req = *request;
 
   httpd_resp_set_status(req, HTTPD_200);
@@ -594,11 +583,9 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
 }
 
 void AsyncEventSourceResponse::prime_() {
-  // Runs on the main loop after AsyncEventSource::loop() adopts this session.
   auto *ws = this->web_server_;
 
-  // Configure reconnect timeout and send config
-  // this should always go through since the tcp send buffer is empty on connect
+  // tcp send buffer is empty on connect, so these should always go through
   auto message = ws->get_config_json();
   this->try_send_nodefer(message.c_str(), "ping", millis(), 30000);
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -511,7 +511,7 @@ bool AsyncEventSource::loop() {
       if (this->on_connect_) {
         this->on_connect_(rsp);
       }
-      rsp->prime_();
+      rsp->start_session_main_loop_();
     }
   }
 
@@ -559,7 +559,7 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
                                                    esphome::web_server_idf::AsyncEventSource *server,
                                                    esphome::web_server::WebServer *ws)
     : server_(server), web_server_(ws), entities_iterator_(ws, server) {
-  // Httpd task only. prime_() on the main loop handles event_buffer_ / iterator setup.
+  // Httpd task only. start_session_main_loop_() handles event_buffer_ / iterator setup.
   httpd_req_t *req = *request;
 
   httpd_resp_set_status(req, HTTPD_200);
@@ -583,7 +583,7 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
   httpd_sess_set_send_override(this->hd_, this->fd_.load(), nonblocking_send);
 }
 
-void AsyncEventSourceResponse::prime_() {
+void AsyncEventSourceResponse::start_session_main_loop_() {
   auto *ws = this->web_server_;
 
   // tcp send buffer is empty on connect, so these should always go through

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -472,10 +472,10 @@ void AsyncResponseStream::printf(const char *fmt, ...) {
 
 #ifdef USE_WEBSERVER
 AsyncEventSource::~AsyncEventSource() {
+  LockGuard guard{this->pending_mutex_};
   for (auto *ses : this->sessions_) {
     delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
   }
-  LockGuard guard{this->pending_mutex_};
   for (auto *ses : this->pending_sessions_) {
     delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
   }

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -505,7 +505,7 @@ bool AsyncEventSource::loop() {
     auto *ses = this->sessions_[i];
     // If the session has a dead socket (marked by destroy callback)
     if (ses->fd_.load() == 0) {
-      ESP_LOGD(TAG, "Removing dead event source session");
+      // destroy() already logged the close with the fd; don't double-log here.
       delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
       // Remove by swapping with last element (O(1) removal, order doesn't matter for sessions)
       this->sessions_[i] = this->sessions_.back();

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -492,6 +492,10 @@ void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
   this->web_server_->enable_loop_soon_any_context();
 }
 
+// clang-analyzer traces a false-positive leak path from loop() through
+// adopt_pending_sessions_main_loop_() into start_session_main_loop_() and
+// finally ArduinoJson. Suppress along the entire in-our-code call chain.
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks)
 bool AsyncEventSource::loop() {
   // Fast path: one atomic load per tick. Slow path is out-of-line on connect.
   if (this->has_pending_sessions_.load(std::memory_order_acquire)) {
@@ -534,13 +538,13 @@ void AsyncEventSource::adopt_pending_sessions_main_loop_() {
     this->sessions_.push_back(rsp);
     // Prime first so on_connect_ observes a session that has already sent its
     // initial ping/config/sorting_groups, matching the pre-refactor ordering.
-    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
     rsp->start_session_main_loop_();
     if (this->on_connect_) {
       this->on_connect_(rsp);
     }
   }
 }
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 void AsyncEventSource::try_send_nodefer(const char *message, const char *event, uint32_t id, uint32_t reconnect) {
   for (auto *ses : this->sessions_) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -475,21 +475,54 @@ AsyncEventSource::~AsyncEventSource() {
   for (auto *ses : this->sessions_) {
     delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
   }
+  LockGuard guard{this->pending_mutex_};
+  for (auto *ses : this->pending_sessions_) {
+    delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
+  }
 }
 
 void AsyncEventSource::handleRequest(AsyncWebServerRequest *request) {
+  // Runs on the httpd task. Do only the HTTP-level setup that needs the live httpd_req_t,
+  // then hand the session off to the main loop for adoption and priming. This keeps
+  // sessions_, event_buffer_, and deferred_queue_ mutated exclusively from the main loop.
   // NOLINTNEXTLINE(cppcoreguidelines-owning-memory,clang-analyzer-cplusplus.NewDeleteLeaks)
   auto *rsp = new AsyncEventSourceResponse(request, this, this->web_server_);
-  if (this->on_connect_) {
-    this->on_connect_(rsp);
+  {
+    LockGuard guard{this->pending_mutex_};
+    this->pending_sessions_.push_back(rsp);
+    // Release-store so the main loop's acquire-load sees the push_back above.
+    this->has_pending_sessions_.store(true, std::memory_order_release);
   }
-  this->sessions_.push_back(rsp);
-  // Wake up WebServer::loop() to drain deferred event queues for this client.
+  // Wake up WebServer::loop() to adopt and prime this client.
   // Safe from httpd task context via the pending_enable_loop_ flag.
   this->web_server_->enable_loop_soon_any_context();
 }
 
 bool AsyncEventSource::loop() {
+  // Adopt sessions handed off from the httpd task. Fast path: one atomic load per tick
+  // when nothing is pending. Only take the lock / touch the vector on a real connect.
+  // Swap under the lock and do the heavy work (on_connect_ callback, initial sends,
+  // entity iterator start) outside it so they cannot race with httpd handlers.
+  if (this->has_pending_sessions_.load(std::memory_order_acquire)) {
+    std::vector<AsyncEventSourceResponse *> incoming;
+    {
+      LockGuard guard{this->pending_mutex_};
+      incoming.swap(this->pending_sessions_);
+      this->has_pending_sessions_.store(false, std::memory_order_relaxed);
+    }
+    for (auto *rsp : incoming) {
+      this->sessions_.push_back(rsp);
+      if (this->on_connect_) {
+        this->on_connect_(rsp);
+      }
+      // Skip priming if the client disconnected before we got here; the cleanup pass below
+      // will delete it.
+      if (rsp->fd_.load() != 0) {
+        rsp->prime_();
+      }
+    }
+  }
+
   // Clean up dead sessions safely
   // This follows the ESP-IDF pattern where free_ctx marks resources as dead
   // and the main loop handles the actual cleanup to avoid race conditions
@@ -534,6 +567,9 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
                                                    esphome::web_server_idf::AsyncEventSource *server,
                                                    esphome::web_server::WebServer *ws)
     : server_(server), web_server_(ws), entities_iterator_(ws, server) {
+  // Runs on the httpd task. Only touch state tied to the live httpd_req_t here; the
+  // main loop will call prime_() later to do the initial sends and start the iterator.
+  // Writing to event_buffer_ / deferred_queue_ from this task would race with the main loop.
   httpd_req_t *req = *request;
 
   httpd_resp_set_status(req, HTTPD_200);
@@ -555,6 +591,11 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
 
   // Use non-blocking send to prevent watchdog timeouts when TCP buffers are full
   httpd_sess_set_send_override(this->hd_, this->fd_.load(), nonblocking_send);
+}
+
+void AsyncEventSourceResponse::prime_() {
+  // Runs on the main loop after AsyncEventSource::loop() adopts this session.
+  auto *ws = this->web_server_;
 
   // Configure reconnect timeout and send config
   // this should always go through since the tcp send buffer is empty on connect
@@ -578,12 +619,6 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
 #endif
 
   this->entities_iterator_.begin(ws->include_internal_);
-
-  // just dump them all up-front and take advantage of the deferred queue
-  //     on second thought that takes too long, but leaving the commented code here for debug purposes
-  // while(!this->entities_iterator_.completed()) {
-  //  this->entities_iterator_.advance();
-  //}
 }
 
 void AsyncEventSourceResponse::destroy(void *ptr) {

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -473,11 +473,10 @@ void AsyncResponseStream::printf(const char *fmt, ...) {
 #ifdef USE_WEBSERVER
 AsyncEventSource::~AsyncEventSource() {
   LockGuard guard{this->pending_mutex_};
-  for (auto *ses : this->sessions_) {
-    delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
-  }
-  for (auto *ses : this->pending_sessions_) {
-    delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
+  for (auto *vec : {&this->sessions_, &this->pending_sessions_}) {
+    for (auto *ses : *vec) {
+      delete ses;  // NOLINT(cppcoreguidelines-owning-memory)
+    }
   }
 }
 

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -589,6 +589,7 @@ AsyncEventSourceResponse::AsyncEventSourceResponse(const AsyncWebServerRequest *
   httpd_sess_set_send_override(this->hd_, this->fd_.load(), nonblocking_send);
 }
 
+// NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
 void AsyncEventSourceResponse::start_session_main_loop_() {
   auto *ws = this->web_server_;
 
@@ -598,13 +599,11 @@ void AsyncEventSourceResponse::start_session_main_loop_() {
 
 #ifdef USE_WEBSERVER_SORTING
   for (auto &group : ws->sorting_groups_) {
-    // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
     json::JsonBuilder builder;
     JsonObject root = builder.root();
     root["name"] = group.second.name;
     root["sorting_weight"] = group.second.weight;
     message = builder.serialize();
-    // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
     // a (very) large number of these should be able to be queued initially without defer
     // since the only thing in the send buffer at this point is the initial ping/config
@@ -614,6 +613,7 @@ void AsyncEventSourceResponse::start_session_main_loop_() {
 
   this->entities_iterator_.begin(ws->include_internal_);
 }
+// NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 void AsyncEventSourceResponse::destroy(void *ptr) {
   auto *rsp = static_cast<AsyncEventSourceResponse *>(ptr);

--- a/esphome/components/web_server_idf/web_server_idf.cpp
+++ b/esphome/components/web_server_idf/web_server_idf.cpp
@@ -534,6 +534,7 @@ void AsyncEventSource::adopt_pending_sessions_main_loop_() {
     this->sessions_.push_back(rsp);
     // Prime first so on_connect_ observes a session that has already sent its
     // initial ping/config/sorting_groups, matching the pre-refactor ordering.
+    // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
     rsp->start_session_main_loop_();
     if (this->on_connect_) {
       this->on_connect_(rsp);

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -299,8 +299,7 @@ class AsyncEventSourceResponse {
   AsyncEventSourceResponse(const AsyncWebServerRequest *request, esphome::web_server_idf::AsyncEventSource *server,
                            esphome::web_server::WebServer *ws);
 
-  // Sends the initial ping/config/sorting_groups and starts the entity iterator.
-  // Must be called from the main loop (writes event_buffer_ and touches entities_iterator_).
+  // Main-loop only: sends initial ping/config/sorting_groups, starts entity iterator.
   void prime_();
 
   void deq_push_back_with_dedup_(void *source, message_generator_t *message_generator);
@@ -351,19 +350,11 @@ class AsyncEventSource : public AsyncWebHandler {
   size_t count() const { return this->sessions_.size(); }
 
  protected:
-  // Members are ordered to minimize padding on 32-bit: all 4-byte-aligned members
-  // first, then the single-byte atomic at the end to consume what would otherwise
-  // be trailing padding.
+  // Ordered to minimize padding on 32-bit: atomic<bool> last consumes trailing pad.
   std::string url_;
-  // Use vector instead of set: SSE sessions are typically 1-5 connections (browsers, dashboards).
-  // Linear search is faster than red-black tree overhead for this small dataset.
-  // Only operations needed: add session, remove session, iterate sessions - no need for sorted order.
-  // Mutated only from the main loop.
+  // Main-loop only. Vector: SSE sessions are 1-5 connections, linear search beats set.
   std::vector<AsyncEventSourceResponse *> sessions_;
-  // Sessions constructed on the httpd task wait here until the main loop adopts them.
-  // All mutations are guarded by pending_mutex_. has_pending_sessions_ (below) is a
-  // fast-path gate so the per-tick cost in loop() when no connect is pending is one
-  // atomic load.
+  // Httpd-task intake; guarded by pending_mutex_, gated by has_pending_sessions_.
   std::vector<AsyncEventSourceResponse *> pending_sessions_;
   Mutex pending_mutex_;
   connect_handler_t on_connect_{};

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -339,6 +339,8 @@ class AsyncEventSource : public AsyncWebHandler {
   // NOLINTNEXTLINE(readability-identifier-naming)
   void handleRequest(AsyncWebServerRequest *request) override;
   // NOLINTNEXTLINE(readability-identifier-naming)
+  // Callback runs on the main loop (not the httpd task) after the session's
+  // initial ping/config/sorting_groups have been sent.
   void onConnect(connect_handler_t &&cb) { this->on_connect_ = std::move(cb); }
 
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -299,6 +299,10 @@ class AsyncEventSourceResponse {
   AsyncEventSourceResponse(const AsyncWebServerRequest *request, esphome::web_server_idf::AsyncEventSource *server,
                            esphome::web_server::WebServer *ws);
 
+  // Sends the initial ping/config/sorting_groups and starts the entity iterator.
+  // Must be called from the main loop (writes event_buffer_ and touches entities_iterator_).
+  void prime_();
+
   void deq_push_back_with_dedup_(void *source, message_generator_t *message_generator);
   void process_deferred_queue_();
   void process_buffer_();
@@ -351,7 +355,14 @@ class AsyncEventSource : public AsyncWebHandler {
   // Use vector instead of set: SSE sessions are typically 1-5 connections (browsers, dashboards).
   // Linear search is faster than red-black tree overhead for this small dataset.
   // Only operations needed: add session, remove session, iterate sessions - no need for sorted order.
+  // Mutated only from the main loop.
   std::vector<AsyncEventSourceResponse *> sessions_;
+  // Sessions constructed on the httpd task wait here until the main loop adopts them.
+  // All mutations are guarded by pending_mutex_. has_pending_sessions_ is a fast-path
+  // gate so the per-tick cost in loop() when no connect is pending is one atomic load.
+  std::vector<AsyncEventSourceResponse *> pending_sessions_;
+  Mutex pending_mutex_;
+  std::atomic<bool> has_pending_sessions_{false};
   connect_handler_t on_connect_{};
   esphome::web_server::WebServer *web_server_;
 };

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -351,6 +351,9 @@ class AsyncEventSource : public AsyncWebHandler {
   size_t count() const { return this->sessions_.size(); }
 
  protected:
+  // Members are ordered to minimize padding on 32-bit: all 4-byte-aligned members
+  // first, then the single-byte atomic at the end to consume what would otherwise
+  // be trailing padding.
   std::string url_;
   // Use vector instead of set: SSE sessions are typically 1-5 connections (browsers, dashboards).
   // Linear search is faster than red-black tree overhead for this small dataset.
@@ -358,13 +361,14 @@ class AsyncEventSource : public AsyncWebHandler {
   // Mutated only from the main loop.
   std::vector<AsyncEventSourceResponse *> sessions_;
   // Sessions constructed on the httpd task wait here until the main loop adopts them.
-  // All mutations are guarded by pending_mutex_. has_pending_sessions_ is a fast-path
-  // gate so the per-tick cost in loop() when no connect is pending is one atomic load.
+  // All mutations are guarded by pending_mutex_. has_pending_sessions_ (below) is a
+  // fast-path gate so the per-tick cost in loop() when no connect is pending is one
+  // atomic load.
   std::vector<AsyncEventSourceResponse *> pending_sessions_;
   Mutex pending_mutex_;
-  std::atomic<bool> has_pending_sessions_{false};
   connect_handler_t on_connect_{};
   esphome::web_server::WebServer *web_server_;
+  std::atomic<bool> has_pending_sessions_{false};
 };
 #endif  // USE_WEBSERVER
 

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -350,6 +350,9 @@ class AsyncEventSource : public AsyncWebHandler {
   size_t count() const { return this->sessions_.size(); }
 
  protected:
+  // Cold path: move sessions from pending_sessions_ into sessions_ and greet each one.
+  void __attribute__((noinline, cold)) adopt_pending_sessions_main_loop_();
+
   std::string url_;
   // Main-loop only. Vector: SSE sessions are 1-5 connections, linear search beats set.
   std::vector<AsyncEventSourceResponse *> sessions_;

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -338,9 +338,9 @@ class AsyncEventSource : public AsyncWebHandler {
   }
   // NOLINTNEXTLINE(readability-identifier-naming)
   void handleRequest(AsyncWebServerRequest *request) override;
-  // NOLINTNEXTLINE(readability-identifier-naming)
   // Callback runs on the main loop (not the httpd task) after the session's
   // initial ping/config/sorting_groups have been sent.
+  // NOLINTNEXTLINE(readability-identifier-naming)
   void onConnect(connect_handler_t &&cb) { this->on_connect_ = std::move(cb); }
 
   void try_send_nodefer(const char *message, const char *event = nullptr, uint32_t id = 0, uint32_t reconnect = 0);

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -350,7 +350,6 @@ class AsyncEventSource : public AsyncWebHandler {
   size_t count() const { return this->sessions_.size(); }
 
  protected:
-  // Ordered to minimize padding on 32-bit: atomic<bool> last consumes trailing pad.
   std::string url_;
   // Main-loop only. Vector: SSE sessions are 1-5 connections, linear search beats set.
   std::vector<AsyncEventSourceResponse *> sessions_;

--- a/esphome/components/web_server_idf/web_server_idf.h
+++ b/esphome/components/web_server_idf/web_server_idf.h
@@ -300,7 +300,7 @@ class AsyncEventSourceResponse {
                            esphome::web_server::WebServer *ws);
 
   // Main-loop only: sends initial ping/config/sorting_groups, starts entity iterator.
-  void prime_();
+  void start_session_main_loop_();
 
   void deq_push_back_with_dedup_(void *source, message_generator_t *message_generator);
   void process_deferred_queue_();


### PR DESCRIPTION
# What does this implement/fix?

`AsyncEventSource::handleRequest()` on the ESP-IDF web server runs on the httpd task. Prior to this change it mutated `sessions_`, `event_buffer_`, `deferred_queue_`, and `entities_iterator_` directly — appending the new response to `sessions_`, sending the initial `ping`/`config`/`sorting_groups` messages via `try_send_nodefer()` (which writes `event_buffer_`), and calling `entities_iterator_.begin()`. The main loop reads and writes the same fields from `WebServer::loop()` on the main task, so every new SSE client connect raced with any in-flight loop tick. With enough traffic this can corrupt `sessions_` (vector realloc while the main loop is iterating it) or the per-response buffers, which shows up as a jump to a near-null corrupted function-pointer address inside `process_deferred_queue_()` or `deferrable_send_state()`.

This PR moves SSE session ownership fully to the main loop:

* The httpd-task constructor now only performs the HTTP-level setup that actually requires the live `httpd_req_t`: response headers, the initial chunk, `sess_ctx` / `free_ctx`, storing `fd_`, and installing the non-blocking send override.
* A new `pending_sessions_` list plus `Mutex pending_mutex_` holds sessions handed off from the httpd task. A `std::atomic<bool> has_pending_sessions_` acts as a fast-path gate so `AsyncEventSource::loop()` only pays one acquire-load per tick when nothing is pending — no lock, no allocation on the hot path.
* On the first tick after a connect, the main loop swaps `pending_sessions_` out under the mutex and then — outside the lock — pushes into `sessions_`, invokes `on_connect_`, and calls the new `AsyncEventSourceResponse::prime_()` which performs the initial sends and starts the entity iterator.
* The destructor drains both `sessions_` and `pending_sessions_`.

After this change `sessions_`, `event_buffer_`, `deferred_queue_`, and `entities_iterator_` are mutated exclusively from the main loop. `fd_` remains the only cross-thread signal: `destroy()` on the httpd/tcpip side still clears it atomically, and the main loop still does the actual `delete` once it observes `fd_ == 0`.

Stack traces in the wild look like this (call chain is authentic; the innermost PC is typically a small low address like `0x42a`, consistent with calling through a corrupted function pointer stored in a `DeferredEvent`):

```
Application::loop()
 └─ WebServer::loop()
   └─ AsyncEventSource::loop()
     └─ AsyncEventSourceResponse::loop()
       └─ ComponentIterator::advance() (StaticVector<event::Event*, N>)
         └─ ListEntitiesIterator::on_event()
           └─ AsyncEventSourceResponse::deferrable_send_state()
             └─ process_deferred_queue_() -> de.message_generator_(...) ← jump to corrupt fn pointer
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Reported on Discord: https://ptb.discord.com/channels/429907082951524364/1497134684188971038/1497134687552929814

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-visible configuration change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible configuration change. Any existing web_server
# config on an ESP-IDF build exercises the fixed path:
esp32:
  framework:
    type: esp-idf

web_server:
  port: 80
  version: 3
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
