### PR TITLE
[core] Strip \\?\ prefix from sys.executable for PlatformIO subprocess

### DIFF
--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -15,19 +15,33 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def _strip_win_long_path_prefix(path: str) -> str:
-    r"""Strip the Windows extended-length path prefix (``\\?\``) from ``path``.
+    r"""Strip the Windows extended-length path prefix from ``path``.
+
+    Handles both forms documented at
+    https://learn.microsoft.com/windows/win32/fileio/naming-a-file:
+
+    * ``\\?\C:\path\to\file`` -> ``C:\path\to\file``
+    * ``\\?\UNC\server\share\path`` -> ``\\server\share\path``
 
     The NSIS-installed ``esphome.exe`` launcher on Windows starts Python with
     ``sys.executable`` already prefixed with ``\\?\``. That prefix propagates
-    into PlatformIO's ``PYTHONEXE`` (set from ``os.path.normpath(sys.executable)``)
-    and ends up baked into SCons-emitted command lines for build steps such as
-    the esp8266 ``elf2bin`` invocation. ``cmd.exe`` does not understand the
-    ``\\?\`` prefix, so the build fails with "The system cannot find the path
-    specified." Stripping the prefix early keeps PlatformIO's ``$PYTHONEXE``
-    shell-quotable.
+    into PlatformIO's ``$PYTHONEXE`` (PlatformIO reads ``PYTHONEXEPATH`` from
+    the environment, falling back to ``os.path.normpath(sys.executable)``)
+    and ends up baked into SCons-emitted command lines for build steps such
+    as the esp8266 ``elf2bin`` invocation. ``cmd.exe`` does not understand
+    the ``\\?\`` prefix, so the build fails with
+    "The system cannot find the path specified." Stripping the prefix early
+    keeps the path shell-quotable.
+
+    No-op on non-Windows platforms.
     """
-    if sys.platform == "win32" and path.startswith("\\\\?\\"):
-        return path[4:]
+    if sys.platform != "win32":
+        return path
+    if path.startswith("\\\\?\\UNC\\"):
+        # \\?\UNC\server\share\... -> \\server\share\...
+        return "\\\\" + path[len("\\\\?\\UNC\\") :]
+    if path.startswith("\\\\?\\"):
+        return path[len("\\\\?\\") :]
     return path
 
 
@@ -42,11 +56,13 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # Increase uv retry count to handle transient network errors (default is 3)
     os.environ.setdefault("UV_HTTP_RETRIES", "10")
     # Strip the Windows extended-length path prefix from sys.executable so it
-    # doesn't propagate into PlatformIO's PYTHONEXE and break SCons-emitted
+    # doesn't propagate into PlatformIO's $PYTHONEXE and break SCons-emitted
     # command lines run through cmd.exe.
     python_exe = _strip_win_long_path_prefix(sys.executable)
-    # Pin PYTHONEXE explicitly as a belt-and-suspenders safeguard for the
-    # subprocess in case its sys.executable is still resolved with the prefix.
+    # Set PYTHONEXEPATH explicitly so PlatformIO's get_pythonexe_path() uses
+    # this stripped path instead of falling back to sys.executable in the
+    # subprocess (in case the subprocess's sys.executable still has the
+    # prefix).
     os.environ["PYTHONEXEPATH"] = python_exe
     cmd = [python_exe, "-m", "esphome.platformio_runner"] + list(args)
 

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -59,11 +59,13 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     # doesn't propagate into PlatformIO's $PYTHONEXE and break SCons-emitted
     # command lines run through cmd.exe.
     python_exe = _strip_win_long_path_prefix(sys.executable)
-    # Set PYTHONEXEPATH explicitly so PlatformIO's get_pythonexe_path() uses
-    # this stripped path instead of falling back to sys.executable in the
-    # subprocess (in case the subprocess's sys.executable still has the
-    # prefix).
-    os.environ["PYTHONEXEPATH"] = python_exe
+    if python_exe != sys.executable:
+        # Only override PYTHONEXEPATH when we actually stripped a prefix.
+        # PlatformIO's get_pythonexe_path() reads this and falls back to
+        # sys.executable otherwise; setting it unconditionally would clobber
+        # a user-provided value (or the unmodified path on platforms that
+        # don't need the strip).
+        os.environ["PYTHONEXEPATH"] = python_exe
     cmd = [python_exe, "-m", "esphome.platformio_runner"] + list(args)
 
     return run_external_process(*cmd, **kwargs)

--- a/esphome/platformio_api.py
+++ b/esphome/platformio_api.py
@@ -14,6 +14,23 @@ from esphome.util import run_external_process
 _LOGGER = logging.getLogger(__name__)
 
 
+def _strip_win_long_path_prefix(path: str) -> str:
+    r"""Strip the Windows extended-length path prefix (``\\?\``) from ``path``.
+
+    The NSIS-installed ``esphome.exe`` launcher on Windows starts Python with
+    ``sys.executable`` already prefixed with ``\\?\``. That prefix propagates
+    into PlatformIO's ``PYTHONEXE`` (set from ``os.path.normpath(sys.executable)``)
+    and ends up baked into SCons-emitted command lines for build steps such as
+    the esp8266 ``elf2bin`` invocation. ``cmd.exe`` does not understand the
+    ``\\?\`` prefix, so the build fails with "The system cannot find the path
+    specified." Stripping the prefix early keeps PlatformIO's ``$PYTHONEXE``
+    shell-quotable.
+    """
+    if sys.platform == "win32" and path.startswith("\\\\?\\"):
+        return path[4:]
+    return path
+
+
 def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ["PLATFORMIO_FORCE_COLOR"] = "true"
     os.environ["PLATFORMIO_BUILD_DIR"] = str(CORE.relative_pioenvs_path().absolute())
@@ -24,7 +41,14 @@ def run_platformio_cli(*args, **kwargs) -> str | int:
     os.environ.setdefault("PYTHONWARNINGS", "ignore::SyntaxWarning")
     # Increase uv retry count to handle transient network errors (default is 3)
     os.environ.setdefault("UV_HTTP_RETRIES", "10")
-    cmd = [sys.executable, "-m", "esphome.platformio_runner"] + list(args)
+    # Strip the Windows extended-length path prefix from sys.executable so it
+    # doesn't propagate into PlatformIO's PYTHONEXE and break SCons-emitted
+    # command lines run through cmd.exe.
+    python_exe = _strip_win_long_path_prefix(sys.executable)
+    # Pin PYTHONEXE explicitly as a belt-and-suspenders safeguard for the
+    # subprocess in case its sys.executable is still resolved with the prefix.
+    os.environ["PYTHONEXEPATH"] = python_exe
+    cmd = [python_exe, "-m", "esphome.platformio_runner"] + list(args)
 
     return run_external_process(*cmd, **kwargs)
 

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -311,6 +311,75 @@ def test_run_platformio_cli_sets_environment_variables(
         assert "arg" in args
 
 
+@pytest.mark.parametrize(
+    ("platform", "input_path", "expected"),
+    [
+        # win32: drive-letter extended-length prefix is stripped
+        (
+            "win32",
+            "\\\\?\\C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe",
+            "C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe",
+        ),
+        # win32: UNC extended-length prefix is translated to a regular UNC path
+        (
+            "win32",
+            "\\\\?\\UNC\\server\\share\\python.exe",
+            "\\\\server\\share\\python.exe",
+        ),
+        # win32: paths without the prefix are returned unchanged
+        (
+            "win32",
+            "C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe",
+            "C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe",
+        ),
+        # non-win32: prefix is left alone (no-op)
+        ("linux", "\\\\?\\C:\\python.exe", "\\\\?\\C:\\python.exe"),
+        ("darwin", "/usr/bin/python3", "/usr/bin/python3"),
+    ],
+)
+def test_strip_win_long_path_prefix(
+    platform: str, input_path: str, expected: str
+) -> None:
+    r"""``\\?\`` and ``\\?\UNC\`` prefixes are stripped only on win32."""
+    with patch("esphome.platformio_api.sys.platform", platform):
+        assert platformio_api._strip_win_long_path_prefix(input_path) == expected
+
+
+def test_run_platformio_cli_strips_win_long_path_prefix(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    r"""Windows ``\\?\`` prefix on sys.executable does not leak into the subprocess.
+
+    The NSIS-installed esphome.exe launcher starts Python with
+    ``sys.executable`` already prefixed by the extended-length path marker.
+    That prefix would otherwise propagate into PlatformIO's ``PYTHONEXE`` and
+    break SCons-emitted command lines run through ``cmd.exe``.
+    """
+    CORE.build_path = str(setup_core / "build" / "test")
+    prefixed_exe = (
+        "\\\\?\\C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe"
+    )
+    stripped_exe = (
+        "C:\\Users\\jesse\\AppData\\Local\\ESPHome Builder\\python\\python.exe"
+    )
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("esphome.platformio_api.sys.platform", "win32"),
+        patch("esphome.platformio_api.sys.executable", prefixed_exe),
+    ):
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test", "arg")
+
+        # The subprocess is invoked with the stripped executable path.
+        mock_run_external_process.assert_called_once()
+        args = mock_run_external_process.call_args[0]
+        assert args[0] == stripped_exe
+        # PYTHONEXEPATH is exported with the stripped path so PlatformIO's
+        # get_pythonexe_path() picks it up in the subprocess.
+        assert os.environ["PYTHONEXEPATH"] == stripped_exe
+
+
 def test_run_platformio_cli_run_builds_command(
     setup_core: Path, mock_run_platformio_cli: Mock
 ) -> None:

--- a/tests/unit_tests/test_platformio_api.py
+++ b/tests/unit_tests/test_platformio_api.py
@@ -368,6 +368,10 @@ def test_run_platformio_cli_strips_win_long_path_prefix(
         patch("esphome.platformio_api.sys.platform", "win32"),
         patch("esphome.platformio_api.sys.executable", prefixed_exe),
     ):
+        # Pop any pre-existing PYTHONEXEPATH so the assertion below reflects
+        # what run_platformio_cli set, not whatever the test runner's
+        # environment happened to contain.
+        os.environ.pop("PYTHONEXEPATH", None)
         mock_run_external_process.return_value = 0
         platformio_api.run_platformio_cli("test", "arg")
 
@@ -378,6 +382,32 @@ def test_run_platformio_cli_strips_win_long_path_prefix(
         # PYTHONEXEPATH is exported with the stripped path so PlatformIO's
         # get_pythonexe_path() picks it up in the subprocess.
         assert os.environ["PYTHONEXEPATH"] == stripped_exe
+
+
+def test_run_platformio_cli_does_not_set_pythonexepath_without_strip(
+    setup_core: Path, mock_run_external_process: Mock
+) -> None:
+    r"""PYTHONEXEPATH is not touched when sys.executable has no ``\\?\`` prefix.
+
+    Setting it unconditionally would clobber a user-provided value (or
+    interfere with non-Windows tooling that has no prefix to strip).
+    """
+    CORE.build_path = str(setup_core / "build" / "test")
+    plain_exe = "/usr/bin/python3"
+
+    with (
+        patch.dict(os.environ, {}, clear=False),
+        patch("esphome.platformio_api.sys.platform", "linux"),
+        patch("esphome.platformio_api.sys.executable", plain_exe),
+    ):
+        os.environ.pop("PYTHONEXEPATH", None)
+        mock_run_external_process.return_value = 0
+        platformio_api.run_platformio_cli("test", "arg")
+
+        mock_run_external_process.assert_called_once()
+        args = mock_run_external_process.call_args[0]
+        assert args[0] == plain_exe
+        assert "PYTHONEXEPATH" not in os.environ
 
 
 def test_run_platformio_cli_run_builds_command(


### PR DESCRIPTION
# What does this implement/fix?

Fixes the `esp8266` (and any other Windows) build failure that surfaces as:

```
Building .pioenvs\<env>\firmware.bin
The system cannot find the path specified.
*** [.pioenvs\<env>\firmware.bin] Error 1
```

The NSIS-installed `esphome.exe` launcher on Windows starts Python with `sys.executable` already prefixed by the Windows extended-length path marker `\\?\`. ESPHome passes `sys.executable` to the PlatformIO subprocess, where PlatformIO uses `os.path.normpath(sys.executable)` as its `PYTHONEXE` and bakes that into SCons-emitted command lines (e.g. the esp8266 framework's `elf2bin.py` invocation). `cmd.exe` does not understand the `\\?\` prefix, so the `firmware.bin` build step fails.

Verified on a Windows 11 VM with the minimal config:

```yaml
esphome:
  name: esp8266

esp8266:
  board: esp01_1m
```

Before the fix the SCons command line shows `"\\?\C:\Users\...\python.exe" ...elf2bin.py ...` and fails. After the fix the prefix is stripped and the build completes:

```
Building .pioenvs\esp8266\firmware.bin
esp8266_copy_factory_bin([".pioenvs\esp8266\firmware.bin"], ...)
esp8266_copy_ota_bin([".pioenvs\esp8266\firmware.bin"], ...)
========================= [SUCCESS] Took 2.90 seconds =========================
INFO Successfully compiled program.
```

esp32 builds were re-checked on the same VM as a regression sanity test and still pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esphome:
  name: esp8266

esp8266:
  board: esp01_1m
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).