### PR TITLE
[core] Reduce copies in Callback/CallbackManager call paths

### DIFF
--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1666,7 +1666,7 @@ template<typename... Ts> struct Callback<void(Ts...)> {
   void *ctx_{nullptr};
 
   /// Invoke the callback. Only valid on Callbacks created via create(), never on default-constructed instances.
-  void call(Ts... args) const { this->fn_(this->ctx_, std::move(args)...); }
+  void call(Ts... args) const { this->fn_(this->ctx_, std::forward<Ts>(args)...); }
 
   /// Create from any callable. Small trivially-copyable callables (like [this] lambdas)
   /// are stored inline in the ctx pointer without heap allocation.

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -1666,7 +1666,7 @@ template<typename... Ts> struct Callback<void(Ts...)> {
   void *ctx_{nullptr};
 
   /// Invoke the callback. Only valid on Callbacks created via create(), never on default-constructed instances.
-  void call(Ts... args) const { this->fn_(this->ctx_, args...); }
+  void call(Ts... args) const { this->fn_(this->ctx_, std::move(args)...); }
 
   /// Create from any callable. Small trivially-copyable callables (like [this] lambdas)
   /// are stored inline in the ctx pointer without heap allocation.
@@ -1742,7 +1742,7 @@ template<typename... Ts> class CallbackManager<void(Ts...)> {
   template<typename F> void add(F &&callback) { this->add_(CbType::create(std::forward<F>(callback))); }
 
   /// Call all callbacks in this manager.
-  inline void ESPHOME_ALWAYS_INLINE call(Ts... args) {
+  inline void ESPHOME_ALWAYS_INLINE call(const Ts &...args) {
     if (this->size_ != 0) {
       for (auto *it = this->data_, *end = it + this->size_; it != end; ++it) {
         it->call(args...);
@@ -1752,7 +1752,7 @@ template<typename... Ts> class CallbackManager<void(Ts...)> {
   uint16_t size() const { return this->size_; }
 
   /// Call all callbacks in this manager.
-  void operator()(Ts... args) { this->call(args...); }
+  void operator()(const Ts &...args) { this->call(args...); }
 
  protected:
   template<typename...> friend class LazyCallbackManager;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `performance-unnecessary-value-param` while migrating from clang-tidy 18 (#16078).

Two related fixes in `esphome/core/helpers.h`:

**`Callback::call` (single-shot, line 1669)** — args were copied into the call parameter, then copied again when forwarded to `fn_`. Move them on forward; args are local rvalues at that point and safe to consume since this is a `const` method and args are local to the function.

```cpp
// before
void call(Ts... args) const { this->fn_(this->ctx_, args...); }
// after
void call(Ts... args) const { this->fn_(this->ctx_, std::move(args)...); }
```

**`CallbackManager::call` and `operator()` (line 1745)** — the manager's args parameter was copied even though it's only used as a const reference to source the per-callback copy. Take by const reference; each callback still gets its own by-value copy as before (when forwarded into `Callback::call`'s value parameter), but we save the outer copy on entry to the manager.

```cpp
// before
void call(Ts... args) { ... it->call(args...); ... }
void operator()(Ts... args) { this->call(args...); }
// after
void call(const Ts &...args) { ... it->call(args...); ... }
void operator()(const Ts &...args) { this->call(args...); }
```

For `N` registered callbacks, copies go from `1 + N` to `0 + N`.

The sibling `StaticCallbackManager` and `LazyCallbackManager` templates have the same shape but weren't flagged in this scan (specific instantiations didn't trip the analyzer); leaving them for now to keep the diff minimal.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).