### PR TITLE
[remote_transmitter] Add support for the `remote_transmitter` component in `radio_frequency`

### DIFF
--- a/esphome/components/remote_transmitter/radio_frequency.py
+++ b/esphome/components/remote_transmitter/radio_frequency.py
@@ -1,6 +1,9 @@
 import esphome.codegen as cg
 from esphome.components import radio_frequency, remote_base
 import esphome.config_validation as cv
+from esphome.const import CONF_CARRIER_DUTY_PERCENT
+import esphome.final_validate as fv
+from esphome.types import ConfigType
 
 remote_transmitter_ns = cg.esphome_ns.namespace("remote_transmitter")
 TransmitterRadioFrequency = remote_transmitter_ns.class_(
@@ -18,6 +21,28 @@ CONFIG_SCHEMA = radio_frequency.radio_frequency_schema(
         ),
     }
 )
+
+
+def _final_validate(config: ConfigType) -> None:
+    """Validate that RF transmitters have carrier duty set to 100%."""
+    if CONF_TRANSMITTER_ID not in config:
+        return
+
+    transmitter_id = config[CONF_TRANSMITTER_ID]
+    full_config = fv.full_config.get()
+    transmitter_path = full_config.get_path_for_id(transmitter_id)[:-1]
+    transmitter_config = full_config.get_config_for_path(transmitter_path)
+
+    duty_percent = transmitter_config.get(CONF_CARRIER_DUTY_PERCENT)
+    if duty_percent is not None and duty_percent != 100:
+        raise cv.Invalid(
+            f"Transmitter '{transmitter_id}' must have '{CONF_CARRIER_DUTY_PERCENT}' "
+            "set to 100% for RF transmission. Dedicated RF hardware handles modulation; "
+            "applying a carrier duty cycle would corrupt the signal"
+        )
+
+
+FINAL_VALIDATE_SCHEMA = _final_validate
 
 
 async def to_code(config):

--- a/esphome/components/remote_transmitter/radio_frequency.py
+++ b/esphome/components/remote_transmitter/radio_frequency.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components import radio_frequency, remote_base
+import esphome.config_validation as cv
+
+remote_transmitter_ns = cg.esphome_ns.namespace("remote_transmitter")
+TransmitterRadioFrequency = remote_transmitter_ns.class_(
+    "TransmitterRadioFrequency", radio_frequency.RadioFrequency
+)
+
+CONF_TRANSMITTER_ID = remote_base.CONF_TRANSMITTER_ID
+
+CONFIG_SCHEMA = radio_frequency.radio_frequency_schema(
+    TransmitterRadioFrequency
+).extend(
+    {
+        cv.GenerateID(CONF_TRANSMITTER_ID): cv.use_id(
+            remote_base.RemoteTransmitterBase
+        ),
+    }
+)
+
+
+async def to_code(config):
+    var = await radio_frequency.new_radio_frequency(config)
+
+    transmitter = await cg.get_variable(config[CONF_TRANSMITTER_ID])
+    cg.add(var.set_transmitter(transmitter))

--- a/esphome/components/remote_transmitter/radio_frequency.py
+++ b/esphome/components/remote_transmitter/radio_frequency.py
@@ -16,9 +16,7 @@ CONFIG_SCHEMA = radio_frequency.radio_frequency_schema(
     TransmitterRadioFrequency
 ).extend(
     {
-        cv.GenerateID(CONF_TRANSMITTER_ID): cv.use_id(
-            remote_base.RemoteTransmitterBase
-        ),
+        cv.Required(CONF_TRANSMITTER_ID): cv.use_id(remote_base.RemoteTransmitterBase),
     }
 )
 

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -27,7 +27,7 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     return;
   }
 
