### PR TITLE
[valve] Add tests for valve.control action field combinations

### DIFF
--- a/tests/components/template/common-base.yaml
+++ b/tests/components/template/common-base.yaml
@@ -442,6 +442,20 @@ valve:
           state: CLOSED
     stop_action:
       - logger.log: stop_action
+      # Exercise valve.control with various field combinations so the
+      # ControlAction codegen paths get build coverage.
+      - valve.control:
+          id: template_valve
+          stop: true
+      - valve.control:
+          id: template_valve
+          position: 50%
+      - valve.control:
+          id: template_valve
+          state: OPEN
+      - valve.control:
+          id: template_valve
+          position: !lambda 'return 0.25f;'
     optimistic: true
 
 text:

--- a/tests/integration/fixtures/valve_control_action.yaml
+++ b/tests/integration/fixtures/valve_control_action.yaml
@@ -1,0 +1,68 @@
+esphome:
+  name: valve-control-action-test
+host:
+api:
+logger:
+  level: DEBUG
+
+globals:
+  - id: test_position
+    type: float
+    initial_value: "0.42"
+
+valve:
+  - platform: template
+    name: "Test Valve"
+    id: test_valve
+    optimistic: true
+    assumed_state: true
+    open_action:
+      - valve.template.publish:
+          id: test_valve
+          position: 1.0
+    close_action:
+      - valve.template.publish:
+          id: test_valve
+          position: 0.0
+    stop_action:
+      - valve.template.publish:
+          id: test_valve
+          current_operation: IDLE
+
+button:
+  # valve.control: position only
+  - platform: template
+    id: btn_position
+    name: "Set Position"
+    on_press:
+      - valve.control:
+          id: test_valve
+          position: 50%
+
+  # valve.control: state alias for position 1.0
+  - platform: template
+    id: btn_open_state
+    name: "Open State"
+    on_press:
+      - valve.control:
+          id: test_valve
+          state: OPEN
+
+  # valve.control: lambda position (exercises lambda path)
+  - platform: template
+    id: btn_lambda_position
+    name: "Lambda Position"
+    on_press:
+      - valve.control:
+          id: test_valve
+          position: !lambda "return id(test_position);"
+
+  # valve.control: stop only — template valve's stop_action publishes
+  # current_operation: IDLE.
+  - platform: template
+    id: btn_stop
+    name: "Stop Valve"
+    on_press:
+      - valve.control:
+          id: test_valve
+          stop: true

--- a/tests/integration/fixtures/valve_control_action.yaml
+++ b/tests/integration/fixtures/valve_control_action.yaml
@@ -14,6 +14,7 @@ valve:
   - platform: template
     name: "Test Valve"
     id: test_valve
+    has_position: true
     optimistic: true
     assumed_state: true
     open_action:

--- a/tests/integration/test_valve_control_action.py
+++ b/tests/integration/test_valve_control_action.py
@@ -1,0 +1,72 @@
+"""Integration test for valve ControlAction.
+
+Tests that valve.control automation actions work correctly across multiple
+field combinations and the lambda path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from aioesphomeapi import ButtonInfo, EntityState, ValveInfo, ValveOperation, ValveState
+import pytest
+
+from .state_utils import InitialStateHelper, require_entity
+from .types import APIClientConnectedFactory, RunCompiledFunction
+
+
+@pytest.mark.asyncio
+async def test_valve_control_action(
+    yaml_config: str,
+    run_compiled: RunCompiledFunction,
+    api_client_connected: APIClientConnectedFactory,
+) -> None:
+    """Test valve ControlAction with constants and a lambda."""
+    loop = asyncio.get_running_loop()
+    async with run_compiled(yaml_config), api_client_connected() as client:
+        valve_state_future: asyncio.Future[ValveState] | None = None
+
+        def on_state(state: EntityState) -> None:
+            if (
+                isinstance(state, ValveState)
+                and valve_state_future is not None
+                and not valve_state_future.done()
+            ):
+                valve_state_future.set_result(state)
+
+        async def wait_for_valve_state(timeout: float = 5.0) -> ValveState:
+            nonlocal valve_state_future
+            valve_state_future = loop.create_future()
+            try:
+                return await asyncio.wait_for(valve_state_future, timeout)
+            finally:
+                valve_state_future = None
+
+        entities, _ = await client.list_entities_services()
+        initial_state_helper = InitialStateHelper(entities)
+        client.subscribe_states(initial_state_helper.on_state_wrapper(on_state))
+        await initial_state_helper.wait_for_initial_states()
+
+        require_entity(entities, "test_valve", ValveInfo)
+
+        async def press_and_wait(name: str) -> ValveState:
+            btn = require_entity(entities, name.lower().replace(" ", "_"), ButtonInfo)
+            client.button_command(btn.key)
+            return await wait_for_valve_state()
+
+        # valve.control: position only
+        state = await press_and_wait("Set Position")
+        assert state.position == pytest.approx(0.5, abs=0.01)
+
+        # valve.control: state alias for position 1.0
+        state = await press_and_wait("Open State")
+        assert state.position == pytest.approx(1.0, abs=0.01)
+
+        # valve.control: lambda position (test_position global = 0.42)
+        state = await press_and_wait("Lambda Position")
+        assert state.position == pytest.approx(0.42, abs=0.01)
+
+        # valve.control: stop only — template valve's stop_action publishes
+        # current_operation: IDLE.
+        state = await press_and_wait("Stop Valve")
+        assert state.current_operation == ValveOperation.IDLE


### PR DESCRIPTION
# What does this implement/fix?

Adds test coverage for `valve.control` action field combinations:

- Component test (`tests/components/template/common-base.yaml`) — extends the template valve's `stop_action` with `valve.control` calls covering `stop`, `position`, `state` (alias for position), and a `!lambda` position, so the codegen paths get build coverage on every template-valve target.
- Integration test (`tests/integration/test_valve_control_action.py` + `fixtures/valve_control_action.yaml`) — drives a host-target template valve through the same field combinations and asserts the resulting `ValveState` matches.

This is intentionally test-only; no code changes. Sets up the regression net before a follow-up refactor of `valve::ControlAction`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (test-only)

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes — the new YAML lives in tests/.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
