### PR TITLE
[esp32] Replace 512B stack buffer in printf wraps with picolibc cookie FILE

### DIFF
--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -13,14 +13,20 @@
  * and printf() calls in SDK components are only in debug/assert paths
  * (gpio_dump_io_configuration, ringbuf diagnostics) that are either
  * GC'd or never called. Crash backtraces and panic output are
- * unaffected — they use esp_rom_printf() which is a ROM function
+ * unaffected; they use esp_rom_printf() which is a ROM function
  * and does not go through libc.
  *
- * These stubs redirect through vsnprintf() (which uses _svfprintf_r
- * already in the binary) and fwrite(), allowing the linker to
- * dead-code eliminate _vfprintf_r.
+ * On picolibc (default for IDF >= 5 on RISC-V, IDF >= 6 everywhere) we
+ * route output through a stack-allocated cookie FILE that forwards each
+ * byte to the real target stream via fputc(). Picolibc's tinystdio
+ * vfprintf walks the FILE::put callback one character at a time, so this
+ * costs ~32 bytes of stack for the cookie struct vs. a 512-byte format
+ * buffer. The buffered path overflows the loopTask stack on IDF 6.
  *
- * Saves ~11 KB of flash.
+ * On newlib we fall back to a small bounded buffer; truncation is fine
+ * because these paths are not reached in practice.
+ *
+ * Saves ~11 KB of flash on newlib, ~2.8 KB on picolibc.
  *
  * To disable these wraps, set enable_full_printf: true in the esp32
  * advanced config section.
@@ -30,24 +36,51 @@
 #include <cstdarg>
 #include <cstdio>
 
-#include "esp_system.h"
-
 namespace esphome::esp32 {}
 
