### PR TITLE
[ci] Split integration tests into 3 buckets when count is more than 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,7 @@ jobs:
       - common
     outputs:
       integration-tests: ${{ steps.determine.outputs.integration-tests }}
-      integration-tests-run-all: ${{ steps.determine.outputs.integration-tests-run-all }}
-      integration-test-files: ${{ steps.determine.outputs.integration-test-files }}
+      integration-test-buckets: ${{ steps.determine.outputs.integration-test-buckets }}
       clang-tidy: ${{ steps.determine.outputs.clang-tidy }}
       clang-tidy-mode: ${{ steps.determine.outputs.clang-tidy-mode }}
       python-linters: ${{ steps.determine.outputs.python-linters }}
@@ -243,8 +242,7 @@ jobs:
 
           # Extract individual fields
           echo "integration-tests=$(echo "$output" | jq -r '.integration_tests')" >> $GITHUB_OUTPUT
-          echo "integration-tests-run-all=$(echo "$output" | jq -r '.integration_tests_run_all')" >> $GITHUB_OUTPUT
-          echo "integration-test-files=$(echo "$output" | jq -c '.integration_test_files')" >> $GITHUB_OUTPUT
+          echo "integration-test-buckets=$(echo "$output" | jq -c '.integration_test_buckets')" >> $GITHUB_OUTPUT
           echo "clang-tidy=$(echo "$output" | jq -r '.clang_tidy')" >> $GITHUB_OUTPUT
           echo "clang-tidy-mode=$(echo "$output" | jq -r '.clang_tidy_mode')" >> $GITHUB_OUTPUT
           echo "python-linters=$(echo "$output" | jq -r '.python_linters')" >> $GITHUB_OUTPUT
@@ -267,12 +265,16 @@ jobs:
           key: components-graph-${{ hashFiles('esphome/components/**/*.py') }}
 
   integration-tests:
-    name: Run integration tests
+    name: Run integration tests (${{ matrix.bucket.name }})
     runs-on: ubuntu-latest
     needs:
       - common
       - determine-jobs
     if: needs.determine-jobs.outputs.integration-tests == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        bucket: ${{ fromJson(needs.determine-jobs.outputs.integration-test-buckets) }}
     steps:
       - name: Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -298,20 +300,9 @@ jobs:
       - name: Register matcher
         run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
       - name: Run integration tests
-        env:
-          INTEGRATION_TEST_FILES: ${{ needs.determine-jobs.outputs.integration-test-files }}
-          INTEGRATION_TESTS_RUN_ALL: ${{ needs.determine-jobs.outputs.integration-tests-run-all }}
         run: |
           . venv/bin/activate
-          if [[ "$INTEGRATION_TESTS_RUN_ALL" == "true" ]]; then
-            echo "Running all integration tests"
-            pytest -vv --no-cov --tb=native -n auto tests/integration/
-          else
-            # Parse JSON array into bash array to avoid shell expansion issues
-            mapfile -t test_files < <(echo "$INTEGRATION_TEST_FILES" | jq -r '.[]')
-            echo "Running ${#test_files[@]} specific integration tests"
-            pytest -vv --no-cov --tb=native -n auto "${test_files[@]}"
-          fi
+          pytest -vv --no-cov --tb=native -n auto ${{ matrix.bucket.tests }}
 
   cpp-unit-tests:
     name: Run C++ unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,9 +300,15 @@ jobs:
       - name: Register matcher
         run: echo "::add-matcher::.github/workflows/matchers/pytest.json"
       - name: Run integration tests
+        env:
+          # JSON array of test paths; parsed into a bash array below to avoid
+          # shell word-splitting / glob hazards.
+          BUCKET_TESTS: ${{ toJson(matrix.bucket.tests) }}
         run: |
           . venv/bin/activate
-          pytest -vv --no-cov --tb=native -n auto ${{ matrix.bucket.tests }}
+          mapfile -t test_files < <(echo "$BUCKET_TESTS" | jq -r '.[]')
+          echo "Bucket ${{ matrix.bucket.name }}: running ${#test_files[@]} integration tests"
+          pytest -vv --no-cov --tb=native -n auto "${test_files[@]}"
 
   cpp-unit-tests:
     name: Run C++ unit tests

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -100,6 +100,43 @@ def _all_integration_test_files() -> list[str]:
     )
 
 
