### PR TITLE
[feedback] Fix bugprone-unchecked-optional-access in start_direction_

### DIFF
--- a/esphome/components/feedback/feedback_cover.cpp
+++ b/esphome/components/feedback/feedback_cover.cpp
@@ -375,12 +375,10 @@ void FeedbackCover::start_direction_(CoverOperation dir) {
   // check if we have a wait time
   if (this->direction_change_waittime_.has_value() && dir != COVER_OPERATION_IDLE &&
       this->current_operation != COVER_OPERATION_IDLE && dir != this->current_operation) {
+    const uint32_t waittime = *this->direction_change_waittime_;
     ESP_LOGD(TAG, "'%s' - Reversing direction.", this->name_.c_str());
     this->start_direction_(COVER_OPERATION_IDLE);
-
-    this->set_timeout(DIRECTION_CHANGE_TIMEOUT_ID, *this->direction_change_waittime_,
-                      [this, dir]() { this->start_direction_(dir); });
-
+    this->set_timeout(DIRECTION_CHANGE_TIMEOUT_ID, waittime, [this, dir]() { this->start_direction_(dir); });
   } else {
     this->set_current_operation_(dir, true);
     this->prev_command_trigger_ = trig;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078). Split out from #16096.

`direction_change_waittime_` is checked with `has_value()` at the top of the if, but the deref happens after a non-const call to `start_direction_`, which the analyzer assumes could reset the optional. Bind to a local before the non-const call.

```cpp
// before
if (this->direction_change_waittime_.has_value() && ...) {
  ESP_LOGD(TAG, "'%s' - Reversing direction.", this->name_.c_str());
  this->start_direction_(COVER_OPERATION_IDLE);
  this->set_timeout(DIRECTION_CHANGE_TIMEOUT_ID, *this->direction_change_waittime_,
                    [this, dir]() { this->start_direction_(dir); });
}

// after
if (this->direction_change_waittime_.has_value() && ...) {
  const uint32_t waittime = *this->direction_change_waittime_;
  ESP_LOGD(TAG, "'%s' - Reversing direction.", this->name_.c_str());
  this->start_direction_(COVER_OPERATION_IDLE);
  this->set_timeout(DIRECTION_CHANGE_TIMEOUT_ID, waittime, [this, dir]() { this->start_direction_(dir); });
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078); split out from #16096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).