### PR TITLE
[sensor] Drop Component from timeout filters, use self-keyed scheduler

### DIFF
--- a/esphome/components/sensor/__init__.py
+++ b/esphome/components/sensor/__init__.py
@@ -280,7 +280,7 @@ ThrottleWithPriorityFilter = sensor_ns.class_(
 ThrottleWithPriorityNanFilter = sensor_ns.class_(
     "ThrottleWithPriorityNanFilter", Filter
 )
-TimeoutFilterBase = sensor_ns.class_("TimeoutFilterBase", Filter, cg.Component)
+TimeoutFilterBase = sensor_ns.class_("TimeoutFilterBase", Filter)
 TimeoutFilterLast = sensor_ns.class_("TimeoutFilterLast", TimeoutFilterBase)
 TimeoutFilterConfigured = sensor_ns.class_("TimeoutFilterConfigured", TimeoutFilterBase)
 DebounceFilter = sensor_ns.class_("DebounceFilter", Filter, cg.Component)
@@ -730,7 +730,6 @@ async def timeout_filter_to_code(config, filter_id):
         filter_id.type = TimeoutFilterConfigured
         template_ = await cg.templatable(config[CONF_VALUE], [], cg.float_)
         var = cg.new_Pvariable(filter_id, config[CONF_TIMEOUT], template_)
-    await cg.register_component(var, {})
     return var
 
 

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -323,8 +323,8 @@ optional<float> or_filter_new_value(Filter **filters, size_t count, float value,
 }
 
 // TimeoutFilterLast - "last" mode: re-arm on every input; output the latest value if no further
-// input arrives within time_period_. Self-keyed scheduler.set_timeout(this, ...) cancels and
-// replaces any pending arm in O(1).
+// input arrives within time_period_. Self-keyed scheduler.set_timeout(this, ...) cancels any
+// pending arm with the same self-key and installs a new one.
 optional<float> TimeoutFilterLast::new_value(float value) {
   this->pending_value_ = value;
   App.scheduler.set_timeout(this, this->time_period_, [this]() { this->output(this->pending_value_); });

--- a/esphome/components/sensor/filter.cpp
+++ b/esphome/components/sensor/filter.cpp
@@ -322,41 +322,19 @@ optional<float> or_filter_new_value(Filter **filters, size_t count, float value,
   return {};
 }
 
-// TimeoutFilterBase - shared loop logic
-void TimeoutFilterBase::loop() {
-  // Check if timeout period has elapsed
-  // Use cached loop start time to avoid repeated millis() calls
-  const uint32_t now = App.get_loop_component_start_time();
-  if (now - this->timeout_start_time_ >= this->time_period_) {
-    // Timeout fired - get output value from derived class and output it
-    this->output(this->get_output_value());
-
-    // Disable loop until next value arrives
-    this->disable_loop();
-  }
-}
-
-float TimeoutFilterBase::get_setup_priority() const { return setup_priority::HARDWARE; }
-
-// TimeoutFilterLast - "last" mode implementation
+// TimeoutFilterLast - "last" mode: re-arm on every input; output the latest value if no further
+// input arrives within time_period_. Self-keyed scheduler.set_timeout(this, ...) cancels and
+// replaces any pending arm in O(1).
 optional<float> TimeoutFilterLast::new_value(float value) {
-  // Store the value to output when timeout fires
   this->pending_value_ = value;
-
-  // Record when timeout started and enable loop
-  this->timeout_start_time_ = millis();
-  this->enable_loop();
-
+  App.scheduler.set_timeout(this, this->time_period_, [this]() { this->output(this->pending_value_); });
   return value;
 }
 
-// TimeoutFilterConfigured - configured value mode implementation
+// TimeoutFilterConfigured - configured-value mode: re-arm on every input; output the configured
+// value (static or lambda) if no further input arrives within time_period_.
 optional<float> TimeoutFilterConfigured::new_value(float value) {
-  // Record when timeout started and enable loop
-  // Note: we don't store the incoming value since we have a configured value
-  this->timeout_start_time_ = millis();
-  this->enable_loop();
-
+  App.scheduler.set_timeout(this, this->time_period_, [this]() { this->output(this->value_.value()); });
   return value;
 }
 

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -412,22 +412,15 @@ class ThrottleWithPriorityNanFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
-// Base class for timeout filters - contains common loop logic
-class TimeoutFilterBase : public Filter, public Component {
- public:
-  void loop() override;
-  float get_setup_priority() const override;
-
+// Base class for timeout filters. Self-keyed scheduler timeout (`this` as key) re-arms on each
+// new_value(). Filter instances live for the program's lifetime, so the scheduler key never dangles.
+class TimeoutFilterBase : public Filter {
  protected:
-  explicit TimeoutFilterBase(uint32_t time_period) : time_period_(time_period) { this->disable_loop(); }
-  virtual float get_output_value() = 0;
-
-  uint32_t time_period_;            // 4 bytes (timeout duration in ms)
-  uint32_t timeout_start_time_{0};  // 4 bytes (when the timeout was started)
-  // Total base: 8 bytes
+  explicit TimeoutFilterBase(uint32_t time_period) : time_period_(time_period) {}
+  uint32_t time_period_;
 };
 
-// Timeout filter for "last" mode - outputs the last received value after timeout
+// "last" mode — outputs the most recent input after time_period_ ms of silence.
 class TimeoutFilterLast : public TimeoutFilterBase {
  public:
   explicit TimeoutFilterLast(uint32_t time_period) : TimeoutFilterBase(time_period) {}
@@ -435,12 +428,10 @@ class TimeoutFilterLast : public TimeoutFilterBase {
   optional<float> new_value(float value) override;
 
  protected:
-  float get_output_value() override { return this->pending_value_; }
-  float pending_value_{0};  // 4 bytes (value to output when timeout fires)
-  // Total: 8 (base) + 4 = 12 bytes + vtable ptr + Component overhead
+  float pending_value_{0};
 };
 
-// Timeout filter with configured value - evaluates TemplatableValue after timeout
+// Configured-value mode — outputs a static or lambda value after time_period_ ms of silence.
 class TimeoutFilterConfigured : public TimeoutFilterBase {
  public:
   explicit TimeoutFilterConfigured(uint32_t time_period, const TemplatableFn<float> &new_value)
@@ -449,9 +440,7 @@ class TimeoutFilterConfigured : public TimeoutFilterBase {
   optional<float> new_value(float value) override;
 
  protected:
-  float get_output_value() override { return this->value_.value(); }
-  TemplatableFn<float> value_;  // 4 bytes (configured output value, can be lambda)
-  // Total: 8 (base) + 4 = 12 bytes + vtable ptr + Component overhead
+  TemplatableFn<float> value_;
 };
 
 class DebounceFilter : public Filter, public Component {


### PR DESCRIPTION
# What does this implement/fix?

Migrates `TimeoutFilterBase` / `TimeoutFilterLast` / `TimeoutFilterConfigured` off `Component`, mirroring what #16132 does for the other `Component`-based sensor filters (`debounce`, `heartbeat`, `throttle_average`). The timeout filters were the ones #16132 explicitly skipped.

They now arm/re-arm via `App.scheduler.set_timeout(this, ...)` keyed on the filter pointer (self-keyed scheduler API from #16127). Each call cancels any pending arm with the same self-key and installs a new one. Filters live for the program's lifetime, so the self-key never dangles.

## This effectively reverts #11922

PR #11922 moved timeout filters off the scheduler and onto a `Component`-driven `loop()` poll specifically because the bounded `SchedulerItem` pool churned hard on devices with many concurrent timers (multi-LD2450 boards saw ~70 heap ops/sec, with the pool oscillating 0↔5 continuously). The fix was to avoid the scheduler entirely; the cost was carrying `Component` overhead on every timeout filter instance plus a partitioned `loop()` callback (gated via `enable_loop()`/`disable_loop()`) that polls `millis()` while a timeout is armed.

#16172 replaces the bounded `std::vector<SchedulerItem*>` pool with an unbounded intrusive freelist, which eliminates the pool-cap-induced churn that motivated #11922 in the first place. With that out of the way, the scheduler is once again the right primitive for this workload, and we can drop the `Component` baggage these filters were carrying solely as a workaround.

## Depends on

- #16172 — **must merge first.** Without the freelist fix, this PR re-introduces exactly the heap churn #11922 was working around. Do not merge this until #16172 lands and bakes.
- #16127 — self-keyed scheduler API (already in dev).

## Sizes

Per timeout-filter instance: lose the second vptr (multi-inheritance with `Component`), packed `Component` bookkeeping bytes, and the `ComponentRuntimeStats` block when `runtime_stats:` is enabled. Also drops the now-unused `timeout_start_time_` field. Drops `get_setup_priority()` override and the `loop()` poll.

On Apollo R_PRO-1 (64× `TimeoutFilterLast`): roughly 3 KB BSS reclaimed.

## Behavior

Sensor timeout-filter YAML syntax is unchanged. Same observable semantics: re-arm on every input; output the last value (or configured value) after `time_period_` ms of silence.

Note on CPU cost: re-arming a self-keyed timer makes the scheduler scan `items_` and `to_add_` linearly to find any existing entry with the same self-key, then heap-insert the new entry. That's O(N) + O(log N) in the currently-scheduled item count -- typically ~5-10 entries on a board like the Apollo R_PRO-1 even though there are 64 filters total, since most timers are not armed simultaneously. The previous design used `enable_loop()`/`disable_loop()` partitioning so its `loop()` poll only ran for actively-armed filters with a single timestamp compare each. The two costs are comparable in magnitude; this PR's win is structural (no Component baggage, no `loop()` machinery, less memory) rather than raw CPU.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Effectively reverts #11922 now that #16172 removes the underlying scheduler-pool churn.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal class layout; YAML filter syntax unchanged)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing config changes.

sensor:
  - platform: template
    id: my_sensor
    lambda: 'return 42.0;'
    update_interval: 100ms
    filters:
      - timeout: 5s              # "last" mode
      - timeout:                 # configured-value mode
          timeout: 5s
          value: 0.0
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under \`tests/\` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).