### PR TITLE
[light] Use bitmask template for LightControlAction unused fields

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -24,8 +24,7 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
   LightState *state_;
 };
 
-// Distinct empty types per field tag so [[no_unique_address]] always coalesces
-// (the same empty type used multiple times is not guaranteed to share an address).
+// Unique Empty<Tag> per field so [[no_unique_address]] is guaranteed to coalesce.
 namespace light_control_detail {
 template<int Tag> struct Empty {};
 }  // namespace light_control_detail

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -24,113 +24,59 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
   LightState *state_;
 };
 
-// Bitmask of fields configured on a LightControlAction. Used as a non-type
-// template parameter so unset fields can be elided via [[no_unique_address]]
-// and skipped at compile time via if constexpr in play().
-namespace LightControlField {
-constexpr uint16_t COLOR_MODE = 1 << 0;
-constexpr uint16_t STATE = 1 << 1;
-constexpr uint16_t TRANSITION_LENGTH = 1 << 2;
-constexpr uint16_t FLASH_LENGTH = 1 << 3;
-constexpr uint16_t BRIGHTNESS = 1 << 4;
-constexpr uint16_t COLOR_BRIGHTNESS = 1 << 5;
-constexpr uint16_t RED = 1 << 6;
-constexpr uint16_t GREEN = 1 << 7;
-constexpr uint16_t BLUE = 1 << 8;
-constexpr uint16_t WHITE = 1 << 9;
-constexpr uint16_t COLOR_TEMPERATURE = 1 << 10;
-constexpr uint16_t COLD_WHITE = 1 << 11;
-constexpr uint16_t WARM_WHITE = 1 << 12;
-constexpr uint16_t EFFECT = 1 << 13;
-}  // namespace LightControlField
-
+// Distinct empty types per field tag so [[no_unique_address]] always coalesces
+// (the same empty type used multiple times is not guaranteed to share an address).
 namespace light_control_detail {
-// Distinct empty types per field so [[no_unique_address]] always coalesces
-// (same empty type used multiple times is not guaranteed to share an address).
 template<int Tag> struct Empty {};
 }  // namespace light_control_detail
+
+// X-macro: (type, field_name, bit_index). Order and bit values must match
+// the FIELDS table in automation.py.
+#define LIGHT_CONTROL_FIELDS(X) \
+  X(ColorMode, color_mode, 0) \
+  X(bool, state, 1) \
+  X(uint32_t, transition_length, 2) \
+  X(uint32_t, flash_length, 3) \
+  X(float, brightness, 4) \
+  X(float, color_brightness, 5) \
+  X(float, red, 6) \
+  X(float, green, 7) \
+  X(float, blue, 8) \
+  X(float, white, 9) \
+  X(float, color_temperature, 10) \
+  X(float, cold_white, 11) \
+  X(float, warm_white, 12) \
+  X(uint32_t, effect, 13)
 
 template<uint16_t Fields, typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
   explicit LightControlAction(LightState *parent) : parent_(parent) {}
 
-#define LIGHT_CONTROL_FIELD(field_bit, type, name, tag) \
-  template<typename V> void set_##name(V value) requires((Fields & LightControlField::field_bit) != 0) { \
-    this->name##_ = value; \
-  }
+#define LIGHT_FIELD_SETTER_(type, name, idx) \
+  template<typename V> void set_##name(V value) requires((Fields & (1 << (idx))) != 0) { this->name##_ = value; }
+#define LIGHT_FIELD_APPLY_(type, name, idx) \
+  if constexpr ((Fields & (1 << (idx))) != 0) \
+    call.set_##name(this->name##_.value(x...));
+#define LIGHT_FIELD_DECL_(type, name, idx) \
+  [[no_unique_address]] std::conditional_t<(Fields & (1 << (idx))) != 0, TemplatableFn<type, Ts...>, \
+                                           light_control_detail::Empty<(idx)>> \
+      name##_{};
 
