### PR TITLE
[host] Use integer math in millis()/micros()

### DIFF
--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -8,7 +8,6 @@
 #include <csignal>
 #include <sched.h>
 #include <time.h>
-#include <cmath>
 #include <cstdlib>
 
 namespace {
@@ -22,9 +21,7 @@ void HOT yield() { ::sched_yield(); }
 uint32_t IRAM_ATTR HOT millis() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
-  time_t seconds = spec.tv_sec;
-  uint32_t ms = round(spec.tv_nsec / 1e6);
-  return ((uint32_t) seconds) * 1000U + ms;
+  return static_cast<uint32_t>(spec.tv_sec) * 1000U + static_cast<uint32_t>(spec.tv_nsec / 1000000);
 }
 uint64_t millis_64() {
   struct timespec spec;
@@ -43,9 +40,7 @@ void HOT delay(uint32_t ms) {
 uint32_t IRAM_ATTR HOT micros() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
-  time_t seconds = spec.tv_sec;
-  uint32_t us = round(spec.tv_nsec / 1e3);
-  return ((uint32_t) seconds) * 1000000U + us;
+  return static_cast<uint32_t>(spec.tv_sec) * 1000000U + static_cast<uint32_t>(spec.tv_nsec / 1000);
 }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) {
   struct timespec ts;

--- a/esphome/components/host/core.cpp
+++ b/esphome/components/host/core.cpp
@@ -21,7 +21,7 @@ void HOT yield() { ::sched_yield(); }
 uint32_t IRAM_ATTR HOT millis() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
-  return static_cast<uint32_t>(spec.tv_sec) * 1000U + static_cast<uint32_t>(spec.tv_nsec / 1000000);
+  return static_cast<uint32_t>(spec.tv_sec * 1000ULL + spec.tv_nsec / 1000000);
 }
 uint64_t millis_64() {
   struct timespec spec;
@@ -40,7 +40,7 @@ void HOT delay(uint32_t ms) {
 uint32_t IRAM_ATTR HOT micros() {
   struct timespec spec;
   clock_gettime(CLOCK_MONOTONIC, &spec);
-  return static_cast<uint32_t>(spec.tv_sec) * 1000000U + static_cast<uint32_t>(spec.tv_nsec / 1000);
+  return static_cast<uint32_t>(spec.tv_sec * 1000000ULL + spec.tv_nsec / 1000);
 }
 void IRAM_ATTR HOT delayMicroseconds(uint32_t us) {
   struct timespec ts;


### PR DESCRIPTION
# What does this implement/fix?

Replace floating-point division and `round()` in the host platform's `millis()` and `micros()` with plain integer division. The previous implementation computed `round(spec.tv_nsec / 1e6)` (and `1e3` for `micros()`), pulling in floating-point math just to truncate a nanosecond counter. Truncation is the correct behavior for these monotonic counters, and `millis_64()` already uses integer division — this just brings the 32-bit variants in line with it.

Also drops the now-unused `<cmath>` include.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host

## Example entry for `config.yaml`:

```yaml
esphome:
  name: host-example
  platform: host
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).