### PR TITLE
[core] Fix null deref in WarnIfComponentBlockingGuard for self-keyed scheduler timers

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -655,7 +655,15 @@ class WarnIfComponentBlockingGuard {
   // Inlined: the fast path is just millis() + subtract + compare
   inline uint32_t HOT finish() {
 #ifdef USE_RUNTIME_STATS
-    this->component_->runtime_stats_.record_time(micros() - this->started_us_);
+    uint32_t elapsed_us = micros() - this->started_us_;
+    // component_ is nullptr for self-keyed scheduler items (set_timeout/set_interval(self, ...))
+    if (this->component_ != nullptr) {
+      this->component_->runtime_stats_.record_time(elapsed_us);
+    } else {
+      // Still accumulate into the global counter so Application::loop() can subtract
+      // this time from before_loop_tasks_ wall time.
+      ComponentRuntimeStats::global_recorded_us += elapsed_us;
+    }
 #endif
     uint32_t curr_time = MillisInternal::get();
 #ifndef USE_BENCHMARK


### PR DESCRIPTION
# What does this implement/fix?

Fixes a null-pointer dereference in `WarnIfComponentBlockingGuard::finish()` (`esphome/core/component.h:658`) that crashes builds with `USE_RUNTIME_STATS` enabled (i.e. configs that include the `runtime_stats:` component) as soon as a self-keyed scheduler timer fires.

`Scheduler::set_timeout(const void *self, ...)` and `set_interval(const void *self, ...)` (`esphome/core/scheduler.cpp:308-314`) intentionally store `component == nullptr` — there is no owning `Component *` for these self-keyed entries. When `Scheduler::execute_item_` (`scheduler.cpp:820`) constructs `WarnIfComponentBlockingGuard guard{item->component, now}` for such an item, `component_` is null. The runtime-stats path inside `finish()` then did:

```cpp
this->component_->runtime_stats_.record_time(micros() - this->started_us_);
```

which dereferences nullptr at the offset of `runtime_stats_`. On RISC-V (e.g. ESP32-C3) this triggers a *Load access fault*.

Example crash from a user device (ESP32-C3, ESPHome 2026.5.0-dev):

```
[E][esp32.crash:329]: *** CRASH DETECTED ON PREVIOUS BOOT ***
[E][esp32.crash:332]:   Reason: Fault - Load access fault
[E][esp32.crash:336]:   Crashed core: 0
[E][esp32.crash:337]:   PC:  0x420242D2  (fault location)
Decoded 0x420242d2: esphome::ComponentRuntimeStats::record_time(unsigned long) at component.h:128
 (inlined by) esphome::WarnIfComponentBlockingGuard::finish() at component.h:658
 (inlined by) esphome::Scheduler::execute_item_(...) at scheduler.cpp:822
```

The sibling cold path (`warn_blocking` in `component.cpp:514-526`) already null-checks `component`. The runtime-stats path missed that check.

### Fix

Skip the per-component `record_time` bookkeeping when `component_` is null, but still accumulate the elapsed time into `ComponentRuntimeStats::global_recorded_us` so `Application::loop()`'s overhead accounting (which subtracts scheduled-callback time from `before_loop_tasks_`) stays accurate for self-keyed timers.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Any config containing runtime_stats: that triggers a self-keyed scheduler
# timer (set_timeout(self, ...) / set_interval(self, ...)) reproduces the
# crash. Minimal repro:

runtime_stats:
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).