-  LIGHT_CONTROL_FIELD(COLOR_MODE, ColorMode, color_mode, 0)
-  LIGHT_CONTROL_FIELD(STATE, bool, state, 1)
-  LIGHT_CONTROL_FIELD(TRANSITION_LENGTH, uint32_t, transition_length, 2)
-  LIGHT_CONTROL_FIELD(FLASH_LENGTH, uint32_t, flash_length, 3)
-  LIGHT_CONTROL_FIELD(BRIGHTNESS, float, brightness, 4)
-  LIGHT_CONTROL_FIELD(COLOR_BRIGHTNESS, float, color_brightness, 5)
-  LIGHT_CONTROL_FIELD(RED, float, red, 6)
-  LIGHT_CONTROL_FIELD(GREEN, float, green, 7)
-  LIGHT_CONTROL_FIELD(BLUE, float, blue, 8)
-  LIGHT_CONTROL_FIELD(WHITE, float, white, 9)
-  LIGHT_CONTROL_FIELD(COLOR_TEMPERATURE, float, color_temperature, 10)
-  LIGHT_CONTROL_FIELD(COLD_WHITE, float, cold_white, 11)
-  LIGHT_CONTROL_FIELD(WARM_WHITE, float, warm_white, 12)
-  LIGHT_CONTROL_FIELD(EFFECT, uint32_t, effect, 13)
-#undef LIGHT_CONTROL_FIELD
+  LIGHT_CONTROL_FIELDS(LIGHT_FIELD_SETTER_)
 
   void play(const Ts &...x) override {
     auto call = this->parent_->make_call();
-    if constexpr ((Fields & LightControlField::COLOR_MODE) != 0)
-      call.set_color_mode(this->color_mode_.value(x...));
-    if constexpr ((Fields & LightControlField::STATE) != 0)
-      call.set_state(this->state_.value(x...));
-    if constexpr ((Fields & LightControlField::TRANSITION_LENGTH) != 0)
-      call.set_transition_length(this->transition_length_.value(x...));
-    if constexpr ((Fields & LightControlField::FLASH_LENGTH) != 0)
-      call.set_flash_length(this->flash_length_.value(x...));
-    if constexpr ((Fields & LightControlField::BRIGHTNESS) != 0)
-      call.set_brightness(this->brightness_.value(x...));
-    if constexpr ((Fields & LightControlField::COLOR_BRIGHTNESS) != 0)
-      call.set_color_brightness(this->color_brightness_.value(x...));
-    if constexpr ((Fields & LightControlField::RED) != 0)
-      call.set_red(this->red_.value(x...));
-    if constexpr ((Fields & LightControlField::GREEN) != 0)
-      call.set_green(this->green_.value(x...));
-    if constexpr ((Fields & LightControlField::BLUE) != 0)
-      call.set_blue(this->blue_.value(x...));
-    if constexpr ((Fields & LightControlField::WHITE) != 0)
-      call.set_white(this->white_.value(x...));
-    if constexpr ((Fields & LightControlField::COLOR_TEMPERATURE) != 0)
-      call.set_color_temperature(this->color_temperature_.value(x...));
-    if constexpr ((Fields & LightControlField::COLD_WHITE) != 0)
-      call.set_cold_white(this->cold_white_.value(x...));
-    if constexpr ((Fields & LightControlField::WARM_WHITE) != 0)
-      call.set_warm_white(this->warm_white_.value(x...));
-    if constexpr ((Fields & LightControlField::EFFECT) != 0)
-      call.set_effect(this->effect_.value(x...));
+    LIGHT_CONTROL_FIELDS(LIGHT_FIELD_APPLY_)
     call.perform();
   }
 
  protected:
   LightState *parent_;
+  LIGHT_CONTROL_FIELDS(LIGHT_FIELD_DECL_)
 
