### PR TITLE
[core] Share matching PlatformIO libdeps across builds

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -814,8 +814,19 @@ def _check_and_emit_build_info() -> None:
 
 def _get_configured_xtal_freq() -> int | None:
     """Read the configured crystal frequency from the sdkconfig file."""
-    sdkconfig_path = CORE.relative_build_path(f"sdkconfig.{CORE.name}")
-    if not sdkconfig_path.is_file():
+    sdkconfig_paths = [CORE.relative_build_path(f"sdkconfig.{CORE.name}")]
+    if not CORE.using_toolchain_esp_idf:
+        from esphome.platformio.toolchain import platformio_env_name
+
+        sdkconfig_paths.insert(
+            0,
+            CORE.relative_build_path(
+                f"sdkconfig.{platformio_env_name(prefer_existing=True)}"
+            ),
+        )
+
+    sdkconfig_path = next((path for path in sdkconfig_paths if path.is_file()), None)
+    if sdkconfig_path is None:
         return None
     with suppress(OSError, ValueError):
         content = sdkconfig_path.read_text()

--- a/esphome/analyze_memory/cli.py
+++ b/esphome/analyze_memory/cli.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable
 import heapq
+import json
 from operator import itemgetter
 from pathlib import Path
+import re
 import sys
 from typing import TYPE_CHECKING
 
@@ -721,6 +723,48 @@ def analyze_elf(
     return analyzer.generate_report(detailed)
 
 
+_INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
+_INI_AUTO_GENERATE_END = "; =========== AUTO GENERATED CODE END ============"
+
+
+def _read_generated_platformio_env_name(build_path: Path) -> str | None:
+    """Return the generated PlatformIO env name for a build directory."""
+    platformio_ini = build_path / "platformio.ini"
+    if not platformio_ini.is_file():
+        return None
+
+    text = platformio_ini.read_text(encoding="utf-8")
+    begin = text.find(_INI_AUTO_GENERATE_BEGIN)
+    end = text.find(_INI_AUTO_GENERATE_END)
+    if begin != -1 and end != -1 and begin < end:
+        text = text[begin + len(_INI_AUTO_GENERATE_BEGIN) : end]
+
+    env_match = re.search(r"^\[env:([^\]]+)\]", text, flags=re.MULTILINE)
+    return env_match.group(1) if env_match else None
+
+
+def _find_firmware_elf(build_path: Path) -> Path | None:
+    """Find firmware.elf in native and generated PlatformIO build layouts."""
+    candidates = [build_path / "firmware.elf"]
+
+    pioenvs_path = build_path / ".pioenvs"
+    if pioenvs_path.is_dir():
+        if env_name := _read_generated_platformio_env_name(build_path):
+            candidates.append(pioenvs_path / env_name / "firmware.elf")
+        candidates.extend(
+            sorted(
+                pioenvs_path.glob("*/firmware.elf"),
+                key=lambda path: path.stat().st_mtime,
+                reverse=True,
+            )
+        )
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def main():
     """CLI entrypoint for memory analysis."""
     if len(sys.argv) < 2:
@@ -735,9 +779,6 @@ def main():
         sys.exit(1)
 
     build_dir = sys.argv[1]
-
-    # Load build directory
-    import json
 
     from esphome.platformio.toolchain import IDEData
 
@@ -759,17 +800,8 @@ def main():
         print(f"Error: {build_path} is not a directory", file=sys.stderr)
         sys.exit(1)
 
-    # Find firmware.elf
-    elf_file = None
-    for elf_candidate in [
-        build_path / "firmware.elf",
-        build_path / ".pioenvs" / build_path.name / "firmware.elf",
-    ]:
-        if elf_candidate.exists():
-            elf_file = str(elf_candidate)
-            break
-
-    if not elf_file:
+    elf_file = _find_firmware_elf(build_path)
+    if elf_file is None:
         print(f"Error: firmware.elf not found in {build_dir}", file=sys.stderr)
         sys.exit(1)
 
@@ -799,7 +831,7 @@ def main():
             file=sys.stderr,
         )
 
-    analyzer = MemoryAnalyzerCLI(elf_file, idedata=idedata)
+    analyzer = MemoryAnalyzerCLI(str(elf_file), idedata=idedata)
     analyzer.analyze()
     report = analyzer.generate_report()
     print(report)

--- a/esphome/build_gen/platformio.py
+++ b/esphome/build_gen/platformio.py
@@ -1,6 +1,7 @@
 from esphome.const import __version__
 from esphome.core import CORE
 from esphome.helpers import mkdir_p, read_file, write_file_if_changed
+from esphome.platformio.toolchain import platformio_env_name
 from esphome.writer import find_begin_end, update_storage_json
 
 INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
@@ -51,14 +52,13 @@ def get_ini_content():
     content = "[platformio]\n"
     content += f"description = ESPHome {__version__}\n"
 
-    content += f"[env:{CORE.name}]\n"
+    content += f"[env:{platformio_env_name()}]\n"
     content += format_ini(CORE.platformio_options)
 
     return content
 
 
 def write_ini(content):
-    update_storage_json()
     path = CORE.relative_build_path("platformio.ini")
 
     if path.is_file():
@@ -71,6 +71,7 @@ def write_ini(content):
     full_file = f"{content_format[0] + INI_AUTO_GENERATE_BEGIN}\n{content}"
     full_file += INI_AUTO_GENERATE_END + content_format[1]
     write_file_if_changed(path, full_file)
+    update_storage_json()
 
 
 def write_project():

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -2506,13 +2506,20 @@ def _format_sdkconfig_val(value: SdkconfigValueType) -> str:
 
 
 def _write_sdkconfig():
-    # sdkconfig.{name} stores the real sdkconfig (modified by esp-idf with default)
-    # sdkconfig.{name}.esphomeinternal stores what esphome last wrote
+    # sdkconfig.{env} stores the real sdkconfig (modified by esp-idf with defaults).
+    # sdkconfig.{env}.esphomeinternal stores what esphome last wrote.
     # we use the internal one to detect if there were any changes, and if so write them to the
     # real sdkconfig
-    sdk_path = Path(CORE.relative_build_path(f"sdkconfig.{CORE.name}"))
+    if CORE.using_toolchain_esp_idf:
+        sdkconfig_name = CORE.name
+    else:
+        from esphome.platformio.toolchain import platformio_env_name
+
+        sdkconfig_name = platformio_env_name()
+
+    sdk_path = Path(CORE.relative_build_path(f"sdkconfig.{sdkconfig_name}"))
     internal_path = Path(
-        CORE.relative_build_path(f"sdkconfig.{CORE.name}.esphomeinternal")
+        CORE.relative_build_path(f"sdkconfig.{sdkconfig_name}.esphomeinternal")
     )
 
     want_opts = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -782,8 +782,7 @@ class EsphomeCore:
     def relative_piolibdeps_path(self, *path: str | Path) -> Path:
         return self.relative_build_path(".piolibdeps", *path)
 
-    @property
-    def firmware_bin(self) -> Path:
+    def firmware_bin_path(self, *, prefer_existing: bool = True) -> Path:
         # Check if using ESP-IDF toolchain
         if self.using_toolchain_esp_idf:
             return self.relative_build_path("build", f"{self.name}.bin")
@@ -793,10 +792,14 @@ class EsphomeCore:
 
         from esphome.platformio.toolchain import platformio_env_name
 
-        env_name = platformio_env_name(prefer_existing=True)
+        env_name = platformio_env_name(prefer_existing=prefer_existing)
         if self.is_libretiny:
             return self.relative_pioenvs_path(env_name, "firmware.uf2")
         return self.relative_pioenvs_path(env_name, "firmware.bin")
+
+    @property
+    def firmware_bin(self) -> Path:
+        return self.firmware_bin_path()
 
     @property
     def partition_table_bin(self) -> Path:

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -787,12 +787,16 @@ class EsphomeCore:
         # Check if using ESP-IDF toolchain
         if self.using_toolchain_esp_idf:
             return self.relative_build_path("build", f"{self.name}.bin")
-        if self.is_libretiny:
-            return self.relative_pioenvs_path(self.name, "firmware.uf2")
         if self.is_host:
             # Host builds produce a native ELF/Mach-O named `program`.
             return self.relative_pioenvs_path(self.name, "program")
-        return self.relative_pioenvs_path(self.name, "firmware.bin")
+
+        from esphome.platformio.toolchain import platformio_env_name
+
+        env_name = platformio_env_name(prefer_existing=True)
+        if self.is_libretiny:
+            return self.relative_pioenvs_path(env_name, "firmware.uf2")
+        return self.relative_pioenvs_path(env_name, "firmware.bin")
 
     @property
     def partition_table_bin(self) -> Path:
@@ -803,13 +807,21 @@ class EsphomeCore:
             return self.relative_build_path(
                 "build", "partition_table", "partition-table.bin"
             )
-        return self.relative_pioenvs_path(self.name, "partitions.bin")
+        from esphome.platformio.toolchain import platformio_env_name
+
+        return self.relative_pioenvs_path(
+            platformio_env_name(prefer_existing=True), "partitions.bin"
+        )
 
     @property
     def bootloader_bin(self) -> Path:
         if self.using_toolchain_esp_idf:
             return self.relative_build_path("build", "bootloader", "bootloader.bin")
-        return self.relative_pioenvs_path(self.name, "bootloader.bin")
+        from esphome.platformio.toolchain import platformio_env_name
+
+        return self.relative_pioenvs_path(
+            platformio_env_name(prefer_existing=True), "bootloader.bin"
+        )
 
     @property
     def target_platform(self):

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -1,4 +1,5 @@
 import configparser
+from contextlib import contextmanager
 import hashlib
 import json
 import logging
@@ -31,7 +32,7 @@ _PLATFORMIO_ENV_FINGERPRINT_OPTIONS = {
     "platform",
     "platform_packages",
 }
-_managed_platformio_libdeps_dir = {"value": None}
+_PLATFORMIO_MANAGED_LIBDEPS_ENV = "ESPHOME_PLATFORMIO_MANAGED_LIBDEPS_DIR"
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
@@ -90,7 +91,12 @@ def _read_common_platformio_lib_deps() -> list[str]:
     config = configparser.RawConfigParser(strict=False)
     try:
         config.read(platformio_ini, encoding="utf-8")
-    except configparser.Error:
+    except configparser.Error as err:
+        _LOGGER.warning(
+            "Could not parse %s for preserved common lib_deps: %s",
+            platformio_ini,
+            err,
+        )
         return []
 
     if not config.has_option("common", "lib_deps"):
@@ -196,21 +202,72 @@ def _platformio_libdeps_dir(core=CORE) -> Path:
     )
 
 
-def _set_platformio_libdeps_dir() -> None:
+def _platformio_uses_shared_libdeps(core=CORE) -> bool:
+    """Return whether this target uses an ESPHome-managed shared libdeps root."""
+    target_platform = core.data.get(KEY_CORE, {}).get(KEY_TARGET_PLATFORM)
+    return target_platform not in (PLATFORM_HOST, PLATFORM_NRF52)
+
+
+def _platformio_libdeps_lock_path() -> Path:
+    """Return the lock path for the current shared PlatformIO libdeps env."""
+    return CORE.relative_internal_path(
+        "platformio", "libdeps", ".locks", f"{platformio_env_name()}.lock"
+    )
+
+
+def _set_platformio_libdeps_dir() -> Path | None:
     """Set ESPHome-managed libdeps dir while preserving user overrides."""
     libdeps_dir = str(_platformio_libdeps_dir().absolute())
     current = os.environ.get("PLATFORMIO_LIBDEPS_DIR")
-    if current is not None and current != _managed_platformio_libdeps_dir["value"]:
-        return
+    managed = os.environ.get(_PLATFORMIO_MANAGED_LIBDEPS_ENV)
+    if current is not None and current != managed:
+        return None
 
     os.environ["PLATFORMIO_LIBDEPS_DIR"] = libdeps_dir
-    _managed_platformio_libdeps_dir["value"] = libdeps_dir
+    os.environ[_PLATFORMIO_MANAGED_LIBDEPS_ENV] = libdeps_dir
+    if not _platformio_uses_shared_libdeps():
+        return None
+    return _platformio_libdeps_lock_path()
+
+
+@contextmanager
+def _platformio_libdeps_lock(lock_path: Path | None):
+    """Hold a cross-process lock while PlatformIO mutates shared libdeps."""
+    if lock_path is None:
+        yield
+        return
+
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        if os.name == "nt":
+            import msvcrt  # pylint: disable=import-error
+
+            lock_file.seek(0)
+            if not lock_file.read(1):
+                lock_file.write(b"\0")
+                lock_file.flush()
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+            return
+
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
-    _set_platformio_libdeps_dir()
+    libdeps_lock_path = _set_platformio_libdeps_dir()
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
@@ -228,7 +285,8 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
         os.environ["PYTHONEXEPATH"] = python_exe
     cmd = [python_exe, "-m", "esphome.platformio.runner"] + list(args)
 
-    return run_external_process(*cmd, **kwargs)
+    with _platformio_libdeps_lock(libdeps_lock_path):
+        return run_external_process(*cmd, **kwargs)
 
 
 def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -1,5 +1,6 @@
 import configparser
 from contextlib import contextmanager
+import errno
 import hashlib
 import json
 import logging
@@ -7,6 +8,7 @@ import os
 from pathlib import Path
 import re
 import sys
