### PR TITLE
[i2c] NOLINT readability-identifier-naming on Zephyr struct forward-decl

### DIFF
--- a/esphome/components/i2c/i2c_bus_zephyr.h
+++ b/esphome/components/i2c/i2c_bus_zephyr.h
@@ -5,7 +5,7 @@
 #include "i2c_bus.h"
 #include "esphome/core/component.h"
 
-struct device;
+struct device;  // NOLINT(readability-identifier-naming) - forward decl of Zephyr's device type
 
 namespace esphome::i2c {
 


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `readability-identifier-naming` while migrating from clang-tidy 18 (#16078).

The forward declaration `struct device;` in `i2c_bus_zephyr.h` is needed so `ZephyrI2CBus` can hold a `const device *` pointer without including Zephyr's `device.h` transitively in the public ESPHome header. Zephyr uses lower_case for its struct names (third-party convention), but ESPHome's `.clang-tidy` configures `readability-identifier-naming.StructCase: 'CamelCase'`. NOLINT this single forward-decl rather than weakening the project-wide naming rule.

```cpp
struct device;  // NOLINT(readability-identifier-naming) - forward decl of Zephyr's device type
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).