+def _compute_integration_test_buckets(
+    integration_run_all: bool,
+    integration_test_files: list[str],
+) -> tuple[bool, list[dict[str, Any]]]:
+    """Compute (run_integration, buckets) from the determine_integration_tests result.
+
+    Pure function for unit testing — no I/O beyond `_all_integration_test_files`
+    when `integration_run_all` is set.
+
+    `buckets` is a list of `{name, tests}` dicts where `tests` is a JSON-friendly
+    list of file paths so the workflow can build a bash array via jq, avoiding
+    shell word-splitting / glob hazards.
+    """
+    if integration_run_all:
+        files = _all_integration_test_files()
+    else:
+        files = sorted(integration_test_files)
+
+    # Empty list (e.g. run_all expansion with no files on disk) would otherwise
+    # cause the workflow to invoke pytest with no path argument and collect
+    # tests outside tests/integration/. Suppress the run instead.
+    if not files:
+        return False, []
+
+    if len(files) > INTEGRATION_TESTS_SPLIT_THRESHOLD:
+        parts = [
+            part for part in _split_list(files, INTEGRATION_TESTS_SPLIT_BUCKETS) if part
+        ]
+        buckets = [
+            {"name": f"{i + 1}/{len(parts)}", "tests": part}
+            for i, part in enumerate(parts)
+        ]
+    else:
+        buckets = [{"name": "1/1", "tests": files}]
+    return True, buckets
+
+
 class Platform(StrEnum):
     """Platform identifiers for memory impact analysis."""
 
@@ -830,43 +867,9 @@ def main() -> None:
     integration_run_all, integration_test_files = determine_integration_tests(
         args.branch
     )
-    run_integration = integration_run_all or bool(integration_test_files)
-
-    # When run_all is set, expand to the full glob here so determine-jobs.py
-    # remains the single source of truth for which tests run. The workflow
-    # never re-globs the filesystem.
-    if integration_run_all:
-        integration_test_files = _all_integration_test_files()
-    else:
-        integration_test_files = sorted(integration_test_files)
-
-    # Guard: if expansion produced no files (shouldn't happen normally, but
-    # would cause the workflow to invoke pytest with no path argument and
-    # collect tests outside tests/integration/), treat as no integration run.
-    if not integration_test_files:
-        run_integration = False
-
-    # Pre-bucket the test list so the CI matrix can consume it directly.
-    # `tests` is a JSON list of file paths so the workflow can build a bash
-    # array via jq, avoiding shell word-splitting / glob hazards.
-    # Below threshold => 1 bucket; above threshold => INTEGRATION_TESTS_SPLIT_BUCKETS.
-    integration_test_buckets: list[dict[str, Any]]
-    if not run_integration:
-        integration_test_buckets = []
-    elif len(integration_test_files) > INTEGRATION_TESTS_SPLIT_THRESHOLD:
-        parts = [
-            part
-            for part in _split_list(
-                integration_test_files, INTEGRATION_TESTS_SPLIT_BUCKETS
-            )
-            if part
-        ]
-        integration_test_buckets = [
-            {"name": f"{i + 1}/{len(parts)}", "tests": part}
-            for i, part in enumerate(parts)
-        ]
-    else:
-        integration_test_buckets = [{"name": "1/1", "tests": integration_test_files}]
+    run_integration, integration_test_buckets = _compute_integration_test_buckets(
+        integration_run_all, integration_test_files
+    )
     run_clang_tidy = should_run_clang_tidy(args.branch)
     run_clang_format = should_run_clang_format(args.branch)
     run_python_linters = should_run_python_linters(args.branch)

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -6,7 +6,7 @@ what files have changed. It outputs JSON with the following structure:
 
 {
   "integration_tests": true/false,
-  "integration_test_buckets": [{"name": "1/3", "tests": "tests/integration/test_foo.py ..."}, ...],
+  "integration_test_buckets": [{"name": "1/3", "tests": ["tests/integration/test_foo.py", ...]}, ...],
   "clang_tidy": true/false,
   "clang_format": true/false,
   "python_linters": true/false,
@@ -840,9 +840,17 @@ def main() -> None:
     else:
         integration_test_files = sorted(integration_test_files)
 
+    # Guard: if expansion produced no files (shouldn't happen normally, but
+    # would cause the workflow to invoke pytest with no path argument and
+    # collect tests outside tests/integration/), treat as no integration run.
+    if not integration_test_files:
+        run_integration = False
+
     # Pre-bucket the test list so the CI matrix can consume it directly.
+    # `tests` is a JSON list of file paths so the workflow can build a bash
+    # array via jq, avoiding shell word-splitting / glob hazards.
     # Below threshold => 1 bucket; above threshold => INTEGRATION_TESTS_SPLIT_BUCKETS.
-    integration_test_buckets: list[dict[str, str]]
+    integration_test_buckets: list[dict[str, Any]]
     if not run_integration:
         integration_test_buckets = []
     elif len(integration_test_files) > INTEGRATION_TESTS_SPLIT_THRESHOLD:
@@ -854,13 +862,11 @@ def main() -> None:
             if part
         ]
         integration_test_buckets = [
-            {"name": f"{i + 1}/{len(parts)}", "tests": " ".join(part)}
+            {"name": f"{i + 1}/{len(parts)}", "tests": part}
             for i, part in enumerate(parts)
         ]
     else:
