### PR TITLE
[kamstrup_kmp][toshiba] Fix signed/unsigned comparisons against sizeof

### DIFF
--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -139,12 +139,12 @@ void KamstrupKMPComponent::clear_uart_rx_buffer_() {
 
 void KamstrupKMPComponent::read_command_(uint16_t command) {
   uint8_t buffer[20] = {0};
-  int buffer_len = 0;
+  size_t buffer_len = 0;
   int data;
   int timeout = 250;  // ms
 
   // Read the data from the UART
-  while (timeout > 0 && buffer_len < static_cast<int>(sizeof(buffer))) {
+  while (timeout > 0 && buffer_len < sizeof(buffer)) {
     if (this->available()) {
       data = this->read();
       if (data > -1) {

--- a/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
+++ b/esphome/components/kamstrup_kmp/kamstrup_kmp.cpp
@@ -183,7 +183,7 @@ void KamstrupKMPComponent::read_command_(uint16_t command) {
   // Decode
   uint8_t msg[20] = {0};
   int msg_len = 0;
-  for (int i = 1; i < buffer_len - 1; i++) {
+  for (size_t i = 1; i < buffer_len - 1; i++) {
     if (buffer[i] == 0x1B) {
       msg[msg_len++] = buffer[i + 1] ^ 0xFF;
       i++;

--- a/esphome/components/toshiba/toshiba.cpp
+++ b/esphome/components/toshiba/toshiba.cpp
@@ -275,7 +275,7 @@ static Ras2819tSecondPacketCodes get_ras_2819t_second_packet_codes(climate::Clim
  */
 static uint8_t get_ras_2819t_temp_code(float temperature) {
   int temp_index = static_cast<int>(temperature) - 18;
-  if (temp_index < 0 || temp_index >= static_cast<int>(sizeof(RAS_2819T_TEMP_CODES))) {
+  if (temp_index < 0 || static_cast<size_t>(temp_index) >= sizeof(RAS_2819T_TEMP_CODES)) {
     ESP_LOGW(TAG, "Temperature %.1f°C out of range [18-30°C], defaulting to 24°C", temperature);
     return 0x40;  // Default to 24°C
   }


### PR DESCRIPTION
# What does this implement/fix?

Two sites compared a signed `int` against `static_cast<int>(sizeof(...))`. The cast silenced the original sign-mismatch warning but loses information for very large buffers and is the pattern `modernize-use-integer-sign-comparison` flags.

- `kamstrup_kmp.cpp::read_command_`: `buffer_len` is initialized to 0 and only ever incremented or reset, so it can simply be `size_t` to match the natural type of the comparison against `sizeof(buffer)`.
- `toshiba.cpp::get_ras_2819t_temp_code`: `temp_index` can legitimately be negative (when `temperature < 18`), so it stays signed; the upper-bound comparison is rewritten as `temp_index < 0 || static_cast<size_t>(temp_index) >= sizeof(...)` — the standard "check non-negative first, then compare unsigned" idiom.

Pulled out of the clang-tidy 22 bump (#16078) so it can land independently.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (preparatory for clang-tidy 22 bump)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No config changes
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).