### PR TITLE
[ci-custom] Lint imports of esphome.components.const outside components

### DIFF
--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -512,13 +512,24 @@ def lint_no_std_string_view(fname, match):
 
 
 @lint_re_check(
-    r"(?:from\s+esphome\.components\.const\s+import|"
-    r"from\s+esphome\.components\s+import\s+(?:[^#\n]*[\s,])?const(?:[\s,]|$)|"
-    r"import\s+esphome\.components\.const)",
+    r"(?:"
+    # `from esphome.components.const import ...`
+    r"from\s+esphome\.components\.const\s+import"
+    r"|"
+    # `import esphome.components.const` (with optional `as` alias)
+    r"import\s+esphome\.components\.const\b"
+    r"|"
+    # `from esphome.components import [(] ... const ... [)]`
+    # Handles parenthesized + multiline import lists by allowing newlines inside
+    # the parens via [^)]*. Single-line form falls back to the [^#\n]* branch.
+    r"from\s+esphome\.components\s+import\s*"
+    r"(?:\([^)]*\bconst\b[^)]*\)|(?:[^#\n]*[\s,])?\bconst\b)"
+    r")",
     include=["*.py"],
     exclude=[
         "esphome/components/*",
         "tests/*",
+        "script/ci-custom.py",
     ],
 )
 def lint_no_components_const_outside_components(fname, match):
@@ -527,8 +538,12 @@ def lint_no_components_const_outside_components(fname, match):
         f"to be shared only between components in {highlight('esphome/components/')}. "
         f"Code outside this folder must not import from "
         f"{highlight('esphome.components.const')}.\n"
-        f"If the constant is needed outside of {highlight('esphome/components/')}, "
-        f"please move it to {highlight('esphome/const.py')} instead."
+        f"For core code, use {highlight('esphome/const.py')} instead. Note that "
+        f"{highlight('esphome/const.py')} is frozen against new {highlight('CONF_')} "
+        f"constants (see {highlight('CONST_PY_MAX_CONF')} / "
+        f"{highlight('lint_const_py_frozen')}) — non-CONF_ core constants can be added "
+        f"there directly; CONF_ constants used only by components belong in "
+        f"{highlight('esphome/components/const/__init__.py')}."
     )
 
 

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -538,12 +538,10 @@ def lint_no_components_const_outside_components(fname, match):
         f"to be shared only between components in {highlight('esphome/components/')}. "
         f"Code outside this folder must not import from "
         f"{highlight('esphome.components.const')}.\n"
-        f"For core code, use {highlight('esphome/const.py')} instead. Note that "
-        f"{highlight('esphome/const.py')} is frozen against new {highlight('CONF_')} "
-        f"constants (see {highlight('CONST_PY_MAX_CONF')} / "
-        f"{highlight('lint_const_py_frozen')}) — non-CONF_ core constants can be added "
-        f"there directly; CONF_ constants used only by components belong in "
-        f"{highlight('esphome/components/const/__init__.py')}."
+        f"For core code (used outside {highlight('esphome/components/')}), define the "
+        f"constant in {highlight('esphome/const.py')} instead. When adding a new "
+        f"{highlight('CONF_')} constant there, bump {highlight('CONST_PY_MAX_CONF')} "
+        f"in this file accordingly (see {highlight('lint_const_py_frozen')})."
     )
 
 

--- a/script/ci-custom.py
+++ b/script/ci-custom.py
@@ -511,6 +511,27 @@ def lint_no_std_string_view(fname, match):
     )
 
 
+@lint_re_check(
+    r"(?:from\s+esphome\.components\.const\s+import|"
+    r"from\s+esphome\.components\s+import\s+(?:[^#\n]*[\s,])?const(?:[\s,]|$)|"
+    r"import\s+esphome\.components\.const)",
+    include=["*.py"],
+    exclude=[
+        "esphome/components/*",
+        "tests/*",
+    ],
+)
+def lint_no_components_const_outside_components(fname, match):
+    return (
+        f"Constants in {highlight('esphome/components/const/__init__.py')} are intended "
+        f"to be shared only between components in {highlight('esphome/components/')}. "
+        f"Code outside this folder must not import from "
+        f"{highlight('esphome.components.const')}.\n"
+        f"If the constant is needed outside of {highlight('esphome/components/')}, "
+        f"please move it to {highlight('esphome/const.py')} instead."
+    )
+
+
 @lint_post_check
 def lint_constants_usage():
     errs = []


### PR DESCRIPTION
# What does this implement/fix?

Adds a lint check in `script/ci-custom.py` that flags any import of `esphome.components.const` from a Python file outside `esphome/components/`. Tests are excluded.

The constants in `esphome/components/const/__init__.py` are intended to be shared between components only. Anything needed by core code (i.e. files outside `esphome/components/`) should live in `esphome/const.py` instead. Without a lint, it is easy to introduce such an import accidentally.

The check matches `from esphome.components.const import ...`, `from esphome.components import const` (with optional siblings on the same line), and `import esphome.components.const`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).