### PR TITLE
[image] Fix RGB565+alpha rendering for multi-frame animations

### DIFF
--- a/esphome/components/animation/animation.cpp
+++ b/esphome/components/animation/animation.cpp
@@ -62,7 +62,12 @@ void Animation::set_frame(int frame) {
 }
 
 void Animation::update_data_start_() {
-  const uint32_t image_size = this->get_width_stride() * this->height_;
+  uint32_t image_size = this->get_width_stride() * this->height_;
+  // RGB565 with an alpha channel stores the alpha plane immediately after the RGB
+  // plane within each frame, so the per-frame stride includes the alpha bytes.
+  if (this->type_ == image::IMAGE_TYPE_RGB565 && this->transparency_ == image::TRANSPARENCY_ALPHA_CHANNEL) {
+    image_size += static_cast<uint32_t>(this->width_) * this->height_;
+  }
   this->data_start_ = this->animation_data_start_ + image_size * this->current_frame_;
 }
 

--- a/esphome/components/image/__init__.py
+++ b/esphome/components/image/__init__.py
@@ -744,21 +744,28 @@ async def write_image(config, all_frames=False):
         if frame_count <= 1:
             _LOGGER.warning("Image file %s has no animation frames", path)
 
-    total_rows = height * frame_count
-    encoder = IMAGE_TYPE[type](width, total_rows, transparency, dither, invert_alpha)
-    if byte_order := config.get(CONF_BYTE_ORDER):
-        # Check for valid type has already been done in validate_settings
-        encoder.set_big_endian(byte_order == "BIG_ENDIAN")
+    # Encode each frame with its own encoder and concatenate. This keeps every
+    # frame self-contained on disk (e.g. RGB565+alpha emits [RGB plane | alpha plane]
+    # per frame) so animation frame stepping in image.cpp / animation.cpp stays
+    # correct without needing to know the total frame count.
+    byte_order = config.get(CONF_BYTE_ORDER)
+    combined_data: list[int] = []
+    encoder: ImageEncoder | None = None
     for frame_index in range(frame_count):
         image.seek(frame_index)
+        encoder = IMAGE_TYPE[type](width, height, transparency, dither, invert_alpha)
+        if byte_order is not None:
+            # Check for valid type has already been done in validate_settings
+            encoder.set_big_endian(byte_order == "BIG_ENDIAN")
         pixels = encoder.convert(image.resize((width, height)), path).getdata()
         for row in range(height):
             for col in range(width):
                 encoder.encode(pixels[row * width + col])
             encoder.end_row()
-    encoder.end_image()
+        encoder.end_image()
+        combined_data.extend(encoder.data)
 
-    rhs = [HexInt(x) for x in encoder.data]
+    rhs = [HexInt(x) for x in combined_data]
     prog_arr = cg.progmem_array(config[CONF_RAW_DATA_ID], rhs)
     image_type = get_image_type_enum(type)
     trans_value = get_transparency_enum(encoder.transparency)

