### PR TITLE
[tlc5971] Remove dead bit-banging delay code

### DIFF
--- a/esphome/components/tlc5971/tlc5971.cpp
+++ b/esphome/components/tlc5971/tlc5971.cpp
@@ -68,13 +68,8 @@ void TLC5971::transfer_(uint8_t send) {
   uint8_t startbit = 0x80;
 
   bool towrite, lastmosi = !(send & startbit);
-  uint8_t bitdelay_us = (1000000 / 1000000) / 2;
 
   for (uint8_t b = startbit; b != 0; b = b >> 1) {
-    if (bitdelay_us) {
-      delayMicroseconds(bitdelay_us);
-    }
-
     towrite = send & b;
     if ((lastmosi != towrite)) {
       this->data_pin_->digital_write(towrite);
@@ -82,11 +77,6 @@ void TLC5971::transfer_(uint8_t send) {
     }
 
     this->clock_pin_->digital_write(true);
-
-    if (bitdelay_us) {
-      delayMicroseconds(bitdelay_us);
-    }
-
     this->clock_pin_->digital_write(false);
   }
 }


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `misc-redundant-expression` check while migrating from clang-tidy 18 (#16078).

```cpp
uint8_t bitdelay_us = (1000000 / 1000000) / 2;
```

The `(1000000 / 1000000)` expression is redundant (`1 / 1`). The full expression evaluates to `0` (integer division: `1 / 2`), so both `if (bitdelay_us) delayMicroseconds(...)` calls in `transfer_()` are dead code — the guard always evaluates false.

The original commit (#6494) likely intended the second `1000000` to be the SCLK frequency (the pattern from Adafruit's TLC59711 driver, where the calculation would be `1000000 / spi_clock_freq_hz / 2`), but the literal value made it a no-op from day one. Bit-banging on ESP32/ESP8266 is already much slower than the TLC5971's 30 MHz SCLK max, so no delay is needed regardless.

Drop the unused variable and dead branches.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).