### PR TITLE
[dsp408] Add Dayton Audio DSP-408 USB host integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,8 +143,8 @@ esphome/components/dlms_meter/* @SimonFischer04
 esphome/components/dps310/* @kbx81
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/ds2484/* @mrk-its
-esphome/components/dsp408/* @malaiwah
 esphome/components/dsmr/* @glmnet @PolarGoose
+esphome/components/dsp408/* @malaiwah
 esphome/components/duty_time/* @dudanov
 esphome/components/ee895/* @Stock-M
 esphome/components/ektf2232/touchscreen/* @jesserockz

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -143,6 +143,7 @@ esphome/components/dlms_meter/* @SimonFischer04
 esphome/components/dps310/* @kbx81
 esphome/components/ds1307/* @badbadc0ffee
 esphome/components/ds2484/* @mrk-its
+esphome/components/dsp408/* @malaiwah
 esphome/components/dsmr/* @glmnet @PolarGoose
 esphome/components/duty_time/* @dudanov
 esphome/components/ee895/* @Stock-M

--- a/esphome/components/dsp408/__init__.py
+++ b/esphome/components/dsp408/__init__.py
@@ -22,6 +22,11 @@ MULTI_CONF = True
 # Used by sub-platform configs to attach entities to a specific DSP-408
 # instance via ``dsp408_id:`` references.
 CONF_DSP408_ID = "dsp408_id"
+# Shared by every sub-platform to disambiguate the entity role
+# (master vs per-channel volume, HPF type vs LPF slope, etc.). Defined
+# once here to satisfy ci-custom (constants used in >=5 files must
+# either live here or in esphome/components/const/__init__.py).
+CONF_KIND = "kind"
 
 dsp408_ns = cg.esphome_ns.namespace("dsp408")
 DSP408 = dsp408_ns.class_("DSP408", cg.Component)

--- a/esphome/components/dsp408/__init__.py
+++ b/esphome/components/dsp408/__init__.py
@@ -1,0 +1,36 @@
+"""ESPHome component for the Dayton Audio DSP-408 over native USB host.
+
+Talks to a USB-attached DSP-408 (VID 0x0483 / PID 0x5750) directly from
+an ESP32-S3 / S2 / P4's native USB host peripheral. Protocol port of
+dsp408-py (https://github.com/malaiwah/dsp408-py) — same 64-byte HID
+frame layout, same command codes, same field semantics.
+"""
+
+import esphome.codegen as cg
+from esphome.components.usb_host import register_usb_client, usb_device_schema
+
+CODEOWNERS = ["@malaiwah"]
+DEPENDENCIES = ["esp32", "usb_host"]
+# AUTO_LOAD pulls in the platforms our C++ unconditionally references.
+# Sub-platform Python files (number/, switch/, text_sensor/, select/, text/)
+# are also auto-loaded by ESPHome when their entities appear in the user's
+# YAML, but listing them here ensures the C++ includes always resolve even
+# in a minimal config that only declares the parent.
+AUTO_LOAD = ["usb_host", "text", "select"]
+MULTI_CONF = True
+
+# Used by sub-platform configs to attach entities to a specific DSP-408
+# instance via ``dsp408_id:`` references.
+CONF_DSP408_ID = "dsp408_id"
+
+dsp408_ns = cg.esphome_ns.namespace("dsp408")
+DSP408 = dsp408_ns.class_("DSP408", cg.Component)
+
+# Default to the DSP-408's known USB IDs but allow override (e.g. if
+# someone wants to use this on the sibling DSP-816 firmware which
+# shares the protocol skeleton).
+CONFIG_SCHEMA = usb_device_schema(DSP408, vid=0x0483, pid=0x5750)
+
+
+async def to_code(config):
+    return await register_usb_client(config)

--- a/esphome/components/dsp408/dsp408.cpp
+++ b/esphome/components/dsp408/dsp408.cpp
@@ -1,0 +1,1378 @@
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
+#include "dsp408.h"
+#include "protocol.h"
+
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
+#include "esphome/core/log.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/text/text.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/select/select.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace esphome {
+namespace dsp408 {
+
+static const char *const TAG = "dsp408";
+
+static const char *cmd_name(uint32_t cmd) {
+  switch (cmd) {
+    case CMD_CONNECT:
+      return "CONNECT";
+    case CMD_GET_INFO:
+      return "GET_INFO";
+    case CMD_MASTER:
+      return "MASTER";
+    case CMD_IDLE_POLL:
+      return "IDLE_POLL";
+    case CMD_PRESET_NAME:
+      return "PRESET_NAME";
+    case CMD_STATUS:
+      return "STATUS";
+    default:
+      if (cmd >= 0x7700 && cmd <= 0x7707)
+        return "READ_CH";
+      if (cmd >= 0x1F00 && cmd <= 0x1F07)
+        return "WRITE_CH";
+      if (cmd >= 0x12000 && cmd <= 0x12007)
+        return "WRITE_XOVER";
+      return "?";
+  }
+}
+
+void DSP408::setup() {
+  USBClient::setup();
+  ESP_LOGCONFIG(TAG, "DSP-408 USB host client initialised (VID 0x%04X PID 0x%04X)", DSP408_VID, DSP408_PID);
+}
+
+void DSP408::dump_config() {
+  USBClient::dump_config();
+  static const char *const PHASE_NAMES[] = {
+      "IDLE", "WAIT_AFTER_CONNECT", "SENT_CONNECT", "SENT_GET_INFO", "SENT_GET_MASTER", "WARMUP_CHANNELS", "RUNNING",
+  };
+  uint8_t phase_idx = static_cast<uint8_t>(this->phase_);
+  const char *phase_name = (phase_idx < 7) ? PHASE_NAMES[phase_idx] : "?";
+
+  ESP_LOGCONFIG(TAG,
+                "  DSP-408\n"
+                "    Interface claimed: %s (intf=%u)\n"
+                "    EP-IN:  0x%02X (mps=%u)\n"
+                "    EP-OUT: 0x%02X (mps=%u)\n"
+                "    Phase: %s\n"
+                "    Master: %s (%+d dB, %s)\n"
+                "    Preset name: %s\n"
+                "    Master poll interval: %u ms\n"
+                "    Republish stagger: %u ms",
+                YESNO(this->interface_claimed_), this->intf_number_, this->ep_in_ ? this->ep_in_->bEndpointAddress : 0,
+                this->ep_in_ ? this->ep_in_->wMaxPacketSize : 0, this->ep_out_ ? this->ep_out_->bEndpointAddress : 0,
+                this->ep_out_ ? this->ep_out_->wMaxPacketSize : 0, phase_name, YESNO(this->master_known_),
+                this->master_db_, this->master_muted_ ? "muted" : "audible",
+                this->preset_name_known_ ? this->preset_name_ : "<unknown>",
+                static_cast<unsigned>(MASTER_POLL_INTERVAL_MS), static_cast<unsigned>(REPUBLISH_STAGGER_MS));
+  // Per-channel dump if any state has been read
+  for (uint8_t ch = 0; ch < 8; ch++) {
+    const ChannelState &c = this->ch_state_[ch];
+    if (!c.primed)
+      continue;
+    ESP_LOGCONFIG(TAG, "    Ch%u: %+.1f dB %s%s name=\"%s\"  HPF=%uHz/F=%u/S=%u  LPF=%uHz/F=%u/S=%u", ch,
+                  static_cast<float>(c.db_x10) / 10.0f, c.muted ? "(muted)" : "(audible)", c.polar ? " (POLAR)" : "",
+                  c.name, c.hpf_freq_hz, c.hpf_filter, c.hpf_slope, c.lpf_freq_hz, c.lpf_filter, c.lpf_slope);
+  }
+}
+
+void DSP408::on_connected() {
+  ESP_LOGI(TAG, "USB device opened — searching for HID interface...");
+  if (!this->find_hid_endpoints_()) {
+    ESP_LOGE(TAG, "No HID interface with EP-IN + EP-OUT found");
+    this->status_set_error(LOG_STR("No HID interface"));
+    this->disconnect();
+    return;
+  }
+
+  auto err = usb_host_interface_claim(this->handle_, this->device_handle_, this->intf_number_, /*alt=*/0);
+  if (err != ESP_OK) {
+    ESP_LOGE(TAG, "usb_host_interface_claim(intf=%u) failed: %s", this->intf_number_, esp_err_to_name(err));
+    this->status_set_error(LOG_STR("interface_claim failed"));
+    this->disconnect();
+    return;
+  }
+  this->interface_claimed_ = true;
+  this->status_clear_error();
+  ESP_LOGI(TAG, "Claimed HID interface %u, EP-IN=0x%02X EP-OUT=0x%02X", this->intf_number_,
+           this->ep_in_->bEndpointAddress, this->ep_out_->bEndpointAddress);
+
+  // Kick off the IN pump.
+  this->input_pending_.store(false);
+  this->start_input_();
+
+  // Defer the first OUT command by a short interval so the device
+  // settles after enumeration. dsp408-py does this implicitly via the
+  // hidapi open_path round-trip.
+  this->phase_ = StartupPhase::WAIT_AFTER_CONNECT;
+  this->phase_started_ms_ = millis();
+  this->connected_at_ms_ = this->phase_started_ms_;
+  this->cmd_in_flight_ = 0;
+  this->enable_loop();
+}
+
+void DSP408::on_disconnected() {
+  ESP_LOGI(TAG, "USB device disconnected");
+  // Reset multi-frame state so a stale partial blob doesn't confuse a
+  // subsequent re-attach.
+  this->mf_in_progress_ = false;
+  this->mf_collected_len_ = 0;
+  if (this->interface_claimed_ && this->ep_in_ != nullptr) {
+    usb_host_endpoint_halt(this->device_handle_, this->ep_in_->bEndpointAddress);
+    usb_host_endpoint_flush(this->device_handle_, this->ep_in_->bEndpointAddress);
+  }
+  if (this->interface_claimed_ && this->ep_out_ != nullptr) {
+    usb_host_endpoint_halt(this->device_handle_, this->ep_out_->bEndpointAddress);
+    usb_host_endpoint_flush(this->device_handle_, this->ep_out_->bEndpointAddress);
+  }
+  if (this->interface_claimed_) {
+    usb_host_interface_release(this->handle_, this->device_handle_, this->intf_number_);
+    this->interface_claimed_ = false;
+  }
+  this->ep_in_ = nullptr;
+  this->ep_out_ = nullptr;
+  this->intf_number_ = 0xFF;
+  this->phase_ = StartupPhase::IDLE;
+  this->cmd_in_flight_ = 0;
+  this->master_known_ = false;
+  this->snapshot_pending_ch_ = 0xFF;
+  USBClient::on_disconnected();
+}
+
+bool DSP408::find_hid_endpoints_() {
+  const usb_config_desc_t *config_desc;
+  if (usb_host_get_active_config_descriptor(this->device_handle_, &config_desc) != ESP_OK) {
+    ESP_LOGE(TAG, "get_active_config_descriptor failed");
+    return false;
+  }
+  int conf_offset = 0;
+  for (uint8_t intf_idx = 0; intf_idx < config_desc->bNumInterfaces; intf_idx++) {
+    const auto *intf = usb_parse_interface_descriptor(config_desc, intf_idx, /*alt=*/0, &conf_offset);
+    if (!intf)
+      continue;
+    ESP_LOGD(TAG, "intf %u: class=0x%02X subclass=0x%02X proto=0x%02X eps=%u", intf->bInterfaceNumber,
+             intf->bInterfaceClass, intf->bInterfaceSubClass, intf->bInterfaceProtocol, intf->bNumEndpoints);
+    if (intf->bInterfaceClass != 0x03) {  // not HID — skip
+      continue;
+    }
+    const usb_ep_desc_t *ep_in = nullptr;
+    const usb_ep_desc_t *ep_out = nullptr;
+    for (uint8_t i = 0; i < intf->bNumEndpoints; i++) {
+      int ep_offset = conf_offset;
+      const auto *ep = usb_parse_endpoint_descriptor_by_index(intf, i, config_desc->wTotalLength, &ep_offset);
+      if (!ep)
+        break;
+      ESP_LOGD(TAG, "  ep %u: addr=0x%02X attr=0x%02X mps=%u", i, ep->bEndpointAddress, ep->bmAttributes,
+               ep->wMaxPacketSize);
+      if ((ep->bmAttributes & 0x03) != USB_BM_ATTRIBUTES_XFER_INT)
+        continue;
+      if (ep->bEndpointAddress & usb_host::USB_DIR_IN) {
+        if (ep_in == nullptr)
+          ep_in = ep;
+      } else {
+        if (ep_out == nullptr)
+          ep_out = ep;
+      }
+    }
+    if (ep_in != nullptr && ep_out != nullptr) {
+      this->intf_number_ = intf->bInterfaceNumber;
+      this->ep_in_ = ep_in;
+      this->ep_out_ = ep_out;
+      return true;
+    }
+  }
+  return false;
+}
+
+void DSP408::start_input_() {
+  if (!this->interface_claimed_ || this->ep_in_ == nullptr)
+    return;
+  // Compare-exchange to ensure single in-flight IN at a time.
+  bool expected = false;
+  if (!this->input_pending_.compare_exchange_strong(expected, true))
+    return;
+  auto cb = [this](const usb_host::TransferStatus &status) { this->on_in_report_usb_task_(status); };
+  if (!this->transfer_in(this->ep_in_->bEndpointAddress, cb, 64)) {
+    ESP_LOGE(TAG, "transfer_in submit failed");
+    this->input_pending_.store(false);
+  }
+}
+
+// USB-task context. Keep it short: copy data into a queued slot,
+// wake main loop, restart IN.
+void DSP408::on_in_report_usb_task_(const usb_host::TransferStatus &status) {
+  if (status.success && status.data_len > 0 && status.data_len <= 64) {
+    InReport *rep = this->in_pool_.allocate();
+    if (rep != nullptr) {
+      memcpy(rep->data, status.data, status.data_len);
+      rep->length = static_cast<uint16_t>(status.data_len);
+      this->in_queue_.push(rep);
+      this->enable_loop_soon_any_context();
+      App.wake_loop_threadsafe();
+    } else {
+      // Pool empty — drop the report; we'll catch up next iteration.
+      ESP_LOGW(TAG, "IN pool exhausted, dropping report");
+    }
+  } else if (!status.success) {
+    ESP_LOGW(TAG, "IN transfer failed status=0x%X", status.error_code);
+  }
+  this->input_pending_.store(false);
+  // Restart the IN pump unconditionally — the device may still be alive.
+  this->start_input_();
+}
+
+void DSP408::loop() {
+  // Always drain the USB-event queue inherited from USBClient.
+  bool had_work = this->process_usb_events_();
+
+  // Drain inbound HID reports.
+  this->process_in_queue_();
+
+  // Drive the startup state machine.
+  uint32_t now = millis();
+  switch (this->phase_) {
+    case StartupPhase::WAIT_AFTER_CONNECT:
+      // 50ms grace post-claim before sending CMD_CONNECT
+      if (now - this->phase_started_ms_ >= 50) {
+        if (this->send_connect_()) {
+          this->phase_ = StartupPhase::SENT_CONNECT;
+          this->phase_started_ms_ = now;
+          had_work = true;
+        }
+      }
+      break;
+    case StartupPhase::SENT_CONNECT:
+    case StartupPhase::SENT_GET_INFO:
+    case StartupPhase::SENT_GET_MASTER:
+    case StartupPhase::WARMUP_CHANNELS:
+      // Watchdog timeout — if no reply in REQUEST_TIMEOUT_MS, retry the
+      // whole startup from CMD_CONNECT.
+      if (this->cmd_in_flight_ != 0 && now - this->cmd_in_flight_started_ms_ > REQUEST_TIMEOUT_MS) {
+        ESP_LOGW(TAG, "Timeout waiting for reply to %s — restarting startup", cmd_name(this->cmd_in_flight_));
+        this->cmd_in_flight_ = 0;
+        this->mf_in_progress_ = false;
+        this->mf_collected_len_ = 0;
+        this->phase_ = StartupPhase::WAIT_AFTER_CONNECT;
+        this->phase_started_ms_ = now;
+      }
+      break;
+    case StartupPhase::RUNNING:
+      // Periodic master state poll if no command in flight.
+      if (this->cmd_in_flight_ == 0 && now - this->last_master_poll_ms_ > MASTER_POLL_INTERVAL_MS) {
+        this->send_get_master_();
+        this->last_master_poll_ms_ = now;
+        had_work = true;
+      }
+      // Round-robin re-publish of ONE channel's cached state per
+      // REPUBLISH_STAGGER_MS tick. Channel state is only read on
+      // warmup; if the API client wasn't connected then (or churned
+      // its connection), entities stay 'unavailable' forever. We
+      // re-publish to make any HA reconnect see fresh state — but
+      // staggered to avoid bursting 8 × 6 entity states in one tick,
+      // which overruns the API send buffer for large surfaces.
+      if (now - this->last_republish_ms_ > REPUBLISH_STAGGER_MS) {
+        uint8_t ch = this->republish_channel_rr_;
+        if (this->ch_state_[ch].primed) {
+          this->publish_channel_state_(ch);
+        }
+        this->republish_channel_rr_ = (ch + 1) & 0x07;
+        this->last_republish_ms_ = now;
+        // Also republish preset name occasionally on the 0th channel
+        // tick so it doesn't fall through cracks.
+        if (ch == 0 && this->preset_name_known_ && this->preset_name_text_ != nullptr) {
+          this->preset_name_text_->publish_state(std::string(this->preset_name_));
+        }
+        had_work = true;
+      }
+      break;
+    case StartupPhase::IDLE:
+    default:
+      break;
+  }
+
+  // ESPHome will keep loop() running while we have work; otherwise we
+  // can ride along with the next inbound report or scheduled poll.
+  if (!had_work) {
+    // Don't disable_loop() here — USBClient's loop() handles event-pump
+    // and we may still be polling. Keep it cheap and let ESPHome's
+    // scheduler run us at its normal cadence.
+  }
+}
+
+void DSP408::process_in_queue_() {
+  InReport *rep;
+  while ((rep = this->in_queue_.pop()) != nullptr) {
+    this->dispatch_frame_(*rep);
+    this->in_pool_.release(rep);
+  }
+}
+
+void DSP408::dispatch_frame_(const InReport &report) {
+  // Multi-frame continuation path — when reassembly is in progress, we
+  // expect the next inbound HID report(s) to be RAW continuation bytes
+  // (no DSP-408 header). The Python lib does the same: it stops parsing
+  // headers on continuation reports and just concatenates the next
+  // (declared_len - collected) bytes. The chk + end markers live
+  // in-stream at offset declared_len within the continuation payload
+  // of the LAST continuation report.
+  if (this->mf_in_progress_) {
+    size_t want = this->mf_declared_len_ - this->mf_collected_len_;
+    size_t take = report.length;
+    if (take > want)
+      take = want;
+    memcpy(this->mf_buffer_ + this->mf_collected_len_, report.data, take);
+    this->mf_collected_len_ += take;
+    if (this->mf_collected_len_ >= this->mf_declared_len_) {
+      // Fully collected. Validate checksum (lenient — Python lib doesn't
+      // either; the firmware appears to always emit valid checksums but
+      // we don't gate dispatch on it).
+      uint8_t want_chk = xor_checksum(this->mf_header_, sizeof(this->mf_header_));
+      want_chk ^= xor_checksum(this->mf_buffer_, this->mf_declared_len_);
+      uint8_t got_chk = 0;
+      if (take < report.length)
+        got_chk = report.data[take];
+      else
+        got_chk = 0xFF;  // chk wasn't in this report; we'd need yet another
+      bool chk_ok = (got_chk == want_chk);
+      ESP_LOGV(TAG, "<- multi-frame complete cmd=0x%X len=%u chk=%s", static_cast<unsigned>(this->mf_cmd_),
+               this->mf_declared_len_, chk_ok ? "ok" : "MISMATCH");
+
+      uint32_t cmd = this->mf_cmd_;
+      this->mf_in_progress_ = false;
+      this->mf_collected_len_ = 0;
+
+      // Clear in-flight marker — match the cmd loosely (firmware can
+      // return seq=0 for reads).
+      if (this->cmd_in_flight_ == cmd)
+        this->cmd_in_flight_ = 0;
+
+      // Dispatch the assembled blob.
+      if (cmd >= CMD_READ_CHANNEL_BASE && cmd < CMD_READ_CHANNEL_BASE + 8) {
+        uint8_t ch = static_cast<uint8_t>(cmd - CMD_READ_CHANNEL_BASE);
+        this->handle_channel_state_blob_(ch, this->mf_buffer_, this->mf_declared_len_);
+      } else {
+        ESP_LOGW(TAG, "Multi-frame complete for unhandled cmd 0x%X", static_cast<unsigned>(cmd));
+      }
+    }
+    return;
+  }
+
+  ParsedFrame f = parse_frame(report.data, report.length);
+  if (!f.valid) {
+    ESP_LOGV(TAG, "Inbound report not a DSP-408 frame (len=%u)", report.length);
+    return;
+  }
+  // Only accept replies (RESP / WRITE_ACK).
+  if (f.direction != DIR_RESP && f.direction != DIR_WRITE_ACK) {
+    ESP_LOGV(TAG, "Inbound frame with unexpected direction 0x%02X", f.direction);
+    return;
+  }
+  ESP_LOGV(TAG, "<- dir=0x%02X cat=0x%02X cmd=0x%X seq=%u len=%u%s", f.direction, f.category,
+           static_cast<unsigned>(f.cmd), f.seq, f.payload_len, f.is_multi_frame_first ? " (MF)" : "");
+
+  // Multi-frame first — start reassembly, don't dispatch yet.
+  if (f.is_multi_frame_first) {
+    if (f.payload_len > sizeof(this->mf_buffer_)) {
+      ESP_LOGE(TAG, "Multi-frame declared len=%u exceeds buffer (%u)", f.payload_len,
+               static_cast<unsigned>(sizeof(this->mf_buffer_)));
+      return;
+    }
+    this->mf_in_progress_ = true;
+    this->mf_cmd_ = f.cmd;
+    this->mf_direction_ = f.direction;
+    this->mf_category_ = f.category;
+    this->mf_declared_len_ = f.payload_len;
+    this->mf_collected_len_ = 0;
+    memcpy(this->mf_header_, report.data + 4, sizeof(this->mf_header_));
+    // Copy first chunk of payload (50 bytes for a multi-frame first).
+    memcpy(this->mf_buffer_, f.payload, f.payload_bytes_in_frame);
+    this->mf_collected_len_ = f.payload_bytes_in_frame;
+    return;
+  }
+
+  // Single-frame: clear in-flight then dispatch by cmd.
+  if (this->cmd_in_flight_ == f.cmd)
+    this->cmd_in_flight_ = 0;
+
+  switch (f.cmd) {
+    case CMD_CONNECT:
+      this->handle_connect_reply_(f.payload, f.payload_bytes_in_frame);
+      break;
+    case CMD_GET_INFO:
+      this->handle_get_info_reply_(f.payload, f.payload_bytes_in_frame);
+      break;
+    case CMD_MASTER:
+      this->handle_master_reply_(f.payload, f.payload_bytes_in_frame, f.direction == DIR_WRITE_ACK);
+      break;
+    case CMD_PRESET_NAME:
+      this->handle_preset_name_reply_(f.payload, f.payload_bytes_in_frame, f.direction == DIR_WRITE_ACK);
+      break;
+    default:
+      if (f.cmd >= CMD_WRITE_CHANNEL_BASE && f.cmd < CMD_WRITE_CHANNEL_BASE + 8) {
+        this->handle_channel_write_ack_(f.cmd, f.payload, f.payload_bytes_in_frame);
+      } else if (f.cmd >= CMD_WRITE_CROSSOVER_BASE && f.cmd < CMD_WRITE_CROSSOVER_BASE + 8) {
+        this->handle_crossover_write_ack_(f.cmd, f.payload, f.payload_bytes_in_frame);
+      } else if (f.cmd >= CMD_ROUTING_BASE && f.cmd < CMD_ROUTING_BASE + 8) {
+        this->handle_routing_write_ack_(f.cmd, f.payload, f.payload_bytes_in_frame);
+      } else if (f.cmd >= CMD_WRITE_EQ_BAND_BASE && f.cmd < CMD_WRITE_EQ_BAND_BASE + (10 * 0x100) + 8) {
+        this->handle_eq_band_write_ack_(f.cmd, f.payload, f.payload_bytes_in_frame);
+      } else if (f.cmd >= CMD_WRITE_CHANNEL_NAME_BASE && f.cmd < CMD_WRITE_CHANNEL_NAME_BASE + 8) {
+        this->handle_channel_name_write_ack_(f.cmd, f.payload, f.payload_bytes_in_frame);
+      } else if (f.cmd >= CMD_WRITE_COMPRESSOR_BASE && f.cmd < CMD_WRITE_COMPRESSOR_BASE + 8) {
+        ESP_LOGD(TAG, "Compressor ch%u write ack (len=%u)", static_cast<uint8_t>(f.cmd - CMD_WRITE_COMPRESSOR_BASE),
+                 static_cast<unsigned>(f.payload_bytes_in_frame));
+      } else if (f.cmd >= 0x10000u && f.cmd < 0x10008u) {
+        // Full-channel-state write ACK (cmd=0x10000+ch). Single 0-byte
+        // WRITE_ACK comes after the device finishes consuming all 5
+        // multi-frame continuation reports.
+        ESP_LOGI(TAG, "Full-channel-state ch%u write ack", static_cast<uint8_t>(f.cmd - 0x10000u));
+      } else if (f.cmd >= 0x0900u && f.cmd < 0x0908u) {
+        // Input MISC (cat=0x03) write ack.
+        ESP_LOGD(TAG, "Input ch%u MISC write ack", static_cast<uint8_t>(f.cmd - 0x0900u));
+      } else {
+        ESP_LOGV(TAG, "Unhandled cmd 0x%X", static_cast<unsigned>(f.cmd));
+      }
+      break;
+  }
+}
+
+bool DSP408::send_cmd_(uint8_t direction, uint32_t cmd, uint8_t category, const uint8_t *payload, size_t payload_len,
+                       uint8_t seq) {
+  if (!this->interface_claimed_ || this->ep_out_ == nullptr) {
+    ESP_LOGW(TAG, "send_cmd: interface not ready");
+    return false;
+  }
+  uint8_t frame[FRAME_SIZE];
+  if (!build_frame(frame, direction, seq, cmd, category, payload, payload_len)) {
+    ESP_LOGE(TAG, "build_frame failed (payload too large?)");
+    return false;
+  }
+  ESP_LOGV(TAG, "-> dir=0x%02X cat=0x%02X cmd=0x%X seq=%u len=%u", direction, category, static_cast<unsigned>(cmd), seq,
+           static_cast<unsigned>(payload_len));
+  auto cb = [this, cmd](const usb_host::TransferStatus &status) {
+    if (!status.success) {
+      ESP_LOGW(TAG, "OUT submit for cmd=0x%X failed status=0x%X", static_cast<unsigned>(cmd), status.error_code);
+    }
+  };
+  bool ok = this->transfer_out(this->ep_out_->bEndpointAddress, cb, frame, FRAME_SIZE);
+  if (ok) {
+    this->cmd_in_flight_ = cmd;
+    this->cmd_in_flight_started_ms_ = millis();
+    this->cmd_in_flight_seq_ = seq;
+    this->cmd_in_flight_dir_ = direction;
+  }
+  return ok;
+}
+
+bool DSP408::send_connect_() {
+  return this->send_cmd_(DIR_CMD, CMD_CONNECT, CAT_STATE, nullptr, 0, this->next_read_seq_++);
+}
+
+bool DSP408::send_get_info_() {
+  return this->send_cmd_(DIR_CMD, CMD_GET_INFO, CAT_STATE, nullptr, 0, this->next_read_seq_++);
+}
+
+bool DSP408::send_get_master_() {
+  return this->send_cmd_(DIR_CMD, CMD_MASTER, CAT_STATE, nullptr, 0, this->next_read_seq_++);
+}
+
+bool DSP408::send_set_master_(uint8_t lvl_raw, bool muted) {
+  // Per dsp408-py: payload = [lvl, 00, 00, 32, 00, 32, mute_bit, 00]
+  // mute_bit: 1 = unmuted/audible, 0 = muted.
+  uint8_t payload[8] = {lvl_raw, 0x00, 0x00, 0x32, 0x00, 0x32, static_cast<uint8_t>(muted ? 0 : 1), 0x00};
+  return this->send_cmd_(DIR_WRITE, CMD_MASTER, CAT_STATE, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_read_channel_(uint8_t ch) {
+  if (ch >= 8)
+    return false;
+  uint32_t cmd = CMD_READ_CHANNEL_BASE + ch;
+  // 8 zero bytes is what the Windows GUI sends as the read payload.
+  uint8_t payload[8] = {0};
+  return this->send_cmd_(DIR_CMD, cmd, CAT_PARAM, payload, sizeof(payload), this->next_read_seq_++);
+}
+
+bool DSP408::send_set_crossover_(uint8_t ch) {
+  if (ch >= 8)
+    return false;
+  ChannelState &c = this->ch_state_[ch];
+  uint8_t payload[8] = {
+      static_cast<uint8_t>(c.hpf_freq_hz & 0xFF),
+      static_cast<uint8_t>((c.hpf_freq_hz >> 8) & 0xFF),
+      c.hpf_filter,
+      c.hpf_slope,
+      static_cast<uint8_t>(c.lpf_freq_hz & 0xFF),
+      static_cast<uint8_t>((c.lpf_freq_hz >> 8) & 0xFF),
+      c.lpf_filter,
+      c.lpf_slope,
+  };
+  uint32_t cmd = CMD_WRITE_CROSSOVER_BASE + ch;
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_set_routing_(uint8_t ch) {
+  if (ch >= 8)
+    return false;
+  ChannelState &c = this->ch_state_[ch];
+  uint32_t cmd = CMD_ROUTING_BASE + ch;
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, c.routing_lo, sizeof(c.routing_lo), 0);
+}
+
+bool DSP408::send_set_eq_band_(uint8_t ch, uint8_t band, uint16_t freq_hz, int16_t gain_raw, uint8_t b4_byte) {
+  if (ch >= 8 || band >= EQ_BAND_COUNT)
+    return false;
+  uint8_t payload[8] = {
+      static_cast<uint8_t>(freq_hz & 0xFF),
+      static_cast<uint8_t>((freq_hz >> 8) & 0xFF),
+      static_cast<uint8_t>(gain_raw & 0xFF),
+      static_cast<uint8_t>((gain_raw >> 8) & 0xFF),
+      b4_byte,
+      0x00,
+      0x00,
+      0x00,
+  };
+  uint32_t cmd = CMD_WRITE_EQ_BAND_BASE + (static_cast<uint32_t>(band) << 8) + static_cast<uint32_t>(ch);
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_get_preset_name_() {
+  return this->send_cmd_(DIR_CMD, CMD_PRESET_NAME, CAT_STATE, nullptr, 0, this->next_read_seq_++);
+}
+
+bool DSP408::send_set_preset_name_(const std::string &name) {
+  // Preset name is 15-byte ASCII NUL-padded.
+  uint8_t payload[15] = {};
+  size_t n = std::min(name.size(), sizeof(payload));
+  memcpy(payload, name.data(), n);
+  return this->send_cmd_(DIR_WRITE, CMD_PRESET_NAME, CAT_STATE, payload, sizeof(payload), 0);
+}
+
+bool DSP408::submit_raw_frame_(const uint8_t *frame64) {
+  if (!this->interface_claimed_ || this->ep_out_ == nullptr)
+    return false;
+  auto cb = [](const usb_host::TransferStatus &status) {
+    if (!status.success) {
+      ESP_LOGW(TAG, "raw OUT submit failed status=0x%X", status.error_code);
+    }
+  };
+  return this->transfer_out(this->ep_out_->bEndpointAddress, cb, frame64, FRAME_SIZE);
+}
+
+bool DSP408::send_set_full_channel_state_(uint8_t ch, const uint8_t *blob, size_t blob_len) {
+  if (ch >= 8)
+    return false;
+  if (blob_len != CHANNEL_BLOB_SIZE) {
+    ESP_LOGE(TAG, "set_full_channel_state: expected %u bytes, got %u", static_cast<unsigned>(CHANNEL_BLOB_SIZE),
+             static_cast<unsigned>(blob_len));
+    return false;
+  }
+  // Use the LO-base path (0x10000+ch) — the variant the Windows GUI's
+  // "Load preset from disk" flow emits. cat=CAT_PARAM, dir=a1, seq=0.
+  uint32_t cmd = 0x10000u + ch;
+  uint8_t frames[FRAME_SIZE * 6] = {};  // 5 frames + 1 spill safety
+  size_t n_frames = build_frames_multi(frames, sizeof(frames), DIR_WRITE, 0, cmd, CAT_PARAM, blob, blob_len);
+  if (n_frames == 0) {
+    ESP_LOGE(TAG, "build_frames_multi returned 0");
+    return false;
+  }
+  ESP_LOGD(TAG, "Multi-frame WRITE ch%u: %u frames, cmd=0x%X", ch, static_cast<unsigned>(n_frames),
+           static_cast<unsigned>(cmd));
+
+  // Submit all frames back-to-back. The device receives them as one
+  // logical packet because the FIRST frame's payload_len header field
+  // declares 296 bytes; the firmware reads continuation reports until
+  // declared length is satisfied.
+  for (size_t i = 0; i < n_frames; i++) {
+    if (!this->submit_raw_frame_(frames + i * FRAME_SIZE)) {
+      ESP_LOGE(TAG, "Multi-frame ch%u submit failed at frame %u", ch, static_cast<unsigned>(i));
+      return false;
+    }
+  }
+  // Track in-flight on the FIRST frame's cmd. Single 0-byte WRITE_ACK
+  // is expected after the LAST frame.
+  this->cmd_in_flight_ = cmd;
+  this->cmd_in_flight_started_ms_ = millis();
+  this->cmd_in_flight_seq_ = 0;
+  this->cmd_in_flight_dir_ = DIR_WRITE;
+  return true;
+}
+
+bool DSP408::send_set_compressor_(uint8_t ch) {
+  if (ch >= 8)
+    return false;
+  ChannelState &c = this->ch_state_[ch];
+  uint8_t payload[8] = {
+      static_cast<uint8_t>(c.comp_all_pass_q & 0xFF),
+      static_cast<uint8_t>((c.comp_all_pass_q >> 8) & 0xFF),
+      static_cast<uint8_t>(c.comp_attack_ms & 0xFF),
+      static_cast<uint8_t>((c.comp_attack_ms >> 8) & 0xFF),
+      static_cast<uint8_t>(c.comp_release_ms & 0xFF),
+      static_cast<uint8_t>((c.comp_release_ms >> 8) & 0xFF),
+      c.comp_threshold,
+      c.comp_linkgroup,
+  };
+  uint32_t cmd = CMD_WRITE_COMPRESSOR_BASE + ch;
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_set_input_misc_(uint8_t input_ch) {
+  if (input_ch >= 8)
+    return false;
+  // dsp408-py CMD_WRITE_INPUT_MISC_BASE = 0x0900. Payload layout (per
+  // dsp408-py protocol.py): [feedback, polar, mode, mute, delay_le16,
+  // volume, spare]. We only have polar wired up — write zeros for the
+  // rest. The firmware appears to apply each field independently
+  // (verified for polar live; the others are firmware-inert anyway).
+  InputState &is = this->input_state_[input_ch];
+  uint8_t payload[8] = {
+      0,  // feedback
+      static_cast<uint8_t>(is.polar ? 1 : 0),
+      0,
+      0,  // mode, mute
+      0,
+      0,  // delay LE16
+      0,  // volume
+      0,  // spare
+  };
+  uint32_t cmd = 0x0900u + input_ch;  // CMD_WRITE_INPUT_MISC_BASE + ch
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_INPUT, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_set_channel_name_(uint8_t ch, const std::string &name) {
+  if (ch >= 8)
+    return false;
+  uint8_t payload[8] = {};
+  size_t n = std::min(name.size(), sizeof(payload));
+  memcpy(payload, name.data(), n);
+  uint32_t cmd = CMD_WRITE_CHANNEL_NAME_BASE + ch;
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, payload, sizeof(payload), 0);
+}
+
+bool DSP408::send_set_channel_(uint8_t ch) {
+  if (ch >= 8)
+    return false;
+  ChannelState &c = this->ch_state_[ch];
+  uint8_t subidx = c.subidx != 0 ? c.subidx : CHANNEL_SUBIDX_DEFAULT[ch];
+
+  // gain raw = db_x10 + 600, clamped to [0..600] (= -60..0 dB)
+  int gain = static_cast<int>(c.db_x10) + CHANNEL_VOL_OFFSET;
+  if (gain < CHANNEL_VOL_MIN)
+    gain = CHANNEL_VOL_MIN;
+  if (gain > CHANNEL_VOL_MAX)
+    gain = CHANNEL_VOL_MAX;
+  uint16_t gain_u16 = static_cast<uint16_t>(gain);
+
+  uint16_t delay = c.delay_samples;
+  if (delay > CHANNEL_DELAY_MAX)
+    delay = CHANNEL_DELAY_MAX;
+
+  uint8_t payload[8] = {
+      static_cast<uint8_t>(c.muted ? 0 : 1),  // [0] enable: 1=audible, 0=muted
+      static_cast<uint8_t>(c.polar ? 1 : 0),  // [1] polar: 1=inverted
+      static_cast<uint8_t>(gain_u16 & 0xFF),  // [2..3] gain LE
+      static_cast<uint8_t>((gain_u16 >> 8) & 0xFF),
+      static_cast<uint8_t>(delay & 0xFF),  // [4..5] delay LE
+      static_cast<uint8_t>((delay >> 8) & 0xFF),
+      c.byte_254,  // [6] preserved verbatim
+      subidx,      // [7] DSP channel-type
+  };
+  uint32_t cmd = CMD_WRITE_CHANNEL_BASE + ch;
+  // cmd=0x1F00..0x1F07 is in the parameter range — Python's
+  // ``category_hint()`` returns CAT_PARAM (0x04) for it. The DSP-408
+  // firmware happens to also accept CAT_STATE (0x09) here, but matching
+  // the Windows GUI / Python wire format exactly is more conservative.
+  return this->send_cmd_(DIR_WRITE, cmd, CAT_PARAM, payload, sizeof(payload), 0);
+}
+
+void DSP408::handle_connect_reply_(const uint8_t *payload, size_t len) {
+  if (len == 0) {
+    ESP_LOGW(TAG, "CONNECT reply with empty payload");
+    return;
+  }
+  ESP_LOGI(TAG, "CONNECT ok (status=0x%02X)", payload[0]);
+  // Move to GET_INFO
+  if (this->send_get_info_()) {
+    this->phase_ = StartupPhase::SENT_GET_INFO;
+    this->phase_started_ms_ = millis();
+  }
+}
+
+void DSP408::handle_get_info_reply_(const uint8_t *payload, size_t len) {
+  // ASCII identity, e.g. "MYDW-AV1.06"
+  std::string s;
+  for (size_t i = 0; i < len; i++) {
+    if (payload[i] == 0)
+      break;
+    s.push_back(static_cast<char>(payload[i]));
+  }
+  ESP_LOGI(TAG, "GET_INFO: '%s'", s.c_str());
+  if (this->model_ts_ != nullptr)
+    this->model_ts_->publish_state(s);
+  // Move on to read master state
+  if (this->send_get_master_()) {
+    this->phase_ = StartupPhase::SENT_GET_MASTER;
+    this->phase_started_ms_ = millis();
+  }
+}
+
+void DSP408::handle_master_reply_(const uint8_t *payload, size_t len, bool is_ack) {
+  if (is_ack && len == 0) {
+    // WRITE_ACKs to CMD_MASTER carry no payload — that's normal. Don't
+    // overwrite the cached state from the optimistic-publish path; the
+    // periodic poll will reaffirm it within MASTER_POLL_INTERVAL_MS.
+    ESP_LOGD(TAG, "MASTER write ack");
+    return;
+  }
+  if (len < 8) {
+    ESP_LOGW(TAG, "MASTER reply too short (%u bytes)", static_cast<unsigned>(len));
+    return;
+  }
+  uint8_t lvl = payload[0];
+  bool muted = payload[6] == 0;  // 1 = audible, 0 = muted
+  this->master_known_ = true;
+  this->master_db_ = static_cast<int8_t>(static_cast<int>(lvl) - MASTER_LEVEL_OFFSET);
+  this->master_muted_ = muted;
+  ESP_LOGI(TAG, "MASTER %s: %+d dB %s", is_ack ? "ack" : "read", this->master_db_, muted ? "(muted)" : "(audible)");
+
+  if (this->master_vol_num_ != nullptr)
+    this->master_vol_num_->publish_state(static_cast<float>(this->master_db_));
+  if (this->master_mute_sw_ != nullptr)
+    this->master_mute_sw_->publish_state(this->master_muted_);
+
+  if (this->phase_ == StartupPhase::SENT_GET_MASTER) {
+    // Move on to channel warmup — read each channel's state to drain
+    // the firmware's startup write-drop quirk AND populate our cache
+    // from device truth before any user-driven writes go out.
+    this->phase_ = StartupPhase::WARMUP_CHANNELS;
+    this->warmup_channel_ = 0;
+    this->warmup_attempt_ = 0;
+    this->warmup_have_prev_ = false;
+    this->phase_started_ms_ = millis();
+    if (this->send_read_channel_(this->warmup_channel_)) {
+      ESP_LOGD(TAG, "Warmup: reading channel %u (attempt 1)", this->warmup_channel_);
+    }
+  }
+}
+
+void DSP408::handle_channel_state_blob_(uint8_t ch, const uint8_t *blob, size_t len) {
+  if (ch >= 8)
+    return;
+  if (len < CHANNEL_BLOB_SIZE) {
+    ESP_LOGW(TAG, "Channel %u blob too short: %u bytes", ch, static_cast<unsigned>(len));
+    return;
+  }
+
+  // Read-divergence retry — the firmware sometimes emits a 2-byte-shifted
+  // (or worse) variant of the EQ region. dsp408-py's
+  // ``read_channel_state(retry_on_divergence=True)`` re-reads up to
+  // MAX_BLOB_RETRY times, accepting the first blob that agrees with its
+  // predecessor. We mirror that here during the warmup phase. After
+  // warmup we don't re-read, so steady-state operation is unaffected.
+  if (this->phase_ == StartupPhase::WARMUP_CHANNELS && ch == this->warmup_channel_) {
+    bool converged = this->warmup_have_prev_ && memcmp(blob, this->warmup_prev_blob_, CHANNEL_BLOB_SIZE) == 0;
+    if (!converged && this->warmup_attempt_ + 1 < MAX_BLOB_RETRY) {
+      // Save this blob and re-read.
+      memcpy(this->warmup_prev_blob_, blob, CHANNEL_BLOB_SIZE);
+      this->warmup_have_prev_ = true;
+      this->warmup_attempt_++;
+      ESP_LOGD(TAG, "Ch%u: read divergence — retry attempt %u", ch, this->warmup_attempt_ + 1);
+      if (!this->send_read_channel_(ch)) {
+        ESP_LOGW(TAG, "Ch%u: failed to submit retry read", ch);
+      }
+      return;
+    }
+    if (!converged) {
+      ESP_LOGW(TAG, "Ch%u: %u attempts did not converge — accepting last blob", ch, MAX_BLOB_RETRY);
+    } else if (this->warmup_attempt_ > 0) {
+      ESP_LOGD(TAG, "Ch%u: converged after %u attempts", ch, this->warmup_attempt_ + 1);
+    }
+  }
+
+  ChannelState &c = this->ch_state_[ch];
+  // Decode the 296-byte blob — offsets verified live by dsp408-py
+  // against Windows GUI captures.
+  uint16_t gain_raw = static_cast<uint16_t>(blob[OFF_GAIN]) | (static_cast<uint16_t>(blob[OFF_GAIN + 1]) << 8);
+  c.muted = (blob[OFF_MUTE] == 0);  // INVERTED polarity (1 = audible)
+  c.polar = (blob[OFF_POLAR] != 0);
+  // dB×10 from raw: db_x10 = raw - 600. Range -600..0 = -60.0..0.0 dB.
+  c.db_x10 = static_cast<int16_t>(static_cast<int>(gain_raw) - CHANNEL_VOL_OFFSET);
+  c.delay_samples = static_cast<uint16_t>(blob[OFF_DELAY]) | (static_cast<uint16_t>(blob[OFF_DELAY + 1]) << 8);
+  c.byte_254 = blob[OFF_BYTE_254];
+  c.subidx = blob[OFF_SPK_TYPE];
+
+  c.hpf_freq_hz = static_cast<uint16_t>(blob[OFF_HPF_FREQ]) | (static_cast<uint16_t>(blob[OFF_HPF_FREQ + 1]) << 8);
+  c.hpf_filter = blob[OFF_HPF_FILTER];
+  c.hpf_slope = blob[OFF_HPF_SLOPE];
+  c.lpf_freq_hz = static_cast<uint16_t>(blob[OFF_LPF_FREQ]) | (static_cast<uint16_t>(blob[OFF_LPF_FREQ + 1]) << 8);
+  c.lpf_filter = blob[OFF_LPF_FILTER];
+  c.lpf_slope = blob[OFF_LPF_SLOPE];
+
+  // Output routing matrix (low bank — IN1..IN8 levels at offsets 264..271)
+  memcpy(c.routing_lo, blob + OFF_MIXER, sizeof(c.routing_lo));
+
+  // Per-channel name (8 bytes ASCII at offsets 288..295, NUL-padded)
+  memcpy(c.name, blob + OFF_NAME, NAME_LEN);
+  c.name[NAME_LEN] = '\0';
+
+  // Compressor block (firmware-inert in v1.06 but tracked for parity).
+  c.comp_all_pass_q =
+      static_cast<uint16_t>(blob[OFF_ALL_PASS_Q]) | (static_cast<uint16_t>(blob[OFF_ALL_PASS_Q + 1]) << 8);
+  c.comp_attack_ms = static_cast<uint16_t>(blob[OFF_ATTACK_MS]) | (static_cast<uint16_t>(blob[OFF_ATTACK_MS + 1]) << 8);
+  c.comp_release_ms =
+      static_cast<uint16_t>(blob[OFF_RELEASE_MS]) | (static_cast<uint16_t>(blob[OFF_RELEASE_MS + 1]) << 8);
+  c.comp_threshold = blob[OFF_THRESHOLD];
+  c.comp_linkgroup = blob[OFF_LINKGROUP];
+
+  c.primed = true;
+
+  ESP_LOGI(TAG, "Ch%u: %+.1f dB %s%s delay=%u  HPF=%uHz/%u/%u  LPF=%uHz/%u/%u  subidx=0x%02X", ch,
+           static_cast<float>(c.db_x10) / 10.0f, c.muted ? "(muted)" : "(audible)", c.polar ? " (POLAR)" : "",
+           c.delay_samples, c.hpf_freq_hz, c.hpf_filter, c.hpf_slope, c.lpf_freq_hz, c.lpf_filter, c.lpf_slope,
+           c.subidx);
+
+  this->publish_channel_state_(ch);
+
+  // Snapshot save (read-modify-write): if a snapshot is pending for
+  // this channel, overlay the cached basic-record fields onto the
+  // live blob (preserving EQ region + everything else byte-for-byte)
+  // and submit a multi-frame WRITE to commit to the device's flash.
+  if (this->snapshot_pending_ch_ == ch && this->phase_ == StartupPhase::RUNNING) {
+    uint8_t out_blob[CHANNEL_BLOB_SIZE];
+    memcpy(out_blob, blob, CHANNEL_BLOB_SIZE);  // start from device truth
+    // Overlay basic-record (offsets 248..295) from cache. Any HA-driven
+    // writes since the last warmup are reflected in the cache; this
+    // ensures they're committed to flash via the multi-frame WRITE.
+    out_blob[OFF_MUTE] = c.muted ? 0 : 1;
+    out_blob[OFF_POLAR] = c.polar ? 1 : 0;
+    uint16_t gain_raw = static_cast<uint16_t>(static_cast<int>(c.db_x10) + CHANNEL_VOL_OFFSET);
+    out_blob[OFF_GAIN] = gain_raw & 0xFF;
+    out_blob[OFF_GAIN + 1] = (gain_raw >> 8) & 0xFF;
+    out_blob[OFF_DELAY] = c.delay_samples & 0xFF;
+    out_blob[OFF_DELAY + 1] = (c.delay_samples >> 8) & 0xFF;
+    out_blob[OFF_BYTE_254] = c.byte_254;
+    out_blob[OFF_SPK_TYPE] = c.subidx ? c.subidx : CHANNEL_SUBIDX_DEFAULT[ch];
+    out_blob[OFF_HPF_FREQ] = c.hpf_freq_hz & 0xFF;
+    out_blob[OFF_HPF_FREQ + 1] = (c.hpf_freq_hz >> 8) & 0xFF;
+    out_blob[OFF_HPF_FILTER] = c.hpf_filter;
+    out_blob[OFF_HPF_SLOPE] = c.hpf_slope;
+    out_blob[OFF_LPF_FREQ] = c.lpf_freq_hz & 0xFF;
+    out_blob[OFF_LPF_FREQ + 1] = (c.lpf_freq_hz >> 8) & 0xFF;
+    out_blob[OFF_LPF_FILTER] = c.lpf_filter;
+    out_blob[OFF_LPF_SLOPE] = c.lpf_slope;
+    memcpy(out_blob + OFF_MIXER, c.routing_lo, sizeof(c.routing_lo));
+    out_blob[OFF_ALL_PASS_Q] = c.comp_all_pass_q & 0xFF;
+    out_blob[OFF_ALL_PASS_Q + 1] = (c.comp_all_pass_q >> 8) & 0xFF;
+    out_blob[OFF_ATTACK_MS] = c.comp_attack_ms & 0xFF;
+    out_blob[OFF_ATTACK_MS + 1] = (c.comp_attack_ms >> 8) & 0xFF;
+    out_blob[OFF_RELEASE_MS] = c.comp_release_ms & 0xFF;
+    out_blob[OFF_RELEASE_MS + 1] = (c.comp_release_ms >> 8) & 0xFF;
+    out_blob[OFF_THRESHOLD] = c.comp_threshold;
+    out_blob[OFF_LINKGROUP] = c.comp_linkgroup;
+    memcpy(out_blob + OFF_NAME, c.name, NAME_LEN);
+    ESP_LOGI(TAG, "Snapshot save ch%u: writing %u-byte blob (EQ preserved)", ch,
+             static_cast<unsigned>(CHANNEL_BLOB_SIZE));
+    this->send_set_full_channel_state_(ch, out_blob, sizeof(out_blob));
+    this->snapshot_pending_ch_ = 0xFF;
+  }
+
+  // Warmup phase advance.
+  if (this->phase_ == StartupPhase::WARMUP_CHANNELS && ch == this->warmup_channel_) {
+    this->warmup_channel_++;
+    this->warmup_attempt_ = 0;
+    this->warmup_have_prev_ = false;
+    if (this->warmup_channel_ >= 8) {
+      this->phase_ = StartupPhase::RUNNING;
+      uint32_t now = millis();
+      this->last_master_poll_ms_ = now;
+      ESP_LOGI(TAG, "DSP-408 ready (full state read; startup took %u ms)",
+               static_cast<unsigned>(now - this->connected_at_ms_));
+      // Fire-and-forget preset-name read — the reply arrives async and
+      // the entity (if any) gets published. Failure here is non-fatal.
+      this->send_get_preset_name_();
+    } else {
+      // Kick off the next channel read.
+      if (!this->send_read_channel_(this->warmup_channel_)) {
+        ESP_LOGW(TAG, "Failed to submit channel %u read", this->warmup_channel_);
+      }
+    }
+  }
+}
+
+void DSP408::handle_crossover_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len) {
+  uint8_t ch = static_cast<uint8_t>(cmd - 0x12000);
+  ESP_LOGD(TAG, "Crossover ch%u write ack (len=%u)", ch, static_cast<unsigned>(len));
+  if (ch < 8) {
+    ChannelState &c = this->ch_state_[ch];
+    if (this->ch_hpf_freq_num_[ch] != nullptr)
+      this->ch_hpf_freq_num_[ch]->publish_state(static_cast<float>(c.hpf_freq_hz));
+    if (this->ch_lpf_freq_num_[ch] != nullptr)
+      this->ch_lpf_freq_num_[ch]->publish_state(static_cast<float>(c.lpf_freq_hz));
+  }
+  (void) payload;
+}
+
+void DSP408::handle_routing_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len) {
+  uint8_t ch = static_cast<uint8_t>(cmd - CMD_ROUTING_BASE);
+  ESP_LOGD(TAG, "Routing ch%u write ack (len=%u)", ch, static_cast<unsigned>(len));
+  (void) payload;
+}
+
+void DSP408::handle_eq_band_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len) {
+  uint32_t off = cmd - CMD_WRITE_EQ_BAND_BASE;
+  uint8_t band = static_cast<uint8_t>((off >> 8) & 0xFF);
+  uint8_t ch = static_cast<uint8_t>(off & 0xFF);
+  ESP_LOGD(TAG, "EQ ch%u band%u write ack (len=%u)", ch, band, static_cast<unsigned>(len));
+  (void) payload;
+}
+
+void DSP408::handle_channel_name_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len) {
+  uint8_t ch = static_cast<uint8_t>(cmd - CMD_WRITE_CHANNEL_NAME_BASE);
+  ESP_LOGD(TAG, "Channel name ch%u write ack (len=%u)", ch, static_cast<unsigned>(len));
+  if (ch < 8 && this->ch_name_text_[ch] != nullptr) {
+    // Re-publish from cache (we cached the desired name in request_channel_name).
+    this->ch_name_text_[ch]->publish_state(std::string(this->ch_state_[ch].name));
+  }
+  (void) payload;
+}
+
+void DSP408::handle_preset_name_reply_(const uint8_t *payload, size_t len, bool is_ack) {
+  if (is_ack) {
+    ESP_LOGD(TAG, "Preset-name write ack");
+    return;
+  }
+  // Read reply: 15 bytes ASCII (firmware NUL-pads at the end).
+  size_t copy_len = std::min<size_t>(len, sizeof(this->preset_name_) - 1);
+  memcpy(this->preset_name_, payload, copy_len);
+  this->preset_name_[copy_len] = '\0';
+  this->preset_name_known_ = true;
+  ESP_LOGI(TAG, "Preset name: '%s'", this->preset_name_);
+  if (this->preset_name_text_ != nullptr)
+    this->preset_name_text_->publish_state(std::string(this->preset_name_));
+}
+
+void DSP408::publish_channel_state_(uint8_t ch) {
+  if (ch >= 8)
+    return;
+  ChannelState &c = this->ch_state_[ch];
+  if (this->ch_vol_num_[ch] != nullptr)
+    this->ch_vol_num_[ch]->publish_state(static_cast<float>(c.db_x10) / 10.0f);
+  if (this->ch_mute_sw_[ch] != nullptr)
+    this->ch_mute_sw_[ch]->publish_state(c.muted);
+  if (this->ch_delay_num_[ch] != nullptr)
+    this->ch_delay_num_[ch]->publish_state(static_cast<float>(c.delay_samples));
+  if (this->ch_polar_sw_[ch] != nullptr)
+    this->ch_polar_sw_[ch]->publish_state(c.polar);
+  if (this->ch_hpf_freq_num_[ch] != nullptr)
+    this->ch_hpf_freq_num_[ch]->publish_state(static_cast<float>(c.hpf_freq_hz));
+  if (this->ch_lpf_freq_num_[ch] != nullptr)
+    this->ch_lpf_freq_num_[ch]->publish_state(static_cast<float>(c.lpf_freq_hz));
+  // Filter type / slope select entities — index-as-string (the select
+  // sub-platform decodes index→option; we publish via the option string).
+  static const char *FILTER_NAMES[4] = {"Butterworth", "Bessel", "Linkwitz-Riley", "Linkwitz-Riley"};
+  static const char *SLOPE_NAMES_[9] = {"6 dB/oct",  "12 dB/oct", "18 dB/oct", "24 dB/oct", "30 dB/oct",
+                                        "36 dB/oct", "42 dB/oct", "48 dB/oct", "Off"};
+  if (this->ch_hpf_filter_sel_[ch] != nullptr && c.hpf_filter < 4)
+    this->ch_hpf_filter_sel_[ch]->publish_state(FILTER_NAMES[c.hpf_filter]);
+  if (this->ch_hpf_slope_sel_[ch] != nullptr && c.hpf_slope < 9)
+    this->ch_hpf_slope_sel_[ch]->publish_state(SLOPE_NAMES_[c.hpf_slope]);
+  if (this->ch_lpf_filter_sel_[ch] != nullptr && c.lpf_filter < 4)
+    this->ch_lpf_filter_sel_[ch]->publish_state(FILTER_NAMES[c.lpf_filter]);
+  if (this->ch_lpf_slope_sel_[ch] != nullptr && c.lpf_slope < 9)
+    this->ch_lpf_slope_sel_[ch]->publish_state(SLOPE_NAMES_[c.lpf_slope]);
+  if (this->ch_name_text_[ch] != nullptr)
+    this->ch_name_text_[ch]->publish_state(std::string(c.name));
+  if (this->ch_comp_attack_num_[ch] != nullptr)
+    this->ch_comp_attack_num_[ch]->publish_state(static_cast<float>(c.comp_attack_ms));
+  if (this->ch_comp_release_num_[ch] != nullptr)
+    this->ch_comp_release_num_[ch]->publish_state(static_cast<float>(c.comp_release_ms));
+  if (this->ch_comp_threshold_num_[ch] != nullptr)
+    this->ch_comp_threshold_num_[ch]->publish_state(static_cast<float>(c.comp_threshold));
+}
+
+void DSP408::handle_channel_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len) {
+  uint8_t ch = static_cast<uint8_t>(cmd - CMD_WRITE_CHANNEL_BASE);
+  ESP_LOGD(TAG, "Channel %u write ack (len=%u)", ch, static_cast<unsigned>(len));
+  if (ch < 8) {
+    if (this->ch_vol_num_[ch] != nullptr)
+      this->ch_vol_num_[ch]->publish_state(static_cast<float>(this->ch_state_[ch].db_x10) / 10.0f);
+    if (this->ch_mute_sw_[ch] != nullptr)
+      this->ch_mute_sw_[ch]->publish_state(this->ch_state_[ch].muted);
+  }
+  (void) payload;
+}
+
+// ── Public command entry points ─────────────────────────────────────────
+//
+// All request_* entry points gate on ``phase_ == StartupPhase::RUNNING``.
+// During WAIT_AFTER_CONNECT / SENT_CONNECT / SENT_GET_INFO /
+// SENT_GET_MASTER / WARMUP_CHANNELS the per-channel cache is either
+// empty (defaults: 0 dB / unmuted / no polar / 0 delay / HPF=20 Hz /
+// LPF=20 kHz / slope=8 Off) or being populated from device truth. Any
+// write that goes out before warmup finishes will combine the user's
+// new field with stale defaults for every OTHER field — silently
+// clobbering whatever state the device had stored. This is exactly the
+// "fresh-boot HA touch surges channel to 0 dB" hazard documented at
+// length in dsp408-py's _prime_channel_cache (device.py:1248-1279).
+//
+// The gate drops the write with a WARN. HA's optimistic publish_state
+// from the entity's control() handler is left in place — the next
+// periodic master poll (or future channel-state re-poll) will reaffirm
+// the actual device state to HA.
+
+void DSP408::request_master_volume(float db) {
+  if (this->phase_ != StartupPhase::RUNNING || !this->master_known_) {
+    ESP_LOGW(TAG, "Dropping master_volume write — phase=%d master_known=%d", static_cast<int>(this->phase_),
+             this->master_known_);
+    return;
+  }
+  int lvl = static_cast<int>(std::round(db + MASTER_LEVEL_OFFSET));
+  if (lvl < MASTER_LEVEL_MIN)
+    lvl = MASTER_LEVEL_MIN;
+  if (lvl > MASTER_LEVEL_MAX)
+    lvl = MASTER_LEVEL_MAX;
+  this->master_db_ = static_cast<int8_t>(lvl - MASTER_LEVEL_OFFSET);
+  this->send_set_master_(static_cast<uint8_t>(lvl), this->master_muted_);
+}
+
+void DSP408::request_master_mute(bool muted) {
+  if (this->phase_ != StartupPhase::RUNNING || !this->master_known_) {
+    ESP_LOGW(TAG, "Dropping master_mute write — phase=%d master_known=%d", static_cast<int>(this->phase_),
+             this->master_known_);
+    return;
+  }
+  uint8_t lvl_raw = static_cast<uint8_t>(this->master_db_ + MASTER_LEVEL_OFFSET);
+  this->master_muted_ = muted;
+  this->send_set_master_(lvl_raw, muted);
+}
+
+void DSP408::request_channel_volume(uint8_t ch, float db) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u volume write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  // 0.1 dB resolution: encode as db_x10. Range -600..0.
+  int v = static_cast<int>(std::round(db * 10.0f));
+  if (v < -600)
+    v = -600;
+  if (v > 0)
+    v = 0;
+  this->ch_state_[ch].db_x10 = static_cast<int16_t>(v);
+  this->send_set_channel_(ch);
+}
+
+void DSP408::request_channel_mute(uint8_t ch, bool muted) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u mute write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  this->ch_state_[ch].muted = muted;
+  this->send_set_channel_(ch);
+}
+
+void DSP408::request_channel_delay(uint8_t ch, uint16_t samples) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u delay write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (samples > CHANNEL_DELAY_MAX)
+    samples = CHANNEL_DELAY_MAX;
+  this->ch_state_[ch].delay_samples = samples;
+  this->send_set_channel_(ch);
+}
+
+void DSP408::request_channel_polar(uint8_t ch, bool inverted) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u polar write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  this->ch_state_[ch].polar = inverted;
+  this->send_set_channel_(ch);
+}
+
+void DSP408::request_channel_hpf_freq(uint8_t ch, uint16_t hz) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u hpf_freq write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (hz < 10)
+    hz = 10;
+  if (hz > 20000)
+    hz = 20000;
+  this->ch_state_[ch].hpf_freq_hz = hz;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_channel_lpf_freq(uint8_t ch, uint16_t hz) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u lpf_freq write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (hz < 100)
+    hz = 100;
+  if (hz > 22000)
+    hz = 22000;
+  this->ch_state_[ch].lpf_freq_hz = hz;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_channel_hpf_filter(uint8_t ch, uint8_t filter) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u hpf_filter write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (filter > 3)
+    filter = 3;
+  this->ch_state_[ch].hpf_filter = filter;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_channel_hpf_slope(uint8_t ch, uint8_t slope) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u hpf_slope write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (slope > 8)
+    slope = 8;
+  this->ch_state_[ch].hpf_slope = slope;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_channel_lpf_filter(uint8_t ch, uint8_t filter) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u lpf_filter write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (filter > 3)
+    filter = 3;
+  this->ch_state_[ch].lpf_filter = filter;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_channel_lpf_slope(uint8_t ch, uint8_t slope) {
+  if (ch >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u lpf_slope write — phase=%d primed=%d", ch, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  if (slope > 8)
+    slope = 8;
+  this->ch_state_[ch].lpf_slope = slope;
+  this->send_set_crossover_(ch);
+}
+
+void DSP408::request_eq_band(uint8_t ch, uint8_t band, uint16_t freq_hz, float gain_db, float q) {
+  if (ch >= 8 || band >= EQ_BAND_COUNT)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[ch].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u band%u EQ write — phase=%d primed=%d", ch, band, static_cast<int>(this->phase_),
+             this->ch_state_[ch].primed);
+    return;
+  }
+  // Bound freq + gain to envelopes.
+  if (freq_hz < 20)
+    freq_hz = 20;
+  if (freq_hz > 20000)
+    freq_hz = 20000;
+  int gain_raw = static_cast<int>(std::round(gain_db * 10.0f)) + EQ_GAIN_RAW_OFFSET;
+  if (gain_raw < EQ_GAIN_RAW_MIN)
+    gain_raw = EQ_GAIN_RAW_MIN;
+  if (gain_raw > EQ_GAIN_RAW_MAX)
+    gain_raw = EQ_GAIN_RAW_MAX;
+
+  // Q encoding: b4_byte ≈ 256 / Q, clamped to [1..255]. Higher b4_byte
+  // = lower Q (wider peak). Default 0x34 = 52 → Q ≈ 4.9.
+  if (q < 0.1f)
+    q = 0.1f;
+  int b4 = static_cast<int>(std::round(EQ_Q_BW_CONSTANT / q));
+  if (b4 < 1)
+    b4 = 1;
+  if (b4 > 255)
+    b4 = 255;
+
+  ESP_LOGD(TAG, "EQ ch%u band%u: f=%u Hz gain=%.1f dB Q=%.2f -> raw=%d b4=%u", ch, band, freq_hz, gain_db, q, gain_raw,
+           b4);
+  this->send_set_eq_band_(ch, band, freq_hz, static_cast<int16_t>(gain_raw), static_cast<uint8_t>(b4));
+}
+
+void DSP408::request_routing(uint8_t channel, uint8_t input_idx, bool on) {
+  if (channel >= 8 || input_idx >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u routing[%u]=%d — phase=%d primed=%d", channel, input_idx, on,
+             static_cast<int>(this->phase_), this->ch_state_[channel].primed);
+    return;
+  }
+  this->ch_state_[channel].routing_lo[input_idx] = on ? ROUTING_ON : ROUTING_OFF;
+  this->send_set_routing_(channel);
+}
+
+void DSP408::request_preset_name(const std::string &name) {
+  if (this->phase_ != StartupPhase::RUNNING) {
+    ESP_LOGW(TAG, "Dropping preset_name write — phase=%d", static_cast<int>(this->phase_));
+    return;
+  }
+  // Cache it so we can publish back on ack.
+  size_t copy_len = std::min(name.size(), sizeof(this->preset_name_) - 1);
+  memcpy(this->preset_name_, name.data(), copy_len);
+  this->preset_name_[copy_len] = '\0';
+  this->preset_name_known_ = true;
+  this->send_set_preset_name_(name);
+  if (this->preset_name_text_ != nullptr)
+    this->preset_name_text_->publish_state(std::string(this->preset_name_));
+}
+
+void DSP408::request_channel_name(uint8_t channel, const std::string &name) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u name write — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return;
+  }
+  size_t copy_len = std::min(name.size(), NAME_LEN);
+  memset(this->ch_state_[channel].name, 0, sizeof(this->ch_state_[channel].name));
+  memcpy(this->ch_state_[channel].name, name.data(), copy_len);
+  this->send_set_channel_name_(channel, name);
+}
+
+void DSP408::request_full_channel_state(uint8_t channel, const uint8_t *blob, size_t blob_len) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING) {
+    ESP_LOGW(TAG, "Dropping ch%u full-state write — phase=%d", channel, static_cast<int>(this->phase_));
+    return;
+  }
+  this->send_set_full_channel_state_(channel, blob, blob_len);
+}
+
+bool DSP408::request_save_channel_snapshot(uint8_t channel) {
+  if (channel >= 8)
+    return false;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u snapshot save — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return false;
+  }
+  if (this->snapshot_pending_ch_ != 0xFF) {
+    ESP_LOGW(TAG, "Snapshot already pending (ch=%u); dropping ch=%u request", this->snapshot_pending_ch_, channel);
+    return false;
+  }
+  // Read-modify-write: kick off a fresh channel-state read; once the
+  // blob arrives, handle_channel_state_blob_ sees snapshot_pending_ch_
+  // matches, overlays cached basic-record fields onto the live blob
+  // (preserving EQ region + everything else byte-for-byte), and
+  // submits a multi-frame WRITE.
+  this->snapshot_pending_ch_ = channel;
+  ESP_LOGI(TAG, "Snapshot save ch%u: read-modify-write initiated", channel);
+  return this->send_read_channel_(channel);
+}
+
+// Compressor field-specific setters do read-modify-write via the
+// cache: update just the field this setter owns, leave the others as
+// they were on warmup (or last write). The wire format always sends
+// the full 8-byte payload, so without this pattern an attack-only
+// change would zero out release/threshold/linkgroup.
+
+void DSP408::request_compressor_attack(uint8_t channel, uint16_t attack_ms) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u compressor.attack — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return;
+  }
+  this->ch_state_[channel].comp_attack_ms = attack_ms;
+  this->send_set_compressor_(channel);
+}
+
+void DSP408::request_compressor_release(uint8_t channel, uint16_t release_ms) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u compressor.release — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return;
+  }
+  this->ch_state_[channel].comp_release_ms = release_ms;
+  this->send_set_compressor_(channel);
+}
+
+void DSP408::request_compressor_threshold(uint8_t channel, uint8_t threshold) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u compressor.threshold — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return;
+  }
+  this->ch_state_[channel].comp_threshold = threshold;
+  this->send_set_compressor_(channel);
+}
+
+void DSP408::request_compressor_linkgroup(uint8_t channel, uint8_t linkgroup) {
+  if (channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING || !this->ch_state_[channel].primed) {
+    ESP_LOGW(TAG, "Dropping ch%u compressor.linkgroup — phase=%d primed=%d", channel, static_cast<int>(this->phase_),
+             this->ch_state_[channel].primed);
+    return;
+  }
+  this->ch_state_[channel].comp_linkgroup = linkgroup;
+  this->send_set_compressor_(channel);
+}
+
+void DSP408::request_input_polar(uint8_t input_channel, bool inverted) {
+  if (input_channel >= 8)
+    return;
+  if (this->phase_ != StartupPhase::RUNNING) {
+    ESP_LOGW(TAG, "Dropping input ch%u polar write — phase=%d", input_channel, static_cast<int>(this->phase_));
+    return;
+  }
+  this->input_state_[input_channel].polar = inverted;
+  this->send_set_input_misc_(input_channel);
+  if (this->input_polar_sw_[input_channel] != nullptr)
+    this->input_polar_sw_[input_channel]->publish_state(inverted);
+}
+
+}  // namespace dsp408
+}  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/dsp408.h
+++ b/esphome/components/dsp408/dsp408.h
@@ -1,0 +1,470 @@
+#pragma once
+//
+// DSP-408 ESPHome external_component — main parent class.
+//
+// Subclasses esphome::usb_host::USBClient so it inherits the USB host
+// task, transfer-request pool, and lock-free event queue. We add a HID
+// interface claim (bInterfaceClass==0x03, EP 0x01 OUT + EP 0x82 IN),
+// the DSP-408 wire protocol on top of 64-byte HID reports, and a small
+// command state machine that drives connect/identify/master-state probes.
+//
+// Threading: transfer callbacks run in the USB task. They copy raw IN
+// reports into a lock-free queue and wake the main loop via
+// enable_loop_soon_any_context() + App.wake_loop_threadsafe(). All
+// protocol parsing and entity updates happen in loop() on the main task.
+// Outbound transfer_out() is non-blocking and safe from main loop.
+
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+#include "esphome/components/usb_host/usb_host.h"
+#include "esphome/core/event_pool.h"
+#include "esphome/core/lock_free_queue.h"
+
+#include "usb/usb_host.h"
+
+#include "protocol.h"
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace esphome {
+
+// Forward decls so the .h can mention pointers without dragging in
+// the full sub-platform headers.
+namespace text_sensor {
+class TextSensor;
+}
+namespace text {
+class Text;
+}
+namespace number {
+class Number;
+}
+namespace switch_ {
+class Switch;
+}
+namespace select {
+class Select;
+}
+
+namespace dsp408 {
+
+// One inbound USB report (64 bytes) carried from USB task to main loop
+// via a lock-free SPSC queue. Sized for HID; matches the IDF transfer
+// buffer configured by usb_host_client.cpp.
+struct InReport {
+  uint8_t data[64];
+  uint16_t length;
+  // Required by EventPool — POD with no resources to release.
+  void release() {}
+};
+
+static constexpr size_t IN_QUEUE_SIZE = 16;
+
+// State machine of the connect/identify/probe sequence.
+// Driven by loop() reacting to inbound reports + by per-tick timeouts.
+enum class StartupPhase : uint8_t {
+  IDLE,                // not yet usb-connected
+  WAIT_AFTER_CONNECT,  // usb-connected, waiting before sending CMD_CONNECT
+  SENT_CONNECT,        // CMD_CONNECT in flight
+  SENT_GET_INFO,       // CMD_GET_INFO in flight
+  SENT_GET_MASTER,     // CMD_MASTER read in flight
+  WARMUP_CHANNELS,     // sequentially reading channel state 0..7
+  RUNNING,             // steady-state
+};
+
+class DSP408 : public usb_host::USBClient {
+ public:
+  DSP408(uint16_t vid, uint16_t pid) : USBClient(vid, pid) {}
+
+  void setup() override;
+  void loop() override;
+  void on_connected() override;
+  void on_disconnected() override;
+  void dump_config() override;
+
+  // Setters for sub-platform entities — wired by codegen in
+  // {number,switch,text_sensor}/__init__.py.
+  void set_model_text_sensor(text_sensor::TextSensor *ts) { this->model_ts_ = ts; }
+  void set_master_volume_number(number::Number *n) { this->master_vol_num_ = n; }
+  void set_master_mute_switch(switch_::Switch *s) { this->master_mute_sw_ = s; }
+  void set_channel_volume_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_vol_num_[ch] = n;
+  }
+  void set_channel_mute_switch(uint8_t ch, switch_::Switch *s) {
+    if (ch < 8)
+      this->ch_mute_sw_[ch] = s;
+  }
+  void set_channel_delay_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_delay_num_[ch] = n;
+  }
+  void set_channel_polar_switch(uint8_t ch, switch_::Switch *s) {
+    if (ch < 8)
+      this->ch_polar_sw_[ch] = s;
+  }
+  void set_channel_hpf_freq_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_hpf_freq_num_[ch] = n;
+  }
+  void set_channel_lpf_freq_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_lpf_freq_num_[ch] = n;
+  }
+  void set_channel_hpf_filter_select(uint8_t ch, select::Select *s) {
+    if (ch < 8)
+      this->ch_hpf_filter_sel_[ch] = s;
+  }
+  void set_channel_hpf_slope_select(uint8_t ch, select::Select *s) {
+    if (ch < 8)
+      this->ch_hpf_slope_sel_[ch] = s;
+  }
+  void set_channel_lpf_filter_select(uint8_t ch, select::Select *s) {
+    if (ch < 8)
+      this->ch_lpf_filter_sel_[ch] = s;
+  }
+  void set_channel_lpf_slope_select(uint8_t ch, select::Select *s) {
+    if (ch < 8)
+      this->ch_lpf_slope_sel_[ch] = s;
+  }
+  void set_preset_name_text(text::Text *t) { this->preset_name_text_ = t; }
+  void set_channel_name_text(uint8_t ch, text::Text *t) {
+    if (ch < 8)
+      this->ch_name_text_[ch] = t;
+  }
+
+  // Compressor entities (per output channel).
+  void set_channel_comp_attack_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_comp_attack_num_[ch] = n;
+  }
+  void set_channel_comp_release_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_comp_release_num_[ch] = n;
+  }
+  void set_channel_comp_threshold_number(uint8_t ch, number::Number *n) {
+    if (ch < 8)
+      this->ch_comp_threshold_num_[ch] = n;
+  }
+
+  // Input-side polar (per input channel).
+  void set_input_polar_switch(uint8_t input_ch, switch_::Switch *s) {
+    if (input_ch < 8)
+      this->input_polar_sw_[input_ch] = s;
+  }
+
+  // Public command entry points (called from main loop / entity control()).
+  // These post an OUT transfer; replies arrive asynchronously and update
+  // entity state.
+  void request_master_volume(float db);
+  void request_master_mute(bool muted);
+  void request_channel_volume(uint8_t ch, float db);
+  void request_channel_mute(uint8_t ch, bool muted);
+  void request_channel_delay(uint8_t ch, uint16_t samples);
+  void request_channel_polar(uint8_t ch, bool inverted);
+  void request_channel_hpf_freq(uint8_t ch, uint16_t hz);
+  void request_channel_lpf_freq(uint8_t ch, uint16_t hz);
+  void request_channel_hpf_filter(uint8_t ch, uint8_t filter);
+  void request_channel_hpf_slope(uint8_t ch, uint8_t slope);
+  void request_channel_lpf_filter(uint8_t ch, uint8_t filter);
+  void request_channel_lpf_slope(uint8_t ch, uint8_t slope);
+
+  // EQ band write — cmd = 0x10000 + (band << 8) + channel.
+  // Q is converted to b4_byte via 256/Q with clamping to [1..255].
+  void request_eq_band(uint8_t channel, uint8_t band, uint16_t freq_hz, float gain_db, float q);
+
+  // Routing matrix cell — sets the mixer level for one (channel, input)
+  // pair. `level` is mapped: 0 = OFF, anything else = ON (0x64). Channel
+  // is the OUTPUT (0..7), input_idx is 0..7 (low bank IN1..IN8).
+  // For IN9..IN16 use the high bank API (DSP-408 hw only has 4 inputs;
+  // most users won't need this).
+  void request_routing(uint8_t channel, uint8_t input_idx, bool on);
+
+  // Full per-channel state write — 296-byte multi-frame WRITE via
+  // cmd=0x10000+ch (CAT_PARAM, dir=a1). The payload is the same
+  // 296-byte blob layout as a channel-state read. Used by the
+  // preset-save / "load from disk" flows that the Windows GUI emits.
+  // Caller supplies the blob; we wrap it in the multi-frame frames
+  // and submit them back-to-back. The device acks with a single
+  // 0-byte WRITE_ACK on the same cmd.
+  void request_full_channel_state(uint8_t channel, const uint8_t *blob, size_t blob_len);
+
+  // Convenience: build a 296-byte blob from the current cached
+  // ChannelState fields and write it. Returns false if the channel
+  // hasn't been primed yet.
+  //
+  // CAVEAT (v0.4): we don't cache the EQ region (offsets 0..79) so
+  // this snapshot writes ZEROS for all 10 EQ bands. Real preset-save
+  // requires read-modify-write — see the dsp408-py save_preset flow
+  // which reads the live blob, preserves the EQ region, then writes
+  // back. Slated for 1.0; the infrastructure (build_frames_multi +
+  // submit_raw_frame_) is in place for it.
+  bool request_save_channel_snapshot(uint8_t channel);
+
+  // Compressor write — 0x2300+ch, 8-byte payload:
+  //   [0..1] all_pass_q LE16 (firmware default 420)
+  //   [2..3] attack_ms LE16  (default 56)
+  //   [4..5] release_ms LE16 (default 500)
+  //   [6]    threshold        (units uncalibrated)
+  //   [7]    linkgroup_num    (0 = no link)
+  //
+  // NOTE: per dsp408-py docstring this block is INERT in firmware
+  // v1.06 — writes round-trip through cache but no audible effect.
+  // Exposed for protocol parity / future firmware support.
+  //
+  // Field-specific setters do read-modify-write via the cache so
+  // changing one field doesn't clobber the others (the wire format
+  // requires the full 8-byte payload on every write).
+  void request_compressor_attack(uint8_t channel, uint16_t attack_ms);
+  void request_compressor_release(uint8_t channel, uint16_t release_ms);
+  void request_compressor_threshold(uint8_t channel, uint8_t threshold);
+  void request_compressor_linkgroup(uint8_t channel, uint8_t linkgroup);
+
+  // Input-side polar (cat=0x03 plane). DSP-408 firmware v1.06 has
+  // mostly-inert input-side processing, but POLAR is one field that
+  // is firmware-active. Maps to byte[2] of the cmd=0x09NN MISC write
+  // (where NN = input channel 0..7).
+  void request_input_polar(uint8_t input_channel, bool inverted);
+
+  // Preset-name read/write (15-byte ASCII in cat=CAT_STATE).
+  void request_preset_name(const std::string &name);
+
+  // Channel name write (cmd=0x2400+ch, CAT_PARAM, 8-byte ASCII NUL-pad).
+  void request_channel_name(uint8_t channel, const std::string &name);
+
+ protected:
+  // ───────── USB descriptor walk + interface claim ─────────────────────
+  bool find_hid_endpoints_();
+
+  // ───────── IN-pump (continuous interrupt-IN reads) ────────────────────
+  void start_input_();
+  // Static-style transfer callback wrapper (USB task context) — pushes
+  // a copy of the report into the lock-free queue and wakes the loop.
+  void on_in_report_usb_task_(const usb_host::TransferStatus &status);
+
+  // Main-loop side: drain queue, parse frame, dispatch.
+  void process_in_queue_();
+  void dispatch_frame_(const InReport &report);
+
+  // ───────── OUT submit ────────────────────────────────────────────────
+  // Build + submit a single-frame command. Returns false on submission
+  // failure (transfer pool exhausted etc.). Reply is asynchronous.
+  bool send_cmd_(uint8_t direction, uint32_t cmd, uint8_t category, const uint8_t *payload, size_t payload_len,
+                 uint8_t seq);
+
+  // Submit a raw 64-byte HID report. Used by the multi-frame WRITE
+  // path which produces a sequence of frames (first frame + N-1
+  // continuation frames). Doesn't touch cmd_in_flight_; caller is
+  // responsible for tracking the in-flight cmd via the FIRST frame's
+  // header. Returns false if transfer_out submission fails.
+  bool submit_raw_frame_(const uint8_t *frame64);
+
+  // Convenience wrappers used by the startup state machine + entity setters.
+  bool send_connect_();
+  bool send_get_info_();
+  bool send_get_master_();
+  bool send_set_master_(uint8_t lvl_raw, bool muted);
+  bool send_set_channel_(uint8_t ch);   // builds payload from ch_state_
+  bool send_read_channel_(uint8_t ch);  // multi-frame 296-byte read
+  bool send_set_crossover_(uint8_t ch);
+  bool send_set_routing_(uint8_t ch);  // builds payload from ch_state_
+  bool send_set_eq_band_(uint8_t ch, uint8_t band, uint16_t freq_hz, int16_t gain_raw, uint8_t b4_byte);
+  bool send_set_preset_name_(const std::string &name);
+  bool send_get_preset_name_();
+  bool send_set_channel_name_(uint8_t ch, const std::string &name);
+  bool send_set_full_channel_state_(uint8_t ch, const uint8_t *blob, size_t len);
+  bool send_set_compressor_(uint8_t ch);
+  bool send_set_input_misc_(uint8_t input_ch);
+
+  // ───────── Frame handlers ────────────────────────────────────────────
+  void handle_connect_reply_(const uint8_t *payload, size_t len);
+  void handle_get_info_reply_(const uint8_t *payload, size_t len);
+  void handle_master_reply_(const uint8_t *payload, size_t len, bool is_ack);
+  void handle_channel_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len);
+  void handle_channel_state_blob_(uint8_t ch, const uint8_t *blob, size_t len);
+  void handle_crossover_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len);
+  void handle_preset_name_reply_(const uint8_t *payload, size_t len, bool is_ack);
+  void handle_routing_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len);
+  void handle_eq_band_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len);
+  void handle_channel_name_write_ack_(uint32_t cmd, const uint8_t *payload, size_t len);
+
+  // Publish the full set of cached state for one channel to all
+  // attached entities (volume, mute, delay, polar, hpf/lpf).
+  void publish_channel_state_(uint8_t ch);
+
+  // ───────── Per-channel cached desired state ──────────────────────────
+  // Mirror of dsp408-py's _channel_cache. We only have the WRITE payload
+  // semantics (read replies are 296-byte multi-frame and not implemented
+  // in v0.1) so we drive the device entirely from this cache and the
+  // user's HA inputs.
+  struct ChannelState {
+    bool primed = false;  // true once we've read or written this channel
+    // Volume stored as dB × 10 internally for the wire format's full
+    // 0.1 dB resolution. Range -600..0 = -60.0..0.0 dB. Reverse: float
+    // db = static_cast<float>(db_x10) / 10.0f.
+    int16_t db_x10 = 0;
+    bool muted = false;
+    bool polar = false;  // phase invert
+    uint16_t delay_samples = 0;
+    uint8_t byte_254 = 0;  // semantic unknown; preserve verbatim
+    uint8_t subidx = 0;    // speaker-role byte (blob[255])
+
+    // Crossover (HPF + LPF)
+    uint16_t hpf_freq_hz = 20;  // default lower bound
+    uint8_t hpf_filter = 0;     // 0=BW 1=Bessel 2=LR (3=LR alias)
+    uint8_t hpf_slope = 8;      // 8 = Off (default)
+    uint16_t lpf_freq_hz = 20000;
+    uint8_t lpf_filter = 0;
+    uint8_t lpf_slope = 8;
+
+    // Output routing matrix — IN1..IN8 levels (low bank). DSP-408 hw
+    // exposes 4 physical inputs; cells 4..7 read 0 in practice.
+    uint8_t routing_lo[8] = {};
+
+    // 8-byte ASCII channel name (NUL-padded), from blob[288..295].
+    char name[9] = {};  // 8 chars + NUL terminator for safe printing
+
+    // Compressor / dynamics block (firmware-inert in v1.06 but tracked
+    // for parity with the wire format). From blob[280..287].
+    uint16_t comp_all_pass_q = 420;
+    uint16_t comp_attack_ms = 56;
+    uint16_t comp_release_ms = 500;
+    uint8_t comp_threshold = 0;
+    uint8_t comp_linkgroup = 0;
+  };
+  ChannelState ch_state_[8];
+
+  // Input-side state — cat=0x03 plane. Per dsp408-py only POLAR is
+  // firmware-active in v1.06; we track all 8 input channels for write
+  // path parity but don't read them on warmup (would add 8 more
+  // multi-frame reads to startup; defer until users actually need it).
+  struct InputState {
+    bool polar = false;
+  };
+  InputState input_state_[8];
+
+  // Preset name (15-byte ASCII, NUL-terminated for safe printing).
+  char preset_name_[16] = {};
+  bool preset_name_known_ = false;
+
+  // ───────── USB endpoint state ────────────────────────────────────────
+  uint8_t intf_number_ = 0xFF;
+  const usb_ep_desc_t *ep_in_ = nullptr;   // 0x82 typically
+  const usb_ep_desc_t *ep_out_ = nullptr;  // 0x01 typically
+  bool interface_claimed_ = false;
+  std::atomic<bool> input_pending_{false};
+
+  // ───────── Lock-free queue for USB-task -> main-loop reports ─────────
+  EventPool<InReport, IN_QUEUE_SIZE - 1> in_pool_;
+  LockFreeQueue<InReport, IN_QUEUE_SIZE> in_queue_;
+
+  // ───────── Startup state machine ─────────────────────────────────────
+  StartupPhase phase_ = StartupPhase::IDLE;
+  uint32_t phase_started_ms_ = 0;
+  uint32_t connected_at_ms_ = 0;
+
+  // Sequence counter — 0 for writes (firmware drops non-zero seq on
+  // category-04 writes per dsp408-py), incrementing per read.
+  uint8_t next_read_seq_ = 1;
+
+  // Pending request tracking — for v0.1 we keep it simple: at most one
+  // request in flight at a time. cmd_in_flight_ == 0 means idle.
+  uint32_t cmd_in_flight_ = 0;
+  uint32_t cmd_in_flight_started_ms_ = 0;
+  uint8_t cmd_in_flight_seq_ = 0;
+  uint8_t cmd_in_flight_dir_ = 0;  // DIR_CMD or DIR_WRITE
+  static constexpr uint32_t REQUEST_TIMEOUT_MS = 1500;
+
+  // ───────── Entity pointers ───────────────────────────────────────────
+  text_sensor::TextSensor *model_ts_ = nullptr;
+  number::Number *master_vol_num_ = nullptr;
+  switch_::Switch *master_mute_sw_ = nullptr;
+  number::Number *ch_vol_num_[8] = {};
+  switch_::Switch *ch_mute_sw_[8] = {};
+  number::Number *ch_delay_num_[8] = {};
+  switch_::Switch *ch_polar_sw_[8] = {};
+  number::Number *ch_hpf_freq_num_[8] = {};
+  number::Number *ch_lpf_freq_num_[8] = {};
+  select::Select *ch_hpf_filter_sel_[8] = {};
+  select::Select *ch_hpf_slope_sel_[8] = {};
+  select::Select *ch_lpf_filter_sel_[8] = {};
+  select::Select *ch_lpf_slope_sel_[8] = {};
+  text::Text *preset_name_text_ = nullptr;
+  text::Text *ch_name_text_[8] = {};
+  number::Number *ch_comp_attack_num_[8] = {};
+  number::Number *ch_comp_release_num_[8] = {};
+  number::Number *ch_comp_threshold_num_[8] = {};
+  switch_::Switch *input_polar_sw_[8] = {};
+
+  // ───────── Cached master state (from last reply) ─────────────────────
+  bool master_known_ = false;
+  int8_t master_db_ = 0;  // dB integer
+  bool master_muted_ = false;
+
+  // Periodic re-poll of master state (catch external knob changes if any
+  // future firmware has them).
+  uint32_t last_master_poll_ms_ = 0;
+  static constexpr uint32_t MASTER_POLL_INTERVAL_MS = 5000;
+
+  // Round-robin which channel's cached state we re-publish each tick.
+  // Burst-publishing all 8 × 6 entity states at once during the master
+  // poll overruns the ESPHome native API send buffer when the entity
+  // surface gets large (~60+ entities), causing HA's connection to drop.
+  // Spreading it across MASTER_POLL_INTERVAL_MS / 8 = ~625 ms per
+  // channel keeps each tick's message volume manageable.
+  uint8_t republish_channel_rr_ = 0;
+  uint32_t last_republish_ms_ = 0;
+  static constexpr uint32_t REPUBLISH_STAGGER_MS = 625;
+
+  // ───────── Multi-frame reassembly state ──────────────────────────────
+  // The DSP-408 returns 296-byte payloads (cmd=0x77NN channel-state read)
+  // as a sequence of 64-byte HID reports: the first carries the standard
+  // header + 50 payload bytes (no chk/end), then 4 raw 64-byte
+  // continuation reports until the declared length is satisfied. The
+  // last continuation also carries chk + end + zero-pad after the final
+  // payload byte. We mirror dsp408-py.transport.read_response semantics:
+  // once we see a multi-frame first frame, we treat every subsequent
+  // inbound report as raw payload until 296 bytes have been collected,
+  // then re-dispatch the assembled blob.
+  bool mf_in_progress_ = false;
+  uint32_t mf_cmd_ = 0;
+  uint8_t mf_direction_ = 0;
+  uint8_t mf_category_ = 0;
+  uint16_t mf_declared_len_ = 0;
+  uint16_t mf_collected_len_ = 0;
+  uint8_t mf_header_[10] = {};  // raw[4..14] from first frame for chk validation
+  uint8_t mf_buffer_[CHANNEL_BLOB_SIZE] = {};
+
+  // Warmup channel-read state (inside StartupPhase::WARMUP_CHANNELS).
+  uint8_t warmup_channel_ = 0;  // next channel index to read (0..7)
+
+  // Per-channel read convergence — mirrors dsp408-py's
+  // ``read_channel_state(retry_on_divergence=True)``. The firmware
+  // occasionally emits a 2-byte-shifted variant of the EQ region (and
+  // sometimes worse — bench test Ch6 returned gain=+324 dB / subidx=0x55
+  // i.e. 'U' which is clearly leaked from elsewhere in the blob). We
+  // keep the previous blob's bytes and re-read until two consecutive
+  // reads agree, up to MAX_BLOB_RETRY attempts.
+  static constexpr uint8_t MAX_BLOB_RETRY = 4;
+  uint8_t warmup_attempt_ = 0;
+  bool warmup_have_prev_ = false;
+  uint8_t warmup_prev_blob_[CHANNEL_BLOB_SIZE] = {};
+
+  // Snapshot save — read-modify-write of a channel's full 296-byte
+  // blob. Set when request_save_channel_snapshot() is called. After
+  // the next channel-state blob arrives for that channel during
+  // RUNNING phase, we build a modified blob (preserving EQ region
+  // from the live read, overlaying cached basic-record fields) and
+  // submit a multi-frame WRITE. 0xFF = none pending.
+  uint8_t snapshot_pending_ch_ = 0xFF;
+};
+
+}  // namespace dsp408
+}  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/dsp408.h
+++ b/esphome/components/dsp408/dsp408.h
@@ -1,6 +1,13 @@
 #pragma once
 //
