### PR TITLE
[sensor] Pack ThrottleAverageFilter have_nan_ into n_ bitfield (-4 B/instance)

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -564,7 +564,12 @@ async def exponential_moving_average_filter_to_code(config, filter_id):
 
 
 @FILTER_REGISTRY.register(
-    "throttle_average", ThrottleAverageFilter, cv.positive_time_period_milliseconds
+    "throttle_average",
+    ThrottleAverageFilter,
+    cv.All(
+        cv.positive_time_period_milliseconds,
+        cv.Range(max=cv.TimePeriod(hours=24)),
+    ),
 )
 async def throttle_average_filter_to_code(config, filter_id):
     var = cg.new_Pvariable(filter_id, config)

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -266,9 +266,12 @@ class ThrottleAverageFilter : public Filter, public Component {
 
  protected:
   float sum_{0.0f};
-  unsigned int n_{0};
   uint32_t time_period_;
-  bool have_nan_{false};
+  // Sample count packed with NaN-seen flag in a single 32-bit word.
+  // n_ is bounded by YAML cap on time_period_ (24 h) × max plausible source
+  // rate (1 kHz) = 86.4M ≪ 2^31, so 31 bits has 25x headroom.
+  uint32_t n_ : 31 {0};
+  uint32_t have_nan_ : 1 {0};
 };
 
 using lambda_filter_t = std::function<optional<float>(float)>;


### PR DESCRIPTION
# What does this implement/fix?

Reduces the per-instance footprint of `ThrottleAverageFilter` from 28 B to 24 B on 32-bit targets by packing the `have_nan_` boolean into the high bit of `n_`.

## Layout before (28 B on 32-bit)

```
Filter base                                12 B
  4  vptr
  4  Filter *next_
  4  Sensor *parent_
ThrottleAverageFilter state                16 B
  4  float    sum_
  4  uint32_t n_
  4  uint32_t time_period_
  1  bool     have_nan_   (+3 padding)
                                         = 28 B
```

## Layout after (24 B on 32-bit)

```
Filter base                                12 B
ThrottleAverageFilter state                12 B
  4  float    sum_
  4  uint32_t time_period_
  4  uint32_t n_         : 31
     uint32_t have_nan_  :  1
                                         = 24 B
```

## Bound on `n_`

`n_` is incremented once per source publish per throttle window and reset at every interval tick. To guarantee no overflow under any realistic configuration, this PR caps the YAML `time_period` at 24 h (`cv.Range(max=cv.TimePeriod(hours=24))`). At a pessimistic 1 kHz source rate the counter peaks at 86.4 M — well below `2^31` (2.1 B), giving ~25× headroom. Most sources update at 1–100 Hz, so the practical margin is much larger.

## Why a 24 h cap is acceptable

A `throttle_average` filter computes the arithmetic mean of values arriving within a fixed time window and emits one result per window. Rolling averages over multi-day windows have very different desired semantics (e.g. exponential decay, percentile thresholds, or sliding-window aggregation against persistent storage) and aren't well served by accumulating an unbounded sample count and a single running sum. Anyone trying to use `throttle_average` with a window longer than a day is almost certainly reaching for the wrong tool — and would also be hitting precision-loss problems with the running float sum well before the bitfield matters.

No real-world ESPHome configurations are expected to specify a `throttle_average` period longer than 24 h.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6556

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
sensor:
  - platform: template
    name: "My Sensor"
    lambda: |-
      return 1.23;
    update_interval: 1s
    filters:
      - throttle_average: 60s   # OK: well under 24 h cap
      # - throttle_average: 48h # rejected: exceeds 24 h cap
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).