### PR TITLE
[mdns] Broadcast config_hash TXT record on _esphomelib._tcp

### DIFF
--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -39,6 +39,37 @@ MDNS_STATIC_CONST_CHAR(SERVICE_TCP, "_tcp");
 // Wrap build-time defines into flash storage
 MDNS_STATIC_CONST_CHAR(VALUE_VERSION, ESPHOME_VERSION);
 
+void MDNSComponent::setup_buffers_and_register_(PlatformRegisterFn platform_register) {
+#ifdef USE_MDNS_STORE_SERVICES
+  auto &services = this->services_;
+#else
+  StaticVector<MDNSService, MDNS_SERVICE_COUNT> services_storage;
+  auto &services = services_storage;
+#endif
+
+#ifdef USE_API
+#ifdef USE_MDNS_STORE_SERVICES
+  get_mac_address_into_buffer(this->mac_address_);
+  char *mac_ptr = this->mac_address_;
+  format_hex_to(this->config_hash_str_, App.get_config_hash());
+  char *cfg_ptr = this->config_hash_str_;
+#else
+  char mac_address[MAC_ADDRESS_BUFFER_SIZE];
+  char config_hash_str[CONFIG_HASH_STR_SIZE];
+  get_mac_address_into_buffer(mac_address);
+  format_hex_to(config_hash_str, App.get_config_hash());
+  char *mac_ptr = mac_address;
+  char *cfg_ptr = config_hash_str;
+#endif
+#else
+  char *mac_ptr = nullptr;
+  char *cfg_ptr = nullptr;
+#endif
+
+  this->compile_records_(services, mac_ptr, cfg_ptr);
+  platform_register(this, services);
+}
+
 void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf,
                                      char *config_hash_buf) {
   // IMPORTANT: The #ifdef blocks below must match COMPONENTS_WITH_MDNS_SERVICES

--- a/esphome/components/mdns/mdns_component.cpp
+++ b/esphome/components/mdns/mdns_component.cpp
@@ -39,7 +39,8 @@ MDNS_STATIC_CONST_CHAR(SERVICE_TCP, "_tcp");
 // Wrap build-time defines into flash storage
 MDNS_STATIC_CONST_CHAR(VALUE_VERSION, ESPHOME_VERSION);
 
-void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf) {
+void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf,
+                                     char *config_hash_buf) {
   // IMPORTANT: The #ifdef blocks below must match COMPONENTS_WITH_MDNS_SERVICES
   // in mdns/__init__.py. If you add a new service here, update both locations.
 
@@ -47,6 +48,7 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
   MDNS_STATIC_CONST_CHAR(SERVICE_ESPHOMELIB, "_esphomelib");
   MDNS_STATIC_CONST_CHAR(TXT_FRIENDLY_NAME, "friendly_name");
   MDNS_STATIC_CONST_CHAR(TXT_VERSION, "version");
+  MDNS_STATIC_CONST_CHAR(TXT_CONFIG_HASH, "config_hash");
   MDNS_STATIC_CONST_CHAR(TXT_MAC, "mac");
   MDNS_STATIC_CONST_CHAR(TXT_PLATFORM, "platform");
   MDNS_STATIC_CONST_CHAR(TXT_BOARD, "board");
@@ -63,7 +65,7 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
     bool friendly_name_empty = friendly_name.empty();
 
     // Calculate exact capacity for txt_records
-    size_t txt_count = 3;  // version, mac, board (always present)
+    size_t txt_count = 4;  // version, config_hash, mac, board (always present)
     if (!friendly_name_empty) {
       txt_count++;  // friendly_name
     }
@@ -90,6 +92,9 @@ void MDNSComponent::compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUN
       txt_records.push_back({MDNS_STR(TXT_FRIENDLY_NAME), MDNS_STR(friendly_name.c_str())});
     }
     txt_records.push_back({MDNS_STR(TXT_VERSION), MDNS_STR(VALUE_VERSION)});
+
+    // Config hash: passed from caller (either member buffer or stack buffer depending on USE_MDNS_STORE_SERVICES)
+    txt_records.push_back({MDNS_STR(TXT_CONFIG_HASH), MDNS_STR(config_hash_buf)});
 
     // MAC address: passed from caller (either member buffer or stack buffer depending on USE_MDNS_STORE_SERVICES)
     txt_records.push_back({MDNS_STR(TXT_MAC), MDNS_STR(mac_address_buf)});

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -1,10 +1,7 @@
 #pragma once
 #include "esphome/core/defines.h"
 #ifdef USE_MDNS
