### PR TITLE
[bluetooth_proxy] Partial revert of loop() → set_interval migration

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -30,19 +30,6 @@ void BluetoothProxy::setup() {
   this->configured_scan_active_ = this->parent_->get_scan_active();
 
   this->parent_->add_scanner_state_listener(this);
-
-  this->set_interval(100, [this]() {
-    if (api::global_api_server->is_connected() && this->api_connection_ != nullptr) {
-      this->flush_pending_advertisements_();
-      return;
-    }
-    for (uint8_t i = 0; i < this->connection_count_; i++) {
-      auto *connection = this->connections_[i];
-      if (connection->get_address() != 0 && !connection->disconnect_pending()) {
-        connection->disconnect();
-      }
-    }
-  });
 }
 
 void BluetoothProxy::on_scanner_state(esp32_ble_tracker::ScannerState state) {
@@ -114,15 +101,25 @@ bool BluetoothProxy::parse_devices(const esp32_ble::BLEScanResult *scan_results,
 
     // Flush if we have reached BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE
     if (this->response_.advertisements_len >= BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE) {
-      this->flush_pending_advertisements_();
+      this->flush_pending_advertisements();
     }
   }
 
   return true;
 }
 
-void BluetoothProxy::log_advertisement_flush_() {
+void BluetoothProxy::flush_pending_advertisements() {
+  if (this->response_.advertisements_len == 0 || !api::global_api_server->is_connected() ||
+      this->api_connection_ == nullptr)
+    return;
+
+  // Send the message
+  this->api_connection_->send_message(this->response_);
+
   ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
+
+  // Reset the length for the next batch
+  this->response_.advertisements_len = 0;
 }
 
 void BluetoothProxy::dump_config() {
@@ -131,6 +128,27 @@ void BluetoothProxy::dump_config() {
                 "  Active: %s\n"
                 "  Connections: %d",
                 YESNO(this->active_), this->connection_count_);
+}
+
+void BluetoothProxy::loop() {
+  if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr) {
+    for (uint8_t i = 0; i < this->connection_count_; i++) {
+      auto *connection = this->connections_[i];
+      if (connection->get_address() != 0 && !connection->disconnect_pending()) {
+        connection->disconnect();
+      }
+    }
+    return;
+  }
+
+  // Flush any pending BLE advertisements that have been accumulated but not yet sent
+  uint32_t now = App.get_loop_component_start_time();
+
+  // Flush accumulated advertisements every 100ms
+  if (now - this->last_advertisement_flush_time_ >= 100) {
+    this->flush_pending_advertisements();
+    this->last_advertisement_flush_time_ = now;
+  }
 }
 
 esp32_ble_tracker::AdvertisementParserType BluetoothProxy::get_advertisement_parser_type() {

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -101,25 +101,15 @@ bool BluetoothProxy::parse_devices(const esp32_ble::BLEScanResult *scan_results,
 
     // Flush if we have reached BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE
     if (this->response_.advertisements_len >= BLUETOOTH_PROXY_ADVERTISEMENT_BATCH_SIZE) {
-      this->flush_pending_advertisements();
+      this->flush_pending_advertisements_();
     }
   }
 
   return true;
 }
 
