### PR TITLE
[pipsolar] Guard handle_qmod_ against empty message

### DIFF
--- a/esphome/components/pipsolar/pipsolar.cpp
+++ b/esphome/components/pipsolar/pipsolar.cpp
@@ -433,13 +433,17 @@ void Pipsolar::handle_qpigs_(const char *message) {
 }
 
 void Pipsolar::handle_qmod_(const char *message) {
-  std::string mode;
-  char device_mode = char(message[1]);
   if (this->last_qmod_) {
     this->last_qmod_->publish_state(message);
   }
+  // QMOD response is "(M" where M is the device-mode character. Bail out if the
+  // message is shorter than 2 chars (e.g. empty error response from
+  // handle_poll_error_) — reading message[1] would otherwise be out of bounds.
+  if (message[0] == '\0' || message[1] == '\0')
+    return;
   if (this->device_mode_) {
-    mode = device_mode;
+    std::string mode;
+    mode = char(message[1]);
     this->device_mode_->publish_state(mode);
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `clang-analyzer-security.ArrayBound` check (new in 22) while migrating from clang-tidy 18 (#16078).

`Pipsolar::handle_poll_error_` dispatches an empty string `""` through `handle_poll_response_` when a poll fails:

```cpp
void Pipsolar::handle_poll_error_(ENUMPollingCommand polling_command) {
  // handlers are designed in a way that an empty message sets all sensors to unknown
  this->handle_poll_response_(polling_command, "");
}
```

All other q-handlers respect that contract — they use length-aware helpers (`read_field_` / `skip_field_` walk the string until `'\0'`) or strlen-bounded loops. `handle_qmod_` was the exception:

```cpp
void Pipsolar::handle_qmod_(const char *message) {
  std::string mode;
  char device_mode = char(message[1]);  // ← UB on the empty-message error path
  ...
}
```

For `message = ""`, only `message[0]` (the `'\0'`) is in-bounds; reading `message[1]` is past the array's end.

Fix: move the raw `last_qmod_` publish above the parse so it still emits `""` on the error path (consistent with other handlers), and guard the device-mode parse on `message[0]` and `message[1]` being non-null.

```cpp
void Pipsolar::handle_qmod_(const char *message) {
  if (this->last_qmod_) {
    this->last_qmod_->publish_state(message);
  }
  // QMOD response is "(M" where M is the device-mode character. Bail out if the
  // message is shorter than 2 chars (e.g. empty error response from
  // handle_poll_error_) — reading message[1] would otherwise be out of bounds.
  if (message[0] == '\0' || message[1] == '\0')
    return;
  if (this->device_mode_) {
    std::string mode;
    mode = char(message[1]);
    this->device_mode_->publish_state(mode);
  }
}
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).