### PR TITLE
[spi][http_request][demo] Fix latent clang-tidy issues in headers

### DIFF
--- a/esphome/components/demo/demo_alarm_control_panel.h
+++ b/esphome/components/demo/demo_alarm_control_panel.h
@@ -29,7 +29,7 @@ class DemoAlarmControlPanel : public AlarmControlPanel, public Component {
  protected:
   void control(const AlarmControlPanelCall &call) override {
     auto state = call.get_state().value_or(ACP_STATE_DISARMED);
-    auto code = call.get_code();
+    const auto &code = call.get_code();
     switch (state) {
       case ACP_STATE_ARMED_AWAY:
         if (this->get_requires_code_to_arm()) {

--- a/esphome/components/http_request/http_request.h
+++ b/esphome/components/http_request/http_request.h
@@ -462,7 +462,7 @@ template<typename... Ts> class HttpRequestSendAction : public Action<Ts...> {
     this->request_headers_.push_back({key, value});
   }
 
-  void add_collect_header(const char *value) { this->lower_case_collect_headers_.push_back(value); }
+  void add_collect_header(const char *value) { this->lower_case_collect_headers_.emplace_back(value); }
 
   void init_json(size_t count) { this->json_.init(count); }
   void add_json(const char *key, TemplatableValue<std::string, Ts...> value) { this->json_.push_back({key, value}); }

--- a/esphome/components/spi/spi.h
+++ b/esphome/components/spi/spi.h
@@ -451,7 +451,7 @@ class SPIDevice : public SPIClient {
 
   uint8_t read_byte() { return this->delegate_->transfer(0); }
 
-  void read_array(uint8_t *data, size_t length) { return this->delegate_->read_array(data, length); }
+  void read_array(uint8_t *data, size_t length) { this->delegate_->read_array(data, length); }
 
   /**
    * Write a single data item, up to 32 bits.


### PR DESCRIPTION
# What does this implement/fix?

Three pre-existing clang-tidy issues in headers, surfaced while migrating clang-tidy from 18.1.8 to 22.1.0.1 (#16078). Splitting them out so the bump doesn't have to carry them.

All three are also flagged by clang-tidy 18 — they aren't new-in-22.

- **`esphome/components/spi/spi.h:454`** — drop the `return` keyword in a `void` function (the body already returns `void`). Fixes `readability-avoid-return-with-void-value`.

  ```cpp
  // before
  void read_array(uint8_t *data, size_t length) { return this->delegate_->read_array(data, length); }
  // after
  void read_array(uint8_t *data, size_t length) { this->delegate_->read_array(data, length); }
  ```

- **`esphome/components/http_request/http_request.h:465`** — `push_back` → `emplace_back` for a `const char *` going into `std::vector<std::string>`. Skips a temporary string move. Fixes `modernize-use-emplace`.

  ```cpp
  // before
  void add_collect_header(const char *value) { this->lower_case_collect_headers_.push_back(value); }
  // after
  void add_collect_header(const char *value) { this->lower_case_collect_headers_.emplace_back(value); }
  ```

- **`esphome/components/demo/demo_alarm_control_panel.h:32`** — bind `call.get_code()` (which returns `const optional<std::string> &`) to `const auto &` instead of copying the whole optional. Fixes `performance-unnecessary-copy-initialization`.

  ```cpp
  // before
  auto code = call.get_code();
  // after
  const auto &code = call.get_code();
  ```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Split out from #16078 (clang-tidy 18 → 22 migration)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).