### PR TITLE
[sendspin] Bumps sendspin-cpp library for a bugfix

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -193,7 +193,7 @@ async def to_code(config: ConfigType) -> None:
         )
 
     # sendspin-cpp library
-    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.3.0")
+    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.3.1")
 
     cg.add_define("USE_SENDSPIN", True)  # for MDNS
 

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -92,6 +92,6 @@ dependencies:
   esp32async/asynctcp:
     version: 3.4.91
   sendspin/sendspin-cpp:
-    version: 0.3.0
+    version: 0.3.1
   lvgl/lvgl:
     version: 9.5.0


### PR DESCRIPTION
# What does this implement/fix?

Bumps the sendspin-cpp library to v0.3.1 ([GitHub](https://github.com/Sendspin/sendspin-cpp/releases/tag/v0.3.1) and [Espressif Registry](https://components.espressif.com/components/sendspin/sendspin-cpp/versions/0.3.1/readme)). This fixes a bug where the persisted static delay was always applied even if it was disabled.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**  not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

sendspin:

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
