### PR TITLE
[core] Use ETag in external_files cache to fix re-downloads from raw.githubusercontent.com

### DIFF
--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -67,7 +67,8 @@ def _read_etag(local_file_path: Path) -> str | None:
 def _write_etag(local_file_path: Path, etag: str | None) -> None:
     etag_path = _etag_sidecar_path(local_file_path)
     if not etag:
-        with contextlib.suppress(FileNotFoundError):
+        # ETag persistence is best-effort; matches `_read_etag`'s tolerance.
+        with contextlib.suppress(OSError):
             etag_path.unlink()
         return
     try:

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -31,37 +31,35 @@ def _etag_sidecar_path(local_file_path: Path) -> Path:
     return local_file_path.parent / f".{local_file_path.name}.etag"
 
 
-def _read_etag(local_file_path: Path) -> str | None:
-    """Return the cached ETag if it still describes the current cached file.
+def _mtime_seconds(path: Path) -> int:
+    """Return `path`'s mtime as integer seconds.
 
-    The sidecar's mtime is kept in sync with the cache file's mtime by
-    `_write_etag`. If they disagree, the cache file was modified out-of-band
-    (manual edit, restored from backup, replaced by another tool) and the
-    ETag no longer corresponds to its contents, so treat the sidecar as
-    stale and delete it.
+    Whole seconds is the common-denominator resolution across all
+    filesystems we run on (FAT/exFAT 2s, NTFS 100ns, APFS/ext4 ns), so
+    comparisons survive setting+reading round-trips that would lose
+    sub-second precision on lower-resolution filesystems.
+    """
+    return int(path.stat().st_mtime)
+
+
+def _read_etag(local_file_path: Path) -> str | None:
+    """Return the cached ETag if its sidecar's mtime still matches the cache
+    file's. A mismatch means the cache file was modified out-of-band, so the
+    ETag no longer describes its contents -- delete the stale sidecar and
+    return None.
     """
     etag_path = _etag_sidecar_path(local_file_path)
     try:
-        etag_mtime_ns = etag_path.stat().st_mtime_ns
-        file_mtime_ns = local_file_path.stat().st_mtime_ns
-    except OSError:
-        return None
-    if etag_mtime_ns != file_mtime_ns:
-        _LOGGER.debug(
-            "ETag sidecar mtime (%d) does not match cached file mtime (%d) at %s; "
-            "treating ETag as stale",
-            etag_mtime_ns,
-            file_mtime_ns,
-            local_file_path,
-        )
-        with contextlib.suppress(OSError):
+        if _mtime_seconds(etag_path) != _mtime_seconds(local_file_path):
+            _LOGGER.debug(
+                "ETag sidecar mtime mismatch at %s; treating as stale",
+                local_file_path,
+            )
             etag_path.unlink()
-        return None
-    try:
-        etag = etag_path.read_text().strip()
+            return None
+        return etag_path.read_text().strip() or None
     except OSError:
         return None
-    return etag or None
 
 
 def _write_etag(local_file_path: Path, etag: str | None) -> None:
@@ -79,8 +77,8 @@ def _write_etag(local_file_path: Path, etag: str | None) -> None:
     # Pin the sidecar's mtime to the cache file's mtime. _read_etag relies on
     # this match to detect out-of-band edits to the cache file.
     try:
-        file_mtime_ns = local_file_path.stat().st_mtime_ns
-        os.utime(etag_path, ns=(file_mtime_ns, file_mtime_ns))
+        file_mtime = _mtime_seconds(local_file_path)
+        os.utime(etag_path, (file_mtime, file_mtime))
     except OSError as e:
         _LOGGER.debug(
             "Could not sync ETag sidecar mtime for %s: %s", local_file_path, e
@@ -100,8 +98,7 @@ def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
                 IF_MODIFIED_SINCE: local_modification_time_str,
                 CACHE_CONTROL: CACHE_CONTROL_MAX_AGE + "3600",
             }
-            etag = _read_etag(local_file_path)
-            if etag:
+            if etag := _read_etag(local_file_path):
                 headers[IF_NONE_MATCH] = etag
             response = requests.head(
                 url, headers=headers, timeout=NETWORK_TIMEOUT, allow_redirects=True
@@ -120,8 +117,7 @@ def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
                     "has_remote_file_changed: File not modified since %s",
                     local_modification_time_str,
                 )
-                new_etag = response.headers.get(ETAG)
-                if new_etag and new_etag != etag:
+                if (new_etag := response.headers.get(ETAG)) and new_etag != etag:
                     _write_etag(local_file_path, new_etag)
                 return False
             _LOGGER.debug("has_remote_file_changed: File modified")

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 from datetime import UTC, datetime
 import logging
+import os
 from pathlib import Path
 
 import requests
@@ -31,8 +32,33 @@ def _etag_sidecar_path(local_file_path: Path) -> Path:
 
 
 def _read_etag(local_file_path: Path) -> str | None:
+    """Return the cached ETag if it still describes the current cached file.
+
+    The sidecar's mtime is kept in sync with the cache file's mtime by
+    `_write_etag`. If they disagree, the cache file was modified out-of-band
+    (manual edit, restored from backup, replaced by another tool) and the
+    ETag no longer corresponds to its contents, so treat the sidecar as
+    stale and delete it.
+    """
+    etag_path = _etag_sidecar_path(local_file_path)
     try:
-        etag = _etag_sidecar_path(local_file_path).read_text().strip()
+        etag_mtime_ns = etag_path.stat().st_mtime_ns
+        file_mtime_ns = local_file_path.stat().st_mtime_ns
+    except OSError:
+        return None
+    if etag_mtime_ns != file_mtime_ns:
+        _LOGGER.debug(
+            "ETag sidecar mtime (%d) does not match cached file mtime (%d) at %s; "
+            "treating ETag as stale",
+            etag_mtime_ns,
+            file_mtime_ns,
+            local_file_path,
+        )
+        with contextlib.suppress(OSError):
+            etag_path.unlink()
+        return None
+    try:
+        etag = etag_path.read_text().strip()
     except OSError:
         return None
     return etag or None
@@ -48,6 +74,16 @@ def _write_etag(local_file_path: Path, etag: str | None) -> None:
         write_file(etag_path, etag)
     except EsphomeError as e:
         _LOGGER.debug("Could not save ETag for %s: %s", local_file_path, e)
+        return
+    # Pin the sidecar's mtime to the cache file's mtime. _read_etag relies on
+    # this match to detect out-of-band edits to the cache file.
+    try:
+        file_mtime_ns = local_file_path.stat().st_mtime_ns
+        os.utime(etag_path, ns=(file_mtime_ns, file_mtime_ns))
+    except OSError as e:
+        _LOGGER.debug(
+            "Could not sync ETag sidecar mtime for %s: %s", local_file_path, e
+        )
 
 
 def has_remote_file_changed(url: str, local_file_path: Path) -> bool:

--- a/esphome/external_files.py
+++ b/esphome/external_files.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from datetime import UTC, datetime
 import logging
 from pathlib import Path
@@ -8,7 +9,8 @@ import requests
 
 import esphome.config_validation as cv
 from esphome.const import __version__
-from esphome.core import CORE, TimePeriodSeconds
+from esphome.core import CORE, EsphomeError, TimePeriodSeconds
+from esphome.helpers import write_file
 
 _LOGGER = logging.getLogger(__name__)
 CODEOWNERS = ["@landonr"]
@@ -16,10 +18,36 @@ CODEOWNERS = ["@landonr"]
 NETWORK_TIMEOUT = 30
 
 IF_MODIFIED_SINCE = "If-Modified-Since"
+IF_NONE_MATCH = "If-None-Match"
+ETAG = "ETag"
 CACHE_CONTROL = "Cache-Control"
 CACHE_CONTROL_MAX_AGE = "max-age="
 CONTENT_DISPOSITION = "content-disposition"
 TEMP_DIR = "temp"
+
+
+def _etag_sidecar_path(local_file_path: Path) -> Path:
+    return local_file_path.parent / f".{local_file_path.name}.etag"
+
+
+def _read_etag(local_file_path: Path) -> str | None:
+    try:
+        etag = _etag_sidecar_path(local_file_path).read_text().strip()
+    except OSError:
+        return None
+    return etag or None
+
+
+def _write_etag(local_file_path: Path, etag: str | None) -> None:
+    etag_path = _etag_sidecar_path(local_file_path)
+    if not etag:
+        with contextlib.suppress(FileNotFoundError):
+            etag_path.unlink()
+        return
+    try:
+        write_file(etag_path, etag)
+    except EsphomeError as e:
+        _LOGGER.debug("Could not save ETag for %s: %s", local_file_path, e)
 
 
 def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
@@ -35,14 +63,18 @@ def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
                 IF_MODIFIED_SINCE: local_modification_time_str,
                 CACHE_CONTROL: CACHE_CONTROL_MAX_AGE + "3600",
             }
+            etag = _read_etag(local_file_path)
+            if etag:
+                headers[IF_NONE_MATCH] = etag
             response = requests.head(
                 url, headers=headers, timeout=NETWORK_TIMEOUT, allow_redirects=True
             )
 
             _LOGGER.debug(
-                "has_remote_file_changed: File %s, Local modified %s, response code %d",
+                "has_remote_file_changed: File %s, Local modified %s, ETag %s, response code %d",
                 local_file_path,
                 local_modification_time_str,
+                etag or "<none>",
                 response.status_code,
             )
 
@@ -51,6 +83,9 @@ def has_remote_file_changed(url: str, local_file_path: Path) -> bool:
                     "has_remote_file_changed: File not modified since %s",
                     local_modification_time_str,
                 )
+                new_etag = response.headers.get(ETAG)
+                if new_etag and new_etag != etag:
+                    _write_etag(local_file_path, new_etag)
                 return False
             _LOGGER.debug("has_remote_file_changed: File modified")
             return True
@@ -112,7 +147,7 @@ def download_content(url: str, path: Path, timeout: int = NETWORK_TIMEOUT) -> by
             return path.read_bytes()
         raise cv.Invalid(f"Could not download from {url}: {e}") from e
 
-    path.parent.mkdir(parents=True, exist_ok=True)
     data = req.content
-    path.write_bytes(data)
+    write_file(path, data)
+    _write_etag(path, req.headers.get(ETAG))
     return data

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -19,9 +19,45 @@ def _seed_etag(cache_file: Path, etag: str) -> Path:
     """
     sidecar = external_files._etag_sidecar_path(cache_file)
     sidecar.write_text(etag)