-void BluetoothProxy::flush_pending_advertisements() {
-  if (this->response_.advertisements_len == 0 || !api::global_api_server->is_connected() ||
-      this->api_connection_ == nullptr)
-    return;
-
-  // Send the message
-  this->api_connection_->send_message(this->response_);
-
+void BluetoothProxy::log_advertisement_flush_() {
   ESP_LOGV(TAG, "Sent batch of %u BLE advertisements", this->response_.advertisements_len);
-
-  // Reset the length for the next batch
-  this->response_.advertisements_len = 0;
 }
 
 void BluetoothProxy::dump_config() {
@@ -131,23 +121,21 @@ void BluetoothProxy::dump_config() {
 }
 
 void BluetoothProxy::loop() {
-  if (!api::global_api_server->is_connected() || this->api_connection_ == nullptr) {
-    for (uint8_t i = 0; i < this->connection_count_; i++) {
-      auto *connection = this->connections_[i];
-      if (connection->get_address() != 0 && !connection->disconnect_pending()) {
-        connection->disconnect();
-      }
-    }
+  // Run advertisement flush / connection cleanup every 100ms
+  uint32_t now = App.get_loop_component_start_time();
+  if (now - this->last_advertisement_flush_time_ < 100)
+    return;
+  this->last_advertisement_flush_time_ = now;
+
+  if (api::global_api_server->is_connected() && this->api_connection_ != nullptr) {
+    this->flush_pending_advertisements_();
     return;
   }
-
-  // Flush any pending BLE advertisements that have been accumulated but not yet sent
-  uint32_t now = App.get_loop_component_start_time();
-
-  // Flush accumulated advertisements every 100ms
-  if (now - this->last_advertisement_flush_time_ >= 100) {
-    this->flush_pending_advertisements();
-    this->last_advertisement_flush_time_ = now;
+  for (uint8_t i = 0; i < this->connection_count_; i++) {
+    auto *connection = this->connections_[i];
+    if (connection->get_address() != 0 && !connection->disconnect_pending()) {
+      connection->disconnect();
+    }
   }
 }
 

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -66,7 +66,6 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
   void dump_config() override;
   void setup() override;
   void loop() override;
-  void flush_pending_advertisements();
   esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
   void register_connection(BluetoothConnection *connection) {
@@ -149,6 +148,18 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
 
  protected:
   void send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerState state);
+
+  /// Caller must ensure api_connection_ is non-null and API server is connected.
+  void flush_pending_advertisements_() {
+    if (this->response_.advertisements_len == 0)
+      return;
+    this->api_connection_->send_message(this->response_);
+#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
+    this->log_advertisement_flush_();
+#endif
+    this->response_.advertisements_len = 0;
+  }
+  void log_advertisement_flush_();
 
   BluetoothConnection *get_connection_(uint64_t address, bool reserve);
   void log_connection_request_ignored_(BluetoothConnection *connection, espbt::ClientState state);

--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.h
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.h
@@ -65,6 +65,8 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
   bool parse_devices(const esp32_ble::BLEScanResult *scan_results, size_t count) override;
   void dump_config() override;
   void setup() override;
+  void loop() override;
+  void flush_pending_advertisements();
   esp32_ble_tracker::AdvertisementParserType get_advertisement_parser_type() override;
 
   void register_connection(BluetoothConnection *connection) {
@@ -148,18 +150,6 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
  protected:
   void send_bluetooth_scanner_state_(esp32_ble_tracker::ScannerState state);
 
-  /// Caller must ensure api_connection_ is non-null and API server is connected.
-  void flush_pending_advertisements_() {
-    if (this->response_.advertisements_len == 0)
-      return;
-    this->api_connection_->send_message(this->response_);
-#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE
-    this->log_advertisement_flush_();
-#endif
-    this->response_.advertisements_len = 0;
-  }
-  void log_advertisement_flush_();
-
   BluetoothConnection *get_connection_(uint64_t address, bool reserve);
   void log_connection_request_ignored_(BluetoothConnection *connection, espbt::ClientState state);
   void log_connection_info_(BluetoothConnection *connection, const char *message);
@@ -175,6 +165,9 @@ class BluetoothProxy final : public esp32_ble_tracker::ESPBTDeviceListener,
 
   // BLE advertisement batching
   api::BluetoothLERawAdvertisementsResponse response_;
+
+  // Group 3: 4-byte types
+  uint32_t last_advertisement_flush_time_{0};
 
   // Pre-allocated response message - always ready to send
   api::BluetoothConnectionsFreeResponse connections_free_response_;


### PR DESCRIPTION
# What does this implement/fix?

**Partial revert of #15347.** The `loop()` → `set_interval(100ms)` migration no longer pays off after #15792 fixed the main-loop cadence — but the structural improvements that came along with #15347 (inlined flush helper, verbose-log gating) are still wins and are kept.

## What's reverted vs. kept

| Change in #15347 | Kept? | Reason |
|---|---|---|
| `loop()` → `set_interval(100ms)` | **Reverted** | Forces extra Phase A wakes after #15792 |
| Disconnect-cleanup in `setup()` callback | **Kept the 100 ms cadence** in `loop()` | Cleaner symmetry with flush half |
| `flush_pending_advertisements_()` inlined in header | **Kept** | Eliminates one indirect call per flush |
| `log_advertisement_flush_()` out-of-line, gated under `#if ESPHOME_LOG_LEVEL >= ESPHOME_LOG_LEVEL_VERBOSE` | **Kept** | Keeps the `ESP_LOGV` format string out of inlined call sites at verbose log levels |

The `loop()` body is now:

```cpp
void BluetoothProxy::loop() {
  uint32_t now = App.get_loop_component_start_time();
  if (now - this->last_advertisement_flush_time_ < 100)
    return;
  this->last_advertisement_flush_time_ = now;

  if (api::global_api_server->is_connected() && this->api_connection_ != nullptr) {
    this->flush_pending_advertisements_();
    return;
  }
  for (uint8_t i = 0; i < this->connection_count_; i++) {
    auto *connection = this->connections_[i];
    if (connection->get_address() != 0 && !connection->disconnect_pending()) {
      connection->disconnect();
    }
  }
}
```

Both halves (flush + connection cleanup) now run at 100 ms cadence — same as #15347's `set_interval` callback — but driven from `loop()` so they fire on the natural Phase B cadence without forcing extra Phase A wakes.

## Why the loop() → set_interval move regressed after #15792

When #15347 landed, every component's `loop()` was running at ~128 Hz (2× the configured `loop_interval_`) because the old `Application::loop()` slept for `min(loop_interval_ − elapsed, next_schedule_in())` with a `delay_time / 2` floor — any scheduler entry due sooner than `loop_interval_/2` pulled the entire component phase forward. Under that regime, dropping bluetooth_proxy from a 128 Hz `loop()` to a 10 Hz `set_interval` was a clear win: ~13× fewer dispatches.

#15792 split the loop into two independent phases (Phase A every tick for scheduler/WDT, Phase B gated by `loop_interval_` for components) and removed the floor. `loop()` now runs at the documented ~62 Hz instead of ~128 Hz. That cuts the dispatch-savings gap roughly in half, and at the same time *increased* the cost of the 100 ms `set_interval`, because the timer now forces extra Phase A wakes that don't align with the natural Phase B cadence — wakes that wouldn't have existed in pre-#15792 timing either.

## Measurements

ESP32-IDF, identical workload, 60 s window:

| Metric | `set_interval(100ms)` | `loop()` gate (this PR) | Δ |
|---|---|---|---|
| main_loop iters | 4305 | 3719 | **−586** (−13.6%) |
| sched (before-bucket) | 41.8 ms | 21.0 ms | **−20.8 ms** (−50%) |
| wdt | 7.2 ms | 3.3 ms | **−3.9 ms** |
| wdt_slow_path avg/hit | 119.28 µs | 56.20 µs | −53% |
| main_loop overhead_total | 68.0 ms | 48.5 ms | **−19.5 ms** |
| bluetooth_proxy total | 155.0 ms | 152.5 ms | −2.5 ms |
| inter_component | 17.6 ms | 22.4 ms | +4.8 ms |

The 100 ms timer was driving ~10 extra Phase A wakes/sec (~600/min) above the natural component cadence. Each paid scheduler dispatch + WDT feed cost. The +4.8 ms `inter_component` from re-adding bluetooth_proxy to the per-tick component list is dwarfed by the −20.8 ms scheduler savings.

bluetooth_proxy per-call avg dropped 0.260 ms → 0.041 ms because most `loop()` calls now hit the cheap timestamp-gate path; the 6× call count is more than offset, and total time is actually slightly *lower*.

## General lesson from this revert

**After #15792, converting a `loop()` body to a sub-`loop_interval_` `set_interval` is generally a pessimization** because the timer forces extra Phase A wakes that wouldn't otherwise occur. Pre-#15792 the math went the other way (loop ran at 2× cadence, scheduler wakes were already happening, set_interval saved real dispatches). Audit of recent refactors:

- **#15347 bluetooth_proxy** (`set_interval(100ms)`) — partially reverted by this PR; clear measured win.
- **#15433 time/CronTrigger** (`set_interval(1000ms)`) — debatable; 1 Hz is far less impactful than 10 Hz, body is trivial. Skipping without measurements.
- **#15432 total_daily_energy** — uses `set_timeout` (one-shot at midnight); not affected.

Documentation guidance has been added in esphome/developers.esphome.io#136.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Partial revert of #15347
- Enabled by #15792 (the cadence-fix that flipped the calculus)
- Documentation: esphome/developers.esphome.io#136

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bluetooth_proxy:
  active: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
