### PR TITLE
[esp32] Make Arduino app metadata reproducible

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1724,15 +1724,16 @@ async def to_code(config):
         CORE.relative_internal_path(".espressif")
     )
 
+    # Both ESP-IDF and ESP32 Arduino builds generate IDF app metadata. Keep
+    # volatile build path/time data out of the binary so equivalent projects can
+    # produce reproducible outputs and downstream tooling can reuse artifacts.
+    add_idf_sdkconfig_option("CONFIG_APP_REPRODUCIBLE_BUILD", True)
+
     if conf[CONF_TYPE] == FRAMEWORK_ESP_IDF:
         cg.add_build_flag("-DUSE_ESP_IDF")
         cg.add_build_flag("-DUSE_ESP32_FRAMEWORK_ESP_IDF")
         if use_platformio:
             cg.add_platformio_option("framework", "espidf")
-            # Strip volatile build path/time metadata from PlatformIO-managed
-            # ESP-IDF builds so equivalent projects can produce reproducible
-            # outputs and downstream tooling can safely reuse artifacts.
-            add_idf_sdkconfig_option("CONFIG_APP_REPRODUCIBLE_BUILD", True)
 
         # Wrap std::__throw_* functions to abort immediately, eliminating ~3KB of
         # exception class overhead. See throw_stubs.cpp for implementation.

--- a/tests/component_tests/esp32/config/reproducible_build_arduino.yaml
+++ b/tests/component_tests/esp32/config/reproducible_build_arduino.yaml
@@ -1,0 +1,8 @@
+esphome:
+  name: test
+
+esp32:
+  board: esp32dev
+  variant: esp32
+  framework:
+    type: arduino

--- a/tests/component_tests/esp32/test_esp32.py
+++ b/tests/component_tests/esp32/test_esp32.py
@@ -16,6 +16,7 @@ from esphome.const import (
     CONF_ESPHOME,
     CONF_IGNORE_PIN_VALIDATION_ERROR,
     CONF_NUMBER,
+    KEY_NATIVE_IDF,
     PlatformFramework,
 )
 from esphome.core import CORE
@@ -240,6 +241,33 @@ def test_platformio_idf_enables_reproducible_build(
 ) -> None:
     """Test PlatformIO ESP-IDF builds enable reproducible app metadata."""
     generate_main(component_config_path("reproducible_build.yaml"))
+
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
+
+
+def test_platformio_arduino_enables_reproducible_build(
+    generate_main: Callable[[str | Path], str],
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test PlatformIO Arduino builds enable reproducible app metadata."""
+    generate_main(component_config_path("reproducible_build_arduino.yaml"))
+
+    sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
+    assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True
+
+
+def test_native_idf_enables_reproducible_build(
+    component_config_path: Callable[[str], Path],
+) -> None:
+    """Test native ESP-IDF builds enable reproducible app metadata."""
+    from esphome.__main__ import generate_cpp_contents
+    from esphome.config import read_config
+
+    CORE.config_path = component_config_path("reproducible_build.yaml")
+    CORE.config = read_config({})
+    CORE.data[KEY_NATIVE_IDF] = True
+    generate_cpp_contents(CORE.config)
 
     sdkconfig = CORE.data[KEY_ESP32][KEY_SDKCONFIG_OPTIONS]
     assert sdkconfig.get("CONFIG_APP_REPRODUCIBLE_BUILD") is True


### PR DESCRIPTION
# What does this implement/fix?

Extends ESP32 reproducible app metadata to the other IDF-backed ESP32 build paths.

`CONFIG_APP_REPRODUCIBLE_BUILD` was enabled for PlatformIO ESP-IDF builds. ESP32 Arduino also builds through ESP-IDF, and native ESP-IDF should get the same app metadata behavior, so this moves the sdkconfig default to the shared ESP32 code generation path.

User-provided `sdkconfig_options` still take precedence because they are applied later in `to_code()`.

Follow-up to #16008.

Validation:
- `.venv/bin/pytest -q tests/component_tests/esp32/test_esp32.py -k reproducible`
- `.venv/bin/pytest -q tests/component_tests/esp32/test_esp32.py`
- `.venv/bin/pre-commit run ruff --files esphome/components/esp32/__init__.py tests/component_tests/esp32/test_esp32.py`
- `.venv/bin/esphome compile tests/component_tests/esp32/config/reproducible_build_arduino.yaml`
- Verified generated Arduino `sdkconfig.test` contains `CONFIG_APP_REPRODUCIBLE_BUILD=y`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- Follow-up to #16008

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- Not applicable, internal build metadata behavior only.

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Not applicable: no user-facing YAML configuration changes.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). Not applicable: no user-facing functionality or configuration variables are added.
