### PR TITLE
[core] Combine set_component_source_ + register_component_ into one call

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -382,7 +382,11 @@ class Application {
 
   /// Register a component, detecting loop() override at compile time.
   /// Uses HasLoopOverride<T> which handles ambiguous &T::loop from multiple inheritance.
-  template<typename T> void register_component_(T *comp) {
+  /// Optionally sets the component source index in the same call to avoid emitting
+  /// a separate set_component_source_() line in generated code.
+  template<typename T> void register_component_(T *comp, uint8_t source_index = 0) {
+    if (source_index != 0)
+      comp->set_component_source_(source_index);
     this->register_component_impl_(comp, HasLoopOverride<T>::value);
   }
 

--- a/esphome/cpp_helpers.py
+++ b/esphome/cpp_helpers.py
@@ -197,9 +197,9 @@ async def register_component(var, config):
         )
     if name is not None:
         idx = register_component_source(name)
-        add(var.set_component_source_(idx))
-
-    add(App.register_component_(var))
+        add(App.register_component_(var, idx))
+    else:
+        add(App.register_component_(var))
 
     # Collect C++ type for compile-time looping component count
     comp_entries = CORE.data.setdefault("looping_component_entries", [])

--- a/tests/component_tests/deep_sleep/test_deep_sleep.py
+++ b/tests/component_tests/deep_sleep/test_deep_sleep.py
@@ -12,7 +12,7 @@ def test_deep_sleep_setup(generate_main):
         in main_cpp
     )
     assert "new(deepsleep) deep_sleep::DeepSleepComponent();" in main_cpp
-    assert "App.register_component_(deepsleep);" in main_cpp
+    assert "App.register_component_(deepsleep, " in main_cpp
 
 
 def test_deep_sleep_sleep_duration(generate_main):

--- a/tests/component_tests/ota/test_web_server_ota.py
+++ b/tests/component_tests/ota/test_web_server_ota.py
@@ -27,7 +27,7 @@ def test_web_server_ota_generated(generate_main: Callable[[str], str]) -> None:
     assert "global_web_server_base" in main_cpp
 
     # Check component is registered
-    assert "App.register_component_(web_server_webserverotacomponent_id)" in main_cpp
+    assert "App.register_component_(web_server_webserverotacomponent_id" in main_cpp
 
 
 def test_web_server_ota_with_callbacks(generate_main: Callable[[str], str]) -> None:

--- a/tests/unit_tests/test_cpp_helpers.py
+++ b/tests/unit_tests/test_cpp_helpers.py
@@ -34,8 +34,9 @@ async def test_register_component(monkeypatch):
     actual = await ch.register_component(var, {})
 
     assert actual is var
-    assert add_mock.call_count == 2
-    app_mock.register_component_.assert_called_with(var)
+    assert add_mock.call_count == 1
+    app_mock.register_component_.assert_called_once()
+    assert app_mock.register_component_.call_args.args[0] is var
     assert core_mock.component_ids == []
 
 
@@ -77,8 +78,9 @@ async def test_register_component__with_setup_priority(monkeypatch):
 
     assert actual is var
     add_mock.assert_called()
-    assert add_mock.call_count == 4
-    app_mock.register_component_.assert_called_with(var)
+    assert add_mock.call_count == 3
+    app_mock.register_component_.assert_called_once()
+    assert app_mock.register_component_.call_args.args[0] is var
     assert core_mock.component_ids == []
 
 


### PR DESCRIPTION
# What does this implement/fix?

Adds an optional `source_index` parameter to `App.register_component_()` so codegen can emit a single registration line per component instead of two.

Before, `register_component()` in `cpp_helpers.py` emitted:
```cpp
comp->set_component_source_(N);
App.register_component_(comp);
```
After:
```cpp
App.register_component_(comp, N);
```

The C++ template handles the source-index assignment when non-zero, preserving existing semantics where `0` means "not set" (the default for components registered without a known source — `component_source_index_{0}`).

## Measured impact

Same-config back-to-back build of a real-world large config (Apollo R-PRO-1, 122 components, ESP32-S3 IDF, same toolchain/SDK):

|              | dev      | this PR  | delta      |
|--------------|---------:|---------:|-----------:|
| Flash `.bin` | 790,375  | 790,195  | **−180 B** |
| ELF `.text`  | 606,979  | 606,799  | **−180 B** |
| ELF `.data`  | 183,684  | 183,684  | 0          |
| ELF `.bss`   | 1,450,417| 1,450,417| 0          |
| RAM used     | 52,392   | 52,392   | 0          |
| `main.cpp`   | 5,815 ln | 5,693 ln | **−122 ln**|

122 components → 122 lines removed from generated `main.cpp` and ~180 bytes of `.text` reclaimed (the per-component `set_component_source_(N)` call sites collapse into the inlined branch inside the `register_component_` template). No RAM impact, behavior identical.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-visible config change. The optimization affects generated main.cpp only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