+import time
 
 from esphome.const import (
     CONF_COMPILE_PROCESS_LIMIT,
@@ -28,12 +30,22 @@ _PLATFORMIO_ENV_FINGERPRINT_OPTIONS = {
     "board",
     "framework",
     "lib_compat_mode",
+    "lib_ignore",
     "lib_ldf_mode",
     "platform",
     "platform_packages",
 }
 _PLATFORMIO_MANAGED_LIBDEPS_ENV = "ESPHOME_PLATFORMIO_MANAGED_LIBDEPS_DIR"
 _LOCAL_LIBDEP_URI_PREFIXES = ("file://", "symlink://")
+_HOME_PATH_RE = re.compile(r"^~(?:$|[/\\]|[^/\\]+[/\\])")
+_WINDOWS_LOCK_RETRY_DELAY = 0.1
+_WINDOWS_LOCK_BUSY_ERRNOS = {
+    errno.EACCES,
+    errno.EAGAIN,
+    errno.EDEADLK,
+}
+if hasattr(errno, "EDEADLOCK"):
+    _WINDOWS_LOCK_BUSY_ERRNOS.add(errno.EDEADLOCK)
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
@@ -121,10 +133,24 @@ def _resolve_local_lib_dep_uri(value: str, project_dir: Path) -> str | None:
     for prefix in _LOCAL_LIBDEP_URI_PREFIXES:
         if not value.startswith(prefix):
             continue
-        target = Path(value[len(prefix) :]).expanduser()
+        target = _platformio_path_value(value[len(prefix) :])
+        if target is None:
+            return None
         resolved = target if target.is_absolute() else project_dir / target
         return f"{prefix}{resolved.resolve()}"
     return None
+
+
+def _platformio_path_value(value: str) -> Path | None:
+    """Return a path candidate, keeping semver "~" constraints literal."""
+    if not value.startswith("~"):
+        return Path(value)
+    if not _HOME_PATH_RE.match(value):
+        return None
+    try:
+        return Path(value).expanduser()
+    except RuntimeError:
+        return None
 
 
 def _resolve_local_lib_dep_target(value: str, project_dir: Path) -> str | None:
@@ -133,7 +159,9 @@ def _resolve_local_lib_dep_target(value: str, project_dir: Path) -> str | None:
     if resolved_uri := _resolve_local_lib_dep_uri(value, project_dir):
         return resolved_uri
 
-    path = Path(value).expanduser()
+    path = _platformio_path_value(value)
+    if path is None:
+        return None
     if path.is_absolute() or value.startswith((".", "~")):
         resolved = path if path.is_absolute() else project_dir / path
         return str(resolved.resolve())
@@ -194,17 +222,61 @@ def _platformio_libdeps_fingerprint_values() -> list[str]:
 
 def _platformio_env_fingerprint_values() -> dict[str, object]:
     """Return values that must stay compatible inside one PlatformIO env."""
+    project_dir = Path(CORE.build_path)
     platformio_options = {}
     for key, value in sorted(CORE.platformio_options.items()):
         if key == "lib_deps":
             continue
         if key in _PLATFORMIO_ENV_FINGERPRINT_OPTIONS or key.startswith("board_build."):
-            platformio_options[key] = _normalize_platformio_values(value)
+            values = _normalize_platformio_values(value)
+            if key in {"platform", "platform_packages"}:
+                values = [
+                    _platformio_lib_dep_fingerprint_value(item, project_dir)
+                    for item in values
+                ]
+            platformio_options[key] = values
 
     return {
         "lib_deps": _platformio_libdeps_fingerprint_values(),
         "platformio_options": platformio_options,
     }
+
+
+def _platformio_env_matches_current_device(env_name: str) -> bool:
+    """Return whether an env name can safely be reused for this config."""
+    if CORE.name and env_name == CORE.name:
+        return True
+
+    device_scope = _platformio_env_device_scope()
+    return env_name.startswith(f"{device_scope}{_platformio_toolchain_cache_key()}-")
+
+
+def _read_stored_platformio_env_name() -> str | None:
+    """Return the env name stored by the last compile for this config."""
+    from esphome.storage_json import StorageJSON, ext_storage_path
+
+    if not isinstance(CORE.config_path, Path):
+        return None
+
+    storage = StorageJSON.load(ext_storage_path(CORE.config_path.name))
+    if storage is None or storage.firmware_bin_path is None:
+        return None
+
+    env_dir = storage.firmware_bin_path.parent
+    pioenvs_dir = CORE.relative_pioenvs_path()
+    try:
+        relative = env_dir.relative_to(pioenvs_dir)
+    except ValueError:
+        try:
+            relative = env_dir.resolve().relative_to(pioenvs_dir.resolve())
+        except ValueError:
+            return None
+
+    if len(relative.parts) != 1:
+        return None
+
+    env_name = relative.parts[0]
+    return env_name if _platformio_env_matches_current_device(env_name) else None
 
 
 def _read_generated_platformio_env_name() -> str | None:
@@ -224,7 +296,10 @@ def _read_generated_platformio_env_name() -> str | None:
         text,
         flags=re.MULTILINE,
     )
-    return env_match.group(1) if env_match else None
+    if env_match is None:
+        return None
+    env_name = env_match.group(1)
+    return env_name if _platformio_env_matches_current_device(env_name) else None
 
 
 def platformio_env_name(*, prefer_existing: bool = False) -> str:
@@ -233,8 +308,11 @@ def platformio_env_name(*, prefer_existing: bool = False) -> str:
     if target_platform in (PLATFORM_HOST, PLATFORM_NRF52):
         return CORE.name
 
