### PR TITLE
[ota] Use WatchdogManager for OTA on ESP32

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -24,6 +24,8 @@ def AUTO_LOAD() -> list[str]:
     components = ["safe_mode"]
     if not CORE.using_zephyr:
         components.extend(["md5"])
+    if CORE.is_esp32:
+        components.extend(["watchdog"])
     return components
 
 

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -2,6 +2,7 @@
 #include "ota_backend_esp_idf.h"
 
 #include "esphome/components/md5/md5.h"
+#include "esphome/components/watchdog/watchdog.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/log.h"
 
@@ -28,28 +29,8 @@ OTAResponseTypes IDFOTABackend::begin(size_t image_size) {
     return OTA_RESPONSE_ERROR_NO_UPDATE_PARTITION;
   }
 
-#if CONFIG_ESP_TASK_WDT_TIMEOUT_S < 15
-  // The following function takes longer than the 5 seconds timeout of WDT
-  esp_task_wdt_config_t wdtc;
-  wdtc.idle_core_mask = 0;
-#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0
-  wdtc.idle_core_mask |= (1 << 0);
-#endif
-#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1
-  wdtc.idle_core_mask |= (1 << 1);
-#endif
-  wdtc.timeout_ms = 15000;
-  wdtc.trigger_panic = false;
-  esp_task_wdt_reconfigure(&wdtc);
-#endif
-
+  watchdog::WatchdogManager watchdog(15000);
   esp_err_t err = esp_ota_begin(this->partition_, image_size, &this->update_handle_);
-
-#if CONFIG_ESP_TASK_WDT_TIMEOUT_S < 15
-  // Set the WDT back to the configured timeout
-  wdtc.timeout_ms = CONFIG_ESP_TASK_WDT_TIMEOUT_S * 1000;
-  esp_task_wdt_reconfigure(&wdtc);
-#endif
 
   if (err != ESP_OK) {
     esp_ota_abort(this->update_handle_);


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Use the `WatchdogManager` instead of direct esp-idf calls to configure the watchdog during OTA updates. Tested with single core and dual core configurations.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
# For single core:
esp32:
  board: esp32dev
  framework:
    type: esp-idf
    sdkconfig_options:
      CONFIG_FREERTOS_UNICORE: y
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
