### PR TITLE
[binary_sensor] Bind at_index_ once in MultiClick on_state_

### DIFF
--- a/esphome/components/binary_sensor/automation.cpp
+++ b/esphome/components/binary_sensor/automation.cpp
@@ -50,29 +50,31 @@ void MultiClickTriggerBase::on_state_(bool state) {
     return;
   }
 
-  if (*this->at_index_ == this->timing_count_) {
+  // at_index_ has a value here (the !has_value() branch above returns).
+  size_t at_index = *this->at_index_;
+  if (at_index == this->timing_count_) {
     this->trigger_();
     return;
   }
 
-  MultiClickTriggerEvent evt = this->timing_[*this->at_index_];
+  MultiClickTriggerEvent evt = this->timing_[at_index];
 
   if (evt.max_length != 4294967294UL) {
-    ESP_LOGV(TAG, "A i=%zu min=%" PRIu32 " max=%" PRIu32, *this->at_index_, evt.min_length, evt.max_length);  // NOLINT
+    ESP_LOGV(TAG, "A i=%zu min=%" PRIu32 " max=%" PRIu32, at_index, evt.min_length, evt.max_length);  // NOLINT
     this->schedule_is_valid_(evt.min_length);
     this->schedule_is_not_valid_(evt.max_length);
-  } else if (*this->at_index_ + 1 != this->timing_count_) {
-    ESP_LOGV(TAG, "B i=%zu min=%" PRIu32, *this->at_index_, evt.min_length);  // NOLINT
+  } else if (at_index + 1 != this->timing_count_) {
+    ESP_LOGV(TAG, "B i=%zu min=%" PRIu32, at_index, evt.min_length);  // NOLINT
     this->cancel_timeout(MULTICLICK_IS_NOT_VALID_ID);
     this->schedule_is_valid_(evt.min_length);
   } else {
-    ESP_LOGV(TAG, "C i=%zu min=%" PRIu32, *this->at_index_, evt.min_length);  // NOLINT
+    ESP_LOGV(TAG, "C i=%zu min=%" PRIu32, at_index, evt.min_length);  // NOLINT
     this->is_valid_ = false;
     this->cancel_timeout(MULTICLICK_IS_NOT_VALID_ID);
     this->set_timeout(MULTICLICK_TRIGGER_ID, evt.min_length, [this]() { this->trigger_(); });
   }
 
-  *this->at_index_ = *this->at_index_ + 1;
+  this->at_index_ = at_index + 1;
 }
 void MultiClickTriggerBase::schedule_cooldown_() {
   ESP_LOGV(TAG, "Multi Click: Invalid length of press, starting cooldown of %" PRIu32 " ms", this->invalid_cooldown_);


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` while migrating from clang-tidy 18 (#16078).

In `MultiClickTriggerBase::on_state_`, the function does an early-return at the top if `at_index_.has_value() == false`:

```cpp
if (!this->at_index_.has_value()) {
  ...
  return;
}
```

After that point, `at_index_` is guaranteed to hold a value, but the function then dereferences it via `*this->at_index_` seven times across the body (in equality checks, indexing, log messages, and a self-assignment `*at_index_ = *at_index_ + 1`). The clang-22 analyzer cannot propagate the precondition across the early-return and flags each subsequent deref.

Bind `*at_index_` to a local `at_index` once the value is known. This is both cleaner (one deref instead of seven) and silences the check. Also replaces the awkward in-place self-assignment with a plain `this->at_index_ = at_index + 1`.

```cpp
// at_index_ has a value here (the !has_value() branch above returns).
size_t at_index = *this->at_index_;
if (at_index == this->timing_count_) {
  ...
}

MultiClickTriggerEvent evt = this->timing_[at_index];
// ... uses at_index throughout ...

this->at_index_ = at_index + 1;
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).