### PR TITLE
[light] Use constexpr template for DimRelativeAction transition_length

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -80,12 +80,15 @@ template<typename... Ts> class LightControlAction : public Action<Ts...> {
   LightState *parent_;
 };
 
-template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
+template<bool HasTransitionLength, typename... Ts> class DimRelativeAction : public Action<Ts...> {
  public:
   explicit DimRelativeAction(LightState *parent) : parent_(parent) {}
 
   TEMPLATABLE_VALUE(float, relative_brightness)
-  TEMPLATABLE_VALUE(uint32_t, transition_length)
+
+  template<typename V> void set_transition_length(V value) requires(HasTransitionLength) {
+    this->transition_length_ = value;
+  }
 
   void play(const Ts &...x) override {
     auto call = this->parent_->make_call();
@@ -99,7 +102,9 @@ template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
     call.set_state(new_brightness != 0.0f);
     call.set_brightness(new_brightness);
 
-    call.set_transition_length(this->transition_length_.optional_value(x...));
+    if constexpr (HasTransitionLength) {
+      call.set_transition_length(this->transition_length_.optional_value(x...));
+    }
     call.perform();
   }
 
@@ -115,6 +120,9 @@ template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
   float min_brightness_{0.0};
   float max_brightness_{1.0};
   LimitMode limit_mode_{LimitMode::CLAMP};
+  struct NoTransition {};
+  [[no_unique_address]] std::conditional_t<HasTransitionLength, TemplatableFn<uint32_t, Ts...>, NoTransition>
+      transition_length_{};
 };
 
 template<typename... Ts> class LightIsOnCondition : public Condition<Ts...> {

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -261,10 +261,12 @@ LIGHT_DIM_RELATIVE_ACTION_SCHEMA = cv.Schema(
 )
 async def light_dim_relative_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, paren)
+    has_transition_length = CONF_TRANSITION_LENGTH in config
+    dim_template_arg = cg.TemplateArguments(has_transition_length, *template_arg)
+    var = cg.new_Pvariable(action_id, dim_template_arg, paren)
     templ = await cg.templatable(config[CONF_RELATIVE_BRIGHTNESS], args, cg.float_)
     cg.add(var.set_relative_brightness(templ))
-    if CONF_TRANSITION_LENGTH in config:
+    if has_transition_length:
         templ = await cg.templatable(config[CONF_TRANSITION_LENGTH], args, cg.uint32)
         cg.add(var.set_transition_length(templ))
     if conf := config.get(CONF_BRIGHTNESS_LIMITS):

--- a/tests/components/light/common.yaml
+++ b/tests/components/light/common.yaml
@@ -108,6 +108,10 @@ esphome:
           relative_brightness: 5%
           brightness_limits:
             max_brightness: 90%
+      - light.dim_relative:
+          id: test_monochromatic_light
+          relative_brightness: -5%
+          transition_length: 250ms
       - light.turn_on:
           id: test_addressable_transition
           brightness: 50%

--- a/tests/integration/fixtures/light_dim_relative_action.yaml
+++ b/tests/integration/fixtures/light_dim_relative_action.yaml
@@ -1,0 +1,60 @@
+esphome:
+  name: light-dim-relative-action-test
+host:
+api:
+logger:
+  level: DEBUG
+
+output:
+  - platform: template
+    id: test_out
+    type: float
+    write_action:
+      - lambda: ""
+
+light:
+  - platform: monochromatic
+    name: "Test Light"
+    id: test_light
+    output: test_out
+    default_transition_length: 0s
+
+button:
+  # Set up: turn on at 50% brightness
+  - platform: template
+    id: btn_setup
+    name: "Setup"
+    on_press:
+      - light.turn_on:
+          id: test_light
+          brightness: 50%
+
+  # Test 1: dim_relative without transition_length (HasTransitionLength=false)
+  - platform: template
+    id: btn_dim_up
+    name: "Dim Up"
+    on_press:
+      - light.dim_relative:
+          id: test_light
+          relative_brightness: 25%
+
+  # Test 2: dim_relative with transition_length (HasTransitionLength=true)
+  - platform: template
+    id: btn_dim_down
+    name: "Dim Down"
+    on_press:
+      - light.dim_relative:
+          id: test_light
+          relative_brightness: -10%
+          transition_length: 0s
+
+  # Test 3: dim_relative with brightness limits
+  - platform: template
+    id: btn_dim_clamp
+    name: "Dim Clamp"
+    on_press:
+      - light.dim_relative:
+          id: test_light
+          relative_brightness: 50%
+          brightness_limits:
+            max_brightness: 80%

