### PR TITLE
DNM: probe integration-test bucketing for cover

### DIFF
--- a/esphome/components/cover/cover.h
+++ b/esphome/components/cover/cover.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// DNM: integration-test bucketing CI probe — do not merge.
 #include "esphome/core/component.h"
 #include "esphome/core/entity_base.h"
 #include "esphome/core/helpers.h"


### PR DESCRIPTION
# What does this implement/fix?

**Do not merge.**

Chained on top of #16152. Touches `esphome/components/cover/cover.h` with a single comment so `determine-jobs.py` selects the cover component's integration tests, which should route through the new bucketed `integration-tests` matrix in #16152 (split into `1/3`, `2/3`, `3/3` since the cover component participates in many integration tests).

Purpose: verify the bucket fan-out works end-to-end in real CI before #16152 merges.

## Types of changes

- [x] Other (CI probe, not for merge)

**Related issue or feature (if applicable):**

- Validates #16152

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI probe — no firmware platforms exercised.)

## Example entry for \`config.yaml\`:

\`\`\`yaml
# N/A — CI probe
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).