### PR TITLE
[core] Unify `skip_external_update` and honor it in external_files for faster `esphome logs`

### DIFF
--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -41,8 +41,6 @@ async def to_code(config: dict[str, Any]) -> None:
 
 
 def _process_git_config(config: dict[str, Any], refresh: TimePeriodSeconds) -> Path:
-    # CORE.skip_external_update (set by `esphome logs`) is honored inside
-    # git.clone_or_update; no need to translate to NEVER_REFRESH here.
     repo_dir, _ = git.clone_or_update(
         url=config[CONF_URL],
         ref=config.get(CONF_REF),

--- a/esphome/components/external_components/__init__.py
+++ b/esphome/components/external_components/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import Any
 
 from esphome import git, loader
 import esphome.config_validation as cv
@@ -17,7 +18,7 @@ from esphome.const import (
     TYPE_GIT,
     TYPE_LOCAL,
 )
-from esphome.core import CORE
+from esphome.core import CORE, TimePeriodSeconds
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,17 +36,17 @@ CONFIG_SCHEMA = cv.ensure_list(
 )
 
 
-async def to_code(config):
+async def to_code(config: dict[str, Any]) -> None:
     pass
 
 
-def _process_git_config(config: dict, refresh, skip_update: bool = False) -> str:
-    # When skip_update is True, use NEVER_REFRESH to prevent updates
-    actual_refresh = git.NEVER_REFRESH if skip_update else refresh
+def _process_git_config(config: dict[str, Any], refresh: TimePeriodSeconds) -> Path:
+    # CORE.skip_external_update (set by `esphome logs`) is honored inside
+    # git.clone_or_update; no need to translate to NEVER_REFRESH here.
     repo_dir, _ = git.clone_or_update(
         url=config[CONF_URL],
         ref=config.get(CONF_REF),
-        refresh=actual_refresh,
+        refresh=refresh,
         domain=DOMAIN,
         username=config.get(CONF_USERNAME),
         password=config.get(CONF_PASSWORD),
@@ -72,12 +73,12 @@ def _process_git_config(config: dict, refresh, skip_update: bool = False) -> str
     return components_dir
 
 
-def _process_single_config(config: dict, skip_update: bool = False):
+def _process_single_config(config: dict[str, Any]) -> None:
     conf = config[CONF_SOURCE]
     if conf[CONF_TYPE] == TYPE_GIT:
         with cv.prepend_path([CONF_SOURCE]):
             components_dir = _process_git_config(
-                config[CONF_SOURCE], config[CONF_REFRESH], skip_update
+                config[CONF_SOURCE], config[CONF_REFRESH]
             )
     elif conf[CONF_TYPE] == TYPE_LOCAL:
         components_dir = Path(CORE.relative_config_path(conf[CONF_PATH]))
@@ -107,7 +108,7 @@ def _process_single_config(config: dict, skip_update: bool = False):
     loader.install_meta_finder(components_dir, allowed_components=allowed_components)
 
 
-def do_external_components_pass(config: dict, skip_update: bool = False) -> None:
+def do_external_components_pass(config: dict[str, Any]) -> None:
     conf = config.get(DOMAIN)
     if conf is None:
         return
@@ -115,4 +116,4 @@ def do_external_components_pass(config: dict, skip_update: bool = False) -> None
         conf = CONFIG_SCHEMA(conf)
         for i, c in enumerate(conf):
             with cv.prepend_path(i):
-                _process_single_config(c, skip_update)
+                _process_single_config(c)

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -205,7 +205,7 @@ CONFIG_SCHEMA = cv.Any(  # under `packages:` we can have either:
 )
 
 
-def _process_remote_package(config: dict, skip_update: bool = False) -> dict:
+def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
     """Clone/update a git repo and load the YAML files listed in the package definition.
 
     Returns ``{"packages": {<filename>: <loaded_yaml>, ...}}`` so the caller
@@ -214,12 +214,14 @@ def _process_remote_package(config: dict, skip_update: bool = False) -> dict:
 
     If loading fails after cloning, attempts a revert and retry in case
     a prior cached checkout is stale.
+
+    CORE.skip_external_update (set by `esphome logs`) is honored inside
+    git.clone_or_update; no need to translate to NEVER_REFRESH here.
     """
-    actual_refresh = git.NEVER_REFRESH if skip_update else config[CONF_REFRESH]
     repo_dir, revert = git.clone_or_update(
         url=config[CONF_URL],
         ref=config.get(CONF_REF),
-        refresh=actual_refresh,
+        refresh=config[CONF_REFRESH],
         domain=DOMAIN,
         username=config.get(CONF_USERNAME),
         password=config.get(CONF_PASSWORD),
@@ -456,11 +458,9 @@ class _PackageProcessor:
         self,
         substitutions: UserDict,
         command_line_substitutions: dict[str, Any] | None,
-        skip_update: bool,
     ) -> None:
         self.substitutions = substitutions
         self.parent_context = UserDict(command_line_substitutions or {})
-        self.skip_update = skip_update
 
     def resolve_package(
         self,
@@ -508,7 +508,7 @@ class _PackageProcessor:
             )
 
         if is_remote_package(package_config):
-            package_config = _process_remote_package(package_config, self.skip_update)
+            package_config = _process_remote_package(package_config)
         return package_config
 
     def collect_substitutions(self, package_config: dict) -> None:
@@ -552,15 +552,17 @@ class _PackageProcessor:
 
 
 def do_packages_pass(
-    config: dict,
+    config: dict[str, Any],
     *,
     command_line_substitutions: dict[str, Any] | None = None,
-    skip_update: bool = False,
-) -> dict:
+) -> dict[str, Any]:
     """Load, validate, and flatten all packages in the config.
 
     Returns the config with all packages loaded in-place (but not yet merged)
     and a consolidated ``substitutions:`` block restored at the front.
+
+    CORE.skip_external_update (set by `esphome logs`) is honored inside
+    git.clone_or_update via _process_remote_package.
     """
     if CONF_PACKAGES not in config:
         return config
@@ -571,9 +573,7 @@ def do_packages_pass(
                 config.pop(CONF_SUBSTITUTIONS, {}), command_line_substitutions
             )
         )