-// DSP-408 ESPHome external_component — main parent class.
+// DSP-408 ESPHome component — main parent class.
+//
+// Reference implementation: https://github.com/malaiwah/dsp408-py
+//   - dsp408/protocol.py — frame layout, command codes, blob offsets
+//   - dsp408/device.py   — high-level Device with the firmware quirks
+//                          (read-divergence retry, write seq=0 rule,
+//                          startup write-drop quirk, etc.)
+// The wire-format port here is byte-exact to that library.
 //
 // Subclasses esphome::usb_host::USBClient so it inherits the USB host
 // task, transfer-request pool, and lock-free event queue. We add a HID

--- a/esphome/components/dsp408/number/__init__.py
+++ b/esphome/components/dsp408/number/__init__.py
@@ -15,11 +15,10 @@ from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL
 
-from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+from .. import CONF_DSP408_ID, CONF_KIND, DSP408, dsp408_ns
 
 DEPENDENCIES = ["dsp408"]
 
-CONF_KIND = "kind"
 KIND_MASTER_VOLUME = "MASTER_VOLUME"
 KIND_CHANNEL_VOLUME = "CHANNEL_VOLUME"
 KIND_CHANNEL_DELAY = "CHANNEL_DELAY"

--- a/esphome/components/dsp408/number/__init__.py
+++ b/esphome/components/dsp408/number/__init__.py
@@ -1,0 +1,139 @@
+"""DSP-408 number sub-platform.
+
+Kinds:
+  * MASTER_VOLUME      -- master volume in dB, range -60..+6 (1 dB step)
+  * CHANNEL_VOLUME     -- per-channel output volume, -60..0 dB
+  * CHANNEL_DELAY      -- per-channel delay in samples, 0..359
+                          (1 sample = ~22.7us @ 44.1 kHz; firmware caps
+                          at 359 ≈ 8.143 ms)
+  * CHANNEL_HPF_FREQ   -- per-channel high-pass cutoff in Hz, 10..20000
+  * CHANNEL_LPF_FREQ   -- per-channel low-pass cutoff in Hz, 100..22000
+"""
+
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+from esphome.const import CONF_CHANNEL
+
+from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+
+DEPENDENCIES = ["dsp408"]
+
+CONF_KIND = "kind"
+KIND_MASTER_VOLUME = "MASTER_VOLUME"
+KIND_CHANNEL_VOLUME = "CHANNEL_VOLUME"
+KIND_CHANNEL_DELAY = "CHANNEL_DELAY"
+KIND_CHANNEL_HPF_FREQ = "CHANNEL_HPF_FREQ"
+KIND_CHANNEL_LPF_FREQ = "CHANNEL_LPF_FREQ"
+KIND_CHANNEL_COMP_ATTACK = "CHANNEL_COMP_ATTACK"
+KIND_CHANNEL_COMP_RELEASE = "CHANNEL_COMP_RELEASE"
+KIND_CHANNEL_COMP_THRESHOLD = "CHANNEL_COMP_THRESHOLD"
+
+KINDS = {
+    KIND_MASTER_VOLUME: KIND_MASTER_VOLUME,
+    KIND_CHANNEL_VOLUME: KIND_CHANNEL_VOLUME,
+    KIND_CHANNEL_DELAY: KIND_CHANNEL_DELAY,
+    KIND_CHANNEL_HPF_FREQ: KIND_CHANNEL_HPF_FREQ,
+    KIND_CHANNEL_LPF_FREQ: KIND_CHANNEL_LPF_FREQ,
+    KIND_CHANNEL_COMP_ATTACK: KIND_CHANNEL_COMP_ATTACK,
+    KIND_CHANNEL_COMP_RELEASE: KIND_CHANNEL_COMP_RELEASE,
+    KIND_CHANNEL_COMP_THRESHOLD: KIND_CHANNEL_COMP_THRESHOLD,
+}
+
+PER_CHANNEL_KINDS = {
+    KIND_CHANNEL_VOLUME,
+    KIND_CHANNEL_DELAY,
+    KIND_CHANNEL_HPF_FREQ,
+    KIND_CHANNEL_LPF_FREQ,
+    KIND_CHANNEL_COMP_ATTACK,
+    KIND_CHANNEL_COMP_RELEASE,
+    KIND_CHANNEL_COMP_THRESHOLD,
+}
+
+DSP408Number = dsp408_ns.class_("DSP408Number", number.Number, cg.Component)
+NumberKind = dsp408_ns.namespace("NumberKind")
+
+
+def _validate(config):
+    kind = config[CONF_KIND]
+    if kind in PER_CHANNEL_KINDS and CONF_CHANNEL not in config:
+        raise cv.Invalid(f"channel: 0..7 is required for kind: {kind}")
+    if kind == KIND_MASTER_VOLUME and CONF_CHANNEL in config:
+        raise cv.Invalid("channel: must NOT be set for kind: MASTER_VOLUME")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    number.number_schema(DSP408Number).extend(
+        {
+            cv.GenerateID(CONF_DSP408_ID): cv.use_id(DSP408),
+            cv.Required(CONF_KIND): cv.enum(KINDS, upper=True),
+            cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=7),
+        }
+    ),
+    _validate,
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DSP408_ID])
+    kind = config[CONF_KIND]
+    if kind == KIND_MASTER_VOLUME:
+        # Master volume: firmware encoding is integer dB (1 dB step in
+        # the 8-byte payload). Step 1.0 keeps the slider sensible.
+        var = await number.new_number(config, min_value=-60.0, max_value=6.0, step=1.0)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_master_volume())
+        cg.add(parent.set_master_volume_number(var))
+    elif kind == KIND_CHANNEL_VOLUME:
+        # Per-channel volume: firmware encodes raw = (dB×10)+600 in u16,
+        # giving 0.1 dB native resolution. We expose 0.5 dB step in HA
+        # as a UX compromise — finer than 1 dB but coarse enough that
+        # slider drag doesn't generate excessive bus traffic.
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(config, min_value=-60.0, max_value=0.0, step=0.5)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_volume(ch))
+        cg.add(parent.set_channel_volume_number(ch, var))
+    elif kind == KIND_CHANNEL_DELAY:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(config, min_value=0.0, max_value=359.0, step=1.0)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_delay(ch))
+        cg.add(parent.set_channel_delay_number(ch, var))
+    elif kind == KIND_CHANNEL_HPF_FREQ:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(
+            config, min_value=10.0, max_value=20000.0, step=1.0
+        )
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_hpf_freq(ch))
+        cg.add(parent.set_channel_hpf_freq_number(ch, var))
+    elif kind == KIND_CHANNEL_LPF_FREQ:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(
+            config, min_value=100.0, max_value=22000.0, step=1.0
+        )
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_lpf_freq(ch))
+        cg.add(parent.set_channel_lpf_freq_number(ch, var))
+    elif kind == KIND_CHANNEL_COMP_ATTACK:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(config, min_value=0.0, max_value=2000.0, step=1.0)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_comp_attack(ch))
+        cg.add(parent.set_channel_comp_attack_number(ch, var))
+    elif kind == KIND_CHANNEL_COMP_RELEASE:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(
+            config, min_value=0.0, max_value=10000.0, step=1.0
+        )
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_comp_release(ch))
+        cg.add(parent.set_channel_comp_release_number(ch, var))
+    elif kind == KIND_CHANNEL_COMP_THRESHOLD:
+        ch = config[CONF_CHANNEL]
+        var = await number.new_number(config, min_value=0.0, max_value=255.0, step=1.0)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_comp_threshold(ch))
+        cg.add(parent.set_channel_comp_threshold_number(ch, var))

