### PR TITLE
[sendspin] Add a metadata text sensor component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -443,6 +443,7 @@ esphome/components/sen6x/* @martgras @mebner86 @mikelawrence @tuct
 esphome/components/sendspin/* @kahrendt
 esphome/components/sendspin/media_player/* @kahrendt
 esphome/components/sendspin/media_source/* @kahrendt
+esphome/components/sendspin/text_sensor/* @kahrendt
 esphome/components/sensirion_common/* @martgras
 esphome/components/sensor/* @esphome/core
 esphome/components/serial_proxy/* @kbx81

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -39,6 +39,10 @@ void SendspinHub::setup() {
   this->controller_role_->set_listener(this);
 #endif
 
+#ifdef USE_SENDSPIN_METADATA
+  this->client_->add_metadata().set_listener(this);
+#endif
+
 #ifdef USE_SENDSPIN_PLAYER
   this->client_->add_player(this->player_config_).set_listener(this->player_listener_);
 #endif
@@ -164,6 +168,13 @@ void SendspinHub::send_client_command(sendspin::SendspinControllerCommand comman
 // THREAD CONTEXT: Main loop (ControllerRoleListener override, fired from client_->loop())
 void SendspinHub::on_controller_state(const sendspin::ServerStateControllerObject &state) {
   this->controller_state_callbacks_.call(state);
+}
+#endif
+
+#ifdef USE_SENDSPIN_METADATA
+// THREAD CONTEXT: Main loop (MetadataRoleListener override, fired from client_->loop())
+void SendspinHub::on_metadata(const sendspin::ServerMetadataStateObject &metadata) {
+  this->metadata_update_callbacks_.call(metadata);
 }
 #endif
 

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -16,6 +16,9 @@
 #ifdef USE_SENDSPIN_CONTROLLER
 #include <sendspin/controller_role.h>
 #endif
+#ifdef USE_SENDSPIN_METADATA
+#include <sendspin/metadata_role.h>
+#endif
 #ifdef USE_SENDSPIN_PLAYER
 #include <sendspin/player_role.h>
 #endif
@@ -66,6 +69,9 @@ struct StaticDelayPref {
 class SendspinHub final : public Component,
 #ifdef USE_SENDSPIN_CONTROLLER
                           public sendspin::ControllerRoleListener,
+#endif
+#ifdef USE_SENDSPIN_METADATA
+                          public sendspin::MetadataRoleListener,
 #endif
                           public sendspin::SendspinClientListener,
                           public sendspin::SendspinNetworkProvider,
@@ -122,6 +128,12 @@ class SendspinHub final : public Component,
   }
 #endif
 
+#ifdef USE_SENDSPIN_METADATA
+  template<typename F> void add_metadata_update_callback(F &&callback) {
+    this->metadata_update_callbacks_.add(std::forward<F>(callback));
+  }
+#endif
+
 #ifdef USE_SENDSPIN_PLAYER
   void set_listener(sendspin::PlayerRoleListener *listener) { this->player_listener_ = listener; }
   void set_player_config(const sendspin::PlayerRoleConfig &config) { this->player_config_ = config; }
@@ -157,6 +169,13 @@ class SendspinHub final : public Component,
 
   // Callback fan-out to child components; they filter as needed
   CallbackManager<void(const sendspin::ServerStateControllerObject &)> controller_state_callbacks_{};
+#endif
+
+#ifdef USE_SENDSPIN_METADATA
+  void on_metadata(const sendspin::ServerMetadataStateObject &metadata) override;
+
+  // Callback fan-out to child components; they filter as needed
+  CallbackManager<void(const sendspin::ServerMetadataStateObject &)> metadata_update_callbacks_{};
 #endif
 
 #ifdef USE_SENDSPIN_PLAYER

--- a/esphome/components/sendspin/text_sensor/__init__.py
+++ b/esphome/components/sendspin/text_sensor/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TYPE, PLATFORM_ESP32
+from esphome.const import CONF_ID, CONF_TYPE
 from esphome.types import ConfigType
 
 from .. import CONF_SENDSPIN_ID, SendspinHub, request_metadata_support, sendspin_ns
@@ -41,7 +41,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Required(CONF_TYPE): cv.enum(SENDSPIN_TEXT_METADATA_TYPES),
         }
     ),
-    cv.only_on([PLATFORM_ESP32]),
+    cv.only_on_esp32,
     _request_roles,
 )
 

--- a/esphome/components/sendspin/text_sensor/__init__.py
+++ b/esphome/components/sendspin/text_sensor/__init__.py
@@ -1,0 +1,55 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_TYPE, PLATFORM_ESP32
+from esphome.types import ConfigType
+
+from .. import CONF_SENDSPIN_ID, SendspinHub, request_metadata_support, sendspin_ns
+
+CODEOWNERS = ["@kahrendt"]
+DEPENDENCIES = ["sendspin"]
+
+SendspinTextSensor = sendspin_ns.class_(
+    "SendspinTextSensor",
+    text_sensor.TextSensor,
+    cg.Component,
+)
+
+SendspinTextMetadataTypes = sendspin_ns.enum("SendspinTextMetadataTypes", is_class=True)
+SENDSPIN_TEXT_METADATA_TYPES = {
+    "title": SendspinTextMetadataTypes.TITLE,
+    "artist": SendspinTextMetadataTypes.ARTIST,
+    "album": SendspinTextMetadataTypes.ALBUM,
+    "album_artist": SendspinTextMetadataTypes.ALBUM_ARTIST,
+    "year": SendspinTextMetadataTypes.YEAR,
+    "track": SendspinTextMetadataTypes.TRACK,
+}
+
+
+def _request_roles(config: ConfigType) -> ConfigType:
+    """Request the necessary Sendspin roles for the text sensor."""
+    request_metadata_support()
+
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    text_sensor.text_sensor_schema().extend(
+        {
+            cv.GenerateID(): cv.declare_id(SendspinTextSensor),
+            cv.GenerateID(CONF_SENDSPIN_ID): cv.use_id(SendspinHub),
+            cv.Required(CONF_TYPE): cv.enum(SENDSPIN_TEXT_METADATA_TYPES),
+        }
+    ),
+    cv.only_on([PLATFORM_ESP32]),
+    _request_roles,
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_SENDSPIN_ID])
+    await text_sensor.register_text_sensor(var, config)
+
+    cg.add(var.set_metadata_type(config[CONF_TYPE]))

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -2,9 +2,10 @@
 
 #if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_TEXT_SENSOR)
 
+#include "esphome/core/helpers.h"
+
 #include <sendspin/metadata_role.h>
 
-#include <cstdio>
 #include <string>
 
 namespace esphome::sendspin_ {
@@ -51,26 +52,20 @@ void SendspinTextSensor::setup() {
     }
     case SendspinTextMetadataTypes::YEAR: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.year.has_value()) {
-          int year = metadata.year.value();
-          if (year >= 0 && year <= 9999) {
-            char buf[5];
-            snprintf(buf, sizeof(buf), "%d", year);
-            this->publish_if_changed_(buf);
-          }
+        if (metadata.year.has_value() && metadata.year.value() <= 9999) {
+          char buf[UINT32_MAX_STR_SIZE];
+          uint32_to_str(buf, metadata.year.value());
+          this->publish_if_changed_(buf);
         }
       });
       break;
     }
     case SendspinTextMetadataTypes::TRACK: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.track.has_value()) {
-          int track = metadata.track.value();
-          if (track >= 0 && track <= 9999) {
-            char buf[5];
-            snprintf(buf, sizeof(buf), "%d", track);
-            this->publish_if_changed_(buf);
-          }
+        if (metadata.track.has_value() && metadata.track.value() <= 9999) {
+          char buf[UINT32_MAX_STR_SIZE];
+          uint32_to_str(buf, metadata.track.value());
+          this->publish_if_changed_(buf);
         }
       });
       break;

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -1,0 +1,82 @@
+#include "sendspin_text_sensor.h"
+
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA)
+
+#include <sendspin/metadata_role.h>
+
+#include <string>
+
+namespace esphome::sendspin_ {
+
+static const char *const TAG = "sendspin.text_sensor";
+
+void SendspinTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Sendspin", this); }
+
+// THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
+// (SendspinHub dispatches metadata from client_->loop()).
+void SendspinTextSensor::setup() {
+  switch (this->metadata_type_) {
+    case SendspinTextMetadataTypes::TITLE: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.title.has_value()) {
+          this->publish_if_changed_(metadata.title.value());
+        }
+      });
+      break;
+    }
+    case SendspinTextMetadataTypes::ARTIST: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.artist.has_value()) {
+          this->publish_if_changed_(metadata.artist.value());
+        }
+      });
+      break;
+    }
+    case SendspinTextMetadataTypes::ALBUM: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.album.has_value()) {
+          this->publish_if_changed_(metadata.album.value());
+        }
+      });
+      break;
+    }
+    case SendspinTextMetadataTypes::ALBUM_ARTIST: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.album_artist.has_value()) {
+          this->publish_if_changed_(metadata.album_artist.value());
+        }
+      });
+      break;
+    }
+    case SendspinTextMetadataTypes::YEAR: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.year.has_value()) {
+          char buf[7];
+          snprintf(buf, sizeof(buf), "%d", metadata.year.value());
+          this->publish_if_changed_(buf);
+        }
+      });
+      break;
+    }
+    case SendspinTextMetadataTypes::TRACK: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.track.has_value()) {
+          char buf[7];
+          snprintf(buf, sizeof(buf), "%d", metadata.track.value());
+          this->publish_if_changed_(buf);
+        }
+      });
+      break;
+    }
+  }
+}
+
+void SendspinTextSensor::publish_if_changed_(const std::string &value) {
+  if (this->get_raw_state() != value) {
+    this->publish_state(value);
+  }
+}
+
+}  // namespace esphome::sendspin_
+
+#endif

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -52,9 +52,12 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::YEAR: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.year.has_value()) {
-          char buf[7];
-          snprintf(buf, sizeof(buf), "%d", metadata.year.value());
-          this->publish_if_changed_(buf);
+          int year = metadata.year.value();
+          if (year >= 0 && year <= 9999) {
+            char buf[5];
+            snprintf(buf, sizeof(buf), "%d", year);
+            this->publish_if_changed_(buf);
+          }
         }
       });
       break;
@@ -62,9 +65,12 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::TRACK: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.track.has_value()) {
-          char buf[7];
-          snprintf(buf, sizeof(buf), "%d", metadata.track.value());
-          this->publish_if_changed_(buf);
+          int track = metadata.track.value();
+          if (track >= 0 && track <= 9999) {
+            char buf[5];
+            snprintf(buf, sizeof(buf), "%d", track);
+            this->publish_if_changed_(buf);
+          }
         }
       });
       break;

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -20,7 +20,7 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::TITLE: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.title.has_value()) {
-          this->publish_if_changed_(metadata.title.value());
+          this->publish_if_changed_(metadata.title.value().c_str());
         }
       });
       break;
@@ -28,7 +28,7 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::ARTIST: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.artist.has_value()) {
-          this->publish_if_changed_(metadata.artist.value());
+          this->publish_if_changed_(metadata.artist.value().c_str());
         }
       });
       break;
@@ -36,7 +36,7 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::ALBUM: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.album.has_value()) {
-          this->publish_if_changed_(metadata.album.value());
+          this->publish_if_changed_(metadata.album.value().c_str());
         }
       });
       break;
@@ -44,7 +44,7 @@ void SendspinTextSensor::setup() {
     case SendspinTextMetadataTypes::ALBUM_ARTIST: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
         if (metadata.album_artist.has_value()) {
-          this->publish_if_changed_(metadata.album_artist.value());
+          this->publish_if_changed_(metadata.album_artist.value().c_str());
         }
       });
       break;
@@ -79,7 +79,7 @@ void SendspinTextSensor::setup() {
 }
 
 // Dedup to avoid frontend churn; TextSensor::publish_state already dedups the string assign but still notifies.
-void SendspinTextSensor::publish_if_changed_(const std::string &value) {
+void SendspinTextSensor::publish_if_changed_(const char *value) {
   if (this->get_raw_state() != value) {
     this->publish_state(value);
   }

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -4,6 +4,7 @@
 
 #include <sendspin/metadata_role.h>
 
+#include <cstdio>
 #include <string>
 
 namespace esphome::sendspin_ {

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -1,6 +1,6 @@
 #include "sendspin_text_sensor.h"
 
-#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA)
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_TEXT_SENSOR)
 
 #include <sendspin/metadata_role.h>
 

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -72,6 +72,7 @@ void SendspinTextSensor::setup() {
   }
 }
 
+// Dedup to avoid frontend churn; TextSensor::publish_state already dedups the string assign but still notifies.
 void SendspinTextSensor::publish_if_changed_(const std::string &value) {
   if (this->get_raw_state() != value) {
     this->publish_state(value);

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
@@ -2,7 +2,7 @@
 
 #include "esphome/core/defines.h"
 
-#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA)
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_TEXT_SENSOR)
 
 #include "esphome/components/sendspin/sendspin_hub.h"
 #include "esphome/components/text_sensor/text_sensor.h"

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
@@ -26,7 +26,7 @@ class SendspinTextSensor : public SendspinChild, public text_sensor::TextSensor 
   void set_metadata_type(SendspinTextMetadataTypes metadata_type) { this->metadata_type_ = metadata_type; }
 
  protected:
-  void publish_if_changed_(const std::string &value);
+  void publish_if_changed_(const char *value);
 
   SendspinTextMetadataTypes metadata_type_;
 };

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA)
+
+#include "esphome/components/sendspin/sendspin_hub.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+
+namespace esphome::sendspin_ {
+
+enum class SendspinTextMetadataTypes {
+  TITLE,
+  ARTIST,
+  ALBUM,
+  ALBUM_ARTIST,
+  YEAR,
+  TRACK,
+};
+
+class SendspinTextSensor : public SendspinChild, public text_sensor::TextSensor {
+ public:
+  void dump_config() override;
+  void setup() override;
+
+  void set_metadata_type(SendspinTextMetadataTypes metadata_type) { this->metadata_type_ = metadata_type; }
+
+ protected:
+  void publish_if_changed_(const std::string &value);
+
+  SendspinTextMetadataTypes metadata_type_;
+};
+
+}  // namespace esphome::sendspin_
+#endif

--- a/tests/components/sendspin/common-text_sensor.yaml
+++ b/tests/components/sendspin/common-text_sensor.yaml
@@ -1,0 +1,21 @@
+<<: !include common.yaml
+
+text_sensor:
+  - platform: sendspin
+    name: "Title"
+    type: title
+  - platform: sendspin
+    name: "Artist"
+    type: artist
+  - platform: sendspin
+    name: "Album"
+    type: album
+  - platform: sendspin
+    name: "Album Artist"
+    type: album_artist
+  - platform: sendspin
+    name: "Year"
+    type: year
+  - platform: sendspin
+    name: "Track Number"
+    type: track

--- a/tests/components/sendspin/test-text_sensor.esp32-idf.yaml
+++ b/tests/components/sendspin/test-text_sensor.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-text_sensor.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new Sendspin text sensor component for displaying metadata about the currently playing audio.

This uses the Sendspin metadata role. Since there can be multiple text sensors, the communication is handled by the hub and distributed to the child components.

Converts the integer based `year` and `track` numbers from the raw metadata object to strings. My belief is that these are generally more useful for end users as text sensors than numerical sensors.

I will follow up with a future PR that adds numerical sensors for track duration and current track progress; e.g., we are currently 7000 ms into a track that is 3100000 ms long.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6522

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sendspin:

text_sensor:
  - platform: sendspin
    name: "Title"
    type: title
  - platform: sendspin
    name: "Artist"
    type: artist
  - platform: sendspin
    name: "Album"
    type: album
  - platform: sendspin
    name: "Album Artist"
    type: album_artist
  - platform: sendspin
    name: "Year"
    type: year
  - platform: sendspin
    name: "Track Number"
    type: track

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
