### PR TITLE
[ens160] Fix sensor initialization timing

### DIFF
--- a/esphome/components/ens160_base/ens160_base.cpp
+++ b/esphome/components/ens160_base/ens160_base.cpp
@@ -5,6 +5,15 @@
 // Implementation based on:
 //   https://github.com/sciosense/ENS160_driver
 
+// For best performance, the sensor shall be operated in normal indoor air in the range -5 to 60°C
+// (typical: 25°C); relative humidity: 20 to 80%RH (typical: 50%RH), non-condensing with no aggressive
+// or poisonous gases present. Prolonged exposure to environments outside these conditions can affect
+// performance and lifetime of the sensor.
+// The sensor is designed for indoor use and is not waterproof or dustproof. It should be protected
+// 24 Note that the status will only be stored in the non-volatile memory after an initial 24h of continuous
+// operation.  If unpowered before conclusion of said period, the ENS160 will resume „Initial Start-up” mode
+// after re-powering.
+
 #include "ens160_base.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
@@ -14,7 +23,9 @@ namespace ens160_base {
 
 static const char *const TAG = "ens160";
 
-static const uint8_t ENS160_BOOTING = 10;
+// Datasheet specifies 10ms, but some users report that 10ms is not sufficient for the
+// sensor to boot and be ready for commands. 11ms seems to be a safe value.
+static const uint8_t ENS160_BOOTING = 11;
 
 static const uint16_t ENS160_PART_ID = 0x0160;
 
@@ -91,6 +102,8 @@ void ENS160Component::setup() {
     this->mark_failed();
     return;
   }
+  delay(ENS160_BOOTING);
+
   // clear command
   if (!this->write_byte(ENS160_REG_COMMAND, ENS160_COMMAND_NOP)) {
     this->error_code_ = WRITE_FAILED;
@@ -102,6 +115,7 @@ void ENS160Component::setup() {
     this->mark_failed();
     return;
   }
+  delay(ENS160_BOOTING);
 
   // read firmware version
   if (!this->write_byte(ENS160_REG_COMMAND, ENS160_COMMAND_GET_APPVER)) {
@@ -109,6 +123,8 @@ void ENS160Component::setup() {
     this->mark_failed();
     return;
   }
+  delay(ENS160_BOOTING);
+
   uint8_t version_data[3];
   if (!this->read_bytes(ENS160_REG_GPR_READ_4, version_data, 3)) {
     this->error_code_ = READ_FAILED;
@@ -223,7 +239,6 @@ void ENS160Component::update() {
   if (this->aqi_ != nullptr) {
     // remove reserved bits, just in case they are used in future
     data_aqi = ENS160_DATA_AQI & data_aqi;
-
     this->aqi_->publish_state(data_aqi);
   }
 

--- a/esphome/components/ens160_base/ens160_base.cpp
+++ b/esphome/components/ens160_base/ens160_base.cpp
@@ -9,10 +9,10 @@
 // (typical: 25°C); relative humidity: 20 to 80%RH (typical: 50%RH), non-condensing with no aggressive
 // or poisonous gases present. Prolonged exposure to environments outside these conditions can affect
 // performance and lifetime of the sensor.
-// The sensor is designed for indoor use and is not waterproof or dustproof. It should be protected
-// 24 Note that the status will only be stored in the non-volatile memory after an initial 24h of continuous
-// operation.  If unpowered before conclusion of said period, the ENS160 will resume „Initial Start-up” mode
-// after re-powering.
+// The sensor is designed for indoor use and is not waterproof or dustproof. It should be protected from
+// water, condensation, dust, and aggressive gases. Note that the status will only be stored in non-volatile
+// memory after an initial 24 h of continuous operation. If unpowered before the conclusion of that period,
+// the ENS160 will resume "Initial Start-up" mode after re-powering.
 
 #include "ens160_base.h"
 #include "esphome/core/log.h"


### PR DESCRIPTION
# What does this implement/fix?

Adds a delay during a reset/boot of 11ms in `setup()` to ensure the sensor has sufficient time to boot and process commands before the next operation. Adds datasheet notes about recommended operating conditions to the source file for reference.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

N/A — no user-facing API or config changes.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: ens160_i2c
    eco2:
      name: "ENS160 eCO2"
    tvoc:
      name: "ENS160 TVOC"
    aqi:
      name: "ENS160 AQI"
    address: 0x53
    update_interval: 60s
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).
