### PR TITLE
[haier] Fix bugprone-unchecked-optional-access; switch HardwareInfo to char[9]

### DIFF
--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -462,8 +462,7 @@ void HonClimate::process_phase(std::chrono::steady_clock::time_point now) {
       if (this->action_request_.has_value()) {
         if (this->action_request_.value().message.has_value()) {
           this->send_message_(this->action_request_.value().message.value(), this->use_crc_);
-          // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-          this->action_request_.value().message.reset();
+          this->action_request_.value().message.reset();  // NOLINT(bugprone-unchecked-optional-access)
         } else {
           // Message already sent, reseting request and return to idle
           this->action_request_.reset();

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -138,6 +138,7 @@ haier_protocol::HandlerError HonClimate::get_device_version_answer_handler_(haie
     tmp[8] = 0;
     strncpy(tmp, answr->protocol_version, 8);
     this->hvac_hardware_info_ = HardwareInfo();
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     this->hvac_hardware_info_.value().protocol_version_ = std::string(tmp);
     strncpy(tmp, answr->software_version, 8);
     this->hvac_hardware_info_.value().software_version_ = std::string(tmp);
@@ -157,6 +158,7 @@ haier_protocol::HandlerError HonClimate::get_device_version_answer_handler_(haie
     this->hvac_hardware_info_.value().functions_[3] = (answr->functions[1] & 0x08) != 0;  // multiple AC support
     this->hvac_hardware_info_.value().functions_[4] = (answr->functions[1] & 0x20) != 0;  // roles support
     this->use_crc_ = this->hvac_hardware_info_.value().functions_[2];
+    // NOLINTEND(bugprone-unchecked-optional-access)
     this->set_phase(ProtocolPhases::SENDING_INIT_2);
     return result;
   } else {
@@ -460,6 +462,7 @@ void HonClimate::process_phase(std::chrono::steady_clock::time_point now) {
       if (this->action_request_.has_value()) {
         if (this->action_request_.value().message.has_value()) {
           this->send_message_(this->action_request_.value().message.value(), this->use_crc_);
+          // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
           this->action_request_.value().message.reset();
         } else {
           // Message already sent, reseting request and return to idle

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -85,7 +85,7 @@ void HonClimate::set_horizontal_airflow(hon_protocol::HorizontalSwingMode direct
   this->force_send_control_ = true;
 }
 
-std::string HonClimate::get_cleaning_status_text() const {
+const char *HonClimate::get_cleaning_status_text() const {
   switch (this->cleaning_status_) {
     case CleaningState::SELF_CLEAN:
       return "Self clean";
@@ -134,11 +134,11 @@ haier_protocol::HandlerError HonClimate::get_device_version_answer_handler_(haie
     }
     // All OK
     hon_protocol::DeviceVersionAnswer *answr = (hon_protocol::DeviceVersionAnswer *) data;
-    HardwareInfo info{};  // zero-init guarantees null-termination of each char[9]
-    strncpy(info.protocol_version_, answr->protocol_version, 8);
-    strncpy(info.software_version_, answr->software_version, 8);
-    strncpy(info.hardware_version_, answr->hardware_version, 8);
-    strncpy(info.device_name_, answr->device_name, 8);
+    HardwareInfo info{};  // zero-init guarantees null-termination
+    strncpy(info.protocol_version_, answr->protocol_version, HARDWARE_INFO_STR_SIZE - 1);
+    strncpy(info.software_version_, answr->software_version, HARDWARE_INFO_STR_SIZE - 1);
+    strncpy(info.hardware_version_, answr->hardware_version, HARDWARE_INFO_STR_SIZE - 1);
+    strncpy(info.device_name_, answr->device_name, HARDWARE_INFO_STR_SIZE - 1);
     info.functions_[0] = (answr->functions[1] & 0x01) != 0;  // interactive mode support
     info.functions_[1] = (answr->functions[1] & 0x02) != 0;  // controller-device mode support
     info.functions_[2] = (answr->functions[1] & 0x04) != 0;  // crc support
@@ -788,7 +788,7 @@ void HonClimate::set_sub_text_sensor(SubTextSensorType type, text_sensor::TextSe
   }
 }
 
-void HonClimate::update_sub_text_sensor_(SubTextSensorType type, const std::string &value) {
+void HonClimate::update_sub_text_sensor_(SubTextSensorType type, const char *value) {
   size_t index = (size_t) type;
   if (this->sub_text_sensors_[index] != nullptr)
     this->sub_text_sensors_[index]->publish_state(value);

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -134,32 +134,22 @@ haier_protocol::HandlerError HonClimate::get_device_version_answer_handler_(haie
     }
     // All OK
     hon_protocol::DeviceVersionAnswer *answr = (hon_protocol::DeviceVersionAnswer *) data;
-    char tmp[9];
-    tmp[8] = 0;
-    strncpy(tmp, answr->protocol_version, 8);
-    HardwareInfo info;
-    info.protocol_version_ = std::string(tmp);
-    strncpy(tmp, answr->software_version, 8);
-    info.software_version_ = std::string(tmp);
-    strncpy(tmp, answr->hardware_version, 8);
-    info.hardware_version_ = std::string(tmp);
-    strncpy(tmp, answr->device_name, 8);
-    info.device_name_ = std::string(tmp);
+    HardwareInfo info{};  // zero-init guarantees null-termination of each char[9]
+    strncpy(info.protocol_version_, answr->protocol_version, 8);
+    strncpy(info.software_version_, answr->software_version, 8);
+    strncpy(info.hardware_version_, answr->hardware_version, 8);
+    strncpy(info.device_name_, answr->device_name, 8);
     info.functions_[0] = (answr->functions[1] & 0x01) != 0;  // interactive mode support
     info.functions_[1] = (answr->functions[1] & 0x02) != 0;  // controller-device mode support
     info.functions_[2] = (answr->functions[1] & 0x04) != 0;  // crc support
     info.functions_[3] = (answr->functions[1] & 0x08) != 0;  // multiple AC support
     info.functions_[4] = (answr->functions[1] & 0x20) != 0;  // roles support
     this->use_crc_ = info.functions_[2];
-    this->hvac_hardware_info_ = std::move(info);
 #ifdef USE_TEXT_SENSOR
-    this->update_sub_text_sensor_(
-        SubTextSensorType::APPLIANCE_NAME,
-        this->hvac_hardware_info_.value().device_name_);  // NOLINT(bugprone-unchecked-optional-access)
-    this->update_sub_text_sensor_(
-        SubTextSensorType::PROTOCOL_VERSION,
-        this->hvac_hardware_info_.value().protocol_version_);  // NOLINT(bugprone-unchecked-optional-access)
+    this->update_sub_text_sensor_(SubTextSensorType::APPLIANCE_NAME, info.device_name_);
+    this->update_sub_text_sensor_(SubTextSensorType::PROTOCOL_VERSION, info.protocol_version_);
 #endif
+    this->hvac_hardware_info_ = info;
     this->set_phase(ProtocolPhases::SENDING_INIT_2);
     return result;
   } else {
@@ -350,10 +340,9 @@ void HonClimate::dump_config() {
                   "  Device software version: %s\n"
                   "  Device hardware version: %s\n"
                   "  Device name: %s",
-                  this->hvac_hardware_info_.value().protocol_version_.c_str(),
-                  this->hvac_hardware_info_.value().software_version_.c_str(),
-                  this->hvac_hardware_info_.value().hardware_version_.c_str(),
-                  this->hvac_hardware_info_.value().device_name_.c_str());
+                  this->hvac_hardware_info_.value().protocol_version_,
+                  this->hvac_hardware_info_.value().software_version_,
+                  this->hvac_hardware_info_.value().hardware_version_, this->hvac_hardware_info_.value().device_name_);
     ESP_LOGCONFIG(TAG, "  Device features:%s%s%s%s%s",
                   (this->hvac_hardware_info_.value().functions_[0] ? " interactive" : ""),
                   (this->hvac_hardware_info_.value().functions_[1] ? " controller-device" : ""),

--- a/esphome/components/haier/hon_climate.cpp
+++ b/esphome/components/haier/hon_climate.cpp
@@ -137,28 +137,29 @@ haier_protocol::HandlerError HonClimate::get_device_version_answer_handler_(haie
     char tmp[9];
     tmp[8] = 0;
     strncpy(tmp, answr->protocol_version, 8);
-    this->hvac_hardware_info_ = HardwareInfo();
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
-    this->hvac_hardware_info_.value().protocol_version_ = std::string(tmp);
+    HardwareInfo info;
+    info.protocol_version_ = std::string(tmp);
     strncpy(tmp, answr->software_version, 8);
-    this->hvac_hardware_info_.value().software_version_ = std::string(tmp);
+    info.software_version_ = std::string(tmp);
     strncpy(tmp, answr->hardware_version, 8);
-    this->hvac_hardware_info_.value().hardware_version_ = std::string(tmp);
+    info.hardware_version_ = std::string(tmp);
     strncpy(tmp, answr->device_name, 8);
-    this->hvac_hardware_info_.value().device_name_ = std::string(tmp);
+    info.device_name_ = std::string(tmp);
+    info.functions_[0] = (answr->functions[1] & 0x01) != 0;  // interactive mode support
+    info.functions_[1] = (answr->functions[1] & 0x02) != 0;  // controller-device mode support
+    info.functions_[2] = (answr->functions[1] & 0x04) != 0;  // crc support
+    info.functions_[3] = (answr->functions[1] & 0x08) != 0;  // multiple AC support
+    info.functions_[4] = (answr->functions[1] & 0x20) != 0;  // roles support
+    this->use_crc_ = info.functions_[2];
+    this->hvac_hardware_info_ = std::move(info);
 #ifdef USE_TEXT_SENSOR
-    this->update_sub_text_sensor_(SubTextSensorType::APPLIANCE_NAME, this->hvac_hardware_info_.value().device_name_);
-    this->update_sub_text_sensor_(SubTextSensorType::PROTOCOL_VERSION,
-                                  this->hvac_hardware_info_.value().protocol_version_);
+    this->update_sub_text_sensor_(
+        SubTextSensorType::APPLIANCE_NAME,
+        this->hvac_hardware_info_.value().device_name_);  // NOLINT(bugprone-unchecked-optional-access)
+    this->update_sub_text_sensor_(
+        SubTextSensorType::PROTOCOL_VERSION,
+        this->hvac_hardware_info_.value().protocol_version_);  // NOLINT(bugprone-unchecked-optional-access)
 #endif
-    this->hvac_hardware_info_.value().functions_[0] = (answr->functions[1] & 0x01) != 0;  // interactive mode support
-    this->hvac_hardware_info_.value().functions_[1] =
-        (answr->functions[1] & 0x02) != 0;  // controller-device mode support
-    this->hvac_hardware_info_.value().functions_[2] = (answr->functions[1] & 0x04) != 0;  // crc support
-    this->hvac_hardware_info_.value().functions_[3] = (answr->functions[1] & 0x08) != 0;  // multiple AC support
-    this->hvac_hardware_info_.value().functions_[4] = (answr->functions[1] & 0x20) != 0;  // roles support
-    this->use_crc_ = this->hvac_hardware_info_.value().functions_[2];
-    // NOLINTEND(bugprone-unchecked-optional-access)
     this->set_phase(ProtocolPhases::SENDING_INIT_2);
     return result;
   } else {

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -167,10 +167,10 @@ class HonClimate : public HaierClimateBase {
   void clear_control_messages_queue_();
 
   struct HardwareInfo {
-    std::string protocol_version_;
-    std::string software_version_;
-    std::string hardware_version_;
-    std::string device_name_;
+    char protocol_version_[9];
+    char software_version_[9];
+    char hardware_version_[9];
+    char device_name_[9];
     bool functions_[5];
   };
 

--- a/esphome/components/haier/hon_climate.h
+++ b/esphome/components/haier/hon_climate.h
@@ -90,7 +90,7 @@ class HonClimate : public HaierClimateBase {
   void set_sub_text_sensor(SubTextSensorType type, text_sensor::TextSensor *sens);
 
  protected:
-  void update_sub_text_sensor_(SubTextSensorType type, const std::string &value);
+  void update_sub_text_sensor_(SubTextSensorType type, const char *value);
   text_sensor::TextSensor *sub_text_sensors_[(size_t) SubTextSensorType::SUB_TEXT_SENSOR_TYPE_COUNT]{nullptr};
 #endif
 #ifdef USE_SWITCH
@@ -116,7 +116,7 @@ class HonClimate : public HaierClimateBase {
   void set_vertical_airflow(hon_protocol::VerticalSwingMode direction);
   esphome::optional<hon_protocol::HorizontalSwingMode> get_horizontal_airflow() const;
   void set_horizontal_airflow(hon_protocol::HorizontalSwingMode direction);
-  std::string get_cleaning_status_text() const;
+  const char *get_cleaning_status_text() const;
   CleaningState get_cleaning_status() const;
   void start_self_cleaning();
   void start_steri_cleaning();
@@ -166,11 +166,12 @@ class HonClimate : public HaierClimateBase {
   void fill_control_messages_queue_();
   void clear_control_messages_queue_();
 
+  static constexpr size_t HARDWARE_INFO_STR_SIZE = 9;
   struct HardwareInfo {
-    char protocol_version_[9];
-    char software_version_[9];
-    char hardware_version_[9];
-    char device_name_[9];
+    char protocol_version_[HARDWARE_INFO_STR_SIZE];
+    char software_version_[HARDWARE_INFO_STR_SIZE];
+    char hardware_version_[HARDWARE_INFO_STR_SIZE];
+    char device_name_[HARDWARE_INFO_STR_SIZE];
     bool functions_[5];
   };
 

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -191,8 +191,7 @@ void Smartair2Climate::process_phase(std::chrono::steady_clock::time_point now) 
       if (this->action_request_.has_value()) {
         if (this->action_request_.value().message.has_value()) {
           this->send_message_(this->action_request_.value().message.value(), this->use_crc_);
-          // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-          this->action_request_.value().message.reset();
+          this->action_request_.value().message.reset();  // NOLINT(bugprone-unchecked-optional-access)
         } else {
           // Message already sent, reseting request and return to idle
           this->action_request_.reset();

--- a/esphome/components/haier/smartair2_climate.cpp
+++ b/esphome/components/haier/smartair2_climate.cpp
@@ -191,6 +191,7 @@ void Smartair2Climate::process_phase(std::chrono::steady_clock::time_point now) 
       if (this->action_request_.has_value()) {
         if (this->action_request_.value().message.has_value()) {
           this->send_message_(this->action_request_.value().message.value(), this->use_crc_);
+          // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
           this->action_request_.value().message.reset();
         } else {
           // Message already sent, reseting request and return to idle


### PR DESCRIPTION
# What does this implement/fix?

Surfaced by clang-tidy 22's `bugprone-unchecked-optional-access` during the migration from clang-tidy 18 (#16078). Three sites across `hon_climate.cpp` and `smartair2_climate.cpp` flagged.

## hon_climate — `HardwareInfo`

The populate path repeatedly accessed `this->hvac_hardware_info_.value().<field>` (14 sites in `get_device_version_answer_handler_`), with the analyzer flagging each. Refactored to:

1. Populate a local `HardwareInfo info{}` (zero-init), then assign to `hvac_hardware_info_` once at the end. No more `.value()` calls in the populate phase.
2. Switch `HardwareInfo`'s string fields from `std::string` to `char[9]` — they always hold the fixed 8-char fields from `hon_protocol::DeviceVersionAnswer` (which are themselves `char[8]` *without* null terminators in the wire protocol). With zero-initialization of the struct, the 9th byte stays as `\0` and acts as the null terminator after `strncpy(dst, src, 8)`.
3. This lets us `strncpy` directly into the struct fields and drop the `tmp[9]` scratch buffer entirely.
4. Eliminates four `std::string` allocations per device-version handler invocation.
5. Move USE_TEXT_SENSOR block above the assignment to the optional, using `info.device_name_` / `info.protocol_version_` directly — no NOLINT needed.

```cpp
// before
char tmp[9];
tmp[8] = 0;
strncpy(tmp, answr->protocol_version, 8);
this->hvac_hardware_info_ = HardwareInfo();
this->hvac_hardware_info_.value().protocol_version_ = std::string(tmp);
strncpy(tmp, answr->software_version, 8);
this->hvac_hardware_info_.value().software_version_ = std::string(tmp);
// ... 12 more .value() accesses

// after
HardwareInfo info{};
strncpy(info.protocol_version_, answr->protocol_version, 8);
strncpy(info.software_version_, answr->software_version, 8);
strncpy(info.hardware_version_, answr->hardware_version, 8);
strncpy(info.device_name_, answr->device_name, 8);
info.functions_[0] = ...;
// ...
this->use_crc_ = info.functions_[2];
#ifdef USE_TEXT_SENSOR
this->update_sub_text_sensor_(SubTextSensorType::APPLIANCE_NAME, info.device_name_);
this->update_sub_text_sensor_(SubTextSensorType::PROTOCOL_VERSION, info.protocol_version_);
#endif
this->hvac_hardware_info_ = info;
```

Use-site adjustments (`dump_config`, `publish_state`): drop `.c_str()` since char[9] decays to const char* for `%s` directly; pass to `publish_state(const std::string &)` via implicit char* → std::string construction (one temp string per subscription, which only happens on sensor wire-up).

## hon_climate — action_request reset

Same `bugprone-unchecked-optional-access` pattern at line 463 (`this->action_request_.value().message.reset();`). Trailing `// NOLINT(bugprone-unchecked-optional-access)`. Matches the existing precedent at `hon_climate.cpp:1303`.

## smartair2_climate — action_request reset

Same fix as above at line 194.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Surfaced during the clang-tidy 18 → 22 migration (#16078); split out from #16096

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).