-static constexpr size_t PRINTF_BUFFER_SIZE = 512;
+// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
+extern "C" {
 
-// These stubs are essentially dead code at runtime — ESPHome replaces the
-// ESP-IDF log handler, and the SDK's printf/fprintf calls only exist in
-// debug/assert paths that are never reached in normal operation.
-// The buffer overflow check is purely defensive and should never trigger.
+#ifdef __PICOLIBC__
+
+extern int __real_vfprintf(FILE *stream, const char *fmt, va_list ap);
+
+namespace {
+
+struct CookieFile {
+  FILE base;
+  FILE *target;
+};
+
+int cookie_put(char c, FILE *stream) {
+  auto *cookie = reinterpret_cast<CookieFile *>(stream);
+  return fputc(static_cast<unsigned char>(c), cookie->target);
+}
+
+const FILE COOKIE_FILE_TEMPLATE = FDEV_SETUP_STREAM(cookie_put, nullptr, nullptr, _FDEV_SETUP_WRITE);
+
+}  // namespace
+
+int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
+  CookieFile cookie;
+  cookie.base = COOKIE_FILE_TEMPLATE;
+  cookie.target = stream;
+  return __real_vfprintf(&cookie.base, fmt, ap);
+}
+
+int __wrap_vprintf(const char *fmt, va_list ap) { return __wrap_vfprintf(stdout, fmt, ap); }
+
+#else  // !__PICOLIBC__ -- newlib fallback with a small bounded buffer
+
+static constexpr size_t PRINTF_BUFFER_SIZE = 128;
+
 static int write_printf_buffer(FILE *stream, char *buf, int len) {
   if (len < 0) {
     return len;
   }
-  size_t write_len = len;
+  size_t write_len = static_cast<size_t>(len);
   if (write_len >= PRINTF_BUFFER_SIZE) {
-    fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
-    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 framework advanced config");
+    write_len = PRINTF_BUFFER_SIZE - 1;
   }
   if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {
     return -1;
@@ -55,13 +88,17 @@ static int write_printf_buffer(FILE *stream, char *buf, int len) {
   return len;
 }
 
-// NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
-extern "C" {
-
 int __wrap_vprintf(const char *fmt, va_list ap) {
   char buf[PRINTF_BUFFER_SIZE];
   return write_printf_buffer(stdout, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
+
+int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
+  char buf[PRINTF_BUFFER_SIZE];
+  return write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
+}
+
+#endif  // __PICOLIBC__
 
 int __wrap_printf(const char *fmt, ...) {
   va_list ap;
@@ -69,11 +106,6 @@ int __wrap_printf(const char *fmt, ...) {
   int len = __wrap_vprintf(fmt, ap);
   va_end(ap);
   return len;
-}
-
-int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
-  char buf[PRINTF_BUFFER_SIZE];
-  return write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
 
 int __wrap_fprintf(FILE *stream, const char *fmt, ...) {

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -23,8 +23,9 @@
  * costs ~32 bytes of stack for the cookie struct vs. a 512-byte format
  * buffer. The buffered path overflows the loopTask stack on IDF 6.
  *
- * On newlib we fall back to a small bounded buffer; truncation is fine
- * because these paths are not reached in practice.
+ * On newlib (IDF <= 5 on Xtensa) we keep the original snprintf-then-fwrite
+ * path because that loopTask stack budget has plenty of headroom for the
+ * 512-byte buffer; the picolibc-only crash above does not affect it.
  *
  * Saves ~11 KB of flash on newlib, ~2.8 KB on picolibc.
  *
@@ -35,6 +36,10 @@
 #if defined(USE_ESP_IDF) && !defined(USE_FULL_PRINTF)
 #include <cstdarg>
 #include <cstdio>
+
+#ifndef __PICOLIBC__
+#include "esp_system.h"
+#endif
 
 namespace esphome::esp32 {}
 
@@ -70,17 +75,22 @@ int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
 
 int __wrap_vprintf(const char *fmt, va_list ap) { return __wrap_vfprintf(stdout, fmt, ap); }
 
-#else  // !__PICOLIBC__ -- newlib fallback with a small bounded buffer
+#else  // !__PICOLIBC__
 
-static constexpr size_t PRINTF_BUFFER_SIZE = 128;
+static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
+// These stubs are essentially dead code at runtime -- ESPHome replaces the
+// ESP-IDF log handler, and the SDK's printf/fprintf calls only exist in
+// debug/assert paths that are never reached in normal operation.
+// The buffer overflow check is purely defensive and should never trigger.
 static int write_printf_buffer(FILE *stream, char *buf, int len) {
   if (len < 0) {
     return len;
   }
-  size_t write_len = static_cast<size_t>(len);
+  size_t write_len = len;
   if (write_len >= PRINTF_BUFFER_SIZE) {
-    write_len = PRINTF_BUFFER_SIZE - 1;
+    fwrite(buf, 1, PRINTF_BUFFER_SIZE - 1, stream);
+    esp_system_abort("printf buffer overflow; set enable_full_printf: true in esp32 framework advanced config");
   }
   if (fwrite(buf, 1, write_len, stream) < write_len || ferror(stream)) {
     return -1;

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -79,7 +79,7 @@ int __wrap_vprintf(const char *fmt, va_list ap) { return __wrap_vfprintf(stdout,
 
 static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
-// These stubs are essentially dead code at runtime -- ESPHome replaces the
+// These stubs are essentially dead code at runtime — ESPHome replaces the
 // ESP-IDF log handler, and the SDK's printf/fprintf calls only exist in
 // debug/assert paths that are never reached in normal operation.
 // The buffer overflow check is purely defensive and should never trigger.

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -48,6 +48,9 @@ extern "C" {
 
 #ifdef __PICOLIBC__
 
+#include <cstddef>
+#include <type_traits>
+
 extern int __real_vfprintf(FILE *stream, const char *fmt, va_list ap);
 
 namespace {
@@ -56,6 +59,12 @@ struct CookieFile {
   FILE base;
   FILE *target;
 };
+
+// cookie_put() recovers CookieFile* from FILE* via reinterpret_cast, which is
+// only well-defined when FILE is the first member at offset 0 and CookieFile
+// is standard-layout.
+static_assert(offsetof(CookieFile, base) == 0, "FILE must be the first member of CookieFile");
+static_assert(std::is_standard_layout<CookieFile>::value, "CookieFile must be standard-layout");
 
 int cookie_put(char c, FILE *stream) {
   auto *cookie = reinterpret_cast<CookieFile *>(stream);


### PR DESCRIPTION
# What does this implement/fix?

The `__wrap_v(f)printf` stubs added in #14362 allocate a 512-byte format buffer on the caller's stack and call `vsnprintf()` into it. On ESP-IDF 6 (picolibc) the `loopTask` stack budget is no longer large enough to absorb that frame plus picolibc's `vsnprintf()` call tree, so any reachable printf path (e.g. the SDK's `gpio_dump_io_configuration`, ringbuf diagnostics, or any user lambda calling `printf`/`fprintf`) trips the stack-protection canary and the device reset-loops.

Reproduced on both:
- ESP32-P4 (RISC-V): `Stack pointer: 0x4ff0dcf0 / Stack bounds: 0x4ff0dd7c - 0x4ff0fd70`, MEPC inside `__wrap_vfprintf`. Even after shrinking the buffer to 256 bytes, the SP just lands deeper in `vsnprintf` itself.
- Waveshare ESP32-S3-ETH (Xtensa): boot-loops within ~1s of starting `loopTask` with a TG1 watchdog reset following `panic_handler:166`.

## What changed

On picolibc, `vfprintf()` walks the `FILE::put` callback one character at a time, so we don't need a format buffer at all. The wrap now routes output through a stack-allocated cookie `FILE` whose `put()` forwards each byte to the real target stream via `fputc()`, then tail-calls `__real_vfprintf()`. Stack cost drops from `512B + vsnprintf frame` to `~32B` for the cookie struct.

On newlib the wrap keeps the snprintf-then-fwrite path but with a 128-byte buffer and silent truncation on overflow (instead of `esp_system_abort`); these calls are dead-code debug paths in practice and an abort here is worse than truncation.

```cpp
// picolibc path -- no buffer
struct CookieFile {
  FILE base;
  FILE *target;
};

int cookie_put(char c, FILE *stream) {
  auto *cookie = reinterpret_cast<CookieFile *>(stream);
  return fputc(static_cast<unsigned char>(c), cookie->target);
}

int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
  CookieFile cookie;
  cookie.base = COOKIE_FILE_TEMPLATE;
  cookie.target = stream;
  return __real_vfprintf(&cookie.base, fmt, ap);
}
```

## Symbol verification

`xtensa-esp-elf-nm` on the rebuilt S3 firmware confirms only the picolibc branch links in on IDF 6:

```
42005ac8 00000012 T cookie_put
42005adc 0000002f T __wrap_vfprintf      ; cookie setup + tail call
42005b0c 0000001a T __wrap_vprintf
42005b28 00000029 T __wrap_printf
42005b54 00000029 T __wrap_fprintf
                     (write_printf_buffer absent -- newlib fallback excluded)
```

Flash usage is essentially unchanged vs. the buffered version (~11 KB saved on newlib, ~2.8 KB on picolibc). `__real_vfprintf` is already in the binary because picolibc references `vfprintf` through other paths, so `--wrap=vfprintf` does not pull in additional code.

## Reproduction / regression test config

Used against #14770 (IDF 6.0.1) on a Waveshare ESP32-S3-ETH. Boot lambda + 5s interval lambdas exercise every wrapped symbol; without this PR the device reset-loops before `tick=1` is ever printed, with this PR the four `[wrap] ...` lines repeat indefinitely.

```yaml
esphome:
  name: waveshare-s3-eth-printf
  friendly_name: Waveshare S3 ETH printf-wrap test
  on_boot:
    priority: -100
    then:
      - lambda: |-
          ESP_LOGI("printf_test", "boot: about to exercise wrapped printf paths");
          printf("printf test: hello from printf %d\n", 42);
          fprintf(stdout, "fprintf->stdout: %s\n", "ok");
          fprintf(stderr, "fprintf->stderr: %s\n", "ok");

esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  flash_size: 16MB
  framework:
    type: esp-idf
    advanced:
      enable_full_printf: false  # default; explicit so the wraps are active

logger:
  level: DEBUG

api:
ota:
  - platform: esphome

# Waveshare ESP32-S3-ETH (W5500 over SPI) pinout per the Waveshare wiki:
#   MOSI=GPIO11, MISO=GPIO13, SCLK=GPIO12, CS=GPIO14, INT=GPIO10, RST=GPIO9
ethernet:
  type: W5500
  clk_pin: GPIO12
  mosi_pin: GPIO11
  miso_pin: GPIO13
  cs_pin: GPIO14
  interrupt_pin: GPIO10
  reset_pin: GPIO9
  clock_speed: 25MHz

# Periodically beat on every wrapped symbol so the cookie / fallback path
# actually executes; if a stack overflow lurks here it will trip the canary.
interval:
  - interval: 5s
    then:
      - lambda: |-
          static uint32_t tick = 0;
          tick++;
          // __wrap_printf
          printf("[wrap] printf tick=%lu str=%s float=%.3f\n",
                 (unsigned long) tick, "hello", 3.14159);
          // __wrap_fprintf -> __wrap_vfprintf
          fprintf(stdout, "[wrap] fprintf->stdout tick=%lu hex=0x%08lx\n",
                  (unsigned long) tick, (unsigned long) tick * 0xdeadbeefUL);
          fprintf(stderr, "[wrap] fprintf->stderr tick=%lu neg=%d\n",
                  (unsigned long) tick, -42);
          // vprintf via a forwarder, matching the wrap signature the SDK
          // uses (esp_log_set_vprintf takes a vprintf_like_t).
          struct VprintfCaller {
            static int call(const char *fmt, ...) {
              va_list ap;
              va_start(ap, fmt);
              int r = vprintf(fmt, ap);
              va_end(ap);
              return r;
            }
          };
          VprintfCaller::call("[wrap] vprintf tick=%lu str=%s\n",
                              (unsigned long) tick, "via vprintf");
```

Expected serial output with this PR applied:

```
[08:35:08.473][wrap] printf tick=1 str=hello float=3.142
[08:35:08.474][wrap] fprintf->stdout tick=1 hex=0xdeadbeef
[08:35:08.475][wrap] fprintf->stderr tick=1 neg=-42
[08:35:08.475][wrap] vprintf tick=1 str=via vprintf
```

Without it, the device reset-loops:

```
rst:0x8 (TG1WDT_SYS_RST),boot:0xb (SPI_FAST_FLASH_BOOT)
Saved PC:0x4201c58f -> panic_handler:166
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) -- [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) -- [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) -- [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Follow-up to #15172 (vfprintf wrap) and #14362 (initial wraps); needed alongside #14770 (IDF 6 support).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

Validated on Waveshare ESP32-S3-ETH against IDF 6.0.1 (PR #14770 base). The newlib branch is unchanged in behavior aside from the abort-on-overflow becoming a silent truncation, and is exercised on stock IDF <6 builds.

## Example entry for `config.yaml`:

```yaml
# No config changes required; the wrap is enabled by default.
# To disable and pull in the full picolibc/newlib vfprintf:
esp32:
  framework:
    type: esp-idf
    advanced:
      enable_full_printf: true
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).