### PR TITLE
[rotary_encoder][at581x] Fix templatable int field types

### DIFF
--- a/esphome/components/at581x/__init__.py
+++ b/esphome/components/at581x/__init__.py
@@ -183,19 +183,19 @@ async def at581x_settings_to_code(config, action_id, template_arg, args):
         cg.add(var.set_sensing_distance(template_))
 
     if selfcheck := config.get(CONF_POWERON_SELFCHECK_TIME):
-        template_ = await cg.templatable(selfcheck, args, cg.int32)
+        template_ = await cg.templatable(selfcheck, args, cg.int_)
         cg.add(var.set_poweron_selfcheck_time(template_))
 
     if protect := config.get(CONF_PROTECT_TIME):
-        template_ = await cg.templatable(protect, args, cg.int32)
+        template_ = await cg.templatable(protect, args, cg.int_)
         cg.add(var.set_protect_time(template_))
 
     if trig_base := config.get(CONF_TRIGGER_BASE):
-        template_ = await cg.templatable(trig_base, args, cg.int32)
+        template_ = await cg.templatable(trig_base, args, cg.int_)
         cg.add(var.set_trigger_base(template_))
 
     if trig_keep := config.get(CONF_TRIGGER_KEEP):
-        template_ = await cg.templatable(trig_keep, args, cg.int32)
+        template_ = await cg.templatable(trig_keep, args, cg.int_)
         cg.add(var.set_trigger_keep(template_))
 
     if (stage_gain := config.get(CONF_STAGE_GAIN)) is not None:

--- a/esphome/components/rotary_encoder/sensor.py
+++ b/esphome/components/rotary_encoder/sensor.py
@@ -129,6 +129,6 @@ async def to_code(config):
 async def sensor_template_publish_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, paren)
-    template_ = await cg.templatable(config[CONF_VALUE], args, cg.int32)
+    template_ = await cg.templatable(config[CONF_VALUE], args, cg.int_)
     cg.add(var.set_value(template_))
     return var


### PR DESCRIPTION
# What does this implement/fix?

Noticed while compiling a Voice PE: every YAML using `sensor.rotary_encoder.set_value` or several `at581x.settings` fields inside a script with parameters emitted a `-Wdeprecated-declarations` warning pointing at `TemplatableFn`.

The C++ fields are declared with `TEMPLATABLE_VALUE(int, ...)`, but the Python codegen was passing `cg.int32` (i.e. `int32_t`). On ESP-IDF / xtensa toolchains, `int32_t` is `long`, not `int`, so the function-pointer type of the codegen-emitted lambda (`int32_t (*)(...)`) does not match `int (*)(...)`. `TemplatableFn` then selects its deprecated casting-trampoline overload and warns at every instantiation.

Fix: use `cg.int_` so the generated lambda's return type matches the C++ field exactly and the direct function-pointer-storage overload is selected.

Affected:
- `esphome/components/rotary_encoder/sensor.py` — `sensor.rotary_encoder.set_value` action
- `esphome/components/at581x/__init__.py` — `at581x.settings` fields `poweron_selfcheck_time`, `protect_time`, `trigger_base`, `trigger_keep`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: rotary_encoder
    id: dial
    pin_a: GPIO1
    pin_b: GPIO2

script:
  - id: control_volume
    parameters:
      increase_volume: bool
    then:
      - sensor.rotary_encoder.set_value:
          id: dial
          value: 0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
