### PR TITLE
[core] Reuse Zephyr compiles with ccache

### DIFF
--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -56,7 +56,7 @@ def _platformio_toolchain_cache_key() -> str:
 
 
 def _configure_zephyr_ccache() -> None:
-    """Use ccache for Zephyr's CMake/Ninja builds when it is available."""
+    """Scope Zephyr's CMake/Ninja ccache state when it is available."""
     core_data = CORE.data.get(KEY_CORE, {})
     if core_data.get(KEY_TARGET_FRAMEWORK) != "zephyr":
         for name in _ZEPHYR_CCACHE_ENV_DEFAULTS:
@@ -69,6 +69,10 @@ def _configure_zephyr_ccache() -> None:
             _unset_platformio_env_default(name)
         return
 
+    # The Nordic Zephyr PlatformIO framework already exposes ccache on PATH.
+    # ESPHome still owns these defaults so update-all style runs use an
+    # ESPHome-scoped cache and do not leak managed Zephyr settings into the next
+    # framework built in the same Python process.
     _set_platformio_env_default("CMAKE_C_COMPILER_LAUNCHER", ccache)
     _set_platformio_env_default("CMAKE_CXX_COMPILER_LAUNCHER", ccache)
     _set_platformio_env_default(

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -50,6 +50,8 @@ def _unset_platformio_env_default(name: str) -> None:
 def _platformio_toolchain_cache_key() -> str:
     """Return the stable key used for toolchain-scoped PlatformIO state."""
     core_data = CORE.data.get(KEY_CORE, {})
+    # Real Zephyr builds set both fields; these fallbacks keep incomplete test
+    # setup or future call ordering from crashing before PlatformIO reports it.
     platform = core_data.get(KEY_TARGET_PLATFORM) or "unknown"
     framework = core_data.get(KEY_TARGET_FRAMEWORK) or "unknown"
     return re.sub(r"[^a-zA-Z0-9_.-]", "_", f"{platform}-{framework}")
@@ -59,12 +61,16 @@ def _configure_zephyr_ccache() -> None:
     """Scope Zephyr's CMake/Ninja ccache state when it is available."""
     core_data = CORE.data.get(KEY_CORE, {})
     if core_data.get(KEY_TARGET_FRAMEWORK) != "zephyr":
+        # Prevent ESPHome-managed Zephyr ccache defaults from leaking into a
+        # later PlatformIO build for another framework in the same process.
         for name in _ZEPHYR_CCACHE_ENV_DEFAULTS:
             _unset_platformio_env_default(name)
         return
 
     ccache = shutil.which("ccache")
     if ccache is None:
+        # If ccache disappears between mixed build runs, remove only the
+        # Zephyr defaults ESPHome owns and leave user overrides untouched.
         for name in _ZEPHYR_CCACHE_ENV_DEFAULTS:
             _unset_platformio_env_default(name)
         return

--- a/esphome/platformio/toolchain.py
+++ b/esphome/platformio/toolchain.py
@@ -3,13 +3,85 @@ import logging
 import os
 from pathlib import Path
 import re
+import shutil
 import sys
 
-from esphome.const import CONF_COMPILE_PROCESS_LIMIT, CONF_ESPHOME, KEY_CORE
+from esphome.const import (
+    CONF_COMPILE_PROCESS_LIMIT,
+    CONF_ESPHOME,
+    KEY_CORE,
+    KEY_TARGET_FRAMEWORK,
+    KEY_TARGET_PLATFORM,
+)
 from esphome.core import CORE, EsphomeError
 from esphome.util import FlashImage, run_external_process
 
 _LOGGER = logging.getLogger(__name__)
+
+_PLATFORMIO_ENV_DEFAULTS: dict[str, str] = {}
+_ZEPHYR_CCACHE_ENV_DEFAULTS = (
+    "CMAKE_C_COMPILER_LAUNCHER",
+    "CMAKE_CXX_COMPILER_LAUNCHER",
+    "CCACHE_DIR",
+    "CCACHE_BASEDIR",
+    "CCACHE_NOHASHDIR",
+    "CCACHE_MAXSIZE",
+)
+
+
+def _set_platformio_env_default(name: str, value: str) -> None:
+    """Set an env default while preserving user-provided overrides."""
+    current = os.environ.get(name)
+    if current is not None and _PLATFORMIO_ENV_DEFAULTS.get(name) != current:
+        return
+
+    os.environ[name] = value
+    _PLATFORMIO_ENV_DEFAULTS[name] = value
+
+
+def _unset_platformio_env_default(name: str) -> None:
+    """Remove an env value only when ESPHome set that default."""
+    current = os.environ.get(name)
+    if current is not None and _PLATFORMIO_ENV_DEFAULTS.get(name) == current:
+        os.environ.pop(name, None)
+    _PLATFORMIO_ENV_DEFAULTS.pop(name, None)
+
+
+def _platformio_toolchain_cache_key() -> str:
+    """Return the stable key used for toolchain-scoped PlatformIO state."""
+    core_data = CORE.data.get(KEY_CORE, {})
+    platform = core_data.get(KEY_TARGET_PLATFORM) or "unknown"
+    framework = core_data.get(KEY_TARGET_FRAMEWORK) or "unknown"
+    return re.sub(r"[^a-zA-Z0-9_.-]", "_", f"{platform}-{framework}")
+
+
+def _configure_zephyr_ccache() -> None:
+    """Use ccache for Zephyr's CMake/Ninja builds when it is available."""
+    core_data = CORE.data.get(KEY_CORE, {})
+    if core_data.get(KEY_TARGET_FRAMEWORK) != "zephyr":
+        for name in _ZEPHYR_CCACHE_ENV_DEFAULTS:
+            _unset_platformio_env_default(name)
+        return
+
+    ccache = shutil.which("ccache")
+    if ccache is None:
+        for name in _ZEPHYR_CCACHE_ENV_DEFAULTS:
+            _unset_platformio_env_default(name)
+        return
+
+    _set_platformio_env_default("CMAKE_C_COMPILER_LAUNCHER", ccache)
+    _set_platformio_env_default("CMAKE_CXX_COMPILER_LAUNCHER", ccache)
+    _set_platformio_env_default(
+        "CCACHE_DIR",
+        str(
+            CORE.relative_internal_path(
+                "platformio", "ccache", _platformio_toolchain_cache_key()
+            ).absolute()
+        ),
+    )
+    _set_platformio_env_default("CCACHE_BASEDIR", str(Path(CORE.build_path).absolute()))
+    _set_platformio_env_default("CCACHE_NOHASHDIR", "true")
+    _set_platformio_env_default("CCACHE_MAXSIZE", "512M")
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
@@ -46,6 +118,7 @@ def _strip_win_long_path_prefix(path: str) -> str:
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
+    _configure_zephyr_ccache()
     os.environ.setdefault(
         "PLATFORMIO_LIBDEPS_DIR", str(CORE.relative_piolibdeps_path().absolute())
     )

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -434,10 +434,12 @@ def test_run_platformio_cli_scopes_zephyr_ccache_when_available(
 
     with (
         patch.dict(os.environ, {}, clear=True),
-        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+        patch(
+            "esphome.platformio.toolchain.shutil.which", return_value="/usr/bin/ccache"
+        ),
     ):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/usr/bin/ccache"
         assert os.environ["CMAKE_CXX_COMPILER_LAUNCHER"] == "/usr/bin/ccache"
@@ -463,10 +465,10 @@ def test_run_platformio_cli_skips_zephyr_ccache_when_unavailable(
 
     with (
         patch.dict(os.environ, {}, clear=True),
-        patch("esphome.platformio_api.shutil.which", return_value=None),
+        patch("esphome.platformio.toolchain.shutil.which", return_value=None),
     ):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert "CMAKE_C_COMPILER_LAUNCHER" not in os.environ
         assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ
@@ -491,10 +493,12 @@ def test_run_platformio_cli_preserves_user_zephyr_ccache_overrides(
     }
     with (
         patch.dict(os.environ, user_env, clear=True),
-        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+        patch(
+            "esphome.platformio.toolchain.shutil.which", return_value="/usr/bin/ccache"
+        ),
     ):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/opt/custom/ccache"
         assert os.environ["CCACHE_DIR"] == "/opt/custom/cache"
@@ -506,7 +510,7 @@ def test_run_platformio_cli_preserves_user_zephyr_ccache_overrides(
             KEY_TARGET_PLATFORM: "esp32",
             KEY_TARGET_FRAMEWORK: "arduino",
         }
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/opt/custom/ccache"
         assert os.environ["CCACHE_DIR"] == "/opt/custom/cache"
@@ -528,10 +532,12 @@ def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(
 
     with (
         patch.dict(os.environ, {}, clear=True),
-        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+        patch(
+            "esphome.platformio.toolchain.shutil.which", return_value="/usr/bin/ccache"
+        ),
     ):
         mock_run_external_process.return_value = 0
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
         assert os.environ["CCACHE_DIR"].endswith("nrf52-zephyr")
 
         CORE.build_path = setup_core / "build" / "esp32-test"
@@ -539,7 +545,7 @@ def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(
             KEY_TARGET_PLATFORM: "esp32",
             KEY_TARGET_FRAMEWORK: "arduino",
         }
-        platformio_api.run_platformio_cli("test")
+        toolchain.run_platformio_cli("test")
 
         assert "CMAKE_C_COMPILER_LAUNCHER" not in os.environ
         assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -19,6 +19,14 @@ from esphome.platformio import runner, toolchain
 from esphome.util import FlashImage
 
 
+@pytest.fixture(autouse=True)
+def reset_platformio_env_defaults() -> None:
+    """Keep module-level PlatformIO env tracking isolated between tests."""
+    toolchain._PLATFORMIO_ENV_DEFAULTS.clear()
+    yield
+    toolchain._PLATFORMIO_ENV_DEFAULTS.clear()
+
+
 def test_idedata_firmware_elf_path(setup_core: Path) -> None:
     """Test IDEData.firmware_elf_path returns correct path."""
     CORE.build_path = setup_core / "build" / "test"

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -420,10 +420,10 @@ def test_run_platformio_cli_does_not_set_pythonexepath_without_strip(
         assert "PYTHONEXEPATH" not in os.environ
 
 
-def test_run_platformio_cli_enables_zephyr_ccache_when_available(
+def test_run_platformio_cli_scopes_zephyr_ccache_when_available(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:
-    """Zephyr CMake/Ninja builds should use a scoped ccache when available."""
+    """Zephyr CMake/Ninja builds should use ESPHome-scoped ccache state."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
     CORE.build_path = setup_core / "build" / "nrf52-test"
@@ -471,6 +471,47 @@ def test_run_platformio_cli_skips_zephyr_ccache_when_unavailable(
         assert "CMAKE_C_COMPILER_LAUNCHER" not in os.environ
         assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ
         assert "CCACHE_DIR" not in os.environ
+
+
+def test_run_platformio_cli_preserves_user_zephyr_ccache_overrides(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """User-provided ccache settings should survive mixed-framework runs."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = setup_core / "build" / "nrf52-test"
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "nrf52",
+        KEY_TARGET_FRAMEWORK: "zephyr",
+    }
+
+    user_env = {
+        "CMAKE_C_COMPILER_LAUNCHER": "/opt/custom/ccache",
+        "CCACHE_DIR": "/opt/custom/cache",
+    }
+    with (
+        patch.dict(os.environ, user_env, clear=True),
+        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+    ):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+
+        assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/opt/custom/ccache"
+        assert os.environ["CCACHE_DIR"] == "/opt/custom/cache"
+        assert os.environ["CMAKE_CXX_COMPILER_LAUNCHER"] == "/usr/bin/ccache"
+        assert os.environ["CCACHE_BASEDIR"] == str(setup_core / "build" / "nrf52-test")
+
+        CORE.build_path = setup_core / "build" / "esp32-test"
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: "esp32",
+            KEY_TARGET_FRAMEWORK: "arduino",
+        }
+        platformio_api.run_platformio_cli("test")
+
+        assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/opt/custom/ccache"
+        assert os.environ["CCACHE_DIR"] == "/opt/custom/cache"
+        assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ
+        assert "CCACHE_BASEDIR" not in os.environ
 
 
 def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -289,7 +289,13 @@ def test_run_platformio_cli_sets_environment_variables(
     setup_core: Path, mock_run_external_process: Mock
 ) -> None:
     """Test run_platformio_cli sets correct environment variables."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
     CORE.build_path = str(setup_core / "build" / "test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "esp8266",
+        KEY_TARGET_FRAMEWORK: "arduino",
+    }
 
     with patch.dict(os.environ, {}, clear=False):
         mock_run_external_process.return_value = 0
@@ -412,6 +418,91 @@ def test_run_platformio_cli_does_not_set_pythonexepath_without_strip(
         args = mock_run_external_process.call_args[0]
         assert args[0] == plain_exe
         assert "PYTHONEXEPATH" not in os.environ
+
+
+def test_run_platformio_cli_enables_zephyr_ccache_when_available(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Zephyr CMake/Ninja builds should use a scoped ccache when available."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "nrf52",
+        KEY_TARGET_FRAMEWORK: "zephyr",
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+    ):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+
+        assert os.environ["CMAKE_C_COMPILER_LAUNCHER"] == "/usr/bin/ccache"
+        assert os.environ["CMAKE_CXX_COMPILER_LAUNCHER"] == "/usr/bin/ccache"
+        assert os.environ["CCACHE_DIR"] == str(
+            setup_core / ".esphome" / "platformio" / "ccache" / "nrf52-zephyr"
+        )
+        assert os.environ["CCACHE_BASEDIR"] == str(setup_core / "build" / "nrf52-test")
+        assert os.environ["CCACHE_NOHASHDIR"] == "true"
+        assert os.environ["CCACHE_MAXSIZE"] == "512M"
+
+
+def test_run_platformio_cli_skips_zephyr_ccache_when_unavailable(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Zephyr builds should still work normally on systems without ccache."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "nrf52",
+        KEY_TARGET_FRAMEWORK: "zephyr",
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("esphome.platformio_api.shutil.which", return_value=None),
+    ):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+
+        assert "CMAKE_C_COMPILER_LAUNCHER" not in os.environ
+        assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ
+        assert "CCACHE_DIR" not in os.environ
+
+
+def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    """Update-all style runs should not leak Zephyr ccache settings."""
+    from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
+
+    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.data[KEY_CORE] = {
+        KEY_TARGET_PLATFORM: "nrf52",
+        KEY_TARGET_FRAMEWORK: "zephyr",
+    }
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("esphome.platformio_api.shutil.which", return_value="/usr/bin/ccache"),
+    ):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test")
+        assert os.environ["CCACHE_DIR"].endswith("nrf52-zephyr")
+
+        CORE.build_path = str(setup_core / "build" / "esp32-test")
+        CORE.data[KEY_CORE] = {
+            KEY_TARGET_PLATFORM: "esp32",
+            KEY_TARGET_FRAMEWORK: "arduino",
+        }
+        platformio_api.run_platformio_cli("test")
+
+        assert "CMAKE_C_COMPILER_LAUNCHER" not in os.environ
+        assert "CMAKE_CXX_COMPILER_LAUNCHER" not in os.environ
+        assert "CCACHE_DIR" not in os.environ
 
 
 def test_run_platformio_cli_run_builds_command(

--- a/tests/unit_tests/test_platformio_toolchain.py
+++ b/tests/unit_tests/test_platformio_toolchain.py
@@ -146,7 +146,7 @@ def test_load_idedata_uses_cache_when_valid(
     setup_core: Path, mock_run_platformio_cli_run: Mock
 ) -> None:
     """Test _load_idedata uses cached data when unchanged."""
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     CORE.name = "test"
 
     # Create platformio.ini
@@ -176,7 +176,7 @@ def test_load_idedata_regenerates_when_platformio_ini_newer(
     setup_core: Path, mock_run_platformio_cli_run: Mock
 ) -> None:
     """Test _load_idedata regenerates when platformio.ini is newer."""
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     CORE.name = "test"
 
     # Create idedata cache file first
@@ -209,7 +209,7 @@ def test_load_idedata_regenerates_on_corrupted_cache(
     setup_core: Path, mock_run_platformio_cli_run: Mock
 ) -> None:
     """Test _load_idedata regenerates when cache file is corrupted."""
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     CORE.name = "test"
 
     # Create platformio.ini
@@ -291,7 +291,7 @@ def test_run_platformio_cli_sets_environment_variables(
     """Test run_platformio_cli sets correct environment variables."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: "esp8266",
         KEY_TARGET_FRAMEWORK: "arduino",
@@ -426,7 +426,7 @@ def test_run_platformio_cli_enables_zephyr_ccache_when_available(
     """Zephyr CMake/Ninja builds should use a scoped ccache when available."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.build_path = setup_core / "build" / "nrf52-test"
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: "nrf52",
         KEY_TARGET_FRAMEWORK: "zephyr",
@@ -455,7 +455,7 @@ def test_run_platformio_cli_skips_zephyr_ccache_when_unavailable(
     """Zephyr builds should still work normally on systems without ccache."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.build_path = setup_core / "build" / "nrf52-test"
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: "nrf52",
         KEY_TARGET_FRAMEWORK: "zephyr",
@@ -479,7 +479,7 @@ def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(
     """Update-all style runs should not leak Zephyr ccache settings."""
     from esphome.const import KEY_CORE, KEY_TARGET_FRAMEWORK, KEY_TARGET_PLATFORM
 
-    CORE.build_path = str(setup_core / "build" / "nrf52-test")
+    CORE.build_path = setup_core / "build" / "nrf52-test"
     CORE.data[KEY_CORE] = {
         KEY_TARGET_PLATFORM: "nrf52",
         KEY_TARGET_FRAMEWORK: "zephyr",
@@ -493,7 +493,7 @@ def test_run_platformio_cli_clears_managed_zephyr_ccache_for_non_zephyr(
         platformio_api.run_platformio_cli("test")
         assert os.environ["CCACHE_DIR"].endswith("nrf52-zephyr")
 
-        CORE.build_path = str(setup_core / "build" / "esp32-test")
+        CORE.build_path = setup_core / "build" / "esp32-test"
         CORE.data[KEY_CORE] = {
             KEY_TARGET_PLATFORM: "esp32",
             KEY_TARGET_FRAMEWORK: "arduino",
@@ -509,14 +509,14 @@ def test_run_platformio_cli_run_builds_command(
     setup_core: Path, mock_run_platformio_cli: Mock
 ) -> None:
     """Test run_platformio_cli_run builds correct command."""
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     mock_run_platformio_cli.return_value = 0
 
     config = {"name": "test"}
     toolchain.run_platformio_cli_run(config, True, "extra", "args")
 
     mock_run_platformio_cli.assert_called_once_with(
-        "run", "-d", CORE.build_path, "-v", "extra", "args"
+        "run", "-d", str(CORE.build_path), "-v", "extra", "args"
     )
 
 
@@ -524,7 +524,7 @@ def test_run_compile(setup_core: Path, mock_run_platformio_cli_run: Mock) -> Non
     """Test run_compile with process limit."""
     from esphome.const import CONF_COMPILE_PROCESS_LIMIT, CONF_ESPHOME
 
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     config = {CONF_ESPHOME: {CONF_COMPILE_PROCESS_LIMIT: 4}}
     mock_run_platformio_cli_run.return_value = 0
 
@@ -554,7 +554,7 @@ def test_get_idedata_caches_result(
     """Test get_idedata caches result in CORE.data."""
     from esphome.const import KEY_CORE
 
-    CORE.build_path = str(setup_core / "build" / "test")
+    CORE.build_path = setup_core / "build" / "test"
     CORE.name = "test"
     CORE.data[KEY_CORE] = {}
 


### PR DESCRIPTION
# What does this implement/fix?

Scopes Zephyr CMake/Ninja `ccache` state for ESPHome PlatformIO builds when `ccache` is available.

The Nordic Zephyr PlatformIO framework already exposes `ccache` on `PATH` when it can find it. This PR keeps that behavior, and adds the ESPHome-managed part that is useful for dashboard/update-all builds:

- sets the CMake compiler launcher defaults for Zephyr PlatformIO builds;
- stores cache data under `.esphome/platformio/ccache/<platform>-<framework>`;
- uses the current device build directory as `CCACHE_BASEDIR` with `CCACHE_NOHASHDIR=true`;
- preserves user-provided ccache/CMake environment overrides;
- removes only ESPHome-managed Zephyr ccache defaults before a later non-Zephyr build in the same Python process;
- keeps the module-level managed-default tracker isolated between tests.

Split from #15983 following the requested split review: https://github.com/esphome/esphome/pull/15983#pullrequestreview-4175643725

Inline context: https://github.com/esphome/esphome/pull/15983#discussion_r3142034129

Reviewer context for the existing framework ccache hook: https://github.com/esphome/esphome/pull/16010#issuecomment-4321784111

Native nRF52 build context: #16388 has merged the `sdk-nrf` groundwork, and #16898 is now the active native-build PR. This PR remains scoped to the current PlatformIO Zephyr path; native `sdk-nrf` ccache handling should be handled separately against the native build path once that surface is ready.

Merge order: independent. Can merge with #16007, #16008, and #16009 in any order. It is intentionally separate from PlatformIO SCons build-cache work in #16013 and from native `sdk-nrf` build work in #16898.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Split from #15983

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable, internal Zephyr build-cache behavior only.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable: no user-facing YAML configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

Validation:
- `venv/bin/python -m pytest -q tests/unit_tests/test_platformio_toolchain.py`
- `venv/bin/ruff format --check esphome/platformio/toolchain.py tests/unit_tests/test_platformio_toolchain.py`
- `venv/bin/ruff check esphome/platformio/toolchain.py tests/unit_tests/test_platformio_toolchain.py`
- `git diff --check`
- `venv/bin/python script/ci-custom.py -c`
- `venv/bin/python -m pre_commit run flake8 --files esphome/platformio/toolchain.py tests/unit_tests/test_platformio_toolchain.py`
- `codex review --base upstream/dev`

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). Not applicable: no user-facing functionality or configuration variables are added.
