### PR TITLE
[tormatic] Use .value() for checked optional access in read_gate_status_

### DIFF
--- a/esphome/components/tormatic/tormatic_cover.cpp
+++ b/esphome/components/tormatic/tormatic_cover.cpp
@@ -282,12 +282,13 @@ optional<GateStatus> Tormatic::read_gate_status_() {
     }
   }
 
+  auto hdr = this->pending_hdr_.value();
+
   // Wait for all payload bytes to arrive before processing.
-  if (this->available() < this->pending_hdr_->payload_size()) {
+  if (this->available() < hdr.payload_size()) {
     return {};
   }
 
-  auto hdr = *this->pending_hdr_;
   this->pending_hdr_.reset();
 
   switch (hdr.type) {


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078).

`Tormatic::read_gate_status_()` accesses `pending_hdr_->payload_size()` and `*pending_hdr_` after a structured if/return chain that establishes `pending_hdr_.has_value()` is true at that point. The clang-22 analyzer can't propagate the precondition across the inner block and flags both derefs as unchecked.

```cpp
// before
if (this->available() < this->pending_hdr_->payload_size()) {
  return {};
}
auto hdr = *this->pending_hdr_;
this->pending_hdr_.reset();

// after
auto hdr = this->pending_hdr_.value();
if (this->available() < hdr.payload_size()) {
  return {};
}
this->pending_hdr_.reset();
```

`.value()` is preferable to `*` / `->` here:

- It's a **checked** access. Under `-fno-exceptions` (ESPHome's setup) `.value()` on an empty optional maps to `abort()` — defined fail-fast — instead of the silent UB of `*`/`->`. If a future refactor adds a path that reaches this point without populating `pending_hdr_`, the program aborts at the deref instead of corrupting state.
- It satisfies `bugprone-unchecked-optional-access` natively, no NOLINT needed.
- Cost: one branch, optimized away when `has_value()` can be statically proven.

`MessageHeader` is 8 bytes (`uint16_t seq + uint32_t len + MessageType type`), so the local copy is essentially free at runtime.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).