-#define LIGHT_CONTROL_STORAGE(field_bit, type, name, tag) \
-  [[no_unique_address]] std::conditional_t<(Fields & LightControlField::field_bit) != 0, TemplatableFn<type, Ts...>, \
-                                           light_control_detail::Empty<tag>> \
-      name##_{};
-
-  LIGHT_CONTROL_STORAGE(COLOR_MODE, ColorMode, color_mode, 0)
-  LIGHT_CONTROL_STORAGE(STATE, bool, state, 1)
-  LIGHT_CONTROL_STORAGE(TRANSITION_LENGTH, uint32_t, transition_length, 2)
-  LIGHT_CONTROL_STORAGE(FLASH_LENGTH, uint32_t, flash_length, 3)
-  LIGHT_CONTROL_STORAGE(BRIGHTNESS, float, brightness, 4)
-  LIGHT_CONTROL_STORAGE(COLOR_BRIGHTNESS, float, color_brightness, 5)
-  LIGHT_CONTROL_STORAGE(RED, float, red, 6)
-  LIGHT_CONTROL_STORAGE(GREEN, float, green, 7)
-  LIGHT_CONTROL_STORAGE(BLUE, float, blue, 8)
-  LIGHT_CONTROL_STORAGE(WHITE, float, white, 9)
-  LIGHT_CONTROL_STORAGE(COLOR_TEMPERATURE, float, color_temperature, 10)
-  LIGHT_CONTROL_STORAGE(COLD_WHITE, float, cold_white, 11)
-  LIGHT_CONTROL_STORAGE(WARM_WHITE, float, warm_white, 12)
-  LIGHT_CONTROL_STORAGE(EFFECT, uint32_t, effect, 13)
-#undef LIGHT_CONTROL_STORAGE
+#undef LIGHT_FIELD_DECL_
+#undef LIGHT_FIELD_APPLY_
+#undef LIGHT_FIELD_SETTER_
 };
 
 template<typename... Ts> class DimRelativeAction : public Action<Ts...> {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -24,60 +24,113 @@ template<typename... Ts> class ToggleAction : public Action<Ts...> {
   LightState *state_;
 };
 
-template<typename... Ts> class LightControlAction : public Action<Ts...> {
+// Bitmask of fields configured on a LightControlAction. Used as a non-type
+// template parameter so unset fields can be elided via [[no_unique_address]]
+// and skipped at compile time via if constexpr in play().
+namespace LightControlField {
+constexpr uint16_t COLOR_MODE = 1 << 0;
+constexpr uint16_t STATE = 1 << 1;
+constexpr uint16_t TRANSITION_LENGTH = 1 << 2;
+constexpr uint16_t FLASH_LENGTH = 1 << 3;
+constexpr uint16_t BRIGHTNESS = 1 << 4;
+constexpr uint16_t COLOR_BRIGHTNESS = 1 << 5;
+constexpr uint16_t RED = 1 << 6;
+constexpr uint16_t GREEN = 1 << 7;
+constexpr uint16_t BLUE = 1 << 8;
+constexpr uint16_t WHITE = 1 << 9;
+constexpr uint16_t COLOR_TEMPERATURE = 1 << 10;
+constexpr uint16_t COLD_WHITE = 1 << 11;
+constexpr uint16_t WARM_WHITE = 1 << 12;
+constexpr uint16_t EFFECT = 1 << 13;
+}  // namespace LightControlField
+
+namespace light_control_detail {
+// Distinct empty types per field so [[no_unique_address]] always coalesces
+// (same empty type used multiple times is not guaranteed to share an address).
+template<int Tag> struct Empty {};
+}  // namespace light_control_detail
+
+template<uint16_t Fields, typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
   explicit LightControlAction(LightState *parent) : parent_(parent) {}
 
-  TEMPLATABLE_VALUE(ColorMode, color_mode)
-  TEMPLATABLE_VALUE(bool, state)
-  TEMPLATABLE_VALUE(uint32_t, transition_length)
-  TEMPLATABLE_VALUE(uint32_t, flash_length)
-  TEMPLATABLE_VALUE(float, brightness)
-  TEMPLATABLE_VALUE(float, color_brightness)
-  TEMPLATABLE_VALUE(float, red)
-  TEMPLATABLE_VALUE(float, green)
-  TEMPLATABLE_VALUE(float, blue)
-  TEMPLATABLE_VALUE(float, white)
-  TEMPLATABLE_VALUE(float, color_temperature)
-  TEMPLATABLE_VALUE(float, cold_white)
-  TEMPLATABLE_VALUE(float, warm_white)
-  TEMPLATABLE_VALUE(uint32_t, effect)
+#define LIGHT_CONTROL_FIELD(field_bit, type, name, tag) \
+  template<typename V> void set_##name(V value) requires((Fields & LightControlField::field_bit) != 0) { \
+    this->name##_ = value; \
+  }
+
+  LIGHT_CONTROL_FIELD(COLOR_MODE, ColorMode, color_mode, 0)
+  LIGHT_CONTROL_FIELD(STATE, bool, state, 1)
+  LIGHT_CONTROL_FIELD(TRANSITION_LENGTH, uint32_t, transition_length, 2)
+  LIGHT_CONTROL_FIELD(FLASH_LENGTH, uint32_t, flash_length, 3)
+  LIGHT_CONTROL_FIELD(BRIGHTNESS, float, brightness, 4)
+  LIGHT_CONTROL_FIELD(COLOR_BRIGHTNESS, float, color_brightness, 5)
+  LIGHT_CONTROL_FIELD(RED, float, red, 6)
+  LIGHT_CONTROL_FIELD(GREEN, float, green, 7)
+  LIGHT_CONTROL_FIELD(BLUE, float, blue, 8)
+  LIGHT_CONTROL_FIELD(WHITE, float, white, 9)
+  LIGHT_CONTROL_FIELD(COLOR_TEMPERATURE, float, color_temperature, 10)
+  LIGHT_CONTROL_FIELD(COLD_WHITE, float, cold_white, 11)
+  LIGHT_CONTROL_FIELD(WARM_WHITE, float, warm_white, 12)
+  LIGHT_CONTROL_FIELD(EFFECT, uint32_t, effect, 13)
+#undef LIGHT_CONTROL_FIELD
 
   void play(const Ts &...x) override {
     auto call = this->parent_->make_call();
-    if (this->color_mode_.has_value())
+    if constexpr ((Fields & LightControlField::COLOR_MODE) != 0)
       call.set_color_mode(this->color_mode_.value(x...));
-    if (this->state_.has_value())
+    if constexpr ((Fields & LightControlField::STATE) != 0)
       call.set_state(this->state_.value(x...));
-    if (this->transition_length_.has_value())
+    if constexpr ((Fields & LightControlField::TRANSITION_LENGTH) != 0)
       call.set_transition_length(this->transition_length_.value(x...));
-    if (this->flash_length_.has_value())
+    if constexpr ((Fields & LightControlField::FLASH_LENGTH) != 0)
       call.set_flash_length(this->flash_length_.value(x...));
-    if (this->brightness_.has_value())
+    if constexpr ((Fields & LightControlField::BRIGHTNESS) != 0)
       call.set_brightness(this->brightness_.value(x...));
-    if (this->color_brightness_.has_value())
+    if constexpr ((Fields & LightControlField::COLOR_BRIGHTNESS) != 0)
       call.set_color_brightness(this->color_brightness_.value(x...));
-    if (this->red_.has_value())
+    if constexpr ((Fields & LightControlField::RED) != 0)
       call.set_red(this->red_.value(x...));
-    if (this->green_.has_value())
+    if constexpr ((Fields & LightControlField::GREEN) != 0)
       call.set_green(this->green_.value(x...));
-    if (this->blue_.has_value())
+    if constexpr ((Fields & LightControlField::BLUE) != 0)
       call.set_blue(this->blue_.value(x...));
-    if (this->white_.has_value())
+    if constexpr ((Fields & LightControlField::WHITE) != 0)
       call.set_white(this->white_.value(x...));
-    if (this->color_temperature_.has_value())
+    if constexpr ((Fields & LightControlField::COLOR_TEMPERATURE) != 0)
       call.set_color_temperature(this->color_temperature_.value(x...));
-    if (this->cold_white_.has_value())
+    if constexpr ((Fields & LightControlField::COLD_WHITE) != 0)
       call.set_cold_white(this->cold_white_.value(x...));
-    if (this->warm_white_.has_value())
+    if constexpr ((Fields & LightControlField::WARM_WHITE) != 0)
       call.set_warm_white(this->warm_white_.value(x...));
-    if (this->effect_.has_value())
+    if constexpr ((Fields & LightControlField::EFFECT) != 0)
       call.set_effect(this->effect_.value(x...));
     call.perform();
   }
 
  protected:
   LightState *parent_;
+
+#define LIGHT_CONTROL_STORAGE(field_bit, type, name, tag) \
+  [[no_unique_address]] std::conditional_t<(Fields & LightControlField::field_bit) != 0, TemplatableFn<type, Ts...>, \
+                                           light_control_detail::Empty<tag>> \
+      name##_{};
+
+  LIGHT_CONTROL_STORAGE(COLOR_MODE, ColorMode, color_mode, 0)
+  LIGHT_CONTROL_STORAGE(STATE, bool, state, 1)
+  LIGHT_CONTROL_STORAGE(TRANSITION_LENGTH, uint32_t, transition_length, 2)
+  LIGHT_CONTROL_STORAGE(FLASH_LENGTH, uint32_t, flash_length, 3)
+  LIGHT_CONTROL_STORAGE(BRIGHTNESS, float, brightness, 4)
+  LIGHT_CONTROL_STORAGE(COLOR_BRIGHTNESS, float, color_brightness, 5)
+  LIGHT_CONTROL_STORAGE(RED, float, red, 6)
+  LIGHT_CONTROL_STORAGE(GREEN, float, green, 7)
+  LIGHT_CONTROL_STORAGE(BLUE, float, blue, 8)
+  LIGHT_CONTROL_STORAGE(WHITE, float, white, 9)
+  LIGHT_CONTROL_STORAGE(COLOR_TEMPERATURE, float, color_temperature, 10)
+  LIGHT_CONTROL_STORAGE(COLD_WHITE, float, cold_white, 11)
+  LIGHT_CONTROL_STORAGE(WARM_WHITE, float, warm_white, 12)
+  LIGHT_CONTROL_STORAGE(EFFECT, uint32_t, effect, 13)
+#undef LIGHT_CONTROL_STORAGE
 };
 
 template<typename... Ts> class DimRelativeAction : public Action<Ts...> {

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -77,6 +77,7 @@ template<uint16_t Fields, typename... Ts> class LightControlAction : public Acti
 #undef LIGHT_FIELD_APPLY_
 #undef LIGHT_FIELD_SETTER_
 };