-        integration_test_buckets = [
-            {"name": "1/1", "tests": " ".join(integration_test_files)}
-        ]
+        integration_test_buckets = [{"name": "1/1", "tests": integration_test_files}]
     run_clang_tidy = should_run_clang_tidy(args.branch)
     run_clang_format = should_run_clang_format(args.branch)
     run_python_linters = should_run_python_linters(args.branch)

--- a/script/determine-jobs.py
+++ b/script/determine-jobs.py
@@ -6,8 +6,7 @@ what files have changed. It outputs JSON with the following structure:
 
 {
   "integration_tests": true/false,
-  "integration_tests_run_all": true/false,
-  "integration_test_files": ["tests/integration/test_foo.py", ...],
+  "integration_test_buckets": [{"name": "1/3", "tests": "tests/integration/test_foo.py ..."}, ...],
   "clang_tidy": true/false,
   "clang_format": true/false,
   "python_linters": true/false,
@@ -80,6 +79,25 @@ CLANG_TIDY_SPLIT_THRESHOLD = 65
 # Component test batch size (weighted)
 # Isolated components count as 10x, groupable components count as 1x
 COMPONENT_TEST_BATCH_SIZE = 40
+
+# Integration test bucketing: when more than the threshold tests are scheduled,
+# fan out across this many parallel jobs. Below the threshold, a single job runs.
+INTEGRATION_TESTS_SPLIT_THRESHOLD = 10
+INTEGRATION_TESTS_SPLIT_BUCKETS = 3
+
+
+def _split_list(items: list[str], n: int) -> list[list[str]]:
+    """Split a list into n roughly-equal contiguous parts (matches script/clang-tidy)."""
+    k, m = divmod(len(items), n)
+    return [items[i * k + min(i, m) : (i + 1) * k + min(i + 1, m)] for i in range(n)]
+
+
+def _all_integration_test_files() -> list[str]:
+    """Return all integration test file paths, sorted, relative to repo root."""
+    return sorted(
+        str(p.relative_to(root_path))
+        for p in (Path(root_path) / "tests" / "integration").glob("test_*.py")
+    )
 
 
 class Platform(StrEnum):
@@ -813,6 +831,36 @@ def main() -> None:
         args.branch
     )
     run_integration = integration_run_all or bool(integration_test_files)
