### PR TITLE
[feedback] Use App.get_loop_component_start_time() and constexpr timeout id

### DIFF
--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -3,10 +3,11 @@
 #include "esphome/core/log.h"
 #include "esphome/core/application.h"
 
-namespace esphome {
-namespace feedback {
+namespace esphome::feedback {
 
 static const char *const TAG = "feedback.cover";
+
+static constexpr uint32_t DIRECTION_CHANGE_TIMEOUT_ID = 1;
 
 using namespace esphome::cover;
 
@@ -37,7 +38,7 @@ void FeedbackCover::setup() {
   }
 #endif
 
-  this->last_recompute_time_ = this->start_dir_time_ = millis();
+  this->last_recompute_time_ = this->start_dir_time_ = App.get_loop_component_start_time();
 }
 
 CoverTraits FeedbackCover::get_traits() {
@@ -135,7 +136,7 @@ void FeedbackCover::set_close_endstop(binary_sensor::BinarySensor *close_endstop
 #endif
 
 void FeedbackCover::endstop_reached_(bool open_endstop) {
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
 
   this->position = open_endstop ? COVER_OPEN : COVER_CLOSED;
 
@@ -174,7 +175,7 @@ void FeedbackCover::set_current_operation_(cover::CoverOperation operation, bool
   if (!is_triggered || (this->open_feedback_ == nullptr || this->close_feedback_ == nullptr))
 #endif
   {
-    auto now = millis();
+    const uint32_t now = App.get_loop_component_start_time();
     this->current_operation = operation;
     this->start_dir_time_ = this->last_recompute_time_ = now;
     this->publish_state();
@@ -306,7 +307,7 @@ void FeedbackCover::control(const CoverCall &call) {
 
 void FeedbackCover::stop_prev_trigger_() {
   if (this->direction_change_waittime_.has_value()) {
-    this->cancel_timeout("direction_change");
+    this->cancel_timeout(DIRECTION_CHANGE_TIMEOUT_ID);
   }
   if (this->prev_command_trigger_ != nullptr) {
     this->prev_command_trigger_->stop_action();
@@ -377,7 +378,7 @@ void FeedbackCover::start_direction_(CoverOperation dir) {
     ESP_LOGD(TAG, "'%s' - Reversing direction.", this->name_.c_str());
     this->start_direction_(COVER_OPERATION_IDLE);
 
-    this->set_timeout("direction_change", *this->direction_change_waittime_,
+    this->set_timeout(DIRECTION_CHANGE_TIMEOUT_ID, *this->direction_change_waittime_,
                       [this, dir]() { this->start_direction_(dir); });
 
   } else {
@@ -395,7 +396,7 @@ void FeedbackCover::recompute_position_() {
   if (this->current_operation == COVER_OPERATION_IDLE)
     return;
 
-  const uint32_t now = millis();
+  const uint32_t now = App.get_loop_component_start_time();
   float dir;
   float action_dur;
   float min_pos;
@@ -451,5 +452,4 @@ void FeedbackCover::recompute_position_() {
   this->last_recompute_time_ = now;
 }
 
-}  // namespace feedback
-}  // namespace esphome
+}  // namespace esphome::feedback

--- a/esphome/components/feedback/feedback_cover.h
+++ b/esphome/components/feedback/feedback_cover.h
@@ -8,8 +8,7 @@
 #endif
 #include "esphome/components/cover/cover.h"
 
-namespace esphome {
-namespace feedback {
+namespace esphome::feedback {
 
 class FeedbackCover : public cover::Cover, public Component {
  public:
@@ -85,5 +84,4 @@ class FeedbackCover : public cover::Cover, public Component {
   uint32_t update_interval_{1000};
 };
 
-}  // namespace feedback
-}  // namespace esphome
+}  // namespace esphome::feedback


### PR DESCRIPTION
# What does this implement/fix?

In the `feedback` cover component, replace `millis()` calls with `App.get_loop_component_start_time()` for timing reads. The cached loop start time avoids redundant `millis()` reads (which on some platforms involve a syscall / 64→32 truncation) on every loop iteration, sensor callback, and control invocation, and keeps the `start_dir_time_` / `last_recompute_time_` / `last_publish_time_` / position-recompute deltas using a single consistent time source.

Also:
- Switch the `direction_change` `set_timeout`/`cancel_timeout` key from a string to a `static constexpr uint32_t` ID, picking up the `uint32_t`-keyed scheduler overload (avoids the string hash on each schedule/cancel).
- Collapse the file's namespace to the C++17 nested form `namespace esphome::feedback { ... }`.

Note: the only path that reads `App.get_loop_component_start_time()` from a scheduler-dispatched callback is the `direction_change` `set_timeout` → `start_direction_(dir)` → `set_current_operation_()` path. The scheduler does not currently freshen `loop_component_start_time_` before executing items, so the value seen there reflects the prior loop iteration's last component. For this component's usage (multi-second `max_duration_`, hundreds-of-ms position deltas) the millisecond-scale staleness is well within tolerance. A separate PR will freshen `loop_component_start_time_` inside the scheduler before each item runs.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
cover:
  - platform: feedback
    name: "Garage Door"
    open_action:
      - switch.turn_on: open_relay
    close_action:
      - switch.turn_on: close_relay
    stop_action:
      - switch.turn_on: stop_relay
    open_duration: 15s
    close_duration: 15s
    direction_change_wait_time: 300ms
    open_endstop: open_endstop_sensor
    close_endstop: close_endstop_sensor
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).