+#undef LIGHT_CONTROL_FIELDS
 
 template<typename... Ts> class DimRelativeAction : public Action<Ts...> {
  public:

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -180,7 +180,8 @@ async def light_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
 
     # (config_key, setter_name, c++ type) — order and bit position must match
-    # LIGHT_CONTROL_FIELDS in automation.h. CONF_EFFECT is the last bit.
+    # LIGHT_CONTROL_FIELDS in automation.h. CONF_EFFECT has special-case
+    # handling below (lambda or static name resolution), so its setter is None.
     FIELDS = (
         (CONF_COLOR_MODE, "set_color_mode", ColorMode),
         (CONF_STATE, "set_state", cg.bool_),
@@ -195,20 +196,17 @@ async def light_control_to_code(config, action_id, template_arg, args):
         (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_),
         (CONF_COLD_WHITE, "set_cold_white", cg.float_),
         (CONF_WARM_WHITE, "set_warm_white", cg.float_),
+        (CONF_EFFECT, None, cg.uint32),
     )
-    EFFECT_BIT = len(FIELDS)
 
     field_mask = sum(1 << i for i, (k, _, _) in enumerate(FIELDS) if k in config)
-    if CONF_EFFECT in config:
-        field_mask |= 1 << EFFECT_BIT
-
     control_template_arg = cg.TemplateArguments(
         cg.RawExpression(f"static_cast<uint16_t>({field_mask})"), *template_arg
     )
     var = cg.new_Pvariable(action_id, control_template_arg, paren)
 
     for conf_key, setter, type_ in FIELDS:
-        if conf_key in config:
+        if conf_key in config and setter is not None:
             template_ = await cg.templatable(config[conf_key], args, type_)
             cg.add(getattr(var, setter)(template_))
 

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -179,35 +179,35 @@ def _resolve_effect_index(config: ConfigType) -> int:
 async def light_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
 
-    # (config_key, setter_name, c++ type, field bit)
-    # Bit values must match LightControlField in automation.h
+    # (config_key, setter_name, c++ type) — order and bit position must match
+    # LIGHT_CONTROL_FIELDS in automation.h. CONF_EFFECT is the last bit.
     FIELDS = (
-        (CONF_COLOR_MODE, "set_color_mode", ColorMode, 1 << 0),
-        (CONF_STATE, "set_state", cg.bool_, 1 << 1),
-        (CONF_TRANSITION_LENGTH, "set_transition_length", cg.uint32, 1 << 2),
-        (CONF_FLASH_LENGTH, "set_flash_length", cg.uint32, 1 << 3),
-        (CONF_BRIGHTNESS, "set_brightness", cg.float_, 1 << 4),
-        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", cg.float_, 1 << 5),
-        (CONF_RED, "set_red", cg.float_, 1 << 6),
-        (CONF_GREEN, "set_green", cg.float_, 1 << 7),
-        (CONF_BLUE, "set_blue", cg.float_, 1 << 8),
-        (CONF_WHITE, "set_white", cg.float_, 1 << 9),
-        (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_, 1 << 10),
-        (CONF_COLD_WHITE, "set_cold_white", cg.float_, 1 << 11),
-        (CONF_WARM_WHITE, "set_warm_white", cg.float_, 1 << 12),
+        (CONF_COLOR_MODE, "set_color_mode", ColorMode),
+        (CONF_STATE, "set_state", cg.bool_),
+        (CONF_TRANSITION_LENGTH, "set_transition_length", cg.uint32),
+        (CONF_FLASH_LENGTH, "set_flash_length", cg.uint32),
+        (CONF_BRIGHTNESS, "set_brightness", cg.float_),
+        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", cg.float_),
+        (CONF_RED, "set_red", cg.float_),
+        (CONF_GREEN, "set_green", cg.float_),
+        (CONF_BLUE, "set_blue", cg.float_),
+        (CONF_WHITE, "set_white", cg.float_),
+        (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_),
+        (CONF_COLD_WHITE, "set_cold_white", cg.float_),
+        (CONF_WARM_WHITE, "set_warm_white", cg.float_),
     )
-    field_mask = 0
-    for conf_key, _, _, bit in FIELDS:
-        if conf_key in config:
-            field_mask |= bit
-    if CONF_EFFECT in config:
-        field_mask |= 1 << 13  # EFFECT bit
+    EFFECT_BIT = len(FIELDS)
 
-    fields_arg = cg.RawExpression(f"static_cast<uint16_t>({field_mask})")
-    control_template_arg = cg.TemplateArguments(fields_arg, *template_arg)
+    field_mask = sum(1 << i for i, (k, _, _) in enumerate(FIELDS) if k in config)
+    if CONF_EFFECT in config:
+        field_mask |= 1 << EFFECT_BIT
+
+    control_template_arg = cg.TemplateArguments(
+        cg.RawExpression(f"static_cast<uint16_t>({field_mask})"), *template_arg
+    )
     var = cg.new_Pvariable(action_id, control_template_arg, paren)
 
-    for conf_key, setter, type_, _ in FIELDS:
+    for conf_key, setter, type_ in FIELDS:
         if conf_key in config:
             template_ = await cg.templatable(config[conf_key], args, type_)
             cg.add(getattr(var, setter)(template_))

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -178,25 +178,36 @@ def _resolve_effect_index(config: ConfigType) -> int:
 )
 async def light_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
