### PR TITLE
[climate] Add climate.control coverage to component tests via thermostat

### DIFF
--- a/tests/components/climate/common.yaml
+++ b/tests/components/climate/common.yaml
@@ -29,3 +29,59 @@ climate:
     heat_action:
       - switch.turn_on: climate_heater_switch
       - switch.turn_off: climate_cooler_switch
+  # Thermostat-based climate so climate.control: action variants get build
+  # coverage (bang_bang doesn't support fan modes, presets, etc.). Climate
+  # has no template platform, so thermostat is the right vehicle.
+  - platform: thermostat
+    id: climate_test_thermostat
+    name: Test Thermostat
+    sensor: climate_temperature_sensor
+    min_idle_time: 30s
+    min_heating_off_time: 300s
+    min_heating_run_time: 300s
+    min_cooling_off_time: 300s
+    min_cooling_run_time: 300s
+    heat_action:
+      - logger.log: heating
+    idle_action:
+      - logger.log: idle
+    cool_action:
+      - logger.log: cooling
+    auto_mode:
+      - logger.log: auto
+    heat_cool_mode:
+      - logger.log: heat_cool
+    preset:
+      - name: Default
+        default_target_temperature_low: 18°C
+        default_target_temperature_high: 22°C
+
+button:
+  # Exercise the climate.control: action so ControlAction templates get
+  # build coverage. Various field combinations are tested.
+  - platform: template
+    name: "Climate Control Mode"
+    on_press:
+      - climate.control:
+          id: climate_test_thermostat
+          mode: HEAT
+  - platform: template
+    name: "Climate Control Mode And Temps"
+    on_press:
+      - climate.control:
+          id: climate_test_thermostat
+          mode: HEAT_COOL
+          target_temperature_low: 19.0°C
+          target_temperature_high: 23.0°C
+  - platform: template
+    name: "Climate Control Lambda Temp"
+    on_press:
+      - climate.control:
+          id: climate_test_thermostat
+          target_temperature_high: !lambda "return 21.5;"
+  - platform: template
+    name: "Climate Control Off"
+    on_press:
+      - climate.control:
+          id: climate_test_thermostat
+          mode: "OFF"


### PR DESCRIPTION
# What does this implement/fix?

Add `climate.control:` action coverage to the climate component tests in `tests/components/climate/common.yaml`.

The existing test only uses a `bang_bang` climate, which doesn't exercise `climate.control:` at all. Climate has no `template` platform, so a `thermostat`-based climate is added alongside the existing one to give CI build coverage for `climate.control:` field combinations users actually write.

Added field combinations:
- `mode` only (`HEAT`, `OFF`)
- `mode + target_temperature_low + target_temperature_high` (HEAT_COOL)
- `target_temperature_high` via lambda (templatable path)

The thermostat is wired with `auto_mode` and `heat_cool_mode` actions so all the mode transitions actually execute when the button presses fire.

This is a pure test-coverage addition. No production code is changed. With this in place, memory-impact analysis on future PRs that touch `climate::ControlAction` reflects real instances rather than zero-instance overhead.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Test-only change. The added entities live in
# tests/components/climate/common.yaml.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
