### PR TITLE
[zigbee] add router for nrf52

### DIFF
--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -89,9 +89,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MODEL, default=CORE.name): cv.All(
                 cv.string, cv.Length(max=31)
             ),
-            cv.Optional(CONF_ROUTER, default=False): cv.All(
-                cv.boolean,
-            ),
+            cv.Optional(CONF_ROUTER, default=False): cv.boolean,
             cv.Optional(CONF_ON_JOIN): cv.All(
                 cv.requires_component("nrf52"),
                 automation.validate_automation(single=True),

--- a/esphome/components/zigbee/__init__.py
+++ b/esphome/components/zigbee/__init__.py
@@ -75,6 +75,13 @@ SENSOR_SCHEMA = cv.Schema({}).extend(zephyr_sensor)
 SWITCH_SCHEMA = cv.Schema({}).extend(zephyr_switch)
 NUMBER_SCHEMA = cv.Schema({}).extend(zephyr_number)
 
+
+def _validate_router_sleepy(config: ConfigType) -> ConfigType:
+    if config.get(CONF_ROUTER) and config.get(CONF_SLEEPY):
+        raise cv.Invalid("router and sleepy are mutually exclusive")
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
@@ -82,8 +89,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_MODEL, default=CORE.name): cv.All(
                 cv.string, cv.Length(max=31)
             ),
-            cv.OnlyWith(CONF_ROUTER, "esp32", default=False): cv.All(
-                cv.requires_component("esp32"),
+            cv.Optional(CONF_ROUTER, default=False): cv.All(
                 cv.boolean,
             ),
             cv.Optional(CONF_ON_JOIN): cv.All(
@@ -113,6 +119,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     ).extend(cv.COMPONENT_SCHEMA),
+    _validate_router_sleepy,
     zigbee_require_vfs_select,
     zigbee_set_core_data,
     cv.Any(

--- a/esphome/components/zigbee/zigbee_zephyr.cpp
+++ b/esphome/components/zigbee/zigbee_zephyr.cpp
@@ -190,7 +190,9 @@ void ZigbeeComponent::setup() {
     ESP_LOGE(TAG, "Cannot load settings, err: %d", err);
     return;
   }
+#ifdef CONFIG_ZIGBEE_ROLE_END_DEVICE
   zigbee_configure_sleepy_behavior(this->sleepy_);
+#endif
   zigbee_enable();
 }
 

--- a/esphome/components/zigbee/zigbee_zephyr.py
+++ b/esphome/components/zigbee/zigbee_zephyr.py
@@ -52,6 +52,7 @@ from esphome.types import ConfigType
 from .const import (
     CONF_ON_JOIN,
     CONF_POWER_SOURCE,
+    CONF_ROUTER,
     CONF_WIPE_ON_BOOT,
     KEY_ZIGBEE,
     POWER_SOURCE,
@@ -160,7 +161,10 @@ zephyr_number = cv.Schema(
 async def zephyr_to_code(config: ConfigType) -> None:
     zephyr_add_prj_conf("ZIGBEE", True)
     zephyr_add_prj_conf("ZIGBEE_APP_UTILS", True)
-    zephyr_add_prj_conf("ZIGBEE_ROLE_END_DEVICE", True)
+    if config[CONF_ROUTER]:
+        zephyr_add_prj_conf("ZIGBEE_ROLE_ROUTER", True)
+    else:
+        zephyr_add_prj_conf("ZIGBEE_ROLE_END_DEVICE", True)
 
     zephyr_add_prj_conf("ZIGBEE_CHANNEL_SELECTION_MODE_MULTI", True)
 

--- a/tests/components/zigbee/test.nrf52-mcumgr.yaml
+++ b/tests/components/zigbee/test.nrf52-mcumgr.yaml
@@ -1,1 +1,4 @@
 <<: !include common_nrf52.yaml
+
+zigbee:
+  router: true


### PR DESCRIPTION
# What does this implement/fix?

Implement router for nrf52 zigbee.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- https://github.com/esphome/esphome-docs/pull/6530

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