-  if (call.get_modulation().has_value() && *call.get_modulation() != radio_frequency::RADIO_FREQUENCY_MODULATION_OOK) {
+  if (call.get_modulation().has_value() && call.get_modulation() != radio_frequency::RADIO_FREQUENCY_MODULATION_OOK) {
     ESP_LOGE(TAG, "Unsupported modulation requested; remote_transmitter only supports OOK.");
     return;
   }

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -9,7 +9,12 @@ namespace esphome::remote_transmitter {
 #ifdef USE_RADIO_FREQUENCY
 static const char *const TAG = "remote_transmitter.radio_frequency";
 
-void TransmitterRadioFrequency::setup() { this->traits_.set_supports_transmitter(true); }
+void TransmitterRadioFrequency::setup() {
+  this->traits_.set_supports_transmitter(true);
+
+  // remote_transmitter/receiver always uses OOK (on-off keying)
+  this->traits_.add_supported_modulation(radio_frequency::Modulation::OOK);
+}
 
 void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCall &call) {
   if (this->transmitter_ == nullptr) {

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -27,6 +27,11 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     return;
   }
 
+  if (call.get_modulation().has_value() && *call.get_modulation() != radio_frequency::Modulation::OOK) {
+    ESP_LOGE(TAG, "Unsupported modulation requested; remote_transmitter only supports OOK.");
+    return;
+  }
+
   auto tx_call = this->transmitter_->transmit();
   auto *tx_data = tx_call.get_data();
 

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -1,0 +1,43 @@
+#include "transmitter_radio_frequency.h"
+#include "esphome/core/log.h"
+
+namespace esphome::remote_transmitter {
+
+static const char *const TAG = "remote_transmitter.radio_frequency";
+
+void TransmitterRadioFrequency::setup() { this->traits_.set_supports_transmitter(true); }
+
+void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCall &call) {
+  if (this->transmitter_ == nullptr) {
+    ESP_LOGE(TAG, "No transmitter configured!");
+    return;
+  }
+
+  if (!call.has_raw_timings()) {
+    ESP_LOGW(TAG, "RadioFrequencyCall has no raw timings to transmit.");
+    return;
+  }
+
+  auto tx_call = this->transmitter_->transmit();
+  auto *tx_data = tx_call.get_data();
+
+  if (call.is_packed()) {
+    tx_data->set_data_from_packed_sint32(call.get_packed_data(), call.get_packed_length(), call.get_packed_count());
+  } else if (call.is_base64url()) {
+    if (!tx_data->set_data_from_base64url(call.get_base64url_data())) {
+      ESP_LOGE(TAG, "Failed to decode base64url data");
+      return;
+    }
+  } else {
+    tx_data->set_data(call.get_raw_timings());
+  }
+
+  if (call.get_frequency().has_value()) {
+    tx_data->set_carrier_frequency(*call.get_frequency());
+  }
+
+  tx_call.set_send_times(call.get_repeat_count());
+  tx_call.perform();
+}
+
+}  // namespace esphome::remote_transmitter

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -27,7 +27,7 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     return;
   }
 
-  if (call.get_modulation().has_value() && call.get_modulation() != radio_frequency::RADIO_FREQUENCY_MODULATION_OOK) {
+  if (call.get_modulation() != radio_frequency::RADIO_FREQUENCY_MODULATION_OOK) {
     ESP_LOGE(TAG, "Unsupported modulation requested; remote_transmitter only supports OOK.");
     return;
   }

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -1,4 +1,7 @@
 #include "transmitter_radio_frequency.h"
+
+#include <cinttypes>
+
 #include "esphome/core/log.h"
 
 namespace esphome::remote_transmitter {
@@ -28,6 +31,16 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
       ESP_LOGE(TAG, "Failed to decode base64url data");
       return;
     }
+    constexpr int32_t max_timing_us = 500000;
+    for (int32_t timing : tx_data->get_data()) {
+      int32_t abs_timing = timing < 0 ? -timing : timing;
+      if (abs_timing > max_timing_us) {
+        ESP_LOGE(TAG, "Invalid timing value: %" PRId32 " µs (max %" PRId32 ")", timing, max_timing_us);
+        return;
+      }
+    }
+    ESP_LOGD(TAG, "Transmitting base64url raw timings: count=%zu, repeat=%" PRIu32, tx_data->get_data().size(),
+             call.get_repeat_count());
   } else {
     tx_data->set_data(call.get_raw_timings());
   }

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -56,9 +56,10 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     tx_data->set_data(call.get_raw_timings());
   }
 
