### PR TITLE
[api] Use custom deleter to fix incomplete-type error on macOS libc++

### DIFF
--- a/esphome/components/api/api_server.cpp
+++ b/esphome/components/api/api_server.cpp
@@ -30,6 +30,11 @@ APIServer *global_api_server = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-c
 
 APIServer::APIServer() { global_api_server = this; }
 
+// Custom deleter defined here so `delete` sees the complete APIConnection type.
+// This prevents libc++ from emitting an "incomplete type" error when other
+// translation units only have the forward declaration of APIConnection.
+void APIServer::APIConnectionDeleter::operator()(APIConnection *p) const { delete p; }
+
 void APIServer::socket_failed_(const LogString *msg) {
   ESP_LOGW(TAG, "Socket %s: errno %d", LOG_STR_ARG(msg), errno);
   this->destroy_socket_();

--- a/esphome/components/api/api_server.h
+++ b/esphome/components/api/api_server.h
@@ -193,7 +193,13 @@ class APIServer final : public Component,
   // Range-for view over the populated slice [0, api_connection_count_). Read-only with respect
   // to ownership — callers get `const unique_ptr&` so they can invoke non-const methods on the
   // APIConnection but cannot reset/move the slot and break the count invariant.
-  using APIConnectionPtr = std::unique_ptr<APIConnection>;
+  // Custom deleter is defined out-of-line in api_server.cpp so libc++ does not
+  // eagerly instantiate `delete static_cast<APIConnection *>(p)` here, where
+  // only the forward declaration of APIConnection is visible (incomplete type).
+  struct APIConnectionDeleter {
+    void operator()(APIConnection *p) const;
+  };
+  using APIConnectionPtr = std::unique_ptr<APIConnection, APIConnectionDeleter>;
   class ActiveClientsView {
     const APIConnectionPtr *begin_;
     const APIConnectionPtr *end_;
@@ -292,7 +298,7 @@ class APIServer final : public Component,
   uint32_t last_connected_{0};
 
   // Slots [0, api_connection_count_) are populated; trailing slots are always nullptr.
-  std::array<std::unique_ptr<APIConnection>, MAX_API_CONNECTIONS> clients_{};
+  std::array<APIConnectionPtr, MAX_API_CONNECTIONS> clients_{};
   // Vectors and strings (12 bytes each on 32-bit)
   // Shared proto write buffer for all connections.
   // Not pre-allocated: all send paths call prepare_first_message_buffer() which


### PR DESCRIPTION
# What does this implement/fix?

Fixes a header-ordering compile error on macOS (libc++) that breaks the host-platform integration test suite when run locally.

## Problem

`api_server.h` declares the connection slots as:

```cpp
std::array<std::unique_ptr<APIConnection>, MAX_API_CONNECTIONS> clients_{};
```

`APIConnection` is only forward-declared at this point (via `list_entities.h`). When a translation unit includes `api_server.h` without first including `api_connection.h` (e.g. `esphome/core/component_iterator.cpp`), libc++ eagerly instantiates `std::default_delete<APIConnection>::operator()` while parsing `<functional>` / `<__memory/unique_ptr.h>`, which contains `static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type")`. The result:

```
unique_ptr.h:63: error: invalid application of 'sizeof' to an incomplete type 'esphome::api::APIConnection'
... in instantiation of 'unique_ptr<APIConnection>::~unique_ptr' requested at api_server.h:300
... in 'list_entities.h:9: forward declaration of esphome::api::APIConnection'
```

Repro: `python3.14 -m pytest tests/integration/test_host_mode_climate_basic_state.py` on macOS fails to compile. (Linux/GCC defers the destructor instantiation, so CI never saw this.)

## Fix

Replace the default `std::default_delete<APIConnection>` with a custom deleter whose `operator()` is defined out-of-line in `api_server.cpp` (where `api_connection.h` is included and the type is complete):

```cpp
// api_server.h
struct APIConnectionDeleter {
  void operator()(APIConnection *p) const;  // declared here
};
using APIConnectionPtr = std::unique_ptr<APIConnection, APIConnectionDeleter>;
std::array<APIConnectionPtr, MAX_API_CONNECTIONS> clients_{};
```

```cpp
// api_server.cpp
void APIServer::APIConnectionDeleter::operator()(APIConnection *p) const { delete p; }
```

The destructor instantiation now needs the deleter type to be complete, but no longer needs `sizeof(APIConnection)` — that's deferred to the out-of-line definition where the type is visible.

## Verification

Verified locally on macOS:
- Before: `python3.14 -m pytest tests/integration/test_host_mode_climate_basic_state.py` fails to compile
- After: same command compiles and passes

No behavior change. ABI-equivalent (custom deleter is empty, so `unique_ptr` size is unchanged).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — internal-only fix.
api:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
