### PR TITLE
[api] Use entity_types.h X-macro for ListEntitiesIterator declarations

### DIFF
--- a/esphome/components/api/list_entities.h
+++ b/esphome/components/api/list_entities.h
@@ -18,83 +18,22 @@ class APIConnection;
 class ListEntitiesIterator final : public ComponentIterator {
  public:
   ListEntitiesIterator(APIConnection *client);
-#ifdef USE_BINARY_SENSOR
-  bool on_binary_sensor(binary_sensor::BinarySensor *entity) override;
-#endif
-#ifdef USE_COVER
-  bool on_cover(cover::Cover *entity) override;
-#endif
-#ifdef USE_FAN
-  bool on_fan(fan::Fan *entity) override;
-#endif
-#ifdef USE_LIGHT
-  bool on_light(light::LightState *entity) override;
-#endif
-#ifdef USE_SENSOR
-  bool on_sensor(sensor::Sensor *entity) override;
-#endif
-#ifdef USE_SWITCH
-  bool on_switch(switch_::Switch *entity) override;
-#endif
-#ifdef USE_BUTTON
-  bool on_button(button::Button *entity) override;
-#endif
-#ifdef USE_TEXT_SENSOR
-  bool on_text_sensor(text_sensor::TextSensor *entity) override;
-#endif
+
+// Entity overrides (generated from entity_types.h).
+// All implementations live in list_entities.cpp via LIST_ENTITIES_HANDLER.
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define ENTITY_TYPE_(type, singular, plural, count, upper) bool on_##singular(type *entity) override;
+#define ENTITY_CONTROLLER_TYPE_(type, singular, plural, count, upper, callback) \
+  ENTITY_TYPE_(type, singular, plural, count, upper)
+#include "esphome/core/entity_types.h"
+#undef ENTITY_TYPE_
+#undef ENTITY_CONTROLLER_TYPE_
+  // NOLINTEND(bugprone-macro-parentheses)
 #ifdef USE_API_USER_DEFINED_ACTIONS
   bool on_service(UserServiceDescriptor *service) override;
 #endif
 #ifdef USE_CAMERA
   bool on_camera(camera::Camera *entity) override;
-#endif
-#ifdef USE_CLIMATE
-  bool on_climate(climate::Climate *entity) override;
-#endif
-#ifdef USE_NUMBER
-  bool on_number(number::Number *entity) override;
-#endif
-#ifdef USE_DATETIME_DATE
-  bool on_date(datetime::DateEntity *entity) override;
-#endif
-#ifdef USE_DATETIME_TIME
-  bool on_time(datetime::TimeEntity *entity) override;
-#endif
-#ifdef USE_DATETIME_DATETIME
-  bool on_datetime(datetime::DateTimeEntity *entity) override;
-#endif
-#ifdef USE_TEXT
-  bool on_text(text::Text *entity) override;
-#endif
-#ifdef USE_SELECT
-  bool on_select(select::Select *entity) override;
-#endif
-#ifdef USE_LOCK
-  bool on_lock(lock::Lock *entity) override;
-#endif
-#ifdef USE_VALVE
-  bool on_valve(valve::Valve *entity) override;
-#endif
-#ifdef USE_MEDIA_PLAYER
-  bool on_media_player(media_player::MediaPlayer *entity) override;
-#endif
-#ifdef USE_ALARM_CONTROL_PANEL
-  bool on_alarm_control_panel(alarm_control_panel::AlarmControlPanel *entity) override;
-#endif
-#ifdef USE_WATER_HEATER
-  bool on_water_heater(water_heater::WaterHeater *entity) override;
-#endif
-#ifdef USE_INFRARED
-  bool on_infrared(infrared::Infrared *entity) override;
-#endif
-#ifdef USE_RADIO_FREQUENCY
-  bool on_radio_frequency(radio_frequency::RadioFrequency *entity) override;
-#endif
-#ifdef USE_EVENT
-  bool on_event(event::Event *entity) override;
-#endif
-#ifdef USE_UPDATE
-  bool on_update(update::UpdateEntity *entity) override;
 #endif
   bool on_end() override;
 


### PR DESCRIPTION
# What does this implement/fix?

Replaces the long, hand-maintained list of `#ifdef USE_*` / `on_<entity>` override declarations in `esphome/components/api/list_entities.h` with the existing `esphome/core/entity_types.h` X-macro (already used by `application.h`, `component_iterator.h`, and #16075).

All entity overrides in `ListEntitiesIterator` are simple forward declarations whose implementations live in `list_entities.cpp` via the existing `LIST_ENTITIES_HANDLER` macro, so both `ENTITY_TYPE_` and `ENTITY_CONTROLLER_TYPE_` map to the same forward-declaration form. The non-entity overrides (`on_service`, `on_camera`, `on_end`) stay as manual entries since they are not in `entity_types.h`.

Net: 11 insertions, 72 deletions. New entity types added to `entity_types.h` automatically get a `ListEntitiesIterator` override.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (follow-up to #16075)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal refactor, no user-visible change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config change — internal API refactor.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).