### PR TITLE
DNM: probe integration-test bucketing for api

### DIFF
--- a/esphome/components/api/api_connection.h
+++ b/esphome/components/api/api_connection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+// DNM: integration-test bucketing CI probe — do not merge.
 #include "esphome/core/defines.h"
 #ifdef USE_API
 #include "api_frame_helper.h"


### PR DESCRIPTION
# What does this implement/fix?

**Do not merge.**

Chained on top of #16152 + the cover DNM probe. Touches `esphome/components/api/api_connection.h` with a single comment so `determine-jobs.py` also pulls in the api component's integration tests on top of the cover probe. Combined with the cover probe this should produce a comfortably split bucket count and validate that bucket sizes are balanced across the three matrix jobs.

Purpose: verify the bucket fan-out works end-to-end in real CI before #16152 merges.

## Types of changes

- [x] Other (CI probe, not for merge)

**Related issue or feature (if applicable):**

- Validates #16152

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(CI probe — no firmware platforms exercised.)

## Example entry for \`config.yaml\`:

\`\`\`yaml
# N/A — CI probe
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).