### PR TITLE
[light] Fold LightControlAction fields into a single stateless lambda

### DIFF
--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -31,60 +31,26 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
       transition_length_{};
 };
 
-// Unique Empty<Tag> per field so [[no_unique_address]] is guaranteed to coalesce.
-namespace light_control_detail {
-template<int Tag> struct Empty {};
-}  // namespace light_control_detail
-
-// X-macro: (type, field_name, bit_index). Order and bit values must match
-// the FIELDS table in automation.py.
-#define LIGHT_CONTROL_FIELDS(X) \
-  X(ColorMode, color_mode, 0) \
-  X(bool, state, 1) \
-  X(uint32_t, transition_length, 2) \
-  X(uint32_t, flash_length, 3) \
-  X(float, brightness, 4) \
-  X(float, color_brightness, 5) \
-  X(float, red, 6) \
-  X(float, green, 7) \
-  X(float, blue, 8) \
-  X(float, white, 9) \
-  X(float, color_temperature, 10) \
-  X(float, cold_white, 11) \
-  X(float, warm_white, 12) \
-  X(uint32_t, effect, 13)
-
-template<uint16_t Fields, typename... Ts> class LightControlAction : public Action<Ts...> {
+// All configured fields are baked into a single stateless lambda whose
+// constants live in flash. The action only stores a function pointer
+// (4 bytes) plus the parent (4 bytes), regardless of how many fields the
+// user set. Trigger args are forwarded to the apply function so user
+// lambdas (e.g. `brightness: !lambda "return x;"`) keep working.
+template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  explicit LightControlAction(LightState *parent) : parent_(parent) {}
-
-#define LIGHT_FIELD_SETTER_(type, name, idx) \
-  template<typename V> void set_##name(V value) requires((Fields & (1 << (idx))) != 0) { this->name##_ = value; }
-#define LIGHT_FIELD_APPLY_(type, name, idx) \
-  if constexpr ((Fields & (1 << (idx))) != 0) \
-    call.set_##name(this->name##_.value(x...));
-#define LIGHT_FIELD_DECL_(type, name, idx) \
-  [[no_unique_address]] std::conditional_t<(Fields & (1 << (idx))) != 0, TemplatableFn<type, Ts...>, \
-                                           light_control_detail::Empty<(idx)>> \
-      name##_{};
-
-  LIGHT_CONTROL_FIELDS(LIGHT_FIELD_SETTER_)
+  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
+  LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {
     auto call = this->parent_->make_call();
-    LIGHT_CONTROL_FIELDS(LIGHT_FIELD_APPLY_)
+    this->apply_(this->parent_, call, x...);
     call.perform();
   }
 
  protected:
   LightState *parent_;
-  LIGHT_CONTROL_FIELDS(LIGHT_FIELD_DECL_)
-
-#undef LIGHT_FIELD_DECL_
-#undef LIGHT_FIELD_APPLY_
-#undef LIGHT_FIELD_SETTER_
+  ApplyFn apply_;
 };
-#undef LIGHT_CONTROL_FIELDS
 
 template<bool HasTransitionLength, typename... Ts> class DimRelativeAction : public Action<Ts...> {
  public:

--- a/esphome/components/light/automation.h
+++ b/esphome/components/light/automation.h
@@ -32,13 +32,13 @@ template<bool HasTransitionLength, typename... Ts> class ToggleAction : public A
 };
 
 // All configured fields are baked into a single stateless lambda whose