--- a/tests/integration/test_light_dim_relative_action.py
+++ b/tests/integration/test_light_dim_relative_action.py
@@ -4,11 +4,14 @@ Tests both DimRelativeAction<HasTransitionLength=false> and
 DimRelativeAction<HasTransitionLength=true> instantiations.
 """
 
-import asyncio
-from typing import Any
+from __future__ import annotations
 
+import asyncio
+
+from aioesphomeapi import ButtonInfo, EntityState, LightInfo, LightState
 import pytest
 
+from .state_utils import InitialStateHelper, require_entity
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -19,31 +22,37 @@ async def test_light_dim_relative_action(
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
     """Test light.dim_relative with and without transition_length."""
+    loop = asyncio.get_running_loop()
     async with run_compiled(yaml_config), api_client_connected() as client:
-        state_futures: dict[int, asyncio.Future[Any]] = {}
+        light_state_future: asyncio.Future[LightState] | None = None
 
-        def on_state(state: Any) -> None:
-            if state.key in state_futures and not state_futures[state.key].done():
-                state_futures[state.key].set_result(state)
+        def on_state(state: EntityState) -> None:
+            if (
+                isinstance(state, LightState)
+                and light_state_future is not None
+                and not light_state_future.done()
+            ):
+                light_state_future.set_result(state)
 
-        client.subscribe_states(on_state)
-
-        entities = await client.list_entities_services()
-        light = next(e for e in entities[0] if e.object_id == "test_light")
-        buttons = {e.name: e for e in entities[0] if hasattr(e, "name")}
-
-        async def wait_for_state(key: int, timeout: float = 5.0) -> Any:
-            loop = asyncio.get_running_loop()
-            state_futures[key] = loop.create_future()
+        async def wait_for_light_state(timeout: float = 5.0) -> LightState:
+            nonlocal light_state_future
+            light_state_future = loop.create_future()
             try:
-                return await asyncio.wait_for(state_futures[key], timeout)
+                return await asyncio.wait_for(light_state_future, timeout)
             finally:
-                state_futures.pop(key, None)
+                light_state_future = None
 
-        async def press_and_wait(button_name: str) -> Any:
-            btn = buttons[button_name]
+        entities, _ = await client.list_entities_services()
+        initial_state_helper = InitialStateHelper(entities)
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        await initial_state_helper.wait_for_initial_states()
+
+        require_entity(entities, "test_light", LightInfo)
+
+        async def press_and_wait(name: str) -> LightState:
+            btn = require_entity(entities, name.lower().replace(" ", "_"), ButtonInfo)
             client.button_command(btn.key)
-            return await wait_for_state(light.key)
+            return await wait_for_light_state()
 
         # Setup: turn on at 50%
         state = await press_and_wait("Setup")

--- a/tests/integration/test_light_dim_relative_action.py
+++ b/tests/integration/test_light_dim_relative_action.py
@@ -1,0 +1,63 @@
+"""Integration test for light::DimRelativeAction.
+
+Tests both DimRelativeAction<HasTransitionLength=false> and
+DimRelativeAction<HasTransitionLength=true> instantiations.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_light_dim_relative_action(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test light.dim_relative with and without transition_length."""
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        state_futures: dict[int, asyncio.Future[Any]] = {}
+
+        def on_state(state: Any) -> None:
+            if state.key in state_futures and not state_futures[state.key].done():
+                state_futures[state.key].set_result(state)
+
+        client.subscribe_states(on_state)
+
+        entities = await client.list_entities_services()
+        light = next(e for e in entities[0] if e.object_id == "test_light")
+        buttons = {e.name: e for e in entities[0] if hasattr(e, "name")}
+
+        async def wait_for_state(key: int, timeout: float = 5.0) -> Any:
+            loop = asyncio.get_running_loop()
+            state_futures[key] = loop.create_future()
+            try:
+                return await asyncio.wait_for(state_futures[key], timeout)
+            finally:
+                state_futures.pop(key, None)
+
+        async def press_and_wait(button_name: str) -> Any:
+            btn = buttons[button_name]
+            client.button_command(btn.key)
+            return await wait_for_state(light.key)
+
+        # Setup: turn on at 50%
+        state = await press_and_wait("Setup")
+        assert state.state is True
+        assert state.brightness == pytest.approx(0.5, abs=0.05)
+
+        # Test 1: dim_relative without transition_length: 50% + 25% = 75%
+        state = await press_and_wait("Dim Up")
+        assert state.brightness == pytest.approx(0.75, abs=0.05)
+
+        # Test 2: dim_relative with transition_length: 75% - 10% = 65%
+        state = await press_and_wait("Dim Down")
+        assert state.brightness == pytest.approx(0.65, abs=0.05)
+
+        # Test 3: dim_relative with max_brightness limit: 65% + 50% clamped to 80%
+        state = await press_and_wait("Dim Clamp")
+        assert state.brightness == pytest.approx(0.80, abs=0.05)


### PR DESCRIPTION
# What does this implement/fix?

Parameterize `light::DimRelativeAction` on a `bool HasTransitionLength` template parameter, mirroring the same pattern applied to `ToggleAction` in #16037 and the `IfAction<HasElse>` pattern. When `transition_length` is not configured in YAML, the `TemplatableFn` field is elided via `[[no_unique_address]]` and the `LightCall::set_transition_length` call is skipped via `if constexpr`.

Python codegen prepends the `HasTransitionLength` flag to the template arguments based on whether `CONF_TRANSITION_LENGTH` is present.

**Measured on a minimal ESP8266 config with two `light.dim_relative` actions (one with, one without `transition_length`):**

| Variant | Storage | `play()` size |
|---|---|---|
| `DimRelativeAction<false>` (no transition_length) | 32 B | 170 B |
| `DimRelativeAction<true>` (with transition_length) | 36 B | 218 B |

Per instance without `transition_length`: **4 B RAM saved + ~48 B flash saved on `play()`**.

`play()` shrinks because `if constexpr` elides the `LightCall::set_transition_length(empty_optional)` call entirely. Behavior is unchanged: `LightCall::transition_length_` defaults to an empty `optional<uint32_t>`, and `perform()` falls back to the light's configured default transition length — the same path the empty-optional setter reached before.

When `transition_length` is configured, the existing storage and call path are preserved.

## API surface

`light::DimRelativeAction` is not part of the documented public API — it is instantiated only by `light_dim_relative_to_code` in `esphome/components/light/automation.py`. A repo-wide grep for `light::DimRelativeAction` outside `esphome/components/light/automation.h` returns zero matches. The Python setter API and `light.dim_relative:` YAML schema are unchanged; the template parameter is added transparently in codegen.

A test case for `light.dim_relative` with `transition_length` (the `HasTransitionLength=true` instantiation) was added to `tests/components/light/common.yaml` so CI exercises both variants.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Dim relative without transition_length — TemplatableFn field is elided
binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_press:
      then:
        - light.dim_relative:
            id: my_light
            relative_brightness: 5%

# Dim relative with transition_length — field is present (existing behavior)
binary_sensor:
  - platform: gpio
    pin: GPIO1
    on_press:
      then:
        - light.dim_relative:
            id: my_light
            relative_brightness: 5%
            transition_length: 250ms
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
