### PR TITLE
[automation] Fix codegen type for component.resume update_interval

### DIFF
--- a/esphome/automation.py
+++ b/esphome/automation.py
@@ -380,7 +380,7 @@ async def component_resume_action_to_code(config, action_id, template_arg, args)
     comp = await cg.get_variable(config[CONF_ID])
     var = cg.new_Pvariable(action_id, template_arg, comp)
     if CONF_UPDATE_INTERVAL in config:
-        template_ = await cg.templatable(config[CONF_UPDATE_INTERVAL], args, int)
+        template_ = await cg.templatable(config[CONF_UPDATE_INTERVAL], args, cg.uint32)
         cg.add(var.set_update_interval(template_))
     return var
 


### PR DESCRIPTION
# What does this implement/fix?

Fixes a codegen type mismatch in `automation.py` for `component.resume`'s `update_interval`. `ResumeComponentAction::set_update_interval` is declared via `TEMPLATABLE_VALUE(uint32_t, update_interval)`, but codegen was passing `int` as the output type to `cg.templatable`. Under the new `TemplatableFn<T>` (introduced for 4-byte function-pointer storage), the emitted lambda returns `int`, which is only *convertible* to `uint32_t` — hitting the `[[deprecated]]` trampoline overload and producing this warning on every build that uses `component.resume` with an `update_interval`:

> `Lambda return type does not match TemplatableFn<T> — use the correct type in codegen [-Wdeprecated-declarations]`

Every other `cg.templatable(...)` call in `esphome/automation.py` for a `uint32_t` field (`CONF_TIME` line 357, line 400, `CONF_COUNT` line 486, `CONF_TIMEOUT` line 516) already uses `cg.uint32`. Line 600 is the lone outlier. This PR matches the existing pattern.

Runtime behaviour is unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes downstream report at https://github.com/ApolloAutomation/TEMP-1/issues/58 (the warning is reproducible in any project using `component.resume` with `update_interval`)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A — no user-facing yaml change; this is an internal codegen typing fix.

## Test Environment

Codegen output is independent of target platform — the change affects the C++ source emitted by the Python layer, not platform-specific code paths.

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Only the platform actually compiled is checked; CI will exercise the rest.)

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: adc
    pin: GPIO4
    id: my_sensor
    update_interval: never

script:
  - id: start_polling
    then:
      - component.resume:
          id: my_sensor
          update_interval: 3s
```

Before this PR: building the above on ESPHome 2026.4.x emits a `-Wdeprecated-declarations` warning pointing at `ResumeComponentAction<Ts>::set_update_interval`. After: clean build.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

No new tests added — runtime behaviour and emitted code are identical modulo the lambda's declared return type. The repository has no existing yaml test exercising `component.resume` with `update_interval`; happy to add one if maintainers prefer.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).