### PR TITLE
[time] Fix bugprone-unchecked-optional-access in CronTrigger::check_time_

### DIFF
--- a/esphome/components/time/automation.cpp
+++ b/esphome/components/time/automation.cpp
@@ -31,13 +31,14 @@ void CronTrigger::check_time_() {
     return;
 
   if (this->last_check_.has_value()) {
-    if (*this->last_check_ > time && this->last_check_->timestamp - time.timestamp > MAX_TIMESTAMP_DRIFT) {
+    auto &last_check = *this->last_check_;
+    if (last_check > time && last_check.timestamp - time.timestamp > MAX_TIMESTAMP_DRIFT) {
       // We went back in time (a lot), probably caused by time synchronization
       ESP_LOGW(TAG, "Time has jumped back!");
-    } else if (*this->last_check_ >= time) {
+    } else if (last_check >= time) {
       // already handled this one
       return;
-    } else if (time > *this->last_check_ && time.timestamp - this->last_check_->timestamp > MAX_TIMESTAMP_DRIFT) {
+    } else if (time > last_check && time.timestamp - last_check.timestamp > MAX_TIMESTAMP_DRIFT) {
       // We went ahead in time (a lot), probably caused by time synchronization
       ESP_LOGW(TAG, "Time has jumped ahead!");
       this->last_check_ = time;
@@ -45,11 +46,11 @@ void CronTrigger::check_time_() {
     }
 
     while (true) {
-      this->last_check_->increment_second();
-      if (*this->last_check_ >= time)
+      last_check.increment_second();
+      if (last_check >= time)
         break;
 
-      if (this->matches(*this->last_check_))
+      if (this->matches(last_check))
         this->trigger();
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078). Split out from #16096.

In `CronTrigger::check_time_()`, the inner block is guarded by `if (this->last_check_.has_value())`, but the analyzer can't propagate the precondition across the non-const `last_check_->increment_second()` call (which it treats as potentially mutating the optional). The result is every subsequent `*last_check_` deref gets flagged as "unchecked".

Bind the optional's contained value to a local reference once the value is known and use the reference throughout. No behavior change — the reference points into the same storage as the optional, so increment-second still mutates it in place.

```cpp
if (this->last_check_.has_value()) {
  auto &last_check = *this->last_check_;
  if (last_check > time && last_check.timestamp - time.timestamp > MAX_TIMESTAMP_DRIFT) {
    ...
  } else if (last_check >= time) {
    ...
  } else if (time > last_check && time.timestamp - last_check.timestamp > MAX_TIMESTAMP_DRIFT) {
    ...
  }

  while (true) {
    last_check.increment_second();
    if (last_check >= time)
      break;
    if (this->matches(last_check))
      this->trigger();
  }
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078); split out from #16096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).