### PR TITLE
[mixer_speaker] NOLINT bugprone-unchecked-optional-access in audio_mixer_task

### DIFF
--- a/esphome/components/mixer/speaker/mixer_speaker.cpp
+++ b/esphome/components/mixer/speaker/mixer_speaker.cpp
@@ -588,6 +588,7 @@ void MixerSpeaker::mix_audio_samples(const int16_t *primary_buffer, audio::Audio
   }
 }
 
+// NOLINTBEGIN(bugprone-unchecked-optional-access) -- audio_stream_info_ always set before this task is created
 void MixerSpeaker::audio_mixer_task(void *params) {
   MixerSpeaker *this_mixer = static_cast<MixerSpeaker *>(params);
 
@@ -764,6 +765,7 @@ void MixerSpeaker::audio_mixer_task(void *params) {
 
   vTaskSuspend(nullptr);  // Suspend this task indefinitely until the loop method deletes it
 }
+// NOLINTEND(bugprone-unchecked-optional-access)
 
 }  // namespace esphome::mixer_speaker
 


### PR DESCRIPTION
# What does this implement/fix?

clang-tidy 22 promotes `bugprone-unchecked-optional-access` to fire on every `this_mixer->audio_stream_info_.value()` call inside `audio_mixer_task` (8 sites). The optional is set in `MixerSpeaker::start()` before the START command bit is raised, and `MixerSpeaker::loop()` only creates the task once that bit is set, so the optional is always engaged for the lifetime of the task.

Wraps `audio_mixer_task` with `NOLINTBEGIN/NOLINTEND(bugprone-unchecked-optional-access)` plus a one-line comment explaining the invariant.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (preparatory for clang-tidy 22 bump)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).