### PR TITLE
[watchdog] Use default CHECK_IDLE_TASK and PANIC when configuring the watchdog

### DIFF
--- a/esphome/components/watchdog/watchdog.cpp
+++ b/esphome/components/watchdog/watchdog.cpp
@@ -39,9 +39,18 @@ void WatchdogManager::set_timeout_(uint32_t timeout_ms) {
 #ifdef USE_ESP32
   esp_task_wdt_config_t wdt_config = {
       .timeout_ms = timeout_ms,
-      .idle_core_mask = (1U << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1U,
-      .trigger_panic = true,
+      .idle_core_mask = 0,
+      .trigger_panic = false,
   };
+#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0
+  wdt_config.idle_core_mask |= (1U << 0U);
+#endif
+#if CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1
+  wdt_config.idle_core_mask |= (1U << 1U);
+#endif
+#if CONFIG_ESP_TASK_WDT_PANIC
+  wdt_config.trigger_panic = true;
+#endif
   esp_task_wdt_reconfigure(&wdt_config);
 #endif  // USE_ESP32
 


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->
Respect the defaults values set in the sdkconfig instead of using hardcoded values for CHECK_IDLE_TASK and PANIC when configuring the watchdog.

During testing, the following values were configured: `mask: 0x0, panic: true`

This is the sdkconfig used:
```
config/sdkconfig.json:    "ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0": false,
config/sdkconfig.json:    "ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1": false,
config/sdkconfig.json:    "ESP_TASK_WDT_EN": true,
config/sdkconfig.json:    "ESP_TASK_WDT_INIT": true,
config/sdkconfig.json:    "ESP_TASK_WDT_PANIC": true,
config/sdkconfig.json:    "ESP_TASK_WDT_TIMEOUT_S": 5,
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_EN "y")
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_INIT "y")
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_PANIC "y")
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_TIMEOUT_S "5")
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0 "")
config/sdkconfig.cmake:set(CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1 "")
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