--- a/tests/component_tests/image/test_init.py
+++ b/tests/component_tests/image/test_init.py
@@ -7,10 +7,12 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from PIL import Image as PILImage
 import pytest
 
 from esphome import config_validation as cv
 from esphome.components.image import (
+    CONF_ALPHA_CHANNEL,
     CONF_INVERT_ALPHA,
     CONF_OPAQUE,
     CONF_TRANSPARENCY,
@@ -410,4 +412,71 @@ async def test_svg_with_mm_dimensions_succeeds(
     )
     assert 30 < height < 50, (
         f"Height should be around 39 pixels for 10mm at 100dpi, got {height}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rgb565_alpha_animation_layout_per_frame(
+    tmp_path: Path,
+    mock_progmem_array: MagicMock,
+) -> None:
+    """RGB565+alpha animations must store each frame as a self-contained
+    [RGB plane | alpha plane] block. Animation::update_data_start_ steps frames
+    with a single per-frame stride, so any cross-frame layout (all RGB then all
+    alpha) makes the C++ alpha read land in the next frame's RGB bytes — that
+    was the regression behind issue #15999.
+    """
+    # Build a 2-frame APNG where each frame is a solid color with a known
+    # alpha. APNG preserves full RGBA per pixel (GIF only has 1-bit alpha so
+    # round-tripping mid-range alpha values does not work). Frame 0 is fully
+    # opaque red, frame 1 is fully transparent blue.
+    width = 4
+    height = 3
+    frame0 = PILImage.new("RGBA", (width, height), (255, 0, 0, 0xFF))
+    frame1 = PILImage.new("RGBA", (width, height), (0, 0, 255, 0x00))
+    apng_path = tmp_path / "anim.png"
+    frame0.save(
+        apng_path,
+        format="PNG",
+        save_all=True,
+        append_images=[frame1],
+        duration=100,
+        loop=0,
+    )
+
+    config = {
+        CONF_FILE: str(apng_path),
+        CONF_TYPE: "RGB565",
+        CONF_TRANSPARENCY: CONF_ALPHA_CHANNEL,
+        CONF_DITHER: "NONE",
+        CONF_INVERT_ALPHA: False,
+        CONF_RAW_DATA_ID: "test_raw_data_id",
+    }
+
+    _, _, _, _, _, frame_count = await write_image(config, all_frames=True)
+    assert frame_count == 2
+
+    # Recover the bytes handed to progmem_array. Signature is (id_, rhs).
+    _, raw_data = mock_progmem_array.call_args.args
+    data = [int(x) for x in raw_data]
+
+    rgb_size = width * height * 2
+    alpha_size = width * height
+    frame_size = rgb_size + alpha_size
+    assert len(data) == frame_size * frame_count, (
+        "RGB565+alpha animation buffer must be (RGB + alpha) per frame, not "
+        "all RGB followed by all alpha"
+    )
+
+    # Frame 0: RGB plane is red, alpha plane is 0xFF. Frame 1: alpha plane is
+    # 0x00. If the layout regresses to [all RGB | all alpha], the alpha bytes
+    # would all land at the tail of the buffer and the per-frame slices below
+    # would point at RGB565 noise instead.
+    frame0_alpha = data[rgb_size : rgb_size + alpha_size]
+    frame1_alpha = data[frame_size + rgb_size : frame_size + rgb_size + alpha_size]
+    assert all(a == 0xFF for a in frame0_alpha), (
+        f"Frame 0 alpha plane should be opaque, got {frame0_alpha}"
+    )
+    assert all(a == 0x00 for a in frame1_alpha), (
+        f"Frame 1 alpha plane should be transparent, got {frame1_alpha}"
     )


### PR DESCRIPTION
# What does this implement/fix?

> ⚠️ **I have not verified this on hardware.** I located the bug, then asked Claude to draft and apply the fix; the diff matches my analysis and the new unit test catches the layout regression, but I have no display/animation setup of my own to confirm the visual result. **Anyone with an `animation:` + `type: RGB565` + `transparency: alpha_channel` + display setup affected by #15999 should pull this branch and confirm the GIF renders correctly before this is merged.**

`Animation` rendering is broken for `type: RGB565` + `transparency: alpha_channel` since the LVGL v9 migration (#12312, commit `2341d510d3`). That commit changed RGB565+alpha from 24 bpp inline (`[R G B A]` per pixel) to a 16 bpp plane format (RGB plane then alpha plane appended in `end_image()`), but `animation.cpp` was not updated:

- The encoder in `image/__init__.py` produced one buffer of `[all-frames-RGB | all-frames-alpha]`.
- `Animation::update_data_start_` still steps frames by `get_width_stride() * height_` (now `w*h*2`).
- `Image::get_rgb565_pixel_` reads alpha from `data_start_ + w*h*2 + (x + y*w)` — which on any frame > 0 lands inside the **next frame's RGB565 bytes**, not the alpha plane.

Result: random "alpha" values, so the `if (color.w >= 0x80)` check in `Image::draw` fires inconsistently — exactly the pink/garbage rendering reported in #15999. Static (non-animated) RGB565+alpha images render correctly because `data_start_` is the buffer base, where `+w*h*2` does land in the alpha plane.

#15873 fixed a separate symptom of the same migration (rodata bloat from `end_image()` being called per frame) but did not touch the read path, so this rendering bug stayed latent for animations.

### Fix

Two coupled changes that restore a self-contained per-frame layout (matching what static images already produce):

1. **`esphome/components/image/__init__.py`** — `write_image` now creates one encoder per frame and concatenates the per-frame data. For RGB565+alpha each frame is `[RGB plane | alpha plane]`. For all other types the buffer is byte-identical to before (their `end_image()` is a no-op).
2. **`esphome/components/animation/animation.cpp`** — `update_data_start_` adds `w*h` to the per-frame stride when `type == RGB565 && transparency == ALPHA_CHANNEL`, so frame stepping skips both planes.

After these two changes, `Image::get_rgb565_pixel_`'s existing `data_start_ + w*h*2 + (x + y*w)` formula lands on the correct alpha byte for every frame of every animation, with no further C++ changes required.

A regression test (`test_rgb565_alpha_animation_layout_per_frame`) builds a 2-frame APNG (opaque red / fully transparent blue) and asserts the encoded buffer is per-frame `[RGB | alpha]` with the correct alpha bytes in each frame's plane. If the encoder regresses to the old "all RGB then all alpha" layout, the per-frame alpha slices land on RGB565 noise and the test fails.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/15999
- regression from https://github.com/esphome/esphome/pull/12312 (commit `2341d510d3`)
- related to https://github.com/esphome/esphome/pull/15873

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

I do not have a display setup that exercises this path; the C++ change is unverified on hardware. Visual confirmation is needed by someone running the original repro from #15999.

## Example entry for `config.yaml`:

```yaml
animation:
  - file: "fanmotion_lent.gif"
    id: my_animation
    type: RGB565
    transparency: alpha_channel
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

---

🤖 The fix in this PR was drafted by [Claude](https://claude.com/claude-code) at my direction after I located the root cause; I have reviewed the diff but have not been able to verify the rendering on real hardware.
