### PR TITLE
[api] Extend NOLINT to cover bugprone-random-generator-seed in MAC varint test

### DIFF
--- a/tests/components/api/test_proto_mac_varint.cpp
+++ b/tests/components/api/test_proto_mac_varint.cpp
@@ -112,7 +112,7 @@ TEST(ProtoMacVarint, AllOnes) { verify_mac(0xFFFFFFFFFFFFULL, 7); }         // F
 
 // 100 deterministic-random 48-bit MACs to catch regressions across the space.
 TEST(ProtoMacVarint, RandomSample) {
-  // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) -- intentional fixed seed for reproducibility.
+  // NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed) -- fixed seed for reproducibility
   std::mt19937_64 rng(0xC0FFEE);
   for (int i = 0; i < 100; i++) {
     uint64_t mac = rng() & 0xFFFFFFFFFFFFULL;


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-random-generator-seed` (new in 22) during the migration from clang-tidy 18 (#16078).

The check fires on the constant-seeded RNG in `TEST(ProtoMacVarint, RandomSample)`:

```cpp
std::mt19937_64 rng(0xC0FFEE);
```

The fixed seed is intentional and the right thing for a test — random regression sampling needs to be reproducible across runs so failures are deterministic. The existing NOLINT already covered the cert-flavored variants of the same concern; extend it to include the new clang-tidy 22 check name:

```cpp
// before
// NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp) -- intentional fixed seed for reproducibility.

// after
// NOLINTNEXTLINE(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed) -- fixed seed for reproducibility
```

Trailing message slightly shortened to keep the directive on a single line (the original wrapped past `ColumnLimit: 120` when the third check name was added; clang-format's split would break NOLINTNEXTLINE's association with the next code line).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).