### PR TITLE
[tormatic] Use .value() for checked optional access in read_gate_status_

### DIFF
--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -282,12 +282,13 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     }
   }
 
+  auto hdr = this->pending_hdr_.value();
+
   // Wait for all payload bytes to arrive before processing.
-  if (this->available() < this->pending_hdr_->payload_size()) {
+  if (this->available() < hdr.payload_size()) {
     return {};
   }
 
-  auto hdr = *this->pending_hdr_;
   this->pending_hdr_.reset();
 
   switch (hdr.type) {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078). Split out from #16096; addresses [Copilot's review feedback](https://github.com/esphome/esphome/pull/16096#discussion_r2473) on the original.

`Tormatic::read_gate_status_()` accesses `pending_hdr_->payload_size()` after a structured if/return chain that establishes `pending_hdr_.has_value()` is true at that point. The clang-22 analyzer can't propagate the precondition across the inner block and flagged it as unchecked.

```cpp
// before
if (this->available() < this->pending_hdr_->payload_size()) {
  return {};
}
auto hdr = *this->pending_hdr_;

// after
auto hdr = this->pending_hdr_.value();
if (this->available() < hdr.payload_size()) {
  return {};
}
```

`.value()` is preferable to `*`/`->` here:

- It's a **checked** access — if the implicit invariant ever breaks (future refactor adding a path that reaches this code without populating `pending_hdr_`), `.value()` aborts immediately rather than triggering UB.
- It satisfies `bugprone-unchecked-optional-access` natively, no NOLINT needed.
- With `-fno-exceptions` (ESPHome's setup) `.value()` on an empty optional maps to `abort()` — defined behavior, immediate fail-fast — instead of the silent corruption of `*` on empty.
- Cost: one branch, optimized out by the compiler when `has_value()` can be statically proven.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078); split out from #16096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).