-    var = cg.new_Pvariable(action_id, template_arg, paren)
 
-    # (config_key, setter_name, c++ type)
+    # (config_key, setter_name, c++ type, field bit)
+    # Bit values must match LightControlField in automation.h
     FIELDS = (
-        (CONF_COLOR_MODE, "set_color_mode", ColorMode),
-        (CONF_STATE, "set_state", cg.bool_),
-        (CONF_TRANSITION_LENGTH, "set_transition_length", cg.uint32),
-        (CONF_FLASH_LENGTH, "set_flash_length", cg.uint32),
-        (CONF_BRIGHTNESS, "set_brightness", cg.float_),
-        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", cg.float_),
-        (CONF_RED, "set_red", cg.float_),
-        (CONF_GREEN, "set_green", cg.float_),
-        (CONF_BLUE, "set_blue", cg.float_),
-        (CONF_WHITE, "set_white", cg.float_),
-        (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_),
-        (CONF_COLD_WHITE, "set_cold_white", cg.float_),
-        (CONF_WARM_WHITE, "set_warm_white", cg.float_),
+        (CONF_COLOR_MODE, "set_color_mode", ColorMode, 1 << 0),
+        (CONF_STATE, "set_state", cg.bool_, 1 << 1),
+        (CONF_TRANSITION_LENGTH, "set_transition_length", cg.uint32, 1 << 2),
+        (CONF_FLASH_LENGTH, "set_flash_length", cg.uint32, 1 << 3),
+        (CONF_BRIGHTNESS, "set_brightness", cg.float_, 1 << 4),
+        (CONF_COLOR_BRIGHTNESS, "set_color_brightness", cg.float_, 1 << 5),
+        (CONF_RED, "set_red", cg.float_, 1 << 6),
+        (CONF_GREEN, "set_green", cg.float_, 1 << 7),
+        (CONF_BLUE, "set_blue", cg.float_, 1 << 8),
+        (CONF_WHITE, "set_white", cg.float_, 1 << 9),
+        (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_, 1 << 10),
+        (CONF_COLD_WHITE, "set_cold_white", cg.float_, 1 << 11),
+        (CONF_WARM_WHITE, "set_warm_white", cg.float_, 1 << 12),
     )