+
+    # When run_all is set, expand to the full glob here so determine-jobs.py
+    # remains the single source of truth for which tests run. The workflow
+    # never re-globs the filesystem.
+    if integration_run_all:
+        integration_test_files = _all_integration_test_files()
+    else:
+        integration_test_files = sorted(integration_test_files)
+
+    # Pre-bucket the test list so the CI matrix can consume it directly.
+    # Below threshold => 1 bucket; above threshold => INTEGRATION_TESTS_SPLIT_BUCKETS.
+    integration_test_buckets: list[dict[str, str]]
+    if not run_integration:
+        integration_test_buckets = []
+    elif len(integration_test_files) > INTEGRATION_TESTS_SPLIT_THRESHOLD:
+        parts = [
+            part
+            for part in _split_list(
+                integration_test_files, INTEGRATION_TESTS_SPLIT_BUCKETS
+            )
+            if part
+        ]
+        integration_test_buckets = [
+            {"name": f"{i + 1}/{len(parts)}", "tests": " ".join(part)}
+            for i, part in enumerate(parts)
+        ]
+    else:
+        integration_test_buckets = [
+            {"name": "1/1", "tests": " ".join(integration_test_files)}
+        ]
     run_clang_tidy = should_run_clang_tidy(args.branch)
     run_clang_format = should_run_clang_format(args.branch)
     run_python_linters = should_run_python_linters(args.branch)
