### PR TITLE
[api] Avoid JsonDocument copy-and-swap operator= in ActionResponse ctor

### DIFF
--- a/esphome/components/api/homeassistant_service.h
+++ b/esphome/components/api/homeassistant_service.h
@@ -78,7 +78,8 @@ class ActionResponse {
       : success_(success), error_message_(error_message) {
     if (data == nullptr || data_len == 0)
       return;
-    this->json_document_ = json::parse_json(data, data_len);
+    JsonDocument tmp = json::parse_json(data, data_len);
+    swap(this->json_document_, tmp);
   }
 #endif
 


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `clang-analyzer-core.StackAddressEscape` during the migration from clang-tidy 18 (#16078).

ArduinoJson's `JsonDocument& operator=(JsonDocument src)` is the copy-and-swap idiom (`swap(*this, src); return *this;`). The clang-22 analyzer's improved cross-procedural depth follows that path and conservatively assumes the swap could leave `*this` holding pointers into `src`'s stack frame, then flags `return *this` as a stack-address escape (`JsonDocument.hpp:54`).

In practice ArduinoJson v7's pool is heap-allocated (no inline-buffer SBO inside the JsonDocument struct), so this is a false positive — but the analyzer can't see through the generic copy-and-swap pattern, and there's no way to suppress it from our side:

- `// NOLINT` / `NOLINTNEXTLINE` / `NOLINTBEGIN/END` at the call site: don't suppress (warning is emitted at the third-party file, not at our line).
- `--header-filter` / `--exclude-header-filter` excluding `managed_components/`: don't apply to clang-analyzer warnings.
- `-isystem` (already applied to `managed_components/`): doesn't suppress static-analyzer findings.
- `[[clang::suppress]]` in any placement: doesn't reach paths whose terminal location is in third-party code.

Per LLVM issue [llvm/llvm-project#166151](https://github.com/llvm/llvm-project/issues/166151) this is a known unresolved limitation.

## The fix

Replace the `json_document_ = parse_json(...)` assignment with an explicit `swap(json_document_, tmp)`:

```cpp
// before
this->json_document_ = json::parse_json(data, data_len);

// after
JsonDocument tmp = json::parse_json(data, data_len);
swap(this->json_document_, tmp);
```

This avoids `JsonDocument::operator=`'s copy-and-swap-then-return path entirely. The analyzer's heuristic specifically watches for "swap-with-by-value-param then return reference" inside `operator=`; doing the swap directly in our code (where there's no return) doesn't match the pattern.

Identical observable behavior:
- The PSRAM allocator that `parse_json` sets up on `tmp`'s pool transfers to `json_document_` via the swap (same as the operator= path did).
- Construction/swap/destruction counts are unchanged.
- `operator=` would be inlined in `-O2` anyway, so the emitted code is essentially identical.

This is the only call site in the codebase that hits the operator= path; all other `parse_json` users go through the lambda-callback variant which doesn't trigger the issue. Net diff: 2 lines.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).