### PR TITLE
[esp32_hosted] Bump esp_hosted to 2.12.6 and esp_wifi_remote to 1.5.1

### DIFF
--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -248,6 +248,7 @@ async def to_code(config):
     if idf_ver >= cv.Version(5, 5, 0):
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
         esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
+        esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.5")
         esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.6")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")

--- a/esphome/components/esp32_hosted/__init__.py
+++ b/esphome/components/esp32_hosted/__init__.py
@@ -246,9 +246,9 @@ async def to_code(config):
     idf_ver = esp32.idf_version()
     os.environ["ESP_IDF_VERSION"] = f"{idf_ver.major}.{idf_ver.minor}"
     if idf_ver >= cv.Version(5, 5, 0):
-        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.4.0")
-        esp32.add_idf_component(name="espressif/eppp_link", ref="1.1.4")
-        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.1")
+        esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="1.5.1")
+        esp32.add_idf_component(name="espressif/wifi_remote_over_eppp", ref="0.3.2")
+        esp32.add_idf_component(name="espressif/esp_hosted", ref="2.12.6")
     else:
         esp32.add_idf_component(name="espressif/esp_wifi_remote", ref="0.13.0")
         esp32.add_idf_component(name="espressif/eppp_link", ref="0.2.0")

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -20,15 +20,15 @@ dependencies:
   espressif/mdns:
     version: 1.11.0
   espressif/esp_wifi_remote:
-    version: 1.4.0
+    version: 1.5.1
     rules:
       - if: "target in [esp32h2, esp32p4]"
-  espressif/eppp_link:
-    version: 1.1.4
+  espressif/wifi_remote_over_eppp:
+    version: 0.3.2
     rules:
       - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
-    version: 2.12.1
+    version: 2.12.6
     rules:
       - if: "target in [esp32h2, esp32p4]"
   zorxx/multipart-parser:

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -27,6 +27,10 @@ dependencies:
     version: 0.3.2
     rules:
       - if: "target in [esp32h2, esp32p4]"
+  espressif/eppp_link:
+    version: 1.1.5
+    rules:
+      - if: "target in [esp32h2, esp32p4]"
   espressif/esp_hosted:
     version: 2.12.6
     rules:


### PR DESCRIPTION
# What does this implement/fix?

Bumps the IDF >=5.5 esp_hosted dependency stack:

- `espressif/esp_hosted`: 2.12.1 → 2.12.6
- `espressif/esp_wifi_remote`: 1.4.0 → 1.5.1
- `espressif/eppp_link`: 1.1.4 → 1.1.5
- Adds explicit pin on `espressif/wifi_remote_over_eppp` 0.3.2

`esp_wifi_remote` depends on `wifi_remote_over_eppp`, which in turn depends on `eppp_link`. The previous config pinned `esp_wifi_remote` and `eppp_link` directly but skipped the middle component; this PR pins all three so the dependency chain is fully explicit and reproducible.

The IDF <5.5 path (`esp_wifi_remote` 0.13.0) is unchanged since it still depends on `eppp_link` directly.

## Notable upstream changes

`esp_hosted` 2.12.2 → 2.12.6:
- 2.12.6: make `TAG` in `mempool.c` static to avoid link-time clash
- 2.12.5: OTA image size calculation fix (16-byte alignment padding before SHA256)
- 2.12.5: external coexistence works alongside BT controller on advanced coex chips
- 2.12.4: signature change to `esp_hosted_register_custom_callback` (not used in ESPHome)
- 2.12.3: fix `esp_wifi_scan_get_ap_records` AP count
- 2.12.2: add `esp_hosted_get_cp_info` API (not used in ESPHome)

`esp_wifi_remote` 1.4.0 → 1.5.1:
- 1.5.1: alignment fixes for IDF v5.3 / v5.5 / v6.0
- 1.5.0: support for manual disable; v6.1 alignment

`eppp_link` 1.1.4 → 1.1.5:
- Use C++ traits to control netif predicate type changes

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32_hosted:
  variant: ESP32C6
  active_high: true
  reset_pin: 7
  clk_pin: 43
  cmd_pin: 44
  d0_pin: 39
  d1_pin: 40
  d2_pin: 41
  d3_pin: 42
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).