### PR TITLE
[ci] Trigger CodSpeed benchmarks on host platform changes

### DIFF
--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -402,8 +402,11 @@ def should_run_benchmarks(branch: str | None = None) -> bool:
     Benchmarks run when any of the following conditions are met:
 
     1. Core C++ files changed (esphome/core/*)
-    2. A directly changed component has benchmark files (no dependency expansion)
-    3. Benchmark infrastructure changed (tests/benchmarks/*, script/cpp_benchmark.py,
+    2. The host platform changed (esphome/components/host/*) — benchmarks
+       are built and run on the host platform, so its implementations of
+       ``millis()``/``micros()``/etc. affect every benchmark
+    3. A directly changed component has benchmark files (no dependency expansion)
+    4. Benchmark infrastructure changed (tests/benchmarks/*, script/cpp_benchmark.py,
        script/build_helpers.py, script/setup_codspeed_lib.py)
 
     Unlike unit tests, benchmarks do NOT expand to dependent components.
@@ -418,6 +421,10 @@ def should_run_benchmarks(branch: str | None = None) -> bool:
     """
     files = changed_files(branch)
     if core_changed(files):
+        return True
+
+    # Host platform supplies the runtime that benchmarks execute on
+    if any(f.startswith("esphome/components/host/") for f in files):
         return True
 
     # Check if benchmark infrastructure changed

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1842,6 +1842,22 @@ def test_should_run_benchmarks_core_header_change() -> None:
         assert determine_jobs.should_run_benchmarks() is True
 
 
+def test_should_run_benchmarks_host_platform_change() -> None:
+    """Test benchmarks trigger on host platform changes.
+
+    Benchmarks build and run on the host platform, so changes to its
+    millis()/micros()/etc. implementations affect every benchmark.
+    """
+    for host_file in [
+        "esphome/components/host/core.cpp",
+        "esphome/components/host/__init__.py",
+    ]:
+        with patch.object(determine_jobs, "changed_files", return_value=[host_file]):
+            assert determine_jobs.should_run_benchmarks() is True, (
+                f"Expected benchmarks to run for {host_file}"
+            )
+
+
 def test_should_run_benchmarks_benchmark_infra_change() -> None:
     """Test benchmarks trigger on benchmark infrastructure changes."""
     for infra_file in [


### PR DESCRIPTION
# What does this implement/fix?

Make `should_run_benchmarks()` in `script/determine-jobs.py` return `True` when any file under `esphome/components/host/` changes.

The CodSpeed benchmark binary is built on, and runs against, the host platform's implementations of `millis()`, `micros()`, `delay()`, `arch_get_cpu_cycle_count()`, etc. (see `esphome/components/host/core.cpp`). Any change to those functions affects every benchmark's timing, so benchmarks should run on host platform changes — not only on `esphome/core/*` changes.

Found while editing `esphome/components/host/core.cpp` and noticing CodSpeed was skipped on a PR that materially changed timing helpers.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840
- [x] Host (CI-only change)

## Example entry for `config.yaml`:

N/A — CI tooling change.

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).