### PR TITLE
[bme680] Rename cal1/cal2 to coeff1/coeff2

### DIFF
--- a/esphome/components/bme680/bme680.cpp
+++ b/esphome/components/bme680/bme680.cpp
@@ -78,43 +78,43 @@ void BME680Component::setup() {
   }
 
   // Read calibration
-  uint8_t cal1[25];
-  if (!this->read_bytes(BME680_REGISTER_COEFF1, cal1, 25)) {
+  uint8_t coeff1[25];
+  if (!this->read_bytes(BME680_REGISTER_COEFF1, coeff1, 25)) {
     this->mark_failed();
     return;
   }
-  uint8_t cal2[16];
-  if (!this->read_bytes(BME680_REGISTER_COEFF2, cal2, 16)) {
+  uint8_t coeff2[16];
+  if (!this->read_bytes(BME680_REGISTER_COEFF2, coeff2, 16)) {
     this->mark_failed();
     return;
   }
 
-  this->calibration_.t1 = cal2[9] << 8 | cal2[8];
-  this->calibration_.t2 = cal1[2] << 8 | cal1[1];
-  this->calibration_.t3 = cal1[3];
+  this->calibration_.t1 = coeff2[9] << 8 | coeff2[8];
+  this->calibration_.t2 = coeff1[2] << 8 | coeff1[1];
+  this->calibration_.t3 = coeff1[3];
 
-  this->calibration_.h1 = cal2[2] << 4 | (cal2[1] & 0x0F);
-  this->calibration_.h2 = cal2[0] << 4 | cal2[1] >> 4;
-  this->calibration_.h3 = cal2[3];
-  this->calibration_.h4 = cal2[4];
-  this->calibration_.h5 = cal2[5];
-  this->calibration_.h6 = cal2[6];
-  this->calibration_.h7 = cal2[7];
+  this->calibration_.h1 = coeff2[2] << 4 | (coeff2[1] & 0x0F);
+  this->calibration_.h2 = coeff2[0] << 4 | coeff2[1] >> 4;
+  this->calibration_.h3 = coeff2[3];
+  this->calibration_.h4 = coeff2[4];
+  this->calibration_.h5 = coeff2[5];
+  this->calibration_.h6 = coeff2[6];
+  this->calibration_.h7 = coeff2[7];
 
-  this->calibration_.p1 = cal1[6] << 8 | cal1[5];
-  this->calibration_.p2 = cal1[8] << 8 | cal1[7];
-  this->calibration_.p3 = cal1[9];
-  this->calibration_.p4 = cal1[12] << 8 | cal1[11];
-  this->calibration_.p5 = cal1[14] << 8 | cal1[13];
-  this->calibration_.p6 = cal1[16];
-  this->calibration_.p7 = cal1[15];
-  this->calibration_.p8 = cal1[20] << 8 | cal1[19];
-  this->calibration_.p9 = cal1[22] << 8 | cal1[21];
-  this->calibration_.p10 = cal1[23];
+  this->calibration_.p1 = coeff1[6] << 8 | coeff1[5];
+  this->calibration_.p2 = coeff1[8] << 8 | coeff1[7];
+  this->calibration_.p3 = coeff1[9];
+  this->calibration_.p4 = coeff1[12] << 8 | coeff1[11];
+  this->calibration_.p5 = coeff1[14] << 8 | coeff1[13];
+  this->calibration_.p6 = coeff1[16];
+  this->calibration_.p7 = coeff1[15];
+  this->calibration_.p8 = coeff1[20] << 8 | coeff1[19];
+  this->calibration_.p9 = coeff1[22] << 8 | coeff1[21];
+  this->calibration_.p10 = coeff1[23];
 
-  this->calibration_.gh1 = cal2[14];
-  this->calibration_.gh2 = cal2[12] << 8 | cal2[13];
-  this->calibration_.gh3 = cal2[15];
+  this->calibration_.gh1 = coeff2[14];
+  this->calibration_.gh2 = coeff2[12] << 8 | coeff2[13];
+  this->calibration_.gh3 = coeff2[15];
 
   uint8_t temp_var = 0;
   if (!this->read_byte(0x02, &temp_var)) {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `misc-confusable-identifiers` check while migrating from clang-tidy 18 (#16078).

`cal1` is visually confusable with `call` (digit `1` versus lowercase `l`), which the check flags. The arrays hold the contents of the BME680 COEFF1 / COEFF2 register banks (read via `BME680_REGISTER_COEFF1` / `BME680_REGISTER_COEFF2`), so use those names directly — it's clearer and removes the ambiguity.

Mechanical rename, no behavior change. 30 occurrences in `bme680.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).