### PR TITLE
[sx126x] Add cold sleep option and drop unused RTC wakeup bit

### DIFF
--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -15,6 +15,7 @@ CONF_SX126X_ID = "sx126x_id"
 CONF_BANDWIDTH = "bandwidth"
 CONF_BITRATE = "bitrate"
 CONF_CODING_RATE = "coding_rate"
+CONF_COLD = "cold"
 CONF_CRC_INVERTED = "crc_inverted"
 CONF_CRC_SIZE = "crc_size"
 CONF_CRC_POLYNOMIAL = "crc_polynomial"
@@ -308,12 +309,6 @@ NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
     synchronous=True,
 )
 @automation.register_action(
-    "sx126x.set_mode_sleep",
-    SetModeSleepAction,
-    NO_ARGS_ACTION_SCHEMA,
-    synchronous=True,
-)
-@automation.register_action(
     "sx126x.set_mode_standby",
     SetModeStandbyAction,
     NO_ARGS_ACTION_SCHEMA,
@@ -322,6 +317,28 @@ NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
 async def no_args_action_to_code(config, action_id, template_arg, args):
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
+    return var
+
+
+SET_MODE_SLEEP_ACTION_SCHEMA = automation.maybe_simple_id(
+    {
+        cv.GenerateID(): cv.use_id(SX126x),
+        cv.Optional(CONF_COLD, default=False): cv.templatable(cv.boolean),
+    }
+)
+
+
+@automation.register_action(
+    "sx126x.set_mode_sleep",
+    SetModeSleepAction,
+    SET_MODE_SLEEP_ACTION_SCHEMA,
+    synchronous=True,
+)
+async def set_mode_sleep_action_to_code(config, action_id, template_arg, args):
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, config[CONF_ID])
+    template_ = await cg.templatable(config[CONF_COLD], args, bool)
+    cg.add(var.set_cold(template_))
     return var
 
 

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -5,6 +5,8 @@ from esphome.components.const import CONF_CRC_ENABLE, CONF_ON_PACKET
 import esphome.config_validation as cv
 from esphome.const import CONF_BUSY_PIN, CONF_DATA, CONF_FREQUENCY, CONF_ID
 from esphome.core import ID, TimePeriod
+from esphome.cpp_generator import MockObj
+from esphome.types import ConfigType, TemplateArgsType
 
 MULTI_CONF = True
 CODEOWNERS = ["@swoboda1337"]
@@ -334,7 +336,12 @@ SET_MODE_SLEEP_ACTION_SCHEMA = automation.maybe_simple_id(
     SET_MODE_SLEEP_ACTION_SCHEMA,
     synchronous=True,
 )
-async def set_mode_sleep_action_to_code(config, action_id, template_arg, args):
+async def set_mode_sleep_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     template_ = await cg.templatable(config[CONF_COLD], args, bool)

--- a/esphome/components/sx126x/__init__.py
+++ b/esphome/components/sx126x/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import spi
@@ -147,7 +149,7 @@ SetModeStandbyAction = sx126x_ns.class_(
 )
 
 
-def validate_raw_data(value):
+def validate_raw_data(value: Any) -> bytes | list[int]:
     if isinstance(value, str):
         return value.encode("utf-8")
     if isinstance(value, list):
@@ -157,7 +159,7 @@ def validate_raw_data(value):
     )
 
 
