### PR TITLE
[dfrobot_sen0395] Brace single-statement else-if in enqueue()

### DIFF
--- a/esphome/components/dfrobot_sen0395/dfrobot_sen0395.cpp
+++ b/esphome/components/dfrobot_sen0395/dfrobot_sen0395.cpp
@@ -104,8 +104,9 @@ int8_t CircularCommandQueue::enqueue(std::unique_ptr<Command> cmd) {
   if (this->is_full()) {
     ESP_LOGE(TAG, "Command queue is full");
     return -1;
-  } else if (this->is_empty())
+  } else if (this->is_empty()) {
     front_++;
+  }
   rear_ = (rear_ + 1) % COMMAND_QUEUE_SIZE;
   commands_[rear_] = std::move(cmd);  // Transfer ownership using std::move
   return 1;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `readability-braces-around-statements` while migrating from clang-tidy 18 (#16078).

In `CircularCommandQueue::enqueue`:

```cpp
if (this->is_full()) {
  ESP_LOGE(TAG, "Command queue is full");
  return -1;
} else if (this->is_empty())
  front_++;
rear_ = (rear_ + 1) % COMMAND_QUEUE_SIZE;
```

The unbraced `else if (...) front_++;` is also visually confusable with the `rear_ = ...` line that follows (same indentation, but only one of them is part of the conditional). Add explicit braces.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).