### PR TITLE
[esp32] Defer preferences nvs_open warning until after logger init

### DIFF
--- a/esphome/components/esp32/preferences.cpp
+++ b/esphome/components/esp32/preferences.cpp
@@ -18,6 +18,12 @@ struct NVSData {
 
 static std::vector<NVSData> s_pending_save;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
+// open() runs from app_main() before the logger is initialized, so any failure
+// must be deferred until after global_logger is set. This is emitted from the
+// first make_preference() call, which runs from the generated setup() after
+// log->pre_setup() has run at EARLY_INIT priority.
+static esp_err_t s_open_err = ESP_OK;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
 bool ESP32PreferenceBackend::save(const uint8_t *data, size_t len) {
   // try find in pending saves and update that
   for (auto &obj : s_pending_save) {
@@ -75,7 +81,7 @@ void ESP32Preferences::open() {
   if (err == 0)
     return;
 
-  ESP_LOGW(TAG, "nvs_open failed: %s - erasing NVS", esp_err_to_name(err));
+  s_open_err = err;
   nvs_flash_deinit();
   nvs_flash_erase();
   nvs_flash_init();
@@ -87,6 +93,10 @@ void ESP32Preferences::open() {
 }
 
 ESPPreferenceObject ESP32Preferences::make_preference(size_t length, uint32_t type) {
+  if (s_open_err != ESP_OK) {
+    ESP_LOGW(TAG, "nvs_open failed: %s - erased NVS", esp_err_to_name(s_open_err));
+    s_open_err = ESP_OK;
+  }
   auto *pref = new ESP32PreferenceBackend();  // NOLINT(cppcoreguidelines-owning-memory)
   pref->nvs_handle = this->nvs_handle;
   pref->key = type;


### PR DESCRIPTION
# What does this implement/fix?

Fixes a latent crash in `ESP32Preferences::open()`: it calls `ESP_LOGW(TAG, "nvs_open failed: %s - erasing NVS", ...)` if `nvs_open` fails, but `setup_preferences()` is called from `app_main()` (`esphome/components/esp32/core.cpp`) **before** the generated `setup()` runs `Logger::pre_setup()` at `EARLY_INIT` priority. At that point `logger::global_logger` is still `nullptr`.

After PR #14538 the runtime null check in `esp_log_printf_()` was intentionally removed (CI catches early-log bugs via `ESPHOME_DEBUG`, and the production hot path is branch-free). That means this `ESP_LOGW` would now:

- assert in `ESPHOME_DEBUG` builds (caught in CI if `nvs_open` happens to fail there), and
- null-deref `logger::global_logger->log_vprintf_(...)` in release builds the moment a device with corrupt/uninitialized NVS boots.

### Fix

Stash the `esp_err_t` from the failed `nvs_open` in a static `s_open_err`, perform the existing erase/reinit recovery silently, and emit the deferred warning from the first `make_preference()` call. `make_preference()` is invoked from generated component init code in `setup()`, which runs after `Logger::pre_setup()` (logger is wired at `CoroPriority.EARLY_INIT` = 1100, before any platform init at 1000), so `global_logger` is guaranteed to be set by then.

The warning text changes from "erasing NVS" to "erased NVS" since by the time it surfaces, the recovery has already completed.

### Audit of related paths

Checked every other platform's `setup_preferences()` and `arch_init()` call chain (the two call sites that run before `Logger::pre_setup()`):

- **esp8266 / rp2040 / zephyr (nrf52)** wire `setup_preferences()` via `cg.add(...)` at `CoroPriority.PLATFORM` (1000), so it lands in the generated `setup()` after `EARLY_INIT` (1100). Their `ESP_LOG*` calls in `open()` are safe.
- **host** `setup_preferences()` only assigns globals; the `ESP_LOGE` for missing `HOME` lives in `setup_()`, only reached via `sync()` from `IntervalSyncer` (BUS priority, well after logger init).
- **libretiny** uses native `LT_*` macros (LibreTiny's own logger), not ESPHome's `ESP_LOG*`.
- All `arch_init()` implementations either don't log or only call code that doesn't log (crash handler reads, watchdog setup, etc.).

So ESP32's `setup_preferences()` was the only real instance of this bug.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- n/a

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- n/a

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No configuration changes required. This is an internal fix.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).