-    if prefer_existing and (env_name := _read_generated_platformio_env_name()):
-        return env_name
+    if prefer_existing:
+        if env_name := _read_generated_platformio_env_name():
+            return env_name
+        if env_name := _read_stored_platformio_env_name():
+            return env_name
 
     fingerprint = hashlib.sha256(
         json.dumps(_platformio_env_fingerprint_values(), sort_keys=True).encode()
@@ -281,6 +359,26 @@ def _set_platformio_libdeps_dir(env_name: str | None = None) -> Path | None:
     return _platformio_libdeps_lock_path(env_name)
 
 
+def _lock_windows_file_byte(lock_file) -> None:
+    """Block until the first byte of ``lock_file`` can be locked on Windows."""
+    import msvcrt  # pylint: disable=import-error
+
+    lock_file.seek(0)
+    if not lock_file.read(1):
+        lock_file.write(b"\0")
+        lock_file.flush()
+
+    while True:
+        lock_file.seek(0)
+        try:
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+        except OSError as err:
+            if err.errno not in _WINDOWS_LOCK_BUSY_ERRNOS:
+                raise
+            time.sleep(_WINDOWS_LOCK_RETRY_DELAY)
+
+
 @contextmanager
 def _platformio_libdeps_lock(lock_path: Path | None):
     """Hold a cross-process lock while PlatformIO mutates shared libdeps."""
@@ -293,12 +391,7 @@ def _platformio_libdeps_lock(lock_path: Path | None):
         if os.name == "nt":
             import msvcrt  # pylint: disable=import-error
 
-            lock_file.seek(0)
-            if not lock_file.read(1):
-                lock_file.write(b"\0")
-                lock_file.flush()
-            lock_file.seek(0)
-            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+            _lock_windows_file_byte(lock_file)
             try:
                 yield
             finally:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -232,7 +232,7 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
 
 
 def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:
-    command = ["run", "-d", str(CORE.build_path)]
+    command = ["run", "-d", str(CORE.build_path), "-e", platformio_env_name()]
     if verbose:
         command += ["-v"]
     command += list(args)

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 import hashlib
 import json
 import logging

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -33,6 +33,7 @@ _PLATFORMIO_ENV_FINGERPRINT_OPTIONS = {
     "platform_packages",
 }
 _PLATFORMIO_MANAGED_LIBDEPS_ENV = "ESPHOME_PLATFORMIO_MANAGED_LIBDEPS_DIR"
+_LOCAL_LIBDEP_URI_PREFIXES = ("file://", "symlink://")
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
@@ -105,8 +106,26 @@ def _read_common_platformio_lib_deps() -> list[str]:
     return _normalize_platformio_values(config.get("common", "lib_deps").splitlines())
 
 
+def _resolve_local_lib_dep_uri(value: str, project_dir: Path) -> str | None:
+    for prefix in _LOCAL_LIBDEP_URI_PREFIXES:
+        if not value.startswith(prefix):
+            continue
+        target = Path(value[len(prefix) :]).expanduser()
+        resolved = target if target.is_absolute() else project_dir / target
+        return f"{prefix}{resolved.resolve()}"
+    return None
+
+
 def _platformio_lib_dep_fingerprint_value(lib_dep: str, project_dir: Path) -> str:
     """Return a stable fingerprint value for one PlatformIO library dependency."""
+    lib_dep = lib_dep.strip()
+    if "=" in lib_dep:
+        name, value = lib_dep.split("=", 1)
+        if resolved_uri := _resolve_local_lib_dep_uri(value.strip(), project_dir):
+            return f"{name.strip()}={resolved_uri}"
+    elif resolved_uri := _resolve_local_lib_dep_uri(lib_dep, project_dir):
+        return resolved_uri
+
     path = Path(lib_dep).expanduser()
     if path.is_absolute() or lib_dep.startswith((".", "~")):
         resolved = path if path.is_absolute() else project_dir / path

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+import hashlib
 import json
 import logging
 import os
@@ -5,7 +7,15 @@ from pathlib import Path
 import re
 import sys
 
-from esphome.const import CONF_COMPILE_PROCESS_LIMIT, CONF_ESPHOME, KEY_CORE
+from esphome.const import (
+    CONF_COMPILE_PROCESS_LIMIT,
+    CONF_ESPHOME,
+    KEY_CORE,
+    KEY_TARGET_FRAMEWORK,
+    KEY_TARGET_PLATFORM,
+    PLATFORM_HOST,
+    PLATFORM_NRF52,
+)
 from esphome.core import CORE, EsphomeError
 from esphome.util import FlashImage, run_external_process
 
@@ -43,11 +53,43 @@ def _strip_win_long_path_prefix(path: str) -> str:
     return path
 
 
+def _platformio_toolchain_cache_key() -> str:
+    """Return the stable key used for toolchain-scoped PlatformIO state."""
+    core_data = CORE.data.get(KEY_CORE, {})
+    platform = core_data.get(KEY_TARGET_PLATFORM) or "unknown"
+    framework = core_data.get(KEY_TARGET_FRAMEWORK) or "unknown"
+    return re.sub(r"[^a-zA-Z0-9_.-]", "_", f"{platform}-{framework}")
+
+
+def _normalize_platformio_values(value: str | list[str] | None) -> list[str]:
+    """Return sorted PlatformIO values for stable fingerprints."""
+    if value is None:
+        return []
+    values = [value] if isinstance(value, str) else value
+    return sorted({item for item in values if item and item != "${common.lib_deps}"})
+
+
+def _platformio_libdeps_dir() -> Path:
+    """Return a libdeps path shared by equivalent embedded PlatformIO configs."""
+    target_platform = CORE.data.get(KEY_CORE, {}).get(KEY_TARGET_PLATFORM)
+    if target_platform in (PLATFORM_HOST, PLATFORM_NRF52):
+        return CORE.relative_piolibdeps_path()
+
+    lib_deps = _normalize_platformio_values(CORE.platformio_options.get("lib_deps"))
+    if not lib_deps:
+        lib_deps = sorted(x.as_lib_dep for x in CORE.platformio_libraries.values())
+
+    fingerprint = hashlib.sha256(json.dumps(lib_deps).encode()).hexdigest()[:16]
+    return CORE.relative_internal_path(
+        "platformio", "libdeps", _platformio_toolchain_cache_key(), fingerprint
+    )
+
+
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
     os.environ.setdefault(
-        "PLATFORMIO_LIBDEPS_DIR", str(CORE.relative_piolibdeps_path().absolute())
+        "PLATFORMIO_LIBDEPS_DIR", str(_platformio_libdeps_dir().absolute())
     )
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -75,6 +75,17 @@ def _platformio_toolchain_cache_key(core=CORE) -> str:
     return re.sub(r"[^a-zA-Z0-9_.-]", "_", f"{platform}-{framework}")
 
 
+def _platformio_env_device_scope(core=CORE) -> str:
+    """Return a device-name env prefix when build outputs share a project dir."""
+    if not core.name or core.build_path is None:
+        return ""
+
+    if Path(core.build_path).name == core.name:
+        return ""
+
+    return f"{core.name}-"
+
+
 def _normalize_platformio_values(value: str | list[str] | None) -> list[str]:
     """Return sorted PlatformIO values for stable fingerprints."""
     if value is None:
@@ -228,7 +239,7 @@ def platformio_env_name(*, prefer_existing: bool = False) -> str:
     fingerprint = hashlib.sha256(
         json.dumps(_platformio_env_fingerprint_values(), sort_keys=True).encode()
     ).hexdigest()[:16]
-    return f"{_platformio_toolchain_cache_key()}-{fingerprint}"
+    return f"{_platformio_env_device_scope()}{_platformio_toolchain_cache_key()}-{fingerprint}"
 
 
 def _platformio_libdeps_dir(core=CORE) -> Path:

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -198,13 +198,10 @@ def _platformio_libdeps_fingerprint_values() -> list[str]:
     generated_lib_deps = [x.as_lib_dep for x in CORE.platformio_libraries.values()] + [
         "${common.lib_deps}"
     ]
-    configured_lib_deps = CORE.platformio_options.get("lib_deps")
-    if isinstance(configured_lib_deps, list):
-        lib_deps = _normalize_platformio_values(
-            configured_lib_deps + generated_lib_deps
-        )
-    else:
-        lib_deps = _normalize_platformio_values(generated_lib_deps)
+    configured_lib_deps = _normalize_platformio_values(
+        CORE.platformio_options.get("lib_deps")
+    )
+    lib_deps = _normalize_platformio_values(configured_lib_deps + generated_lib_deps)
 
     project_dir = Path(CORE.build_path)
     values = []

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -116,20 +116,31 @@ def _resolve_local_lib_dep_uri(value: str, project_dir: Path) -> str | None:
     return None
 
 
+def _resolve_local_lib_dep_target(value: str, project_dir: Path) -> str | None:
+    """Return a resolved target for local PlatformIO dependency specs."""
+    value = value.strip()
+    if resolved_uri := _resolve_local_lib_dep_uri(value, project_dir):
+        return resolved_uri
+
+    path = Path(value).expanduser()
+    if path.is_absolute() or value.startswith((".", "~")):
+        resolved = path if path.is_absolute() else project_dir / path
+        return str(resolved.resolve())
+    return None
+
+
 def _platformio_lib_dep_fingerprint_value(lib_dep: str, project_dir: Path) -> str:
     """Return a stable fingerprint value for one PlatformIO library dependency."""
     lib_dep = lib_dep.strip()
     if "=" in lib_dep:
         name, value = lib_dep.split("=", 1)
-        if resolved_uri := _resolve_local_lib_dep_uri(value.strip(), project_dir):
-            return f"{name.strip()}={resolved_uri}"
-    elif resolved_uri := _resolve_local_lib_dep_uri(lib_dep, project_dir):
-        return resolved_uri
+        value = value.strip()
+        if resolved_target := _resolve_local_lib_dep_target(value, project_dir):
+            return f"{name.strip()}={resolved_target}"
+        return f"{name.strip()}={value}"
 
-    path = Path(lib_dep).expanduser()
-    if path.is_absolute() or lib_dep.startswith((".", "~")):
-        resolved = path if path.is_absolute() else project_dir / path
-        return str(resolved.resolve())
+    if resolved_target := _resolve_local_lib_dep_target(lib_dep, project_dir):
+        return resolved_target
     return lib_dep
 
 
@@ -227,14 +238,14 @@ def _platformio_uses_shared_libdeps(core=CORE) -> bool:
     return target_platform not in (PLATFORM_HOST, PLATFORM_NRF52)
 
 
-def _platformio_libdeps_lock_path() -> Path:
+def _platformio_libdeps_lock_path(env_name: str | None = None) -> Path:
     """Return the lock path for the current shared PlatformIO libdeps env."""
     return CORE.relative_internal_path(
-        "platformio", "libdeps", ".locks", f"{platformio_env_name()}.lock"
+        "platformio", "libdeps", ".locks", f"{env_name or platformio_env_name()}.lock"
     )
 
 
-def _set_platformio_libdeps_dir() -> Path | None:
+def _set_platformio_libdeps_dir(env_name: str | None = None) -> Path | None:
     """Set ESPHome-managed libdeps dir while preserving user overrides."""
     libdeps_dir = str(_platformio_libdeps_dir().absolute())
     current = os.environ.get("PLATFORMIO_LIBDEPS_DIR")
@@ -246,7 +257,7 @@ def _set_platformio_libdeps_dir() -> Path | None:
     os.environ[_PLATFORMIO_MANAGED_LIBDEPS_ENV] = libdeps_dir
     if not _platformio_uses_shared_libdeps():
         return None
-    return _platformio_libdeps_lock_path()
+    return _platformio_libdeps_lock_path(env_name)
 
 
 @contextmanager
@@ -283,10 +294,12 @@ def _platformio_libdeps_lock(lock_path: Path | None):
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
 
-def run_platformio_cli(*args, **kwargs) -> str | int:
+def run_platformio_cli(
+    *args, libdeps_env_name: str | None = None, **kwargs
+) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
-    libdeps_lock_path = _set_platformio_libdeps_dir()
+    libdeps_lock_path = _set_platformio_libdeps_dir(libdeps_env_name)
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
@@ -309,17 +322,18 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
 
 
 def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:
+    env_name = platformio_env_name(prefer_existing=True)
     command = [
         "run",
         "-d",
         str(CORE.build_path),
         "-e",
-        platformio_env_name(prefer_existing=True),
+        env_name,
     ]
     if verbose:
         command += ["-v"]
     command += list(args)
-    return run_platformio_cli(*command, **kwargs)
+    return run_platformio_cli(*command, libdeps_env_name=env_name, **kwargs)
 
 
 def run_compile(config, verbose):

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -1,3 +1,4 @@
+import configparser
 import hashlib
 import json
 import logging
@@ -19,6 +20,18 @@ from esphome.core import CORE, EsphomeError
 from esphome.util import FlashImage, run_external_process
 
 _LOGGER = logging.getLogger(__name__)
+
+_INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
+_INI_AUTO_GENERATE_END = "; =========== AUTO GENERATED CODE END ============"
+_PLATFORMIO_ENV_FINGERPRINT_OPTIONS = {
+    "board",
+    "framework",
+    "lib_compat_mode",
+    "lib_ldf_mode",
+    "platform",
+    "platform_packages",
+}
+_managed_platformio_libdeps_dir = {"value": None}
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
@@ -52,9 +65,9 @@ def _strip_win_long_path_prefix(path: str) -> str:
     return path
 
 
-def _platformio_toolchain_cache_key() -> str:
+def _platformio_toolchain_cache_key(core=CORE) -> str:
     """Return the stable key used for toolchain-scoped PlatformIO state."""
-    core_data = CORE.data.get(KEY_CORE, {})
+    core_data = core.data.get(KEY_CORE, {})
     platform = core_data.get(KEY_TARGET_PLATFORM) or "unknown"
     framework = core_data.get(KEY_TARGET_FRAMEWORK) or "unknown"
     return re.sub(r"[^a-zA-Z0-9_.-]", "_", f"{platform}-{framework}")
@@ -65,31 +78,139 @@ def _normalize_platformio_values(value: str | list[str] | None) -> list[str]:
     if value is None:
         return []
     values = [value] if isinstance(value, str) else value
-    return sorted({item for item in values if item and item != "${common.lib_deps}"})
+    return sorted({item for item in values if item})
 
 
-def _platformio_libdeps_dir() -> Path:
-    """Return a libdeps path shared by equivalent embedded PlatformIO configs."""
+def _read_common_platformio_lib_deps() -> list[str]:
+    """Return preserved user lib_deps from the existing platformio.ini common section."""
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    if not platformio_ini.is_file():
+        return []
+
+    config = configparser.RawConfigParser(strict=False)
+    try:
+        config.read(platformio_ini, encoding="utf-8")
+    except configparser.Error:
+        return []
+
+    if not config.has_option("common", "lib_deps"):
+        return []
+
+    return _normalize_platformio_values(config.get("common", "lib_deps").splitlines())
+
+
+def _platformio_lib_dep_fingerprint_value(lib_dep: str, project_dir: Path) -> str:
+    """Return a stable fingerprint value for one PlatformIO library dependency."""
+    path = Path(lib_dep).expanduser()
+    if path.is_absolute() or lib_dep.startswith((".", "~")):
+        resolved = path if path.is_absolute() else project_dir / path
+        return str(resolved.resolve())
+    return lib_dep
+
+
+def _platformio_libdeps_fingerprint_values() -> list[str]:
+    """Return dependency values with project-local paths resolved for cache safety."""
+    generated_lib_deps = [x.as_lib_dep for x in CORE.platformio_libraries.values()] + [
+        "${common.lib_deps}"
+    ]
+    configured_lib_deps = CORE.platformio_options.get("lib_deps")
+    if isinstance(configured_lib_deps, list):
+        lib_deps = _normalize_platformio_values(
+            configured_lib_deps + generated_lib_deps
+        )
+    else:
+        lib_deps = _normalize_platformio_values(generated_lib_deps)
+
+    project_dir = Path(CORE.build_path)
+    values = []
+    for lib_dep in lib_deps:
+        if lib_dep == "${common.lib_deps}":
+            values.extend(
+                _platformio_lib_dep_fingerprint_value(common_lib_dep, project_dir)
+                for common_lib_dep in _read_common_platformio_lib_deps()
+            )
+            continue
+
+        values.append(_platformio_lib_dep_fingerprint_value(lib_dep, project_dir))
+    return values
+
+
+def _platformio_env_fingerprint_values() -> dict[str, object]:
+    """Return values that must stay compatible inside one PlatformIO env."""
+    platformio_options = {}
+    for key, value in sorted(CORE.platformio_options.items()):
+        if key == "lib_deps":
+            continue
+        if key in _PLATFORMIO_ENV_FINGERPRINT_OPTIONS or key.startswith("board_build."):
+            platformio_options[key] = _normalize_platformio_values(value)
+
+    return {
+        "lib_deps": _platformio_libdeps_fingerprint_values(),
+        "platformio_options": platformio_options,
+    }
+
+
+def _read_generated_platformio_env_name() -> str | None:
+    """Return the env name from an existing generated platformio.ini."""
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    if not platformio_ini.is_file():
+        return None
+
+    text = platformio_ini.read_text(encoding="utf-8")
+    begin = text.find(_INI_AUTO_GENERATE_BEGIN)
+    end = text.find(_INI_AUTO_GENERATE_END)
+    if begin != -1 and end != -1 and begin < end:
+        text = text[begin + len(_INI_AUTO_GENERATE_BEGIN) : end]
+
+    env_match = re.search(
+        r"^\[env:([^\]]+)\]",
+        text,
+        flags=re.MULTILINE,
+    )
+    return env_match.group(1) if env_match else None
+
+
+def platformio_env_name(*, prefer_existing: bool = False) -> str:
+    """Return the generated PlatformIO env name for this build."""
     target_platform = CORE.data.get(KEY_CORE, {}).get(KEY_TARGET_PLATFORM)
     if target_platform in (PLATFORM_HOST, PLATFORM_NRF52):
-        return CORE.relative_piolibdeps_path()
+        return CORE.name
 
-    lib_deps = _normalize_platformio_values(CORE.platformio_options.get("lib_deps"))
-    if not lib_deps:
-        lib_deps = sorted(x.as_lib_dep for x in CORE.platformio_libraries.values())
+    if prefer_existing and (env_name := _read_generated_platformio_env_name()):
+        return env_name
 
-    fingerprint = hashlib.sha256(json.dumps(lib_deps).encode()).hexdigest()[:16]
-    return CORE.relative_internal_path(
-        "platformio", "libdeps", _platformio_toolchain_cache_key(), fingerprint
+    fingerprint = hashlib.sha256(
+        json.dumps(_platformio_env_fingerprint_values(), sort_keys=True).encode()
+    ).hexdigest()[:16]
+    return f"{_platformio_toolchain_cache_key()}-{fingerprint}"
+
+
+def _platformio_libdeps_dir(core=CORE) -> Path:
+    """Return a libdeps path shared by equivalent embedded PlatformIO configs."""
+    target_platform = core.data.get(KEY_CORE, {}).get(KEY_TARGET_PLATFORM)
+    if target_platform in (PLATFORM_HOST, PLATFORM_NRF52):
+        return core.relative_piolibdeps_path()
+
+    return core.relative_internal_path(
+        "platformio", "libdeps", _platformio_toolchain_cache_key(core)
     )
+
+
+def _set_platformio_libdeps_dir() -> None:
+    """Set ESPHome-managed libdeps dir while preserving user overrides."""
+    libdeps_dir = str(_platformio_libdeps_dir().absolute())
+    current = os.environ.get("PLATFORMIO_LIBDEPS_DIR")
+    if current is not None and current != _managed_platformio_libdeps_dir["value"]:
+        return
+
+    os.environ["PLATFORMIO_LIBDEPS_DIR"] = libdeps_dir
+    _managed_platformio_libdeps_dir["value"] = libdeps_dir
 
 
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
-    os.environ.setdefault(
-        "PLATFORMIO_LIBDEPS_DIR", str(_platformio_libdeps_dir().absolute())
-    )
+    _set_platformio_libdeps_dir()
     # Suppress Python syntax warnings from third-party scripts during compilation
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -139,6 +139,16 @@ def _platformio_lib_dep_fingerprint_value(lib_dep: str, project_dir: Path) -> st
             return f"{name.strip()}={resolved_target}"
         return f"{name.strip()}={value}"
 
+    if "@" in lib_dep:
+        name, value = lib_dep.split("@", 1)
+        value = value.strip()
+        if (
+            name.strip()
+            and value
+            and (resolved_target := _resolve_local_lib_dep_target(value, project_dir))
+        ):
+            return f"{name.strip()} @ {resolved_target}"
+
     if resolved_target := _resolve_local_lib_dep_target(lib_dep, project_dir):
         return resolved_target
     return lib_dep

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -290,7 +290,13 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
 
 
 def run_platformio_cli_run(config, verbose, *args, **kwargs) -> str | int:
-    command = ["run", "-d", str(CORE.build_path), "-e", platformio_env_name()]
+    command = [
+        "run",
+        "-d",
+        str(CORE.build_path),
+        "-e",
+        platformio_env_name(prefer_existing=True),
+    ]
     if verbose:
         command += ["-v"]
     command += list(args)

--- a/esphome/storage_json.py
+++ b/esphome/storage_json.py
@@ -184,7 +184,7 @@ class StorageJSON:
             web_port=esph.web_port,
             target_platform=hardware,
             build_path=esph.build_path,
-            firmware_bin_path=esph.firmware_bin,
+            firmware_bin_path=esph.firmware_bin_path(prefer_existing=False),
             loaded_integrations=esph.loaded_integrations,
             loaded_platforms=esph.loaded_platforms,
             no_mdns=(

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -479,15 +479,19 @@ def write_cpp(code_s):
 
 
 def clean_cmake_cache():
+    from esphome.platformio.toolchain import platformio_env_name
+
     pioenvs = CORE.relative_pioenvs_path()
     if pioenvs.is_dir():
-        pioenvs_cmake_path = pioenvs / CORE.name / "CMakeCache.txt"
+        pioenvs_cmake_path = pioenvs / platformio_env_name() / "CMakeCache.txt"
         if pioenvs_cmake_path.is_file():
             _LOGGER.info("Deleting %s", pioenvs_cmake_path)
             pioenvs_cmake_path.unlink()
 
 
 def clean_build(clear_pio_cache: bool = True):
+    from esphome.platformio.toolchain import _platformio_libdeps_dir
+
     # Allow skipping cache cleaning for integration tests
     if os.environ.get("ESPHOME_SKIP_CLEAN_BUILD"):
         _LOGGER.warning("Skipping build cleaning (ESPHOME_SKIP_CLEAN_BUILD set)")
@@ -497,14 +501,11 @@ def clean_build(clear_pio_cache: bool = True):
     if pioenvs.is_dir():
         _LOGGER.info("Deleting %s", pioenvs)
         rmtree(pioenvs)
-    piolibdeps = CORE.relative_piolibdeps_path()
-    if piolibdeps.is_dir():
-        _LOGGER.info("Deleting %s", piolibdeps)
-        rmtree(piolibdeps)
-    shared_piolibdeps = CORE.relative_internal_path("platformio", "libdeps")
-    if shared_piolibdeps.is_dir():
-        _LOGGER.info("Deleting %s", shared_piolibdeps)
-        rmtree(shared_piolibdeps)
+    piolibdeps_dirs = {CORE.relative_piolibdeps_path(), _platformio_libdeps_dir(CORE)}
+    for piolibdeps in piolibdeps_dirs:
+        if piolibdeps.is_dir():
+            _LOGGER.info("Deleting %s", piolibdeps)
+            rmtree(piolibdeps)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -501,6 +501,10 @@ def clean_build(clear_pio_cache: bool = True):
     if piolibdeps.is_dir():
         _LOGGER.info("Deleting %s", piolibdeps)
         rmtree(piolibdeps)
+    shared_piolibdeps = CORE.relative_internal_path("platformio", "libdeps")
+    if shared_piolibdeps.is_dir():
+        _LOGGER.info("Deleting %s", shared_piolibdeps)
+        rmtree(shared_piolibdeps)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -490,8 +490,6 @@ def clean_cmake_cache():
 
 
 def clean_build(clear_pio_cache: bool = True):
-    from esphome.platformio.toolchain import _platformio_libdeps_dir
-
     # Allow skipping cache cleaning for integration tests
     if os.environ.get("ESPHOME_SKIP_CLEAN_BUILD"):
         _LOGGER.warning("Skipping build cleaning (ESPHOME_SKIP_CLEAN_BUILD set)")
@@ -501,11 +499,10 @@ def clean_build(clear_pio_cache: bool = True):
     if pioenvs.is_dir():
         _LOGGER.info("Deleting %s", pioenvs)
         rmtree(pioenvs)
-    piolibdeps_dirs = {CORE.relative_piolibdeps_path(), _platformio_libdeps_dir(CORE)}
-    for piolibdeps in piolibdeps_dirs:
-        if piolibdeps.is_dir():
-            _LOGGER.info("Deleting %s", piolibdeps)
-            rmtree(piolibdeps)
+    piolibdeps = CORE.relative_piolibdeps_path()
+    if piolibdeps.is_dir():
+        _LOGGER.info("Deleting %s", piolibdeps)
+        rmtree(piolibdeps)
     dependencies_lock = CORE.relative_build_path("dependencies.lock")
     if dependencies_lock.is_file():
         _LOGGER.info("Deleting %s", dependencies_lock)

--- a/script/ci_memory_impact_extract.py
+++ b/script/ci_memory_impact_extract.py
@@ -80,15 +80,11 @@ def _pioenv_dirs(build_path: Path) -> list[Path]:
 
 def _find_elf_path(build_path: Path) -> str | None:
     """Find firmware.elf/raw_firmware.elf in current and historical layouts."""
-    for elf_candidate in [
-        build_path / "firmware.elf",
-        *[pioenv_dir / "firmware.elf" for pioenv_dir in _pioenv_dirs(build_path)],
-        # LibreTiny uses raw_firmware.elf
-        build_path / "raw_firmware.elf",
-        *[pioenv_dir / "raw_firmware.elf" for pioenv_dir in _pioenv_dirs(build_path)],
-    ]:
-        if elf_candidate.exists():
-            return str(elf_candidate)
+    for artifact_dir in [build_path, *_pioenv_dirs(build_path)]:
+        for elf_name in ("firmware.elf", "raw_firmware.elf"):
+            elf_candidate = artifact_dir / elf_name
+            if elf_candidate.exists():
+                return str(elf_candidate)
 
     return None
 

--- a/script/ci_memory_impact_extract.py
+++ b/script/ci_memory_impact_extract.py
@@ -33,6 +33,77 @@ from script.ci_helpers import write_github_output
 _RAM_PATTERN = re.compile(r"RAM:\s+\[.*?\]\s+\d+\.\d+%\s+\(used\s+(\d+)\s+bytes")
 _FLASH_PATTERN = re.compile(r"Flash:\s+\[.*?\]\s+\d+\.\d+%\s+\(used\s+(\d+)\s+bytes")
 _BUILD_PATH_PATTERN = re.compile(r"Build path: (.+)")
+_INI_AUTO_GENERATE_BEGIN = "; ========== AUTO GENERATED CODE BEGIN ==========="
+_INI_AUTO_GENERATE_END = "; =========== AUTO GENERATED CODE END ============"
+
+
+def _read_generated_platformio_env_name(build_path: Path) -> str | None:
+    """Return the generated PlatformIO env name for a build directory."""
+    platformio_ini = build_path / "platformio.ini"
+    if not platformio_ini.is_file():
+        return None
+
+    text = platformio_ini.read_text(encoding="utf-8")
+    begin = text.find(_INI_AUTO_GENERATE_BEGIN)
+    end = text.find(_INI_AUTO_GENERATE_END)
+    if begin != -1 and end != -1 and begin < end:
+        text = text[begin + len(_INI_AUTO_GENERATE_BEGIN) : end]
+
+    env_match = re.search(r"^\[env:([^\]]+)\]", text, flags=re.MULTILINE)
+    return env_match.group(1) if env_match else None
+
+
+def _append_unique_path(paths: list[Path], path: Path) -> None:
+    if path not in paths:
+        paths.append(path)
+
+
+def _pioenv_dirs(build_path: Path) -> list[Path]:
+    """Return active, historical, and discovered PlatformIO env directories."""
+    pioenvs_path = build_path / ".pioenvs"
+    env_dirs: list[Path] = []
+
+    if env_name := _read_generated_platformio_env_name(build_path):
+        _append_unique_path(env_dirs, pioenvs_path / env_name)
+    _append_unique_path(env_dirs, pioenvs_path / build_path.name)
+
+    if pioenvs_path.is_dir():
+        for env_dir in sorted(
+            (path for path in pioenvs_path.iterdir() if path.is_dir()),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        ):
+            _append_unique_path(env_dirs, env_dir)
+
+    return env_dirs
+
+
+def _find_elf_path(build_path: Path) -> str | None:
+    """Find firmware.elf/raw_firmware.elf in current and historical layouts."""
+    for elf_candidate in [
+        build_path / "firmware.elf",
+        *[pioenv_dir / "firmware.elf" for pioenv_dir in _pioenv_dirs(build_path)],
+        # LibreTiny uses raw_firmware.elf
+        build_path / "raw_firmware.elf",
+        *[pioenv_dir / "raw_firmware.elf" for pioenv_dir in _pioenv_dirs(build_path)],
+    ]:
+        if elf_candidate.exists():
+            return str(elf_candidate)
+
+    return None
+
+
+def _idedata_candidates(build_path: Path) -> list[Path]:
+    """Return idedata search paths in current and historical layouts."""
+    device_name = build_path.name
+    return [
+        # In .pioenvs for test builds
+        *[pioenv_dir / "idedata.json" for pioenv_dir in _pioenv_dirs(build_path)],
+        # In .esphome/idedata for regular builds
+        Path.home() / ".esphome" / "idedata" / f"{device_name}.json",
+        # Check parent directories for .esphome/idedata (for test_build_components)
+        build_path.parent.parent.parent / "idedata" / f"{device_name}.json",
+    ]
 
 
 def extract_from_compile_output(
@@ -92,18 +163,7 @@ def run_detailed_analysis(build_dir: str) -> dict | None:
         print(f"Build directory not found: {build_dir}", file=sys.stderr)
         return None
 
-    # Find firmware.elf (or raw_firmware.elf for LibreTiny)
-    elf_path = None
-    for elf_candidate in [
-        build_path / "firmware.elf",
-        build_path / ".pioenvs" / build_path.name / "firmware.elf",
-        # LibreTiny uses raw_firmware.elf
-        build_path / "raw_firmware.elf",
-        build_path / ".pioenvs" / build_path.name / "raw_firmware.elf",
-    ]:
-        if elf_candidate.exists():
-            elf_path = str(elf_candidate)
-            break
+    elf_path = _find_elf_path(build_path)
 
     if not elf_path:
         print(
@@ -111,19 +171,8 @@ def run_detailed_analysis(build_dir: str) -> dict | None:
         )
         return None
 
-    # Find idedata.json - check multiple locations
-    device_name = build_path.name
-    idedata_candidates = [
-        # In .pioenvs for test builds
-        build_path / ".pioenvs" / device_name / "idedata.json",
-        # In .esphome/idedata for regular builds
-        Path.home() / ".esphome" / "idedata" / f"{device_name}.json",
-        # Check parent directories for .esphome/idedata (for test_build_components)
-        build_path.parent.parent.parent / "idedata" / f"{device_name}.json",
-    ]
-
     idedata = None
-    for idedata_path in idedata_candidates:
+    for idedata_path in _idedata_candidates(build_path):
         if not idedata_path.exists():
             continue
         try:

--- a/tests/unit_tests/analyze_memory/test_ci_memory_impact_extract.py
+++ b/tests/unit_tests/analyze_memory/test_ci_memory_impact_extract.py
@@ -1,0 +1,92 @@
+"""Tests for script/ci_memory_impact_extract.py path handling."""
+
+import os
+from pathlib import Path
+import sys
+import time
+
+# Add script directory to path so we can import the module.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent / "script"))
+
+from ci_memory_impact_extract import (  # noqa: E402
+    _INI_AUTO_GENERATE_BEGIN,
+    _INI_AUTO_GENERATE_END,
+    _find_elf_path,
+    _idedata_candidates,
+)
+
+
+def _write_platformio_ini(build_path: Path, env_name: str) -> None:
+    build_path.mkdir(parents=True, exist_ok=True)
+    (build_path / "platformio.ini").write_text(
+        f"{_INI_AUTO_GENERATE_BEGIN}\n"
+        f"[env:{env_name}]\n"
+        "platform = test\n"
+        f"{_INI_AUTO_GENERATE_END}\n",
+        encoding="utf-8",
+    )
+
+
+def test_find_elf_path_uses_generated_platformio_env(tmp_path: Path) -> None:
+    """CI detailed analysis should find firmware.elf under the generated PIO env."""
+    build_path = tmp_path / "test-device"
+    _write_platformio_ini(build_path, "esp32-arduino-abc123")
+    firmware_elf = build_path / ".pioenvs" / "esp32-arduino-abc123" / "firmware.elf"
+    firmware_elf.parent.mkdir(parents=True)
+    firmware_elf.touch()
+
+    assert _find_elf_path(build_path) == str(firmware_elf)
+
+
+def test_find_elf_path_falls_back_to_legacy_platformio_env(tmp_path: Path) -> None:
+    """Historical CI artifacts used the device name as the PIO env."""
+    build_path = tmp_path / "test-device"
+    firmware_elf = build_path / ".pioenvs" / "test-device" / "firmware.elf"
+    firmware_elf.parent.mkdir(parents=True)
+    firmware_elf.touch()
+
+    assert _find_elf_path(build_path) == str(firmware_elf)
+
+
+def test_find_elf_path_scans_newest_platformio_env(tmp_path: Path) -> None:
+    """Detailed analysis should still work without generated ini metadata."""
+    build_path = tmp_path / "test-device"
+    old_elf = build_path / ".pioenvs" / "old-env" / "firmware.elf"
+    new_elf = build_path / ".pioenvs" / "new-env" / "firmware.elf"
+    old_elf.parent.mkdir(parents=True)
+    new_elf.parent.mkdir(parents=True)
+    old_elf.touch()
+    new_elf.touch()
+
+    old_time = time.time() - 10
+    new_time = time.time()
+    os.utime(old_elf.parent, (old_time, old_time))
+    os.utime(new_elf.parent, (new_time, new_time))
+
+    assert _find_elf_path(build_path) == str(new_elf)
+
+
+def test_find_elf_path_uses_generated_libretiny_raw_firmware(tmp_path: Path) -> None:
+    """The LibreTiny raw_firmware.elf also lives under the generated PIO env."""
+    build_path = tmp_path / "test-device"
+    _write_platformio_ini(build_path, "bk72xx-arduino-abc123")
+    raw_firmware_elf = (
+        build_path / ".pioenvs" / "bk72xx-arduino-abc123" / "raw_firmware.elf"
+    )
+    raw_firmware_elf.parent.mkdir(parents=True)
+    raw_firmware_elf.touch()
+
+    assert _find_elf_path(build_path) == str(raw_firmware_elf)
+
+
+def test_idedata_candidates_check_generated_env_before_legacy(
+    tmp_path: Path,
+) -> None:
+    """Detailed analysis should prefer current generated-env idedata."""
+    build_path = tmp_path / "test-device"
+    _write_platformio_ini(build_path, "esp32-arduino-abc123")
+
+    assert _idedata_candidates(build_path)[:2] == [
+        build_path / ".pioenvs" / "esp32-arduino-abc123" / "idedata.json",
+        build_path / ".pioenvs" / "test-device" / "idedata.json",
+    ]

--- a/tests/unit_tests/analyze_memory/test_ci_memory_impact_extract.py
+++ b/tests/unit_tests/analyze_memory/test_ci_memory_impact_extract.py
@@ -79,6 +79,24 @@ def test_find_elf_path_uses_generated_libretiny_raw_firmware(tmp_path: Path) -> 
     assert _find_elf_path(build_path) == str(raw_firmware_elf)
 
 
+def test_find_elf_path_prefers_current_libretiny_raw_firmware(
+    tmp_path: Path,
+) -> None:
+    """A stale firmware.elf must not hide the active LibreTiny raw ELF."""
+    build_path = tmp_path / "test-device"
+    _write_platformio_ini(build_path, "bk72xx-arduino-abc123")
+    stale_firmware_elf = build_path / ".pioenvs" / "test-device" / "firmware.elf"
+    raw_firmware_elf = (
+        build_path / ".pioenvs" / "bk72xx-arduino-abc123" / "raw_firmware.elf"
+    )
+    stale_firmware_elf.parent.mkdir(parents=True)
+    raw_firmware_elf.parent.mkdir(parents=True)
+    stale_firmware_elf.touch()
+    raw_firmware_elf.touch()
+
+    assert _find_elf_path(build_path) == str(raw_firmware_elf)
+
+
 def test_idedata_candidates_check_generated_env_before_legacy(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit_tests/analyze_memory/test_cli.py
+++ b/tests/unit_tests/analyze_memory/test_cli.py
@@ -1,0 +1,45 @@
+"""Tests for memory analyzer CLI helpers."""
+
+import os
+from pathlib import Path
+import time
+
+from esphome.analyze_memory.cli import (
+    _INI_AUTO_GENERATE_BEGIN,
+    _INI_AUTO_GENERATE_END,
+    _find_firmware_elf,
+)
+
+
+def test_find_firmware_elf_uses_generated_platformio_env(tmp_path: Path) -> None:
+    """Generated PlatformIO env names are no longer tied to device names."""
+    build_path = tmp_path / "build" / "kitchen-display"
+    generated_env = build_path / ".pioenvs" / "esp32-arduino-abc123"
+    generated_env.mkdir(parents=True)
+    firmware_elf = generated_env / "firmware.elf"
+    firmware_elf.write_bytes(b"elf")
+
+    assert _find_firmware_elf(build_path) == firmware_elf
+
+
+def test_find_firmware_elf_prefers_active_generated_env(tmp_path: Path) -> None:
+    """When several generated envs exist, use platformio.ini's active env."""
+    build_path = tmp_path / "build" / "kitchen-display"
+    old_elf = build_path / ".pioenvs" / "kitchen-display" / "firmware.elf"
+    new_elf = build_path / ".pioenvs" / "esp32-arduino-new" / "firmware.elf"
+    build_path.mkdir(parents=True)
+    old_elf.parent.mkdir(parents=True)
+    new_elf.parent.mkdir(parents=True)
+    old_elf.write_bytes(b"old")
+    new_elf.write_bytes(b"new")
+    (build_path / "platformio.ini").write_text(
+        f"{_INI_AUTO_GENERATE_BEGIN}\n"
+        "[env:kitchen-display]\n"
+        "platform = espressif32\n"
+        f"{_INI_AUTO_GENERATE_END}\n"
+    )
+
+    old_time = time.time() - 10
+    os.utime(old_elf, (old_time, old_time))
+
+    assert _find_firmware_elf(build_path) == old_elf

--- a/tests/unit_tests/build_gen/test_platformio.py
+++ b/tests/unit_tests/build_gen/test_platformio.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from esphome.build_gen import platformio
+from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 from esphome.core import CORE
 
 
@@ -48,6 +49,21 @@ framework = arduino
     assert content in file_content
     assert platformio.INI_AUTO_GENERATE_BEGIN in file_content
     assert platformio.INI_AUTO_GENERATE_END in file_content
+
+
+def test_get_ini_content_uses_shared_libdeps_env_name(setup_core: Path) -> None:
+    """Embedded builds use the stable PlatformIO env that owns shared libdeps."""
+    CORE.name = "kitchen-display"
+    CORE.build_path = str(setup_core / "build" / "kitchen-display")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+
+    content = platformio.get_ini_content()
+
+    assert "[env:kitchen-display]" not in content
+    assert "[env:rp2040-arduino-" in content
 
 
 def test_write_ini_updates_existing_file(
@@ -185,4 +201,37 @@ def test_write_ini_calls_update_storage_json(
     content = "[env:test]\nplatform = esp32"
 
     platformio.write_ini(content)
+    mock_update_storage_json.assert_called_once()
+
+
+def test_write_ini_updates_storage_after_env_name_is_written(
+    tmp_path: Path,
+    mock_update_storage_json: MagicMock,
+    mock_write_file_if_changed: MagicMock,
+) -> None:
+    """Ensure StorageJSON sees the new generated env."""
+    CORE.build_path = str(tmp_path)
+    ini_file = tmp_path / "platformio.ini"
+    ini_file.write_text(
+        f"{platformio.INI_BASE_FORMAT[0]}"
+        f"{platformio.INI_AUTO_GENERATE_BEGIN}\n"
+        "[env:old-env]\n"
+        "platform = old\n"
+        f"{platformio.INI_AUTO_GENERATE_END}"
+        f"{platformio.INI_BASE_FORMAT[1]}"
+    )
+
+    def write_side_effect(path: Path, contents: str) -> bool:
+        path.write_text(contents)
+        return True
+
+    def update_side_effect() -> None:
+        assert "[env:new-env]" in ini_file.read_text()
+
+    mock_write_file_if_changed.side_effect = write_side_effect
+    mock_update_storage_json.side_effect = update_side_effect
+
+    platformio.write_ini("[env:new-env]\nplatform = new\n")
+
+    mock_write_file_if_changed.assert_called_once()
     mock_update_storage_json.assert_called_once()

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -592,20 +592,28 @@ class TestEsphomeCore:
         assert target.is_esp8266 is True
 
     def test_firmware_bin__default(self, target):
-        """Default platforms produce <pioenvs>/<name>/firmware.bin."""
+        """Default PlatformIO builds use the generated env artifact path."""
         target.name = "test-device"
         target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "esp32"}
-        assert target.firmware_bin == Path(
-            "foo/build/.pioenvs/test-device/firmware.bin"
-        )
+        with patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="esp32-arduino-abc123",
+        ):
+            assert target.firmware_bin == Path(
+                "foo/build/.pioenvs/esp32-arduino-abc123/firmware.bin"
+            )
 
     def test_firmware_bin__libretiny(self, target):
         """The libretiny platform produces firmware.uf2."""
         target.name = "test-device"
         target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "bk72xx"}
-        assert target.firmware_bin == Path(
-            "foo/build/.pioenvs/test-device/firmware.uf2"
-        )
+        with patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="bk72xx-arduino-abc123",
+        ):
+            assert target.firmware_bin == Path(
+                "foo/build/.pioenvs/bk72xx-arduino-abc123/firmware.uf2"
+            )
 
     def test_firmware_bin__host(self, target):
         """Host platform produces a native ELF/Mach-O named `program`,
@@ -890,9 +898,26 @@ class TestEsphomeCore:
         target.name = "test-device"
         target.toolchain = const.Toolchain.PLATFORMIO
 
-        assert target.bootloader_bin == Path(
-            "foo/build/.pioenvs/test-device/bootloader.bin"
-        )
+        with patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="esp32-arduino-abc123",
+        ):
+            assert target.bootloader_bin == Path(
+                "foo/build/.pioenvs/esp32-arduino-abc123/bootloader.bin"
+            )
+
+    def test_partition_table_bin__platformio(self, target):
+        """For PlatformIO builds partitions.bin lives in the env-specific .pioenvs directory."""
+        target.name = "test-device"
+        target.toolchain = const.Toolchain.PLATFORMIO
+
+        with patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="esp32-arduino-abc123",
+        ):
+            assert target.partition_table_bin == Path(
+                "foo/build/.pioenvs/esp32-arduino-abc123/partitions.bin"
+            )
 
     def test_add_library__extracts_short_name_from_path(self, target):
         """Test add_library extracts short name from library paths like owner/lib."""

--- a/tests/unit_tests/test_core.py
+++ b/tests/unit_tests/test_core.py
@@ -603,6 +603,23 @@ class TestEsphomeCore:
                 "foo/build/.pioenvs/esp32-arduino-abc123/firmware.bin"
             )
 
+    def test_firmware_bin_path_can_ignore_existing_env(self, target):
+        """Storage metadata should describe the newly generated env path."""
+        target.name = "test-device"
+        target.data[const.KEY_CORE] = {const.KEY_TARGET_PLATFORM: "esp32"}
+        with patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            side_effect=lambda *, prefer_existing: (
+                "test-device" if prefer_existing else "esp32-arduino-abc123"
+            ),
+        ):
+            assert target.firmware_bin == Path(
+                "foo/build/.pioenvs/test-device/firmware.bin"
+            )
+            assert target.firmware_bin_path(prefer_existing=False) == Path(
+                "foo/build/.pioenvs/esp32-arduino-abc123/firmware.bin"
+            )
+
     def test_firmware_bin__libretiny(self, target):
         """The libretiny platform produces firmware.uf2."""
         target.name = "test-device"

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -60,6 +60,7 @@ from esphome.address_cache import AddressCache
 from esphome.bundle import BUNDLE_EXTENSION, BundleFile, BundleResult
 from esphome.components import esp32
 from esphome.components.esp32 import KEY_ESP32, KEY_VARIANT, VARIANT_ESP32
+import esphome.config_validation as cv
 from esphome.const import (
     CONF_API,
     CONF_AUTH,
@@ -85,6 +86,7 @@ from esphome.const import (
     CONF_WEB_SERVER,
     CONF_WIFI,
     KEY_CORE,
+    KEY_FRAMEWORK_VERSION,
     KEY_TARGET_PLATFORM,
     PLATFORM_BK72XX,
     PLATFORM_ESP32,
@@ -5795,6 +5797,7 @@ def test_esp32_write_sdkconfig_uses_generated_platformio_env(
 ) -> None:
     """ESP32 PlatformIO sdkconfig must match the generated $PIOENV."""
     setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test-device")
+    CORE.data[KEY_CORE][KEY_FRAMEWORK_VERSION] = cv.Version(5, 5, 4)
     CORE.data[KEY_ESP32] = {esp32.KEY_SDKCONFIG_OPTIONS: {"CONFIG_TEST_VALUE": True}}
 
     with (
@@ -5820,8 +5823,9 @@ def test_esp32_write_sdkconfig_uses_generated_platformio_env(
         / "test-device"
         / "sdkconfig.esp32-arduino-abc123.esphomeinternal"
     )
-    assert sdkconfig.read_text() == "CONFIG_TEST_VALUE=y\n"
-    assert internal.read_text() == "CONFIG_TEST_VALUE=y\n"
+    expected = "# ESPHOME_IDF_VERSION=5.5.4\nCONFIG_TEST_VALUE=y\n"
+    assert sdkconfig.read_text() == expected
+    assert internal.read_text() == expected
     assert not (
         tmp_path / ".esphome" / "build" / "test-device" / "sdkconfig.test-device"
     ).exists()

--- a/tests/unit_tests/test_main.py
+++ b/tests/unit_tests/test_main.py
@@ -164,6 +164,19 @@ def setup_core(
         CORE.build_path = str(tmp_path / ".esphome" / "build" / name)
 
 
+def expected_platformio_firmware_path(tmp_path: Path, name: str = "test") -> Path:
+    """Return the firmware path for the generated PlatformIO environment."""
+    return (
+        tmp_path
+        / ".esphome"
+        / "build"
+        / name
+        / ".pioenvs"
+        / toolchain.platformio_env_name()
+        / "firmware.bin"
+    )
+
+
 @pytest.fixture
 def mock_no_serial_ports() -> Generator[Mock]:
     """Mock get_serial_ports to return no ports."""
@@ -1616,9 +1629,7 @@ def test_upload_program_ota_success(
 
     assert exit_code == 0
     assert host == "192.168.1.100"
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.1.100"], 3232, "secret", expected_firmware, OTA_TYPE_UPDATE_APP
     )
@@ -2117,9 +2128,7 @@ def test_upload_program_web_server_only_auto_dispatches(
 
     assert exit_code == 0
     assert host == "192.168.1.100"
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_web_server_ota.assert_called_once_with(
         ["192.168.1.100"], 80, "admin", "pw", expected_firmware
     )
@@ -2147,9 +2156,7 @@ def test_upload_program_web_server_no_auth(
 
     assert exit_code == 0
     assert host == "192.168.1.100"
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_web_server_ota.assert_called_once_with(
         ["192.168.1.100"], 8080, None, None, expected_firmware
     )
@@ -2376,9 +2383,7 @@ def test_upload_program_ota_with_mqtt_resolution(
     assert exit_code == 0
     assert host == "192.168.1.100"
     mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.1.100"], 3232, None, expected_firmware, OTA_TYPE_UPDATE_APP
     )
@@ -2424,9 +2429,7 @@ def test_upload_program_ota_with_mqtt_empty_broker(
     # Verify MQTT was attempted but failed gracefully
     mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
     # Verify we fell back to the IP address
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.1.50"], 3232, None, expected_firmware, OTA_TYPE_UPDATE_APP
     )
@@ -4389,9 +4392,7 @@ def test_upload_program_ota_static_ip_with_mqttip(
     mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
 
     # Verify espota2.run_ota was called with both IPs
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.1.100", "192.168.2.50"],
         3232,
@@ -4436,9 +4437,7 @@ def test_upload_program_ota_multiple_mqttip_resolves_once(
     mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
 
     # Verify espota2.run_ota was called with all unique IPs
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.2.50", "192.168.2.51", "192.168.1.100"],
         3232,
@@ -4605,9 +4604,7 @@ def test_upload_program_ota_mqtt_timeout_fallback(
     mock_mqtt_get_ip.assert_called_once_with(config, "user", "pass", "client")
 
     # Verify espota2.run_ota was called with only the static IP (MQTT failed)
-    expected_firmware = (
-        tmp_path / ".esphome" / "build" / "test" / ".pioenvs" / "test" / "firmware.bin"
-    )
+    expected_firmware = expected_platformio_firmware_path(tmp_path)
     mock_run_ota.assert_called_once_with(
         ["192.168.1.100"], 3232, None, expected_firmware, OTA_TYPE_UPDATE_APP
     )
@@ -4927,7 +4924,7 @@ def _setup_build_info_test(
     setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test_device")
 
     build_path = tmp_path / ".esphome" / "build" / "test_device"
-    pioenvs_path = build_path / ".pioenvs" / "test_device"
+    pioenvs_path = build_path / ".pioenvs" / toolchain.platformio_env_name()
     pioenvs_path.mkdir(parents=True, exist_ok=True)
 
     build_info_path = build_path / "build_info.json"
@@ -5745,6 +5742,29 @@ def test_get_configured_xtal_freq_reads_sdkconfig(tmp_path: Path) -> None:
     assert _get_configured_xtal_freq() == 26
 
 
+def test_get_configured_xtal_freq_reads_generated_platformio_env(
+    tmp_path: Path,
+) -> None:
+    """Generated PlatformIO ESP32 sdkconfig follows the env name."""
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test-device")
+
+    with patch(
+        "esphome.platformio.toolchain.platformio_env_name",
+        return_value="esp32-arduino-abc123",
+    ):
+        sdkconfig = (
+            tmp_path
+            / ".esphome"
+            / "build"
+            / "test-device"
+            / "sdkconfig.esp32-arduino-abc123"
+        )
+        sdkconfig.parent.mkdir(parents=True)
+        sdkconfig.write_text("CONFIG_XTAL_FREQ=26\n")
+
+        assert _get_configured_xtal_freq() == 26
+
+
 def test_get_configured_xtal_freq_default_40(tmp_path: Path) -> None:
     """Test reading default 40MHz XTAL_FREQ from sdkconfig."""
     CORE.name = "test-device"
@@ -5768,6 +5788,44 @@ def test_get_configured_xtal_freq_no_xtal_line(tmp_path: Path) -> None:
     sdkconfig = tmp_path / "sdkconfig.test-device"
     sdkconfig.write_text("CONFIG_OTHER=123\n")
     assert _get_configured_xtal_freq() is None
+
+
+def test_esp32_write_sdkconfig_uses_generated_platformio_env(
+    tmp_path: Path,
+) -> None:
+    """ESP32 PlatformIO sdkconfig must match the generated $PIOENV."""
+    setup_core(platform=PLATFORM_ESP32, tmp_path=tmp_path, name="test-device")
+    CORE.data[KEY_ESP32] = {esp32.KEY_SDKCONFIG_OPTIONS: {"CONFIG_TEST_VALUE": True}}
+
+    with (
+        patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="esp32-arduino-abc123",
+        ),
+        patch("esphome.components.esp32.clean_build") as mock_clean_build,
+    ):
+        esp32._write_sdkconfig()
+
+    sdkconfig = (
+        tmp_path
+        / ".esphome"
+        / "build"
+        / "test-device"
+        / "sdkconfig.esp32-arduino-abc123"
+    )
+    internal = (
+        tmp_path
+        / ".esphome"
+        / "build"
+        / "test-device"
+        / "sdkconfig.esp32-arduino-abc123.esphomeinternal"
+    )
+    assert sdkconfig.read_text() == "CONFIG_TEST_VALUE=y\n"
+    assert internal.read_text() == "CONFIG_TEST_VALUE=y\n"
+    assert not (
+        tmp_path / ".esphome" / "build" / "test-device" / "sdkconfig.test-device"
+    ).exists()
+    mock_clean_build.assert_called_once_with(clear_pio_cache=False)
 
 
 def test_crystal_freq_callback_mismatch() -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -338,6 +338,49 @@ def test_run_platformio_cli_sets_environment_variables(
         assert "arg" in args
 
 
+def test_run_platformio_cli_locks_shared_libdeps_env(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Shared libdeps runs are serialized by env to avoid cross-process races."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    lock_paths = []
+
+    def record_lock(lock_path: Path | None):
+        @contextmanager
+        def lock_context():
+            lock_paths.append(lock_path)
+            yield
+
+        return lock_context()
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "esphome.platformio.toolchain._platformio_libdeps_lock",
+            side_effect=record_lock,
+        ),
+    ):
+        mock_run_external_process.return_value = 0
+        toolchain.run_platformio_cli("test")
+
+    fingerprint = _expected_env_fingerprint([])
+    assert lock_paths == [
+        setup_core
+        / ".esphome"
+        / "platformio"
+        / "libdeps"
+        / ".locks"
+        / f"esp8266-arduino-{fingerprint}.lock"
+    ]
+
+
 @pytest.mark.parametrize(
     ("platform", "input_path", "expected"),
     [
@@ -517,6 +560,32 @@ lib_deps =
     assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
 
 
+def test_platformio_env_name_logs_malformed_common_libdeps(
+    setup_core: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed preserved platformio.ini lib_deps are diagnosable."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", ["${common.lib_deps}"])
+    CORE.relative_build_path().mkdir(parents=True)
+    CORE.relative_build_path("platformio.ini").write_text(
+        "[common\nlib_deps = Broken/Dependency\n",
+        encoding="utf-8",
+    )
+
+    with caplog.at_level("WARNING"):
+        assert toolchain.platformio_env_name().startswith("rp2040-arduino-")
+
+    assert "Could not parse" in caplog.text
+    assert "preserved common lib_deps" in caplog.text
+
+
 def test_platformio_env_name_resolves_common_local_libdeps(
     setup_core: Path,
 ) -> None:
@@ -608,7 +677,6 @@ def test_run_platformio_cli_updates_managed_libdeps_between_targets(
     """Long-lived processes update ESPHome-managed libdeps per target."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    toolchain._managed_platformio_libdeps_dir["value"] = None
     with patch.dict(os.environ, {}, clear=True):
         mock_run_external_process.return_value = 0
         CORE.build_path = str(setup_core / "build" / "esp8266")
@@ -638,7 +706,6 @@ def test_run_platformio_cli_preserves_user_libdeps_override(
     """User-provided PLATFORMIO_LIBDEPS_DIR remains authoritative."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    toolchain._managed_platformio_libdeps_dir["value"] = None
     CORE.build_path = str(setup_core / "build" / "test")
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: "esp8266",
@@ -652,7 +719,7 @@ def test_run_platformio_cli_preserves_user_libdeps_override(
         toolchain.run_platformio_cli("test")
 
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == "/custom/libdeps"
-        assert toolchain._managed_platformio_libdeps_dir["value"] is None
+        assert toolchain._PLATFORMIO_MANAGED_LIBDEPS_ENV not in os.environ
 
 
 def test_run_platformio_cli_preserves_late_user_libdeps_override(
@@ -661,7 +728,6 @@ def test_run_platformio_cli_preserves_late_user_libdeps_override(
     """Per-config environment overrides win after a previous managed compile."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    toolchain._managed_platformio_libdeps_dir["value"] = None
     mock_run_external_process.return_value = 0
     with patch.dict(os.environ, {}, clear=True):
         CORE.build_path = str(setup_core / "build" / "first")
@@ -678,7 +744,7 @@ def test_run_platformio_cli_preserves_late_user_libdeps_override(
 
         assert managed_value != "/custom/libdeps"
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == "/custom/libdeps"
-        assert toolchain._managed_platformio_libdeps_dir["value"] == managed_value
+        assert os.environ[toolchain._PLATFORMIO_MANAGED_LIBDEPS_ENV] == managed_value
 
 
 def test_platformio_env_name_resolves_local_libdeps(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -298,7 +298,7 @@ def test_run_platformio_cli_sets_environment_variables(
         KEY_TARGET_FRAMEWORK: "arduino",
     }
 
-    with patch.dict(os.environ, {}, clear=False):
+    with patch.dict(os.environ, {}, clear=True):
         mock_run_external_process.return_value = 0
         toolchain.run_platformio_cli("test", "arg")
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 
 from contextlib import contextmanager
+import hashlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
 import os
@@ -289,7 +290,13 @@ def test_run_platformio_cli_sets_environment_variables(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:
     """Test run_platformio_cli sets correct environment variables."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
     CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
 
     with patch.dict(os.environ, {}, clear=False):
         mock_run_external_process.return_value = 0
@@ -302,7 +309,15 @@ def test_run_platformio_cli_sets_environment_variables(
             in Path(os.environ["PLATFORMIO_BUILD_DIR"]).parents
             or Path(os.environ["PLATFORMIO_BUILD_DIR"]) == setup_core / "build" / "test"
         )
-        assert "PLATFORMIO_LIBDEPS_DIR" in os.environ
+        fingerprint = hashlib.sha256(json.dumps([]).encode()).hexdigest()[:16]
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
+            setup_core
+            / ".esphome"
+            / "platformio"
+            / "libdeps"
+            / "esp8266-arduino"
+            / fingerprint
+        )
         assert "PYTHONWARNINGS" in os.environ
 
         # Check command was called correctly — runs PlatformIO as a subprocess
@@ -412,6 +427,78 @@ def test_run_platformio_cli_does_not_set_pythonexepath_without_strip(
         args = mock_run_external_process.call_args[0]
         assert args[0] == plain_exe
         assert "PYTHONEXEPATH" not in os.environ
+
+
+def test_run_platformio_cli_scopes_libdeps_by_toolchain_and_dependencies(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Equivalent embedded PlatformIO configs should share one libdeps dir."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option(
+        "lib_deps",
+        [
+            "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+            "${common.lib_deps}",
+            "ESP32Async/ESPAsyncTCP @ 2.0.0",
+            "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+        ],
+    )
+
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            [
+                "ESP32Async/ESPAsyncTCP @ 2.0.0",
+                "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+            ]
+        ).encode()
+    ).hexdigest()[:16]
+
+    with patch.dict(os.environ, {}, clear=True):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
+            setup_core
+            / ".esphome"
+            / "platformio"
+            / "libdeps"
+            / "rp2040-arduino"
+            / fingerprint
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_platform", "target_framework"),
+    [("host", "arduino"), ("nrf52", "zephyr")],
+)
+def test_run_platformio_cli_keeps_special_platform_libdeps_device_scoped(
+    setup_core: Path,
+    mock_run_external_process: Mock,
+    target_platform: str,
+    target_framework: str,
+) -> None:
+    """Host and Zephyr builds should keep historical device-scoped libdeps."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: target_platform,
+        KEY_TARGET_FRAMEWORK: target_framework,
+    }
+
+    with patch.dict(os.environ, {}, clear=True):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
+            (setup_core / "build" / "test" / ".piolibdeps").absolute()
+        )
 
 
 def test_run_platformio_cli_run_builds_command(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -518,6 +518,29 @@ def test_run_platformio_cli_scopes_libdeps_by_toolchain_and_dependencies(
         assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
 
 
+def test_platformio_env_name_disambiguates_shared_custom_build_path(
+    setup_core: Path,
+) -> None:
+    """Two devices sharing one build path must not overwrite PIO artifacts."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    shared_build_path = setup_core / "build" / "shared"
+    CORE.build_path = shared_build_path
+    CORE.name = "living-room"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    first_env = toolchain.platformio_env_name()
+
+    CORE.name = "kitchen"
+    second_env = toolchain.platformio_env_name()
+
+    assert first_env.startswith("living-room-rp2040-arduino-")
+    assert second_env.startswith("kitchen-rp2040-arduino-")
+    assert first_env != second_env
+
+
 def test_platformio_env_name_includes_preserved_common_libdeps(
     setup_core: Path,
 ) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -3,6 +3,7 @@
 # pylint: disable=protected-access
 
 from contextlib import contextmanager
+import errno
 import hashlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import json
@@ -32,6 +33,53 @@ def _expected_env_fingerprint(
             sort_keys=True,
         ).encode()
     ).hexdigest()[:16]
+
+
+def _write_platformio_ini(build_path: Path, env_name: str) -> None:
+    build_path.mkdir(parents=True, exist_ok=True)
+    (build_path / "platformio.ini").write_text(
+        f"""
+; ========== AUTO GENERATED CODE BEGIN ===========
+
+[env:{env_name}]
+lib_deps =
+    Component/Generated @ 2.0.0
+; =========== AUTO GENERATED CODE END ============
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_storage_json(config_filename: str, firmware_bin_path: Path) -> None:
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+    from esphome.storage_json import ext_storage_path
+
+    core_data = CORE.data[KEY_CORE]
+    path = ext_storage_path(config_filename)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "storage_version": 1,
+                "name": CORE.name,
+                "friendly_name": None,
+                "comment": None,
+                "esphome_version": "2026.1.0",
+                "src_version": 1,
+                "address": "test.local",
+                "web_port": None,
+                "esp_platform": core_data[KEY_TARGET_PLATFORM].upper(),
+                "build_path": str(CORE.build_path),
+                "firmware_bin_path": str(firmware_bin_path),
+                "loaded_integrations": [],
+                "loaded_platforms": [],
+                "no_mdns": False,
+                "framework": core_data[KEY_TARGET_FRAMEWORK],
+                "core_platform": core_data[KEY_TARGET_PLATFORM],
+                "toolchain": "platformio",
+            }
+        )
+    )
 
 
 def test_idedata_firmware_elf_path(setup_core: Path) -> None:
@@ -541,6 +589,107 @@ def test_platformio_env_name_disambiguates_shared_custom_build_path(
     assert first_env != second_env
 
 
+def test_platformio_env_name_ignores_foreign_generated_env_for_shared_build_path(
+    setup_core: Path,
+) -> None:
+    """Upload-only paths must not reuse another device's generated PIO env."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    shared_build_path = setup_core / "build" / "shared"
+    CORE.name = "living-room"
+    CORE.build_path = shared_build_path
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    _write_platformio_ini(shared_build_path, "kitchen-rp2040-arduino-compiled1234")
+
+    env_name = toolchain.platformio_env_name(prefer_existing=True)
+
+    assert env_name.startswith("living-room-rp2040-arduino-")
+
+
+def test_platformio_env_name_rejects_prefix_matched_foreign_env(
+    setup_core: Path,
+) -> None:
+    """Shared-build env reuse matches the exact device/toolchain prefix."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    shared_build_path = setup_core / "build" / "shared"
+    CORE.name = "plug"
+    CORE.build_path = shared_build_path
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    _write_platformio_ini(shared_build_path, "plug-kitchen-rp2040-arduino-compiled")
+
+    env_name = toolchain.platformio_env_name(prefer_existing=True)
+
+    assert env_name.startswith("plug-rp2040-arduino-")
+
+
+def test_platformio_env_name_rejects_unscoped_foreign_env(
+    setup_core: Path,
+) -> None:
+    """Existing generated env reuse still checks ownership on normal paths."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.name = "plug"
+    CORE.build_path = setup_core / "build" / "plug"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    _write_platformio_ini(CORE.build_path, "kitchen-rp2040-arduino-compiled")
+
+    env_name = toolchain.platformio_env_name(prefer_existing=True)
+
+    assert env_name.startswith("rp2040-arduino-")
+
+
+def test_platformio_env_name_reuses_legacy_device_env(
+    setup_core: Path,
+) -> None:
+    """Legacy upload-only envs remain valid when they exactly match the device."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    shared_build_path = setup_core / "build" / "shared"
+    CORE.name = "living-room"
+    CORE.build_path = shared_build_path
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    _write_platformio_ini(shared_build_path, "living-room")
+
+    assert toolchain.platformio_env_name(prefer_existing=True) == "living-room"
+
+
+def test_platformio_env_name_reuses_stored_env_when_shared_ini_is_foreign(
+    setup_core: Path,
+) -> None:
+    """Per-config storage keeps upload-only artifact paths device-safe."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    shared_build_path = setup_core / "build" / "shared"
+    CORE.config_path = setup_core / "living-room.yaml"
+    CORE.name = "living-room"
+    CORE.build_path = shared_build_path
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    stored_env = "living-room-rp2040-arduino-compiled1234"
+    _write_storage_json(
+        CORE.config_filename,
+        shared_build_path / ".pioenvs" / stored_env / "firmware.bin",
+    )
+    _write_platformio_ini(shared_build_path, "kitchen-rp2040-arduino-compiled5678")
+
+    assert toolchain.platformio_env_name(prefer_existing=True) == stored_env
+
+
 def test_platformio_env_name_includes_preserved_common_libdeps(
     setup_core: Path,
 ) -> None:
@@ -636,6 +785,64 @@ lib_deps =
     fingerprint = _expected_env_fingerprint([str(local_lib.resolve())])
 
     assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_preserves_tilde_version_constraints(
+    setup_core: Path,
+) -> None:
+    """Ensure PlatformIO semver "~" constraints are not expanded as home paths."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", ["User/CustomLib @ ~1.2.3"])
+    CORE.add_platformio_option("platform", "libretiny @ ~1.9.0")
+    CORE.add_platformio_option("platform_packages", ["framework-local @ ~2.0.0"])
+    CORE.relative_build_path().mkdir(parents=True)
+    CORE.relative_build_path("platformio.ini").write_text(
+        """
+[common]
+lib_deps =
+    Common/Library @ ~3.4.5
+""",
+        encoding="utf-8",
+    )
+
+    fingerprint = _expected_env_fingerprint(
+        [
+            "Common/Library @ ~3.4.5",
+            "User/CustomLib @ ~1.2.3",
+        ],
+        {
+            "platform": ["libretiny @ ~1.9.0"],
+            "platform_packages": ["framework-local @ ~2.0.0"],
+        },
+    )
+
+    assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+@pytest.mark.parametrize("config_path", [None, "test.yaml"])
+def test_platformio_env_name_skips_storage_lookup_without_path_config_path(
+    setup_core: Path,
+    config_path: Path | str | None,
+) -> None:
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.config_path = config_path
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.name = "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+
+    env_name = toolchain.platformio_env_name(prefer_existing=True)
+
+    assert env_name.startswith("rp2040-arduino-")
 
 
 def test_platformio_env_name_includes_common_libdeps_before_ini_regeneration(
@@ -770,6 +977,39 @@ def test_run_platformio_cli_preserves_late_user_libdeps_override(
         assert os.environ[toolchain._PLATFORMIO_MANAGED_LIBDEPS_ENV] == managed_value
 
 
+def test_platformio_libdeps_lock_waits_for_windows_contention(
+    tmp_path: Path,
+) -> None:
+    """Windows libdeps locking should wait past msvcrt's short retry window."""
+    calls = []
+    attempts = {"count": 0}
+
+    def locking(_fd: int, mode: int, _nbytes: int) -> None:
+        calls.append(mode)
+        if mode == fake_msvcrt.LK_NBLCK and attempts["count"] < 2:
+            attempts["count"] += 1
+            raise OSError(errno.EACCES, "busy")
+
+    fake_msvcrt = SimpleNamespace(LK_NBLCK=1, LK_UNLCK=2, locking=locking)
+    lock_path = tmp_path / "env.lock"
+
+    with (
+        patch("esphome.platformio.toolchain.os.name", "nt"),
+        patch.dict("sys.modules", {"msvcrt": fake_msvcrt}),
+        patch("esphome.platformio.toolchain.time.sleep") as mock_sleep,
+        toolchain._platformio_libdeps_lock(lock_path),
+    ):
+        pass
+
+    assert calls == [
+        fake_msvcrt.LK_NBLCK,
+        fake_msvcrt.LK_NBLCK,
+        fake_msvcrt.LK_NBLCK,
+        fake_msvcrt.LK_UNLCK,
+    ]
+    assert mock_sleep.call_count == 2
+
+
 def test_platformio_env_name_resolves_local_libdeps(
     setup_core: Path,
 ) -> None:
@@ -840,13 +1080,48 @@ def test_platformio_env_name_includes_toolchain_options(
     CORE.add_platformio_option(
         "platform_packages", ["framework-arduinoespressif32 @ 3.2.0"]
     )
+    CORE.add_platformio_option("lib_ignore", ["IRremoteESP8266"])
     CORE.add_platformio_option("build_flags", ["-DDEVICE_SPECIFIC"])
 
     fingerprint = _expected_env_fingerprint(
         ["AsyncTCP-esphome @ 2.1.4"],
         {
+            "lib_ignore": ["IRremoteESP8266"],
             "platform": ["platformio/espressif32 @ 6.10.0"],
             "platform_packages": ["framework-arduinoespressif32 @ 3.2.0"],
+        },
+    )
+
+    assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_resolves_local_platform_options(
+    setup_core: Path,
+) -> None:
+    """Local PlatformIO platform specs are fingerprinted by resolved path."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "project" / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    local_platform = setup_core / "project" / "build" / "local_platform"
+    local_framework = setup_core / "project" / "build" / "local_framework"
+    local_platform.mkdir(parents=True)
+    local_framework.mkdir()
+    CORE.add_platformio_option("platform", "file://../local_platform")
+    CORE.add_platformio_option(
+        "platform_packages", ["framework-local=file://../local_framework"]
+    )
+
+    fingerprint = _expected_env_fingerprint(
+        [],
+        {
+            "platform": [f"file://{local_platform.resolve()}"],
+            "platform_packages": [
+                f"framework-local=file://{local_framework.resolve()}"
+            ],
         },
     )
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -772,13 +772,14 @@ def test_platformio_env_name_resolves_local_libdeps(
     [
         ("file://../local_lib", "file://{local_lib}"),
         ("symlink://../local_lib", "symlink://{local_lib}"),
+        ("Custom=../local_lib", "Custom={local_lib}"),
         ("Custom=file://../local_lib", "Custom=file://{local_lib}"),
     ],
 )
 def test_platformio_env_name_resolves_local_libdep_uri_targets(
     setup_core: Path, lib_dep: str, fingerprint_value: str
 ) -> None:
-    """Local URI libdeps are fingerprinted by their resolved target path."""
+    """Local libdeps are fingerprinted by their resolved target path."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
     CORE.build_path = str(setup_core / "build" / "test")
@@ -949,6 +950,7 @@ def test_run_platformio_cli_run_builds_command(
         "-v",
         "extra",
         "args",
+        libdeps_env_name=toolchain.platformio_env_name(),
     )
 
 
@@ -992,7 +994,67 @@ lib_deps =
         "upload",
         "-t",
         "nobuild",
+        libdeps_env_name="rp2040-arduino-compiled1234",
     )
+
+
+def test_run_platformio_cli_run_locks_existing_generated_env(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Upload-only runs lock the same generated env passed to PlatformIO."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    lock_paths = []
+
+    def record_lock(lock_path: Path | None):
+        @contextmanager
+        def lock_context():
+            lock_paths.append(lock_path)
+            yield
+
+        return lock_context()
+
+    CORE.name = "living-room"
+    CORE.build_path = setup_core / "build" / "living-room"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    platformio_ini.parent.mkdir(parents=True)
+    platformio_ini.write_text(
+        """
+; ========== AUTO GENERATED CODE BEGIN ===========
+
+[env:rp2040-arduino-compiled1234]
+lib_deps =
+    Component/Generated @ 2.0.0
+; =========== AUTO GENERATED CODE END ============
+""",
+        encoding="utf-8",
+    )
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "esphome.platformio.toolchain._platformio_libdeps_lock",
+            side_effect=record_lock,
+        ),
+    ):
+        mock_run_external_process.return_value = 0
+        toolchain.run_platformio_cli_run({}, False, "-t", "upload")
+
+    mock_run_external_process.assert_called_once()
+    assert "-e" in mock_run_external_process.call_args[0]
+    assert "rp2040-arduino-compiled1234" in mock_run_external_process.call_args[0]
+    assert lock_paths == [
+        setup_core
+        / ".esphome"
+        / "platformio"
+        / "libdeps"
+        / ".locks"
+        / "rp2040-arduino-compiled1234.lock"
+    ]
 
 
 def test_run_compile(setup_core: Path, mock_run_platformio_cli_run: Mock) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -774,6 +774,9 @@ def test_platformio_env_name_resolves_local_libdeps(
         ("symlink://../local_lib", "symlink://{local_lib}"),
         ("Custom=../local_lib", "Custom={local_lib}"),
         ("Custom=file://../local_lib", "Custom=file://{local_lib}"),
+        ("Custom @ ../local_lib", "Custom @ {local_lib}"),
+        ("Custom @ file://../local_lib", "Custom @ file://{local_lib}"),
+        ("Custom @ symlink://../local_lib", "Custom @ symlink://{local_lib}"),
     ],
 )
 def test_platformio_env_name_resolves_local_libdep_uri_targets(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -461,7 +461,7 @@ def test_run_platformio_cli_scopes_libdeps_by_toolchain_and_dependencies(
 
     with patch.dict(os.environ, {}, clear=True):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
             setup_core
@@ -494,7 +494,7 @@ def test_run_platformio_cli_keeps_special_platform_libdeps_device_scoped(
 
     with patch.dict(os.environ, {}, clear=True):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
             (setup_core / "build" / "test" / ".piolibdeps").absolute()

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -15,9 +15,23 @@ from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
-from esphome.core import CORE, EsphomeError
+from esphome.core import CORE, EsphomeError, Library
 from esphome.platformio import runner, toolchain
 from esphome.util import FlashImage
+
+
+def _expected_env_fingerprint(
+    lib_deps: list[str], platformio_options: dict[str, list[str]] | None = None
+) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            {
+                "lib_deps": lib_deps,
+                "platformio_options": platformio_options or {},
+            },
+            sort_keys=True,
+        ).encode()
+    ).hexdigest()[:16]
 
 
 def test_idedata_firmware_elf_path(setup_core: Path) -> None:
@@ -309,14 +323,8 @@ def test_run_platformio_cli_sets_environment_variables(
             in Path(os.environ["PLATFORMIO_BUILD_DIR"]).parents
             or Path(os.environ["PLATFORMIO_BUILD_DIR"]) == setup_core / "build" / "test"
         )
-        fingerprint = hashlib.sha256(json.dumps([]).encode()).hexdigest()[:16]
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
-            setup_core
-            / ".esphome"
-            / "platformio"
-            / "libdeps"
-            / "esp8266-arduino"
-            / fingerprint
+            setup_core / ".esphome" / "platformio" / "libdeps" / "esp8266-arduino"
         )
         assert "PYTHONWARNINGS" in os.environ
 
@@ -450,27 +458,352 @@ def test_run_platformio_cli_scopes_libdeps_by_toolchain_and_dependencies(
         ],
     )
 
-    fingerprint = hashlib.sha256(
-        json.dumps(
-            [
-                "ESP32Async/ESPAsyncTCP @ 2.0.0",
-                "ESP32Async/ESPAsyncWebServer @ 3.9.6",
-            ]
-        ).encode()
-    ).hexdigest()[:16]
+    fingerprint = _expected_env_fingerprint(
+        [
+            "ESP32Async/ESPAsyncTCP @ 2.0.0",
+            "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+        ]
+    )
 
     with patch.dict(os.environ, {}, clear=True):
         mock_run_external_process.return_value = 0
         toolchain.run_platformio_cli("test")
 
         assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
-            setup_core
-            / ".esphome"
-            / "platformio"
-            / "libdeps"
-            / "rp2040-arduino"
-            / fingerprint
+            setup_core / ".esphome" / "platformio" / "libdeps" / "rp2040-arduino"
         )
+        assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_includes_preserved_common_libdeps(
+    setup_core: Path,
+) -> None:
+    """Preserved user common lib_deps keep shared PlatformIO envs distinct."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option(
+        "lib_deps",
+        [
+            "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+            "${common.lib_deps}",
+            "ESP32Async/ESPAsyncTCP @ 2.0.0",
+        ],
+    )
+    CORE.relative_build_path().mkdir(parents=True)
+    CORE.relative_build_path("platformio.ini").write_text(
+        """
+[common]
+lib_deps =
+    Custom/Zeta @ 2.0.0
+    Custom/Alpha @ 1.0.0
+""",
+        encoding="utf-8",
+    )
+
+    fingerprint = _expected_env_fingerprint(
+        [
+            "Custom/Alpha @ 1.0.0",
+            "Custom/Zeta @ 2.0.0",
+            "ESP32Async/ESPAsyncTCP @ 2.0.0",
+            "ESP32Async/ESPAsyncWebServer @ 3.9.6",
+        ]
+    )
+
+    assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_resolves_common_local_libdeps(
+    setup_core: Path,
+) -> None:
+    """Relative preserved common libdeps are fingerprinted by resolved path."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    local_lib = setup_core / "build" / "local_lib"
+    local_lib.mkdir(parents=True)
+    CORE.add_platformio_option("lib_deps", ["${common.lib_deps}"])
+    CORE.relative_build_path().mkdir(parents=True)
+    CORE.relative_build_path("platformio.ini").write_text(
+        """
+[common]
+lib_deps =
+    ../local_lib
+""",
+        encoding="utf-8",
+    )
+
+    fingerprint = _expected_env_fingerprint([str(local_lib.resolve())])
+
+    assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_includes_common_libdeps_before_ini_regeneration(
+    setup_core: Path,
+) -> None:
+    """ESP32 sdkconfig generation sees the same env hash as platformio.ini."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_library(Library("ESPAsyncTCP", "2.0.0"))
+    CORE.relative_build_path().mkdir(parents=True)
+    CORE.relative_build_path("platformio.ini").write_text(
+        """
+[common]
+lib_deps =
+    Custom/Alpha @ 1.0.0
+""",
+        encoding="utf-8",
+    )
+
+    fingerprint = _expected_env_fingerprint(
+        [
+            "Custom/Alpha @ 1.0.0",
+            "ESPAsyncTCP@2.0.0",
+        ]
+    )
+
+    assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_includes_configured_and_generated_libdeps(
+    setup_core: Path,
+) -> None:
+    """User lib_deps and component-generated libraries share one final env hash."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", ["User/CustomLib @ 1.0.0"])
+    CORE.add_library(Library("ESPAsyncTCP", "2.0.0"))
+
+    fingerprint = _expected_env_fingerprint(
+        [
+            "ESPAsyncTCP@2.0.0",
+            "User/CustomLib @ 1.0.0",
+        ]
+    )
+
+    assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
+
+
+def test_run_platformio_cli_updates_managed_libdeps_between_targets(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Long-lived processes update ESPHome-managed libdeps per target."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    toolchain._managed_platformio_libdeps_dir["value"] = None
+    with patch.dict(os.environ, {}, clear=True):
+        mock_run_external_process.return_value = 0
+        CORE.build_path = str(setup_core / "build" / "esp8266")
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: "esp8266",
+            KEY_TARGET_FRAMEWORK: "arduino",
+        }
+        toolchain.run_platformio_cli("test")
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
+            setup_core / ".esphome" / "platformio" / "libdeps" / "esp8266-arduino"
+        )
+
+        CORE.build_path = str(setup_core / "build" / "esp32")
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: "esp32",
+            KEY_TARGET_FRAMEWORK: "arduino",
+        }
+        toolchain.run_platformio_cli("test")
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == str(
+            setup_core / ".esphome" / "platformio" / "libdeps" / "esp32-arduino"
+        )
+
+
+def test_run_platformio_cli_preserves_user_libdeps_override(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """User-provided PLATFORMIO_LIBDEPS_DIR remains authoritative."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    toolchain._managed_platformio_libdeps_dir["value"] = None
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+
+    with patch.dict(
+        os.environ, {"PLATFORMIO_LIBDEPS_DIR": "/custom/libdeps"}, clear=True
+    ):
+        mock_run_external_process.return_value = 0
+        toolchain.run_platformio_cli("test")
+
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == "/custom/libdeps"
+        assert toolchain._managed_platformio_libdeps_dir["value"] is None
+
+
+def test_run_platformio_cli_preserves_late_user_libdeps_override(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Per-config environment overrides win after a previous managed compile."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    toolchain._managed_platformio_libdeps_dir["value"] = None
+    mock_run_external_process.return_value = 0
+    with patch.dict(os.environ, {}, clear=True):
+        CORE.build_path = str(setup_core / "build" / "first")
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: "esp8266",
+            KEY_TARGET_FRAMEWORK: "arduino",
+        }
+        toolchain.run_platformio_cli("test")
+        managed_value = os.environ["PLATFORMIO_LIBDEPS_DIR"]
+
+        os.environ["PLATFORMIO_LIBDEPS_DIR"] = "/custom/libdeps"
+        CORE.build_path = str(setup_core / "build" / "second")
+        toolchain.run_platformio_cli("test")
+
+        assert managed_value != "/custom/libdeps"
+        assert os.environ["PLATFORMIO_LIBDEPS_DIR"] == "/custom/libdeps"
+        assert toolchain._managed_platformio_libdeps_dir["value"] == managed_value
+
+
+def test_platformio_env_name_resolves_local_libdeps(
+    setup_core: Path,
+) -> None:
+    """Relative local libdeps are fingerprinted by resolved project path."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    local_lib = setup_core / "build" / "local_lib"
+    local_lib.mkdir(parents=True)
+    CORE.add_platformio_option("lib_deps", ["../local_lib"])
+
+    fingerprint = _expected_env_fingerprint([str(local_lib.resolve())])
+
+    assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_includes_toolchain_options(
+    setup_core: Path,
+) -> None:
+    """Selected PlatformIO options keep resolver envs distinct."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", ["AsyncTCP-esphome @ 2.1.4"])
+    CORE.add_platformio_option("platform", "platformio/espressif32 @ 6.10.0")
+    CORE.add_platformio_option(
+        "platform_packages", ["framework-arduinoespressif32 @ 3.2.0"]
+    )
+    CORE.add_platformio_option("build_flags", ["-DDEVICE_SPECIFIC"])
+
+    fingerprint = _expected_env_fingerprint(
+        ["AsyncTCP-esphome @ 2.1.4"],
+        {
+            "platform": ["platformio/espressif32 @ 6.10.0"],
+            "platform_packages": ["framework-arduinoespressif32 @ 3.2.0"],
+        },
+    )
+
+    assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
+
+
+def test_platformio_env_name_reuses_existing_generated_env(
+    setup_core: Path,
+) -> None:
+    """Upload-only flows reuse the env that the previous compile generated."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.name = "living-room"
+    CORE.build_path = setup_core / "build" / "living-room"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    platformio_ini.parent.mkdir(parents=True)
+    platformio_ini.write_text(
+        """
+[platformio]
+description = ESPHome test
+
+[env:user-custom]
+platform = custom
+
+; ========== AUTO GENERATED CODE BEGIN ===========
+
+[env:esp8266-arduino-compiled1234]
+lib_deps =
+    ESP8266WiFi
+; =========== AUTO GENERATED CODE END ============
+""",
+        encoding="utf-8",
+    )
+
+    assert (
+        toolchain.platformio_env_name(prefer_existing=True)
+        == "esp8266-arduino-compiled1234"
+    )
+    assert toolchain.platformio_env_name().startswith("esp8266-arduino-")
+
+
+def test_platformio_env_name_reuses_existing_env_with_user_libdeps(
+    setup_core: Path,
+) -> None:
+    """Upload-only flows should not recompute a partial libdeps fingerprint."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.name = "living-room"
+    CORE.build_path = setup_core / "build" / "living-room"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", ["User/CustomLib @ 1.0.0"])
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    platformio_ini.parent.mkdir(parents=True)
+    platformio_ini.write_text(
+        """
+[platformio]
+description = ESPHome test
+
+; ========== AUTO GENERATED CODE BEGIN ===========
+
+[env:esp8266-arduino-compiled1234]
+lib_deps =
+    User/CustomLib @ 1.0.0
+    Component/Generated @ 2.0.0
+; =========== AUTO GENERATED CODE END ============
+""",
+        encoding="utf-8",
+    )
+
+    assert (
+        toolchain.platformio_env_name(prefer_existing=True)
+        == "esp8266-arduino-compiled1234"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -913,12 +913,55 @@ def test_run_platformio_cli_run_builds_command(
     mock_run_platformio_cli.assert_called_once_with(
         "run",
         "-d",
-        CORE.build_path,
+        str(CORE.build_path),
         "-e",
         toolchain.platformio_env_name(),
         "-v",
         "extra",
         "args",
+    )
+
+
+def test_run_platformio_cli_run_reuses_existing_generated_env(
+    setup_core: Path, mock_run_platformio_cli: Mock
+) -> None:
+    """Upload-only PlatformIO runs should use the env from generated ini."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.name = "living-room"
+    CORE.build_path = setup_core / "build" / "living-room"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    platformio_ini = CORE.relative_build_path("platformio.ini")
+    platformio_ini.parent.mkdir(parents=True)
+    platformio_ini.write_text(
+        """
+; ========== AUTO GENERATED CODE BEGIN ===========
+
+[env:rp2040-arduino-compiled1234]
+lib_deps =
+    Component/Generated @ 2.0.0
+; =========== AUTO GENERATED CODE END ============
+""",
+        encoding="utf-8",
+    )
+    mock_run_platformio_cli.return_value = 0
+
+    config = {"name": "test"}
+    toolchain.run_platformio_cli_run(config, False, "-t", "upload", "-t", "nobuild")
+
+    mock_run_platformio_cli.assert_called_once_with(
+        "run",
+        "-d",
+        str(CORE.build_path),
+        "-e",
+        "rp2040-arduino-compiled1234",
+        "-t",
+        "upload",
+        "-t",
+        "nobuild",
     )
 
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -845,7 +845,14 @@ def test_run_platformio_cli_run_builds_command(
     toolchain.run_platformio_cli_run(config, True, "extra", "args")
 
     mock_run_platformio_cli.assert_called_once_with(
-        "run", "-d", CORE.build_path, "-v", "extra", "args"
+        "run",
+        "-d",
+        CORE.build_path,
+        "-e",
+        toolchain.platformio_env_name(),
+        "-v",
+        "extra",
+        "args",
     )
 
 

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -901,6 +901,30 @@ def test_platformio_env_name_includes_configured_and_generated_libdeps(
     assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
 
 
+def test_platformio_env_name_includes_scalar_configured_libdeps(
+    setup_core: Path,
+) -> None:
+    """Scalar user lib_deps values must isolate generated envs too."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp32",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    CORE.add_platformio_option("lib_deps", "OneOff/ScalarLib @ 4.2.0")
+    CORE.add_library(Library("GeneratedAsync", "2.0.0"))
+
+    fingerprint = _expected_env_fingerprint(
+        [
+            "GeneratedAsync@2.0.0",
+            "OneOff/ScalarLib @ 4.2.0",
+        ]
+    )
+
+    assert toolchain.platformio_env_name() == f"esp32-arduino-{fingerprint}"
+
+
 def test_run_platformio_cli_updates_managed_libdeps_between_targets(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -767,6 +767,36 @@ def test_platformio_env_name_resolves_local_libdeps(
     assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
 
 
+@pytest.mark.parametrize(
+    ("lib_dep", "fingerprint_value"),
+    [
+        ("file://../local_lib", "file://{local_lib}"),
+        ("symlink://../local_lib", "symlink://{local_lib}"),
+        ("Custom=file://../local_lib", "Custom=file://{local_lib}"),
+    ],
+)
+def test_platformio_env_name_resolves_local_libdep_uri_targets(
+    setup_core: Path, lib_dep: str, fingerprint_value: str
+) -> None:
+    """Local URI libdeps are fingerprinted by their resolved target path."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "rp2040",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
+    local_lib = setup_core / "build" / "local_lib"
+    local_lib.mkdir(parents=True)
+    CORE.add_platformio_option("lib_deps", [lib_dep])
+
+    fingerprint = _expected_env_fingerprint(
+        [fingerprint_value.format(local_lib=local_lib.resolve())]
+    )
+
+    assert toolchain.platformio_env_name() == f"rp2040-arduino-{fingerprint}"
+
+
 def test_platformio_env_name_includes_toolchain_options(
     setup_core: Path,
 ) -> None:

--- a/tests/unit_tests/test_storage_json.py
+++ b/tests/unit_tests/test_storage_json.py
@@ -303,7 +303,7 @@ def test_storage_json_from_esphome_core(setup_core: Path) -> None:
     mock_core.target_platform = "esp32"
     mock_core.is_esp32 = True
     mock_core.build_path = "/build/my_device"
-    mock_core.firmware_bin = "/build/my_device/firmware.bin"
+    mock_core.firmware_bin_path.return_value = "/build/my_device/firmware.bin"
     mock_core.loaded_integrations = {"wifi", "api"}
     mock_core.loaded_platforms = {"sensor"}
     mock_core.config = {CONF_MDNS: {CONF_DISABLED: True}}
@@ -323,6 +323,7 @@ def test_storage_json_from_esphome_core(setup_core: Path) -> None:
     assert result.target_platform == "ESP32-C3"
     assert result.build_path == "/build/my_device"
     assert result.firmware_bin_path == "/build/my_device/firmware.bin"
+    mock_core.firmware_bin_path.assert_called_once_with(prefer_existing=False)
     assert result.loaded_integrations == {"wifi", "api"}
     assert result.loaded_platforms == {"sensor"}
     assert result.no_mdns is True
@@ -342,7 +343,7 @@ def test_storage_json_from_esphome_core_mdns_enabled(setup_core: Path) -> None:
     mock_core.target_platform = "esp8266"
     mock_core.is_esp32 = False
     mock_core.build_path = "/build"
-    mock_core.firmware_bin = "/build/firmware.bin"
+    mock_core.firmware_bin_path.return_value = "/build/firmware.bin"
     mock_core.loaded_integrations = set()
     mock_core.loaded_platforms = set()
     mock_core.config = {}  # No MDNS config means enabled

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -440,6 +440,10 @@ def test_clean_build(
     piolibdeps_dir.mkdir()
     (piolibdeps_dir / "library").mkdir()
 
+    shared_piolibdeps_dir = tmp_path / ".esphome" / "platformio" / "libdeps"
+    shared_piolibdeps_dir.mkdir(parents=True)
+    (shared_piolibdeps_dir / "shared-library").mkdir()
+
     dependencies_lock = tmp_path / "dependencies.lock"
     dependencies_lock.write_text("lock file")
 
@@ -462,11 +466,13 @@ def test_clean_build(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
+    mock_core.relative_internal_path.return_value = shared_piolibdeps_dir
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify all exist before
     assert pioenvs_dir.exists()
     assert piolibdeps_dir.exists()
+    assert shared_piolibdeps_dir.exists()
     assert dependencies_lock.exists()
     assert idf_build_dir.exists()
     assert managed_components_dir.exists()
@@ -491,6 +497,7 @@ def test_clean_build(
     # Verify all were removed
     assert not pioenvs_dir.exists()
     assert not piolibdeps_dir.exists()
+    assert not shared_piolibdeps_dir.exists()
     assert not dependencies_lock.exists()
     assert not idf_build_dir.exists()
     assert not managed_components_dir.exists()
@@ -500,6 +507,7 @@ def test_clean_build(
     assert "Deleting" in caplog.text
     assert ".pioenvs" in caplog.text
     assert ".piolibdeps" in caplog.text
+    assert "platformio/libdeps" in caplog.text
     assert "dependencies.lock" in caplog.text
     assert str(idf_build_dir) in caplog.text
     assert str(managed_components_dir) in caplog.text
@@ -524,6 +532,9 @@ def test_clean_build_partial_exists(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify only pioenvs exists
@@ -561,6 +572,9 @@ def test_clean_build_nothing_exists(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify nothing exists
@@ -597,6 +611,9 @@ def test_clean_build_platformio_not_available(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify all exist before
@@ -635,6 +652,9 @@ def test_clean_build_empty_cache_dir(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify pioenvs exists before
@@ -1363,6 +1383,9 @@ def test_clean_build_handles_readonly_files(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     # Verify file is read-only

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -507,7 +507,7 @@ def test_clean_build(
     assert "Deleting" in caplog.text
     assert ".pioenvs" in caplog.text
     assert ".piolibdeps" in caplog.text
-    assert "platformio/libdeps" in caplog.text
+    assert str(shared_piolibdeps_dir) in caplog.text
     assert "dependencies.lock" in caplog.text
     assert str(idf_build_dir) in caplog.text
     assert str(managed_components_dir) in caplog.text

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -437,7 +437,7 @@ def test_clean_build(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test clean_build removes all build artifacts."""
+    """Test clean_build removes device build artifacts without shared libdeps."""
     # Create directory structure and files
     pioenvs_dir = tmp_path / ".pioenvs"
     pioenvs_dir.mkdir()
@@ -486,15 +486,9 @@ def test_clean_build(
     assert platformio_cache_dir.exists()
 
     # Mock PlatformIO's ProjectConfig cache_dir
-    with (
-        patch(
-            "platformio.project.config.ProjectConfig.get_instance"
-        ) as mock_get_instance,
-        patch(
-            "esphome.platformio.toolchain._platformio_libdeps_dir",
-            return_value=shared_piolibdeps_dir,
-        ),
-    ):
+    with patch(
+        "platformio.project.config.ProjectConfig.get_instance"
+    ) as mock_get_instance:
         mock_config = MagicMock()
         mock_get_instance.return_value = mock_config
         mock_config.get.side_effect = lambda section, option: (
@@ -507,10 +501,11 @@ def test_clean_build(
         with caplog.at_level("INFO"):
             clean_build()
 
-    # Verify all were removed
+    # Verify device-scoped paths were removed; shared libdeps are preserved
+    # because sibling builds may be using the same PlatformIO env.
     assert not pioenvs_dir.exists()
     assert not piolibdeps_dir.exists()
-    assert not shared_piolibdeps_dir.exists()
+    assert shared_piolibdeps_dir.exists()
     assert not dependencies_lock.exists()
     assert not idf_build_dir.exists()
     assert not managed_components_dir.exists()
@@ -520,7 +515,7 @@ def test_clean_build(
     assert "Deleting" in caplog.text
     assert ".pioenvs" in caplog.text
     assert ".piolibdeps" in caplog.text
-    assert str(shared_piolibdeps_dir) in caplog.text
+    assert str(shared_piolibdeps_dir) not in caplog.text
     assert "dependencies.lock" in caplog.text
     assert str(idf_build_dir) in caplog.text
     assert str(managed_components_dir) in caplog.text

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -358,13 +358,18 @@ def test_clean_cmake_cache(
 
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
-    mock_core.name = "test_device"
 
     # Verify file exists before
     assert cmake_cache_file.exists()
 
     # Call the function
-    with caplog.at_level("INFO"):
+    with (
+        patch(
+            "esphome.platformio.toolchain.platformio_env_name",
+            return_value="test_device",
+        ),
+        caplog.at_level("INFO"),
+    ):
         clean_cmake_cache()
 
     # Verify file was removed
@@ -412,13 +417,15 @@ def test_clean_cmake_cache_no_cmake_file(
 
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
-    mock_core.name = "test_device"
 
     # Verify file doesn't exist
     assert not cmake_cache_file.exists()
 
     # Call the function - should not crash
-    clean_cmake_cache()
+    with patch(
+        "esphome.platformio.toolchain.platformio_env_name", return_value="test_device"
+    ):
+        clean_cmake_cache()
 
     # Verify file still doesn't exist
     assert not cmake_cache_file.exists()
@@ -479,9 +486,15 @@ def test_clean_build(
     assert platformio_cache_dir.exists()
 
     # Mock PlatformIO's ProjectConfig cache_dir
-    with patch(
-        "platformio.project.config.ProjectConfig.get_instance"
-    ) as mock_get_instance:
+    with (
+        patch(
+            "platformio.project.config.ProjectConfig.get_instance"
+        ) as mock_get_instance,
+        patch(
+            "esphome.platformio.toolchain._platformio_libdeps_dir",
+            return_value=shared_piolibdeps_dir,
+        ),
+    ):
         mock_config = MagicMock()
         mock_get_instance.return_value = mock_config
         mock_config.get.side_effect = lambda section, option: (
@@ -512,7 +525,6 @@ def test_clean_build(
     assert str(idf_build_dir) in caplog.text
     assert str(managed_components_dir) in caplog.text
     assert "PlatformIO cache" in caplog.text
-    mock_core.relative_internal_path.assert_called_once_with("platformio", "libdeps")
 
 
 @patch("esphome.writer.CORE")
@@ -534,7 +546,7 @@ def test_clean_build_partial_exists(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
     mock_core.relative_internal_path.return_value = (
-        tmp_path / ".esphome" / "platformio" / "libdeps"
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
     )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
@@ -574,7 +586,7 @@ def test_clean_build_nothing_exists(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
     mock_core.relative_internal_path.return_value = (
-        tmp_path / ".esphome" / "platformio" / "libdeps"
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
     )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
@@ -613,7 +625,7 @@ def test_clean_build_platformio_not_available(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = piolibdeps_dir
     mock_core.relative_internal_path.return_value = (
-        tmp_path / ".esphome" / "platformio" / "libdeps"
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
     )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
@@ -654,7 +666,7 @@ def test_clean_build_empty_cache_dir(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
     mock_core.relative_internal_path.return_value = (
-        tmp_path / ".esphome" / "platformio" / "libdeps"
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
     )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
@@ -1385,7 +1397,7 @@ def test_clean_build_handles_readonly_files(
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
     mock_core.relative_internal_path.return_value = (
-        tmp_path / ".esphome" / "platformio" / "libdeps"
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
     )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
@@ -1451,6 +1463,9 @@ def test_clean_build_reraises_for_other_errors(
     # Setup mocks
     mock_core.relative_pioenvs_path.return_value = pioenvs_dir
     mock_core.relative_piolibdeps_path.return_value = tmp_path / ".piolibdeps"
+    mock_core.relative_internal_path.return_value = (
+        tmp_path / ".esphome" / "platformio" / "libdeps" / "unknown-unknown"
+    )
     mock_core.relative_build_path.side_effect = lambda name: tmp_path / name
 
     try:

--- a/tests/unit_tests/test_writer.py
+++ b/tests/unit_tests/test_writer.py
@@ -512,6 +512,7 @@ def test_clean_build(
     assert str(idf_build_dir) in caplog.text
     assert str(managed_components_dir) in caplog.text
     assert "PlatformIO cache" in caplog.text
+    mock_core.relative_internal_path.assert_called_once_with("platformio", "libdeps")
 
 
 @patch("esphome.writer.CORE")


### PR DESCRIPTION
# What does this implement/fix?

Shares PlatformIO `libdeps` directories across embedded configs with matching platform/framework and dependency fingerprints. Host and nRF52/Zephyr remain device-scoped. Shared libdeps are preserved during single-device build cleans, and PlatformIO runs that mutate a shared libdeps env are serialized with a per-env lock.

Split from #15983 following the requested split review: https://github.com/esphome/esphome/pull/15983#pullrequestreview-4175643725

Merge order: independent. Can merge with #16007, #16008, and #16010 in any order. Does not block the ordered env/cache wave, but it is part of the original #15983 split.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Split from #15983

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable, internal PlatformIO dependency-cache behavior only.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable: no user-facing YAML configuration changes.
```

## Checklist:

- [x] The code change is tested and works locally.
- [x] Tests have been added to verify that the new code works (under `tests/` folder).

Validation:

- `PYTHONPATH=. /home/kom/proj/hass/esphome/.venv/bin/python -m pytest -q tests/unit_tests/test_platformio_toolchain.py tests/unit_tests/test_writer.py`
- `PYTHONPATH=. /home/kom/proj/hass/esphome/.venv/bin/python -m ruff format --check esphome/platformio/toolchain.py esphome/writer.py tests/unit_tests/test_platformio_toolchain.py tests/unit_tests/test_writer.py`
- `PYTHONPATH=. /home/kom/proj/hass/esphome/.venv/bin/python -m ruff check esphome/platformio/toolchain.py esphome/writer.py tests/unit_tests/test_platformio_toolchain.py tests/unit_tests/test_writer.py`
- `PYTHONPATH=. /home/kom/proj/hass/esphome/.venv/bin/python script/ci-custom.py esphome/platformio/toolchain.py esphome/writer.py tests/unit_tests/test_platformio_toolchain.py tests/unit_tests/test_writer.py`
- `git diff --check`

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). Not applicable: no user-facing functionality or configuration variables are added.
