### PR TITLE
[watchdog] Fix WatchdogManager on single core apps

### DIFF
--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -6,7 +6,6 @@
 #include <cinttypes>
 #include <cstdint>
 #ifdef USE_ESP32
-#include <soc/soc_caps.h>
 #include "esp_idf_version.h"
 #include "esp_task_wdt.h"
 #endif
@@ -40,7 +39,7 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
 #ifdef USE_ESP32
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = timeout_ms,
-      .idle_core_mask = (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
+      .idle_core_mask = (1U << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1U,
       .trigger_panic = true,
   };
   esp_task_wdt_reconfigure(&wdt_config);

--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -40,7 +40,7 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
 #ifdef USE_ESP32
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = timeout_ms,
-      .idle_core_mask = (1 << SOC_CPU_CORES_NUM) - 1,
+      .idle_core_mask = (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
       .trigger_panic = true,
   };
   esp_task_wdt_reconfigure(&wdt_config);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Use the correct constant `CONFIG_FREERTOS_NUMBER_OF_CORES` for the core count. This is the one that gets checked by esp_task_wdt_reconfigure.

Before this PR, WatchdogManager would fail to configure the watchdog on single core apps (with `CONFIG_FREERTOS_UNICORE: y`) running on dual core ESPs.

Error:
`E (40735) task_wdt: esp_task_wdt_reconfigure(559): Invalid arguments`

Debug info:
```
Dual core ESP, Dual core app
Old mask: 0x3, New mask: 0x3

Dual core ESP, Single core app
Old mask: 0x3, New mask: 0x1
```
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
