### PR TITLE
[aqi] Use std::max initializer-list for non-negative AQI clamp

### DIFF
--- a/esphome/components/aqi/aqi_calculator.h
+++ b/esphome/components/aqi/aqi_calculator.h
@@ -15,10 +15,7 @@ class AQICalculator : public AbstractAQICalculator {
     float pm2_5_index = calculate_index(pm2_5_value, PM2_5_GRID);
     float pm10_0_index = calculate_index(pm10_0_value, PM10_0_GRID);
 
-    float aqi = std::max(pm2_5_index, pm10_0_index);
-    if (aqi < 0.0f) {
-      aqi = 0.0f;
-    }
+    float aqi = std::max({pm2_5_index, pm10_0_index, 0.0f});
     return static_cast<uint16_t>(std::lround(aqi));
   }
 

--- a/esphome/components/aqi/aqi_calculator.h
+++ b/esphome/components/aqi/aqi_calculator.h
@@ -14,7 +14,6 @@ class AQICalculator : public AbstractAQICalculator {
   uint16_t get_aqi(float pm2_5_value, float pm10_0_value) override {
     float pm2_5_index = calculate_index(pm2_5_value, PM2_5_GRID);
     float pm10_0_index = calculate_index(pm10_0_value, PM10_0_GRID);
-
     float aqi = std::max({pm2_5_index, pm10_0_index, 0.0f});
     return static_cast<uint16_t>(std::lround(aqi));
   }

--- a/esphome/components/aqi/caqi_calculator.h
+++ b/esphome/components/aqi/caqi_calculator.h
@@ -13,10 +13,7 @@ class CAQICalculator : public AbstractAQICalculator {
     float pm2_5_index = calculate_index(pm2_5_value, PM2_5_GRID);
     float pm10_0_index = calculate_index(pm10_0_value, PM10_0_GRID);
 
-    float aqi = std::max(pm2_5_index, pm10_0_index);
-    if (aqi < 0.0f) {
-      aqi = 0.0f;
-    }
+    float aqi = std::max({pm2_5_index, pm10_0_index, 0.0f});
     return static_cast<uint16_t>(std::lround(aqi));
   }
 

--- a/esphome/components/aqi/caqi_calculator.h
+++ b/esphome/components/aqi/caqi_calculator.h
@@ -12,7 +12,6 @@ class CAQICalculator : public AbstractAQICalculator {
   uint16_t get_aqi(float pm2_5_value, float pm10_0_value) override {
     float pm2_5_index = calculate_index(pm2_5_value, PM2_5_GRID);
     float pm10_0_index = calculate_index(pm10_0_value, PM10_0_GRID);
-
     float aqi = std::max({pm2_5_index, pm10_0_index, 0.0f});
     return static_cast<uint16_t>(std::lround(aqi));
   }


### PR DESCRIPTION
# What does this implement/fix?

`AQICalculator::get_aqi` and `CAQICalculator::get_aqi` clamp the result with an `if (aqi < 0.0f) aqi = 0.0f;` pattern. Replaces both with a single `std::max({pm2_5_index, pm10_0_index, 0.0f})` initializer-list call — same behavior, one expression instead of an `if`.

This is one of the patterns `readability-use-std-min-max` flags. Pulled out of the clang-tidy 22 bump (#16078) so it can land independently.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (preparatory for clang-tidy 22 bump)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No config changes
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).