### PR TITLE
[dashboard] Add --no-states support to logs WebSocket handler

### DIFF
--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -440,6 +440,7 @@ class EsphomeLogsHandler(EsphomePortCommandWebSocket):
         cmd = await self.build_device_command(["logs"], json_message)
         if json_message.get("no_states"):
             cmd.append("--no-states")
+            _LOGGER.debug("Built command: %s", cmd)
         return cmd
 
 

--- a/esphome/dashboard/web_server.py
+++ b/esphome/dashboard/web_server.py
@@ -437,7 +437,10 @@ class EsphomePortCommandWebSocket(EsphomeCommandWebSocket):
 class EsphomeLogsHandler(EsphomePortCommandWebSocket):
     async def build_command(self, json_message: dict[str, Any]) -> list[str]:
         """Build the command to run."""
-        return await self.build_device_command(["logs"], json_message)
+        cmd = await self.build_device_command(["logs"], json_message)
+        if json_message.get("no_states"):
+            cmd.append("--no-states")
+        return cmd
 
 
 class EsphomeRenameHandler(EsphomeCommandWebSocket):

--- a/tests/dashboard/test_web_server.py
+++ b/tests/dashboard/test_web_server.py
@@ -1744,6 +1744,64 @@ def test_proc_on_exit_skips_when_already_closed() -> None:
     handler.close.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_esphome_logs_handler_appends_no_states_when_set() -> None:
+    """Test --no-states is appended when no_states is truthy in the message."""
+    handler = Mock(spec=web_server.EsphomeLogsHandler)
+    handler.build_device_command = AsyncMock(
+        return_value=["esphome", "logs", "device.yaml", "--device", "OTA"]
+    )
+
+    json_message = {
+        "configuration": "device.yaml",
+        "port": "OTA",
+        "no_states": True,
+    }
+    cmd = await web_server.EsphomeLogsHandler.build_command(handler, json_message)
+
+    assert cmd == [
+        "esphome",
+        "logs",
+        "device.yaml",
+        "--device",
+        "OTA",
+        "--no-states",
+    ]
+    handler.build_device_command.assert_awaited_once_with(["logs"], json_message)
+
+
+@pytest.mark.asyncio
+async def test_esphome_logs_handler_omits_no_states_when_missing() -> None:
+    """Test --no-states is not added when no_states is absent from the message."""
+    handler = Mock(spec=web_server.EsphomeLogsHandler)
+    handler.build_device_command = AsyncMock(
+        return_value=["esphome", "logs", "device.yaml", "--device", "OTA"]
+    )
+
+    cmd = await web_server.EsphomeLogsHandler.build_command(
+        handler, {"configuration": "device.yaml", "port": "OTA"}
+    )
+
+    assert "--no-states" not in cmd
+    assert cmd == ["esphome", "logs", "device.yaml", "--device", "OTA"]
+
+
+@pytest.mark.asyncio
+async def test_esphome_logs_handler_omits_no_states_when_false() -> None:
+    """Test --no-states is not added when no_states is explicitly False."""
+    handler = Mock(spec=web_server.EsphomeLogsHandler)
+    handler.build_device_command = AsyncMock(
+        return_value=["esphome", "logs", "device.yaml", "--device", "OTA"]
+    )
+
+    cmd = await web_server.EsphomeLogsHandler.build_command(
+        handler,
+        {"configuration": "device.yaml", "port": "OTA", "no_states": False},
+    )
+
+    assert "--no-states" not in cmd
+
+
 def _make_auth_handler(auth_header: str | None = None) -> Mock:
     """Create a mock handler with the given Authorization header."""
     handler = Mock()


### PR DESCRIPTION
# What does this implement/fix?

> **Context:** the dashboard is slated to be replaced by a new system in the future. This PR is the minimal short-term change needed to fill the gap so users running the current dashboard have a way to opt out of entity-state log spam without dropping to a shell.

Adds a `no_states` flag to the dashboard logs WebSocket spawn message, which is forwarded to the spawned `esphome logs` subprocess as `--no-states`. This lets the dashboard frontend suppress the noisy `[S][sensor]` / `[S][text_sensor]` entity-state log lines that ship by default when streaming logs over the API.

The change is gated on `EsphomeLogsHandler` only, so existing handlers (`upload`, `run`) that share `EsphomePortCommandWebSocket.build_device_command` are unaffected.

The frontend half (a per-session checkbox in the logs viewer) lives in the companion dashboard PR esphome/dashboard#902; both halves are independent — this PR is safe to merge on its own.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15987
- also fixes https://github.com/esphome/esphome/issues/15865
- companion dashboard PR: esphome/dashboard#902

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<TBD>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No YAML changes required. The flag is a per-log-session option
# selectable from the dashboard UI; backend just forwards the existing
# `esphome logs --no-states` CLI flag.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
