### PR TITLE
[ota] Add wall-clock timeout to OTA data transfer loop

### DIFF
--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -292,6 +292,7 @@ void ESPHomeOTAComponent::handle_data_() {
   bool update_started = false;
   size_t total = 0;
   uint32_t last_progress = 0;
+  uint32_t last_data_ms = 0;
   uint8_t buf[OTA_BUFFER_SIZE];
   char *sbuf = reinterpret_cast<char *>(buf);
   size_t ota_size;
@@ -355,10 +356,11 @@ void ESPHomeOTAComponent::handle_data_() {
   // can't wedge the device indefinitely. Without this, the loop only exits
   // on actual data, EOF, or a non-EWOULDBLOCK error from read(), and lwIP
   // TCP keepalive isn't enabled here.
-  uint32_t last_data_ms = millis();
+  last_data_ms = millis();
   while (total < ota_size) {
     if (millis() - last_data_ms > OTA_SOCKET_TIMEOUT_DATA) {
       ESP_LOGW(TAG, "No data received for %u ms", (unsigned) OTA_SOCKET_TIMEOUT_DATA);
+      error_code = ota::OTA_RESPONSE_ERROR_UNKNOWN;
       goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
     size_t remaining = ota_size - total;

--- a/esphome/components/esphome/ota/ota_esphome.cpp
+++ b/esphome/components/esphome/ota/ota_esphome.cpp
@@ -350,8 +350,17 @@ void ESPHomeOTAComponent::handle_data_() {
   // Acknowledge MD5 OK - 1 byte
   this->write_byte_(ota::OTA_RESPONSE_BIN_MD5_OK);
 
+  // Track when we last received data so a silently-vanished peer (no FIN/RST
+  // delivered, e.g. uploader killed mid-transfer or NAT/router dropped state)
+  // can't wedge the device indefinitely. Without this, the loop only exits
+  // on actual data, EOF, or a non-EWOULDBLOCK error from read(), and lwIP
+  // TCP keepalive isn't enabled here.
+  uint32_t last_data_ms = millis();
   while (total < ota_size) {
-    // TODO: timeout check
+    if (millis() - last_data_ms > OTA_SOCKET_TIMEOUT_DATA) {
+      ESP_LOGW(TAG, "No data received for %u ms", (unsigned) OTA_SOCKET_TIMEOUT_DATA);
+      goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
+    }
     size_t remaining = ota_size - total;
     size_t requested = remaining < OTA_BUFFER_SIZE ? remaining : OTA_BUFFER_SIZE;
     ssize_t read = this->client_->read(buf, requested);
@@ -369,6 +378,7 @@ void ESPHomeOTAComponent::handle_data_() {
       goto error;  // NOLINT(cppcoreguidelines-avoid-goto)
     }
 
+    last_data_ms = millis();
     error_code = this->backend_->write(buf, read);
     if (error_code != ota::OTA_RESPONSE_OK) {
       ESP_LOGW(TAG, "Flash write err %d", error_code);


### PR DESCRIPTION
# What does this implement/fix?

Closes the long-standing `// TODO: timeout check` in `ESPHomeOTAComponent::handle_data_()`'s main data-transfer loop. The TODO was introduced in commit [`40dd9c5dce`](https://github.com/esphome/esphome/commit/40dd9c5dce) ("Socket refactor and SSL") on **2021-08-09** when the OTA receive path was switched to socket-based reads, and was carried over verbatim into `esphome/components/esphome/ota/ota_esphome.cpp` in [#6459](https://github.com/esphome/esphome/pull/6459) on 2024-05-15. **It has been sitting there for ~4 years 9 months.**

Every other phase of the OTA protocol (`handle_handshake_()`, `readall_()`, `writeall_()`) has a 90 s `OTA_SOCKET_TIMEOUT_DATA` bound; the data-transfer loop did not.

If the uploader side dropped the TCP connection without a FIN/RST being delivered to the device (uploader process killed mid-transfer, NAT/router state dropped, packet loss eating the RST), then on the device:

- `LWIPRawImpl::recv_fn` is never called with `err != ERR_OK` or `pb == nullptr`, so `rx_closed_` stays false.
- `LWIPRawImpl::s_err_fn` is never called, so `pcb_` stays non-null.
- `waiting_for_data_()` therefore stays true forever.
- The loop spins on `client_->read()` returning `-1`/`EWOULDBLOCK`, executes `App.feed_wdt(); continue;`, and never exits.

LwIP TCP keepalive is not enabled on the OTA socket, and even where it is enabled the default keepalive timer is hours, not seconds. So in this scenario the device is effectively unresponsive (won't accept a new OTA, won't reboot the OTA component) until the user power-cycles. That matches the "device unresponsive until I do a hard power-reset" symptom reported in #15953.

This change tracks the timestamp of the most recent successful `read()` and aborts the OTA if no data has arrived for `OTA_SOCKET_TIMEOUT_DATA` (90 s, same constant the rest of the OTA path already uses). The timeout resets on every successful read, so a slow-but-live link does not false-trigger; only true silence for 90 s does.

The `// TODO: timeout check` is removed.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- partial mitigation for https://github.com/esphome/esphome/issues/15953 (bounds the worst-case "device unresponsive until power-cycle" window)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A; internal behaviour change with no user-facing config.

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config; internal change to the esphome OTA platform.
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).