### PR TITLE
[sprinkler][pn532] Fix bugprone-unchecked-optional-access

### DIFF
--- a/esphome/components/pn532/pn532.cpp
+++ b/esphome/components/pn532/pn532.cpp
@@ -317,6 +317,7 @@ enum PN532ReadReady PN532::read_ready_(bool block) {
   if (!this->rd_start_time_.has_value()) {
     this->rd_start_time_ = millis();
   }
+  const uint32_t rd_start_time = *this->rd_start_time_;
 
   while (true) {
     if (this->is_read_ready()) {
@@ -324,7 +325,7 @@ enum PN532ReadReady PN532::read_ready_(bool block) {
       break;
     }
 
-    if (millis() - *this->rd_start_time_ > 100) {
+    if (millis() - rd_start_time > 100) {
       ESP_LOGV(TAG, "Timed out waiting for readiness from PN532!");
       this->rd_ready_ = TIMEOUT;
       break;

--- a/esphome/components/sprinkler/sprinkler.cpp
+++ b/esphome/components/sprinkler/sprinkler.cpp
@@ -897,11 +897,12 @@ void Sprinkler::resume() {
   }
 
   if (this->paused_valve_.has_value() && (this->resume_duration_.has_value())) {
+    const size_t paused_valve = *this->paused_valve_;
+    const uint32_t resume_duration = *this->resume_duration_;
     // Resume only if valve has not been completed yet
-    if (!this->valve_cycle_complete_(this->paused_valve_.value())) {
-      ESP_LOGD(TAG, "Resuming valve %zu with %" PRIu32 " seconds remaining", this->paused_valve_.value_or(0),
-               this->resume_duration_.value_or(0));
-      this->fsm_request_(this->paused_valve_.value(), this->resume_duration_.value());
+    if (!this->valve_cycle_complete_(paused_valve)) {
+      ESP_LOGD(TAG, "Resuming valve %zu with %" PRIu32 " seconds remaining", paused_valve, resume_duration);
+      this->fsm_request_(paused_valve, resume_duration);
     }
     this->reset_resume();
   } else {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078). Split out from #16096 to keep per-component review surface small.

The check can't propagate `has_value()` guards across non-const method calls, so it flags subsequent dereferences as unchecked even when the surrounding code has established the optional has a value. Each fix binds the optional's value to a local once the value is known, then uses the local throughout. No behavior change.

- **`sprinkler/sprinkler.cpp:904`** — bind `paused_valve_` and `resume_duration_` to locals before calling the non-const `valve_cycle_complete_` (which the analyzer assumes could mutate the optionals).
- **`pn532/pn532.cpp:327`** — copy `*rd_start_time_` to a local right after the `if (!has_value())` populates it in `read_ready_()`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078); split out from #16096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).