-  if (call.get_frequency().has_value()) {
-    tx_data->set_carrier_frequency(*call.get_frequency());
-  }
+  // RF transmissions must not enable IR carrier modulation. Any RF frequency
+  // provided by the call should be treated as metadata elsewhere, not mapped
+  // to the remote transmitter carrier frequency.
+  tx_data->set_carrier_frequency(0);
 
   if (call.get_repeat_count() > 0) {
     tx_call.set_send_times(call.get_repeat_count());

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -6,6 +6,7 @@
 
 namespace esphome::remote_transmitter {
 
+#ifdef USE_RADIO_FREQUENCY
 static const char *const TAG = "remote_transmitter.radio_frequency";
 
 void TransmitterRadioFrequency::setup() { this->traits_.set_supports_transmitter(true); }
@@ -54,5 +55,6 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
   }
   tx_call.perform();
 }
+#endif  // USE_RADIO_FREQUENCY
 
 }  // namespace esphome::remote_transmitter

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -49,7 +49,9 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     tx_data->set_carrier_frequency(*call.get_frequency());
   }
 
-  tx_call.set_send_times(call.get_repeat_count());
+  if (call.get_repeat_count() > 0) {
+    tx_call.set_send_times(call.get_repeat_count());
+  }
   tx_call.perform();
 }
 

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.cpp
@@ -13,7 +13,7 @@ void TransmitterRadioFrequency::setup() {
   this->traits_.set_supports_transmitter(true);
 
   // remote_transmitter/receiver always uses OOK (on-off keying)
-  this->traits_.add_supported_modulation(radio_frequency::Modulation::OOK);
+  this->traits_.add_supported_modulation(radio_frequency::RADIO_FREQUENCY_MODULATION_OOK);
 }
 
 void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCall &call) {
@@ -27,7 +27,7 @@ void TransmitterRadioFrequency::control(const radio_frequency::RadioFrequencyCal
     return;
   }
 
-  if (call.get_modulation().has_value() && *call.get_modulation() != radio_frequency::Modulation::OOK) {
+  if (call.get_modulation().has_value() && *call.get_modulation() != radio_frequency::RADIO_FREQUENCY_MODULATION_OOK) {
     ESP_LOGE(TAG, "Unsupported modulation requested; remote_transmitter only supports OOK.");
     return;
   }

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.h
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/radio_frequency/radio_frequency.h"
+#include "esphome/components/remote_base/remote_base.h"
+
+namespace esphome::remote_transmitter {
+
+class TransmitterRadioFrequency : public radio_frequency::RadioFrequency {
+ public:
+  void set_transmitter(remote_base::RemoteTransmitterBase *transmitter) { this->transmitter_ = transmitter; }
+
+  void setup() override;
+
+ protected:
+  void control(const radio_frequency::RadioFrequencyCall &call) override;
+
+  remote_base::RemoteTransmitterBase *transmitter_{nullptr};
+};
+
+}  // namespace esphome::remote_transmitter

--- a/esphome/components/remote_transmitter/transmitter_radio_frequency.h
+++ b/esphome/components/remote_transmitter/transmitter_radio_frequency.h
@@ -1,11 +1,16 @@
 #pragma once
 
 #include "esphome/core/component.h"
-#include "esphome/components/radio_frequency/radio_frequency.h"
+
 #include "esphome/components/remote_base/remote_base.h"
+
+#ifdef USE_RADIO_FREQUENCY
+#include "esphome/components/radio_frequency/radio_frequency.h"
+#endif
 
 namespace esphome::remote_transmitter {
 
+#ifdef USE_RADIO_FREQUENCY
 class TransmitterRadioFrequency : public radio_frequency::RadioFrequency {
  public:
   void set_transmitter(remote_base::RemoteTransmitterBase *transmitter) { this->transmitter_ = transmitter; }
@@ -17,5 +22,6 @@ class TransmitterRadioFrequency : public radio_frequency::RadioFrequency {
 
   remote_base::RemoteTransmitterBase *transmitter_{nullptr};
 };
+#endif  // USE_RADIO_FREQUENCY
 
 }  // namespace esphome::remote_transmitter

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -260,3 +260,8 @@ button:
       - remote_transmitter.digital_write: true
       - remote_transmitter.digital_write:
           value: false
+
+radio_frequency:
+  - platform: remote_transmitter
+    transmitter_id: xmitr
+    name: "Test RF TX"

--- a/tests/components/remote_transmitter/common-buttons.yaml
+++ b/tests/components/remote_transmitter/common-buttons.yaml
@@ -260,8 +260,3 @@ button:
       - remote_transmitter.digital_write: true
       - remote_transmitter.digital_write:
           value: false
-
-radio_frequency:
-  - platform: remote_transmitter
-    transmitter_id: xmitr
-    name: "Test RF TX"

--- a/tests/components/remote_transmitter/esp32-common.yaml
+++ b/tests/components/remote_transmitter/esp32-common.yaml
@@ -1,7 +1,7 @@
 remote_transmitter:
   - id: xmitr
     pin: ${pin}
-    carrier_duty_percent: 100%
+    carrier_duty_percent: 50%
     non_blocking: true
     clock_resolution: ${clock_resolution}
     rmt_symbols: ${rmt_symbols}

--- a/tests/components/remote_transmitter/esp32-common.yaml
+++ b/tests/components/remote_transmitter/esp32-common.yaml
@@ -1,7 +1,7 @@
 remote_transmitter:
   - id: xmitr
     pin: ${pin}
-    carrier_duty_percent: 50%
+    carrier_duty_percent: 100%
     non_blocking: true
     clock_resolution: ${clock_resolution}
     rmt_symbols: ${rmt_symbols}

--- a/tests/components/remote_transmitter/test.esp32-c2-idf.yaml
+++ b/tests/components/remote_transmitter/test.esp32-c2-idf.yaml
@@ -1,7 +1,7 @@
 remote_transmitter:
   id: xmitr
   pin: GPIO2
-  carrier_duty_percent: 50%
+  carrier_duty_percent: 100%
 
 packages:
   buttons: !include common-buttons.yaml

--- a/tests/components/remote_transmitter/test.esp32-s3-idf.yaml
+++ b/tests/components/remote_transmitter/test.esp32-s3-idf.yaml
@@ -7,7 +7,7 @@ substitutions:
 remote_transmitter:
   - id: xmitr
     pin: ${pin}
-    carrier_duty_percent: 50%
+    carrier_duty_percent: 100%
     clock_resolution: ${clock_resolution}
     rmt_symbols: ${rmt_symbols}
     use_dma: "true"

--- a/tests/components/remote_transmitter/test.esp8266-ard.yaml
+++ b/tests/components/remote_transmitter/test.esp8266-ard.yaml
@@ -1,7 +1,7 @@
 remote_transmitter:
   id: xmitr
   pin: GPIO5
-  carrier_duty_percent: 50%
+  carrier_duty_percent: 100%
 
 packages:
   buttons: !include common-buttons.yaml

--- a/tests/components/remote_transmitter/test.rp2040-ard.yaml
+++ b/tests/components/remote_transmitter/test.rp2040-ard.yaml
@@ -1,7 +1,7 @@
 remote_transmitter:
   id: xmitr
   pin: GPIO5
-  carrier_duty_percent: 50%
+  carrier_duty_percent: 100%
 
 packages:
   buttons: !include common-buttons.yaml


### PR DESCRIPTION
# What does this implement/fix?

Expands the baseline established by https://github.com/esphome/esphome/pull/15556 in order to allow `remote_transmitter` components in `radio_frequency`.

I'm pretty sure this is somewhat planned (by the looks of [the latest Home Assistant release notes](https://rc.home-assistant.io/blog/2026/04/29/release-20265/#meet-the-radio-frequency-platform), but I can't find any PR, issue, or component in the repository, so I did my own implementation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

_not applicable_

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6554

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Tested with a CC1101 and an ESP32-C3.

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
remote_transmitter:
  id: cc1101_tx_hub
  pin: GPIO05 # Must match GDO0
  carrier_duty_percent: 100%
  on_transmit:
    then:
      - cc1101.begin_tx
  on_complete:
    then:
      - cc1101.begin_rx

radio_frequency:
  - platform: remote_transmitter
    transmitter_id: cc1101_tx_hub
    name: "CC1101 RF Transmitter"
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
