### PR TITLE
[core] Freshen loop_component_start_time_ before scheduler dispatch

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -103,12 +103,6 @@ class Application {
   void set_current_component(Component *component) { this->current_component_ = component; }
   Component *get_current_component() { return this->current_component_; }
 
-  /// Update the cached loop component start time. Used by the scheduler before
-  /// dispatching a queued callback so callers reading
-  /// get_loop_component_start_time() inside the callback observe a fresh value
-  /// instead of one inherited from the prior loop iteration's last component.
-  void set_loop_component_start_time(uint32_t now) { this->loop_component_start_time_ = now; }
-
 // Entity register methods (generated from entity_types.h).
 // Each entity type gets two overloads:
 //   - register_<entity>(obj)                              — bare push_back
@@ -383,11 +377,18 @@ class Application {
 
  protected:
   friend Component;
+  friend class Scheduler;
 #ifdef USE_RUNTIME_STATS
   friend class runtime_stats::RuntimeStatsCollector;
 #endif
   friend void ::setup();
   friend void ::original_setup();
+
+  /// Update the cached loop component start time. Used by the scheduler before
+  /// dispatching a queued callback so callers reading
+  /// get_loop_component_start_time() inside the callback observe a fresh value
+  /// instead of one inherited from the prior loop iteration's last component.
+  void set_loop_component_start_time_(uint32_t now) { this->loop_component_start_time_ = now; }
 
   /// Walk all registered components looking for any whose component_state_
   /// has the given flag set. Used by Component::status_clear_*_slow_path_()

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -103,6 +103,12 @@ class Application {
   void set_current_component(Component *component) { this->current_component_ = component; }
   Component *get_current_component() { return this->current_component_; }
 
+  /// Update the cached loop component start time. Used by the scheduler before
+  /// dispatching a queued callback so callers reading
+  /// get_loop_component_start_time() inside the callback observe a fresh value
+  /// instead of one inherited from the prior loop iteration's last component.
+  void set_loop_component_start_time(uint32_t now) { this->loop_component_start_time_ = now; }
+
 // Entity register methods (generated from entity_types.h).
 // Each entity type gets two overloads:
 //   - register_<entity>(obj)                              — bare push_back

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -384,10 +384,7 @@ class Application {
   friend void ::setup();
   friend void ::original_setup();
 
-  /// Update the cached loop component start time. Used by the scheduler before
-  /// dispatching a queued callback so callers reading
-  /// get_loop_component_start_time() inside the callback observe a fresh value
-  /// instead of one inherited from the prior loop iteration's last component.
+  /// Freshen the cached loop component start time. Called by Scheduler before each dispatch.
   void set_loop_component_start_time_(uint32_t now) { this->loop_component_start_time_ = now; }
 
   /// Walk all registered components looking for any whose component_state_

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -772,10 +772,7 @@ Scheduler::SchedulerItem *HOT Scheduler::pop_raw_locked_() {
 // Helper to execute a scheduler item
 uint32_t HOT Scheduler::execute_item_(SchedulerItem *item, uint32_t now) {
   App.set_current_component(item->component);
-  // Freshen the cached loop component start time so callbacks reading
-  // App.get_loop_component_start_time() observe the dispatch time of this
-  // item rather than a stale value from the prior loop iteration's last
-  // component phase.
+  // Freshen so callbacks reading App.get_loop_component_start_time() see this item's dispatch time.
   App.set_loop_component_start_time_(now);
   WarnIfComponentBlockingGuard guard{item->component, now};
   item->callback();

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -772,6 +772,11 @@ Scheduler::SchedulerItem *HOT Scheduler::pop_raw_locked_() {
 // Helper to execute a scheduler item
 uint32_t HOT Scheduler::execute_item_(SchedulerItem *item, uint32_t now) {
   App.set_current_component(item->component);
+  // Freshen the cached loop component start time so callbacks reading
+  // App.get_loop_component_start_time() observe the dispatch time of this
+  // item rather than a stale value from the prior loop iteration's last
+  // component phase.
+  App.set_loop_component_start_time(now);
   WarnIfComponentBlockingGuard guard{item->component, now};
   item->callback();
   uint32_t end = guard.finish();

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -776,7 +776,7 @@ uint32_t HOT Scheduler::execute_item_(SchedulerItem *item, uint32_t now) {
   // App.get_loop_component_start_time() observe the dispatch time of this
   // item rather than a stale value from the prior loop iteration's last
   // component phase.
-  App.set_loop_component_start_time(now);
+  App.set_loop_component_start_time_(now);
   WarnIfComponentBlockingGuard guard{item->component, now};
   item->callback();
   uint32_t end = guard.finish();


### PR DESCRIPTION
# What does this implement/fix?

Update `Scheduler::execute_item_` to refresh `Application::loop_component_start_time_` to the dispatch timestamp (`now`) before invoking each scheduled callback. Previously the cached value was only written before each component's `loop()` (and during setup), so callbacks dispatched by `set_timeout` / `set_interval` / `defer` observed a stale value carried over from the prior loop iteration's last component.

The setter (`set_loop_component_start_time_`) is `protected`; `Scheduler` is added as a `friend` of `Application` so only the scheduler can poke this internal cache.

This makes `App.get_loop_component_start_time()` safe to use from any scheduler-dispatched callback, removing the need to fall back to `millis()` for components that prefer the cached time source (e.g. the cleanup just done in the `feedback` cover component).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Internal core scheduler change.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).