### PR TITLE
[analyze_memory] Attribute main.cpp setup()/loop() to esphome core

### DIFF
--- a/esphome/analyze_memory/__init__.py
+++ b/esphome/analyze_memory/__init__.py
@@ -793,8 +793,11 @@ class MemoryAnalyzer:
         """Scan ESPHome source object files to map extern "C" symbols to components.
 
         When no linker map file is available, this uses ``nm`` to scan ``.o`` files
-        under ``src/esphome/`` and build a symbol-to-component mapping. This catches
-        ``extern "C"`` functions and other symbols that lack C++ namespace prefixes.
+        under ``src/`` (including ``src/main.cpp.o`` and everything beneath
+        ``src/esphome/``) and build a symbol-to-component mapping. This catches
+        ``extern "C"`` functions, the ESPHome-generated ``setup()``/``loop()``
+        entry points in ``main.cpp``, and other symbols that lack C++ namespace
+        prefixes.
 
         Skips scanning if ``_source_symbol_map`` was already populated by
         ``_parse_map_file()``.
@@ -806,12 +809,12 @@ class MemoryAnalyzer:
         if obj_dir is None:
             return
 
-        # Find ESPHome source object files
-        esphome_src_dir = obj_dir / "src" / "esphome"
-        if not esphome_src_dir.is_dir():
+        # Scan all ESPHome-owned source object files: src/main.cpp.o and src/esphome/...
+        src_dir = obj_dir / "src"
+        if not src_dir.is_dir():
             return
 
-        obj_files = sorted(esphome_src_dir.rglob("*.o"))
+        obj_files = sorted(src_dir.rglob("*.o"))
         if not obj_files:
             return
 
@@ -1063,6 +1066,10 @@ class MemoryAnalyzer:
                     return f"{_COMPONENT_PREFIX_ESPHOME}{component_name}"
                 if component_name in self.external_components:
                     return f"{_COMPONENT_PREFIX_EXTERNAL}{component_name}"
+
+        # ESPHome-generated entry point: src/main.cpp.o (contains setup()/loop())
+        if len(parts) >= 2 and parts[-2:] == ("src", "main.cpp.o"):
+            return _COMPONENT_CORE
 
         # ESPHome core: src/esphome/core/... or src/esphome/...
         if "core" in parts and "esphome" in parts:

--- a/tests/unit_tests/analyze_memory/test_source_file_attribution.py
+++ b/tests/unit_tests/analyze_memory/test_source_file_attribution.py
@@ -1,0 +1,43 @@
+"""Tests for source-file-to-component attribution in memory analyzer."""
+
+from unittest.mock import patch
+
+from esphome.analyze_memory import MemoryAnalyzer
+
+
+def _make_analyzer(external_components: set[str] | None = None) -> MemoryAnalyzer:
+    """Create a MemoryAnalyzer with mocked dependencies."""
+    with patch.object(MemoryAnalyzer, "__init__", lambda self, *a, **kw: None):
+        analyzer = MemoryAnalyzer.__new__(MemoryAnalyzer)
+        analyzer.external_components = external_components or set()
+        analyzer._lib_hash_to_name = {}
+    return analyzer
+
+
+def test_source_file_to_component_main_cpp_relative() -> None:
+    """ESPHome-generated src/main.cpp.o (nm path form) attributes to core."""
+    analyzer = _make_analyzer()
+    assert analyzer._source_file_to_component("src/main.cpp.o") == "[esphome]core"
+
+
+def test_source_file_to_component_main_cpp_pioenvs_path() -> None:
+    """Linker map paths like .pioenvs/<env>/src/main.cpp.o attribute to core."""
+    analyzer = _make_analyzer()
+    result = analyzer._source_file_to_component(".pioenvs/drivewaygate/src/main.cpp.o")
+    assert result == "[esphome]core"
+
+
+def test_source_file_to_component_esphome_core() -> None:
+    """Sources under src/esphome/core/ attribute to core."""
+    analyzer = _make_analyzer()
+    result = analyzer._source_file_to_component("src/esphome/core/application.cpp.o")
+    assert result == "[esphome]core"
+
+
+def test_source_file_to_component_known_component() -> None:
+    """Known ESPHome components attribute to their component name."""
+    analyzer = _make_analyzer()
+    result = analyzer._source_file_to_component(
+        "src/esphome/components/wifi/wifi_component.cpp.o"
+    )
+    assert result == "[esphome]wifi"


### PR DESCRIPTION
# What does this implement/fix?

`esphome analyze-memory` was miscategorizing `setup()` (and any non-inlined `loop()`) from the generated `src/main.cpp` as the catch-all `app_framework` heuristic instead of `[esphome]core`.

Two issues caused this, on both the nm-scan and linker-map code paths:

1. `_scan_source_symbols` only walked `src/esphome/`, so symbols defined in `src/main.cpp.o` were never added to `_source_symbol_map`.
2. `_source_file_to_component` had no rule for `…/src/main.cpp.o`. The linker-map path therefore returned `src` / `.pioenvs` (which doesn't start with `[esphome]`/`[external]`), so `_parse_map_file` rejected the entry, and `_identify_component` then matched `setup`/`loop` against `SYMBOL_PATTERNS["app_framework"]` in `const.py`.

Fix:
- `_scan_source_symbols` now scans all of `src/` (covers both `src/main.cpp.o` and everything under `src/esphome/`).
- `_source_file_to_component` recognizes `.../src/main.cpp.o` and returns `[esphome]core`.

Verified `setup()` is now reported as `[esphome]core` (1699 B on a gatetrigger build, 3368 B on a drivewaygate build) on both code paths.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml
# N/A — tooling-only change. Run on any compiled project:
#   esphome analyze-memory <config>.yaml
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).