-    for conf_key, setter, type_ in FIELDS:
+    field_mask = 0
+    for conf_key, _, _, bit in FIELDS:
+        if conf_key in config:
+            field_mask |= bit
+    if CONF_EFFECT in config:
+        field_mask |= 1 << 13  # EFFECT bit
+
+    fields_arg = cg.RawExpression(f"static_cast<uint16_t>({field_mask})")
+    control_template_arg = cg.TemplateArguments(fields_arg, *template_arg)
+    var = cg.new_Pvariable(action_id, control_template_arg, paren)
+
+    for conf_key, setter, type_, _ in FIELDS:
         if conf_key in config:
             template_ = await cg.templatable(config[conf_key], args, type_)
             cg.add(getattr(var, setter)(template_))

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -179,9 +179,8 @@ def _resolve_effect_index(config: ConfigType) -> int:
 async def light_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
 
-    # (config_key, setter_name, c++ type) — order and bit position must match
-    # LIGHT_CONTROL_FIELDS in automation.h. CONF_EFFECT has special-case
-    # handling below (lambda or static name resolution), so its setter is None.
+    # Order/bits must match LIGHT_CONTROL_FIELDS in automation.h.
+    # EFFECT has special handling below; setter=None skips the generic loop.
     FIELDS = (
         (CONF_COLOR_MODE, "set_color_mode", ColorMode),
         (CONF_STATE, "set_state", cg.bool_),

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -197,6 +197,8 @@ async def light_control_to_code(config, action_id, template_arg, args):
         (CONF_WARM_WHITE, "set_warm_white", cg.float_),
         (CONF_EFFECT, None, cg.uint32),
     )