-#include <cinttypes>
-#include <cstdio>
 #include <string>
-#include "esphome/core/application.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -74,7 +71,7 @@ class MDNSComponent final : public Component
   void dump_config() override;
 
   /// Size of buffer required for config hash hex string (8 hex chars + null terminator)
-  static constexpr size_t CONFIG_HASH_STR_SIZE = 9;
+  static constexpr size_t CONFIG_HASH_STR_SIZE = format_hex_size(sizeof(uint32_t));
 
 #ifdef USE_MDNS_EVENT_DRIVEN_POLLING
   // LEAmDNS has meaningful work only during the probe+announce phase (3×250ms probes +
@@ -130,35 +127,7 @@ class MDNSComponent final : public Component
   /// Helper to set up services and MAC buffers, then call platform-specific registration
   using PlatformRegisterFn = void (*)(MDNSComponent *, StaticVector<MDNSService, MDNS_SERVICE_COUNT> &);
 
-  void setup_buffers_and_register_(PlatformRegisterFn platform_register) {
-#ifdef USE_MDNS_STORE_SERVICES
-    auto &services = this->services_;
-#else
-    StaticVector<MDNSService, MDNS_SERVICE_COUNT> services_storage;
-    auto &services = services_storage;
-#endif
-
-#ifdef USE_API
-#ifdef USE_MDNS_STORE_SERVICES
-    get_mac_address_into_buffer(this->mac_address_);
-    char *mac_ptr = this->mac_address_;
-    char *cfg_ptr = this->config_hash_str_;
-#else
-    char mac_address[MAC_ADDRESS_BUFFER_SIZE];
-    char config_hash_str[CONFIG_HASH_STR_SIZE];
-    get_mac_address_into_buffer(mac_address);
-    char *mac_ptr = mac_address;
-    char *cfg_ptr = config_hash_str;
-#endif
-    snprintf(cfg_ptr, CONFIG_HASH_STR_SIZE, "%08" PRIx32, App.get_config_hash());
-#else
-    char *mac_ptr = nullptr;
-    char *cfg_ptr = nullptr;
-#endif
-
-    this->compile_records_(services, mac_ptr, cfg_ptr);
-    platform_register(this, services);
-  }
+  void setup_buffers_and_register_(PlatformRegisterFn platform_register);
 
 #ifdef USE_MDNS_DYNAMIC_TXT
   /// Storage for runtime-generated TXT values from user lambdas

--- a/esphome/components/mdns/mdns_component.h
+++ b/esphome/components/mdns/mdns_component.h
@@ -1,7 +1,10 @@
 #pragma once
 #include "esphome/core/defines.h"
 #ifdef USE_MDNS
+#include <cinttypes>
+#include <cstdio>
 #include <string>
+#include "esphome/core/application.h"
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
@@ -70,6 +73,9 @@ class MDNSComponent final : public Component
   void setup() override;
   void dump_config() override;
 
+  /// Size of buffer required for config hash hex string (8 hex chars + null terminator)
+  static constexpr size_t CONFIG_HASH_STR_SIZE = 9;
+
 #ifdef USE_MDNS_EVENT_DRIVEN_POLLING
   // LEAmDNS has meaningful work only during the probe+announce phase (3×250ms probes +
   // 8×1000ms announces, ~9s). Afterwards every internal timer is resetToNeverExpires()
@@ -136,16 +142,21 @@ class MDNSComponent final : public Component
 #ifdef USE_MDNS_STORE_SERVICES
     get_mac_address_into_buffer(this->mac_address_);
     char *mac_ptr = this->mac_address_;
+    char *cfg_ptr = this->config_hash_str_;
 #else
     char mac_address[MAC_ADDRESS_BUFFER_SIZE];
+    char config_hash_str[CONFIG_HASH_STR_SIZE];
     get_mac_address_into_buffer(mac_address);
     char *mac_ptr = mac_address;
+    char *cfg_ptr = config_hash_str;
 #endif
+    snprintf(cfg_ptr, CONFIG_HASH_STR_SIZE, "%08" PRIx32, App.get_config_hash());
 #else
     char *mac_ptr = nullptr;
+    char *cfg_ptr = nullptr;
 #endif
 
-    this->compile_records_(services, mac_ptr);
+    this->compile_records_(services, mac_ptr, cfg_ptr);
     platform_register(this, services);
   }
 
