### PR TITLE
[ezo] Use make_unique to construct EzoCommand

### DIFF
--- a/esphome/components/ezo/ezo.cpp
+++ b/esphome/components/ezo/ezo.cpp
@@ -35,7 +35,7 @@ void EZOSensor::update() {
     }
 
     if (!found) {
-      std::unique_ptr<EzoCommand> ezo_command(new EzoCommand);
+      auto ezo_command = make_unique<EzoCommand>();
       ezo_command->command = "R";
       ezo_command->command_type = EzoCommandType::EZO_READ;
       ezo_command->delay_ms = 900;
@@ -162,7 +162,7 @@ void EZOSensor::loop() {
 }
 
 void EZOSensor::add_command_(const char *command, EzoCommandType command_type, uint16_t delay_ms) {
-  std::unique_ptr<EzoCommand> ezo_command(new EzoCommand);
+  auto ezo_command = make_unique<EzoCommand>();
   ezo_command->command = command;
   ezo_command->command_type = command_type;
   ezo_command->delay_ms = delay_ms;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `modernize-make-unique` while migrating from clang-tidy 18 (#16078).

```cpp
// before
std::unique_ptr<EzoCommand> ezo_command(new EzoCommand);
// after
auto ezo_command = make_unique<EzoCommand>();
```

ESPHome configures `.clang-tidy` to use its own `make_unique` helper from `esphome/core/helpers.h` as the smart-pointer factory. Replaces both call sites in `ezo.cpp`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).