### PR TITLE
[mcp23xxx_base] Reject unsupported interrupt_pin options (inverted, allow_other_uses)

### DIFF
--- a/esphome/components/mcp23xxx_base/__init__.py
+++ b/esphome/components/mcp23xxx_base/__init__.py
@@ -2,6 +2,7 @@ from esphome import pins
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.const import (
+    CONF_ALLOW_OTHER_USES,
     CONF_ID,
     CONF_INPUT,
     CONF_INTERRUPT,
@@ -30,10 +31,29 @@ MCP23XXX_INTERRUPT_MODES = {
     "FALLING": MCP23XXXInterruptMode.MCP23XXX_FALLING,
 }
 
+
+def _validate_interrupt_pin(value):
+    # The MCP component owns INT polarity (active-low, hardcoded falling-edge ISR)
+    # and installs a single ISR per GPIO, so neither inversion nor sharing is supported.
+    value = pins.internal_gpio_input_pin_schema(value)
+    if value.get(CONF_INVERTED):
+        raise cv.Invalid(
+            f"'{CONF_INVERTED}: true' is not supported on '{CONF_INTERRUPT_PIN}'; "
+            "the MCP23xxx INT line is fixed active-low"
+        )
+    if value.get(CONF_ALLOW_OTHER_USES):
+        raise cv.Invalid(
+            f"'{CONF_ALLOW_OTHER_USES}: true' is not supported on '{CONF_INTERRUPT_PIN}'; "
+            "sharing the interrupt pin between multiple MCP23xxx (or other components) "
+            "is not implemented. Remove the interrupt_pin to fall back to polling."
+        )
+    return value
+
+
 MCP23XXX_CONFIG_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_OPEN_DRAIN_INTERRUPT, default=False): cv.boolean,
-        cv.Optional(CONF_INTERRUPT_PIN): pins.internal_gpio_input_pin_schema,
+        cv.Optional(CONF_INTERRUPT_PIN): _validate_interrupt_pin,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 


### PR DESCRIPTION
# What does this implement/fix?

The MCP23xxx interrupt path hardcodes active-low INT and installs a single falling-edge ISR per GPIO. Two configurations silently broke at runtime instead of being rejected at config time:

- `inverted: true` on `interrupt_pin` — `esp32/gpio.cpp` flips `INTERRUPT_FALLING_EDGE` to `GPIO_INTR_POSEDGE` when the pin is inverted, so the ISR only fired when MCP released INT (rising edge), not on assertion. The same flag also inverted the "INT released?" check in `MCP23XXXBase::loop()`, disabling the loop while INT was still pending.
- `allow_other_uses: true` on `interrupt_pin` — multiple MCPs each call `interrupt_pin_->attach_interrupt(...)`, but `gpio_isr_handler_add` in esp-idf stores one handler per pin and each call overwrites the previous. Only the last MCP to set up actually responds; the others' loops stay disabled forever.

Adding real support for either case (custom INTPOL, shared INT fan-out) is a non-trivial design change that needs hardware to test. For now, reject both at config-validation time with a clear error pointing at polling as the workaround (drop `interrupt_pin` to fall back to the polling loop).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes https://github.com/esphome/esphome/issues/16147

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Both of these now fail validation with a clear message instead of silently breaking at runtime:

```yaml
# Rejected: inverted on the MCP INT pin
mcp23017:
  - id: mcp1
    address: 0x20
    interrupt_pin:
      number: 4
      inverted: true        # <-- now an error

# Rejected: sharing one INT pin between multiple MCPs
mcp23017:
  - id: mcp1
    address: 0x20
    interrupt_pin:
      number: 4
      allow_other_uses: true   # <-- now an error
  - id: mcp2
    address: 0x22
    interrupt_pin:
      number: 4
      allow_other_uses: true
```

Working configs (single MCP, plain interrupt pin) still validate as before.

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).