### PR TITLE
[online_image][sim800l] Use std::string::starts_with for prefix checks

### DIFF
--- a/esphome/components/online_image/online_image.cpp
+++ b/esphome/components/online_image/online_image.cpp
@@ -28,7 +28,7 @@ bool OnlineImage::validate_url_(const std::string &url) {
     ESP_LOGE(TAG, "URL is too long");
     return false;
   }
-  if (url.compare(0, 7, "http://") != 0 && url.compare(0, 8, "https://") != 0) {
+  if (!url.starts_with("http://") && !url.starts_with("https://")) {
     ESP_LOGE(TAG, "URL must start with http:// or https://");
     return false;
   }

--- a/esphome/components/sim800l/sim800l.cpp
+++ b/esphome/components/sim800l/sim800l.cpp
@@ -110,7 +110,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
     case STATE_INIT: {
       // While we were waiting for update to check for messages, this notifies a message
       // is available.
-      bool message_available = message.compare(0, 6, "+CMTI:") == 0;
+      bool message_available = message.starts_with("+CMTI:");
       if (!message_available) {
         if (message == "RING") {
           // Incoming call...
@@ -120,7 +120,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
             this->call_state_ = 6;
             this->call_disconnected_callback_.call();
           }
-        } else if (message.compare(0, 6, "+CUSD:") == 0) {
+        } else if (message.starts_with("+CUSD:")) {
           // Incoming USSD MESSAGE
           this->state_ = STATE_CHECK_USSD;
         }
@@ -175,7 +175,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       break;
     case STATE_CHECK_USSD:
       ESP_LOGD(TAG, "Check ussd code: '%s'", message.c_str());
-      if (message.compare(0, 6, "+CUSD:") == 0) {
+      if (message.starts_with("+CUSD:")) {
         this->state_ = STATE_RECEIVED_USSD;
         this->ussd_ = "";
         size_t start = 10;
@@ -196,8 +196,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
     case STATE_CREG_WAIT: {
       // Response: "+CREG: 0,1" -- the one there means registered ok
       //           "+CREG: -,-" means not registered ok
-      bool registered =
-          message.size() > 9 && message.compare(0, 6, "+CREG:") == 0 && (message[9] == '1' || message[9] == '5');
+      bool registered = message.size() > 9 && message.starts_with("+CREG:") && (message[9] == '1' || message[9] == '5');
       if (registered) {
         if (!this->registered_) {
           ESP_LOGD(TAG, "Registered OK");
@@ -223,7 +222,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       this->state_ = STATE_CSQ_RESPONSE;
       break;
     case STATE_CSQ_RESPONSE:
-      if (message.compare(0, 5, "+CSQ:") == 0) {
+      if (message.starts_with("+CSQ:")) {
         size_t comma = message.find(',', 6);
         if (comma != 6) {
           int rssi = parse_number<int>(message.substr(6, comma - 6)).value_or(0);
@@ -243,7 +242,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       this->state_ = STATE_CHECK_SMS;
       break;
     case STATE_PARSE_SMS_RESPONSE:
-      if (message.compare(0, 6, "+CMGL:") == 0 && this->parse_index_ == 0) {
+      if (message.starts_with("+CMGL:") && this->parse_index_ == 0) {
         size_t start = 7;
         size_t end = message.find(',', start);
         uint8_t item = 0;
@@ -278,7 +277,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       }
       break;
     case STATE_CHECK_CALL:
-      if (message.compare(0, 6, "+CLCC:") == 0 && this->parse_index_ == 0) {
+      if (message.starts_with("+CLCC:") && this->parse_index_ == 0) {
         this->expect_ack_ = true;
         size_t start = 7;
         size_t end = message.find(',', start);
@@ -324,7 +323,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       /* Our recipient is set and the message body is in message
         kick ESPHome callback now
       */
-      if (ok || message.compare(0, 6, "+CMGL:") == 0) {
+      if (ok || message.starts_with("+CMGL:")) {
         ESP_LOGD(TAG,
                  "Received SMS from: %s\n"
                  "  %s",
@@ -360,7 +359,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       }
       break;
     case STATE_SENDING_SMS_3:
-      if (message.compare(0, 6, "+CMGS:") == 0) {
+      if (message.starts_with("+CMGS:")) {
         ESP_LOGD(TAG, "SMS Sent OK: %s", message.c_str());
         this->send_pending_ = false;
         this->state_ = STATE_CHECK_SMS;
@@ -383,7 +382,7 @@ void Sim800LComponent::parse_cmd_(std::string message) {
       this->state_ = STATE_INIT;
       break;
     case STATE_PARSE_CLIP:
-      if (message.compare(0, 6, "+CLIP:") == 0) {
+      if (message.starts_with("+CLIP:")) {
         std::string caller_id;
         size_t start = 7;
         size_t end = message.find(',', start);


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `modernize-use-starts-ends-with` while migrating from clang-tidy 18 (#16078).

Replaces `compare(0, n, prefix) == 0` with C++20's `starts_with(prefix)` — more readable and removes the off-by-one risk of having to keep the length argument `n` in sync with the literal `prefix` (e.g. `compare(0, 6, "+CUSD:")` would silently break if someone changed the prefix to `"+CUSDX:"` without updating the `6`).

- **`online_image/online_image.cpp:31`** — 1 line, 2 sites (HTTP/HTTPS URL prefix guard).
- **`sim800l/sim800l.cpp`** — 8 sites (modem response prefix checks: `+CMTI:`, `+CUSD:` ×2, `+CREG:`, `+CSQ:`, `+CMGL:` ×2, `+CLCC:`, `+CMGS:`, `+CLIP:`). The 5 flagged by the CI run are fixed plus the 3 sibling ones in the same file using the same pattern.

ESPHome targets `gnu++20` so `std::string::starts_with` is available.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).