### PR TITLE
[sendspin] Add metadata sensor component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -443,6 +443,7 @@ esphome/components/sen6x/* @martgras @mebner86 @mikelawrence @tuct
 esphome/components/sendspin/* @kahrendt
 esphome/components/sendspin/media_player/* @kahrendt
 esphome/components/sendspin/media_source/* @kahrendt
+esphome/components/sendspin/sensor/* @kahrendt
 esphome/components/sendspin/text_sensor/* @kahrendt
 esphome/components/sensirion_common/* @martgras
 esphome/components/sensor/* @esphome/core

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -40,7 +40,8 @@ void SendspinHub::setup() {
 #endif
 
 #ifdef USE_SENDSPIN_METADATA
-  this->client_->add_metadata().set_listener(this);
+  this->metadata_role_ = &this->client_->add_metadata();
+  this->metadata_role_->set_listener(this);
 #endif
 
 #ifdef USE_SENDSPIN_PLAYER
@@ -175,6 +176,14 @@ void SendspinHub::on_controller_state(const sendspin::ServerStateControllerObjec
 // THREAD CONTEXT: Main loop (MetadataRoleListener override, fired from client_->loop())
 void SendspinHub::on_metadata(const sendspin::ServerMetadataStateObject &metadata) {
   this->metadata_update_callbacks_.call(metadata);
+}
+
+// THREAD CONTEXT: Main loop (invoked from Sendspin components)
+uint32_t SendspinHub::get_track_progress_ms() {
+  if (this->is_ready()) {
+    return this->metadata_role_->get_track_progress_ms();
+  }
+  return 0;
 }
 #endif
 

--- a/esphome/components/sendspin/sendspin_hub.cpp
+++ b/esphome/components/sendspin/sendspin_hub.cpp
@@ -179,7 +179,7 @@ void SendspinHub::on_metadata(const sendspin::ServerMetadataStateObject &metadat
 }
 
 // THREAD CONTEXT: Main loop (invoked from Sendspin components)
-uint32_t SendspinHub::get_track_progress_ms() {
+uint32_t SendspinHub::get_track_progress_ms() const {
   if (this->is_ready()) {
     return this->metadata_role_->get_track_progress_ms();
   }

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -132,6 +132,9 @@ class SendspinHub final : public Component,
   template<typename F> void add_metadata_update_callback(F &&callback) {
     this->metadata_update_callbacks_.add(std::forward<F>(callback));
   }
+
+  /// @brief Returns the interpolated track progress in milliseconds, or 0 if the hub is not yet ready.
+  uint32_t get_track_progress_ms();
 #endif
 
 #ifdef USE_SENDSPIN_PLAYER
@@ -172,6 +175,8 @@ class SendspinHub final : public Component,
 #endif
 
 #ifdef USE_SENDSPIN_METADATA
+  sendspin::MetadataRole *metadata_role_{nullptr};
+
   void on_metadata(const sendspin::ServerMetadataStateObject &metadata) override;
 
   // Callback fan-out to child components; they filter as needed

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -134,7 +134,7 @@ class SendspinHub final : public Component,
   }
 
   /// @brief Returns the interpolated track progress in milliseconds, or 0 if the hub is not yet ready.
-  uint32_t get_track_progress_ms();
+  uint32_t get_track_progress_ms() const;
 #endif
 
 #ifdef USE_SENDSPIN_PLAYER

--- a/esphome/components/sendspin/sendspin_hub.h
+++ b/esphome/components/sendspin/sendspin_hub.h
@@ -216,6 +216,16 @@ class SendspinChild : public Component, public Parented<SendspinHub> {
   float get_setup_priority() const override { return sendspin_priority::CHILD; }
 };
 
+/// @brief Base class for sendspin subcomponents that need polling behavior.
+///
+/// Same purpose as SendspinChild but inherits from PollingComponent for subcomponents
+/// that poll on a fixed interval. Subcomponents should inherit from this instead of
+/// listing PollingComponent/Parented individually and must not override get_setup_priority().
+class SendspinPollingChild : public PollingComponent, public Parented<SendspinHub> {
+ public:
+  float get_setup_priority() const override { return sendspin_priority::CHILD; }
+};
+
 }  // namespace esphome::sendspin_
 
 #endif  // USE_ESP32

--- a/esphome/components/sendspin/sensor/__init__.py
+++ b/esphome/components/sendspin/sensor/__init__.py
@@ -1,7 +1,13 @@
 import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TYPE, STATE_CLASS_MEASUREMENT, UNIT_MILLISECOND
+from esphome.const import (
+    CONF_ID,
+    CONF_TYPE,
+    CONF_YEAR,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_MILLISECOND,
+)
 from esphome.types import ConfigType
 
 from .. import CONF_SENDSPIN_ID, SendspinHub, request_metadata_support, sendspin_ns
@@ -9,16 +15,29 @@ from .. import CONF_SENDSPIN_ID, SendspinHub, request_metadata_support, sendspin
 CODEOWNERS = ["@kahrendt"]
 DEPENDENCIES = ["sendspin"]
 
+CONF_TRACK = "track"
+CONF_TRACK_PROGRESS = "track_progress"
+CONF_TRACK_DURATION = "track_duration"
+
 SendspinTrackProgressSensor = sendspin_ns.class_(
     "SendspinTrackProgressSensor",
     sensor.Sensor,
     cg.PollingComponent,
 )
-SendspinTrackDurationSensor = sendspin_ns.class_(
-    "SendspinTrackDurationSensor",
+SendspinMetadataSensor = sendspin_ns.class_(
+    "SendspinMetadataSensor",
     sensor.Sensor,
     cg.Component,
 )
+
+SendspinNumericMetadataTypes = sendspin_ns.enum(
+    "SendspinNumericMetadataTypes", is_class=True
+)
+_METADATA_TYPE_ENUM = {
+    CONF_TRACK_DURATION: SendspinNumericMetadataTypes.TRACK_DURATION,
+    CONF_YEAR: SendspinNumericMetadataTypes.YEAR,
+    CONF_TRACK: SendspinNumericMetadataTypes.TRACK,
+}
 
 
 def _request_roles(config: ConfigType) -> ConfigType:
@@ -28,25 +47,39 @@ def _request_roles(config: ConfigType) -> ConfigType:
     return config
 
 
-_SENSOR_SCHEMA = sensor.sensor_schema(
-    accuracy_decimals=0,
-    state_class=STATE_CLASS_MEASUREMENT,
-    unit_of_measurement=UNIT_MILLISECOND,
-).extend(
-    {
-        cv.GenerateID(CONF_SENDSPIN_ID): cv.use_id(SendspinHub),
-    }
-)
+_HUB_ID_SCHEMA = cv.Schema({cv.GenerateID(CONF_SENDSPIN_ID): cv.use_id(SendspinHub)})
+
+
+def _metadata_schema(**sensor_kwargs):
+    """Schema for event-driven numeric metadata sensors (duration/year/track)."""
+    return (
+        sensor.sensor_schema(
+            SendspinMetadataSensor,
+            accuracy_decimals=0,
+            **sensor_kwargs,
+        )
+        .extend(_HUB_ID_SCHEMA)
+        .extend(cv.COMPONENT_SCHEMA)
+    )
+
 
 CONFIG_SCHEMA = cv.All(
     cv.typed_schema(
         {
-            "track_progress": _SENSOR_SCHEMA.extend(
-                {cv.GenerateID(): cv.declare_id(SendspinTrackProgressSensor)}
-            ).extend(cv.polling_component_schema("1s")),
-            "track_duration": _SENSOR_SCHEMA.extend(
-                {cv.GenerateID(): cv.declare_id(SendspinTrackDurationSensor)}
-            ).extend(cv.COMPONENT_SCHEMA),
+            CONF_TRACK_PROGRESS: sensor.sensor_schema(
+                SendspinTrackProgressSensor,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+                unit_of_measurement=UNIT_MILLISECOND,
+            )
+            .extend(_HUB_ID_SCHEMA)
+            .extend(cv.polling_component_schema("1s")),
+            CONF_TRACK_DURATION: _metadata_schema(
+                state_class=STATE_CLASS_MEASUREMENT,
+                unit_of_measurement=UNIT_MILLISECOND,
+            ),
+            CONF_YEAR: _metadata_schema(),
+            CONF_TRACK: _metadata_schema(),
         },
         key=CONF_TYPE,
     ),
@@ -60,3 +93,6 @@ async def to_code(config: ConfigType) -> None:
     await cg.register_component(var, config)
     await cg.register_parented(var, config[CONF_SENDSPIN_ID])
     await sensor.register_sensor(var, config)
+
+    if (metadata_type := _METADATA_TYPE_ENUM.get(config[CONF_TYPE])) is not None:
+        cg.add(var.set_metadata_type(metadata_type))

--- a/esphome/components/sendspin/sensor/__init__.py
+++ b/esphome/components/sendspin/sensor/__init__.py
@@ -1,0 +1,62 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_TYPE, STATE_CLASS_MEASUREMENT, UNIT_MILLISECOND
+from esphome.types import ConfigType
+
+from .. import CONF_SENDSPIN_ID, SendspinHub, request_metadata_support, sendspin_ns
+
+CODEOWNERS = ["@kahrendt"]
+DEPENDENCIES = ["sendspin"]
+
+SendspinTrackProgressSensor = sendspin_ns.class_(
+    "SendspinTrackProgressSensor",
+    sensor.Sensor,
+    cg.PollingComponent,
+)
+SendspinTrackDurationSensor = sendspin_ns.class_(
+    "SendspinTrackDurationSensor",
+    sensor.Sensor,
+    cg.Component,
+)
+
+
+def _request_roles(config: ConfigType) -> ConfigType:
+    """Request the necessary Sendspin roles for the sensor."""
+    request_metadata_support()
+
+    return config
+
+
+_SENSOR_SCHEMA = sensor.sensor_schema(
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_MEASUREMENT,
+    unit_of_measurement=UNIT_MILLISECOND,
+).extend(
+    {
+        cv.GenerateID(CONF_SENDSPIN_ID): cv.use_id(SendspinHub),
+    }
+)
+
+CONFIG_SCHEMA = cv.All(
+    cv.typed_schema(
+        {
+            "track_progress": _SENSOR_SCHEMA.extend(
+                {cv.GenerateID(): cv.declare_id(SendspinTrackProgressSensor)}
+            ).extend(cv.polling_component_schema("1s")),
+            "track_duration": _SENSOR_SCHEMA.extend(
+                {cv.GenerateID(): cv.declare_id(SendspinTrackDurationSensor)}
+            ).extend(cv.COMPONENT_SCHEMA),
+        },
+        key=CONF_TYPE,
+    ),
+    cv.only_on_esp32,
+    _request_roles,
+)
+
+
+async def to_code(config: ConfigType) -> None:
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await cg.register_parented(var, config[CONF_SENDSPIN_ID])
+    await sensor.register_sensor(var, config)

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -11,7 +11,7 @@ static const char *const TAG = "sendspin.sensor";
 // --- SendspinTrackProgressSensor ---
 
 void SendspinTrackProgressSensor::dump_config() {
-  LOG_SENSOR("", "Sendspin Track Progress", this);
+  LOG_SENSOR("", "Track Progress", this);
   LOG_UPDATE_INTERVAL(this);
 }
 
@@ -42,22 +42,55 @@ void SendspinTrackProgressSensor::setup() {
 // speed, giving us a fresh value on every poll.
 void SendspinTrackProgressSensor::update() { this->publish_state(this->parent_->get_track_progress_ms()); }
 
-// --- SendspinTrackDurationSensor ---
+// --- SendspinMetadataSensor ---
 
-void SendspinTrackDurationSensor::dump_config() { LOG_SENSOR("", "Sendspin Track Duration", this); }
+void SendspinMetadataSensor::dump_config() {
+  switch (this->metadata_type_) {
+    case SendspinNumericMetadataTypes::TRACK_DURATION:
+      LOG_SENSOR("", "Track Duration", this);
+      break;
+    case SendspinNumericMetadataTypes::YEAR:
+      LOG_SENSOR("", "Year", this);
+      break;
+    case SendspinNumericMetadataTypes::TRACK:
+      LOG_SENSOR("", "Track", this);
+      break;
+  }
+}
 
 // THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
 // (SendspinHub dispatches metadata from client_->loop()).
-void SendspinTrackDurationSensor::setup() {
-  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-    if (metadata.progress.has_value()) {
-      this->publish_if_changed_(metadata.progress.value().track_duration);
+void SendspinMetadataSensor::setup() {
+  switch (this->metadata_type_) {
+    case SendspinNumericMetadataTypes::TRACK_DURATION: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.progress.has_value()) {
+          this->publish_if_changed_(metadata.progress.value().track_duration);
+        }
+      });
+      break;
     }
-  });
+    case SendspinNumericMetadataTypes::YEAR: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.year.has_value() && metadata.year.value() <= 9999) {
+          this->publish_if_changed_(metadata.year.value());
+        }
+      });
+      break;
+    }
+    case SendspinNumericMetadataTypes::TRACK: {
+      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+        if (metadata.track.has_value() && metadata.track.value() <= 9999) {
+          this->publish_if_changed_(metadata.track.value());
+        }
+      });
+      break;
+    }
+  }
 }
 
 // Dedup to avoid frontend churn; Sensor::publish_state always notifies without checking for changes.
-void SendspinTrackDurationSensor::publish_if_changed_(float value) {
+void SendspinMetadataSensor::publish_if_changed_(float value) {
   if (this->get_raw_state() != value) {
     this->publish_state(value);
   }

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -58,35 +58,32 @@ void SendspinMetadataSensor::dump_config() {
   }
 }
 
+std::optional<float> SendspinMetadataSensor::extract_value_(const sendspin::ServerMetadataStateObject &metadata) const {
+  switch (this->metadata_type_) {
+    case SendspinNumericMetadataTypes::TRACK_DURATION:
+      if (metadata.progress.has_value())
+        return metadata.progress.value().track_duration;
+      return std::nullopt;
+    case SendspinNumericMetadataTypes::YEAR:
+      if (metadata.year.has_value())
+        return metadata.year.value();
+      return std::nullopt;
+    case SendspinNumericMetadataTypes::TRACK:
+      if (metadata.track.has_value())
+        return metadata.track.value();
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
 // THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
 // (SendspinHub dispatches metadata from client_->loop()).
 void SendspinMetadataSensor::setup() {
-  switch (this->metadata_type_) {
-    case SendspinNumericMetadataTypes::TRACK_DURATION: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.progress.has_value()) {
-          this->publish_if_changed_(metadata.progress.value().track_duration);
-        }
-      });
-      break;
+  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+    if (auto value = this->extract_value_(metadata)) {
+      this->publish_if_changed_(*value);
     }
-    case SendspinNumericMetadataTypes::YEAR: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.year.has_value()) {
-          this->publish_if_changed_(metadata.year.value());
-        }
-      });
-      break;
-    }
-    case SendspinNumericMetadataTypes::TRACK: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.track.has_value()) {
-          this->publish_if_changed_(metadata.track.value());
-        }
-      });
-      break;
-    }
-  }
+  });
 }
 
 // Dedup to avoid frontend churn; Sensor::publish_state always notifies without checking for changes.

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -10,7 +10,10 @@ static const char *const TAG = "sendspin.sensor";
 
 // --- SendspinTrackProgressSensor ---
 
-void SendspinTrackProgressSensor::dump_config() { LOG_SENSOR("", "Sendspin Track Progress", this); }
+void SendspinTrackProgressSensor::dump_config() {
+  LOG_SENSOR("", "Sendspin Track Progress", this);
+  LOG_UPDATE_INTERVAL(this);
+}
 
 // THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
 // (SendspinHub dispatches metadata from client_->loop()).

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -72,7 +72,7 @@ void SendspinMetadataSensor::setup() {
     }
     case SendspinNumericMetadataTypes::YEAR: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.year.has_value() && metadata.year.value() <= 9999) {
+        if (metadata.year.has_value()) {
           this->publish_if_changed_(metadata.year.value());
         }
       });
@@ -80,7 +80,7 @@ void SendspinMetadataSensor::setup() {
     }
     case SendspinNumericMetadataTypes::TRACK: {
       this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.track.has_value() && metadata.track.value() <= 9999) {
+        if (metadata.track.has_value()) {
           this->publish_if_changed_(metadata.track.value());
         }
       });

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -25,6 +25,9 @@ void SendspinTrackProgressSensor::setup() {
       this->stop_poller();
       this->publish_state(progress.track_progress);
     } else {
+      // Resumed: publish the fresh interpolated position immediately so the frontend doesn't show a stale
+      // paused value until the next poll tick.
+      this->publish_state(this->parent_->get_track_progress_ms());
       this->start_poller();
     }
   });

--- a/esphome/components/sendspin/sensor/sendspin_sensor.cpp
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.cpp
@@ -1,0 +1,62 @@
+#include "sendspin_sensor.h"
+
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_SENSOR)
+
+#include <sendspin/metadata_role.h>
+
+namespace esphome::sendspin_ {
+
+static const char *const TAG = "sendspin.sensor";
+
+// --- SendspinTrackProgressSensor ---
+
+void SendspinTrackProgressSensor::dump_config() { LOG_SENSOR("", "Sendspin Track Progress", this); }
+
+// THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
+// (SendspinHub dispatches metadata from client_->loop()).
+void SendspinTrackProgressSensor::setup() {
+  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+    if (!metadata.progress.has_value()) {
+      return;
+    }
+    const auto &progress = metadata.progress.value();
+    if (progress.playback_speed == 0) {
+      // Paused: freeze progress at the reported position and stop polling to save cycles.
+      this->stop_poller();
+      this->publish_state(progress.track_progress);
+    } else {
+      this->start_poller();
+    }
+  });
+}
+
+// THREAD CONTEXT: Main loop.
+// Sendspin only pushes progress on state changes (play/pause/seek/speed change), not continuously during
+// playback. The hub helper interpolates the current position from the last server update and the playback
+// speed, giving us a fresh value on every poll.
+void SendspinTrackProgressSensor::update() { this->publish_state(this->parent_->get_track_progress_ms()); }
+
+// --- SendspinTrackDurationSensor ---
+
+void SendspinTrackDurationSensor::dump_config() { LOG_SENSOR("", "Sendspin Track Duration", this); }
+
+// THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
+// (SendspinHub dispatches metadata from client_->loop()).
+void SendspinTrackDurationSensor::setup() {
+  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+    if (metadata.progress.has_value()) {
+      this->publish_if_changed_(metadata.progress.value().track_duration);
+    }
+  });
+}
+
+// Dedup to avoid frontend churn; Sensor::publish_state always notifies without checking for changes.
+void SendspinTrackDurationSensor::publish_if_changed_(float value) {
+  if (this->get_raw_state() != value) {
+    this->publish_state(value);
+  }
+}
+
+}  // namespace esphome::sendspin_
+
+#endif

--- a/esphome/components/sendspin/sensor/sendspin_sensor.h
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.h
@@ -9,17 +9,15 @@
 
 namespace esphome::sendspin_ {
 
-class SendspinTrackProgressSensor : public sensor::Sensor, public PollingComponent, public Parented<SendspinHub> {
+class SendspinTrackProgressSensor : public sensor::Sensor, public SendspinPollingChild {
  public:
-  float get_setup_priority() const override { return sendspin_priority::CHILD; }
   void dump_config() override;
   void setup() override;
   void update() override;
 };
 
-class SendspinTrackDurationSensor : public sensor::Sensor, public Component, public Parented<SendspinHub> {
+class SendspinTrackDurationSensor : public sensor::Sensor, public SendspinChild {
  public:
-  float get_setup_priority() const override { return sendspin_priority::CHILD; }
   void dump_config() override;
   void setup() override;
 

--- a/esphome/components/sendspin/sensor/sendspin_sensor.h
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.h
@@ -7,6 +7,8 @@
 #include "esphome/components/sendspin/sendspin_hub.h"
 #include "esphome/components/sensor/sensor.h"
 
+#include <optional>
+
 namespace esphome::sendspin_ {
 
 class SendspinTrackProgressSensor : public sensor::Sensor, public SendspinPollingChild {
@@ -30,6 +32,7 @@ class SendspinMetadataSensor : public sensor::Sensor, public SendspinChild {
   void set_metadata_type(SendspinNumericMetadataTypes metadata_type) { this->metadata_type_ = metadata_type; }
 
  protected:
+  std::optional<float> extract_value_(const sendspin::ServerMetadataStateObject &metadata) const;
   void publish_if_changed_(float value);
 
   SendspinNumericMetadataTypes metadata_type_;

--- a/esphome/components/sendspin/sensor/sendspin_sensor.h
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.h
@@ -16,13 +16,23 @@ class SendspinTrackProgressSensor : public sensor::Sensor, public SendspinPollin
   void update() override;
 };
 
-class SendspinTrackDurationSensor : public sensor::Sensor, public SendspinChild {
+enum class SendspinNumericMetadataTypes {
+  TRACK_DURATION,
+  YEAR,
+  TRACK,
+};
+
+class SendspinMetadataSensor : public sensor::Sensor, public SendspinChild {
  public:
   void dump_config() override;
   void setup() override;
 
+  void set_metadata_type(SendspinNumericMetadataTypes metadata_type) { this->metadata_type_ = metadata_type; }
+
  protected:
   void publish_if_changed_(float value);
+
+  SendspinNumericMetadataTypes metadata_type_;
 };
 
 }  // namespace esphome::sendspin_

--- a/esphome/components/sendspin/sensor/sendspin_sensor.h
+++ b/esphome/components/sendspin/sensor/sendspin_sensor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "esphome/core/defines.h"
+
+#if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_SENSOR)
+
+#include "esphome/components/sendspin/sendspin_hub.h"
+#include "esphome/components/sensor/sensor.h"
+
+namespace esphome::sendspin_ {
+
+class SendspinTrackProgressSensor : public sensor::Sensor, public PollingComponent, public Parented<SendspinHub> {
+ public:
+  float get_setup_priority() const override { return sendspin_priority::CHILD; }
+  void dump_config() override;
+  void setup() override;
+  void update() override;
+};
+
+class SendspinTrackDurationSensor : public sensor::Sensor, public Component, public Parented<SendspinHub> {
+ public:
+  float get_setup_priority() const override { return sendspin_priority::CHILD; }
+  void dump_config() override;
+  void setup() override;
+
+ protected:
+  void publish_if_changed_(float value);
+};
+
+}  // namespace esphome::sendspin_
+#endif

--- a/tests/components/sendspin/common-sensor.yaml
+++ b/tests/components/sendspin/common-sensor.yaml
@@ -7,3 +7,9 @@ sensor:
   - platform: sendspin
     name: "Sendspin Track Duration"
     type: track_duration
+  - platform: sendspin
+    name: "Sendspin Year"
+    type: year
+  - platform: sendspin
+    name: "Sendspin Track"
+    type: track

--- a/tests/components/sendspin/common-sensor.yaml
+++ b/tests/components/sendspin/common-sensor.yaml
@@ -1,0 +1,9 @@
+<<: !include common.yaml
+
+sensor:
+  - platform: sendspin
+    name: "Sendspin Track Progress"
+    type: track_progress
+  - platform: sendspin
+    name: "Sendspin Track Duration"
+    type: track_duration

--- a/tests/components/sendspin/test-sensor.esp32-idf.yaml
+++ b/tests/components/sendspin/test-sensor.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common-sensor.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds several metadata sensors to Sendspin. One is a polling sensor (updating every second) that reports the current track progress in milliseconds, and the others are non-polling sensor that reports the total duration of the track, the track number, and the year (the last two are currently `text_sensor`s and will be removed in a follow up PR). These sensors aren't necessarily intended for reporting to Home Assistant. They are designed mostly be used as internal sensors that help drive displays.

Adds a ``metadata_role_`` member variable to the hub that the track progress sensor uses to get the current playback. Sendspin only sends metadata updates on a state change, so once a track has started playing, it will not send progress updates through the listener interface. The role's ``get_track_progress_ms()`` helper interpolates based on when playback started and the playback speed.

The track progress sensor automatically disables the poller when the current track is paused and resumes whenever playback has started again.

The total duration sensor deduplicates repeated updates to avoid churn, otherwise every pause and resume would push a new update even though its the same value.

Adds a new `SendspinPollingChild` class so that setup priorities (and how they are configured) are uniform across all Sendspin child components.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6523

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sendspin:

sensor:
  - platform: sendspin
    name: "Track Duration"
    type: track_duration
  - platform: sendspin
    name: "Track Progress"
    type: track_progress
  - platform: sendspin
    name: "Track Number"
    type: track
  - platform: sendspin
    name: "Year"
    type: year


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
