### PR TITLE
[espnow] Cleanup method visibility and naming

### DIFF
--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -26,9 +26,9 @@ espnow_ns = cg.esphome_ns.namespace("espnow")
 ESPNowComponent = espnow_ns.class_("ESPNowComponent", cg.Component)
 
 # Handler interfaces that other components can use to register callbacks
-ESPNowReceivedPacketHandler = espnow_ns.class_("ESPNowReceivedPacketHandler")
+ESPNowReceivePacketHandler = espnow_ns.class_("ESPNowReceivePacketHandler")
 ESPNowUnknownPeerHandler = espnow_ns.class_("ESPNowUnknownPeerHandler")
-ESPNowBroadcastedHandler = espnow_ns.class_("ESPNowBroadcastedHandler")
+ESPNowBroadcastHandler = espnow_ns.class_("ESPNowBroadcastHandler")
 
 ESPNowRecvInfo = espnow_ns.class_("ESPNowRecvInfo")
 ESPNowRecvInfoConstRef = ESPNowRecvInfo.operator("const").operator("ref")
@@ -48,10 +48,10 @@ OnUnknownPeerTrigger = espnow_ns.class_(
     "OnUnknownPeerTrigger", ESPNowHandlerTrigger, ESPNowUnknownPeerHandler
 )
 OnReceiveTrigger = espnow_ns.class_(
-    "OnReceiveTrigger", ESPNowHandlerTrigger, ESPNowReceivedPacketHandler
+    "OnReceiveTrigger", ESPNowHandlerTrigger, ESPNowReceivePacketHandler
 )
 OnBroadcastTrigger = espnow_ns.class_(
-    "OnBroadcastTrigger", ESPNowHandlerTrigger, ESPNowBroadcastedHandler
+    "OnBroadcastTrigger", ESPNowHandlerTrigger, ESPNowBroadcastHandler
 )
 
 
@@ -140,11 +140,11 @@ async def to_code(config):
 
     for on_receive in config.get(CONF_ON_RECEIVE, []):
         trigger = await _trigger_to_code(on_receive)
-        cg.add(var.register_received_handler(trigger))
+        cg.add(var.register_receive_handler(trigger))
 
     for on_receive in config.get(CONF_ON_BROADCAST, []):
         trigger = await _trigger_to_code(on_receive)
-        cg.add(var.register_broadcasted_handler(trigger))
+        cg.add(var.register_broadcast_handler(trigger))
 
 
 # ========================================== A C T I O N S ================================================

--- a/esphome/components/espnow/__init__.py
+++ b/esphome/components/espnow/__init__.py
@@ -50,8 +50,8 @@ OnUnknownPeerTrigger = espnow_ns.class_(
 OnReceiveTrigger = espnow_ns.class_(
     "OnReceiveTrigger", ESPNowHandlerTrigger, ESPNowReceivedPacketHandler
 )
-OnBroadcastedTrigger = espnow_ns.class_(
-    "OnBroadcastedTrigger", ESPNowHandlerTrigger, ESPNowBroadcastedHandler
+OnBroadcastTrigger = espnow_ns.class_(
+    "OnBroadcastTrigger", ESPNowHandlerTrigger, ESPNowBroadcastedHandler
 )
 
 
@@ -94,7 +94,7 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_ON_BROADCAST): automation.validate_automation(
                 {
-                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnBroadcastedTrigger),
+                    cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(OnBroadcastTrigger),
                     cv.Optional(CONF_ADDRESS): cv.mac_address,
                 }
             ),

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -67,6 +67,7 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
     }
   }
 
+ protected:
   void play(const Ts &...x) override { /* ignore - see play_complex */
   }
 
@@ -75,7 +76,6 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
     this->error_.stop();
   }
 
- protected:
   ActionList<Ts...> sent_;
   ActionList<Ts...> error_;
 