+    # Bitmask is passed as uint16_t in C++ — must stay within 16 bits.
+    assert len(FIELDS) <= 16, "LightControlAction Fields bitmask exceeds uint16_t"
 
     field_mask = sum(1 << i for i, (k, _, _) in enumerate(FIELDS) if k in config)
     control_template_arg = cg.TemplateArguments(


### PR DESCRIPTION
# What does this implement/fix?

Parameterize `light::LightControlAction` on a `uint16_t Fields` bitmask encoding which of its 14 templatable fields are configured. Unset fields are elided from the instance via `[[no_unique_address]]` and skipped at compile time in `play()` via `if constexpr`. This continues the same approach used in #16037 (`ToggleAction`) and #16038 (`DimRelativeAction`), but generalized to handle 14 fields via a single bitmask template parameter.

Python codegen computes the bitmask from the YAML and passes it as the leading template argument, so each unique field combination produces its own type with only the storage and `play()` branches it actually needs.

## Why this works

Real-world configs typically use only 1–5 of the 14 fields. Across two representative production configs (apollo-r-pro-1, apollo-pump):

- **15 total `LightControlAction` instances**
- Only **3 unique field combinations** used
- **9 of 14 fields completely unused** in any instance: `color_mode`, `transition_length`, `flash_length`, `color_brightness`, `white`, `color_temperature`, `cold_white`, `warm_white`, `effect`

## Measured savings (apollo-pump-1, ESP32, 7 instances)

| Pattern | Before | After | Saved |
|---|---|---|---|
| state only (×2) | 72 B | 20 B | 52 B each (104 B total) |
| state + RGB (×2) | 72 B | 32 B | 40 B each (80 B total) |
| state + brightness + RGB (×3) | 72 B | 36 B | 36 B each (108 B total) |
| **Total RAM** | | | **~292 B** |

Three unique `play()` instantiations (44 + 86 + 100 = 230 B) vs the original ~200 B single function. Flash overhead is ~30–70 B for the extra `play()` variants and vtables — small relative to the RAM win.

## Trade-offs

- **More instantiations:** Each unique bitmask produces its own type. In practice this is bounded — across both apollo configs, only 3 unique types are needed across 15 instances. Configs with many lights all using the same field combination still produce one shared type.
- **No user-visible change:** The Python setter API and YAML schema are unchanged. `LightControlAction` is only used internally by `light_control_to_code`; the bitmask template parameter is added transparently in codegen.
- **CI memory analysis** will show the actual flash impact across the test suite; opening as draft to gather that data first.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Each call generates a different bitmask -> each gets minimal storage
binary_sensor:
  - platform: gpio
    pin: GPIO0
    on_press:
      then:
        # mask = STATE only (1<<1 = 2): 20 B instance
        - light.turn_on:
            id: my_light
  - platform: gpio
    pin: GPIO1
    on_press:
      then:
        # mask = STATE | RED | GREEN | BLUE (450): 32 B instance
        - light.turn_on:
            id: my_light
            red: 100%
            green: 0%
            blue: 50%
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