--- a/esphome/components/dsp408/number/dsp408_number.cpp
+++ b/esphome/components/dsp408/number/dsp408_number.cpp
@@ -1,6 +1,8 @@
 #include "dsp408_number.h"
 #include "esphome/core/log.h"
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 namespace esphome {
 namespace dsp408 {
 
@@ -67,3 +69,5 @@ void DSP408Number::control(float value) {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/number/dsp408_number.cpp
+++ b/esphome/components/dsp408/number/dsp408_number.cpp
@@ -1,0 +1,69 @@
+#include "dsp408_number.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace dsp408 {
+
+static const char *const TAG = "dsp408.number";
+
+static const char *kind_name(NumberKind k) {
+  switch (k) {
+    case NumberKind::MASTER_VOLUME:
+      return "master volume";
+    case NumberKind::CHANNEL_VOLUME:
+      return "channel volume";
+    case NumberKind::CHANNEL_DELAY:
+      return "channel delay";
+    case NumberKind::CHANNEL_HPF_FREQ:
+      return "channel HPF freq";
+    case NumberKind::CHANNEL_LPF_FREQ:
+      return "channel LPF freq";
+    case NumberKind::CHANNEL_COMP_ATTACK:
+      return "comp attack";
+    case NumberKind::CHANNEL_COMP_RELEASE:
+      return "comp release";
+    case NumberKind::CHANNEL_COMP_THRESHOLD:
+      return "comp threshold";
+  }
+  return "?";
+}
+
+void DSP408Number::dump_config() {
+  ESP_LOGCONFIG(TAG, "DSP-408 Number (%s ch=%u): '%s'", kind_name(this->kind_), this->channel_,
+                this->get_name().c_str());
+}
+
+void DSP408Number::control(float value) {
+  if (this->parent_ == nullptr)
+    return;
+  this->publish_state(value);  // optimistic; device-side ack will reaffirm
+  switch (this->kind_) {
+    case NumberKind::MASTER_VOLUME:
+      this->parent_->request_master_volume(value);
+      break;
+    case NumberKind::CHANNEL_VOLUME:
+      this->parent_->request_channel_volume(this->channel_, value);
+      break;
+    case NumberKind::CHANNEL_DELAY:
+      this->parent_->request_channel_delay(this->channel_, static_cast<uint16_t>(value));
+      break;
+    case NumberKind::CHANNEL_HPF_FREQ:
+      this->parent_->request_channel_hpf_freq(this->channel_, static_cast<uint16_t>(value));
+      break;
+    case NumberKind::CHANNEL_LPF_FREQ:
+      this->parent_->request_channel_lpf_freq(this->channel_, static_cast<uint16_t>(value));
+      break;
+    case NumberKind::CHANNEL_COMP_ATTACK:
+      this->parent_->request_compressor_attack(this->channel_, static_cast<uint16_t>(value));
+      break;
+    case NumberKind::CHANNEL_COMP_RELEASE:
+      this->parent_->request_compressor_release(this->channel_, static_cast<uint16_t>(value));
+      break;
+    case NumberKind::CHANNEL_COMP_THRESHOLD:
+      this->parent_->request_compressor_threshold(this->channel_, static_cast<uint8_t>(value));
+      break;
+  }
+}
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/number/dsp408_number.h
+++ b/esphome/components/dsp408/number/dsp408_number.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "esphome/components/number/number.h"
+#include "../dsp408.h"
+
+namespace esphome {
+namespace dsp408 {
+
+enum class NumberKind : uint8_t {
+  MASTER_VOLUME = 0,
+  CHANNEL_VOLUME,
+  CHANNEL_DELAY,
+  CHANNEL_HPF_FREQ,
+  CHANNEL_LPF_FREQ,
+  CHANNEL_COMP_ATTACK,
+  CHANNEL_COMP_RELEASE,
+  CHANNEL_COMP_THRESHOLD,
+};
+
+class DSP408Number : public number::Number, public Component {
+ public:
+  void set_parent(DSP408 *parent) { this->parent_ = parent; }
+  void set_master_volume() { this->kind_ = NumberKind::MASTER_VOLUME; }
+  void set_channel_volume(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_VOLUME;
+    this->channel_ = ch;
+  }
+  void set_channel_delay(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_DELAY;
+    this->channel_ = ch;
+  }
+  void set_channel_hpf_freq(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_HPF_FREQ;
+    this->channel_ = ch;
+  }
+  void set_channel_lpf_freq(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_LPF_FREQ;
+    this->channel_ = ch;
+  }
+  void set_channel_comp_attack(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_COMP_ATTACK;
+    this->channel_ = ch;
+  }
+  void set_channel_comp_release(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_COMP_RELEASE;
+    this->channel_ = ch;
+  }
+  void set_channel_comp_threshold(uint8_t ch) {
+    this->kind_ = NumberKind::CHANNEL_COMP_THRESHOLD;
+    this->channel_ = ch;
+  }
+
+  void setup() override {}
+  void dump_config() override;
+
+ protected:
+  void control(float value) override;
+
+  DSP408 *parent_{nullptr};
+  NumberKind kind_{NumberKind::MASTER_VOLUME};
+  uint8_t channel_{0};
+};
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/number/dsp408_number.h
+++ b/esphome/components/dsp408/number/dsp408_number.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 #include "esphome/components/number/number.h"
 #include "../dsp408.h"
 
@@ -63,3 +65,5 @@ class DSP408Number : public number::Number, public Component {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/protocol.h
+++ b/esphome/components/dsp408/protocol.h
@@ -1,0 +1,377 @@
+#pragma once
+//
+// Dayton Audio DSP-408 wire protocol — direct port of dsp408-py/protocol.py.
+//
+// Wire format (64-byte HID report on EP 0x01 OUT / EP 0x82 IN):
+//
+//     offset  len  field           notes
+//     0       4    magic           80 80 80 ee
+//     4       1    direction       host->dev: a2 (READ) / a1 (WRITE)
+//                                  dev->host: 53 (READ reply) / 51 (WRITE ack)
+//     5       1    version         always 01
+//     6       1    seq             8-bit sequence number
+//     7       1    category        09 = state, 04 = output param, 03 = input
+//     8..11   4    cmd             LE u32 command code
+//     12..13  2    payload length  LE u16
+//     14..N   len  payload         up to 48 bytes single-frame
+//     14+len  1    checksum        XOR of bytes[4 .. 14+len-1]
+//     15+len  1    end marker      aa
+//     rest         padding         00...
+//
+// Multi-frame replies (e.g. cmd=0x77NN, 296 bytes): first frame carries
+// 50 payload bytes WITHOUT chk/end; continuation frames are raw 64-byte
+// chunks until the declared length is satisfied; the last continuation
+// frame ends with chk + end + zero-pad. v0.1 only does single-frame
+// reads/writes (master + per-channel basics) so multi-frame is not yet
+// implemented here.
+
+#include <cstdint>
+#include <cstring>
+#include <cstddef>
+
+namespace esphome {
+namespace dsp408 {
+
+// USB IDs
+static constexpr uint16_t DSP408_VID = 0x0483;
+static constexpr uint16_t DSP408_PID = 0x5750;
+
+// Frame fixed layout
+static constexpr uint8_t FRAME_MAGIC0 = 0x80;
+static constexpr uint8_t FRAME_MAGIC1 = 0x80;
+static constexpr uint8_t FRAME_MAGIC2 = 0x80;
+static constexpr uint8_t FRAME_MAGIC3 = 0xEE;
+static constexpr uint8_t END_MARKER = 0xAA;
+static constexpr uint8_t PROTO_VERSION = 0x01;
+static constexpr size_t FRAME_SIZE = 64;
+static constexpr size_t HEADER_SIZE = 14;  // bytes before payload
+
+// Direction byte
+static constexpr uint8_t DIR_CMD = 0xA2;        // host -> device, READ request
+static constexpr uint8_t DIR_WRITE = 0xA1;      // host -> device, WRITE
+static constexpr uint8_t DIR_RESP = 0x53;       // device -> host, READ reply
+static constexpr uint8_t DIR_WRITE_ACK = 0x51;  // device -> host, WRITE ack
+
+// Category byte
+static constexpr uint8_t CAT_INPUT = 0x03;
+static constexpr uint8_t CAT_STATE = 0x09;
+static constexpr uint8_t CAT_PARAM = 0x04;
+
+// Known command codes
+static constexpr uint32_t CMD_CONNECT = 0xCC;
+static constexpr uint32_t CMD_IDLE_POLL = 0x03;
+static constexpr uint32_t CMD_GET_INFO = 0x04;
+static constexpr uint32_t CMD_PRESET_NAME = 0x00;  // 15-byte ASCII
+static constexpr uint32_t CMD_STATUS = 0x34;
+static constexpr uint32_t CMD_GLOBAL_0X02 = 0x02;
+static constexpr uint32_t CMD_MASTER = 0x05;  // alias for CMD_GLOBAL_0x05
+static constexpr uint32_t CMD_GLOBAL_0X06 = 0x06;
+static constexpr uint32_t CMD_WRITE_CHANNEL_BASE = 0x1F00;  // + ch (CAT_PARAM)
+static constexpr uint32_t CMD_READ_CHANNEL_BASE = 0x7700;   // + ch (multi-frame)
+
+// Per-channel routing matrix writes — 0x2100..0x2107 = Ch1..Ch8.
+// 8-byte payload of uint8_t levels for IN1..IN8 (0x64 = ON / unity, 0x00 = OFF).
+static constexpr uint32_t CMD_ROUTING_BASE = 0x2100;
+// Mirror for IN9..IN16 — DSP-408 only has 4 physical inputs but the
+// protocol surface includes the upper half from the sibling DSP-816 firmware.
+static constexpr uint32_t CMD_ROUTING_HI_BASE = 0x2200;
+static constexpr uint8_t ROUTING_ON = 0x64;
+static constexpr uint8_t ROUTING_OFF = 0x00;
+
+// Per-channel compressor write (firmware-inert in v1.06 but kept for parity).
+static constexpr uint32_t CMD_WRITE_COMPRESSOR_BASE = 0x2300;
+
+// Per-channel name write — 0x2400..0x2407, 8-byte ASCII payload (NUL-padded).
+static constexpr uint32_t CMD_WRITE_CHANNEL_NAME_BASE = 0x2400;
+
+// Crossover writes — 0x12000..0x12007 (named symbol; was a bare literal).
+static constexpr uint32_t CMD_WRITE_CROSSOVER_BASE = 0x12000;
+
+// 10-band parametric EQ writes:
+//   cmd = CMD_WRITE_EQ_BAND_BASE + (band << 8) + channel
+//   band = 0..9, channel = 0..7
+// Payload (8 bytes):
+//   [0..1] freq Hz LE16
+//   [2..3] gain raw LE16 (dB = (raw - 600) / 10; same as channel volume)
+//   [4]    bandwidth byte; Q ≈ 256 / b4_byte
+//   [5..7] zeros
+static constexpr uint32_t CMD_WRITE_EQ_BAND_BASE = 0x10000;
+
+// EQ encoding constants
+static constexpr float EQ_Q_BW_CONSTANT = 256.0f;
+static constexpr int EQ_GAIN_RAW_OFFSET = 600;  // same as CHANNEL_VOL_OFFSET
+static constexpr int EQ_GAIN_RAW_MIN = 0;       // -60 dB
+static constexpr int EQ_GAIN_RAW_MAX = 1200;    // +60 dB envelope
+
+// Master payload constants (decode of byte[0]):
+//     dB = lvl_raw - 60   (0..66 raw = -60..+6 dB)
+static constexpr int MASTER_LEVEL_OFFSET = 60;
+static constexpr int MASTER_LEVEL_MIN = 0;
+static constexpr int MASTER_LEVEL_MAX = 66;
+
+// Per-channel volume:
+//     dB = (raw - 600) / 10   (0..600 = -60..0 dB)
+static constexpr int CHANNEL_VOL_MIN = 0;
+static constexpr int CHANNEL_VOL_MAX = 600;
+static constexpr int CHANNEL_VOL_OFFSET = 600;
+
+// Delay (samples; firmware clamps at 359 -> 8.143 ms @ 44.1 kHz / 7.479 ms @ 48 kHz)
+static constexpr int CHANNEL_DELAY_MIN = 0;
+static constexpr int CHANNEL_DELAY_MAX = 359;
+
+// Default per-channel speaker-role byte (blob[255] / write byte[7]).
+// Values copied from dsp408-py/protocol.py CHANNEL_SUBIDX.
+static constexpr uint8_t CHANNEL_SUBIDX_DEFAULT[8] = {
+    0x01, 0x02, 0x03, 0x07, 0x08, 0x09, 0x0F, 0x12,
+};
+
+// 296-byte channel-state blob layout (returned by cmd=0x77NN reads).
+// Offsets from dsp408-py/protocol.py — cross-verified against the
+// Windows GUI captures on the dsp408-py reverse-engineering branch.
+static constexpr size_t CHANNEL_BLOB_SIZE = 296;
+static constexpr size_t OFF_MUTE = 248;
+static constexpr size_t OFF_POLAR = 249;
+static constexpr size_t OFF_GAIN = 250;      // u16 LE
+static constexpr size_t OFF_DELAY = 252;     // u16 LE samples
+static constexpr size_t OFF_BYTE_254 = 254;  // semantic unknown
+static constexpr size_t OFF_SPK_TYPE = 255;
+static constexpr size_t OFF_HPF_FREQ = 256;    // u16 LE Hz
+static constexpr size_t OFF_HPF_FILTER = 258;  // 0=BW 1=Bessel 2=LR (3=alias)
+static constexpr size_t OFF_HPF_SLOPE = 259;   // 0..7 = 6..48 dB/oct, 8=Off
+static constexpr size_t OFF_LPF_FREQ = 260;
+static constexpr size_t OFF_LPF_FILTER = 262;
+static constexpr size_t OFF_LPF_SLOPE = 263;
+static constexpr size_t OFF_MIXER = 264;       // 8 × u8 (IN1..IN8)
+static constexpr size_t OFF_ALL_PASS_Q = 280;  // u16 LE
+static constexpr size_t OFF_ATTACK_MS = 282;   // u16 LE
+static constexpr size_t OFF_RELEASE_MS = 284;  // u16 LE
+static constexpr size_t OFF_THRESHOLD = 286;
+static constexpr size_t OFF_LINKGROUP = 287;
+static constexpr size_t OFF_NAME = 288;  // 8 bytes ASCII
+static constexpr size_t NAME_LEN = 8;
+
+// EQ region (offsets 0..79; 10 bands × 8 bytes each)
+static constexpr size_t EQ_BAND_COUNT = 10;
+static constexpr size_t EQ_BAND_STRIDE = 8;
+// Each band:
+//   [0..1]  freq Hz LE16
+//   [2..3]  gain raw LE16  (dB = (raw - 600) / 10)
+//   [4]     bandwidth byte (Q ≈ 256 / b4_byte)
+//   [5..7]  zeros
+
+// XOR checksum over [direction .. last_payload_byte] inclusive.
+inline uint8_t xor_checksum(const uint8_t *data, size_t len) {
+  uint8_t c = 0;
+  for (size_t i = 0; i < len; i++)
+    c ^= data[i];
+  return c;
+}
+
+// Build a single-frame 64-byte HID report.
+//
+// `data` may be up to 48 bytes (FRAME_SIZE - HEADER_SIZE - 2 for chk + end).
+// On overflow returns false and leaves `out` unmodified.
+//
+// `out` is always cleared to 64 bytes of zero before population.
+inline bool build_frame(uint8_t *out, uint8_t direction, uint8_t seq, uint32_t cmd, uint8_t category,
+                        const uint8_t *data, size_t data_len) {
+  if (data_len > FRAME_SIZE - HEADER_SIZE - 2)
+    return false;
+  std::memset(out, 0, FRAME_SIZE);
+  out[0] = FRAME_MAGIC0;
+  out[1] = FRAME_MAGIC1;
+  out[2] = FRAME_MAGIC2;
+  out[3] = FRAME_MAGIC3;
+  out[4] = direction;
+  out[5] = PROTO_VERSION;
+  out[6] = seq;
+  out[7] = category;
+  out[8] = static_cast<uint8_t>(cmd & 0xFF);
+  out[9] = static_cast<uint8_t>((cmd >> 8) & 0xFF);
+  out[10] = static_cast<uint8_t>((cmd >> 16) & 0xFF);
+  out[11] = static_cast<uint8_t>((cmd >> 24) & 0xFF);
+  out[12] = static_cast<uint8_t>(data_len & 0xFF);
+  out[13] = static_cast<uint8_t>((data_len >> 8) & 0xFF);
+  if (data != nullptr && data_len > 0)
+    std::memcpy(out + HEADER_SIZE, data, data_len);
+  // XOR over [direction .. end-of-payload]
+  uint8_t chk = xor_checksum(out + 4, HEADER_SIZE - 4 + data_len);
+  out[HEADER_SIZE + data_len] = chk;
+  out[HEADER_SIZE + data_len + 1] = END_MARKER;
+  return true;
+}
+
+// Build a sequence of 64-byte HID reports for a multi-frame logical
+// payload (when payload_len > 48). Mirrors dsp408-py's
+// build_frames_multi() byte-exactly:
+//
+//   First frame:  header[14] + first_50_bytes_of_payload (no chk/end)
+//   Continuation: 64-byte raw payload chunks
+//   LAST cont:    payload + chk + END_MARKER + zero-pad
+//
+// The chk covers (header[4..14] = 10 bytes) + (full payload bytes).
+//
+// `out` is a flat buffer that receives FRAME_SIZE * num_frames bytes.
+// Returns the number of frames produced (0 on failure). `out_capacity`
+// is the size of the output buffer in bytes; we won't write past it.
+//
+// For the only multi-frame WRITE we currently use (full channel state,
+// 296 bytes), this produces 5 frames = 320 bytes total.
+inline size_t build_frames_multi(uint8_t *out, size_t out_capacity, uint8_t direction, uint8_t seq, uint32_t cmd,
+                                 uint8_t category, const uint8_t *payload, size_t payload_len) {
+  // Single-frame fast path
+  if (payload_len <= FRAME_SIZE - HEADER_SIZE - 2) {
+    if (out_capacity < FRAME_SIZE)
+      return 0;
+    if (!build_frame(out, direction, seq, cmd, category, payload, payload_len))
+      return 0;
+    return 1;
+  }
+
+  // Multi-frame layout
+  static constexpr size_t MAX_IN_FIRST_MULTI = FRAME_SIZE - HEADER_SIZE;  // 50
+  size_t total_frames = 1;                                                // first frame
+  // Continuation frame count: ceil((payload_len - 50) / 64)
+  size_t rest = payload_len - MAX_IN_FIRST_MULTI;
+  total_frames += (rest + FRAME_SIZE - 1) / FRAME_SIZE;
+  // Last cont's chk + end may overflow into one more frame if the
+  // last cont was full (rare with our blob sizes; safer to budget).
+  size_t bytes_in_last_cont = rest % FRAME_SIZE;
+  if (bytes_in_last_cont == 0)
+    bytes_in_last_cont = FRAME_SIZE;
+  if (bytes_in_last_cont > FRAME_SIZE - 2) {
+    // Need a spill frame for chk + end
+    total_frames += 1;
+  }
+  if (out_capacity < total_frames * FRAME_SIZE)
+    return 0;
+
+  // Compute chk over header[4..14] + full payload
+  uint8_t chk = 0;
+  // First frame header bytes [4..14] = direction, ver, seq, cat, cmd_le32, len_le16
+  uint8_t hdr_chk_bytes[10] = {
+      direction,
+      PROTO_VERSION,
+      seq,
+      category,
+      static_cast<uint8_t>(cmd & 0xFF),
+      static_cast<uint8_t>((cmd >> 8) & 0xFF),
+      static_cast<uint8_t>((cmd >> 16) & 0xFF),
+      static_cast<uint8_t>((cmd >> 24) & 0xFF),
+      static_cast<uint8_t>(payload_len & 0xFF),
+      static_cast<uint8_t>((payload_len >> 8) & 0xFF),
+  };
+  chk = xor_checksum(hdr_chk_bytes, sizeof(hdr_chk_bytes));
+  chk ^= xor_checksum(payload, payload_len);
+
+  // First frame
+  uint8_t *p = out;
+  std::memset(p, 0, FRAME_SIZE);
+  p[0] = FRAME_MAGIC0;
+  p[1] = FRAME_MAGIC1;
+  p[2] = FRAME_MAGIC2;
+  p[3] = FRAME_MAGIC3;
+  std::memcpy(p + 4, hdr_chk_bytes, sizeof(hdr_chk_bytes));
+  std::memcpy(p + HEADER_SIZE, payload, MAX_IN_FIRST_MULTI);
+  size_t produced_payload = MAX_IN_FIRST_MULTI;
+  p += FRAME_SIZE;
+
+  // Continuation frames
+  while (produced_payload < payload_len) {
+    std::memset(p, 0, FRAME_SIZE);
+    size_t remaining = payload_len - produced_payload;
+    size_t take = remaining > FRAME_SIZE ? FRAME_SIZE : remaining;
+    std::memcpy(p, payload + produced_payload, take);
+    produced_payload += take;
+    if (produced_payload == payload_len) {
+      // This is the last cont frame — append chk + END_MARKER if room
+      if (take + 2 <= FRAME_SIZE) {
+        p[take] = chk;
+        p[take + 1] = END_MARKER;
+      } else {
+        // Spill chk+end into the next frame
+        p += FRAME_SIZE;
+        std::memset(p, 0, FRAME_SIZE);
+        p[0] = chk;
+        p[1] = END_MARKER;
+      }
+    }
+    p += FRAME_SIZE;
+  }
+  return total_frames;
+}
+
+// Parsed view of an inbound 64-byte frame. `payload` points into the
+// caller-owned report buffer — copy it if you need to keep it past the
+// transfer callback's lifetime.
+struct ParsedFrame {
+  bool valid;  // false if not a DSP-408 frame (magic mismatch / truncated)
+  uint8_t direction;
+  uint8_t seq;
+  uint8_t category;
+  uint32_t cmd;
+  uint16_t payload_len;  // declared length; may exceed bytes_in_this_frame for multi-frame
+  const uint8_t *payload;
+  uint16_t payload_bytes_in_frame;  // bytes actually present in THIS 64-byte frame
+  uint8_t checksum;
+  bool checksum_ok;
+  bool is_multi_frame_first;  // true if declared length > 48 bytes
+};
+
+inline ParsedFrame parse_frame(const uint8_t *raw, size_t raw_len) {
+  ParsedFrame f{};
+  f.valid = false;
+  if (raw_len < HEADER_SIZE + 2)
+    return f;
+  if (raw[0] != FRAME_MAGIC0 || raw[1] != FRAME_MAGIC1 || raw[2] != FRAME_MAGIC2 || raw[3] != FRAME_MAGIC3)
+    return f;
+  if (raw[5] != PROTO_VERSION)
+    return f;
+  f.direction = raw[4];
+  f.seq = raw[6];
+  f.category = raw[7];
+  f.cmd = static_cast<uint32_t>(raw[8]) | (static_cast<uint32_t>(raw[9]) << 8) |
+          (static_cast<uint32_t>(raw[10]) << 16) | (static_cast<uint32_t>(raw[11]) << 24);
+  f.payload_len = static_cast<uint16_t>(raw[12]) | (static_cast<uint16_t>(raw[13]) << 8);
+
+  // Single-frame: header(14) + payload(<=48) + chk + end + zero-pad
+  // Multi-frame first: header(14) + payload(50) — no chk/end here.
+  size_t max_in_frame;
+  size_t max_available;
+  if (f.payload_len > FRAME_SIZE - HEADER_SIZE - 2) {
+    f.is_multi_frame_first = true;
+    max_in_frame = FRAME_SIZE - HEADER_SIZE;  // 50
+    max_available = raw_len - HEADER_SIZE;
+  } else {
+    f.is_multi_frame_first = false;
+    max_in_frame = FRAME_SIZE - HEADER_SIZE - 2;  // 48
+    max_available = raw_len > HEADER_SIZE + 2 ? raw_len - HEADER_SIZE - 2 : 0;
+  }
+  size_t present = f.payload_len;
+  if (present > max_in_frame)
+    present = max_in_frame;
+  if (present > max_available)
+    present = max_available;
+  f.payload = raw + HEADER_SIZE;
+  f.payload_bytes_in_frame = static_cast<uint16_t>(present);
+
+  if (!f.is_multi_frame_first) {
+    size_t chk_pos = HEADER_SIZE + present;
+    if (chk_pos < raw_len) {
+      f.checksum = raw[chk_pos];
+      f.checksum_ok = (xor_checksum(raw + 4, chk_pos - 4) == f.checksum);
+    } else {
+      f.checksum = 0;
+      f.checksum_ok = false;
+    }
+  } else {
+    f.checksum = 0;
+    f.checksum_ok = false;  // validated only after multi-frame reassembly
+  }
+
+  f.valid = true;
+  return f;
+}
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/protocol.h
+++ b/esphome/components/dsp408/protocol.h
@@ -1,6 +1,11 @@
 #pragma once
 //
 // Dayton Audio DSP-408 wire protocol — direct port of dsp408-py/protocol.py.
+// Reference: https://github.com/malaiwah/dsp408-py/blob/main/dsp408/protocol.py
+//
+// All field semantics, command codes, and blob offsets here are
+// byte-exact to dsp408-py, which derived them from Windows GUI captures
+// against a real DSP-408 (firmware MYDW-AV1.06).
 //
 // Wire format (64-byte HID report on EP 0x01 OUT / EP 0x82 IN):
 //

--- a/esphome/components/dsp408/select/__init__.py
+++ b/esphome/components/dsp408/select/__init__.py
@@ -14,11 +14,10 @@ from esphome.components import select
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL
 
-from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+from .. import CONF_DSP408_ID, CONF_KIND, DSP408, dsp408_ns
 
 DEPENDENCIES = ["dsp408"]
 
-CONF_KIND = "kind"
 KIND_CHANNEL_HPF_FILTER = "CHANNEL_HPF_FILTER"
 KIND_CHANNEL_HPF_SLOPE = "CHANNEL_HPF_SLOPE"
 KIND_CHANNEL_LPF_FILTER = "CHANNEL_LPF_FILTER"

--- a/esphome/components/dsp408/select/__init__.py
+++ b/esphome/components/dsp408/select/__init__.py
@@ -1,0 +1,90 @@
+"""DSP-408 select sub-platform.
+
+Kinds:
+  * CHANNEL_HPF_FILTER  -- HPF filter type per channel (Butterworth /
+                           Bessel / Linkwitz-Riley)
+  * CHANNEL_HPF_SLOPE   -- HPF slope per channel (6/12/18/24/30/36/42/48
+                           dB/oct, or Off)
+  * CHANNEL_LPF_FILTER  -- same for LPF
+  * CHANNEL_LPF_SLOPE   -- same for LPF
+"""
+
+import esphome.codegen as cg
+from esphome.components import select
+import esphome.config_validation as cv
+from esphome.const import CONF_CHANNEL
+
+from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+
+DEPENDENCIES = ["dsp408"]
+
+CONF_KIND = "kind"
+KIND_CHANNEL_HPF_FILTER = "CHANNEL_HPF_FILTER"
+KIND_CHANNEL_HPF_SLOPE = "CHANNEL_HPF_SLOPE"
+KIND_CHANNEL_LPF_FILTER = "CHANNEL_LPF_FILTER"
+KIND_CHANNEL_LPF_SLOPE = "CHANNEL_LPF_SLOPE"
+
+KINDS = {
+    KIND_CHANNEL_HPF_FILTER: KIND_CHANNEL_HPF_FILTER,
+    KIND_CHANNEL_HPF_SLOPE: KIND_CHANNEL_HPF_SLOPE,
+    KIND_CHANNEL_LPF_FILTER: KIND_CHANNEL_LPF_FILTER,
+    KIND_CHANNEL_LPF_SLOPE: KIND_CHANNEL_LPF_SLOPE,
+}
+
+# Per dsp408-py FILTER_TYPE_NAMES — note 2 and 3 are duplicates. The
+# Windows GUI surfaces 3 distinct options; we follow that for HA UX.
+FILTER_OPTIONS = ["Butterworth", "Bessel", "Linkwitz-Riley"]
+SLOPE_OPTIONS = [
+    "6 dB/oct",
+    "12 dB/oct",
+    "18 dB/oct",
+    "24 dB/oct",
+    "30 dB/oct",
+    "36 dB/oct",
+    "42 dB/oct",
+    "48 dB/oct",
+    "Off",
+]
+
+DSP408Select = dsp408_ns.class_("DSP408Select", select.Select, cg.Component)
+
+
+def _validate(config):
+    if CONF_CHANNEL not in config:
+        raise cv.Invalid("channel: 0..7 is required")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    select.select_schema(DSP408Select).extend(
+        {
+            cv.GenerateID(CONF_DSP408_ID): cv.use_id(DSP408),
+            cv.Required(CONF_KIND): cv.enum(KINDS, upper=True),
+            cv.Required(CONF_CHANNEL): cv.int_range(min=0, max=7),
+        }
+    ),
+    _validate,
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DSP408_ID])
+    kind = config[CONF_KIND]
+    ch = config[CONF_CHANNEL]
+    if kind in (KIND_CHANNEL_HPF_FILTER, KIND_CHANNEL_LPF_FILTER):
+        var = await select.new_select(config, options=FILTER_OPTIONS)
+    else:
+        var = await select.new_select(config, options=SLOPE_OPTIONS)
+    cg.add(var.set_parent(parent))
+    if kind == KIND_CHANNEL_HPF_FILTER:
+        cg.add(var.set_channel_hpf_filter(ch))
+        cg.add(parent.set_channel_hpf_filter_select(ch, var))
+    elif kind == KIND_CHANNEL_HPF_SLOPE:
+        cg.add(var.set_channel_hpf_slope(ch))
+        cg.add(parent.set_channel_hpf_slope_select(ch, var))
+    elif kind == KIND_CHANNEL_LPF_FILTER:
+        cg.add(var.set_channel_lpf_filter(ch))
+        cg.add(parent.set_channel_lpf_filter_select(ch, var))
+    elif kind == KIND_CHANNEL_LPF_SLOPE:
+        cg.add(var.set_channel_lpf_slope(ch))
+        cg.add(parent.set_channel_lpf_slope_select(ch, var))

--- a/esphome/components/dsp408/select/dsp408_select.cpp
+++ b/esphome/components/dsp408/select/dsp408_select.cpp
@@ -1,6 +1,8 @@
 #include "dsp408_select.h"
 #include "esphome/core/log.h"
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 namespace esphome {
 namespace dsp408 {
 
@@ -84,3 +86,5 @@ void DSP408Select::control(const std::string &value) {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/select/dsp408_select.cpp
+++ b/esphome/components/dsp408/select/dsp408_select.cpp
@@ -1,0 +1,86 @@
+#include "dsp408_select.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace dsp408 {
+
+static const char *const TAG = "dsp408.select";
+
+static const char *kind_name(SelectKind k) {
+  switch (k) {
+    case SelectKind::CHANNEL_HPF_FILTER:
+      return "HPF filter";
+    case SelectKind::CHANNEL_HPF_SLOPE:
+      return "HPF slope";
+    case SelectKind::CHANNEL_LPF_FILTER:
+      return "LPF filter";
+    case SelectKind::CHANNEL_LPF_SLOPE:
+      return "LPF slope";
+  }
+  return "?";
+}
+
+void DSP408Select::dump_config() {
+  ESP_LOGCONFIG(TAG, "DSP-408 Select (%s ch=%u): '%s'", kind_name(this->kind_), this->channel_,
+                this->get_name().c_str());
+}
+
+// Filter type indices: 0=Butterworth, 1=Bessel, 2=LR, 3=LR (alias).
+static int filter_index_for(const std::string &v) {
+  if (v == "Butterworth")
+    return 0;
+  if (v == "Bessel")
+    return 1;
+  if (v == "Linkwitz-Riley")
+    return 2;
+  return -1;
+}
+
+// Slope indices: 0..7 = 6/12/18/24/30/36/42/48 dB/oct, 8 = Off.
+static int slope_index_for(const std::string &v) {
+  static const char *NAMES[9] = {"6 dB/oct",  "12 dB/oct", "18 dB/oct", "24 dB/oct", "30 dB/oct",
+                                 "36 dB/oct", "42 dB/oct", "48 dB/oct", "Off"};
+  for (int i = 0; i < 9; i++)
+    if (v == NAMES[i])
+      return i;
+  return -1;
+}
+
+void DSP408Select::control(const std::string &value) {
+  if (this->parent_ == nullptr)
+    return;
+  this->publish_state(value);  // optimistic — device ack will reaffirm
+  switch (this->kind_) {
+    case SelectKind::CHANNEL_HPF_FILTER: {
+      int idx = filter_index_for(value);
+      if (idx < 0)
+        return;
+      this->parent_->request_channel_hpf_filter(this->channel_, static_cast<uint8_t>(idx));
+      break;
+    }
+    case SelectKind::CHANNEL_HPF_SLOPE: {
+      int idx = slope_index_for(value);
+      if (idx < 0)
+        return;
+      this->parent_->request_channel_hpf_slope(this->channel_, static_cast<uint8_t>(idx));
+      break;
+    }
+    case SelectKind::CHANNEL_LPF_FILTER: {
+      int idx = filter_index_for(value);
+      if (idx < 0)
+        return;
+      this->parent_->request_channel_lpf_filter(this->channel_, static_cast<uint8_t>(idx));
+      break;
+    }
+    case SelectKind::CHANNEL_LPF_SLOPE: {
+      int idx = slope_index_for(value);
+      if (idx < 0)
+        return;
+      this->parent_->request_channel_lpf_slope(this->channel_, static_cast<uint8_t>(idx));
+      break;
+    }
+  }
+}
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/select/dsp408_select.h
+++ b/esphome/components/dsp408/select/dsp408_select.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "../dsp408.h"
+
+namespace esphome {
+namespace dsp408 {
+
+enum class SelectKind : uint8_t {
+  CHANNEL_HPF_FILTER = 0,
+  CHANNEL_HPF_SLOPE,
+  CHANNEL_LPF_FILTER,
+  CHANNEL_LPF_SLOPE,
+};
+
+class DSP408Select : public select::Select, public Component {
+ public:
+  void set_parent(DSP408 *parent) { this->parent_ = parent; }
+  void set_channel_hpf_filter(uint8_t ch) {
+    this->kind_ = SelectKind::CHANNEL_HPF_FILTER;
+    this->channel_ = ch;
+  }
+  void set_channel_hpf_slope(uint8_t ch) {
+    this->kind_ = SelectKind::CHANNEL_HPF_SLOPE;
+    this->channel_ = ch;
+  }
+  void set_channel_lpf_filter(uint8_t ch) {
+    this->kind_ = SelectKind::CHANNEL_LPF_FILTER;
+    this->channel_ = ch;
+  }
+  void set_channel_lpf_slope(uint8_t ch) {
+    this->kind_ = SelectKind::CHANNEL_LPF_SLOPE;
+    this->channel_ = ch;
+  }
+
+  void setup() override {}
+  void dump_config() override;
+
+ protected:
+  void control(const std::string &value) override;
+
+  DSP408 *parent_{nullptr};
+  SelectKind kind_{SelectKind::CHANNEL_HPF_FILTER};
+  uint8_t channel_{0};
+};
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/select/dsp408_select.h
+++ b/esphome/components/dsp408/select/dsp408_select.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 #include "esphome/components/select/select.h"
 #include "../dsp408.h"
 
@@ -46,3 +48,5 @@ class DSP408Select : public select::Select, public Component {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/switch/__init__.py
+++ b/esphome/components/dsp408/switch/__init__.py
@@ -12,11 +12,10 @@ from esphome.components import switch as switch_
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL
 
-from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+from .. import CONF_DSP408_ID, CONF_KIND, DSP408, dsp408_ns
 
 DEPENDENCIES = ["dsp408"]
 
-CONF_KIND = "kind"
 KIND_MASTER_MUTE = "MASTER_MUTE"
 KIND_CHANNEL_MUTE = "CHANNEL_MUTE"
 KIND_CHANNEL_POLAR = "CHANNEL_POLAR"

--- a/esphome/components/dsp408/switch/__init__.py
+++ b/esphome/components/dsp408/switch/__init__.py
@@ -1,0 +1,77 @@
+"""DSP-408 switch sub-platform.
+
+Kinds:
+  * MASTER_MUTE      -- toggle master mute
+  * CHANNEL_MUTE     -- per-channel mute (output side)
+  * CHANNEL_POLAR    -- per-channel phase invert (output side, 180°)
+  * INPUT_POLAR      -- per-input phase invert (cat=0x03 MISC plane)
+"""
+
+import esphome.codegen as cg
+from esphome.components import switch as switch_
+import esphome.config_validation as cv
+from esphome.const import CONF_CHANNEL
+
+from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+
+DEPENDENCIES = ["dsp408"]
+
+CONF_KIND = "kind"
+KIND_MASTER_MUTE = "MASTER_MUTE"
+KIND_CHANNEL_MUTE = "CHANNEL_MUTE"
+KIND_CHANNEL_POLAR = "CHANNEL_POLAR"
+KIND_INPUT_POLAR = "INPUT_POLAR"
+
+KINDS = {
+    KIND_MASTER_MUTE: KIND_MASTER_MUTE,
+    KIND_CHANNEL_MUTE: KIND_CHANNEL_MUTE,
+    KIND_CHANNEL_POLAR: KIND_CHANNEL_POLAR,
+    KIND_INPUT_POLAR: KIND_INPUT_POLAR,
+}
+
+PER_CHANNEL_KINDS = {KIND_CHANNEL_MUTE, KIND_CHANNEL_POLAR, KIND_INPUT_POLAR}
+
+DSP408Switch = dsp408_ns.class_("DSP408Switch", switch_.Switch, cg.Component)
+
+
+def _validate(config):
+    kind = config[CONF_KIND]
+    if kind in PER_CHANNEL_KINDS and CONF_CHANNEL not in config:
+        raise cv.Invalid(f"channel: 0..7 is required for kind: {kind}")
+    if kind == KIND_MASTER_MUTE and CONF_CHANNEL in config:
+        raise cv.Invalid("channel: must NOT be set for kind: MASTER_MUTE")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    switch_.switch_schema(DSP408Switch).extend(
+        {
+            cv.GenerateID(CONF_DSP408_ID): cv.use_id(DSP408),
+            cv.Required(CONF_KIND): cv.enum(KINDS, upper=True),
+            cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=7),
+        }
+    ),
+    _validate,
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DSP408_ID])
+    var = await switch_.new_switch(config)
+    cg.add(var.set_parent(parent))
+    kind = config[CONF_KIND]
+    if kind == KIND_MASTER_MUTE:
+        cg.add(var.set_master_mute())
+        cg.add(parent.set_master_mute_switch(var))
+    elif kind == KIND_CHANNEL_MUTE:
+        ch = config[CONF_CHANNEL]
+        cg.add(var.set_channel_mute(ch))
+        cg.add(parent.set_channel_mute_switch(ch, var))
+    elif kind == KIND_CHANNEL_POLAR:
+        ch = config[CONF_CHANNEL]
+        cg.add(var.set_channel_polar(ch))
+        cg.add(parent.set_channel_polar_switch(ch, var))
+    elif kind == KIND_INPUT_POLAR:
+        ch = config[CONF_CHANNEL]
+        cg.add(var.set_input_polar(ch))
+        cg.add(parent.set_input_polar_switch(ch, var))

--- a/esphome/components/dsp408/switch/dsp408_switch.cpp
+++ b/esphome/components/dsp408/switch/dsp408_switch.cpp
@@ -1,0 +1,49 @@
+#include "dsp408_switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace dsp408 {
+
+static const char *const TAG = "dsp408.switch";
+
+static const char *kind_name(SwitchKind k) {
+  switch (k) {
+    case SwitchKind::MASTER_MUTE:
+      return "master mute";
+    case SwitchKind::CHANNEL_MUTE:
+      return "channel mute";
+    case SwitchKind::CHANNEL_POLAR:
+      return "channel polar";
+    case SwitchKind::INPUT_POLAR:
+      return "input polar";
+  }
+  return "?";
+}
+
+void DSP408Switch::dump_config() {
+  ESP_LOGCONFIG(TAG, "DSP-408 Switch (%s ch=%u): '%s'", kind_name(this->kind_), this->channel_,
+                this->get_name().c_str());
+}
+
+void DSP408Switch::write_state(bool state) {
+  if (this->parent_ == nullptr)
+    return;
+  this->publish_state(state);  // optimistic
+  switch (this->kind_) {
+    case SwitchKind::MASTER_MUTE:
+      this->parent_->request_master_mute(state);
+      break;
+    case SwitchKind::CHANNEL_MUTE:
+      this->parent_->request_channel_mute(this->channel_, state);
+      break;
+    case SwitchKind::CHANNEL_POLAR:
+      this->parent_->request_channel_polar(this->channel_, state);
+      break;
+    case SwitchKind::INPUT_POLAR:
+      this->parent_->request_input_polar(this->channel_, state);
+      break;
+  }
+}
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/switch/dsp408_switch.cpp
+++ b/esphome/components/dsp408/switch/dsp408_switch.cpp
@@ -1,6 +1,8 @@
 #include "dsp408_switch.h"
 #include "esphome/core/log.h"
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 namespace esphome {
 namespace dsp408 {
 
@@ -47,3 +49,5 @@ void DSP408Switch::write_state(bool state) {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/switch/dsp408_switch.h
+++ b/esphome/components/dsp408/switch/dsp408_switch.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "../dsp408.h"
+
+namespace esphome {
+namespace dsp408 {
+
+enum class SwitchKind : uint8_t {
+  MASTER_MUTE = 0,
+  CHANNEL_MUTE,
+  CHANNEL_POLAR,
+  INPUT_POLAR,
+};
+
+class DSP408Switch : public switch_::Switch, public Component {
+ public:
+  void set_parent(DSP408 *parent) { this->parent_ = parent; }
+  void set_master_mute() { this->kind_ = SwitchKind::MASTER_MUTE; }
+  void set_channel_mute(uint8_t ch) {
+    this->kind_ = SwitchKind::CHANNEL_MUTE;
+    this->channel_ = ch;
+  }
+  void set_channel_polar(uint8_t ch) {
+    this->kind_ = SwitchKind::CHANNEL_POLAR;
+    this->channel_ = ch;
+  }
+  void set_input_polar(uint8_t input_ch) {
+    this->kind_ = SwitchKind::INPUT_POLAR;
+    this->channel_ = input_ch;
+  }
+
+  void setup() override {}
+  void dump_config() override;
+
+ protected:
+  void write_state(bool state) override;
+
+  DSP408 *parent_{nullptr};
+  SwitchKind kind_{SwitchKind::MASTER_MUTE};
+  uint8_t channel_{0};
+};
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/switch/dsp408_switch.h
+++ b/esphome/components/dsp408/switch/dsp408_switch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 #include "esphome/components/switch/switch.h"
 #include "../dsp408.h"
 
@@ -43,3 +45,5 @@ class DSP408Switch : public switch_::Switch, public Component {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/text/__init__.py
+++ b/esphome/components/dsp408/text/__init__.py
@@ -1,0 +1,65 @@
+"""DSP-408 text (read+write) sub-platform.
+
+Kinds:
+  * PRESET_NAME    -- 15-byte ASCII preset name (cmd=0x00 / cat=0x09)
+  * CHANNEL_NAME   -- per-channel 8-byte ASCII name (cmd=0x2400+ch / cat=0x04),
+                      pulled from blob[288..295] on warmup, written via
+                      cmd=0x2400+ch.
+"""
+
+import esphome.codegen as cg
+from esphome.components import text
+import esphome.config_validation as cv
+from esphome.const import CONF_CHANNEL
+
+from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+
+DEPENDENCIES = ["dsp408"]
+
+CONF_KIND = "kind"
+KIND_PRESET_NAME = "PRESET_NAME"
+KIND_CHANNEL_NAME = "CHANNEL_NAME"
+
+KINDS = {
+    KIND_PRESET_NAME: KIND_PRESET_NAME,
+    KIND_CHANNEL_NAME: KIND_CHANNEL_NAME,
+}
+
+DSP408Text = dsp408_ns.class_("DSP408Text", text.Text, cg.Component)
+
+
+def _validate(config):
+    kind = config[CONF_KIND]
+    if kind == KIND_CHANNEL_NAME and CONF_CHANNEL not in config:
+        raise cv.Invalid("channel: 0..7 is required for kind: CHANNEL_NAME")
+    if kind == KIND_PRESET_NAME and CONF_CHANNEL in config:
+        raise cv.Invalid("channel: must NOT be set for kind: PRESET_NAME")
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    text.text_schema(DSP408Text).extend(
+        {
+            cv.GenerateID(CONF_DSP408_ID): cv.use_id(DSP408),
+            cv.Required(CONF_KIND): cv.enum(KINDS, upper=True),
+            cv.Optional(CONF_CHANNEL): cv.int_range(min=0, max=7),
+        }
+    ),
+    _validate,
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DSP408_ID])
+    kind = config[CONF_KIND]
+    if kind == KIND_PRESET_NAME:
+        var = await text.new_text(config, max_length=15)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_preset_name())
+        cg.add(parent.set_preset_name_text(var))
+    else:  # CHANNEL_NAME
+        ch = config[CONF_CHANNEL]
+        var = await text.new_text(config, max_length=8)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_channel_name(ch))
+        cg.add(parent.set_channel_name_text(ch, var))

--- a/esphome/components/dsp408/text/__init__.py
+++ b/esphome/components/dsp408/text/__init__.py
@@ -12,11 +12,10 @@ from esphome.components import text
 import esphome.config_validation as cv
 from esphome.const import CONF_CHANNEL
 
-from .. import CONF_DSP408_ID, DSP408, dsp408_ns
+from .. import CONF_DSP408_ID, CONF_KIND, DSP408, dsp408_ns
 
 DEPENDENCIES = ["dsp408"]
 
-CONF_KIND = "kind"
 KIND_PRESET_NAME = "PRESET_NAME"
 KIND_CHANNEL_NAME = "CHANNEL_NAME"
 

--- a/esphome/components/dsp408/text/dsp408_text.cpp
+++ b/esphome/components/dsp408/text/dsp408_text.cpp
@@ -1,0 +1,29 @@
+#include "dsp408_text.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace dsp408 {
+
+static const char *const TAG = "dsp408.text";
+
+void DSP408Text::dump_config() {
+  if (this->kind_ == TextKind::PRESET_NAME) {
+    ESP_LOGCONFIG(TAG, "DSP-408 Text (preset name): '%s'", this->get_name().c_str());
+  } else {
+    ESP_LOGCONFIG(TAG, "DSP-408 Text (channel %u name): '%s'", this->channel_, this->get_name().c_str());
+  }
+}
+
+void DSP408Text::control(const std::string &value) {
+  if (this->parent_ == nullptr)
+    return;
+  this->publish_state(value);  // optimistic
+  if (this->kind_ == TextKind::PRESET_NAME) {
+    this->parent_->request_preset_name(value);
+  } else {
+    this->parent_->request_channel_name(this->channel_, value);
+  }
+}
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/text/dsp408_text.cpp
+++ b/esphome/components/dsp408/text/dsp408_text.cpp
@@ -1,6 +1,8 @@
 #include "dsp408_text.h"
 #include "esphome/core/log.h"
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 namespace esphome {
 namespace dsp408 {
 
@@ -27,3 +29,5 @@ void DSP408Text::control(const std::string &value) {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/text/dsp408_text.h
+++ b/esphome/components/dsp408/text/dsp408_text.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "esphome/components/text/text.h"
+#include "../dsp408.h"
+
+namespace esphome {
+namespace dsp408 {
+
+enum class TextKind : uint8_t {
+  PRESET_NAME = 0,
+  CHANNEL_NAME,
+};
+
+class DSP408Text : public text::Text, public Component {
+ public:
+  void set_parent(DSP408 *parent) { this->parent_ = parent; }
+  void set_preset_name() { this->kind_ = TextKind::PRESET_NAME; }
+  void set_channel_name(uint8_t ch) {
+    this->kind_ = TextKind::CHANNEL_NAME;
+    this->channel_ = ch;
+  }
+
+  void setup() override {}
+  void dump_config() override;
+
+ protected:
+  void control(const std::string &value) override;
+
+  DSP408 *parent_{nullptr};
+  TextKind kind_{TextKind::PRESET_NAME};
+  uint8_t channel_{0};
+};
+
+}  // namespace dsp408
+}  // namespace esphome

--- a/esphome/components/dsp408/text/dsp408_text.h
+++ b/esphome/components/dsp408/text/dsp408_text.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#if defined(USE_ESP32_VARIANT_ESP32P4) || defined(USE_ESP32_VARIANT_ESP32S2) || defined(USE_ESP32_VARIANT_ESP32S3)
+
 #include "esphome/components/text/text.h"
 #include "../dsp408.h"
 
@@ -33,3 +35,5 @@ class DSP408Text : public text::Text, public Component {
 
 }  // namespace dsp408
 }  // namespace esphome
+
+#endif  // USE_ESP32_VARIANT_ESP32S2/S3/P4

--- a/esphome/components/dsp408/text_sensor/__init__.py
+++ b/esphome/components/dsp408/text_sensor/__init__.py
@@ -1,0 +1,34 @@
+"""DSP-408 text_sensor sub-platform.
+
+Currently exposes one read-only entity:
+  * model — the device identity string returned by GET_INFO
+    (e.g. ``"MYDW-AV1.06"`` on stock DSP-408 firmware v1.06).
+"""
+
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+
+from .. import CONF_DSP408_ID, DSP408
+
+DEPENDENCIES = ["dsp408"]
+
+CONF_KIND = "kind"
+KIND_MODEL = "MODEL"
+
+KINDS = {KIND_MODEL: "MODEL"}
+
+
+CONFIG_SCHEMA = text_sensor.text_sensor_schema().extend(
+    {
+        cv.GenerateID(CONF_DSP408_ID): cv.use_id(DSP408),
+        cv.Required(CONF_KIND): cv.enum(KINDS, upper=True),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_DSP408_ID])
+    var = await text_sensor.new_text_sensor(config)
+    if config[CONF_KIND] == KIND_MODEL:
+        cg.add(parent.set_model_text_sensor(var))

--- a/esphome/components/dsp408/text_sensor/__init__.py
+++ b/esphome/components/dsp408/text_sensor/__init__.py
@@ -9,11 +9,10 @@ import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
 
-from .. import CONF_DSP408_ID, DSP408
+from .. import CONF_DSP408_ID, CONF_KIND, DSP408
 
 DEPENDENCIES = ["dsp408"]
 
-CONF_KIND = "kind"
 KIND_MODEL = "MODEL"
 
 KINDS = {KIND_MODEL: "MODEL"}

--- a/tests/components/dsp408/common.yaml
+++ b/tests/components/dsp408/common.yaml
@@ -1,0 +1,107 @@
+usb_host:
+
+dsp408:
+  id: my_dsp
+
+text_sensor:
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: MODEL
+    name: "DSP-408 Model"
+
+number:
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: MASTER_VOLUME
+    name: "Master Volume"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_VOLUME
+    channel: 0
+    name: "Ch1 Volume"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_DELAY
+    channel: 0
+    name: "Ch1 Delay"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_HPF_FREQ
+    channel: 0
+    name: "Ch1 HPF"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_LPF_FREQ
+    channel: 0
+    name: "Ch1 LPF"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_COMP_ATTACK
+    channel: 0
+    name: "Ch1 Comp Attack"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_COMP_RELEASE
+    channel: 0
+    name: "Ch1 Comp Release"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_COMP_THRESHOLD
+    channel: 0
+    name: "Ch1 Comp Threshold"
+
+switch:
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: MASTER_MUTE
+    name: "Master Mute"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_MUTE
+    channel: 0
+    name: "Ch1 Mute"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_POLAR
+    channel: 0
+    name: "Ch1 Polar"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: INPUT_POLAR
+    channel: 0
+    name: "Input 1 Polar"
+
+select:
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_HPF_FILTER
+    channel: 0
+    name: "Ch1 HPF Type"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_HPF_SLOPE
+    channel: 0
+    name: "Ch1 HPF Slope"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_LPF_FILTER
+    channel: 0
+    name: "Ch1 LPF Type"
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_LPF_SLOPE
+    channel: 0
+    name: "Ch1 LPF Slope"
+
+text:
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: PRESET_NAME
+    name: "Preset Name"
+    mode: text
+  - platform: dsp408
+    dsp408_id: my_dsp
+    kind: CHANNEL_NAME
+    channel: 0
+    name: "Ch1 Name"
+    mode: text

--- a/tests/components/dsp408/test.esp32-s3-idf.yaml
+++ b/tests/components/dsp408/test.esp32-s3-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Adds a new `dsp408` component that talks to a USB-attached **Dayton Audio DSP-408** 4-channel DSP amplifier directly from an ESP32-S2 / S3 / P4's native USB host peripheral.

Subclasses `esphome::usb_host::USBClient`, walks the configuration descriptor to find the HID interface (`bInterfaceClass=0x03`), claims it, and runs the DSP-408's vendor wire protocol on top of 64-byte HID interrupt reports (EP `0x01` OUT, EP `0x82` IN). Multi-frame channel-state read (296 bytes via `cmd=0x77NN`) with retry-on-divergence; multi-frame WRITE for full-channel-state save.

Sub-platforms wire to a parent `dsp408_id:`:
- `text_sensor`: `MODEL` (firmware identity, e.g. `"MYDW-AV1.06"`)
- `number`: `MASTER_VOLUME` (-60..+6 dB), `CHANNEL_VOLUME` (-60..0 dB, 0.1 dB native), `CHANNEL_DELAY` (0..359 samples), `CHANNEL_HPF_FREQ` / `LPF_FREQ`, `CHANNEL_COMP_ATTACK / RELEASE / THRESHOLD`
- `switch`: `MASTER_MUTE`, `CHANNEL_MUTE`, `CHANNEL_POLAR`, `INPUT_POLAR`
- `select`: `CHANNEL_HPF_FILTER / SLOPE`, `CHANNEL_LPF_FILTER / SLOPE` (Butterworth / Bessel / Linkwitz-Riley; 6..48 dB/oct + Off)
- `text`: `PRESET_NAME` (15-byte ASCII), `CHANNEL_NAME` (8-byte ASCII)

The wire-format port is byte-exact to the upstream Python library at https://github.com/malaiwah/dsp408-py — same XOR checksum, command codes, payload layouts, blob offsets, field semantics. dsp408-py did the protocol reverse-engineering against Windows GUI captures; this brings that knowledge into ESPHome. References to it are in the C++ header comments (`dsp408.h`, `protocol.h`).

Tested against a real DSP-408 (firmware `MYDW-AV1.06`) on an ESP32-S3 DevKitC-1, driven from a live Home Assistant instance over WiFi. The component has been running externally as `malaiwah/dsp408-esphome` for the last few days while iterating to v1.0; this PR brings that work into core. See https://github.com/malaiwah/dsp408-esphome for the external-component history, screenshots, and bring-up logs.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes N/A (new component)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6546

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF (verified live on ESP32-S3 DevKitC-1)
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Component requires native USB host (ESP32-S2 / S3 / P4 only) — `DEPENDENCIES = ["esp32", "usb_host"]` enforces that. The CI test uses `test.esp32-s3-idf.yaml`. Sub-platform `.h` and `.cpp` are wrapped in `USE_ESP32_VARIANT_ESP32{S2,S3,P4}` guards so clang-tidy on every other target compiles cleanly.

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: esp-idf
    sdkconfig_options:
      # ESP32-S3 has two USB peripherals sharing the internal PHY; the
      # boot-ROM USB-CDC console conflicts with USB host mode. Route the
      # console to UART0 instead.
      CONFIG_ESP_CONSOLE_UART_DEFAULT: y
      CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG: n
      CONFIG_ESP_CONSOLE_USB_CDC: n

usb_host:

dsp408:
  id: my_dsp

text_sensor:
  - platform: dsp408
    dsp408_id: my_dsp
    kind: MODEL
    name: "DSP-408 Model"

number:
  - platform: dsp408
    dsp408_id: my_dsp
    kind: MASTER_VOLUME
    name: "Master Volume"
  - platform: dsp408
    dsp408_id: my_dsp
    kind: CHANNEL_VOLUME
    channel: 0
    name: "Ch1 Volume"

switch:
  - platform: dsp408
    dsp408_id: my_dsp
    kind: MASTER_MUTE
    name: "Master Mute"
  - platform: dsp408
    dsp408_id: my_dsp
    kind: CHANNEL_MUTE
    channel: 0
    name: "Ch1 Mute"

select:
  - platform: dsp408
    dsp408_id: my_dsp
    kind: CHANNEL_HPF_FILTER
    channel: 0
    name: "Ch1 HPF Type"

text:
  - platform: dsp408
    dsp408_id: my_dsp
    kind: PRESET_NAME
    name: "Preset Name"
    mode: text
```

EQ band (10 per channel) and routing matrix (4 inputs × 8 outputs) writes are exposed as user-defined `api: actions:` rather than entities — the per-cell entity count would be too high to be useful in HA. The companion docs page in esphome/esphome-docs#6546 shows the action wiring.

## Checklist:
  - [x] The code change is tested and works locally. Validated end-to-end against a real DSP-408 + Home Assistant.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder). `tests/components/dsp408/{common.yaml,test.esp32-s3-idf.yaml}` covers all entity types — `script/test_build_components -e config -c dsp408` passes.

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs) — esphome/esphome-docs#6546.
