### PR TITLE
[esp32_ble] Widen loop variable in as_128bit() to match uuid_.len type

### DIFF
--- a/esphome/components/esp32_ble/ble_uuid.cpp
+++ b/esphome/components/esp32_ble/ble_uuid.cpp
@@ -104,7 +104,7 @@ ESPBTUUID ESPBTUUID::as_128bit() const {
   } else {
     uuid32 = this->uuid_.uuid.uuid16;
   }
-  for (uint8_t i = 0; i < this->uuid_.len; i++) {
+  for (uint16_t i = 0; i < this->uuid_.len; i++) {
     data[12 + i] = ((uuid32 >> i * 8) & 0xFF);
   }
   return ESPBTUUID::from_raw(data);


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-too-small-loop-variable` check while migrating from clang-tidy 18 (#16078).

In `ESPBTUUID::as_128bit()`:

```cpp
for (uint8_t i = 0; i < this->uuid_.len; i++) {
  data[12 + i] = ((uuid32 >> i * 8) & 0xFF);
}
```

`this->uuid_.len` is `uint16_t` in ESP-IDF's `esp_bt_uuid_t` struct, but the loop variable was `uint8_t`. In practice `len` is at most 16 (ESP_UUID_LEN_128), so the type difference is harmless, but clang-tidy correctly notes that mismatched widths are a class of bug worth flagging. Widen the loop variable to `uint16_t` to match the bound; no behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).