### PR TITLE
[core] Raise ESP32 WDT feed interval to 1/5 of configured timeout

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -17,6 +17,10 @@
 #include "esphome/core/string_ref.h"
 #include "esphome/core/version.h"
 
+#ifdef USE_ESP32
+#include <sdkconfig.h>  // for CONFIG_ESP_TASK_WDT_TIMEOUT_S (drives WDT_FEED_INTERVAL_MS)
+#endif
+
 #ifdef USE_DEVICES
 #include "esphome/core/device.h"
 #endif
@@ -216,24 +220,30 @@ class Application {
   /// loops and scheduler items still feed after every op, so any op exceeding
   /// this threshold triggers a real feed naturally.
   /// Safety margins vs. platform watchdog timeouts:
-  ///   - ESP32 task WDT default (5 s):  ~5x  <-- platform override below
-  ///   - ESP8266 soft WDT (~1.6 s):     ~5x  <-- floor case; any future change
-  ///                                              must keep comfortable margin here
-  ///   - ESP8266 HW WDT (~6 s):         ~20x
-  ///   - BK72xx HW WDT (10 s):          ~5x  <-- platform override below
+  ///   - ESP32 task WDT (user-configurable):  ~5x  <-- auto-scaled below
+  ///   - ESP8266 soft WDT (~1.6 s):           ~5x  <-- floor case; any future change
+  ///                                                   must keep comfortable margin here
+  ///   - ESP8266 HW WDT (~6 s):               ~20x
+  ///   - BK72xx HW WDT (10 s):                ~5x  <-- platform override below
 #ifdef USE_BK72XX
   // BDK busy-waits 200us per WDT reload (sctrl_dpll_delay200us). LibreTiny
   // sets HW WDT to 10s; 2000ms keeps ~5x margin. See wdt_ctrl WCMD_RELOAD_PERIOD:
   // https://github.com/libretiny-eu/framework-beken-bdk/blob/44800e7451ea30fbcbd3bb6e905315de59349fee/beken378/driver/wdt/wdt.c#L75-L87
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 2000;
 #elif defined(USE_ESP32)
-  // ESP32 task WDT default timeout is 5 s (CONFIG_ESP_TASK_WDT_TIMEOUT_S).
-  // 1000ms keeps a comfortable ~5x margin — matching the bk72xx safety factor —
-  // while cutting the per-hit feed overhead to ~1/3 of the old 300ms cadence.
+  // Auto-scale to 1/5 of the configured ESP32 task WDT timeout so the safety
+  // margin stays constant when the user raises esp32.watchdog_timeout (default
+  // 5 s → 1000 ms feed; 10 s → 2000 ms; 60 s → 12000 ms). The esp32 component
+  // writes CONFIG_ESP_TASK_WDT_TIMEOUT_S into sdkconfig (range is validated
+  // to ≥ 5 s in esp32/__init__.py), giving us the value at compile time.
   // esp_task_wdt_reset() takes a spinlock and walks the WDT task list, so
-  // each call costs tens of microseconds; feeding less often materially
-  // reduces the main-loop's wdt bucket.
-  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 1000;
+  // each call costs tens of microseconds; longer intervals materially reduce
+  // the main-loop's wdt bucket. Component loops and scheduler items still
+  // feed after every op, so any op exceeding this threshold triggers a real
+  // feed naturally regardless of the rate-limit.
+  static_assert(CONFIG_ESP_TASK_WDT_TIMEOUT_S >= 5,
+                "CONFIG_ESP_TASK_WDT_TIMEOUT_S must be at least 5s for a safe WDT feed interval");
+  static constexpr uint32_t WDT_FEED_INTERVAL_MS = (CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000U) / 5U;
 #else
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
 #endif

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -216,7 +216,7 @@ class Application {
   /// loops and scheduler items still feed after every op, so any op exceeding
   /// this threshold triggers a real feed naturally.
   /// Safety margins vs. platform watchdog timeouts:
-  ///   - ESP32 task WDT default (5 s):  ~16x
+  ///   - ESP32 task WDT default (5 s):  ~5x  <-- platform override below
   ///   - ESP8266 soft WDT (~1.6 s):     ~5x  <-- floor case; any future change
   ///                                              must keep comfortable margin here
   ///   - ESP8266 HW WDT (~6 s):         ~20x
@@ -226,6 +226,14 @@ class Application {
   // sets HW WDT to 10s; 2000ms keeps ~5x margin. See wdt_ctrl WCMD_RELOAD_PERIOD:
   // https://github.com/libretiny-eu/framework-beken-bdk/blob/44800e7451ea30fbcbd3bb6e905315de59349fee/beken378/driver/wdt/wdt.c#L75-L87
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 2000;
+#elif defined(USE_ESP32)
+  // ESP32 task WDT default timeout is 5 s (CONFIG_ESP_TASK_WDT_TIMEOUT_S).
+  // 1000ms keeps a comfortable ~5x margin — matching the bk72xx safety factor —
+  // while cutting the per-hit feed overhead to ~1/3 of the old 300ms cadence.
+  // esp_task_wdt_reset() takes a spinlock and walks the WDT task list, so
+  // each call costs tens of microseconds; feeding less often materially
+  // reduces the main-loop's wdt bucket.
+  static constexpr uint32_t WDT_FEED_INTERVAL_MS = 1000;
 #else
   static constexpr uint32_t WDT_FEED_INTERVAL_MS = 300;
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Follow-up to #15908 which made the ESP32 task WDT timeout user-configurable via `esp32.watchdog_timeout` (default 5 s, range 5–60 s). Now that the timeout can move, the feed interval should move with it.

This PR mirrors the existing bk72xx platform override, but **auto-scales** to the user-configurable `esp32.watchdog_timeout` (→ `CONFIG_ESP_TASK_WDT_TIMEOUT_S`) instead of hard-coding a constant: the feed interval is always **1/5 of the configured task WDT timeout**, so the safety margin stays constant regardless of user configuration.

| `esp32.watchdog_timeout` | Feed interval | Safety margin |
|---|---|---|
| 5 s (default) | **1000 ms** (was 300 ms) | ~5x |
| 10 s | 2000 ms | ~5x |
| 60 s (max) | 12000 ms | ~5x |

`esp_task_wdt_reset()` takes a spinlock and walks the WDT task list; each call costs tens of microseconds. At the normal ~62 Hz main loop, the old 300 ms cadence produced ~200 `feed_wdt_slow_` hits per 60 s. With the default 5 s WDT, the new 1000 ms cadence drops that to ~60 hits per 60 s (**-70%**).

`esp32/__init__.py` (from #15908) already constrains `watchdog_timeout` to 5–60 s, and a `static_assert` in `application.h` guards against anyone tweaking sdkconfig below that floor, so the feed interval can never drop below the previous 1000 ms baseline.

Component-level feeds inside `Component::loop()` and scheduler items are unaffected — they continue to call `arch_feed_wdt` after every operation, so any op exceeding this rate-limit triggers a real feed naturally. The rate-limit only applies to the outer guard in `Application::loop()` that fires when nothing else fed recently.

## Measured on ESP32 IDF (gatetrigger.yaml, default 5 s WDT, via `runtime_stats`):

| Bucket | 300 ms cadence | **1000 ms cadence** | Δ |
|---|---|---|---|
| `wdt_slow_path` hits / 60 s | 197 | **60** | -70% |
| `wdt_slow_path` % of iters | 5.3 % | 1.6 % | -3.7 pp |
| `wdt` bucket ms / 60 s | ~8.4 | **~5.8** | **-2.6 ms** |
| `wdt` µs / iter | 2.24 | **1.56** | **-0.68** |

Clean periods averaged across multiple 60 s windows.

## Updated safety margin table

| Platform | WDT timeout | Feed interval | Margin |
|---|---|---|---|
| ESP8266 soft WDT | ~1.6 s | 300 ms | ~5x |
| ESP8266 HW WDT | ~6 s | 300 ms | ~20x |
| **ESP32 task WDT** | **5–60 s (user, via #15908)** | **timeout / 5** | **~5x (constant)** |
| BK72xx HW WDT | 10 s | 2000 ms | ~5x |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15908 ([esp32] add watchdog_timeout configuration variable)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change required; the feed interval auto-scales to whatever
# watchdog_timeout the user (or default) sets. Example with a custom value:
esp32:
  board: esp32-evb
  watchdog_timeout: 10s   # → feed interval auto-scales to 2000ms
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).