### PR TITLE
[api] Use entity_types.h X-macro for InitialStateIterator declarations

### DIFF
--- a/esphome/components/api/subscribe_state.cpp
+++ b/esphome/components/api/subscribe_state.cpp
@@ -67,7 +67,10 @@ INITIAL_STATE_HANDLER(water_heater, water_heater::WaterHeater)
 INITIAL_STATE_HANDLER(update, update::UpdateEntity)
 #endif
 
-// Special cases (button and event) are already defined inline in subscribe_state.h
+// event is an ENTITY_CONTROLLER_TYPE_ but has no state to send.
+#ifdef USE_EVENT
+bool InitialStateIterator::on_event(event::Event *entity) { return true; }
+#endif
 
 InitialStateIterator::InitialStateIterator(APIConnection *client) : client_(client) {}
 

--- a/esphome/components/api/subscribe_state.h
+++ b/esphome/components/api/subscribe_state.h
@@ -19,78 +19,20 @@ class APIConnection;
 class InitialStateIterator final : public ComponentIterator {
  public:
   InitialStateIterator(APIConnection *client);
-#ifdef USE_BINARY_SENSOR
-  bool on_binary_sensor(binary_sensor::BinarySensor *entity) override;
-#endif
-#ifdef USE_COVER
-  bool on_cover(cover::Cover *entity) override;
-#endif
-#ifdef USE_FAN
-  bool on_fan(fan::Fan *entity) override;
-#endif
-#ifdef USE_LIGHT
-  bool on_light(light::LightState *entity) override;
-#endif
-#ifdef USE_SENSOR
-  bool on_sensor(sensor::Sensor *entity) override;
-#endif
-#ifdef USE_SWITCH
-  bool on_switch(switch_::Switch *entity) override;
-#endif
-#ifdef USE_BUTTON
-  bool on_button(button::Button *button) override { return true; };
-#endif
-#ifdef USE_TEXT_SENSOR
-  bool on_text_sensor(text_sensor::TextSensor *entity) override;
-#endif
-#ifdef USE_CLIMATE
-  bool on_climate(climate::Climate *entity) override;
-#endif
-#ifdef USE_NUMBER
-  bool on_number(number::Number *entity) override;
-#endif
-#ifdef USE_DATETIME_DATE
-  bool on_date(datetime::DateEntity *entity) override;
-#endif
-#ifdef USE_DATETIME_TIME
-  bool on_time(datetime::TimeEntity *entity) override;
-#endif
-#ifdef USE_DATETIME_DATETIME
-  bool on_datetime(datetime::DateTimeEntity *entity) override;
-#endif
-#ifdef USE_TEXT
-  bool on_text(text::Text *entity) override;
-#endif
-#ifdef USE_SELECT
-  bool on_select(select::Select *entity) override;
-#endif
-#ifdef USE_LOCK
-  bool on_lock(lock::Lock *entity) override;
-#endif
-#ifdef USE_VALVE
-  bool on_valve(valve::Valve *entity) override;
-#endif
-#ifdef USE_MEDIA_PLAYER
-  bool on_media_player(media_player::MediaPlayer *entity) override;
-#endif
-#ifdef USE_ALARM_CONTROL_PANEL
-  bool on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *entity) override;
-#endif
-#ifdef USE_WATER_HEATER
-  bool on_water_heater(water_heater::WaterHeater *entity) override;
-#endif
-#ifdef USE_INFRARED
-  bool on_infrared(infrared::Infrared *infrared) override { return true; };
-#endif
-#ifdef USE_RADIO_FREQUENCY
-  bool on_radio_frequency(radio_frequency::RadioFrequency *radio_frequency) override { return true; };
-#endif
-#ifdef USE_EVENT
-  bool on_event(event::Event *event) override { return true; };
-#endif
-#ifdef USE_UPDATE
-  bool on_update(update::UpdateEntity *entity) override;
-#endif
+
+// Entity overrides (generated from entity_types.h).
+// ENTITY_TYPE_ entities have no state to send and default to a no-op.
+// ENTITY_CONTROLLER_TYPE_ entities are implemented in subscribe_state.cpp via INITIAL_STATE_HANDLER,
+// except on_event which has no state (defined out-of-line in subscribe_state.cpp).
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define ENTITY_TYPE_(type, singular, plural, count, upper) \
+  bool on_##singular(type *entity) override { return true; }
+#define ENTITY_CONTROLLER_TYPE_(type, singular, plural, count, upper, callback) \
+  bool on_##singular(type *entity) override;
+#include "esphome/core/entity_types.h"
+#undef ENTITY_TYPE_
+#undef ENTITY_CONTROLLER_TYPE_
+  // NOLINTEND(bugprone-macro-parentheses)
 
  protected:
   APIConnection *client_;


### PR DESCRIPTION
# What does this implement/fix?

Replaces the long, hand-maintained list of `#ifdef USE_*` / `on_<entity>` override declarations in `esphome/components/api/subscribe_state.h` with the existing `esphome/core/entity_types.h` X-macro (already used by `application.h` and `component_iterator.h`).

- `ENTITY_TYPE_` entries (button, infrared, radio_frequency — no state to send) get an inline `return true` body.
- `ENTITY_CONTROLLER_TYPE_` entries get a forward declaration; implementations remain in `subscribe_state.cpp` via the existing `INITIAL_STATE_HANDLER` macro.
- `on_event` is the only `ENTITY_CONTROLLER_TYPE_` without a `send_*_state`; it gets a small out-of-line no-op in `subscribe_state.cpp`.

Net: 86-line header shrinks to ~18 meaningful lines; new entity types automatically get an `InitialStateIterator` override when added to `entity_types.h`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactor, no user-visible change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal API refactor.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).