### PR TITLE
[audio] Bump microDecoder library to v0.2.0

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -220,7 +220,7 @@ async def to_code(config):
     data = _get_data()
 
     if data.micro_decoder_support:
-        add_idf_component(name="esphome/micro-decoder", ref="0.1.1")
+        add_idf_component(name="esphome/micro-decoder", ref="0.2.0")
 
         # All codecs are enabled by default in micro-decoder, so disable the ones that aren't requested to save flash
         if not data.flac_support:

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -6,7 +6,7 @@ dependencies:
   esphome/esp-micro-speech-features:
     version: 1.2.3
   esphome/micro-decoder:
-    version: 0.1.1
+    version: 0.2.0
   esphome/micro-flac:
     version: 0.1.1
   esphome/micro-opus:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the microDecoder library to v0.2.0 ([GitHub](https://github.com/esphome-libs/micro-decoder) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-decoder/versions/0.2.0/readme)) used by the ``audio_http`` media source component.

- Fixes a bug where small files would never play from an http source
- Fixes a bug where the last chunk of encoded data from on http source could be dropped
- Fixes logging so it shows up by default in ESPHome
- Adds a default user agent string for http requests
- Loosens restrictions on external decoder library versions (in preparation for releasing microFLAC v1.0.0)


## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

media_source:
  - platform: audio_http
    id: announcement_http_source

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