-def validate_config(config):
+def validate_config(config: ConfigType) -> ConfigType:
     lora_bws = [
         "7_8kHz",
         "10_4kHz",
@@ -238,7 +240,7 @@ CONFIG_SCHEMA = (
 )
 
 
-async def to_code(config):
+async def to_code(config: ConfigType) -> None:
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await spi.register_spi_device(var, config)
@@ -316,7 +318,12 @@ NO_ARGS_ACTION_SCHEMA = automation.maybe_simple_id(
     NO_ARGS_ACTION_SCHEMA,
     synchronous=True,
 )
-async def no_args_action_to_code(config, action_id, template_arg, args):
+async def no_args_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     return var
@@ -364,7 +371,12 @@ SEND_PACKET_ACTION_SCHEMA = cv.maybe_simple_value(
     SEND_PACKET_ACTION_SCHEMA,
     synchronous=True,
 )
-async def send_packet_action_to_code(config, action_id, template_arg, args):
+async def send_packet_action_to_code(
+    config: ConfigType,
+    action_id: ID,
+    template_arg: cg.TemplateArguments,
+    args: TemplateArgsType,
+) -> MockObj:
     var = cg.new_Pvariable(action_id, template_arg)
     await cg.register_parented(var, config[CONF_ID])
     data = config[CONF_DATA]

--- a/esphome/components/sx126x/automation.h
+++ b/esphome/components/sx126x/automation.h
@@ -56,7 +56,8 @@ template<typename... Ts> class SetModeRxAction : public Action<Ts...>, public Pa
 
 template<typename... Ts> class SetModeSleepAction : public Action<Ts...>, public Parented<SX126x> {
  public:
-  void play(const Ts &...x) override { this->parent_->set_mode_sleep(); }
+  TEMPLATABLE_VALUE(bool, cold)
+  void play(const Ts &...x) override { this->parent_->set_mode_sleep(this->cold_.value(x...)); }
 };
 
 template<typename... Ts> class SetModeStandbyAction : public Action<Ts...>, public Parented<SX126x> {

--- a/esphome/components/sx126x/sx126x.cpp
+++ b/esphome/components/sx126x/sx126x.cpp
@@ -459,9 +459,10 @@ void SX126x::set_mode_tx() {
   this->write_opcode_(RADIO_SET_TX, buf, 3);
 }
 
-void SX126x::set_mode_sleep() {
+void SX126x::set_mode_sleep(bool cold) {
+  // 0x04 = warm start (config retained), 0x00 = cold start (config lost, lowest power)
   uint8_t buf[1];
-  buf[0] = 0x05;
+  buf[0] = cold ? 0x00 : 0x04;
   this->write_opcode_(RADIO_SET_SLEEP, buf, 1);
 }
 

--- a/esphome/components/sx126x/sx126x.h
+++ b/esphome/components/sx126x/sx126x.h
@@ -79,7 +79,7 @@ class SX126x : public Component,
   void set_mode_rx();
   void set_mode_tx();
   void set_mode_standby(SX126xStandbyMode mode);
-  void set_mode_sleep();
+  void set_mode_sleep(bool cold = false);
   void set_modulation(uint8_t modulation) { this->modulation_ = modulation; }
   void set_pa_power(int8_t power) { this->pa_power_ = power; }
   void set_pa_ramp(uint8_t ramp) { this->pa_ramp_ = ramp; }


### PR DESCRIPTION
# What does this implement/fix?

Two related changes to `set_mode_sleep`:

1. **Drop the RTC wakeup bit from the warm-sleep config byte.** Today
   `set_mode_sleep` writes `0x05` (bit 0 = RTC wakeup, bit 2 = warm start),
   but the component never configures an RTC timeout (no
   `RADIO_SET_RX_DUTY_CYCLE` or related config anywhere). The RTC oscillator
   is left running in sleep for nothing, which raises the warm-sleep current
   above what the datasheet quotes for warm sleep alone. Changed to `0x04`.
2. **Add a `cold:` option to the action.** Cold sleep (`0x00`, ~0.6&nbsp;µA per
   the SX1262 datasheet section 13.1) is ~1000× lower than warm sleep
   (~600&nbsp;µA), but it does not retain config — so it is intended to be
   paired with ESP32 deep sleep, where the chip reboots and re-runs `setup()`
   on wake. Default is `false` to preserve the (newly correct) warm-sleep
   behavior.

Surfaces a feature requested in https://github.com/orgs/esphome/discussions/3638
which also pointed out that the warm-sleep current was higher than expected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/orgs/esphome/discussions/3638

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6552

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
on_...:
  - sx126x.set_mode_sleep            # warm sleep (config retained)
  - sx126x.set_mode_sleep:
      cold: true                     # cold sleep, ~0.6 uA, config lost
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).