### PR TITLE
[bluetooth_proxy] Drop redundant remote_bda_ write in connect handler

### DIFF
--- a/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
+++ b/esphome/components/bluetooth_proxy/bluetooth_proxy.cpp
@@ -201,7 +201,6 @@ void BluetoothProxy::bluetooth_device_request(const api::BluetoothDeviceRequest 
         connection->set_connection_type(espbt::ConnectionType::V3_WITHOUT_CACHE);
         this->log_connection_info_(connection, "v3 without cache");
       }
-      uint64_to_bd_addr(msg.address, connection->remote_bda_);
       connection->set_remote_addr_type(static_cast<esp_ble_addr_type_t>(msg.address_type));
       connection->set_state(espbt::ClientState::DISCOVERED);
       this->send_connections_free();


### PR DESCRIPTION
# What does this implement/fix?

Removes a redundant `uint64_to_bd_addr(msg.address, connection->remote_bda_)` call in `BluetoothProxy::bluetooth_device_request()` for the `BLUETOOTH_DEVICE_REQUEST_TYPE_CONNECT_V3_*` cases.

`get_connection_(msg.address, true)` already guarantees that `connection->remote_bda_` encodes `msg.address` by the time it returns:

- If an existing slot is found because `connection->get_address() == msg.address`, then `address_` and `remote_bda_` already match `msg.address` (they're kept in sync by `set_address()`, the only writer).
- If a free slot is reserved, `connection->set_address(msg.address)` is called, which `BluetoothConnection::set_address` forwards to `BLEClientBase::set_address`, writing `remote_bda_[0..5]` from `msg.address`'s bytes.

The follow-up `uint64_to_bd_addr(msg.address, connection->remote_bda_)` was rewriting the identical 6 bytes. Pure dead code removal — no behavior change.

The `uint64_to_bd_addr` helper itself stays; it's still used by the `UNPAIR` and `CLEAR_CACHE` request paths where the bytes are needed in a local buffer for IDF APIs without a `BluetoothConnection` to pull `remote_bda_` from.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
bluetooth_proxy:
  active: true

esp32_ble_tracker:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
