### PR TITLE
[core] Inline loop gate expression to avoid stale local reuse

### DIFF
--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -637,10 +637,12 @@ inline void ESPHOME_ALWAYS_INLINE Application::loop() {
   // flag preserves it. wake_request_take() exchange-clears the flag; wakes
   // that arrive during Phase B re-set it and run Phase B again on the next
   // iteration.
-  const bool high_frequency = HighFrequencyLoopRequester::is_high_frequency();
-  const uint32_t elapsed = now - this->last_loop_;
-  const bool woke = esphome::wake_request_take();
-  const bool do_component_phase = high_frequency || woke || (elapsed >= this->loop_interval_);
+  //
+  // wake_request_take() must always be called first since it does an
+  // atomic exchange to clear the flag, and we want to run the component phase
+  // if either the flag was set or the scheduler requested a high-frequency loop.
+  const bool do_component_phase = esphome::wake_request_take() || HighFrequencyLoopRequester::is_high_frequency() ||
+                                  (now - this->last_loop_ >= this->loop_interval_);
 
   if (do_component_phase) {
     ComponentPhaseGuard phase_guard{*this};


### PR DESCRIPTION
# What does this implement/fix?

Inlines the `do_component_phase` gate expression in `Application::loop()` so that `HighFrequencyLoopRequester::is_high_frequency()`, `wake_request_take()`, and the `last_loop_`/`loop_interval_` comparison are no longer captured into named locals (`high_frequency`, `woke`, `elapsed`).

Locals are easy to reuse later in the function, and we have hit bugs in the past where a value captured at the top of `loop()` was read again further down instead of being re-evaluated. Most recently this happened with `is_high_frequency` — the second use saw a stale value because the local was reused instead of querying the requester again.

By inlining the expression directly into `do_component_phase`, there is nothing tempting to reuse downstream and any future reader of these values is forced to re-evaluate them at the point of use.

`wake_request_take()` is placed first in the chain so its atomic exchange is never short-circuited away; the wake flag is unconditionally cleared once per loop iteration, matching the pre-existing comment block above the gate.

No behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [ ] nRF52840

## Example entry for \`config.yaml\`:

\`\`\`yaml
# Example config.yaml

\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).