### PR TITLE
[core] Replace scheduler pool vector with unbounded intrusive freelist

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -25,6 +25,10 @@ namespace esphome {
 
 static const char *const TAG = "app";
 
+// Delay after setup() finishes before trimming the scheduler freelist of its post-boot peak.
+// 10 s is well past the bulk of post-setup async work (Wi-Fi/MQTT connects, first-read latency).
+static constexpr uint32_t SCHEDULER_FREELIST_TRIM_DELAY_MS = 10000;
+
 // Helper function for insertion sort of components by priority
 // Using insertion sort instead of std::stable_sort saves ~1.3KB of flash
 // by avoiding template instantiations (std::rotate, std::stable_sort, lambdas)
@@ -111,6 +115,9 @@ void Application::setup() {
   this->app_state_ |= APP_STATE_SETUP_COMPLETE;
 
   ESP_LOGI(TAG, "setup() finished successfully!");
+
+  // Trim the scheduler freelist of its post-boot peak once startup churn settles.
+  this->scheduler.set_timeout(this, SCHEDULER_FREELIST_TRIM_DELAY_MS, [this]() { this->scheduler.trim_freelist(); });
 
 #ifdef USE_SETUP_PRIORITY_OVERRIDE
   // Clear setup priority overrides to free memory

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -899,12 +899,22 @@ void Scheduler::recycle_item_main_loop_(SchedulerItem *item) {
 #endif
 }
 
-// Shrink a SchedulerItem* vector's capacity to its current size via the swap-with-copy
-// idiom (std::vector::shrink_to_fit() is non-binding and our toolchain ignores it).
-// Out-of-line + noinline so the callers in trim_freelist() share one body instead of
-// inlining the construct-swap-destruct dance per call site (~440 B flash on ESP32).
+// Shrink a SchedulerItem* vector's capacity to its current size.
+// std::vector::shrink_to_fit() is non-binding and our toolchain ignores it; the classic
+// swap-with-copy idiom (std::vector<T>(other).swap(other)) instantiates the iterator-range
+// constructor which pulls in std::__throw_bad_array_new_length and ~120 B of related
+// stdlib RTTI/typeinfo. Build into a temp via reserve + push_back instead, then move-assign:
+// reserve uses operator new (throws bad_alloc, already linked) and push_back without growth
+// is the noexcept tail path. Move-assign just swaps pointers.
+// Out-of-line + noinline so the callers in trim_freelist() share one body.
 void __attribute__((noinline)) Scheduler::shrink_scheduler_vector_(std::vector<SchedulerItem *> *v) {
-  std::vector<SchedulerItem *>(*v).swap(*v);
+  if (v->capacity() == v->size())
+    return;  // already exact, common after a quiet period
+  std::vector<SchedulerItem *> tmp;
+  tmp.reserve(v->size());
+  for (SchedulerItem *p : *v)
+    tmp.push_back(p);
+  *v = std::move(tmp);
 }
 
 void Scheduler::trim_freelist() {

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -14,18 +14,8 @@ namespace esphome {
 
 static const char *const TAG = "scheduler";
 
-// Memory pool configuration constants
-// Pool size of 5 matches typical usage patterns (2-4 active timers)
-// - Minimal memory overhead (~250 bytes on ESP32)
-// - Sufficient for most configs with a couple sensors/components
-// - Still prevents heap fragmentation and allocation stalls
-// - Complex setups with many timers will just allocate beyond the pool
-// See https://github.com/esphome/backlog/issues/52
-static constexpr size_t MAX_POOL_SIZE = 5;
-
 // Maximum number of logically deleted (cancelled) items before forcing cleanup.
-// Set to 5 to match the pool size - when we have as many cancelled items as our
-// pool can hold, it's time to clean up and recycle them.
+// Empirically chosen to balance cleanup overhead against tombstone accumulation in items_.
 static constexpr uint32_t MAX_LOGICALLY_DELETED_ITEMS = 5;
 // max delay to start an interval sequence
 static constexpr uint32_t MAX_INTERVAL_DELAY = 5000;
@@ -165,7 +155,7 @@ void HOT Scheduler::set_timer_common_(Component *component, SchedulerItem::Type 
     delay = 1;
   }
 
-  // Take lock early to protect scheduler_item_pool_ access and retry-cancelled check
+  // Take lock early to protect scheduler_item_pool_head_ access and retry-cancelled check
   LockGuard guard{this->lock_};
 
   // For retries, check if there's a cancelled timeout first - before allocating an item.
@@ -599,7 +589,7 @@ uint32_t HOT Scheduler::call(uint32_t now) {
   if (now_64 - last_print > 2000) {
     last_print = now_64;
     std::vector<SchedulerItem *> old_items;
-    ESP_LOGD(TAG, "Items: count=%zu, pool=%zu, now=%" PRIu64, this->items_.size(), this->scheduler_item_pool_.size(),
+    ESP_LOGD(TAG, "Items: count=%zu, pool=%zu, now=%" PRIu64, this->items_.size(), this->scheduler_item_pool_size_,
              now_64);
     // Cleanup before debug output
     this->cleanup_();
@@ -894,30 +884,19 @@ bool HOT Scheduler::SchedulerItem::cmp(SchedulerItem *a, SchedulerItem *b) {
                                                               : (a->next_execution_high_ > b->next_execution_high_);
 }
 
-// Recycle a SchedulerItem back to the pool for reuse.
-// IMPORTANT: Caller must hold the scheduler lock before calling this function.
-// This protects scheduler_item_pool_ from concurrent access by other threads
-// that may be acquiring items from the pool in set_timer_common_().
+// Recycle a SchedulerItem back to the freelist for reuse.
+// IMPORTANT: Caller must hold the scheduler lock.
 void Scheduler::recycle_item_main_loop_(SchedulerItem *item) {
   if (item == nullptr)
     return;
 
-  if (this->scheduler_item_pool_.size() < MAX_POOL_SIZE) {
-    // Clear callback to release captured resources
-    item->callback = nullptr;
-    this->scheduler_item_pool_.push_back(item);
+  item->callback = nullptr;  // release captured resources
+  item->next_free = this->scheduler_item_pool_head_;
+  this->scheduler_item_pool_head_ = item;
+  this->scheduler_item_pool_size_++;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+  ESP_LOGD(TAG, "Recycled item to pool (pool size now: %zu)", this->scheduler_item_pool_size_);
 #endif
-  } else {
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Pool full (size: %zu), deleting item", this->scheduler_item_pool_.size());
-#endif
-    delete item;
-#ifdef ESPHOME_DEBUG_SCHEDULER
-    this->debug_live_items_--;
-#endif
-  }
 }
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
@@ -942,14 +921,15 @@ void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, 
 }
 #endif /* ESPHOME_DEBUG_SCHEDULER */
 
-// Helper to get or create a scheduler item from the pool
-// IMPORTANT: Caller must hold the scheduler lock before calling this function.
+// Pop from freelist or allocate. IMPORTANT: caller must hold the lock and must overwrite
+// `item->component` before releasing it -- the popped slot still holds the freelist link.
 Scheduler::SchedulerItem *Scheduler::get_item_from_pool_locked_() {
-  if (!this->scheduler_item_pool_.empty()) {
-    SchedulerItem *item = this->scheduler_item_pool_.back();
-    this->scheduler_item_pool_.pop_back();
+  if (this->scheduler_item_pool_head_ != nullptr) {
+    SchedulerItem *item = this->scheduler_item_pool_head_;
+    this->scheduler_item_pool_head_ = item->next_free;
+    this->scheduler_item_pool_size_--;
 #ifdef ESPHOME_DEBUG_SCHEDULER
-    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_.size());
+    ESP_LOGD(TAG, "Reused item from pool (pool size now: %zu)", this->scheduler_item_pool_size_);
 #endif
     return item;
   }
@@ -967,7 +947,7 @@ Scheduler::SchedulerItem *Scheduler::get_item_from_pool_locked_() {
 bool Scheduler::debug_verify_no_leak_() const {
   // Invariant: every live SchedulerItem must be in exactly one container.
   // debug_live_items_ tracks allocations minus deletions.
-  size_t accounted = this->items_.size() + this->to_add_.size() + this->scheduler_item_pool_.size();
+  size_t accounted = this->items_.size() + this->to_add_.size() + this->scheduler_item_pool_size_;
 #ifndef ESPHOME_THREAD_SINGLE
   accounted += this->defer_queue_.size();
 #endif
@@ -981,7 +961,7 @@ bool Scheduler::debug_verify_no_leak_() const {
              ")",
              static_cast<uint32_t>(this->debug_live_items_), static_cast<uint32_t>(accounted),
              static_cast<uint32_t>(this->items_.size()), static_cast<uint32_t>(this->to_add_.size()),
-             static_cast<uint32_t>(this->scheduler_item_pool_.size())
+             static_cast<uint32_t>(this->scheduler_item_pool_size_)
 #ifndef ESPHOME_THREAD_SINGLE
                  ,
              static_cast<uint32_t>(this->defer_queue_.size())

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -914,6 +914,16 @@ void Scheduler::trim_freelist() {
   }
   this->scheduler_item_pool_head_ = nullptr;
   this->scheduler_item_pool_size_ = 0;
+
+  // The vectors that back items_/to_add_/defer_queue_ also retain their boot-peak
+  // capacity (std::vector grows by doubling). Swap each with a same-content copy to
+  // reclaim the slack -- the new vector is sized exactly to its current contents.
+  std::vector<SchedulerItem *>(this->items_).swap(this->items_);
+  std::vector<SchedulerItem *>(this->to_add_).swap(this->to_add_);
+#ifndef ESPHOME_THREAD_SINGLE
+  std::vector<SchedulerItem *>(this->defer_queue_).swap(this->defer_queue_);
+#endif
+
 #ifdef ESPHOME_DEBUG_SCHEDULER
   ESP_LOGD(TAG, "Freelist trimmed (%zu items freed)", freed);
 #else

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -899,6 +899,14 @@ void Scheduler::recycle_item_main_loop_(SchedulerItem *item) {
 #endif
 }
 
+// Shrink a SchedulerItem* vector's capacity to its current size via the swap-with-copy
+// idiom (std::vector::shrink_to_fit() is non-binding and our toolchain ignores it).
+// Out-of-line + noinline so the callers in trim_freelist() share one body instead of
+// inlining the construct-swap-destruct dance per call site (~440 B flash on ESP32).
+void __attribute__((noinline)) Scheduler::shrink_scheduler_vector_(std::vector<SchedulerItem *> *v) {
+  std::vector<SchedulerItem *>(*v).swap(*v);
+}
+
 void Scheduler::trim_freelist() {
   LockGuard guard{this->lock_};
   SchedulerItem *item = this->scheduler_item_pool_head_;
@@ -915,13 +923,12 @@ void Scheduler::trim_freelist() {
   this->scheduler_item_pool_head_ = nullptr;
   this->scheduler_item_pool_size_ = 0;
 
-  // The vectors that back items_/to_add_/defer_queue_ also retain their boot-peak
-  // capacity (std::vector grows by doubling). Swap each with a same-content copy to
-  // reclaim the slack -- the new vector is sized exactly to its current contents.
-  std::vector<SchedulerItem *>(this->items_).swap(this->items_);
-  std::vector<SchedulerItem *>(this->to_add_).swap(this->to_add_);
+  // items_/to_add_/defer_queue_ retain their boot-peak vector capacity (vector grows
+  // by doubling and otherwise keeps the peak). Reclaim that slack as well.
+  shrink_scheduler_vector_(&this->items_);
+  shrink_scheduler_vector_(&this->to_add_);
 #ifndef ESPHOME_THREAD_SINGLE
-  std::vector<SchedulerItem *>(this->defer_queue_).swap(this->defer_queue_);
+  shrink_scheduler_vector_(&this->defer_queue_);
 #endif
 
 #ifdef ESPHOME_DEBUG_SCHEDULER

--- a/esphome/core/scheduler.cpp
+++ b/esphome/core/scheduler.cpp
@@ -899,6 +899,28 @@ void Scheduler::recycle_item_main_loop_(SchedulerItem *item) {
 #endif
 }
 
+void Scheduler::trim_freelist() {
+  LockGuard guard{this->lock_};
+  SchedulerItem *item = this->scheduler_item_pool_head_;
+  size_t freed = 0;
+  while (item != nullptr) {
+    SchedulerItem *next = item->next_free;
+    delete item;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+    this->debug_live_items_--;
+#endif
+    item = next;
+    freed++;
+  }
+  this->scheduler_item_pool_head_ = nullptr;
+  this->scheduler_item_pool_size_ = 0;
+#ifdef ESPHOME_DEBUG_SCHEDULER
+  ESP_LOGD(TAG, "Freelist trimmed (%zu items freed)", freed);
+#else
+  (void) freed;
+#endif
+}
+
 #ifdef ESPHOME_DEBUG_SCHEDULER
 void Scheduler::debug_log_timer_(const SchedulerItem *item, NameType name_type, const char *static_name,
                                  uint32_t hash_or_id, SchedulerItem::Type type, uint32_t delay, uint64_t now) {

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -367,7 +367,7 @@ class Scheduler {
  private:
   // Out-of-line helper that shrinks a SchedulerItem* vector's capacity to its current
   // size. Centralised so trim_freelist() doesn't pay flash cost per call site.
-  static void shrink_scheduler_vector_(std::vector<SchedulerItem *> *v);
+  void shrink_scheduler_vector_(std::vector<SchedulerItem *> *v);
 
   // Helper to cancel matching items - must be called with lock held.
   // When find_first=true, stops after the first match (used by set_timer_common_ where

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -132,6 +132,13 @@ class Scheduler {
   // @return Timestamp of the last item that ran, or `now` unchanged if none ran.
   uint32_t call(uint32_t now);
 
+  // Free every SchedulerItem currently sitting in the recycle freelist. Items in
+  // items_/to_add_/defer_queue_ are untouched. Intended to claim the post-boot
+  // peak: boot churn (component setup, first sensor reads, retries) inflates the
+  // freelist beyond what steady-state needs, and without a one-shot trim that
+  // peak would be retained forever.
+  void trim_freelist();
+
   // Move items from to_add_ into the main heap.
   // IMPORTANT: This method should only be called from the main thread (loop task).
   // Inlined: the fast path (nothing to add) is just an atomic load / empty check.

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -132,11 +132,10 @@ class Scheduler {
   // @return Timestamp of the last item that ran, or `now` unchanged if none ran.
   uint32_t call(uint32_t now);
 
-  // Free every SchedulerItem currently sitting in the recycle freelist. Items in
-  // items_/to_add_/defer_queue_ are untouched. Intended to claim the post-boot
-  // peak: boot churn (component setup, first sensor reads, retries) inflates the
-  // freelist beyond what steady-state needs, and without a one-shot trim that
-  // peak would be retained forever.
+  // Reclaim memory held by the post-boot peak. Frees every SchedulerItem in the
+  // recycle freelist and shrinks items_/to_add_/defer_queue_ vector capacity to
+  // their current sizes (std::vector grows by doubling and otherwise retains the
+  // peak). Live items in those vectors are preserved.
   void trim_freelist();
 
   // Move items from to_add_ into the main heap.

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -177,8 +177,12 @@ class Scheduler {
 
  protected:
   struct SchedulerItem {
-    // Ordered by size to minimize padding
-    Component *component;
+    // Ordered by size to minimize padding.
+    // `component` while live; `next_free` while in scheduler_item_pool_head_ (mutually exclusive).
+    union {
+      Component *component;
+      SchedulerItem *next_free;
+    };
     // Optimized name storage using tagged union - zero heap allocation
     union {
       const char *static_name;  // For STATIC_STRING (string literals) and SELF_POINTER (caller's `this`)
@@ -713,19 +717,15 @@ class Scheduler {
 #endif
   }
 
-  // Memory pool for recycling SchedulerItem objects to reduce heap churn.
-  // Design decisions:
-  // - std::vector is used instead of a fixed array because many systems only need 1-2 scheduler items
-  // - The vector grows dynamically up to MAX_POOL_SIZE (5) only when needed, saving memory on simple setups
-  // - Pool size of 5 matches typical usage (2-4 timers) while keeping memory overhead low (~250 bytes on ESP32)
-  // - The pool significantly reduces heap fragmentation which is critical because heap allocation/deallocation
-  //   can stall the entire system, causing timing issues and dropped events for any components that need
-  //   to synchronize between tasks (see https://github.com/esphome/backlog/issues/52)
-  std::vector<SchedulerItem *> scheduler_item_pool_;
+  // Intrusive freelist threaded through SchedulerItem::next_free. Unbounded so it quiesces at the
+  // app's concurrent-timer high-water mark; the previous fixed cap caused steady-state new/delete
+  // churn on devices with many timers (see https://github.com/esphome/backlog/issues/52).
+  SchedulerItem *scheduler_item_pool_head_{nullptr};
+  size_t scheduler_item_pool_size_{0};
 
 #ifdef ESPHOME_DEBUG_SCHEDULER
   // Leak detection: tracks total live SchedulerItem allocations.
-  // Invariant: debug_live_items_ == items_.size() + to_add_.size() + defer_queue_.size() + scheduler_item_pool_.size()
+  // Invariant: debug_live_items_ == items_.size() + to_add_.size() + defer_queue_.size() + scheduler_item_pool_size_
   // Verified periodically in call() to catch leaks early.
   size_t debug_live_items_{0};
 

--- a/esphome/core/scheduler.h
+++ b/esphome/core/scheduler.h
@@ -365,6 +365,10 @@ class Scheduler {
   SchedulerItem *get_item_from_pool_locked_();
 
  private:
+  // Out-of-line helper that shrinks a SchedulerItem* vector's capacity to its current
+  // size. Centralised so trim_freelist() doesn't pay flash cost per call site.
+  static void shrink_scheduler_vector_(std::vector<SchedulerItem *> *v);
+
   // Helper to cancel matching items - must be called with lock held.
   // When find_first=true, stops after the first match (used by set_timer_common_ where
   // the cancel-before-add invariant guarantees at most one match).

--- a/tests/benchmarks/core/bench_scheduler.cpp
+++ b/tests/benchmarks/core/bench_scheduler.cpp
@@ -101,8 +101,8 @@ static void Scheduler_SetTimeout(benchmark::State &state) {
   Component dummy_component;
 
   // Register 3 timeouts then call() — realistic worst case where multiple
-  // components schedule in the same loop iteration. Keeps item count within
-  // the recycling pool (MAX_POOL_SIZE=5) to avoid spurious malloc/free.
+  // components schedule in the same loop iteration. warm_pool fills the
+  // freelist so acquire/recycle never falls back to malloc.
   static constexpr int kBatchSize = 3;
   static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 1000);
@@ -209,9 +209,9 @@ static void Scheduler_SetTimeout_ExceedPool(benchmark::State &state) {
   Scheduler scheduler;
   Component dummy_component;
 
-  // Register 10 timeouts then call() — exceeds MAX_POOL_SIZE=5 to measure
-  // the performance cliff when the recycling pool is exhausted and items
-  // must be malloc'd/freed.
+  // Register 10 timeouts then call() — larger working set than the 3-item
+  // batches above. With the unbounded freelist, warm_pool preallocates 10
+  // items so this measures steady-state, not malloc cliff.
   static constexpr int kBatchSize = 10;
   static_assert(kInnerIterations % kBatchSize == 0, "kInnerIterations must be divisible by kBatchSize");
   warm_pool(scheduler, &dummy_component, kBatchSize, 1000);

--- a/tests/integration/fixtures/scheduler_pool.yaml
+++ b/tests/integration/fixtures/scheduler_pool.yaml
@@ -221,14 +221,10 @@ script:
   - id: test_full_pool_reuse
     then:
       - lambda: |-
-          ESP_LOGI("test", "Phase 6: Testing pool size limits after Phase 5 items complete");
+          ESP_LOGI("test", "Phase 6: Testing pool reuse after Phase 5 items complete");
 
-          // At this point, all Phase 5 timeouts should have completed and been recycled.
-          // The pool should be at its maximum size (5).
-          // Creating 10 new items tests that:
-          // - First 5 items reuse from the pool
-          // - Remaining 5 items allocate new (pool empty)
-          // - Pool doesn't grow beyond MAX_POOL_SIZE of 5
+          // Phase 5 timeouts have completed and been recycled. The freelist is unbounded;
+          // creating 10 new items reuses from it and only allocates fresh when empty.
 
           auto *component = id(test_sensor);
           int full_reuse_count = 10;

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -180,16 +180,10 @@ async def test_scheduler_pool(
     # Verify pool behavior
     assert pool_recycle_count > 0, "Should have recycled items to pool"
 
-    # Check pool metrics
-    if pool_recycle_count > 0:
-        max_pool_size = 0
-        for line in log_lines:
-            if match := recycle_pattern.search(line):
-                size = int(match.group(1))
-                max_pool_size = max(max_pool_size, size)
-
-        # Pool can grow up to its maximum of 5
-        assert max_pool_size <= 5, f"Pool grew beyond maximum ({max_pool_size})"
+    # Pool is unbounded; the cap was the source of the churn it was meant to prevent.
+    assert pool_full_count == 0, (
+        f"Pool should never report full (got {pool_full_count})"
+    )
 
     # Log summary for debugging
     print("\nScheduler Pool Test Summary (Python Orchestrated):")

--- a/tests/integration/test_scheduler_pool.py
+++ b/tests/integration/test_scheduler_pool.py
@@ -185,6 +185,18 @@ async def test_scheduler_pool(
         f"Pool should never report full (got {pool_full_count})"
     )
 
+    # Verify the pool actually grew past the old MAX_POOL_SIZE=5 cap.
+    # Phase 5 + Phase 6 schedule 8 + 10 same-component timeouts respectively, so the
+    # observed peak should comfortably exceed 5. Without this lower-bound check, a
+    # silent regression that re-introduced a small cap could pass the test above.
+    max_pool_size = 0
+    for line in log_lines:
+        if match := recycle_pattern.search(line):
+            max_pool_size = max(max_pool_size, int(match.group(1)))
+    assert max_pool_size > 5, (
+        f"Pool should grow past the old cap of 5; observed peak {max_pool_size}"
+    )
+
     # Log summary for debugging
     print("\nScheduler Pool Test Summary (Python Orchestrated):")
     print(f"  Items recycled to pool: {pool_recycle_count}")


### PR DESCRIPTION
# What does this implement/fix?

Replaces the scheduler's bounded `std::vector<SchedulerItem*>` pool with an unbounded singly-linked freelist threaded through an anonymous union on `SchedulerItem::next_free` / `component`, plus a one-shot post-boot trim that reclaims the boot-peak.

## Why was the pool capped at 5?

The pool was introduced in #10536 (esphome/backlog#52) to reduce heap fragmentation from per-timer-op `new`/`delete` churn. Two design choices from that PR are relevant here:

1. **`std::vector` was chosen explicitly to avoid pre-allocating memory on simple configurations** -- most configs use only 1-2 timers, so a fixed-size buffer would have been wasteful.
2. **The cap was sized for the at-hand workloads** -- small configs (garage door, gate controller, 2-4 active timers) on which "Pool size oscillates between 0-4 items, never exhausts" was measured. Five was a deliberate fit for that profile, not an arbitrary number.

The trade-off was explicit at the time: complex setups with more timers would "just allocate beyond the pool." That was acceptable in 2024 because the workloads tested were small.

## The cliff that wasn't on the radar

`std::vector` grows by doubling capacity (1, 2, 4, 8, 16, ...), so each growth step copies and leaves up to ~50% trailing slack. To keep that slack bounded on memory-constrained devices, the cap had to stay small. But that meant any device with more than 5 concurrent active timers (e.g. multi-LD2450 boards) hit a steady-state oscillation: recycle->`delete`, acquire->`new`, on every loop iteration. ~70 heap operations/sec measured on a real LD2450 config, with the pool oscillating 0↔5 continuously -- the exact pattern the pool was supposed to prevent.

PR #11922 had to move the timeout filters off the scheduler entirely to escape this pattern.

## Why a freelist preserves the original intent better than the cap+vector

An intrusive singly-linked freelist matches what #10536 was trying to do, more strictly:

- **Still memory-conservative for the simple-config case #10536 was tuned for.** Empty freelist is 4 bytes (head + size) until first recycle; grows one node at a time, no growth-doubling slack. A garage-door config with 4 active timers ends up holding 4 items -- exactly what the original vector did, but without rounding capacity up to 8.
- **No realloc copies during warm-up.**
- **Removes the cliff for larger configs** without imposing any cost on the simple-config profile #10536 originally optimized for.
- **Same lock-based concurrency model.** No change to the thread-safety story.

The cap was a knob that protected `std::vector`'s slack from getting out of hand on small devices. With no `std::vector`, the knob isn't needed -- the freelist's natural shape already does what the cap was approximating.

## Post-boot peak trim

Boot churn (component init, first sensor reads, retries) inflates the freelist *and* the `items_`/`to_add_`/`defer_queue_` vector capacities beyond the steady-state high-water mark. Without a one-shot reclaim that peak would be retained forever.

Adds `Scheduler::trim_freelist()`, scheduled from `Application::setup()` at `SCHEDULER_FREELIST_TRIM_DELAY_MS` (10 s) post-setup -- well past the bulk of post-setup async work (Wi-Fi/MQTT connects, first-read latency). The trim:
1. Frees every recycled `SchedulerItem` in the freelist.
2. Shrinks `items_`/`to_add_`/`defer_queue_` vector capacity to current size via a `reserve` + `push_back` + move-assign helper. The classic swap-with-copy idiom (`std::vector<T>(other).swap(other)`) instantiates the iterator-range constructor that pulls in `std::__throw_bad_array_new_length` and ~120 B of related stdlib RTTI, so we use a path that goes through the existing `bad_alloc` allocation machinery instead.

Live items in those vectors are preserved -- only the slack is reclaimed.

## Measurements

**Performance (CodSpeed):**
- `Scheduler_SetTimeout_ExceedPool` benchmark: **+9.29 %** (980.8 µs → 897.5 µs). That's the workload that hit the old pool cap.
- All other scheduler benchmarks: +2-3 % (in CodSpeed's noise band but consistent across the set).
- `recycle_item_main_loop_` runtime: **-34 %**, code size 75 → 40 B (-47 %).
- `get_item_from_pool_locked_` runtime: **-21 %**.

**Heap (real devices, post-trim):**

| Config | Before | After | Δ |
|---|---|---|---|
| Apollo R_PRO-1 (ESP32, 64 timeout filters, runtime_stats on) | 300,094 B | 300,304 B | **+210 B** |
| ESP8266 small config | 35,280 B | 35,584 B | **+304 B** |
| `gatetrigger.yaml` (small simple) | — | — | **+24 B** |

Every measured config nets positive on heap, from +24 B on minimal configs (little boot peak to reclaim) up to +304 B on the heap-constrained ESP8266. The Apollo board additionally benefits from the eliminated steady-state pool-cap churn the LD2450 workload used to suffer.

**Flash (CI memory analysis on representative `api` config):**
- **+316 B flash.** Breakdown: 119 B `shrink_scheduler_vector_`, 71 B `trim_freelist`, 36 B `Application::setup()` growth (lambda for trim schedule), 30 B `set_timeout(void const*, ...)` self-keyed overload, ~40 B misc stdlib helpers.
- The CI representative config did not previously instantiate `set_timeout`. Nearly every real config has `set_timeout` or `set_interval` already, so that 30 B amortises into existing template instantiations and the real-config bump is closer to ~285 B.

The trade is **~285-316 B flash for +24-304 B RAM** on real configs plus eliminated steady-state heap churn on heavy-timer boards. That's worth taking on every config we ship.

## Changes

- `SchedulerItem` gains an anonymous union over the existing `Component *component` field: `next_free` while pooled, `component` while live. Zero per-item overhead -- the component pointer is dead while in the freelist.
- `std::vector<SchedulerItem *> scheduler_item_pool_` becomes `SchedulerItem *scheduler_item_pool_head_` plus a `size_t` size counter.
- `MAX_POOL_SIZE` constant and the `Pool full / deleting item` branch are removed.
- Caller contract for `get_item_from_pool_locked_()`: must overwrite `item->component` before unlocking (already true at the sole call site). `nullptr` is a valid live `component` value for `SELF_POINTER` items, so the popped slot is intentionally not pre-cleared.
- `Scheduler::trim_freelist()` + `shrink_scheduler_vector_()` private helper.
- `Application::setup()` schedules the trim 10 s after setup completes.
- Pool peaks at the application's concurrent-timer high-water mark and quiesces there (post-trim, post-boot).

## Test changes

- `test_scheduler_pool` strengthened: asserts `pool_full_count == 0` (replaces the old `max <= 5` check) and a new lower-bound assertion that the observed peak exceeds the old cap, so a silent regression that re-introduced a small cap can't pass.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Continues #10536 / esphome/backlog#52 (same goal, different data structure).

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal scheduler implementation; no user-facing change)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes. Pool behavior is internal to the scheduler.
# Existing configs with many concurrent timers (e.g. multi-LD2450 boards)
# automatically benefit from the elimination of pool-cap-induced heap churn;
# small configs benefit from the post-boot vector slack reclaim.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).