### PR TITLE
[remote_base][core] Drop redundant typename in dependent type contexts

### DIFF
--- a/esphome/components/remote_base/remote_base.h
+++ b/esphome/components/remote_base/remote_base.h
@@ -164,7 +164,7 @@ class RemoteTransmitterBase : public RemoteComponentBase {
     return TransmitCall(this);
   }
   template<typename Protocol>
-  void transmit(const typename Protocol::ProtocolData &data, uint32_t send_times = 1, uint32_t send_wait = 0) {
+  void transmit(const Protocol::ProtocolData &data, uint32_t send_times = 1, uint32_t send_wait = 0) {
     auto call = this->transmit();
     Protocol().encode(call.get_data(), data);
     call.set_send_times(send_times);
@@ -250,10 +250,10 @@ template<typename T> class RemoteReceiverBinarySensor : public RemoteReceiverBin
   }
 
  public:
-  void set_data(typename T::ProtocolData data) { data_ = data; }
+  void set_data(T::ProtocolData data) { data_ = data; }
 
  protected:
-  typename T::ProtocolData data_;
+  T::ProtocolData data_;
 };
 
 template<typename T>
@@ -278,7 +278,7 @@ class RemoteTransmittable {
 
  protected:
   template<typename Protocol>
-  void transmit_(const typename Protocol::ProtocolData &data, uint32_t send_times = 1, uint32_t send_wait = 0) {
+  void transmit_(const Protocol::ProtocolData &data, uint32_t send_times = 1, uint32_t send_wait = 0) {
     this->transmitter_->transmit<Protocol>(data, send_times, send_wait);
   }
   RemoteTransmitterBase *transmitter_;

--- a/esphome/core/finite_set_mask.h
+++ b/esphome/core/finite_set_mask.h
@@ -55,7 +55,7 @@ template<typename ValueType, int MaxBits> struct DefaultBitPolicy {
 ///
 template<typename ValueType, typename BitPolicy = DefaultBitPolicy<ValueType, 16>> class FiniteSetMask {
  public:
-  using bitmask_t = typename BitPolicy::mask_t;
+  using bitmask_t = BitPolicy::mask_t;
 
   constexpr FiniteSetMask() = default;
 


### PR DESCRIPTION
# What does this implement/fix?

C++20 made the `typename` keyword optional in several contexts where the qualified-id can only refer to a type:

- function parameter declarations of templates
- type-id in `using` aliases
- data member declarations whose context unambiguously requires a type

`readability-redundant-typename` (new in clang-tidy 22) flags these. Drops the keyword in 5 sites:

- `remote_base.h`: 4 sites — `transmit()`, `transmit_()` parameter types and `RemoteReceiverBinarySensorBase::set_data` parameter + `data_` member
- `finite_set_mask.h`: 1 site — `using bitmask_t = BitPolicy::mask_t`

The project standard is `gnu++20` so all 5 are guaranteed-safe to drop. Pulled out of the clang-tidy 22 bump (#16078) so it can land independently.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A (preparatory for clang-tidy 22 bump)

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No config changes
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).