-    file_mtime_ns = cache_file.stat().st_mtime_ns
-    os.utime(sidecar, ns=(file_mtime_ns, file_mtime_ns))
+    file_mtime = int(cache_file.stat().st_mtime)
+    os.utime(sidecar, (file_mtime, file_mtime))
     return sidecar
+
+
+@pytest.fixture
+def mock_requests_head() -> MagicMock:
+    """Patch `external_files.requests.head` so the conditional HEAD-request
+    validator can be tested without doing real HTTP.
+    """
+    with patch("esphome.external_files.requests.head") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_requests_get() -> MagicMock:
+    """Patch `external_files.requests.get` so the download path can be
+    tested without doing real HTTP.
+    """
+    with patch("esphome.external_files.requests.get") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_has_remote_file_changed() -> MagicMock:
+    """Patch `external_files.has_remote_file_changed` so download tests can
+    control the conditional check independently from the GET path.
+    """
+    with patch("esphome.external_files.has_remote_file_changed") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_write_file() -> MagicMock:
+    """Patch `external_files.write_file` so atomic-write failures can be
+    injected without involving the real filesystem helper.
+    """
+    with patch("esphome.external_files.write_file") as m:
+        yield m
 
 
 def test_compute_local_file_dir(setup_core: Path) -> None:
