### PR TITLE
[esp32_ble_tracker] Hold COEX_PREFER_BT for the lifetime of any active connection

### DIFF
--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -166,9 +166,9 @@ void ESP32BLETracker::loop() {
   ClientStateCounts counts = this->count_client_states_();
   if (counts != this->client_state_counts_) {
     this->client_state_counts_ = counts;
-    ESP_LOGD(TAG, "connecting: %d, discovered: %d, disconnecting: %d, active: %d", this->client_state_counts_.connecting,
-             this->client_state_counts_.discovered, this->client_state_counts_.disconnecting,
-             this->client_state_counts_.active);
+    ESP_LOGD(TAG, "connecting: %d, discovered: %d, disconnecting: %d, active: %d",
+             this->client_state_counts_.connecting, this->client_state_counts_.discovered,
+             this->client_state_counts_.disconnecting, this->client_state_counts_.active);
   }
 
   // Scanner failure: reached when set_scanner_state_(FAILED) or scan_set_param_failed_ set

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -191,13 +191,15 @@ void ESP32BLETracker::loop() {
   */
 
   // Start scan: reached when scanner_state_ becomes IDLE (via set_scanner_state_()) and
-  // all clients are idle (their state changes increment version when they finish)
+  // no clients are in the transient CONNECTING / DISCOVERED / DISCONNECTING states
+  // (their state changes increment version when they finish). CONNECTED / ESTABLISHED
+  // clients do NOT block this branch — the coex revert below has its own active-count gate.
   if (this->scanner_state_ == ScannerState::IDLE && !counts.connecting && !counts.disconnecting && !counts.discovered) {
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
     // Only revert to BALANCE when no connections are active. Established connections
-    // continue to need PREFER_BT so the lock's GATT Write Response can reach us while
-    // WiFi traffic (advertisement upload, log streaming) competes for the shared radio.
-    // Reverting too early causes Bluedroid to time out at ~20s and synthesize status=133.
+    // continue to need PREFER_BT so peer GATT responses can reach us while WiFi traffic
+    // (advertisement upload, log streaming) competes for the shared radio. Reverting too
+    // early causes Bluedroid to time out at ~20s and synthesize status=133.
     if (!counts.active) {
       this->update_coex_preference_(false);
     }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp
@@ -166,8 +166,9 @@ void ESP32BLETracker::loop() {
   ClientStateCounts counts = this->count_client_states_();
   if (counts != this->client_state_counts_) {
     this->client_state_counts_ = counts;
-    ESP_LOGD(TAG, "connecting: %d, discovered: %d, disconnecting: %d", this->client_state_counts_.connecting,
-             this->client_state_counts_.discovered, this->client_state_counts_.disconnecting);
+    ESP_LOGD(TAG, "connecting: %d, discovered: %d, disconnecting: %d, active: %d", this->client_state_counts_.connecting,
+             this->client_state_counts_.discovered, this->client_state_counts_.disconnecting,
+             this->client_state_counts_.active);
   }
 
   // Scanner failure: reached when set_scanner_state_(FAILED) or scan_set_param_failed_ set
@@ -193,7 +194,13 @@ void ESP32BLETracker::loop() {
   // all clients are idle (their state changes increment version when they finish)
   if (this->scanner_state_ == ScannerState::IDLE && !counts.connecting && !counts.disconnecting && !counts.discovered) {
 #ifdef USE_ESP32_BLE_SOFTWARE_COEXISTENCE
-    this->update_coex_preference_(false);
+    // Only revert to BALANCE when no connections are active. Established connections
+    // continue to need PREFER_BT so the lock's GATT Write Response can reach us while
+    // WiFi traffic (advertisement upload, log streaming) competes for the shared radio.
+    // Reverting too early causes Bluedroid to time out at ~20s and synthesize status=133.
+    if (!counts.active) {
+      this->update_coex_preference_(false);
+    }
 #endif
     if (this->scan_continuous_) {
       this->start_scan_(false);  // first = false
@@ -701,9 +708,10 @@ void ESP32BLETracker::dump_config() {
                 this->scan_active_ ? "ACTIVE" : "PASSIVE", YESNO(this->scan_continuous_));
   ESP_LOGCONFIG(TAG,
                 "  Scanner State: %s\n"
-                "  Connecting: %d, discovered: %d, disconnecting: %d",
+                "  Connecting: %d, discovered: %d, disconnecting: %d, active: %d",
                 this->scanner_state_to_string_(this->scanner_state_), this->client_state_counts_.connecting,
-                this->client_state_counts_.discovered, this->client_state_counts_.disconnecting);
+                this->client_state_counts_.discovered, this->client_state_counts_.disconnecting,
+                this->client_state_counts_.active);
   if (this->scan_start_fail_count_) {
     ESP_LOGCONFIG(TAG, "  Scan Start Fail Count: %d", this->scan_start_fail_count_);
   }

--- a/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
+++ b/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h
@@ -160,9 +160,13 @@ struct ClientStateCounts {
   uint8_t connecting = 0;
   uint8_t discovered = 0;
   uint8_t disconnecting = 0;
+  // CONNECTED + ESTABLISHED clients. Tracked so coex stays at PREFER_BT
+  // while active connections may still need to send/receive GATT traffic.
+  uint8_t active = 0;
 
   bool operator==(const ClientStateCounts &other) const {
-    return connecting == other.connecting && discovered == other.discovered && disconnecting == other.disconnecting;
+    return connecting == other.connecting && discovered == other.discovered && disconnecting == other.disconnecting &&
+           active == other.active;
   }
 
   bool operator!=(const ClientStateCounts &other) const { return !(*this == other); }
@@ -380,6 +384,10 @@ class ESP32BLETracker : public Component,
           break;
         case ClientState::CONNECTING:
           counts.connecting++;
+          break;
+        case ClientState::CONNECTED:
+        case ClientState::ESTABLISHED:
+          counts.active++;
           break;
         default:
           break;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a long-standing class of `esp_gattc_write_char_descr` failures (host-synthesized `status=0x85` / `status=133`) that hits `bluetooth_proxy` users whenever WiFi is busy while a BLE connection is active. Most commonly reported with Yale/August locks, but the underlying bug is generic to any GATT operation that needs the peer's response while BT/WiFi share the radio.

## Root cause

`esp32_ble_tracker::loop()` reverts BT/WiFi coexistence from `ESP_COEX_PREFER_BT` back to `ESP_COEX_PREFER_BALANCE` as soon as the *transient* client states clear (`!connecting && !disconnecting && !discovered`):

https://github.com/esphome/esphome/blob/dev/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp#L194-L201

`count_client_states_()` only tracks `CONNECTING`, `DISCOVERED`, and `DISCONNECTING`; it does not count `CONNECTED` or `ESTABLISHED` clients:

https://github.com/esphome/esphome/blob/dev/esphome/components/esp32_ble_tracker/esp32_ble_tracker.h#L370-L390

So the moment a connection settles, coex returns to BALANCE while the connection is still up. Sustained WiFi traffic (every `bluetooth_proxy` is constantly streaming raw advertisements back to HA) then crowds out the BT radio's ability to receive the peer's GATT response. `esp_ble_gattc_write_char_descr` returns 0 to the caller, the descriptor write goes out, but the response can't get back. After ~20 s Bluedroid synthesizes `WRITE_DESCR_EVT` with `status=0x85` and the peer disconnects (`reason=0x08`, "Connection Timeout").

## Fix (~12 lines net)

Track `CONNECTED` and `ESTABLISHED` as an `active` count. Hold `PREFER_BT` until that count drops to zero, i.e. until *all* connections are torn down, not just until each one finishes its connect handshake.

The scan-restart logic stays unchanged; scan continues to come back up as soon as transient states clear. Only the coex revert is gated on active connections.

## Reproduction (synthetic)

A minimal `bluetooth_proxy` config plus a Python script using `aioesphomeapi` to drive the connect, start_notify, write_descriptor sequence directly. Subscribe-logs at `LOG_LEVEL_VERBOSE` to push WiFi traffic; subscribe at `LOG_LEVEL_WARN` for the control case.

| Subscribe level | Same firmware, same lock, same code path | CCCD write |
|-----------------|------------------------------------------|------------|
| WARN (control) | `status=0` SUCCESS | 185 ms |
| VERBOSE (heavy WiFi) | `status=0x85` (host-synthesized 133) | 19 s timeout |

## Validation (this patch)

Same A/B test, patched firmware:

| Subscribe level | Result | CCCD write |
|-----------------|--------|------------|
| WARN | `status=0` SUCCESS | 185 ms |
| **VERBOSE** | **`status=0` SUCCESS** | **228 ms** (was 19 s timeout) |

Then deployed to a production HA instance: M5 Atom Lite running the patched firmware as a `bluetooth_proxy` near a Yale BETA211123 lock that previously needed direct BlueZ. With the host's BlueZ stopped (so the M5 was the only path), the lock unlocked cleanly:

```
ConnectionInfo(rssi=-73)   # lock's view of the central, confirms M5 path
yalexs_ble.session: Receiving response via notify ... waiting=True
yalexs_ble.lock: State changed: ... LockStatus.UNLOCKED
```

Zero `status=133`, zero retries, zero hangs across initial test cycles. A multi-day production soak window will be added here as it accumulates.

## Breaking change rationale

Under the previous behavior, coex returned to `ESP_COEX_PREFER_BALANCE` shortly after each connection settled. With this patch coex stays at `ESP_COEX_PREFER_BT` for the full lifetime of any active connection. For `bluetooth_proxy` (short-lived connect/operate/disconnect cycles) this is the desired behavior, and is the case that was producing the timeout. For configurations that hold long-lived BLE connections (e.g. `ble_client` to a persistent sensor), WiFi throughput may be lower while the connection is up, since the radio is no longer balanced. There is no YAML or API change; what changes is the radio-arbitration policy during established connections.

No opt-out is being added: this is almost certainly the correct default everywhere (without it, any sustained WiFi load can synthesize `status=133` on a live BLE connection), and adding a knob now would be YAGNI. **If you hit a real-world workload where the new policy is a regression for you (e.g. a long-lived `ble_client` sensor where WiFi throughput dropped), please open a GitHub issue with your config and a description of the impact** so we can evaluate whether an opt-out is warranted.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes esphome/issues#3761

Same root cause across ESP32 variants (ESP32-PICO-D4, LilyGO ESP32-S3) and lock models. See also home-assistant/core#132018, home-assistant/core#79685, home-assistant/core#79930, home-assistant/core#81468.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal coex behavior, no user-facing API change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change required; behavior change is internal to esp32_ble_tracker.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (synthetic A/B reproduction plus production validation with host BlueZ disabled).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
