### PR TITLE
[core] Scheduler: don't sleep while defer queue is non-empty

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -417,6 +417,14 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // It performs cleanup and accesses items_[0] without holding a lock, which is only
   // safe when called from the main thread. Other threads must not call this method.
 
+#ifndef ESPHOME_THREAD_SINGLE
+  // defer() items live in a separate queue that is drained at the top of every
+  // loop tick via process_defer_queue_(). If any are pending, the next loop
+  // iteration has work to do right now -- don't let the caller sleep.
+  if (!this->defer_empty_())
+    return 0;
+#endif
+
   // If no items, return empty optional
   if (!this->cleanup_())
     return {};

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -423,6 +423,12 @@ optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // iteration has work to do right now -- don't let the caller sleep.
   if (!this->defer_empty_())
     return 0;
+#else
+  // On single-threaded builds, defer() routes through set_timeout(..., 0) which
+  // stages in to_add_. process_to_add() runs at the top of every scheduler.call(),
+  // so anything in to_add_ becomes runnable on the next iteration; don't sleep.
+  if (!this->to_add_empty_())
+    return 0;
 #endif
 
   // If no items, return empty optional

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -414,8 +414,13 @@ bool HOT Scheduler::cancel_retry(Component *component, uint32_t id) {
 
 optional<uint32_t> HOT Scheduler::next_schedule_in(uint32_t now) {
   // IMPORTANT: This method should only be called from the main thread (loop task).
-  // It performs cleanup and accesses items_[0] without holding a lock, which is only
-  // safe when called from the main thread. Other threads must not call this method.
+  // Accesses items_[0] and the fast-path empty checks without holding a lock, which
+  // is only safe from the main thread. Other threads must not call this method.
+  //
+  // Note: cleanup_() is only invoked on the items_[0] path below. The early returns
+  // skip it because they don't read items_[0], and Scheduler::call() at the top of
+  // every loop iteration already performs its own cleanup before the next sleep-
+  // duration computation happens.
 
 #ifndef ESPHOME_THREAD_SINGLE
   // defer() items live in a separate queue that is drained at the top of every


### PR DESCRIPTION
# What does this implement/fix?

`Scheduler::next_schedule_in` only inspects `items_[0]`, the top of the main heap. That misses two cases where runnable work is already staged but not yet visible in `items_`:

1. **Multi-thread platforms (ESP32, LibreTiny, host):** `defer()` items bypass `items_` entirely and go straight into a separate `defer_queue_` (see `scheduler.cpp:200` — the thread-safe 0-delay fast path).
2. **Single-thread platforms (ESP8266, RP2040):** `defer()` routes through `set_timeout(..., 0)` and stages in `to_add_`. `process_to_add()` promotes it into `items_` at the top of the next `scheduler.call()`.

In both cases, a defer posted from a component's `loop()` is invisible to `next_schedule_in`, so the main loop uses `until_phase` as the sleep duration (`application.h:665`):

```cpp
const uint32_t until_sched = this->scheduler.next_schedule_in(now).value_or(until_phase);
delay_time = std::min(until_phase, until_sched);
...
wakeable_delay(delay_time);   // ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(delay_time))
```

`min(until_phase, until_sched)` caps the sleep at `loop_interval_` (default 16ms), so a pending defer gets picked up on the next loop tick rather than stalling for seconds — but that per-tick ceiling still costs up to a full `loop_interval_` of latency on every cross-thread/cross-tick defer. Enough to be noticeable on the initial SSE connect over LAN, where the rest of the handshake is sub-millisecond.

This PR checks the appropriate staging area at the top of `next_schedule_in` and returns `0` when pending work exists. Both checks use existing cheap fast-path predicates (`defer_empty_()` / `to_add_empty_()`) so the common "nothing pending" case is still a single load + branch:

- `!ESPHOME_THREAD_SINGLE` → check `defer_empty_()` (`scheduler.h:594`)
- `ESPHOME_THREAD_SINGLE` → check `to_add_empty_()` (`scheduler.h:544`)

When the check fires, the loop yields (`wakeable_delay(0)` → `taskYIELD()` on ESP32, `wake.h:111`) instead of sleeping, and the defer runs on the very next tick. On single-threaded the `to_add_` check is slightly broader — any newly-staged timer (not just 0-delay defers) will cause one skipped sleep — but the cost is a single yield vs. the stall it closes.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Discovered while auditing the SSE session-ownership path in #15967.

### Validated in the field

Before this fix, opening the ESPHome web UI on an ESP32-IDF device had a **noticeable stall** after the SSE connection was established. With this fix the web UI connects and populates instantly. This stall **predates #15967** — the session-ownership refactor didn't introduce it; the same pattern applied to the Arduino path via `ws->defer(...)` in `on_client_connect_`, and it now applies to the IDF path through the main-loop handoff added in #15967.

The stall length matches the `loop_interval_` cap on `until_phase` (default 16ms) rather than a multi-second sleep — `min(until_phase, until_sched)` always clamped to 16ms per tick. That's small in isolation, but when the initial SSE dump is chained through the defer on every step it accumulates, and the first `ping` message to the browser was always ~one `loop_interval_` late relative to socket-accept. Over LAN the rest of the handshake is sub-millisecond, so 16ms of wait-for-nothing is clearly visible.

This fix removes that ceiling by making `next_schedule_in` return `0` whenever `defer_queue_` is non-empty, so the loop yields (`wakeable_delay(0)`) instead of sleeping and the defer drains on the very next tick.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-visible configuration change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible configuration change. Any config exercising defer()
# across threads benefits (e.g. web_server on ESP32-IDF or Arduino).
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
