### PR TITLE
[audio] bump microOpus to v0.4.0 to use fixed-point by default on ESP32

### DIFF
--- a/esphome/components/audio/__init__.py
+++ b/esphome/components/audio/__init__.py
@@ -238,4 +238,4 @@ async def to_code(config):
         cg.add_define("USE_AUDIO_MP3_SUPPORT")
     if data.opus_support:
         cg.add_define("USE_AUDIO_OPUS_SUPPORT")
-        add_idf_component(name="esphome/micro-opus", ref="0.3.6")
+        add_idf_component(name="esphome/micro-opus", ref="0.4.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -10,7 +10,7 @@ dependencies:
   esphome/micro-flac:
     version: 0.1.1
   esphome/micro-opus:
-    version: 0.3.6
+    version: 0.4.0
   espressif/esp-dsp:
     version: "1.7.1"
   espressif/esp-tflite-micro:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the microOpus library to v0.4.0 ([GitHub](https://github.com/esphome-libs/micro-opus/releases/tag/v0.4.0) and [Espressif Registry](https://components.espressif.com/components/esphome/micro-opus/versions/0.4.0/readme)).

This version uses fixed-point math on plain ESP32 platform by default, which benchmark better than floating point operations. ESP32-S3 platform will still use floating-point by default, as it is quite a bit faster.

This makes decoding mono Opus achievable, but stereo is still border-line to decode in real time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
