### PR TITLE
[bh1750] Downgrade per-reading Illuminance log to verbose

### DIFF
--- a/esphome/components/bh1750/bh1750.cpp
+++ b/esphome/components/bh1750/bh1750.cpp
@@ -154,7 +154,7 @@ void BH1750Sensor::loop() {
         break;
       }
 
-      ESP_LOGD(TAG, "'%s': Illuminance=%.1flx", this->get_name().c_str(), lx);
+      ESP_LOGV(TAG, "'%s': Illuminance=%.1flx", this->get_name().c_str(), lx);
       this->status_clear_warning();
       this->publish_state(lx);
       this->state_ = IDLE;


### PR DESCRIPTION
# What does this implement/fix?

The bh1750 sensor logs `'<name>': Illuminance=<value>lx` at `ESP_LOGD` on every reading. The base `sensor` framework already emits the published state at the `[S]` log level on every publish, so the component-level debug line is redundant log spam during normal operation.

Example noise that motivated this change:
```
[D][bh1750.sensor:157]: 'Light Sensor': Illuminance=2.0lx
[S][sensor]: 'Light Sensor' >> 2.0 lx
[D][bh1750.sensor:157]: 'Light Sensor': Illuminance=1.9lx
[S][sensor]: 'Light Sensor' >> 1.9 lx
```

Drop the per-reading bh1750 log to `ESP_LOGV` so it can still be enabled when debugging the component, but is not emitted at the default debug level.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
i2c:
  sda: GPIO21
  scl: GPIO22

sensor:
  - platform: bh1750
    name: "Light Sensor"
    update_interval: 5s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).