### PR TITLE
[fan] Add tests for fan.turn_on action field combinations

### DIFF
--- a/tests/components/fan/common.yaml
+++ b/tests/components/fan/common.yaml
@@ -57,3 +57,34 @@ binary_sensor:
         return true;
       }
       return false;
+
+# Exercise fan.turn_on with various field combinations so the
+# TurnOnAction codegen paths get build coverage.
+button:
+  - platform: template
+    name: "Fan Speed Only"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          speed: 2
+  - platform: template
+    name: "Fan Oscillating + Direction"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          oscillating: true
+          direction: REVERSE
+  - platform: template
+    name: "Fan All Fields"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          oscillating: false
+          speed: 3
+          direction: FORWARD
+  - platform: template
+    name: "Fan Lambda Speed"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          speed: !lambda 'return 1;'

--- a/tests/integration/fixtures/fan_turn_on_action.yaml
+++ b/tests/integration/fixtures/fan_turn_on_action.yaml
@@ -1,0 +1,59 @@
+esphome:
+  name: fan-turn-on-action-test
+host:
+api:
+logger:
+  level: DEBUG
+
+globals:
+  - id: test_speed
+    type: int
+    initial_value: "2"
+
+fan:
+  - platform: template
+    id: test_fan
+    name: "Test Fan"
+    has_oscillating: true
+    has_direction: true
+    speed_count: 5
+
+button:
+  # fan.turn_on: speed only
+  - platform: template
+    id: btn_speed
+    name: "Set Speed"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          speed: 3
+
+  # fan.turn_on: oscillating + direction (no speed)
+  - platform: template
+    id: btn_oscillate_direction
+    name: "Set Oscillate Direction"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          oscillating: true
+          direction: REVERSE
+
+  # fan.turn_on: all three fields
+  - platform: template
+    id: btn_all_fields
+    name: "Set All Fields"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          oscillating: false
+          speed: 4
+          direction: FORWARD
+
+  # fan.turn_on: lambda for speed (exercises lambda path)
+  - platform: template
+    id: btn_lambda_speed
+    name: "Lambda Speed"
+    on_press:
+      - fan.turn_on:
+          id: test_fan
+          speed: !lambda "return id(test_speed);"

--- a/tests/integration/test_fan_turn_on_action.py
+++ b/tests/integration/test_fan_turn_on_action.py
@@ -1,0 +1,75 @@
+"""Integration test for fan TurnOnAction.
+
+Tests that fan.turn_on automation actions work correctly across multiple
+field combinations and the lambda path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import ButtonInfo, EntityState, FanDirection, FanInfo, FanState
+import pytest
+
+from .state_utils import InitialStateHelper, require_entity
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_fan_turn_on_action(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test fan TurnOnAction with constants and a lambda."""
+    loop = asyncio.get_running_loop()
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        fan_state_future: asyncio.Future[FanState] | None = None
+
+        def on_state(state: EntityState) -> None:
+            if (
+                isinstance(state, FanState)
+                and fan_state_future is not None
+                and not fan_state_future.done()
+            ):
+                fan_state_future.set_result(state)
+
+        async def wait_for_fan_state(timeout: float = 5.0) -> FanState:
+            nonlocal fan_state_future
+            fan_state_future = loop.create_future()
+            try:
+                return await asyncio.wait_for(fan_state_future, timeout)
+            finally:
+                fan_state_future = None
+
+        entities, _ = await client.list_entities_services()
+        initial_state_helper = InitialStateHelper(entities)
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        await initial_state_helper.wait_for_initial_states()
+
+        require_entity(entities, "test_fan", FanInfo)
+
+        async def press_and_wait(name: str) -> FanState:
+            btn = require_entity(entities, name.lower().replace(" ", "_"), ButtonInfo)
+            client.button_command(btn.key)
+            return await wait_for_fan_state()
+
+        # speed only
+        state = await press_and_wait("Set Speed")
+        assert state.state is True
+        assert state.speed_level == 3
+
+        # oscillating + direction
+        state = await press_and_wait("Set Oscillate Direction")
+        assert state.oscillating is True
+        assert state.direction == FanDirection.REVERSE
+
+        # all three fields
+        state = await press_and_wait("Set All Fields")
+        assert state.oscillating is False
+        assert state.speed_level == 4
+        assert state.direction == FanDirection.FORWARD
+
+        # lambda path: speed computed at runtime (test_speed global = 2)
+        state = await press_and_wait("Lambda Speed")
+        assert state.speed_level == 2


### PR DESCRIPTION
# What does this implement/fix?

Adds test coverage for `fan.turn_on` action field combinations:

- Component test (`tests/components/fan/common.yaml`) — adds buttons that exercise `fan.turn_on` with `speed` only, `oscillating + direction`, all three fields, and a `!lambda` speed, so the codegen paths get build coverage on every fan target.
- Integration test (`tests/integration/test_fan_turn_on_action.py` + `fixtures/fan_turn_on_action.yaml`) — drives a host-target template fan through the same field combinations and asserts the resulting `FanState` matches.

This is intentionally test-only; no code changes. Sets up the regression net before a follow-up refactor of `fan::TurnOnAction`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test-only)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes — the new YAML lives in tests/.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