-// constants live in flash. The action only stores a function pointer
-// (4 bytes) plus the parent (4 bytes), regardless of how many fields the
-// user set. Trigger args are forwarded to the apply function so user
-// lambdas (e.g. `brightness: !lambda "return x;"`) keep working.
+// constants live in flash. The action only stores one function pointer
+// plus one parent pointer, regardless of how many fields the user set.
+// Trigger args are forwarded to the apply function so user lambdas
+// (e.g. `brightness: !lambda "return x;"`) keep working.
 template<typename... Ts> class LightControlAction : public Action<Ts...> {
  public:
-  using ApplyFn = void (*)(LightState *, LightCall &, Ts...);
+  using ApplyFn = void (*)(LightState *, LightCall &, const Ts &...);
   LightControlAction(LightState *parent, ApplyFn apply) : parent_(parent), apply_(apply) {}
 
   void play(const Ts &...x) override {

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -230,10 +230,11 @@ async def light_control_to_code(config, action_id, template_arg, args):
                 f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
 
+    # Match LightControlAction::ApplyFn signature: const Ts &... for trigger args.
     apply_args = [
         (LightState.operator("ptr"), "parent"),
         (LightCall.operator("ref"), "call"),
-        *args,
+        *((t.operator("const").operator("ref"), n) for t, n in args),
     ]
     apply_lambda = LambdaExpression(
         ["\n".join(body_lines)],

--- a/esphome/components/light/automation.py
+++ b/esphome/components/light/automation.py
@@ -37,6 +37,7 @@ from .types import (
     AddressableSet,
     ColorMode,
     DimRelativeAction,
+    LightCall,
     LightControlAction,
     LightIsOffCondition,
     LightIsOnCondition,
@@ -181,8 +182,8 @@ def _resolve_effect_index(config: ConfigType) -> int:
 async def light_control_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
 
-    # Order/bits must match LIGHT_CONTROL_FIELDS in automation.h.
-    # EFFECT has special handling below; setter=None skips the generic loop.
+    # All configured fields are folded into a single stateless lambda whose
+    # constants live in flash; the action stores only a function pointer.
     FIELDS = (
         (CONF_COLOR_MODE, "set_color_mode", ColorMode),
         (CONF_STATE, "set_state", cg.bool_),
@@ -197,49 +198,50 @@ async def light_control_to_code(config, action_id, template_arg, args):
         (CONF_COLOR_TEMPERATURE, "set_color_temperature", cg.float_),
         (CONF_COLD_WHITE, "set_cold_white", cg.float_),
         (CONF_WARM_WHITE, "set_warm_white", cg.float_),
-        (CONF_EFFECT, None, cg.uint32),
     )
-    # Bitmask is passed as uint16_t in C++ — must stay within 16 bits.
-    assert len(FIELDS) <= 16, "LightControlAction Fields bitmask exceeds uint16_t"
 
-    field_mask = sum(1 << i for i, (k, _, _) in enumerate(FIELDS) if k in config)
-    control_template_arg = cg.TemplateArguments(
-        cg.RawExpression(f"static_cast<uint16_t>({field_mask})"), *template_arg
-    )
-    var = cg.new_Pvariable(action_id, control_template_arg, paren)
+    fwd_args = ", ".join(name for _, name in args)
+    body_lines: list[str] = []
 
     for conf_key, setter, type_ in FIELDS:
-        if conf_key in config and setter is not None:
-            template_ = await cg.templatable(config[conf_key], args, type_)
-            cg.add(getattr(var, setter)(template_))
+        if conf_key not in config:
+            continue
+        value = config[conf_key]
+        if isinstance(value, Lambda):
+            inner = await cg.process_lambda(value, args, return_type=type_)
+            body_lines.append(f"call.{setter}(({inner})({fwd_args}));")
+        else:
+            body_lines.append(f"call.{setter}({cg.safe_exp(value)});")
 
     if CONF_EFFECT in config:
         if isinstance(config[CONF_EFFECT], Lambda):
-            # Lambda returns a string — wrap in a C++ lambda that resolves
-            # the effect name to its uint32_t index at runtime
             inner_lambda = await cg.process_lambda(
                 config[CONF_EFFECT], args, return_type=cg.std_string
             )
-            fwd_args = ", ".join(n for _, n in args)
-            # capture="" is correct: paren is a global variable name
-            # string-interpolated into the body at codegen time, not a
-            # C++ runtime capture.
-            wrapper = LambdaExpression(
-                f"auto __effect_s = ({inner_lambda})({fwd_args});\n"
-                f"return {paren}->get_effect_index("
-                f"__effect_s.c_str(), __effect_s.size());",
-                args,
-                capture="",
-                return_type=cg.uint32,
+            body_lines.append(
+                f"{{ auto __effect_s = ({inner_lambda})({fwd_args});\n"
+                f"call.set_effect(parent->get_effect_index("
+                f"__effect_s.c_str(), __effect_s.size())); }}"
             )
-            cg.add(var.set_effect(wrapper))
         else:
-            # Static string — resolve effect name to index at codegen time
-            template_ = await cg.templatable(
-                _resolve_effect_index(config), args, cg.uint32
+            # Cast disambiguates between set_effect(uint32_t) and
+            # set_effect(optional<uint32_t>) when the literal is an int.
+            body_lines.append(
+                f"call.set_effect(static_cast<uint32_t>({_resolve_effect_index(config)}));"
             )
-            cg.add(var.set_effect(template_))
-    return var
+
+    apply_args = [
+        (LightState.operator("ptr"), "parent"),
+        (LightCall.operator("ref"), "call"),
+        *args,
+    ]
+    apply_lambda = LambdaExpression(
+        ["\n".join(body_lines)],
+        apply_args,
+        capture="",
+        return_type=cg.void,
+    )
+    return cg.new_Pvariable(action_id, template_arg, paren, apply_lambda)
 
 
 CONF_RELATIVE_BRIGHTNESS = "relative_brightness"

--- a/esphome/components/light/types.py
+++ b/esphome/components/light/types.py
@@ -13,6 +13,7 @@ Color = cg.esphome_ns.class_("Color")
 LightColorValues = light_ns.class_("LightColorValues")
 
 LightStateRTCState = light_ns.struct("LightStateRTCState")
+LightCall = light_ns.class_("LightCall")
 
 # Color modes
 ColorMode = light_ns.enum("ColorMode", is_class=True)


### PR DESCRIPTION
# What does this implement/fix?

Replaces the per-field `TemplatableFn` storage in `light::LightControlAction` with a single stateless function pointer that applies all configured fields to the underlying `LightCall`.

Each `light.turn_on` / `light.turn_off` / `light.control` action previously stored one `TemplatableFn` (4 bytes) per configured field; the action's instance size grew with every field set. After this change every instance stores just `LightState *parent_` plus a `void (*apply_)(LightState *, LightCall &, const Ts &...)` — 8 bytes total, regardless of how many fields the user configured.

Codegen now emits one stateless lambda whose body calls `call.set_*(...)` for every configured field. Constants render as immediate operands that live in flash; user lambdas (e.g. `brightness: !lambda 'return x;'`) are invoked inline so trigger args still flow through. The `effect` field keeps its existing semantics: static names resolve to a 1-based index at codegen time; lambda effects are wrapped to call `parent->get_effect_index(...)` at runtime.

Multiple call sites with different field combinations from the same trigger now collapse to a single `LightControlAction<Ts...>` instantiation rather than a separate type per field combination.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal codegen / class layout change; no public configuration surface change)

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes — existing YAML for light.turn_on / light.turn_off /
# light.control continues to work, including templatable field lambdas
# and effect names (static or via !lambda).

light:
  - platform: monochromatic
    id: my_light
    name: My Light
    output: my_output
    effects:
      - strobe:
          name: Strobe

binary_sensor:
  - platform: gpio
    pin: 0
    on_press:
      - light.turn_on:
          id: my_light
          brightness: 50%
          effect: Strobe
      - light.control:
          id: my_light
          brightness: !lambda 'return 0.25f;'
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