-    processor = _PackageProcessor(
-        substitutions, command_line_substitutions, skip_update
-    )
+    processor = _PackageProcessor(substitutions, command_line_substitutions)
     _update_substitutions_context(processor.parent_context, substitutions)
 
     context_vars = push_context(

--- a/esphome/components/packages/__init__.py
+++ b/esphome/components/packages/__init__.py
@@ -214,9 +214,6 @@ def _process_remote_package(config: dict[str, Any]) -> dict[str, Any]:
 
     If loading fails after cloning, attempts a revert and retry in case
     a prior cached checkout is stale.
-
-    CORE.skip_external_update (set by `esphome logs`) is honored inside
-    git.clone_or_update; no need to translate to NEVER_REFRESH here.
     """
     repo_dir, revert = git.clone_or_update(
         url=config[CONF_URL],
@@ -560,9 +557,6 @@ def do_packages_pass(
 
     Returns the config with all packages loaded in-place (but not yet merged)
     and a consolidated ``substitutions:`` block restored at the front.
-
-    CORE.skip_external_update (set by `esphome logs`) is honored inside
-    git.clone_or_update via _process_remote_package.
     """
     if CONF_PACKAGES not in config:
         return config

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -1011,7 +1011,6 @@ def validate_config(
             config = do_packages_pass(
                 config,
                 command_line_substitutions=command_line_substitutions,
-                skip_update=skip_external_update,
             )
         except vol.Invalid as err:
             result.update(config)
@@ -1052,7 +1051,7 @@ def validate_config(
 
         result.add_output_path([CONF_EXTERNAL_COMPONENTS], CONF_EXTERNAL_COMPONENTS)
         try:
-            do_external_components_pass(config, skip_update=skip_external_update)
+            do_external_components_pass(config)
         except vol.Invalid as err:
             result.update(config)
             result.add_error(err)
@@ -1343,7 +1342,9 @@ def strip_default_ids(config):
     return config
 
 
-def read_config(command_line_substitutions, skip_external_update=False):
+def read_config(
+    command_line_substitutions: dict[str, Any], skip_external_update: bool = False
+) -> Config | None:
     _LOGGER.info("Reading configuration %s...", CORE.config_path)
     try:
         res = load_config(command_line_substitutions, skip_external_update)

--- a/esphome/config.py
+++ b/esphome/config.py
@@ -997,6 +997,8 @@ def validate_config(
 ) -> Config:
     result = Config()
 
+    CORE.skip_external_update = skip_external_update
+
     loader.clear_component_meta_finders()
     loader.install_custom_components_meta_finder()
 

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -615,6 +615,9 @@ class EsphomeCore:
         self.address_cache: AddressCache | None = None
         # Cached config hash (computed lazily)
         self._config_hash: int | None = None
+        # When True, skip network freshness checks for cached external files
+        # (e.g. for `esphome logs`, where remote downloads aren't needed)
+        self.skip_external_update: bool = False
 
     def reset(self):
         from esphome.pins import PIN_SCHEMA_REGISTRY
@@ -644,6 +647,7 @@ class EsphomeCore:
         self.current_component = None
         self.address_cache = None
         self._config_hash = None
+        self.skip_external_update = False
         PIN_SCHEMA_REGISTRY.reset()
 
     @contextmanager

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -81,7 +81,7 @@ def compute_local_file_dir(domain: str) -> Path:
     return base_directory
 
 
-def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> bytes:
+def download_content(url: str, path: Path, timeout: int = NETWORK_TIMEOUT) -> bytes:
     if CORE.skip_external_update and path.exists():
         _LOGGER.debug("Skipping update for %s (refresh disabled)", url)
         return path.read_bytes()

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -82,6 +82,9 @@ def compute_local_file_dir(domain: str) -> Path:
 
 
 def download_content(url: str, path: Path, timeout=NETWORK_TIMEOUT) -> bytes:
+    if CORE.skip_external_update and path.exists():
+        _LOGGER.debug("Skipping update for %s (refresh disabled)", url)
+        return path.read_bytes()
     if not has_remote_file_changed(url, path):
         _LOGGER.debug("Remote file has not changed %s", url)
         return path.read_bytes()

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -151,8 +151,9 @@ def clone_or_update(
 
     else:
         # Check refresh needed
-        # Skip refresh if NEVER_REFRESH is specified
-        if refresh == NEVER_REFRESH:
+        # Skip refresh if NEVER_REFRESH is specified or external updates are
+        # globally disabled for this run (e.g. `esphome logs`).
+        if refresh == NEVER_REFRESH or CORE.skip_external_update:
             _LOGGER.debug("Skipping update for %s (refresh disabled)", key)
             return repo_dir, None
 

--- a/esphome/git.py
+++ b/esphome/git.py
@@ -150,9 +150,6 @@ def clone_or_update(
             raise
 
     else:
-        # Check refresh needed
-        # Skip refresh if NEVER_REFRESH is specified or external updates are
-        # globally disabled for this run (e.g. `esphome logs`).
         if refresh == NEVER_REFRESH or CORE.skip_external_update:
             _LOGGER.debug("Skipping update for %s (refresh disabled)", key)
             return repo_dir, None

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from esphome.components.external_components import do_external_components_pass
 from esphome.const import (
     CONF_EXTERNAL_COMPONENTS,
@@ -38,18 +36,10 @@ def _make_config(tmp_path: Path) -> dict[str, Any]:
     }
 
 
-@pytest.fixture
-def reset_skip_external_update() -> None:
-    """Ensure CORE.skip_external_update is restored between tests."""
-    yield
-    CORE.skip_external_update = False
-
-
 def test_external_components_skip_update_via_core_flag(
     tmp_path: Path,
     mock_clone_or_update: MagicMock,
     mock_install_meta_finder: MagicMock,
-    reset_skip_external_update: None,
 ) -> None:
     """When CORE.skip_external_update is True, refresh is still passed through;
     git.clone_or_update itself short-circuits the actual fetch."""
@@ -69,7 +59,6 @@ def test_external_components_normal_refresh(
     tmp_path: Path,
     mock_clone_or_update: MagicMock,
     mock_install_meta_finder: MagicMock,
-    reset_skip_external_update: None,
 ) -> None:
     """When CORE.skip_external_update is False, the configured refresh value is used."""
     mock_clone_or_update.return_value = (tmp_path, None)

--- a/tests/component_tests/external_components/test_init.py
+++ b/tests/component_tests/external_components/test_init.py
@@ -1,8 +1,10 @@
-"""Tests for the external_components skip_update functionality."""
+"""Tests for the external_components skip-update behavior driven by CORE.skip_external_update."""
 
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 from esphome.components.external_components import do_external_components_pass
 from esphome.const import (
@@ -12,25 +14,17 @@ from esphome.const import (
     CONF_URL,
     TYPE_GIT,
 )
+from esphome.core import CORE, TimePeriodSeconds
 
 
-def test_external_components_skip_update_true(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_install_meta_finder: MagicMock
-) -> None:
-    """Test that external components don't update when skip_update=True."""
-    # Create a components directory structure
+def _make_config(tmp_path: Path) -> dict[str, Any]:
     components_dir = tmp_path / "components"
     components_dir.mkdir()
-
-    # Create a test component
     test_component_dir = components_dir / "test_component"
     test_component_dir.mkdir()
     (test_component_dir / "__init__.py").write_text("# Test component")
 
-    # Set up mock to return our tmp_path
-    mock_clone_or_update.return_value = (tmp_path, None)
-
-    config: dict[str, Any] = {
+    return {
         CONF_EXTERNAL_COMPONENTS: [
             {
                 CONF_SOURCE: {
@@ -43,92 +37,46 @@ def test_external_components_skip_update_true(
         ]
     }
 
-    # Call with skip_update=True
-    do_external_components_pass(config, skip_update=True)
 
-    # Verify clone_or_update was called with NEVER_REFRESH
-    mock_clone_or_update.assert_called_once()
-    call_args = mock_clone_or_update.call_args
-    from esphome import git
-
-    assert call_args.kwargs["refresh"] == git.NEVER_REFRESH
+@pytest.fixture
+def reset_skip_external_update() -> None:
+    """Ensure CORE.skip_external_update is restored between tests."""
+    yield
+    CORE.skip_external_update = False
 
 
-def test_external_components_skip_update_false(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_install_meta_finder: MagicMock
+def test_external_components_skip_update_via_core_flag(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    reset_skip_external_update: None,
 ) -> None:
-    """Test that external components update when skip_update=False."""
-    # Create a components directory structure
-    components_dir = tmp_path / "components"
-    components_dir.mkdir()
-
-    # Create a test component
-    test_component_dir = components_dir / "test_component"
-    test_component_dir.mkdir()
-    (test_component_dir / "__init__.py").write_text("# Test component")
-
-    # Set up mock to return our tmp_path
+    """When CORE.skip_external_update is True, refresh is still passed through;
+    git.clone_or_update itself short-circuits the actual fetch."""
     mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
 
-    config: dict[str, Any] = {
-        CONF_EXTERNAL_COMPONENTS: [
-            {
-                CONF_SOURCE: {
-                    "type": TYPE_GIT,
-                    CONF_URL: "https://github.com/test/components",
-                },
-                CONF_REFRESH: "1d",
-                "components": "all",
-            }
-        ]
-    }
+    CORE.skip_external_update = True
+    do_external_components_pass(config)
 
-    # Call with skip_update=False
-    do_external_components_pass(config, skip_update=False)
-
-    # Verify clone_or_update was called with actual refresh value
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
-    from esphome.core import TimePeriodSeconds
-
+    # Refresh is passed through verbatim — the global flag is enforced inside git.clone_or_update.
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)
 
 
-def test_external_components_default_no_skip(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_install_meta_finder: MagicMock
+def test_external_components_normal_refresh(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_install_meta_finder: MagicMock,
+    reset_skip_external_update: None,
 ) -> None:
-    """Test that external components update by default when skip_update not specified."""
-    # Create a components directory structure
-    components_dir = tmp_path / "components"
-    components_dir.mkdir()
-
-    # Create a test component
-    test_component_dir = components_dir / "test_component"
-    test_component_dir.mkdir()
-    (test_component_dir / "__init__.py").write_text("# Test component")
-
-    # Set up mock to return our tmp_path
+    """When CORE.skip_external_update is False, the configured refresh value is used."""
     mock_clone_or_update.return_value = (tmp_path, None)
+    config = _make_config(tmp_path)
 
-    config: dict[str, Any] = {
-        CONF_EXTERNAL_COMPONENTS: [
-            {
-                CONF_SOURCE: {
-                    "type": TYPE_GIT,
-                    CONF_URL: "https://github.com/test/components",
-                },
-                CONF_REFRESH: "1d",
-                "components": "all",
-            }
-        ]
-    }
-
-    # Call without skip_update parameter
     do_external_components_pass(config)
 
-    # Verify clone_or_update was called with actual refresh value
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
-    from esphome.core import TimePeriodSeconds
-
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)

--- a/tests/component_tests/packages/test_init.py
+++ b/tests/component_tests/packages/test_init.py
@@ -4,8 +4,6 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-import pytest
-
 from esphome.components.packages import do_packages_pass
 from esphome.const import CONF_FILES, CONF_PACKAGES, CONF_REFRESH, CONF_URL
 from esphome.core import CORE, TimePeriodSeconds
@@ -24,18 +22,10 @@ def _make_config() -> dict[str, Any]:
     }
 
 
-@pytest.fixture
-def reset_skip_external_update() -> None:
-    """Ensure CORE.skip_external_update is restored between tests."""
-    yield
-    CORE.skip_external_update = False
-
-
 def test_packages_skip_update_via_core_flag(
     tmp_path: Path,
     mock_clone_or_update: MagicMock,
     mock_load_yaml: MagicMock,
-    reset_skip_external_update: None,
 ) -> None:
     """When CORE.skip_external_update is True, refresh is still passed through;
     git.clone_or_update itself short-circuits the actual fetch."""
@@ -60,7 +50,6 @@ def test_packages_normal_refresh(
     tmp_path: Path,
     mock_clone_or_update: MagicMock,
     mock_load_yaml: MagicMock,
-    reset_skip_external_update: None,
 ) -> None:
     """When CORE.skip_external_update is False, the configured refresh value is used."""
     mock_clone_or_update.return_value = (tmp_path, None)

--- a/tests/component_tests/packages/test_init.py
+++ b/tests/component_tests/packages/test_init.py
@@ -1,29 +1,19 @@
-"""Tests for the packages component skip_update functionality."""
+"""Tests for the packages skip-update behavior driven by CORE.skip_external_update."""
 
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from esphome.components.packages import do_packages_pass
 from esphome.const import CONF_FILES, CONF_PACKAGES, CONF_REFRESH, CONF_URL
+from esphome.core import CORE, TimePeriodSeconds
 from esphome.util import OrderedDict
 
 
-def test_packages_skip_update_true(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_load_yaml: MagicMock
-) -> None:
-    """Test that packages don't update when skip_update=True."""
-    # Set up mock to return our tmp_path
-    mock_clone_or_update.return_value = (tmp_path, None)
-
-    # Create the test yaml file
-    test_file = tmp_path / "test.yaml"
-    test_file.write_text("sensor: []")
-
-    # Set mock_load_yaml to return some valid config
-    mock_load_yaml.return_value = OrderedDict({"sensor": []})
-
-    config: dict[str, Any] = {
+def _make_config() -> dict[str, Any]:
+    return {
         CONF_PACKAGES: {
             "test_package": {
                 CONF_URL: "https://github.com/test/repo",
@@ -33,82 +23,56 @@ def test_packages_skip_update_true(
         }
     }
 
-    # Call with skip_update=True
-    do_packages_pass(config, skip_update=True)
 
-    # Verify clone_or_update was called with NEVER_REFRESH
-    mock_clone_or_update.assert_called_once()
-    call_args = mock_clone_or_update.call_args
-    from esphome import git
-
-    assert call_args.kwargs["refresh"] == git.NEVER_REFRESH
+@pytest.fixture
+def reset_skip_external_update() -> None:
+    """Ensure CORE.skip_external_update is restored between tests."""
+    yield
+    CORE.skip_external_update = False
 
 
-def test_packages_skip_update_false(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_load_yaml: MagicMock
+def test_packages_skip_update_via_core_flag(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_load_yaml: MagicMock,
+    reset_skip_external_update: None,
 ) -> None:
-    """Test that packages update when skip_update=False."""
-    # Set up mock to return our tmp_path
+    """When CORE.skip_external_update is True, refresh is still passed through;
+    git.clone_or_update itself short-circuits the actual fetch."""
     mock_clone_or_update.return_value = (tmp_path, None)
 
-    # Create the test yaml file
     test_file = tmp_path / "test.yaml"
     test_file.write_text("sensor: []")
-
-    # Set mock_load_yaml to return some valid config
     mock_load_yaml.return_value = OrderedDict({"sensor": []})
 
-    config: dict[str, Any] = {
-        CONF_PACKAGES: {
-            "test_package": {
-                CONF_URL: "https://github.com/test/repo",
-                CONF_FILES: ["test.yaml"],
-                CONF_REFRESH: "1d",
-            }
-        }
-    }
+    config = _make_config()
 
-    # Call with skip_update=False (default)
-    do_packages_pass(config, command_line_substitutions={}, skip_update=False)
+    CORE.skip_external_update = True
+    do_packages_pass(config, command_line_substitutions={})
 
-    # Verify clone_or_update was called with actual refresh value
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
-    from esphome.core import TimePeriodSeconds
-
+    # Refresh is passed through verbatim — the global flag is enforced inside git.clone_or_update.
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)
 
 
-def test_packages_default_no_skip(
-    tmp_path: Path, mock_clone_or_update: MagicMock, mock_load_yaml: MagicMock
+def test_packages_normal_refresh(
+    tmp_path: Path,
+    mock_clone_or_update: MagicMock,
+    mock_load_yaml: MagicMock,
+    reset_skip_external_update: None,
 ) -> None:
-    """Test that packages update by default when skip_update not specified."""
-    # Set up mock to return our tmp_path
+    """When CORE.skip_external_update is False, the configured refresh value is used."""
     mock_clone_or_update.return_value = (tmp_path, None)
 
-    # Create the test yaml file
     test_file = tmp_path / "test.yaml"
     test_file.write_text("sensor: []")
-
-    # Set mock_load_yaml to return some valid config
     mock_load_yaml.return_value = OrderedDict({"sensor": []})
 
-    config: dict[str, Any] = {
-        CONF_PACKAGES: {
-            "test_package": {
-                CONF_URL: "https://github.com/test/repo",
-                CONF_FILES: ["test.yaml"],
-                CONF_REFRESH: "1d",
-            }
-        }
-    }
+    config = _make_config()
 
-    # Call without skip_update parameter
     do_packages_pass(config, command_line_substitutions={})
 
-    # Verify clone_or_update was called with actual refresh value
     mock_clone_or_update.assert_called_once()
     call_args = mock_clone_or_update.call_args
-    from esphome.core import TimePeriodSeconds
-
     assert call_args.kwargs["refresh"] == TimePeriodSeconds(days=1)

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -236,3 +236,51 @@ def test_download_content_with_network_error_no_cache_fails(
 
     with pytest.raises(Invalid, match="Could not download from.*Network error"):
         external_files.download_content(url, test_file)
+
+
+@patch("esphome.external_files.requests.get")
+@patch("esphome.external_files.has_remote_file_changed")
+def test_download_content_skip_external_update_uses_cache(
+    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+) -> None:
+    """Test download_content skips network checks when CORE.skip_external_update is set."""
+    test_file = setup_core / "cached.txt"
+    cached_content = b"cached content"
+    test_file.write_bytes(cached_content)
+
+    CORE.skip_external_update = True
+    try:
+        url = "https://example.com/file.txt"
+        result = external_files.download_content(url, test_file)
+    finally:
+        CORE.skip_external_update = False
+
+    assert result == cached_content
+    mock_has_changed.assert_not_called()
+    mock_get.assert_not_called()
+
+
+@patch("esphome.external_files.requests.get")
+@patch("esphome.external_files.has_remote_file_changed")
+def test_download_content_skip_external_update_downloads_when_missing(
+    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+) -> None:
+    """Test download_content still downloads when file is missing, even with skip_external_update."""
+    test_file = setup_core / "missing.txt"
+    new_content = b"fresh content"
+
+    mock_has_changed.return_value = True
+    mock_response = MagicMock()
+    mock_response.content = new_content
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    CORE.skip_external_update = True
+    try:
+        url = "https://example.com/file.txt"
+        result = external_files.download_content(url, test_file)
+    finally:
+        CORE.skip_external_update = False
+
+    assert result == new_content
+    assert test_file.read_bytes() == new_content

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -241,7 +241,9 @@ def test_download_content_with_network_error_no_cache_fails(
 @patch("esphome.external_files.requests.get")
 @patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_skip_external_update_uses_cache(
-    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+    mock_has_changed: MagicMock,
+    mock_get: MagicMock,
+    setup_core: Path,
 ) -> None:
     """Test download_content skips network checks when CORE.skip_external_update is set."""
     test_file = setup_core / "cached.txt"
@@ -249,11 +251,8 @@ def test_download_content_skip_external_update_uses_cache(
     test_file.write_bytes(cached_content)
 
     CORE.skip_external_update = True
-    try:
-        url = "https://example.com/file.txt"
-        result = external_files.download_content(url, test_file)
-    finally:
-        CORE.skip_external_update = False
+    url = "https://example.com/file.txt"
+    result = external_files.download_content(url, test_file)
 
     assert result == cached_content
     mock_has_changed.assert_not_called()
@@ -263,7 +262,9 @@ def test_download_content_skip_external_update_uses_cache(
 @patch("esphome.external_files.requests.get")
 @patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_skip_external_update_downloads_when_missing(
-    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+    mock_has_changed: MagicMock,
+    mock_get: MagicMock,
+    setup_core: Path,
 ) -> None:
     """Test download_content still downloads when file is missing, even with skip_external_update."""
     test_file = setup_core / "missing.txt"
@@ -276,11 +277,8 @@ def test_download_content_skip_external_update_downloads_when_missing(
     mock_get.return_value = mock_response
 
     CORE.skip_external_update = True
-    try:
-        url = "https://example.com/file.txt"
-        result = external_files.download_content(url, test_file)
-    finally:
-        CORE.skip_external_update = False
+    url = "https://example.com/file.txt"
+    result = external_files.download_content(url, test_file)
 
     assert result == new_content
     assert test_file.read_bytes() == new_content

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -253,15 +253,12 @@ def test_clone_or_update_skips_when_core_skip_external_update(
     (git_dir / "FETCH_HEAD").write_text("test")
 
     CORE.skip_external_update = True
-    try:
-        result_dir, revert = git.clone_or_update(
-            url=url,
-            ref=ref,
-            refresh=TimePeriodSeconds(days=1),
-            domain=domain,
-        )
-    finally:
-        CORE.skip_external_update = False
+    result_dir, revert = git.clone_or_update(
+        url=url,
+        ref=ref,
+        refresh=TimePeriodSeconds(days=1),
+        domain=domain,
+    )
 
     mock_run_git_command.assert_not_called()
     assert result_dir == repo_dir

--- a/tests/unit_tests/test_git.py
+++ b/tests/unit_tests/test_git.py
@@ -236,6 +236,38 @@ def test_clone_or_update_with_never_refresh(
     assert revert is None
 
 
+def test_clone_or_update_skips_when_core_skip_external_update(
+    tmp_path: Path, mock_run_git_command: Mock
+) -> None:
+    """CORE.skip_external_update short-circuits the refresh for existing repos."""
+    CORE.config_path = tmp_path / "test.yaml"
+
+    url = "https://github.com/test/repo"
+    ref = None
+    domain = "test"
+    repo_dir = _compute_repo_dir(url, ref, domain)
+
+    repo_dir.mkdir(parents=True)
+    git_dir = repo_dir / ".git"
+    git_dir.mkdir()
+    (git_dir / "FETCH_HEAD").write_text("test")
+
+    CORE.skip_external_update = True
+    try:
+        result_dir, revert = git.clone_or_update(
+            url=url,
+            ref=ref,
+            refresh=TimePeriodSeconds(days=1),
+            domain=domain,
+        )
+    finally:
+        CORE.skip_external_update = False
+
+    mock_run_git_command.assert_not_called()
+    assert result_dir == repo_dir
+    assert revert is None
+
+
 def test_clone_or_update_with_refresh_updates_old_repo(
     tmp_path: Path, mock_run_git_command: Mock
 ) -> None:

--- a/tests/unit_tests/test_substitutions.py
+++ b/tests/unit_tests/test_substitutions.py
@@ -654,7 +654,7 @@ def test_resolve_package_max_depth_exceeded(tmp_path: Path) -> None:
     package_config = yaml_util.IncludeFile(
         parent, "test.yaml", None, always_returns_include
     )
-    processor = _PackageProcessor({}, None, False)
+    processor = _PackageProcessor({}, None)
     with pytest.raises(
         cv.Invalid,
         match=f"Maximum include nesting depth \\({MAX_INCLUDE_DEPTH}\\) exceeded",
@@ -776,7 +776,7 @@ def test_resolve_package_undefined_var_in_include_filename(tmp_path: Path) -> No
     package_config = yaml_util.IncludeFile(
         parent, "${undefined_var}.yaml", None, loader
     )
-    processor = _PackageProcessor({}, None, False)
+    processor = _PackageProcessor({}, None)
     with pytest.raises(cv.Invalid, match="unresolved substitutions"):
         processor.resolve_package(package_config, substitutions.ContextVars(), [])
 


### PR DESCRIPTION
# What does this implement/fix?

Speeds up `esphome logs` for projects that pull files from remote URLs (audio files, micro_wake_word models, fonts, images, BSEC2 blobs) and unifies the existing `skip_external_update` plumbing.

`esphome logs` already passed `skip_external_update=True` through to git operations (so `external_components` / `packages` / `git`-sourced sources skipped refresh). However:

1. `external_files.download_content()` — used by `audio_file`, `micro_wake_word`, `speaker/media_player`, `image`, `font`, and `bme68x_bsec2` — ignored this flag and performed a synchronous HTTP `HEAD` request per URL on every invocation, even when the local cached file existed.
2. The `skip_update` flag was threaded as an explicit parameter through 5 layers (`__main__` → `read_config` → `_load_config` → `validate_config` → `do_packages_pass` / `do_external_components_pass` → `_process_remote_package` / `_process_git_config` → `git.clone_or_update`), with each git-using component translating `skip_update=True` into `git.NEVER_REFRESH`.

For projects like `home-assistant-voice-pe` (which references ~16 audio files plus several mWW manifests/models), this added many seconds of sequential network round-trips before logs could start streaming, and could fail entirely if any single endpoint was slow or returned 5xx.

## Changes

- Add `CORE.skip_external_update` flag (single source of truth), set once by `validate_config()`.
- `external_files.download_content()` short-circuits when the flag is set and the local file already exists. If the file is missing, it still downloads (safety unchanged).
- `git.clone_or_update()` also honors `CORE.skip_external_update` (in addition to the existing `NEVER_REFRESH` sentinel, which is preserved as the YAML-level "never refresh" signal used by `cv.source_refresh("0s")`).
- Drop the `skip_update` parameter from `do_packages_pass`, `do_external_components_pass`, `_process_remote_package`, `_process_git_config`, `_process_single_config`, `_PackageProcessor.__init__`, and the corresponding plumbing in `validate_config()`. Existing tests updated to drive behavior through `CORE.skip_external_update`.
- Add full typing on every signature touched.

Result: ~20 sequential `HEAD` requests during config validation drop to zero when running `esphome logs` against a previously-cached `home-assistant-voice-pe` config; the parameter chain collapses from 5 layers to one global flag enforced at the two leaves (`git.clone_or_update` and `external_files.download_content`).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (no user-facing config change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change. To exercise the path:
#   esphome logs home-assistant-voice-090073.yaml
# (or any config that uses audio_file / micro_wake_word / image / font with remote URLs)
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).