### PR TITLE
[core] Trim Scheduler::call fast path

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -601,14 +601,21 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // Cleanup removed items before processing
-  // First try to clean items from the top of the heap (fast path)
-  this->cleanup_();
+  // Cleanup removed items before processing. Read the counter once so the
+  // common zero-case is a single atomic load + branch; the old code called
+  // cleanup_() (which loads to_remove_) and then to_remove_count_() again for
+  // the MAX check, producing a redundant memw+load pair on the fast path.
+  if (this->to_remove_count_() != 0) {
+    // First try to clean items from the top of the heap (fast path).
+    this->cleanup_slow_path_();
 
-  // If we still have too many cancelled items, do a full cleanup
-  // This only happens if cancelled items are stuck in the middle/bottom of the heap
-  if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) {
-    this->full_cleanup_removed_items_();
+    // If we still have too many cancelled items, do a full cleanup.
+    // This only happens if cancelled items are stuck in the middle/bottom
+    // of the heap. Re-read to_remove_ because cleanup_slow_path_ may have
+    // decremented it.
+    if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) {
+      this->full_cleanup_removed_items_();
+    }
   }
   // IMPORTANT: This loop uses index-based access (items_[0]), NOT iterators.
   // This is intentional — fired intervals are pushed back into items_ via

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -118,7 +118,7 @@ class Scheduler {
   bool cancel_retry(Component *component, uint32_t id);
 
   /// Get 64-bit millisecond timestamp (handles 32-bit millis() rollover)
-  uint64_t millis_64() { return esphome::millis_64(); }
+  uint64_t ESPHOME_ALWAYS_INLINE millis_64() { return esphome::millis_64(); }
 
   // Calculate when the next scheduled item should run.
   // @param now On ESP32, unused for 64-bit extension (native); on other platforms, extended to 64-bit via rollover.


### PR DESCRIPTION
# What does this implement/fix?

Two small wins on the per-loop `Scheduler::call` fast path, observed while auditing main-loop overhead on an ESP32 IDF build (`runtime_stats` reporting `sched=16.6ms` per 60s window on a minimal gatetrigger config).

**1. Mark `Scheduler::millis_64()` `ESPHOME_ALWAYS_INLINE`.**

The inner `esphome::millis_64()` defined in `hal.h` is already `always_inline`, but the thin scheduler-side wrapper at `scheduler.h:121`
```cpp
uint64_t millis_64() { return esphome::millis_64(); }
```
was not annotated. As a result, GCC emitted an out-of-line clone (`_ZN7esphome9Scheduler9millis_64Ev$isra$0`) with its own `entry a1, 32` / `retw` register-window prologue and epilogue at every call site (ESP32 Xtensa). Annotating the wrapper lets both calls fold into the caller, leaving only the direct `call8 esp_timer_get_time` plus the `micros_to_millis` divide.

**2. Read `to_remove_` once on the `Scheduler::call` fast path.**

The previous sequence
```cpp
this->cleanup_();                                       // loads to_remove_ via to_remove_empty_()
if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) { ... }  // reloads to_remove_
```
produced two atomic reads of the same field on the all-zero fast path:
```
memw; l32i a8, [to_remove_]; beqz ...   ; to_remove_empty_()
memw; l32i a8, [to_remove_]; bltui 5    ; to_remove_count_()
```
GCC cannot CSE across the `memw` barriers that `std::atomic<uint32_t>::load(memory_order_relaxed)` emits on Xtensa. Reading the counter once into a local and branching on the result collapses the zero-case to a single `memw; l32i; beqz`. The non-zero path pays one extra read after `cleanup_slow_path_` (which may have decremented the counter) — that path already takes `lock_` so the extra load is negligible.

## Verified in disassembly

`Scheduler::call` on ESP32 IDF (gatetrigger build):

| | Before | After |
|---|---|---|
| fn size | 344 B | 400 B |
| `memw`+`l32i` pairs on fast path | 4 | 3 |
| out-of-line `millis_64$isra$0` call | yes | inlined |

`Scheduler::next_schedule_in` grew 88 → 153 B for the same reason (millis_64 inlined).

Net flash increase: **+121 B**. Measured per-iteration savings on the scheduler fast path:

| Platform/config | Before | After | Δ |
|---|---|---|---|
| gatetrigger (minimal) — `sched` µs/iter | 4.42 | 3.84 | **-0.58** (≈ -2.2 ms/60s, ~13%) |

Clean periods averaged across multiple 60 s windows via `runtime_stats`.

## History

An earlier iteration of this PR also tried to thread `now_64` between `Scheduler::call` and `Scheduler::next_schedule_in` (to save the second `esp_timer_get_time()` MMIO per iteration). That change measured well in theory and in disassembly, but on real ESP32 hardware the ABI shuffling and code-layout shifts caused `feed_wdt_slow_`-adjacent MMIO timing to regress, netting a slight overall slowdown (confirmed on both gatetrigger and winefridge configs). Those commits have been dropped from this PR; only the two wins above remain.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change; behavior is internal. Verified on:
esphome:
  name: gatetrigger
esp32:
  board: esp32-evb
  framework:
    type: esp-idf
runtime_stats:
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