@@ -100,9 +136,8 @@ def test_is_file_recent_with_zero_refresh(setup_core: Path) -> None:
         assert result is False
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_not_modified(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed returns False when file not modified."""
     test_file = setup_core / "cached.txt"
@@ -111,23 +146,22 @@ def test_has_remote_file_changed_not_modified(
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     result = external_files.has_remote_file_changed(url, test_file)
 
     assert result is False
-    mock_head.assert_called_once()
+    mock_requests_head.assert_called_once()
 
-    call_args = mock_head.call_args
+    call_args = mock_requests_head.call_args
     headers = call_args[1]["headers"]
     assert external_files.IF_MODIFIED_SINCE in headers
     assert external_files.CACHE_CONTROL in headers
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_modified(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed returns True when file modified."""
     test_file = setup_core / "cached.txt"
@@ -136,7 +170,7 @@ def test_has_remote_file_changed_modified(
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     result = external_files.has_remote_file_changed(url, test_file)
@@ -154,15 +188,16 @@ def test_has_remote_file_changed_no_local_file(setup_core: Path) -> None:
     assert result is True
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_network_error(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed returns False on network error when file is cached."""
     test_file = setup_core / "cached.txt"
     test_file.write_text("cached content")
 
-    mock_head.side_effect = requests.exceptions.RequestException("Network error")
+    mock_requests_head.side_effect = requests.exceptions.RequestException(
+        "Network error"
+    )
 
     url = "https://example.com/file.txt"
     result = external_files.has_remote_file_changed(url, test_file)
@@ -170,9 +205,8 @@ def test_has_remote_file_changed_network_error(
     assert result is False
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_timeout(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed respects timeout."""
     test_file = setup_core / "cached.txt"
@@ -181,18 +215,17 @@ def test_has_remote_file_changed_timeout(
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     external_files.has_remote_file_changed(url, test_file)
 
-    call_args = mock_head.call_args
+    call_args = mock_requests_head.call_args
     assert call_args[1]["timeout"] == external_files.NETWORK_TIMEOUT
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_uses_etag(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed sends If-None-Match when ETag is cached."""
     test_file = setup_core / "cached.txt"
@@ -202,19 +235,18 @@ def test_has_remote_file_changed_uses_etag(
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     result = external_files.has_remote_file_changed(url, test_file)
 
     assert result is False
-    headers = mock_head.call_args[1]["headers"]
+    headers = mock_requests_head.call_args[1]["headers"]
     assert headers[external_files.IF_NONE_MATCH] == '"abc123"'
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_no_etag_no_if_none_match(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed omits If-None-Match when no ETag is cached."""
     test_file = setup_core / "cached.txt"
@@ -223,18 +255,17 @@ def test_has_remote_file_changed_no_etag_no_if_none_match(
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     external_files.has_remote_file_changed(url, test_file)
 
-    headers = mock_head.call_args[1]["headers"]
+    headers = mock_requests_head.call_args[1]["headers"]
     assert external_files.IF_NONE_MATCH not in headers
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_refreshes_etag_on_304(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """Test has_remote_file_changed updates the cached ETag when the 304 sends a new one."""
     test_file = setup_core / "cached.txt"
@@ -244,7 +275,7 @@ def test_has_remote_file_changed_refreshes_etag_on_304(
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {external_files.ETAG: '"new"'}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
     external_files.has_remote_file_changed(url, test_file)
@@ -252,9 +283,8 @@ def test_has_remote_file_changed_refreshes_etag_on_304(
     assert external_files._etag_sidecar_path(test_file).read_text() == '"new"'
 
 
-@patch("esphome.external_files.requests.head")
 def test_has_remote_file_changed_ignores_etag_when_mtime_diverges(
-    mock_head: MagicMock, setup_core: Path
+    mock_requests_head: MagicMock, setup_core: Path
 ) -> None:
     """If the cache file was edited out-of-band (mtime no longer matches the
     sidecar's), the cached ETag must not be used -- it no longer describes the
@@ -264,49 +294,46 @@ def test_has_remote_file_changed_ignores_etag_when_mtime_diverges(
     test_file.write_text("cached content")
     sidecar = _seed_etag(test_file, '"abc123"')
 
-    # Simulate an out-of-band edit to the cache file -- mtime advances but the
-    # sidecar is left untouched, so the recorded ETag is now stale.
+    # Simulate an out-of-band edit to the cache file -- mtime advances by a
+    # full second (so it diverges at whole-second resolution) but the sidecar
+    # is left untouched, so the recorded ETag is now stale.
     file_stat = test_file.stat()
-    os.utime(
-        test_file, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns + 1_000_000_000)
-    )
+    os.utime(test_file, (file_stat.st_atime, file_stat.st_mtime + 1))
 
     mock_response = MagicMock()
     mock_response.status_code = 304
     mock_response.headers = {}
-    mock_head.return_value = mock_response
+    mock_requests_head.return_value = mock_response
 
     external_files.has_remote_file_changed("https://example.com/file.txt", test_file)
 
-    headers = mock_head.call_args[1]["headers"]
+    headers = mock_requests_head.call_args[1]["headers"]
     assert external_files.IF_NONE_MATCH not in headers
     # Stale sidecar should be removed so future calls don't keep paying the
     # mtime-comparison cost on a known-bad sidecar.
     assert not sidecar.exists()
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_pins_etag_mtime_to_file_mtime(
-    mock_has_changed: MagicMock,
-    mock_get: MagicMock,
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
     setup_core: Path,
 ) -> None:
     """After a successful download, the sidecar's mtime must equal the cache
     file's mtime so `_read_etag` accepts it on the next call.
     """
     test_file = setup_core / "fresh.txt"
-    mock_has_changed.return_value = True
+    mock_has_remote_file_changed.return_value = True
     mock_response = MagicMock()
     mock_response.content = b"fresh content"
     mock_response.headers = {external_files.ETAG: '"deadbeef"'}
     mock_response.raise_for_status = MagicMock()
-    mock_get.return_value = mock_response
+    mock_requests_get.return_value = mock_response
 
     external_files.download_content("https://example.com/file.txt", test_file)
 
     sidecar = external_files._etag_sidecar_path(test_file)
-    assert sidecar.stat().st_mtime_ns == test_file.stat().st_mtime_ns
+    assert int(sidecar.stat().st_mtime) == int(test_file.stat().st_mtime)
 
 
 def test_compute_local_file_dir_creates_parent_dirs(setup_core: Path) -> None:
@@ -334,10 +361,10 @@ def test_is_file_recent_handles_float_seconds(setup_core: Path) -> None:
     assert result is True
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_with_network_error_uses_cache(
-    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
+    setup_core: Path,
 ) -> None:
     """Test download_content uses cached file when network fails."""
     test_file = setup_core / "cached.txt"
@@ -345,8 +372,10 @@ def test_download_content_with_network_error_uses_cache(
     test_file.write_bytes(cached_content)
 
     # Simulate file has changed, so it tries to download
-    mock_has_changed.return_value = True
-    mock_get.side_effect = requests.exceptions.RequestException("Network error")
+    mock_has_remote_file_changed.return_value = True
+    mock_requests_get.side_effect = requests.exceptions.RequestException(
+        "Network error"
+    )
 
     url = "https://example.com/file.txt"
     result = external_files.download_content(url, test_file)
@@ -354,17 +383,19 @@ def test_download_content_with_network_error_uses_cache(
     assert result == cached_content
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_with_network_error_no_cache_fails(
-    mock_has_changed: MagicMock, mock_get: MagicMock, setup_core: Path
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
+    setup_core: Path,
 ) -> None:
     """Test download_content raises error when network fails and no cache exists."""
     test_file = setup_core / "nonexistent.txt"
 
     # Simulate file has changed (doesn't exist), so it tries to download
-    mock_has_changed.return_value = True
-    mock_get.side_effect = requests.exceptions.RequestException("Network error")
+    mock_has_remote_file_changed.return_value = True
+    mock_requests_get.side_effect = requests.exceptions.RequestException(
+        "Network error"
+    )
 
     url = "https://example.com/file.txt"
 
@@ -372,11 +403,9 @@ def test_download_content_with_network_error_no_cache_fails(
         external_files.download_content(url, test_file)
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_skip_external_update_uses_cache(
-    mock_has_changed: MagicMock,
-    mock_get: MagicMock,
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
     setup_core: Path,
 ) -> None:
     """Test download_content skips network checks when CORE.skip_external_update is set."""
@@ -389,27 +418,25 @@ def test_download_content_skip_external_update_uses_cache(
     result = external_files.download_content(url, test_file)
 
     assert result == cached_content
-    mock_has_changed.assert_not_called()
-    mock_get.assert_not_called()
+    mock_has_remote_file_changed.assert_not_called()
+    mock_requests_get.assert_not_called()
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_skip_external_update_downloads_when_missing(
-    mock_has_changed: MagicMock,
-    mock_get: MagicMock,
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
     setup_core: Path,
 ) -> None:
     """Test download_content still downloads when file is missing, even with skip_external_update."""
     test_file = setup_core / "missing.txt"
     new_content = b"fresh content"
 
-    mock_has_changed.return_value = True
+    mock_has_remote_file_changed.return_value = True
     mock_response = MagicMock()
     mock_response.content = new_content
     mock_response.headers = {}
     mock_response.raise_for_status = MagicMock()
-    mock_get.return_value = mock_response
+    mock_requests_get.return_value = mock_response
 
     CORE.skip_external_update = True
     url = "https://example.com/file.txt"
@@ -419,23 +446,21 @@ def test_download_content_skip_external_update_downloads_when_missing(
     assert test_file.read_bytes() == new_content
 
 
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_saves_etag(
-    mock_has_changed: MagicMock,
-    mock_get: MagicMock,
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
     setup_core: Path,
 ) -> None:
     """Test download_content writes the ETag sidecar after a successful download."""
     test_file = setup_core / "fresh.txt"
     new_content = b"fresh content"
 
-    mock_has_changed.return_value = True
+    mock_has_remote_file_changed.return_value = True
     mock_response = MagicMock()
     mock_response.content = new_content
     mock_response.headers = {external_files.ETAG: '"deadbeef"'}
     mock_response.raise_for_status = MagicMock()
-    mock_get.return_value = mock_response
+    mock_requests_get.return_value = mock_response
 
     url = "https://example.com/file.txt"
     external_files.download_content(url, test_file)
@@ -443,12 +468,9 @@ def test_download_content_saves_etag(
     assert external_files._etag_sidecar_path(test_file).read_text() == '"deadbeef"'
 
 
-@patch("esphome.external_files.write_file")
-@patch("esphome.external_files.requests.get")
-@patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_atomic_write_no_partial_on_failure(
-    mock_has_changed: MagicMock,
-    mock_get: MagicMock,
+    mock_has_remote_file_changed: MagicMock,
+    mock_requests_get: MagicMock,
     mock_write_file: MagicMock,
     setup_core: Path,
 ) -> None:
@@ -463,12 +485,12 @@ def test_download_content_atomic_write_no_partial_on_failure(
     original_content = b"original content"
     test_file.write_bytes(original_content)
 
-    mock_has_changed.return_value = True
+    mock_has_remote_file_changed.return_value = True
     mock_response = MagicMock()
     mock_response.content = b"new content"
     mock_response.headers = {}
     mock_response.raise_for_status = MagicMock()
-    mock_get.return_value = mock_response
+    mock_requests_get.return_value = mock_response
 
     mock_write_file.side_effect = EsphomeError("disk full")
 

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -443,33 +443,41 @@ def test_download_content_saves_etag(
     assert external_files._etag_sidecar_path(test_file).read_text() == '"deadbeef"'
 
 
+@patch("esphome.external_files.write_file")
 @patch("esphome.external_files.requests.get")
 @patch("esphome.external_files.has_remote_file_changed")
 def test_download_content_atomic_write_no_partial_on_failure(
     mock_has_changed: MagicMock,
     mock_get: MagicMock,
+    mock_write_file: MagicMock,
     setup_core: Path,
 ) -> None:
-    """Test download_content does not corrupt the existing file if the write step fails."""
+    """If `write_file` (the atomic-write helper) fails, the existing cache
+    file must remain untouched and no temp files may be left behind. Patching
+    `write_file` directly exercises the atomic-rename path -- a failure inside
+    `write_file` is the only reason the rename wouldn't have happened.
+    """
+    from esphome.core import EsphomeError
+
     test_file = setup_core / "cached.txt"
     original_content = b"original content"
     test_file.write_bytes(original_content)
 
     mock_has_changed.return_value = True
     mock_response = MagicMock()
-    # Accessing .content raises, simulating a streaming/decode failure
-    type(mock_response).content = property(
-        lambda self: (_ for _ in ()).throw(OSError("disk full"))
-    )
+    mock_response.content = b"new content"
+    mock_response.headers = {}
     mock_response.raise_for_status = MagicMock()
     mock_get.return_value = mock_response
 
-    url = "https://example.com/file.txt"
-    with pytest.raises(OSError, match="disk full"):
-        external_files.download_content(url, test_file)
+    mock_write_file.side_effect = EsphomeError("disk full")
 
-    # Original file is untouched (atomic rename never happened)
+    with pytest.raises(EsphomeError, match="disk full"):
+        external_files.download_content("https://example.com/file.txt", test_file)
+
+    # Original file is untouched -- write_file aborted before its rename step.
     assert test_file.read_bytes() == original_content
-    # No leftover temp files from tempfile.NamedTemporaryFile
+    # write_file is responsible for cleaning its own temp files; nothing leaks
+    # into the cache directory either way.
     leftover_tmps = list(setup_core.glob("tmp*"))
     assert leftover_tmps == []

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -10,7 +10,7 @@ import requests
 
 from esphome import external_files
 from esphome.config_validation import Invalid
-from esphome.core import CORE, TimePeriod
+from esphome.core import CORE, EsphomeError, TimePeriod
 
 
 def _seed_etag(cache_file: Path, etag: str) -> Path:
@@ -334,6 +334,54 @@ def test_download_content_pins_etag_mtime_to_file_mtime(
 
     sidecar = external_files._etag_sidecar_path(test_file)
     assert int(sidecar.stat().st_mtime) == int(test_file.stat().st_mtime)
+
+
+def test_write_etag_swallows_write_file_failure(
+    mock_write_file: MagicMock, setup_core: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If `write_file` raises, _write_etag must not propagate -- ETag
+    persistence is best-effort and a failure here must not abort the
+    surrounding download.
+    """
+    cache_file = setup_core / "cached.txt"
+    cache_file.write_text("cached content")
+    mock_write_file.side_effect = EsphomeError("disk full")
+
+    with caplog.at_level("DEBUG", logger="esphome.external_files"):
+        external_files._write_etag(cache_file, '"abc123"')
+
+    assert "Could not save ETag" in caplog.text
+    # Sidecar wasn't created, since write_file was mocked to fail before
+    # reaching the os.utime step.
+    assert not external_files._etag_sidecar_path(cache_file).exists()
+
+
+def test_write_etag_swallows_utime_failure(
+    setup_core: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """If `os.utime` raises while pinning the sidecar's mtime, _write_etag
+    must not propagate. The sidecar is still written; if its mtime later
+    fails to match the cache file, `_read_etag` will discard it on next
+    read.
+    """
+    cache_file = setup_core / "cached.txt"
+    cache_file.write_text("cached content")
+
+    with (
+        patch(
+            "esphome.external_files.os.utime",
+            side_effect=PermissionError("nope"),
+        ),
+        caplog.at_level("DEBUG", logger="esphome.external_files"),
+    ):
+        external_files._write_etag(cache_file, '"abc123"')
+
+    assert "Could not sync ETag sidecar mtime" in caplog.text
+    # write_file succeeded, so the sidecar exists with the new value even
+    # though we couldn't pin its mtime.
+    sidecar = external_files._etag_sidecar_path(cache_file)
+    assert sidecar.exists()
+    assert sidecar.read_text() == '"abc123"'
 
 
 def test_compute_local_file_dir_creates_parent_dirs(setup_core: Path) -> None:

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -98,6 +98,7 @@ def test_has_remote_file_changed_not_modified(
 
     mock_response = MagicMock()
     mock_response.status_code = 304
+    mock_response.headers = {}
     mock_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
@@ -122,6 +123,7 @@ def test_has_remote_file_changed_modified(
 
     mock_response = MagicMock()
     mock_response.status_code = 200
+    mock_response.headers = {}
     mock_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
@@ -166,6 +168,7 @@ def test_has_remote_file_changed_timeout(
 
     mock_response = MagicMock()
     mock_response.status_code = 304
+    mock_response.headers = {}
     mock_head.return_value = mock_response
 
     url = "https://example.com/file.txt"
@@ -173,6 +176,68 @@ def test_has_remote_file_changed_timeout(
 
     call_args = mock_head.call_args
     assert call_args[1]["timeout"] == external_files.NETWORK_TIMEOUT
+
+
+@patch("esphome.external_files.requests.head")
+def test_has_remote_file_changed_uses_etag(
+    mock_head: MagicMock, setup_core: Path
+) -> None:
+    """Test has_remote_file_changed sends If-None-Match when ETag is cached."""
+    test_file = setup_core / "cached.txt"
+    test_file.write_text("cached content")
+    external_files._etag_sidecar_path(test_file).write_text('"abc123"')
+
+    mock_response = MagicMock()
+    mock_response.status_code = 304
+    mock_response.headers = {}
+    mock_head.return_value = mock_response
+
+    url = "https://example.com/file.txt"
+    result = external_files.has_remote_file_changed(url, test_file)
+
+    assert result is False
+    headers = mock_head.call_args[1]["headers"]
+    assert headers[external_files.IF_NONE_MATCH] == '"abc123"'
+
+
+@patch("esphome.external_files.requests.head")
+def test_has_remote_file_changed_no_etag_no_if_none_match(
+    mock_head: MagicMock, setup_core: Path
+) -> None:
+    """Test has_remote_file_changed omits If-None-Match when no ETag is cached."""
+    test_file = setup_core / "cached.txt"
+    test_file.write_text("cached content")
+
+    mock_response = MagicMock()
+    mock_response.status_code = 304
+    mock_response.headers = {}
+    mock_head.return_value = mock_response
+
+    url = "https://example.com/file.txt"
+    external_files.has_remote_file_changed(url, test_file)
+
+    headers = mock_head.call_args[1]["headers"]
+    assert external_files.IF_NONE_MATCH not in headers
+
+
+@patch("esphome.external_files.requests.head")
+def test_has_remote_file_changed_refreshes_etag_on_304(
+    mock_head: MagicMock, setup_core: Path
+) -> None:
+    """Test has_remote_file_changed updates the cached ETag when the 304 sends a new one."""
+    test_file = setup_core / "cached.txt"
+    test_file.write_text("cached content")
+    external_files._etag_sidecar_path(test_file).write_text('"old"')
+
+    mock_response = MagicMock()
+    mock_response.status_code = 304
+    mock_response.headers = {external_files.ETAG: '"new"'}
+    mock_head.return_value = mock_response
+
+    url = "https://example.com/file.txt"
+    external_files.has_remote_file_changed(url, test_file)
+
+    assert external_files._etag_sidecar_path(test_file).read_text() == '"new"'
 
 
 def test_compute_local_file_dir_creates_parent_dirs(setup_core: Path) -> None:
@@ -273,6 +338,7 @@ def test_download_content_skip_external_update_downloads_when_missing(
     mock_has_changed.return_value = True
     mock_response = MagicMock()
     mock_response.content = new_content
+    mock_response.headers = {}
     mock_response.raise_for_status = MagicMock()
     mock_get.return_value = mock_response
 
@@ -282,3 +348,59 @@ def test_download_content_skip_external_update_downloads_when_missing(
 
     assert result == new_content
     assert test_file.read_bytes() == new_content
+
+
+@patch("esphome.external_files.requests.get")
+@patch("esphome.external_files.has_remote_file_changed")
+def test_download_content_saves_etag(
+    mock_has_changed: MagicMock,
+    mock_get: MagicMock,
+    setup_core: Path,
+) -> None:
+    """Test download_content writes the ETag sidecar after a successful download."""
+    test_file = setup_core / "fresh.txt"
+    new_content = b"fresh content"
+
+    mock_has_changed.return_value = True
+    mock_response = MagicMock()
+    mock_response.content = new_content
+    mock_response.headers = {external_files.ETAG: '"deadbeef"'}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    url = "https://example.com/file.txt"
+    external_files.download_content(url, test_file)
+
+    assert external_files._etag_sidecar_path(test_file).read_text() == '"deadbeef"'
+
+
+@patch("esphome.external_files.requests.get")
+@patch("esphome.external_files.has_remote_file_changed")
+def test_download_content_atomic_write_no_partial_on_failure(
+    mock_has_changed: MagicMock,
+    mock_get: MagicMock,
+    setup_core: Path,
+) -> None:
+    """Test download_content does not corrupt the existing file if the write step fails."""
+    test_file = setup_core / "cached.txt"
+    original_content = b"original content"
+    test_file.write_bytes(original_content)
+
+    mock_has_changed.return_value = True
+    mock_response = MagicMock()
+    # Accessing .content raises, simulating a streaming/decode failure
+    type(mock_response).content = property(
+        lambda self: (_ for _ in ()).throw(OSError("disk full"))
+    )
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    url = "https://example.com/file.txt"
+    with pytest.raises(OSError, match="disk full"):
+        external_files.download_content(url, test_file)
+
+    # Original file is untouched (atomic rename never happened)
+    assert test_file.read_bytes() == original_content
+    # No leftover temp files from tempfile.NamedTemporaryFile
+    leftover_tmps = list(setup_core.glob("tmp*"))
+    assert leftover_tmps == []

--- a/tests/unit_tests/test_external_files.py
+++ b/tests/unit_tests/test_external_files.py
@@ -1,5 +1,6 @@
 """Tests for external_files.py functions."""
 
+import os
 from pathlib import Path
 import time
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,17 @@ import requests
 from esphome import external_files
 from esphome.config_validation import Invalid
 from esphome.core import CORE, TimePeriod
+
+
+def _seed_etag(cache_file: Path, etag: str) -> Path:
+    """Write an ETag sidecar with its mtime synced to the cache file's mtime,
+    matching the invariant that `_write_etag` enforces in production.
+    """
+    sidecar = external_files._etag_sidecar_path(cache_file)
+    sidecar.write_text(etag)
+    file_mtime_ns = cache_file.stat().st_mtime_ns
+    os.utime(sidecar, ns=(file_mtime_ns, file_mtime_ns))
+    return sidecar
 
 
 def test_compute_local_file_dir(setup_core: Path) -> None:
@@ -185,7 +197,7 @@ def test_has_remote_file_changed_uses_etag(
     """Test has_remote_file_changed sends If-None-Match when ETag is cached."""
     test_file = setup_core / "cached.txt"
     test_file.write_text("cached content")
-    external_files._etag_sidecar_path(test_file).write_text('"abc123"')
+    _seed_etag(test_file, '"abc123"')
 
     mock_response = MagicMock()
     mock_response.status_code = 304
@@ -227,7 +239,7 @@ def test_has_remote_file_changed_refreshes_etag_on_304(
     """Test has_remote_file_changed updates the cached ETag when the 304 sends a new one."""
     test_file = setup_core / "cached.txt"
     test_file.write_text("cached content")
-    external_files._etag_sidecar_path(test_file).write_text('"old"')
+    _seed_etag(test_file, '"old"')
 
     mock_response = MagicMock()
     mock_response.status_code = 304
@@ -238,6 +250,63 @@ def test_has_remote_file_changed_refreshes_etag_on_304(
     external_files.has_remote_file_changed(url, test_file)
 
     assert external_files._etag_sidecar_path(test_file).read_text() == '"new"'
+
+
+@patch("esphome.external_files.requests.head")
+def test_has_remote_file_changed_ignores_etag_when_mtime_diverges(
+    mock_head: MagicMock, setup_core: Path
+) -> None:
+    """If the cache file was edited out-of-band (mtime no longer matches the
+    sidecar's), the cached ETag must not be used -- it no longer describes the
+    bytes on disk.
+    """
+    test_file = setup_core / "cached.txt"
+    test_file.write_text("cached content")
+    sidecar = _seed_etag(test_file, '"abc123"')
+
+    # Simulate an out-of-band edit to the cache file -- mtime advances but the
+    # sidecar is left untouched, so the recorded ETag is now stale.
+    file_stat = test_file.stat()
+    os.utime(
+        test_file, ns=(file_stat.st_atime_ns, file_stat.st_mtime_ns + 1_000_000_000)
+    )
+
+    mock_response = MagicMock()
+    mock_response.status_code = 304
+    mock_response.headers = {}
+    mock_head.return_value = mock_response
+
+    external_files.has_remote_file_changed("https://example.com/file.txt", test_file)
+
+    headers = mock_head.call_args[1]["headers"]
+    assert external_files.IF_NONE_MATCH not in headers
+    # Stale sidecar should be removed so future calls don't keep paying the
+    # mtime-comparison cost on a known-bad sidecar.
+    assert not sidecar.exists()
+
+
+@patch("esphome.external_files.requests.get")
+@patch("esphome.external_files.has_remote_file_changed")
+def test_download_content_pins_etag_mtime_to_file_mtime(
+    mock_has_changed: MagicMock,
+    mock_get: MagicMock,
+    setup_core: Path,
+) -> None:
+    """After a successful download, the sidecar's mtime must equal the cache
+    file's mtime so `_read_etag` accepts it on the next call.
+    """
+    test_file = setup_core / "fresh.txt"
+    mock_has_changed.return_value = True
+    mock_response = MagicMock()
+    mock_response.content = b"fresh content"
+    mock_response.headers = {external_files.ETAG: '"deadbeef"'}
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    external_files.download_content("https://example.com/file.txt", test_file)
+
+    sidecar = external_files._etag_sidecar_path(test_file)
+    assert sidecar.stat().st_mtime_ns == test_file.stat().st_mtime_ns
 
 
 def test_compute_local_file_dir_creates_parent_dirs(setup_core: Path) -> None:


### PR DESCRIPTION
# What does this implement/fix?

`raw.githubusercontent.com` ignores `If-Modified-Since` (always returns
`200`) but honors `If-None-Match` with `ETag` (returns `304`). The previous
`has_remote_file_changed` only sent `If-Modified-Since`, so every
`esphome compile`/`esphome config` re-downloaded every cached external
file from a `/raw/...` GitHub URL — `audio_file`, `micro_wake_word`,
`image`, `font`, `bme68x_bsec2`, etc. Visibly slow on configs like Home
Assistant Voice PE.

This PR:

- Sends `If-None-Match` with the cached `ETag` when one is on disk.
- Persists each download's `ETag` in a hidden sidecar (`.{name}.etag`)
  with its mtime pinned to the cache file's mtime. If the two diverge
  (cache file edited out-of-band) the sidecar is treated as stale and
  removed. mtime comparisons use whole-second resolution so they survive
  set+read round-trips on every supported filesystem (FAT/exFAT 2s,
  NTFS 100ns, APFS/ext4 ns).
- Replaces `path.write_bytes()` with `helpers.write_file()` so a crash
  mid-download can't leave a partially-written cache file behind.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Affects any component that uses
# external_files.download_content with a remote URL, e.g.:
audio_file:
  - id: my_sound
    file:
      type: web
      url: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
