### PR TITLE
[core] Collapse duplicate to_remove_ read in Scheduler::call fast path

### DIFF
--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -601,14 +601,24 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-  // Cleanup removed items before processing
-  // First try to clean items from the top of the heap (fast path)
-  this->cleanup_();
+  // Cleanup removed items before processing. Read the counter once so the
+  // common zero-case is a single atomic load + branch; the old code called
+  // cleanup_() (which loads to_remove_) and then to_remove_count_() again for
+  // the MAX check, producing a redundant memw+load pair on the fast path.
+  // GCC cannot CSE across the memw barriers that std::atomic<uint32_t>::load
+  // emits on Xtensa, so the duplicate load was unavoidable without manual
+  // restructuring.
+  if (this->to_remove_count_() != 0) {
+    // First try to clean items from the top of the heap (fast path).
+    this->cleanup_slow_path_();
 
-  // If we still have too many cancelled items, do a full cleanup
-  // This only happens if cancelled items are stuck in the middle/bottom of the heap
-  if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) {
-    this->full_cleanup_removed_items_();
+    // If we still have too many cancelled items, do a full cleanup.
+    // This only happens if cancelled items are stuck in the middle/bottom
+    // of the heap. Re-read to_remove_ because cleanup_slow_path_ may have
+    // decremented it.
+    if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) {
+      this->full_cleanup_removed_items_();
+    }
   }
   // IMPORTANT: This loop uses index-based access (items_[0]), NOT iterators.
   // This is intentional — fired intervals are pushed back into items_ via


### PR DESCRIPTION
# What does this implement/fix?

Narrow version of the previously-closed #15982. Collapses the duplicate `to_remove_` atomic read in `Scheduler::call()` **without** touching code size — so there's no flash-layout shift and none of the cache-line / MMIO-timing side effects that made the earlier, larger change a net loss on a busy config.

## The change

The previous cleanup sequence
```cpp
this->cleanup_();                                       // loads to_remove_ via to_remove_empty_()
if (this->to_remove_count_() >= MAX_LOGICALLY_DELETED_ITEMS) { ... }  // reloads to_remove_
```
produced two atomic reads of the same field on the all-zero fast path:

```
memw; l32i a8, [to_remove_]; beqz ...   ; to_remove_empty_()
memw; l32i a8, [to_remove_]; bltui 5    ; to_remove_count_()
```

GCC cannot CSE across the `memw` barriers that `std::atomic<uint32_t>::load(memory_order_relaxed)` emits on Xtensa. Reading the counter once into a local and branching on the result collapses the zero-case to a single `memw; l32i; beqz`. The non-zero path pays one extra read after `cleanup_slow_path_` (which may have decremented the counter) — that path already takes `lock_` so the extra load is negligible.

## Why just this change

`Scheduler::call` stays at **344 B** (unchanged from `dev`) — no flash-layout shift, so `feed_wdt_slow_` and other adjacent code stay in the same cache lines.

#15982 tried to also mark `Scheduler::millis_64()` `ESPHOME_ALWAYS_INLINE`, which shaved an out-of-line `$isra$0` clone and gave a clean −0.58 µs/iter `sched` win on a minimal gatetrigger config. But that change grew `Scheduler::call` from 344 → 400 B (+56 B), pushed `feed_wdt_slow_` to a slightly-less-favourable flash position, and on a busy winefridge config (CSE7766 at 62 Hz, mDNS at 20 Hz, WiFi + API) produced a **+1.7 µs/iter total overhead regression**. The inlining cost more than it saved on configs where `Scheduler::call`'s fast path barely exists.

This PR keeps only the cost-neutral memw collapse.

## Verified in disassembly

ESP32 IDF build, `Scheduler::call`:

| | dev | **this PR** |
|---|---|---|
| fn size | 344 B | **344 B** |
| `memw`+`l32i` pairs for `to_remove_` on fast path | 2 | **1** |

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Narrower follow-up to #15982 (closed).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change; behavior is internal.
esphome:
  name: gatetrigger
esp32:
  board: esp32-evb
  framework:
    type: esp-idf
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