@@ -89,7 +89,7 @@ template<typename... Ts> class SendAction : public Action<Ts...>, public Parente
 template<typename... Ts> class AddPeerAction : public Action<Ts...>, public Parented<ESPNowComponent> {
   TEMPLATABLE_VALUE(peer_address_t, address);
 
- public:
+ protected:
   void play(const Ts &...x) override {
     peer_address_t address = this->address_.value(x...);
     this->parent_->add_peer(address.data());
@@ -99,7 +99,7 @@ template<typename... Ts> class AddPeerAction : public Action<Ts...>, public Pare
 template<typename... Ts> class DeletePeerAction : public Action<Ts...>, public Parented<ESPNowComponent> {
   TEMPLATABLE_VALUE(peer_address_t, address);
 
- public:
+ protected:
   void play(const Ts &...x) override {
     peer_address_t address = this->address_.value(x...);
     this->parent_->del_peer(address.data());
@@ -107,8 +107,9 @@ template<typename... Ts> class DeletePeerAction : public Action<Ts...>, public P
 };
 
 template<typename... Ts> class SetChannelAction : public Action<Ts...>, public Parented<ESPNowComponent> {
- public:
   TEMPLATABLE_VALUE(uint8_t, channel)
+
+ protected:
   void play(const Ts &...x) override {
     if (this->parent_->is_wifi_enabled()) {
       return;
@@ -125,9 +126,9 @@ class OnReceiveTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_t *,
     memcpy(this->address_, address.data(), ESP_NOW_ETH_ALEN);
   }
 
-  explicit OnReceiveTrigger() : has_address_(false) {}
+  explicit OnReceiveTrigger() {}
 
-  bool on_received(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override {
+  bool on_receive(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override {
     bool match = !this->has_address_ || (memcmp(this->address_, info.src_addr, ESP_NOW_ETH_ALEN) == 0);
     if (!match)
       return false;
@@ -138,7 +139,7 @@ class OnReceiveTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_t *,
 
  protected:
   bool has_address_{false};
-  uint8_t address_[ESP_NOW_ETH_ALEN];
+  uint8_t address_[ESP_NOW_ETH_ALEN]{};
 };
 class OnUnknownPeerTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_t *, uint8_t>,
                              public ESPNowUnknownPeerHandler {
@@ -154,9 +155,9 @@ class OnBroadcastedTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_
   explicit OnBroadcastedTrigger(std::array<uint8_t, ESP_NOW_ETH_ALEN> address) : has_address_(true) {
     memcpy(this->address_, address.data(), ESP_NOW_ETH_ALEN);
   }
-  explicit OnBroadcastedTrigger() : has_address_(false) {}
+  explicit OnBroadcastedTrigger() {}
 
-  bool on_broadcasted(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override {
+  bool on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override {
     bool match = !this->has_address_ || (memcmp(this->address_, info.src_addr, ESP_NOW_ETH_ALEN) == 0);
     if (!match)
       return false;
@@ -167,7 +168,7 @@ class OnBroadcastedTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_
 
  protected:
   bool has_address_{false};
-  uint8_t address_[ESP_NOW_ETH_ALEN];
+  uint8_t address_[ESP_NOW_ETH_ALEN]{};
 };
 
 }  // namespace esphome::espnow

--- a/esphome/components/espnow/automation.h
+++ b/esphome/components/espnow/automation.h
@@ -149,13 +149,13 @@ class OnUnknownPeerTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_
     return false;  // Return false to continue processing other internal handlers
   }
 };
-class OnBroadcastedTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_t *, uint8_t>,
-                             public ESPNowBroadcastedHandler {
+class OnBroadcastTrigger : public Trigger<const ESPNowRecvInfo &, const uint8_t *, uint8_t>,
+                           public ESPNowBroadcastHandler {
  public:
-  explicit OnBroadcastedTrigger(std::array<uint8_t, ESP_NOW_ETH_ALEN> address) : has_address_(true) {
+  explicit OnBroadcastTrigger(std::array<uint8_t, ESP_NOW_ETH_ALEN> address) : has_address_(true) {
     memcpy(this->address_, address.data(), ESP_NOW_ETH_ALEN);
   }
-  explicit OnBroadcastedTrigger() {}
+  explicit OnBroadcastTrigger() {}
 
   bool on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override {
     bool match = !this->has_address_ || (memcmp(this->address_, info.src_addr, ESP_NOW_ETH_ALEN) == 0);

--- a/esphome/components/espnow/espnow_component.cpp
+++ b/esphome/components/espnow/espnow_component.cpp
@@ -299,13 +299,13 @@ void ESPNowComponent::loop() {
                    format_hex_pretty_to(hex_buf, packet->packet_.receive.data, packet->packet_.receive.size));
 #endif
           if (memcmp(info.des_addr, ESPNOW_BROADCAST_ADDR, ESP_NOW_ETH_ALEN) == 0) {
-            for (auto *handler : this->broadcasted_handlers_) {
-              if (handler->on_broadcasted(info, packet->packet_.receive.data, packet->packet_.receive.size))
+            for (auto *handler : this->broadcast_handlers_) {
+              if (handler->on_broadcast(info, packet->packet_.receive.data, packet->packet_.receive.size))
                 break;  // If a handler returns true, stop processing further handlers
             }
           } else {
-            for (auto *handler : this->received_handlers_) {
-              if (handler->on_received(info, packet->packet_.receive.data, packet->packet_.receive.size))
+            for (auto *handler : this->receive_handlers_) {
+              if (handler->on_receive(info, packet->packet_.receive.data, packet->packet_.receive.size))
                 break;  // If a handler returns true, stop processing further handlers
             }
           }

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -74,7 +74,7 @@ class ESPNowReceivedPacketHandler {
   /// @param data Pointer to the received data payload
   /// @param size Size of the received data in bytes
   /// @return true if the packet was handled, false otherwise
-  virtual bool on_received(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) = 0;
+  virtual bool on_receive(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) = 0;
 };
 /// Handler interface for receiving broadcasted ESPNow packets
 /// Components should inherit from this class to handle incoming ESPNow data
@@ -85,7 +85,7 @@ class ESPNowBroadcastedHandler {
   /// @param data Pointer to the received data payload
   /// @param size Size of the received data in bytes
   /// @return true if the packet was handled, false otherwise
-  virtual bool on_broadcasted(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) = 0;
+  virtual bool on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) = 0;
 };
 
 class ESPNowComponent : public Component {
@@ -136,13 +136,11 @@ class ESPNowComponent : public Component {
   esp_err_t send(const uint8_t *peer_address, const uint8_t *payload, size_t size,
                  const send_callback_t &callback = nullptr);
 
-  void register_received_handler(ESPNowReceivedPacketHandler *handler) { this->received_handlers_.push_back(handler); }
+  void register_received_handler(ESPNowReceivedPacketHandler *handler) { this->receive_handlers_.push_back(handler); }
   void register_unknown_peer_handler(ESPNowUnknownPeerHandler *handler) {
     this->unknown_peer_handlers_.push_back(handler);
   }
-  void register_broadcasted_handler(ESPNowBroadcastedHandler *handler) {
-    this->broadcasted_handlers_.push_back(handler);
-  }
+  void register_broadcasted_handler(ESPNowBroadcastedHandler *handler) { this->broadcast_handlers_.push_back(handler); }
 
  protected:
   friend void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size);
@@ -156,8 +154,8 @@ class ESPNowComponent : public Component {
   void send_();
 
   std::vector<ESPNowUnknownPeerHandler *> unknown_peer_handlers_;
-  std::vector<ESPNowReceivedPacketHandler *> received_handlers_;
-  std::vector<ESPNowBroadcastedHandler *> broadcasted_handlers_;
+  std::vector<ESPNowReceivedPacketHandler *> receive_handlers_;
+  std::vector<ESPNowBroadcastedHandler *> broadcast_handlers_;
 
   std::vector<ESPNowPeer> peers_{};
 

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -76,11 +76,11 @@ class ESPNowReceivedPacketHandler {
   /// @return true if the packet was handled, false otherwise
   virtual bool on_receive(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) = 0;
 };
-/// Handler interface for receiving broadcasted ESPNow packets
+/// Handler interface for receiving ESPNow broadcast packets
 /// Components should inherit from this class to handle incoming ESPNow data
-class ESPNowBroadcastedHandler {
+class ESPNowBroadcastHandler {
  public:
-  /// Called when a broadcasted ESPNow packet is received
+  /// Called when an ESPNow broadcast packet is received
   /// @param info Information about the received packet (sender MAC, etc.)
   /// @param data Pointer to the received data payload
   /// @param size Size of the received data in bytes
@@ -140,7 +140,7 @@ class ESPNowComponent : public Component {
   void register_unknown_peer_handler(ESPNowUnknownPeerHandler *handler) {
     this->unknown_peer_handlers_.push_back(handler);
   }
-  void register_broadcasted_handler(ESPNowBroadcastedHandler *handler) { this->broadcast_handlers_.push_back(handler); }
+  void register_broadcasted_handler(ESPNowBroadcastHandler *handler) { this->broadcast_handlers_.push_back(handler); }
 
  protected:
   friend void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size);
@@ -155,7 +155,7 @@ class ESPNowComponent : public Component {
 
   std::vector<ESPNowUnknownPeerHandler *> unknown_peer_handlers_;
   std::vector<ESPNowReceivedPacketHandler *> receive_handlers_;
-  std::vector<ESPNowBroadcastedHandler *> broadcast_handlers_;
+  std::vector<ESPNowBroadcastHandler *> broadcast_handlers_;
 
   std::vector<ESPNowPeer> peers_{};
 

--- a/esphome/components/espnow/espnow_component.h
+++ b/esphome/components/espnow/espnow_component.h
@@ -31,8 +31,8 @@ using peer_address_t = std::array<uint8_t, ESP_NOW_ETH_ALEN>;
 enum class ESPNowTriggers : uint8_t {
   TRIGGER_NONE = 0,
   ON_NEW_PEER = 1,
-  ON_RECEIVED = 2,
-  ON_BROADCASTED = 3,
+  ON_RECEIVE = 2,
+  ON_BROADCAST = 3,
   ON_SUCCEED = 10,
   ON_FAILED = 11,
 };
@@ -136,11 +136,11 @@ class ESPNowComponent : public Component {
   esp_err_t send(const uint8_t *peer_address, const uint8_t *payload, size_t size,
                  const send_callback_t &callback = nullptr);
 
-  void register_received_handler(ESPNowReceivedPacketHandler *handler) { this->receive_handlers_.push_back(handler); }
+  void register_receive_handler(ESPNowReceivedPacketHandler *handler) { this->receive_handlers_.push_back(handler); }
   void register_unknown_peer_handler(ESPNowUnknownPeerHandler *handler) {
     this->unknown_peer_handlers_.push_back(handler);
   }
-  void register_broadcasted_handler(ESPNowBroadcastHandler *handler) { this->broadcast_handlers_.push_back(handler); }
+  void register_broadcast_handler(ESPNowBroadcastHandler *handler) { this->broadcast_handlers_.push_back(handler); }
 
  protected:
   friend void on_data_received(const esp_now_recv_info_t *info, const uint8_t *data, int size);

--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -26,10 +26,10 @@ void ESPNowTransport::setup() {
            this->peer_address_[5]);
 
   // Register received handler
-  this->parent_->register_received_handler(this);
+  this->parent_->register_receive_handler(this);
 
-  // Register broadcasted handler
-  this->parent_->register_broadcasted_handler(this);
+  // Register broadcast handler
+  this->parent_->register_broadcast_handler(this);
 }
 
 void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {

--- a/esphome/components/espnow/packet_transport/espnow_transport.cpp
+++ b/esphome/components/espnow/packet_transport/espnow_transport.cpp
@@ -56,7 +56,7 @@ void ESPNowTransport::send_packet(const std::vector<uint8_t> &buf) const {
   });
 }
 
-bool ESPNowTransport::on_received(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) {
+bool ESPNowTransport::on_receive(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) {
   ESP_LOGV(TAG, "Received packet of size %u from %02X:%02X:%02X:%02X:%02X:%02X", size, info.src_addr[0],
            info.src_addr[1], info.src_addr[2], info.src_addr[3], info.src_addr[4], info.src_addr[5]);
 
@@ -71,7 +71,7 @@ bool ESPNowTransport::on_received(const ESPNowRecvInfo &info, const uint8_t *dat
   return false;  // Allow other handlers to run
 }
 
-bool ESPNowTransport::on_broadcasted(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) {
+bool ESPNowTransport::on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) {
   ESP_LOGV(TAG, "Received broadcast packet of size %u from %02X:%02X:%02X:%02X:%02X:%02X", size, info.src_addr[0],
            info.src_addr[1], info.src_addr[2], info.src_addr[3], info.src_addr[4], info.src_addr[5]);
 

--- a/esphome/components/espnow/packet_transport/espnow_transport.h
+++ b/esphome/components/espnow/packet_transport/espnow_transport.h
@@ -15,7 +15,7 @@ namespace espnow {
 class ESPNowTransport : public packet_transport::PacketTransport,
                         public Parented<ESPNowComponent>,
                         public ESPNowReceivedPacketHandler,
-                        public ESPNowBroadcastedHandler {
+                        public ESPNowBroadcastHandler {
  public:
   void setup() override;
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }

--- a/esphome/components/espnow/packet_transport/espnow_transport.h
+++ b/esphome/components/espnow/packet_transport/espnow_transport.h
@@ -25,8 +25,8 @@ class ESPNowTransport : public packet_transport::PacketTransport,
   }
 
   // ESPNow handler interface
-  bool on_received(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override;
-  bool on_broadcasted(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override;
+  bool on_receive(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override;
+  bool on_broadcast(const ESPNowRecvInfo &info, const uint8_t *data, uint8_t size) override;
 
  protected:
   void send_packet(const std::vector<uint8_t> &buf) const override;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

The ESPNOW component had some errors in method visibility (promoting `play` from protected to public in particular.) Naming of some methods and properties was inconsistent with the corresponding YAML triggers (e.g. `broadcasted` vs `broadcast`) and potentially misleading (`on_broadcasted` could be interpreted to mean "when the device has *sent* a broadcast rather then received a broadcast.)


* Fix method visibility
* Make method naming consistent with YAML names.



## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [x] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
