### PR TITLE
[core] Drop unused DELAY_ACTION from InternalSchedulerID enum

### DIFF
--- a/esphome/core/component.h
+++ b/esphome/core/component.h
@@ -65,7 +65,6 @@ inline constexpr uint32_t SCHEDULER_DONT_RUN = 4294967295UL;
 /// with component-level NUMERIC_ID values, even if the uint32_t values overlap.
 enum class InternalSchedulerID : uint32_t {
   POLLING_UPDATE = 0,  // PollingComponent interval
-  DELAY_ACTION = 1,    // DelayAction timeout
 };
 
 // Forward declaration


### PR DESCRIPTION
# What does this implement/fix?

Followup to #16129. That PR switched `DelayAction` to a self-pointer scheduler key (`NameType::SELF_POINTER`), so the `DELAY_ACTION` value in the `InternalSchedulerID` enum is no longer referenced anywhere in the tree. This PR removes the dead enum value.

Verified with grep that the only remaining matches for `DELAY_ACTION` are in `speaker_source/media_player.py` (`SET_PLAYLIST_DELAY_ACTION_SCHEMA`), which is unrelated.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- followup to #16129

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#N/A

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing change; internal enum cleanup only.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).