### PR TITLE
[sendspin] remove year and track number text sensors and refactor

### DIFF
--- a/esphome/components/sendspin/text_sensor/__init__.py
+++ b/esphome/components/sendspin/text_sensor/__init__.py
@@ -21,8 +21,6 @@ SENDSPIN_TEXT_METADATA_TYPES = {
     "artist": SendspinTextMetadataTypes.ARTIST,
     "album": SendspinTextMetadataTypes.ALBUM,
     "album_artist": SendspinTextMetadataTypes.ALBUM_ARTIST,
-    "year": SendspinTextMetadataTypes.YEAR,
-    "track": SendspinTextMetadataTypes.TRACK,
 }
 
 

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.cpp
@@ -2,8 +2,6 @@
 
 #if defined(USE_ESP32) && defined(USE_SENDSPIN_METADATA) && defined(USE_TEXT_SENSOR)
 
-#include "esphome/core/helpers.h"
-
 #include <sendspin/metadata_role.h>
 
 #include <string>
@@ -14,63 +12,36 @@ static const char *const TAG = "sendspin.text_sensor";
 
 void SendspinTextSensor::dump_config() { LOG_TEXT_SENSOR("", "Sendspin", this); }
 
+const char *SendspinTextSensor::extract_value_(const sendspin::ServerMetadataStateObject &metadata) const {
+  switch (this->metadata_type_) {
+    case SendspinTextMetadataTypes::TITLE:
+      if (metadata.title.has_value())
+        return metadata.title.value().c_str();
+      return nullptr;
+    case SendspinTextMetadataTypes::ARTIST:
+      if (metadata.artist.has_value())
+        return metadata.artist.value().c_str();
+      return nullptr;
+    case SendspinTextMetadataTypes::ALBUM:
+      if (metadata.album.has_value())
+        return metadata.album.value().c_str();
+      return nullptr;
+    case SendspinTextMetadataTypes::ALBUM_ARTIST:
+      if (metadata.album_artist.has_value())
+        return metadata.album_artist.value().c_str();
+      return nullptr;
+  }
+  return nullptr;
+}
+
 // THREAD CONTEXT: Main loop. The registered metadata callback also fires on the main loop
 // (SendspinHub dispatches metadata from client_->loop()).
 void SendspinTextSensor::setup() {
-  switch (this->metadata_type_) {
-    case SendspinTextMetadataTypes::TITLE: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.title.has_value()) {
-          this->publish_if_changed_(metadata.title.value().c_str());
-        }
-      });
-      break;
+  this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
+    if (const char *value = this->extract_value_(metadata)) {
+      this->publish_if_changed_(value);
     }
-    case SendspinTextMetadataTypes::ARTIST: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.artist.has_value()) {
-          this->publish_if_changed_(metadata.artist.value().c_str());
-        }
-      });
-      break;
-    }
-    case SendspinTextMetadataTypes::ALBUM: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.album.has_value()) {
-          this->publish_if_changed_(metadata.album.value().c_str());
-        }
-      });
-      break;
-    }
-    case SendspinTextMetadataTypes::ALBUM_ARTIST: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.album_artist.has_value()) {
-          this->publish_if_changed_(metadata.album_artist.value().c_str());
-        }
-      });
-      break;
-    }
-    case SendspinTextMetadataTypes::YEAR: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.year.has_value() && metadata.year.value() <= 9999) {
-          char buf[UINT32_MAX_STR_SIZE];
-          uint32_to_str(buf, metadata.year.value());
-          this->publish_if_changed_(buf);
-        }
-      });
-      break;
-    }
-    case SendspinTextMetadataTypes::TRACK: {
-      this->parent_->add_metadata_update_callback([this](const sendspin::ServerMetadataStateObject &metadata) {
-        if (metadata.track.has_value() && metadata.track.value() <= 9999) {
-          char buf[UINT32_MAX_STR_SIZE];
-          uint32_to_str(buf, metadata.track.value());
-          this->publish_if_changed_(buf);
-        }
-      });
-      break;
-    }
-  }
+  });
 }
 
 // Dedup to avoid frontend churn; TextSensor::publish_state already dedups the string assign but still notifies.

--- a/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
+++ b/esphome/components/sendspin/text_sensor/sendspin_text_sensor.h
@@ -7,6 +7,8 @@
 #include "esphome/components/sendspin/sendspin_hub.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
+#include <sendspin/metadata_role.h>
+
 namespace esphome::sendspin_ {
 
 enum class SendspinTextMetadataTypes {
@@ -14,8 +16,6 @@ enum class SendspinTextMetadataTypes {
   ARTIST,
   ALBUM,
   ALBUM_ARTIST,
-  YEAR,
-  TRACK,
 };
 
 class SendspinTextSensor : public SendspinChild, public text_sensor::TextSensor {
@@ -26,6 +26,7 @@ class SendspinTextSensor : public SendspinChild, public text_sensor::TextSensor 
   void set_metadata_type(SendspinTextMetadataTypes metadata_type) { this->metadata_type_ = metadata_type; }
 
  protected:
+  const char *extract_value_(const sendspin::ServerMetadataStateObject &metadata) const;
   void publish_if_changed_(const char *value);
 
   SendspinTextMetadataTypes metadata_type_;

--- a/tests/components/sendspin/common-text_sensor.yaml
+++ b/tests/components/sendspin/common-text_sensor.yaml
@@ -13,9 +13,3 @@ text_sensor:
   - platform: sendspin
     name: "Album Artist"
     type: album_artist
-  - platform: sendspin
-    name: "Year"
-    type: year
-  - platform: sendspin
-    name: "Track Number"
-    type: track


### PR DESCRIPTION
# What does this implement/fix?

Removes the year and track number text sensors, as they are now regular sensors (added in #15971). Also refactors how the remaining text sensors are updated to follow the pattern used in the Sendspin sensor component.

The merged text sensor documentation already omitted the year and track number text sensors, so no doc changes needed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