@@ -159,6 +170,8 @@ class MDNSComponent final : public Component
 #if defined(USE_API) && defined(USE_MDNS_STORE_SERVICES)
   /// Fixed buffer for MAC address (only needed when services are stored)
   char mac_address_[MAC_ADDRESS_BUFFER_SIZE];
+  /// Fixed buffer for config hash hex string (only needed when services are stored)
+  char config_hash_str_[CONFIG_HASH_STR_SIZE];
 #endif
 #ifdef USE_MDNS_STORE_SERVICES
   StaticVector<MDNSService, MDNS_SERVICE_COUNT> services_{};
@@ -167,7 +180,8 @@ class MDNSComponent final : public Component
   // RP2040 defers MDNS.begin() until the first IP-up event; this tracks that.
   bool initialized_{false};
 #endif
-  void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf);
+  void compile_records_(StaticVector<MDNSService, MDNS_SERVICE_COUNT> &services, char *mac_address_buf,
+                        char *config_hash_buf);
 };
 
 }  // namespace esphome::mdns

--- a/esphome/components/mdns/mdns_host.cpp
+++ b/esphome/components/mdns/mdns_host.cpp
@@ -3,6 +3,8 @@
 
 #include "esphome/components/network/ip_address.h"
 #include "esphome/components/network/util.h"
+#include "esphome/core/application.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "mdns_component.h"
 
@@ -13,10 +15,13 @@ void MDNSComponent::setup() {
 #ifdef USE_API
   get_mac_address_into_buffer(this->mac_address_);
   char *mac_ptr = this->mac_address_;
+  format_hex_to(this->config_hash_str_, App.get_config_hash());
+  char *cfg_ptr = this->config_hash_str_;
 #else
   char *mac_ptr = nullptr;
+  char *cfg_ptr = nullptr;
 #endif
-  this->compile_records_(this->services_, mac_ptr);
+  this->compile_records_(this->services_, mac_ptr, cfg_ptr);
 #endif
   // Host platform doesn't have actual mDNS implementation
 }


### PR DESCRIPTION
# What does this implement/fix?

Adds a `config_hash` TXT record (8 lowercase hex chars of `App.get_config_hash()`) to the existing `_esphomelib._tcp` mDNS service published by the API component. The dashboard already discovers devices via mDNS and reads TXT records (version, mac, board, friendly_name, etc.); today it can only check the ESPHome version. After a YAML edit, devices that have not been re-flashed are indistinguishable from up-to-date ones over the wire.

The same hash is already exposed via the `version_text_sensor` and over MQTT — this just makes it available to any mDNS client (dashboard, third-party tools) without an API connection. The dashboard-side change to actually parse the new TXT and surface an "out of date" indicator is a follow-up.

Implementation notes:
- Hash formatted once at `setup()` via the existing `format_hex_to(buffer, App.get_config_hash())` helper from `core/helpers.h` into a 9-byte buffer (8 hex + null), sized via `format_hex_size(sizeof(uint32_t))`.
- Buffer follows the same pattern as the existing MAC buffer: a class member when `USE_MDNS_STORE_SERVICES` is on, a stack buffer in `setup_buffers_and_register_()` otherwise.
- `setup_buffers_and_register_()` body lives in the `.cpp` (only its declaration is in the header) so the header gains no new transitive includes.
- All four platform registration paths (ESP-IDF, ESP8266 LEAmDNS, RP2040 LEAmDNS, libretiny mDNS) either copy the strings into the underlying library or read flash via `FPSTR()`, so the stack-buffer lifetime is sufficient.
- Baseline `txt_count` bumped from 3 to 4; the record is unconditionally present so dashboards can rely on it.
- Adds 1 TXT record (~22 bytes on the wire) and a 9-byte buffer per device when `USE_MDNS_STORE_SERVICES` is on.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<TBD>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Existing mdns: block automatically gains the
# new TXT record; verify with `dns-sd -L <name> _esphomelib._tcp` (macOS) or
# `avahi-browse -r _esphomelib._tcp` (Linux):
#
#   config_hash=1a2b3c4d
#
mdns:
  disabled: false
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

Existing `tests/components/mdns/test-enabled.{esp32-idf,esp8266-ard,rp2040-ard}.yaml` config tests pass; esp32-idf full compile passes. There are no TXT-record content assertions in the test suite today, so no new tests were added.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).