### PR TITLE
[inkbird_ibsth1_mini][speaker][speaker_source] Fix performance-unnecessary-copy-initialization

### DIFF
--- a/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
+++ b/esphome/components/inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp
@@ -41,12 +41,12 @@ bool InkbirdIbstH1Mini::parse_device(const esp32_ble_tracker::ESPBTDevice &devic
     ESP_LOGVV(TAG, "parse_device(): service_data is expected to be empty");
     return false;
   }
-  auto mnf_datas = device.get_manufacturer_datas();
+  const auto &mnf_datas = device.get_manufacturer_datas();
   if (mnf_datas.size() != 1) {
     ESP_LOGVV(TAG, "parse_device(): manufacturer_datas is expected to have a single element");
     return false;
   }
-  auto mnf_data = mnf_datas[0];
+  const auto &mnf_data = mnf_datas[0];
   if (mnf_data.uuid.get_uuid().len != ESP_UUID_LEN_16) {
     ESP_LOGVV(TAG, "parse_device(): manufacturer data element is expected to have uuid of length 16");
     return false;

--- a/esphome/components/speaker/media_player/speaker_media_player.cpp
+++ b/esphome/components/speaker/media_player/speaker_media_player.cpp
@@ -502,7 +502,7 @@ void SpeakerMediaPlayer::control(const media_player::MediaPlayerCall &call) {
     media_command.announce = false;
   }
 
-  auto media_url = call.get_media_url();
+  const auto &media_url = call.get_media_url();
   if (media_url.has_value()) {
     media_command.url =
         new std::string(*media_url);  // Must be manually deleted after receiving media_command from a queue

--- a/esphome/components/speaker_source/speaker_source_media_player.cpp
+++ b/esphome/components/speaker_source/speaker_source_media_player.cpp
@@ -698,7 +698,7 @@ void SpeakerSourceMediaPlayer::control(const media_player::MediaPlayerCall &call
     }
   }
 
-  auto media_url = call.get_media_url();
+  const auto &media_url = call.get_media_url();
   if (media_url.has_value()) {
     auto command = call.get_command();
     bool enqueue = command.has_value() && command.value() == media_player::MEDIA_PLAYER_COMMAND_ENQUEUE;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `performance-unnecessary-copy-initialization` during the migration from clang-tidy 18 (#16078). Same pattern as #16094 (wifi EAP).

All three sites bind the result of a function that returns `const T &` to `auto` (which deduces to `T` and copies) and then only read the local — switch to `const auto &` so the local refers into the source object directly.

- **`inkbird_ibsth1_mini/inkbird_ibsth1_mini.cpp:44,49`** — `device.get_manufacturer_datas()` returns `const std::vector<ServiceData> &`. The local `mnf_datas` was copying the whole vector and then `mnf_datas[0]` was copying a `ServiceData` (which itself owns a `std::vector<uint8_t>` data buffer). Both bindings can be const refs.
- **`speaker/media_player/speaker_media_player.cpp:505`** — same pattern with `call.get_media_url()` returning `const optional<std::string> &`.
- **`speaker_source/speaker_source_media_player.cpp:701`** — identical pattern in the speaker_source variant of the media player.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).