### PR TITLE
[api] Hoist memw out of socket ready check to once per main-loop iter

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -9,6 +9,10 @@
 #include <vector>
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
+
+#if defined(USE_LWIP_FAST_SELECT) && defined(ESPHOME_THREAD_MULTI_ATOMICS)
+#include <atomic>  // for std::atomic_thread_fence in Application::loop()
+#endif
 #include "esphome/core/hal.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/preferences.h"
@@ -542,6 +546,14 @@ inline ESPHOME_ALWAYS_INLINE Application::ComponentPhaseGuard::ComponentPhaseGua
 }
 
 inline void ESPHOME_ALWAYS_INLINE Application::loop() {
+#if defined(USE_LWIP_FAST_SELECT) && defined(ESPHOME_THREAD_MULTI_ATOMICS)
+  // Pairs with the TCP/IP thread's SYS_ARCH_UNPROTECT release on rcvevent so
+  // every Socket::ready() in this iter uses a relaxed load (no per-call memw).
+  // Wake is independent (xTaskNotifyGive/ulTaskNotifyTake), so non-losing.
+  // Skipped on MULTI_NO_ATOMICS (e.g. BK72xx) — that path keeps `volatile` in
+  // esphome_lwip_socket_has_data() instead.
+  std::atomic_thread_fence(std::memory_order_acquire);
+#endif
 #ifdef USE_RUNTIME_STATS
   // Capture the start of the active (non-sleeping) portion of this iteration.
   // Used to derive main-loop overhead = active time − Σ(component time) −

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -548,10 +548,11 @@ inline ESPHOME_ALWAYS_INLINE Application::ComponentPhaseGuard::ComponentPhaseGua
 inline void ESPHOME_ALWAYS_INLINE Application::loop() {
 #if defined(USE_LWIP_FAST_SELECT) && defined(ESPHOME_THREAD_MULTI_ATOMICS)
   // Pairs with the TCP/IP thread's SYS_ARCH_UNPROTECT release on rcvevent so
-  // every Socket::ready() in this iter uses a relaxed load (no per-call memw).
-  // Wake is independent (xTaskNotifyGive/ulTaskNotifyTake), so non-losing.
-  // Skipped on MULTI_NO_ATOMICS (e.g. BK72xx) — that path keeps `volatile` in
-  // esphome_lwip_socket_has_data() instead.
+  // subsequent Socket::ready() checks in this iter observe the published state
+  // without a per-call memw. Wake is independent (xTaskNotifyGive/
+  // ulTaskNotifyTake), so non-losing. Skipped on MULTI_NO_ATOMICS (e.g.
+  // BK72xx) — that path keeps `volatile` in esphome_lwip_socket_has_data()
+  // instead.
   std::atomic_thread_fence(std::memory_order_acquire);
 #endif
 #ifdef USE_RUNTIME_STATS

--- a/esphome/core/lwip_fast_select.h
+++ b/esphome/core/lwip_fast_select.h
@@ -26,25 +26,23 @@ extern "C" {
 struct lwip_sock *esphome_lwip_get_sock(int fd);
 
 /// Check if a cached LwIP socket has data ready via unlocked hint read of rcvevent.
-/// This avoids lwIP core lock contention between the main loop (CPU0) and
-/// streaming/networking work (CPU1). Correctness is preserved because callers
-/// already handle EWOULDBLOCK on nonblocking sockets — a stale hint simply causes
-/// a harmless retry on the next loop iteration. In practice, stale reads have not
-/// been observed across multi-day testing, but the design does not depend on that.
-///
-/// The sock pointer must have been obtained from esphome_lwip_get_sock() and must
-/// remain valid (caller owns socket lifetime — no concurrent close).
-/// Hot path: inlined volatile 16-bit load — no function call overhead.
-/// Uses offset-based access because lwip/priv/sockets_priv.h conflicts with C++.
+/// On ESPHOME_THREAD_MULTI_ATOMICS builds, the caller must run on the main
+/// loop task after Application::loop's per-iter std::atomic_thread_fence
+/// (memory_order_acquire); that fence pairs with the TCP/IP thread's
+/// SYS_ARCH_UNPROTECT release, so a plain load suffices and avoids the
+/// per-call `memw` that volatile would emit on Xtensa under default
+/// -mserialize-volatile. Without atomics (e.g. BK72xx), the fence is skipped
+/// and the volatile load provides ordering on its own.
+/// Stale reads are harmless either way: the hooked event_callback
+/// xTaskNotifyGives on RCVPLUS, so the next iteration re-snapshots and
+/// ulTaskNotifyTake never loses a wake.
 /// The offset and size are verified at compile time in lwip_fast_select.c.
 static inline bool esphome_lwip_socket_has_data(struct lwip_sock *sock) {
-  // Unlocked hint read — no lwIP core lock needed.
-  // volatile prevents the compiler from caching/reordering this cross-thread read.
-  // The write side (TCP/IP thread) commits via SYS_ARCH_UNPROTECT which releases a
-  // FreeRTOS mutex (ESP32) or resumes the scheduler (LibreTiny), ensuring the value
-  // is visible. Aligned 16-bit reads are single-instruction loads (L16SI/LH/LDRH) on
-  // Xtensa/RISC-V/ARM and cannot produce torn values.
+#ifdef ESPHOME_THREAD_MULTI_ATOMICS
+  return *(int16_t *) ((char *) sock + (int) ESPHOME_LWIP_SOCK_RCVEVENT_OFFSET) > 0;
+#else
   return *(volatile int16_t *) ((char *) sock + (int) ESPHOME_LWIP_SOCK_RCVEVENT_OFFSET) > 0;
+#endif
 }
 
 /// Hook a socket's netconn callback to notify the main loop task on receive events.


### PR DESCRIPTION
# What does this implement/fix?

On Xtensa under default `-mserialize-volatile`, GCC emits a `memw` before every `volatile` load. `esphome_lwip_socket_has_data()` is called once per socket per main-loop iteration (one for the listening socket in `APIServer::loop`, one per connected client in `APIConnection::loop`, plus other `Socket::ready()` callers like `AsyncClient::loop` and the captive-portal DNS server), making per-call `memw` a measurable cost on the idle path.

This replaces the per-call `memw` with a single `std::atomic_thread_fence(std::memory_order_acquire)` at the top of `Application::loop()`. The fence pairs with the TCP/IP thread's existing release barrier in `SYS_ARCH_UNPROTECT` when it bumps `rcvevent`.

The wake path is independent of `rcvevent` visibility and is non-losing:

- The lwip event-callback hook (`lwip_fast_select.c`) calls `xTaskNotifyGive` on every `RCVPLUS`.
- The main loop sleeps in `ulTaskNotifyTake(pdTRUE, …)` (`wake.h`).
- FreeRTOS task notifications use internal critical sections; a `xTaskNotifyGive` arriving between the fence and the sleep call increments the counter atomically, so `ulTaskNotifyTake` returns immediately and the next iteration runs (re-snapshotting `rcvevent` under a fresh fence).

So: a write that lands between this iteration's fence and the next sleep is picked up by the next iteration; no wakes are lost.

The optimization is gated on `ESPHOME_THREAD_MULTI_ATOMICS`. BK72xx (ARMv5TE, lacks LDREX/STREX, intentionally built without libatomic) keeps the original `volatile` load path. ESP32, RTL87xx and LN882x get the optimization. ESP8266 / RP2040 / host go through the `socket_ready_fd` fallback and are unaffected.

**Disassembly diff** (ESP32 IDF, gatetrigger):

| Function | Before | After | Δ |
|---|---|---|---|
| `APIServer::loop` | 183 B | 175 B | −8 B (no `memw` before rcvevent `l16si`) |
| `APIConnection::loop` | 296 B | 291 B | −5 B (same) |
| `loop_task` | n/a | n/a | +1 `memw` (fence) |

Net per idle iteration with N API clients: save N `memw` on ready paths, add 1 for the fence. Savings scale with client count and grow further when other `Socket::ready()` callers (`AsyncClient::loop`, captive-portal DNS) are active.

**Measured runtime impact** (ESP32, gatetrigger, 60s `runtime_stats` window, stabilized device, **single API connection** — multi-client setups will see proportionally larger wins):

| Metric | Before | After | Δ |
|---|---|---|---|
| `api` total | 16.4 ms | 14.9 ms | **−1.5 ms (−9.1%)** |
| `api` avg | 0.004 ms | 0.004 ms | ≈ |
| `main_loop active_total` | 53.6 ms | 51.6 ms | −2.0 ms |
| `main_loop overhead_total` | 36.9 ms | 35.7 ms | −1.2 ms |
| `inter_component` | 13.1 ms | 10.6 ms | −2.5 ms |
| iters | 3751 | 3750 | ≈ |

The `api` slice is the cleanest signal — same iteration count, same work, ~9% less time per 60-second window with one client. Most of the savings show up in `inter_component` (the gap between component loop calls), which is where the per-call `memw` was sitting. With a second or third API client connected, per-iter savings grow linearly since each adds another `Socket::ready()` call.

`max` values also moved down (`api max` 2.39 → 1.35 ms, `active_max` 2.42 → 1.38 ms) but those are single-iteration spikes and could be network jitter / Wi-Fi activity rather than this change.

**Tested on:** ESP32 IDF (gatetrigger), BK72xx, RTL87xx, ESP8266 (compile only) — all building and running cleanly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

```yaml
# No user-facing config change. Verified with the standard api: stanza.
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
