### PR TITLE
[improv_serial] Reduce per-loop overhead

### DIFF
--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -17,6 +17,7 @@ void ImprovSerialComponent::setup() {
   global_improv_serial_component = this;
 #ifdef USE_ESP32
   this->uart_num_ = logger::global_logger->get_uart_num();
+  this->uart_selection_ = logger::global_logger->get_uart();
 #elif defined(USE_ARDUINO)
   this->hw_serial_ = logger::global_logger->get_hw_serial();
 #endif
@@ -29,7 +30,8 @@ void ImprovSerialComponent::setup() {
 }
 
 void ImprovSerialComponent::loop() {
-  if (this->last_read_byte_ && (millis() - this->last_read_byte_ > IMPROV_SERIAL_TIMEOUT)) {
+  const uint32_t now = App.get_loop_component_start_time();
+  if (this->last_read_byte_ && (now - this->last_read_byte_ > IMPROV_SERIAL_TIMEOUT)) {
     this->last_read_byte_ = 0;
     this->rx_buffer_.clear();
     ESP_LOGV(TAG, "Timeout");
@@ -38,7 +40,7 @@ void ImprovSerialComponent::loop() {
   auto byte = this->read_byte_();
   while (byte.has_value()) {
     if (this->parse_improv_serial_byte_(byte.value())) {
-      this->last_read_byte_ = millis();
+      this->last_read_byte_ = now;
     } else {
       this->last_read_byte_ = 0;
       this->rx_buffer_.clear();
@@ -61,55 +63,6 @@ void ImprovSerialComponent::loop() {
 }
 
 void ImprovSerialComponent::dump_config() { ESP_LOGCONFIG(TAG, "Improv Serial:"); }
-
-optional<uint8_t> ImprovSerialComponent::read_byte_() {
-  optional<uint8_t> byte;
-  uint8_t data = 0;
-#ifdef USE_ESP32
-  switch (logger::global_logger->get_uart()) {
-    case logger::UART_SELECTION_UART0:
-    case logger::UART_SELECTION_UART1:
-#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
-    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
-    case logger::UART_SELECTION_UART2:
-#endif  // !USE_ESP32_VARIANT_ESP32C3 && !USE_ESP32_VARIANT_ESP32C6 && !USE_ESP32_VARIANT_ESP32C61 &&
-        // !USE_ESP32_VARIANT_ESP32S2 && !USE_ESP32_VARIANT_ESP32S3
-      if (this->uart_num_ >= 0) {
-        size_t available;
-        uart_get_buffered_data_len(this->uart_num_, &available);
-        if (available) {
-          uart_read_bytes(this->uart_num_, &data, 1, 0);
-          byte = data;
-        }
-      }
-      break;
-#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
-    case logger::UART_SELECTION_USB_CDC:
-      if (esp_usb_console_available_for_read()) {
-        esp_usb_console_read_buf((char *) &data, 1);
-        byte = data;
-      }
-      break;
-#endif  // USE_LOGGER_USB_CDC
-#ifdef USE_LOGGER_USB_SERIAL_JTAG
-    case logger::UART_SELECTION_USB_SERIAL_JTAG: {
-      if (usb_serial_jtag_read_bytes((char *) &data, 1, 0)) {
-        byte = data;
-      }
-      break;
-    }
-#endif  // USE_LOGGER_USB_SERIAL_JTAG
-    default:
-      break;
-  }
-#elif defined(USE_ARDUINO)
-  if (this->hw_serial_->available()) {
-    this->hw_serial_->readBytes(&data, 1);
-    byte = data;
-  }
-#endif
-  return byte;
-}
 
 void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) {
   // First, set length field
@@ -134,7 +87,7 @@ void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) 
   this->tx_header_[TX_CHECKSUM_IDX] = checksum;
 
 #ifdef USE_ESP32
-  switch (logger::global_logger->get_uart()) {
+  switch (this->uart_selection_) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
 #if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && \

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -38,15 +38,16 @@ void ImprovSerialComponent::loop() {
     ESP_LOGV(TAG, "Timeout");
   }
 
-  auto byte = this->read_byte_();
-  while (byte.has_value()) {
+  while (true) {
+    auto byte = this->read_byte_();
+    if (!byte.has_value())
+      break;
     if (this->parse_improv_serial_byte_(byte.value())) {
       this->last_read_byte_ = now;
     } else {
       this->last_read_byte_ = 0;
       this->rx_buffer_.clear();
     }
-    byte = this->read_byte_();
   }
 
   if (this->state_ == improv::STATE_PROVISIONING) {

--- a/esphome/components/improv_serial/improv_serial_component.cpp
+++ b/esphome/components/improv_serial/improv_serial_component.cpp
@@ -16,6 +16,7 @@ void ImprovSerialComponent::setup() {
   global_improv_serial_component = this;
 #ifdef USE_ESP32
   this->uart_num_ = logger::global_logger->get_uart_num();
+  this->uart_selection_ = logger::global_logger->get_uart();
 #elif defined(USE_ARDUINO)
   this->hw_serial_ = logger::global_logger->get_hw_serial();
 #endif
@@ -30,7 +31,8 @@ void ImprovSerialComponent::setup() {
 }
 
 void ImprovSerialComponent::loop() {
-  if (this->last_read_byte_ && (millis() - this->last_read_byte_ > IMPROV_SERIAL_TIMEOUT)) {
+  const uint32_t now = App.get_loop_component_start_time();
+  if (this->last_read_byte_ && (now - this->last_read_byte_ > IMPROV_SERIAL_TIMEOUT)) {
     this->last_read_byte_ = 0;
     this->rx_buffer_.clear();
     ESP_LOGV(TAG, "Timeout");
@@ -39,7 +41,7 @@ void ImprovSerialComponent::loop() {
   auto byte = this->read_byte_();
   while (byte.has_value()) {
     if (this->parse_improv_serial_byte_(byte.value())) {
-      this->last_read_byte_ = millis();
+      this->last_read_byte_ = now;
     } else {
       this->last_read_byte_ = 0;
       this->rx_buffer_.clear();
@@ -62,53 +64,6 @@ void ImprovSerialComponent::loop() {
 }
 
 void ImprovSerialComponent::dump_config() { ESP_LOGCONFIG(TAG, "Improv Serial:"); }
-
-optional<uint8_t> ImprovSerialComponent::read_byte_() {
-  optional<uint8_t> byte;
-  uint8_t data = 0;
-#ifdef USE_ESP32
-  switch (logger::global_logger->get_uart()) {
-    case logger::UART_SELECTION_UART0:
-    case logger::UART_SELECTION_UART1:
-#if defined(USE_ESP32_VARIANT_ESP32)
-    case logger::UART_SELECTION_UART2:
-#endif
-      if (this->uart_num_ >= 0) {
-        size_t available;
-        uart_get_buffered_data_len(this->uart_num_, &available);
-        if (available) {
-          uart_read_bytes(this->uart_num_, &data, 1, 0);
-          byte = data;
-        }
-      }
-      break;
-#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
-    case logger::UART_SELECTION_USB_CDC:
-      if (esp_usb_console_available_for_read()) {
-        esp_usb_console_read_buf((char *) &data, 1);
-        byte = data;
-      }
-      break;
-#endif  // USE_LOGGER_USB_CDC
-#ifdef USE_LOGGER_USB_SERIAL_JTAG
-    case logger::UART_SELECTION_USB_SERIAL_JTAG: {
-      if (usb_serial_jtag_read_bytes((char *) &data, 1, 0)) {
-        byte = data;
-      }
-      break;
-    }
-#endif  // USE_LOGGER_USB_SERIAL_JTAG
-    default:
-      break;
-  }
-#elif defined(USE_ARDUINO)
-  if (this->hw_serial_->available()) {
-    this->hw_serial_->readBytes(&data, 1);
-    byte = data;
-  }
-#endif
-  return byte;
-}
 
 void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) {
   // First, set length field
@@ -133,7 +88,7 @@ void ImprovSerialComponent::write_data_(const uint8_t *data, const size_t size) 
   this->tx_header_[TX_CHECKSUM_IDX] = checksum;
 
 #ifdef USE_ESP32
-  switch (logger::global_logger->get_uart()) {
+  switch (this->uart_selection_) {
     case logger::UART_SELECTION_UART0:
     case logger::UART_SELECTION_UART1:
 #if defined(USE_ESP32_VARIANT_ESP32)

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/components/improv_base/improv_base.h"
+#include "esphome/components/logger/logger.h"
 #include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -65,7 +66,52 @@ class ImprovSerialComponent final : public Component, public improv_base::Improv
   std::vector<uint8_t> build_rpc_settings_response_(improv::Command command);
   std::vector<uint8_t> build_version_info_();
 
-  optional<uint8_t> read_byte_();
+  ESPHOME_ALWAYS_INLINE optional<uint8_t> read_byte_() {
+    optional<uint8_t> byte;
+    uint8_t data = 0;
+#ifdef USE_ESP32
+    switch (this->uart_selection_) {
+      case logger::UART_SELECTION_UART0:
+      case logger::UART_SELECTION_UART1:
+#if defined(USE_ESP32_VARIANT_ESP32)
+      case logger::UART_SELECTION_UART2:
+#endif
+        if (this->uart_num_ >= 0) {
+          size_t available;
+          uart_get_buffered_data_len(this->uart_num_, &available);
+          if (available) {
+            uart_read_bytes(this->uart_num_, &data, 1, 0);
+            byte = data;
+          }
+        }
+        break;
+#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
+      case logger::UART_SELECTION_USB_CDC:
+        if (esp_usb_console_available_for_read()) {
+          esp_usb_console_read_buf((char *) &data, 1);
+          byte = data;
+        }
+        break;
+#endif
+#ifdef USE_LOGGER_USB_SERIAL_JTAG
+      case logger::UART_SELECTION_USB_SERIAL_JTAG: {
+        if (usb_serial_jtag_read_bytes((char *) &data, 1, 0)) {
+          byte = data;
+        }
+        break;
+      }
+#endif
+      default:
+        break;
+    }
+#elif defined(USE_ARDUINO)
+    if (this->hw_serial_->available()) {
+      this->hw_serial_->readBytes(&data, 1);
+      byte = data;
+    }
+#endif
+    return byte;
+  }
   void write_data_(const uint8_t *data = nullptr, size_t size = 0);
 
   uint8_t tx_header_[TX_BUFFER_SIZE] = {
@@ -85,6 +131,7 @@ class ImprovSerialComponent final : public Component, public improv_base::Improv
 
 #ifdef USE_ESP32
   uart_port_t uart_num_;
+  logger::UARTSelection uart_selection_{logger::UART_SELECTION_UART0};
 #elif defined(USE_ARDUINO)
   Stream *hw_serial_{nullptr};
 #endif

--- a/esphome/components/improv_serial/improv_serial_component.h
+++ b/esphome/components/improv_serial/improv_serial_component.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/components/improv_base/improv_base.h"
+#include "esphome/components/logger/logger.h"
 #include "esphome/components/wifi/wifi_component.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
@@ -66,7 +67,53 @@ class ImprovSerialComponent : public Component, public improv_base::ImprovBase {
   std::vector<uint8_t> build_rpc_settings_response_(improv::Command command);
   std::vector<uint8_t> build_version_info_();
 
-  optional<uint8_t> read_byte_();
+  ESPHOME_ALWAYS_INLINE optional<uint8_t> read_byte_() {
+    optional<uint8_t> byte;
+    uint8_t data = 0;
+#ifdef USE_ESP32
+    switch (this->uart_selection_) {
+      case logger::UART_SELECTION_UART0:
+      case logger::UART_SELECTION_UART1:
+#if !defined(USE_ESP32_VARIANT_ESP32C3) && !defined(USE_ESP32_VARIANT_ESP32C6) && \
+    !defined(USE_ESP32_VARIANT_ESP32C61) && !defined(USE_ESP32_VARIANT_ESP32S2) && !defined(USE_ESP32_VARIANT_ESP32S3)
+      case logger::UART_SELECTION_UART2:
+#endif
+        if (this->uart_num_ >= 0) {
+          size_t available;
+          uart_get_buffered_data_len(this->uart_num_, &available);
+          if (available) {
+            uart_read_bytes(this->uart_num_, &data, 1, 0);
+            byte = data;
+          }
+        }
+        break;
+#if defined(USE_LOGGER_USB_CDC) && defined(CONFIG_ESP_CONSOLE_USB_CDC)
+      case logger::UART_SELECTION_USB_CDC:
+        if (esp_usb_console_available_for_read()) {
+          esp_usb_console_read_buf((char *) &data, 1);
+          byte = data;
+        }
+        break;
+#endif
+#ifdef USE_LOGGER_USB_SERIAL_JTAG
+      case logger::UART_SELECTION_USB_SERIAL_JTAG: {
+        if (usb_serial_jtag_read_bytes((char *) &data, 1, 0)) {
+          byte = data;
+        }
+        break;
+      }
+#endif
+      default:
+        break;
+    }
+#elif defined(USE_ARDUINO)
+    if (this->hw_serial_->available()) {
+      this->hw_serial_->readBytes(&data, 1);
+      byte = data;
+    }
+#endif
+    return byte;
+  }
   void write_data_(const uint8_t *data = nullptr, size_t size = 0);
 
   uint8_t tx_header_[TX_BUFFER_SIZE] = {
@@ -86,6 +133,7 @@ class ImprovSerialComponent : public Component, public improv_base::ImprovBase {
 
 #ifdef USE_ESP32
   uart_port_t uart_num_;
+  logger::UARTSelection uart_selection_{logger::UART_SELECTION_UART0};
 #elif defined(USE_ARDUINO)
   Stream *hw_serial_{nullptr};
 #endif


### PR DESCRIPTION
# What does this implement/fix?

Reduces per-iteration cost of `ImprovSerialComponent::loop()` for devices that always run improv_serial, even when no bytes are flowing. Observed on a Kauf plug (ESP8266) where improv_serial was the second-heaviest component in the runtime stats (≈18.9 µs/iter, second only to the api component).

Changes:
- Cache `logger::global_logger->get_uart()` once in `setup()` into a new `uart_selection_` member. Each loop iteration previously dereferenced the global logger pointer and made a non-inlined `Logger::get_uart()` call to drive the switch in `read_byte_()` and `write_data_()`; now the cached value is used directly.
- In `loop()`, replace the two `millis()` calls (one for the timeout check, one for `last_read_byte_`) with a single read of `App.get_loop_component_start_time()`. On ESP8266 `millis()` reads a 64‑bit timer with interrupt-locked access, so this halves the time-source cost on the loop hot path.
- Move `read_byte_()` into the header as `ESPHOME_ALWAYS_INLINE`. The function was previously defined in the `.cpp`, so without LTO it cost a real call/ret per iteration plus stack staging of the `optional<uint8_t>` return. Inlining lets the compiler drop the call/ret and elide the optional construction since the result is consumed immediately by `byte.has_value()` in `loop()`.

No behavior change. The ESP-IDF UART read sequence (`uart_get_buffered_data_len` guard followed by `uart_read_bytes`) is preserved: that fast-path guard is cheaper than calling `uart_read_bytes` unconditionally because `get_buffered_data_len` is just a single spinlock read, while `uart_read_bytes` takes the rx_mux semaphore plus additional ringbuffer/spinlock work even when there is nothing to read.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal optimization, no user-facing change)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Flash on esp32-idf (component test build, app image): 675,920 bytes on dev, 675,872 bytes with this PR; the inlined read path is 48 bytes smaller since loop() drains bytes through a single call site.

## Example entry for `config.yaml`:

```yaml
# No config change. Existing improv_serial config still works as-is.
improv_serial:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
