### PR TITLE
[light] Use constexpr template for ToggleAction transition_length

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -8,20 +8,27 @@ namespace esphome::light {
 
 enum class LimitMode { CLAMP, DO_NOTHING };
 
-template<typename... Ts> class ToggleAction : public Action<Ts...> {
+template<bool HasTransitionLength, typename... Ts> class ToggleAction : public Action<Ts...> {
  public:
   explicit ToggleAction(LightState *state) : state_(state) {}
 
-  TEMPLATABLE_VALUE(uint32_t, transition_length)
+  template<typename V> void set_transition_length(V value) requires(HasTransitionLength) {
+    this->transition_length_ = value;
+  }
 
   void play(const Ts &...x) override {
     auto call = this->state_->toggle();
-    call.set_transition_length(this->transition_length_.optional_value(x...));
+    if constexpr (HasTransitionLength) {
+      call.set_transition_length(this->transition_length_.optional_value(x...));
+    }
     call.perform();
   }
 
  protected:
   LightState *state_;
+  struct NoTransition {};
+  [[no_unique_address]] std::conditional_t<HasTransitionLength, TemplatableFn<uint32_t, Ts...>, NoTransition>
+      transition_length_{};
 };
 
 template<typename... Ts> class LightControlAction : public Action<Ts...> {

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -60,8 +60,10 @@ from .types import (
 )
 async def light_toggle_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, paren)
-    if CONF_TRANSITION_LENGTH in config:
+    has_transition_length = CONF_TRANSITION_LENGTH in config
+    toggle_template_arg = cg.TemplateArguments(has_transition_length, *template_arg)
+    var = cg.new_Pvariable(action_id, toggle_template_arg, paren)
+    if has_transition_length:
         template_ = await cg.templatable(
             config[CONF_TRANSITION_LENGTH], args, cg.uint32
         )

--- a/tests/integration/fixtures/light_toggle_action.yaml
+++ b/tests/integration/fixtures/light_toggle_action.yaml
@@ -1,0 +1,37 @@
+esphome:
+  name: light-toggle-action-test
+host:
+api:
+logger:
+  level: DEBUG
+
+output:
+  - platform: template
+    id: test_out
+    type: float
+    write_action:
+      - lambda: ""
+
+light:
+  - platform: monochromatic
+    name: "Test Light"
+    id: test_light
+    output: test_out
+    default_transition_length: 0s
+
+button:
+  # Test 1: light.toggle without transition_length (HasTransitionLength=false)
+  - platform: template
+    id: btn_toggle
+    name: "Toggle"
+    on_press:
+      - light.toggle: test_light
+
+  # Test 2: light.toggle with transition_length (HasTransitionLength=true)
+  - platform: template
+    id: btn_toggle_with_trans
+    name: "Toggle With Trans"
+    on_press:
+      - light.toggle:
+          id: test_light
+          transition_length: 0s

--- a/tests/integration/test_light_toggle_action.py
+++ b/tests/integration/test_light_toggle_action.py
@@ -4,11 +4,14 @@ Tests both ToggleAction<HasTransitionLength=false> and
 ToggleAction<HasTransitionLength=true> instantiations.
 """
 
-import asyncio
-from typing import Any
+from __future__ import annotations
 
+import asyncio
+
+from aioesphomeapi import ButtonInfo, EntityState, LightInfo, LightState
 import pytest
 
+from .state_utils import InitialStateHelper, require_entity
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -19,31 +22,37 @@ async def test_light_toggle_action(
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
     """Test light.toggle with and without transition_length."""
+    loop = asyncio.get_running_loop()
     async with run_compiled(yaml_config), api_client_connected() as client:
-        state_futures: dict[int, asyncio.Future[Any]] = {}
+        light_state_future: asyncio.Future[LightState] | None = None
 
-        def on_state(state: Any) -> None:
-            if state.key in state_futures and not state_futures[state.key].done():
-                state_futures[state.key].set_result(state)
+        def on_state(state: EntityState) -> None:
+            if (
+                isinstance(state, LightState)
+                and light_state_future is not None
+                and not light_state_future.done()
+            ):
+                light_state_future.set_result(state)
 
-        client.subscribe_states(on_state)
-
-        entities = await client.list_entities_services()
-        light = next(e for e in entities[0] if e.object_id == "test_light")
-        buttons = {e.name: e for e in entities[0] if hasattr(e, "name")}
-
-        async def wait_for_state(key: int, timeout: float = 5.0) -> Any:
-            loop = asyncio.get_running_loop()
-            state_futures[key] = loop.create_future()
+        async def wait_for_light_state(timeout: float = 5.0) -> LightState:
+            nonlocal light_state_future
+            light_state_future = loop.create_future()
             try:
-                return await asyncio.wait_for(state_futures[key], timeout)
+                return await asyncio.wait_for(light_state_future, timeout)
             finally:
-                state_futures.pop(key, None)
+                light_state_future = None
 
-        async def press_and_wait(button_name: str) -> Any:
-            btn = buttons[button_name]
+        entities, _ = await client.list_entities_services()
+        initial_state_helper = InitialStateHelper(entities)
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        await initial_state_helper.wait_for_initial_states()
+
+        require_entity(entities, "test_light", LightInfo)
+
+        async def press_and_wait(name: str) -> LightState:
+            btn = require_entity(entities, name.lower().replace(" ", "_"), ButtonInfo)
             client.button_command(btn.key)
-            return await wait_for_state(light.key)
+            return await wait_for_light_state()
 
         # Test 1: toggle without transition_length flips off->on
         state = await press_and_wait("Toggle")

--- a/tests/integration/test_light_toggle_action.py
+++ b/tests/integration/test_light_toggle_action.py
@@ -1,0 +1,58 @@
+"""Integration test for light::ToggleAction.
+
+Tests both ToggleAction<HasTransitionLength=false> and
+ToggleAction<HasTransitionLength=true> instantiations.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_light_toggle_action(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test light.toggle with and without transition_length."""
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        state_futures: dict[int, asyncio.Future[Any]] = {}
+
+        def on_state(state: Any) -> None:
+            if state.key in state_futures and not state_futures[state.key].done():
+                state_futures[state.key].set_result(state)
+
+        client.subscribe_states(on_state)
+
+        entities = await client.list_entities_services()
+        light = next(e for e in entities[0] if e.object_id == "test_light")
+        buttons = {e.name: e for e in entities[0] if hasattr(e, "name")}
+
+        async def wait_for_state(key: int, timeout: float = 5.0) -> Any:
+            loop = asyncio.get_running_loop()
+            state_futures[key] = loop.create_future()
+            try:
+                return await asyncio.wait_for(state_futures[key], timeout)
+            finally:
+                state_futures.pop(key, None)
+
+        async def press_and_wait(button_name: str) -> Any:
+            btn = buttons[button_name]
+            client.button_command(btn.key)
+            return await wait_for_state(light.key)
+
+        # Test 1: toggle without transition_length flips off->on
+        state = await press_and_wait("Toggle")
+        assert state.state is True
+
+        # Test 2: toggle with transition_length flips on->off
+        state = await press_and_wait("Toggle With Trans")
+        assert state.state is False
+
+        # Test 3: toggle without transition_length flips off->on again
+        state = await press_and_wait("Toggle")
+        assert state.state is True


### PR DESCRIPTION
# What does this implement/fix?

Parameterize `light::ToggleAction` on a `bool HasTransitionLength` template parameter, mirroring the `IfAction<HasElse>` pattern. When `transition_length` is not configured in YAML, the `TemplatableFn` field is elided via `[[no_unique_address]]` and the `LightCall::set_transition_length` call is skipped via `if constexpr`.

Python codegen prepends the `HasTransitionLength` flag to the template arguments based on whether `CONF_TRANSITION_LENGTH` is present.

**Measured on `athom-rgb-light` (ESP8266) — `light.toggle` without `transition_length`:**

| Metric | Before | After | Saved |
|---|---|---|---|
| `ToggleAction<>` instance (.bss) | 20 B | 16 B | **4 B RAM** |
| `ToggleAction::play()` code | 79 B | 28 B | **51 B flash** |
| Overall firmware flash | 447,201 B | 447,105 B | 96 B |

`play()` shrinks substantially because `if constexpr` elides the `LightCall::set_transition_length(empty_optional)` call entirely. Behavior is unchanged: `LightCall::transition_length_` defaults to an empty `optional<uint32_t>`, and `perform()` falls back to the light's configured default transition length — the same path the empty-optional setter reached before.

When `transition_length` is configured, the existing storage and call path are preserved.

## API surface

`light::ToggleAction` is not part of the documented public API — it is instantiated only by `light_toggle_to_code` in `esphome/components/light/automation.py`. A repo-wide grep for `light::ToggleAction` outside `esphome/components/light/automation.h` returns zero matches. The Python setter API and `light.toggle:` YAML schema are unchanged; the bitmask template parameter is added transparently in codegen.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Toggle without transition_length — TemplatableFn field is elided
binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_press:
      then:
        - light.toggle: led

# Toggle with transition_length — field is present (existing behavior)
binary_sensor:
  - platform: gpio
    pin: GPIO1
    on_press:
      then:
        - light.toggle:
            id: led
            transition_length: 500ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
