### PR TITLE
[json] NOLINT StackAddressEscape false positive in parse_json

### DIFF
--- a/esphome/components/json/json_util.cpp
+++ b/esphome/components/json/json_util.cpp
@@ -39,7 +39,8 @@ bool parse_json(const uint8_t *data, size_t len, const json_parse_t &f) {
 }
 
 JsonDocument parse_json(const uint8_t *data, size_t len) {
-  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks) false positive with ArduinoJson
+  // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks,clang-analyzer-core.StackAddressEscape) false positives with
+  // ArduinoJson
   if (data == nullptr || len == 0) {
     ESP_LOGE(TAG, "No data to parse");
     return JsonObject();  // return unbound object
@@ -63,7 +64,7 @@ JsonDocument parse_json(const uint8_t *data, size_t len) {
   }
   ESP_LOGE(TAG, "Parse error: %s", err.c_str());
   return JsonObject();  // return unbound object
-  // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks)
+  // NOLINTEND(clang-analyzer-cplusplus.NewDeleteLeaks,clang-analyzer-core.StackAddressEscape)
 }
 
 SerializationBuffer<> JsonBuilder::serialize() {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `clang-analyzer-core.StackAddressEscape` while migrating from clang-tidy 18 (#16078).

The check fires on `return json_document;` in `parse_json` because it can't track ArduinoJson's internal pointer fix-up across the move/copy of `JsonDocument` (which holds pointers into a buffer that get rewritten on move). This is the same kind of false positive as the existing `clang-analyzer-cplusplus.NewDeleteLeaks` NOLINT in this function — both stem from the analyzer not modeling ArduinoJson internals.

Extend the existing `NOLINTBEGIN`/`NOLINTEND` pair around `parse_json(const uint8_t*, size_t)` to cover the new check too.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).