### PR TITLE
[esp32] Add ESP-IDF 6.0.1 platform entry

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -730,6 +730,9 @@ ESP_IDF_FRAMEWORK_VERSION_LOOKUP = {
 }
 ESP_IDF_PLATFORM_VERSION_LOOKUP = {
     cv.Version(
+        6, 0, 1
+    ): "https://github.com/pioarduino/platform-espressif32.git#prep_IDF6",
+    cv.Version(
         6, 0, 0
     ): "https://github.com/pioarduino/platform-espressif32.git#prep_IDF6",
     cv.Version(5, 5, 4): cv.Version(55, 3, 38, "1"),


### PR DESCRIPTION
# What does this implement/fix?

Adds a `cv.Version(6, 0, 1)` entry to `ESP_IDF_PLATFORM_VERSION_LOOKUP` pointing at the `prep_IDF6` branch of `pioarduino/platform-espressif32`, alongside the existing 6.0.0 entry. pioarduino published [esp-idf v6.0.1](https://github.com/pioarduino/esp-idf/releases/tag/v6.0.1) so users selecting that IDF version can resolve to a platform.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [x] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  framework:
    type: esp-idf
    version: 6.0.1
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).