@@ -944,8 +992,7 @@ def main() -> None:
 
     output: dict[str, Any] = {
         "integration_tests": run_integration,
-        "integration_tests_run_all": integration_run_all,
-        "integration_test_files": integration_test_files,
+        "integration_test_buckets": integration_test_buckets,
         "clang_tidy": run_clang_tidy,
         "clang_tidy_mode": clang_tidy_mode,
         "clang_format": run_clang_format,

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1,9 +1,7 @@
 """Unit tests for script/determine-jobs.py module."""
 
 from collections.abc import Generator
-import contextlib
 import importlib.util
-import io
 import json
 import os
 from pathlib import Path
@@ -382,106 +380,41 @@ def test_main_with_branch_argument(
     assert output["cpp_unit_tests_components"] == ["mqtt"]
 
 
-def _run_main_for_integration_buckets(
-    *,
-    integration_return: tuple[bool, list[str]],
-    glob_files: list[str] | None = None,
-) -> dict:
-    """Drive determine_jobs.main() with stubbed inputs and return its parsed output.
-
-    Helper for testing integration_test_buckets in isolation. Bypasses every
-    unrelated branch (clang-tidy, components, memory, cpp tests, batches) so
-    the test focuses purely on the bucketing decision logic.
-    """
-    patches: list = [
-        patch.object(
-            determine_jobs,
-            "determine_integration_tests",
-            return_value=integration_return,
-        ),
-        patch.object(determine_jobs, "should_run_clang_tidy", return_value=False),
-        patch.object(determine_jobs, "should_run_clang_format", return_value=False),
-        patch.object(determine_jobs, "should_run_python_linters", return_value=False),
-        patch.object(determine_jobs, "should_run_import_time", return_value=False),
-        patch.object(determine_jobs, "count_changed_cpp_files", return_value=0),
-        patch.object(determine_jobs, "changed_files", return_value=[]),
-        patch.object(determine_jobs, "get_changed_components", return_value=[]),
-        patch.object(
-            determine_jobs, "get_components_with_dependencies", return_value=[]
-        ),
-        patch.object(
-            determine_jobs,
-            "detect_memory_impact_config",
-            return_value={"should_run": "false"},
-        ),
-        patch.object(
-            determine_jobs, "create_intelligent_batches", return_value=([], {})
-        ),
-        patch.object(
-            determine_jobs, "determine_cpp_unit_tests", return_value=(False, [])
-        ),
-        patch.object(determine_jobs, "should_run_benchmarks", return_value=False),
-        patch.object(determine_jobs, "get_target_branch", return_value="dev"),
-        patch("sys.argv", ["determine-jobs.py"]),
-    ]
-    if glob_files is not None:
-        patches.append(
-            patch.object(
-                determine_jobs,
-                "_all_integration_test_files",
-                return_value=glob_files,
-            )
-        )
-
-    buf = io.StringIO()
-    with contextlib.ExitStack() as stack:
-        for p in patches:
-            stack.enter_context(p)
-        with contextlib.redirect_stdout(buf):
-            determine_jobs.main()
-    return json.loads(buf.getvalue())
+def test_compute_integration_test_buckets_empty() -> None:
+    """No integration tests scheduled => (False, [])."""
+    run, buckets = determine_jobs._compute_integration_test_buckets(False, [])
+    assert run is False
+    assert buckets == []
 
 
-def test_integration_buckets_empty_when_no_tests() -> None:
-    """No integration tests scheduled => integration_test_buckets is []."""
-    output = _run_main_for_integration_buckets(integration_return=(False, []))
-    assert output["integration_tests"] is False
-    assert output["integration_test_buckets"] == []
+def test_compute_integration_test_buckets_below_threshold() -> None:
+    """A small explicit list (<= threshold) => single 1/1 bucket with that list."""
+    files = [f"tests/integration/test_{name}.py" for name in ("c", "a", "b")]
+    run, buckets = determine_jobs._compute_integration_test_buckets(False, files)
+    assert run is True
+    assert buckets == [{"name": "1/1", "tests": sorted(files)}]
 
 
-def test_integration_buckets_specific_files_below_threshold() -> None:
-    """A small explicit list (<= threshold) produces a single 1/1 bucket
-    containing exactly that list as a JSON array."""
-    files = [f"tests/integration/test_{name}.py" for name in ("a", "b", "c", "d", "e")]
-    output = _run_main_for_integration_buckets(integration_return=(False, files))
-    assert output["integration_tests"] is True
-    buckets = output["integration_test_buckets"]
-    assert len(buckets) == 1
-    assert buckets[0]["name"] == "1/1"
-    assert buckets[0]["tests"] == sorted(files)
-
-
-def test_integration_buckets_at_threshold_stays_single() -> None:
-    """Exactly INTEGRATION_TESTS_SPLIT_THRESHOLD files stays as one bucket
+def test_compute_integration_test_buckets_at_threshold_stays_single() -> None:
+    """Exactly INTEGRATION_TESTS_SPLIT_THRESHOLD files => still one bucket
     (the split kicks in only when count is strictly greater than threshold)."""
     files = [
         f"tests/integration/test_{i:02d}.py"
         for i in range(determine_jobs.INTEGRATION_TESTS_SPLIT_THRESHOLD)
     ]
-    output = _run_main_for_integration_buckets(integration_return=(False, files))
-    buckets = output["integration_test_buckets"]
+    run, buckets = determine_jobs._compute_integration_test_buckets(False, files)
+    assert run is True
     assert len(buckets) == 1
     assert buckets[0]["name"] == "1/1"
     assert buckets[0]["tests"] == sorted(files)
 
 
-def test_integration_buckets_just_over_threshold_splits() -> None:
-    """One file over the threshold triggers the 3-bucket fan-out."""
+def test_compute_integration_test_buckets_just_over_threshold_splits() -> None:
+    """One file over the threshold triggers the 3-bucket fan-out, balanced."""
     n = determine_jobs.INTEGRATION_TESTS_SPLIT_THRESHOLD + 1
     files = [f"tests/integration/test_{i:02d}.py" for i in range(n)]
-    output = _run_main_for_integration_buckets(integration_return=(False, files))
-    buckets = output["integration_test_buckets"]
-    assert len(buckets) == determine_jobs.INTEGRATION_TESTS_SPLIT_BUCKETS
+    run, buckets = determine_jobs._compute_integration_test_buckets(False, files)
+    assert run is True
     assert [b["name"] for b in buckets] == ["1/3", "2/3", "3/3"]
     union = [path for b in buckets for path in b["tests"]]
     assert union == sorted(files)
@@ -489,15 +422,15 @@ def test_integration_buckets_just_over_threshold_splits() -> None:
     assert max(sizes) - min(sizes) <= 1
 
 
-def test_integration_buckets_run_all_with_empty_glob_disables_run() -> None:
-    """If run_all=True but the glob unexpectedly returns no files, the run is
-    suppressed (otherwise pytest would be invoked with no path argument and
-    collect tests outside tests/integration/)."""
-    output = _run_main_for_integration_buckets(
-        integration_return=(True, []), glob_files=[]
-    )
-    assert output["integration_tests"] is False
-    assert output["integration_test_buckets"] == []
+def test_compute_integration_test_buckets_run_all_with_empty_glob_disables_run() -> (
+    None
+):
+    """run_all=True but glob returns no files => run suppressed (otherwise
+    pytest would collect tests outside tests/integration/)."""
+    with patch.object(determine_jobs, "_all_integration_test_files", return_value=[]):
+        run, buckets = determine_jobs._compute_integration_test_buckets(True, [])
+    assert run is False
+    assert buckets == []
 
 
 def test_determine_integration_tests(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -1,7 +1,9 @@
 """Unit tests for script/determine-jobs.py module."""
 
 from collections.abc import Generator
+import contextlib
 import importlib.util
+import io
 import json
 import os
 from pathlib import Path
@@ -430,8 +432,6 @@ def _run_main_for_integration_buckets(
                 return_value=glob_files,
             )
         )
-    import contextlib
-    import io
 
     buf = io.StringIO()
     with contextlib.ExitStack() as stack:

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -170,7 +170,8 @@ def test_main_all_tests_should_run(
     output = json.loads(captured.out)
 
     assert output["integration_tests"] is True
-    # run_all=True expands to the full glob and pre-buckets into 3 parts
+    # run_all=True expands to the full glob and pre-buckets into 3 parts.
+    # Each bucket's `tests` is a JSON list of file paths.
     assert isinstance(output["integration_test_buckets"], list)
     assert len(output["integration_test_buckets"]) == 3
     assert [b["name"] for b in output["integration_test_buckets"]] == [
@@ -178,13 +179,15 @@ def test_main_all_tests_should_run(
         "2/3",
         "3/3",
     ]
-    bucket_files = [
-        f
-        for b in output["integration_test_buckets"]
-        for f in b["tests"].split(" ")
-        if f
-    ]
+    for bucket in output["integration_test_buckets"]:
+        assert isinstance(bucket["tests"], list)
+        for path in bucket["tests"]:
+            assert isinstance(path, str)
+    bucket_files = [f for b in output["integration_test_buckets"] for f in b["tests"]]
     assert bucket_files == fake_test_files
+    # Bucket sizes are balanced (max-min difference at most 1).
+    sizes = [len(b["tests"]) for b in output["integration_test_buckets"]]
+    assert max(sizes) - min(sizes) <= 1
     assert output["clang_tidy"] is True
     assert output["clang_tidy_mode"] in ["nosplit", "split"]
     assert output["clang_format"] is True
@@ -375,6 +378,126 @@ def test_main_with_branch_argument(
     assert output["memory_impact"]["should_run"] == "false"
     assert output["cpp_unit_tests_run_all"] is False
     assert output["cpp_unit_tests_components"] == ["mqtt"]
+
+
+def _run_main_for_integration_buckets(
+    *,
+    integration_return: tuple[bool, list[str]],
+    glob_files: list[str] | None = None,
+) -> dict:
+    """Drive determine_jobs.main() with stubbed inputs and return its parsed output.
+
+    Helper for testing integration_test_buckets in isolation. Bypasses every
+    unrelated branch (clang-tidy, components, memory, cpp tests, batches) so
+    the test focuses purely on the bucketing decision logic.
+    """
+    patches: list = [
+        patch.object(
+            determine_jobs,
+            "determine_integration_tests",
+            return_value=integration_return,
+        ),
+        patch.object(determine_jobs, "should_run_clang_tidy", return_value=False),
+        patch.object(determine_jobs, "should_run_clang_format", return_value=False),
+        patch.object(determine_jobs, "should_run_python_linters", return_value=False),
+        patch.object(determine_jobs, "should_run_import_time", return_value=False),
+        patch.object(determine_jobs, "count_changed_cpp_files", return_value=0),
+        patch.object(determine_jobs, "changed_files", return_value=[]),
+        patch.object(determine_jobs, "get_changed_components", return_value=[]),
+        patch.object(
+            determine_jobs, "get_components_with_dependencies", return_value=[]
+        ),
+        patch.object(
+            determine_jobs,
+            "detect_memory_impact_config",
+            return_value={"should_run": "false"},
+        ),
+        patch.object(
+            determine_jobs, "create_intelligent_batches", return_value=([], {})
+        ),
+        patch.object(
+            determine_jobs, "determine_cpp_unit_tests", return_value=(False, [])
+        ),
+        patch.object(determine_jobs, "should_run_benchmarks", return_value=False),
+        patch.object(determine_jobs, "get_target_branch", return_value="dev"),
+        patch("sys.argv", ["determine-jobs.py"]),
+    ]
+    if glob_files is not None:
+        patches.append(
+            patch.object(
+                determine_jobs,
+                "_all_integration_test_files",
+                return_value=glob_files,
+            )
+        )
+    import contextlib
+    import io
+
+    buf = io.StringIO()
+    with contextlib.ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
+        with contextlib.redirect_stdout(buf):
+            determine_jobs.main()
+    return json.loads(buf.getvalue())
+
+
+def test_integration_buckets_empty_when_no_tests() -> None:
+    """No integration tests scheduled => integration_test_buckets is []."""
+    output = _run_main_for_integration_buckets(integration_return=(False, []))
+    assert output["integration_tests"] is False
+    assert output["integration_test_buckets"] == []
+
+
+def test_integration_buckets_specific_files_below_threshold() -> None:
+    """A small explicit list (<= threshold) produces a single 1/1 bucket
+    containing exactly that list as a JSON array."""
+    files = [f"tests/integration/test_{name}.py" for name in ("a", "b", "c", "d", "e")]
+    output = _run_main_for_integration_buckets(integration_return=(False, files))
+    assert output["integration_tests"] is True
+    buckets = output["integration_test_buckets"]
+    assert len(buckets) == 1
+    assert buckets[0]["name"] == "1/1"
+    assert buckets[0]["tests"] == sorted(files)
+
+
+def test_integration_buckets_at_threshold_stays_single() -> None:
+    """Exactly INTEGRATION_TESTS_SPLIT_THRESHOLD files stays as one bucket
+    (the split kicks in only when count is strictly greater than threshold)."""
+    files = [
+        f"tests/integration/test_{i:02d}.py"
+        for i in range(determine_jobs.INTEGRATION_TESTS_SPLIT_THRESHOLD)
+    ]
+    output = _run_main_for_integration_buckets(integration_return=(False, files))
+    buckets = output["integration_test_buckets"]
+    assert len(buckets) == 1
+    assert buckets[0]["name"] == "1/1"
+    assert buckets[0]["tests"] == sorted(files)
+
+
+def test_integration_buckets_just_over_threshold_splits() -> None:
+    """One file over the threshold triggers the 3-bucket fan-out."""
+    n = determine_jobs.INTEGRATION_TESTS_SPLIT_THRESHOLD + 1
+    files = [f"tests/integration/test_{i:02d}.py" for i in range(n)]
+    output = _run_main_for_integration_buckets(integration_return=(False, files))
+    buckets = output["integration_test_buckets"]
+    assert len(buckets) == determine_jobs.INTEGRATION_TESTS_SPLIT_BUCKETS
+    assert [b["name"] for b in buckets] == ["1/3", "2/3", "3/3"]
+    union = [path for b in buckets for path in b["tests"]]
+    assert union == sorted(files)
+    sizes = [len(b["tests"]) for b in buckets]
+    assert max(sizes) - min(sizes) <= 1
+
+
+def test_integration_buckets_run_all_with_empty_glob_disables_run() -> None:
+    """If run_all=True but the glob unexpectedly returns no files, the run is
+    suppressed (otherwise pytest would be invoked with no path argument and
+    collect tests outside tests/integration/)."""
+    output = _run_main_for_integration_buckets(
+        integration_return=(True, []), glob_files=[]
+    )
+    assert output["integration_tests"] is False
+    assert output["integration_test_buckets"] == []
 
 
 def test_determine_integration_tests(

--- a/tests/script/test_determine_jobs.py
+++ b/tests/script/test_determine_jobs.py
@@ -122,10 +122,19 @@ def test_main_all_tests_should_run(
         "esphome/helpers.py",
     ]
 
+    # Stable, deterministic stand-in for the tests/integration/ glob so the
+    # bucket assertions don't drift with the real test count.
+    fake_test_files = [f"tests/integration/test_{i:03d}.py" for i in range(15)]
+
     # Run main function with mocked argv
     with (
         patch("sys.argv", ["determine-jobs.py"]),
         patch.object(determine_jobs, "_is_clang_tidy_full_scan", return_value=False),
+        patch.object(
+            determine_jobs,
+            "_all_integration_test_files",
+            return_value=fake_test_files,
+        ),
         patch.object(
             determine_jobs,
             "get_changed_components",
@@ -161,8 +170,21 @@ def test_main_all_tests_should_run(
     output = json.loads(captured.out)
 
     assert output["integration_tests"] is True
-    assert output["integration_tests_run_all"] is True
-    assert output["integration_test_files"] == []
+    # run_all=True expands to the full glob and pre-buckets into 3 parts
+    assert isinstance(output["integration_test_buckets"], list)
+    assert len(output["integration_test_buckets"]) == 3
+    assert [b["name"] for b in output["integration_test_buckets"]] == [
+        "1/3",
+        "2/3",
+        "3/3",
+    ]
+    bucket_files = [
+        f
+        for b in output["integration_test_buckets"]
+        for f in b["tests"].split(" ")
+        if f
+    ]
+    assert bucket_files == fake_test_files
     assert output["clang_tidy"] is True
     assert output["clang_tidy_mode"] in ["nosplit", "split"]
     assert output["clang_format"] is True
@@ -247,8 +269,7 @@ def test_main_no_tests_should_run(
     output = json.loads(captured.out)
 
     assert output["integration_tests"] is False
-    assert output["integration_tests_run_all"] is False
-    assert output["integration_test_files"] == []
+    assert output["integration_test_buckets"] == []
     assert output["clang_tidy"] is False
     assert output["clang_tidy_mode"] == "disabled"
     assert output["clang_format"] is False
@@ -332,8 +353,7 @@ def test_main_with_branch_argument(
     output = json.loads(captured.out)
 
     assert output["integration_tests"] is False
-    assert output["integration_tests_run_all"] is False
-    assert output["integration_test_files"] == []
+    assert output["integration_test_buckets"] == []
     assert output["clang_tidy"] is True
     assert output["clang_tidy_mode"] in ["nosplit", "split"]
     assert output["clang_format"] is False


### PR DESCRIPTION
# What does this implement/fix?

When more than 10 integration tests are scheduled in CI (or any change that triggers `run_all`, e.g. core/infra changes that would run all 117 files in `tests/integration/`), this fans out the pytest job into 3 parallel matrix entries so the long-pole test job no longer dominates wall-clock CI time. Below the threshold a single bucket runs, so small targeted PRs see no extra job overhead.

`script/determine-jobs.py` now owns the bucketing end-to-end:

- It expands `run_all=True` into the explicit glob of `tests/integration/test_*.py`, so the workflow never re-globs the filesystem and `determine-jobs` remains the single source of truth for which tests run.
- It pre-splits the sorted file list using the same balanced contiguous-partition formula as `script/clang-tidy` (`split_list`) so bucket sizes differ by at most one.
- It emits `integration_test_buckets`: a list of `{name, tests}` objects, one per bucket. Below the threshold this is a single-element list named `1/1`; above the threshold it is three buckets named `1/3`, `2/3`, `3/3`.

The CI workflow consumes the precomputed buckets directly via `fromJson()` in the matrix — mirroring how `component-test-batches` works at `ci.yml:646` — so no shell-side splitting is needed.

The previous `integration-tests-run-all` and `integration-test-files` workflow outputs are replaced by a single `integration-test-buckets` list-of-objects. The `integration-tests` gate boolean is unchanged, and the existing `ci-status` aggregator already lists `integration-tests` under `needs:` and handles matrix expansion / skipped jobs correctly with no further changes.

Existing unit tests in `tests/script/test_determine_jobs.py` were updated for the new output shape; one test injects a deterministic 15-file stand-in for the integration-test glob so bucket assertions don't drift with the real test count.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI-only change — no firmware platforms exercised.)

## Example entry for `config.yaml`:

```yaml
# N/A — CI workflow change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).