### PR TITLE
[cover] Add cover.control / cover.template.publish coverage to template tests

### DIFF
--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -293,6 +293,56 @@ cover:
             cover.is_closed: template_cover_with_triggers
           then:
             logger.log: Cover is closed
+  # Exercise cover.control / cover.template.publish action variants so the
+  # ControlAction / CoverPublishAction templates are instantiated for the
+  # bitmask combinations seen in real configs.
+  - platform: template
+    name: "Template Cover Bitmask"
+    id: template_cover_bitmask
+    has_position: true
+    optimistic: true
+    open_action:
+      - cover.template.publish:
+          id: template_cover_bitmask
+          position: 1.0
+      - cover.template.publish:
+          id: template_cover_bitmask
+          current_operation: IDLE
+    close_action:
+      - cover.template.publish:
+          id: template_cover_bitmask
+          position: 0.0
+          tilt: 0.0
+    stop_action:
+      - cover.template.publish:
+          id: template_cover_bitmask
+          current_operation: IDLE
+    tilt_action:
+      - lambda: |-
+          id(template_cover_bitmask).tilt = tilt;
+          id(template_cover_bitmask).publish_state();
+    on_idle:
+      # mask = position only
+      - cover.control:
+          id: template_cover_bitmask
+          position: 50%
+      # mask = tilt only
+      - cover.control:
+          id: template_cover_bitmask
+          tilt: 75%
+      # mask = position + tilt
+      - cover.control:
+          id: template_cover_bitmask
+          position: 25%
+          tilt: 30%
+      # mask = stop
+      - cover.control:
+          id: template_cover_bitmask
+          stop: true
+      # CONF_STATE alias for position bit
+      - cover.control:
+          id: template_cover_bitmask
+          state: OPEN
 
 number:
   - platform: template

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -293,55 +293,55 @@ cover:
             cover.is_closed: template_cover_with_triggers
           then:
             logger.log: Cover is closed
-  # Exercise cover.control / cover.template.publish action variants so the
-  # ControlAction / CoverPublishAction templates are instantiated for the
-  # bitmask combinations seen in real configs.
+  # Exercise cover.control / cover.template.publish action variants so they
+  # get build coverage in CI (and so memory-impact analysis on PRs that
+  # touch ControlAction / CoverPublishAction sees real instances).
   - platform: template
-    name: "Template Cover Bitmask"
-    id: template_cover_bitmask
+    name: "Template Cover Actions"
+    id: template_cover_actions
     has_position: true
     optimistic: true
     open_action:
       - cover.template.publish:
-          id: template_cover_bitmask
+          id: template_cover_actions
           position: 1.0
       - cover.template.publish:
-          id: template_cover_bitmask
+          id: template_cover_actions
           current_operation: IDLE
     close_action:
       - cover.template.publish:
-          id: template_cover_bitmask
+          id: template_cover_actions
           position: 0.0
           tilt: 0.0
     stop_action:
       - cover.template.publish:
-          id: template_cover_bitmask
+          id: template_cover_actions
           current_operation: IDLE
     tilt_action:
       - lambda: |-
-          id(template_cover_bitmask).tilt = tilt;
-          id(template_cover_bitmask).publish_state();
+          id(template_cover_actions).tilt = tilt;
+          id(template_cover_actions).publish_state();
     on_idle:
-      # mask = position only
+      # position only
       - cover.control:
-          id: template_cover_bitmask
+          id: template_cover_actions
           position: 50%
-      # mask = tilt only
+      # tilt only
       - cover.control:
-          id: template_cover_bitmask
+          id: template_cover_actions
           tilt: 75%
-      # mask = position + tilt
+      # position + tilt
       - cover.control:
-          id: template_cover_bitmask
+          id: template_cover_actions
           position: 25%
           tilt: 30%
-      # mask = stop
+      # stop
       - cover.control:
-          id: template_cover_bitmask
+          id: template_cover_actions
           stop: true
-      # CONF_STATE alias for position bit
+      # CONF_STATE alias for position
       - cover.control:
-          id: template_cover_bitmask
+          id: template_cover_actions
           state: OPEN
 
 number:

--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -302,6 +302,10 @@ cover:
     has_position: true
     optimistic: true
     open_action:
+      # CONF_STATE alias for the position bit
+      - cover.template.publish:
+          id: template_cover_actions
+          state: OPEN
       - cover.template.publish:
           id: template_cover_actions
           position: 1.0


### PR DESCRIPTION
# What does this implement/fix?

Add `cover.control:` and `cover.template.publish:` action coverage to the template cover tests in `tests/components/template/common-base.yaml`.

These actions currently have **no component-level test coverage**. The new `template_cover_actions` entity exercises the various field combinations users actually write — `position`, `tilt`, `position + tilt`, `stop`, `state: OPEN` — so CI builds these code paths and memory-impact analysis on future PRs that touch `cover::ControlAction` / `cover::CoverPublishAction` reflects real instances rather than zero-instance overhead.

This is a pure test-coverage addition. No production code is changed.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test-only change. The added entity lives in
# tests/components/template/common-base.yaml.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
