### PR TITLE
[sendspin] Use sendspin-cpp to v0.4.0 to reduce stuttering

### DIFF
--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -52,8 +52,6 @@ MEMORY_LOCATION_ENUM = {
     MEMORY_INTERNAL: SendspinMemoryLocation.PREFER_INTERNAL,
 }
 
-_MEMORY_LOCATION_VALIDATOR = cv.one_of(*MEMORY_LOCATIONS, lower=True)
-
 # Trailing underscore avoids clashing with sendspin-cpp's global `sendspin` namespace.
 # Analysis tools strip the trailing underscore (same pattern as `template_`).
 sendspin_ns = cg.esphome_ns.namespace("sendspin_")

--- a/esphome/components/sendspin/__init__.py
+++ b/esphome/components/sendspin/__init__.py
@@ -24,6 +24,7 @@ CONF_SENDSPIN_ID = "sendspin_id"
 
 CONF_INITIAL_STATIC_DELAY = "initial_static_delay"
 CONF_FIXED_DELAY = "fixed_delay"
+CONF_DECODE_MEMORY = "decode_memory"
 
 # sendspin-cpp library lives in the global `sendspin` namespace.
 sendspin_library_ns = cg.global_ns.namespace("sendspin")
@@ -38,6 +39,20 @@ CODEC_FORMAT_UNSUPPORTED = SendspinCodecFormat.enum("UNSUPPORTED")
 # Library Structs
 AudioSupportedFormatObject = sendspin_library_ns.struct("AudioSupportedFormatObject")
 PlayerRoleConfig = sendspin_library_ns.struct("PlayerRoleConfig")
+
+# MemoryLocation enum (from sendspin/types.h) controls SPIRAM-vs-internal-RAM placement
+# preference for the player role's transfer buffers.
+SendspinMemoryLocation = sendspin_library_ns.enum("MemoryLocation", is_class=True)
+
+MEMORY_PSRAM = "psram"
+MEMORY_INTERNAL = "internal"
+MEMORY_LOCATIONS = [MEMORY_PSRAM, MEMORY_INTERNAL]
+MEMORY_LOCATION_ENUM = {
+    MEMORY_PSRAM: SendspinMemoryLocation.PREFER_EXTERNAL,
+    MEMORY_INTERNAL: SendspinMemoryLocation.PREFER_INTERNAL,
+}
+
+_MEMORY_LOCATION_VALIDATOR = cv.one_of(*MEMORY_LOCATIONS, lower=True)
 
 # Trailing underscore avoids clashing with sendspin-cpp's global `sendspin` namespace.
 # Analysis tools strip the trailing underscore (same pattern as `template_`).
@@ -193,7 +208,7 @@ async def to_code(config: ConfigType) -> None:
         )
 
     # sendspin-cpp library
-    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.3.1")
+    esp32.add_idf_component(name="sendspin/sendspin-cpp", ref="0.4.0")
 
     cg.add_define("USE_SENDSPIN", True)  # for MDNS
 
@@ -249,14 +264,23 @@ async def to_code(config: ConfigType) -> None:
                 "CONFIG_SPIRAM_ALLOW_STACK_EXTERNAL_MEMORY", True
             )
 
-        player_config_struct = cg.StructInitializer(
-            PlayerRoleConfig,
+        # Library defaults: priority 18 (one above httpd_priority 17 so the decoder is not
+        # starved by the HTTP server during the initial encoded-audio burst at stream start),
+        # interpolation/decode buffer locations PREFER_EXTERNAL.
+        player_struct_fields = [
             ("audio_formats", audio_format_structs),
             ("audio_buffer_capacity", player_cfg[CONF_BUFFER_SIZE]),
             ("fixed_delay_us", player_cfg[CONF_FIXED_DELAY]),
             ("initial_static_delay_ms", player_cfg[CONF_INITIAL_STATIC_DELAY]),
             ("psram_stack", psram_stack),
-            ("priority", 2),
+        ]
+        if (decode_memory := player_cfg.get(CONF_DECODE_MEMORY)) is not None:
+            player_struct_fields.append(
+                ("decode_buffer_location", MEMORY_LOCATION_ENUM[decode_memory])
+            )
+        player_config_struct = cg.StructInitializer(
+            PlayerRoleConfig,
+            *player_struct_fields,
         )
         cg.add(var.set_player_config(player_config_struct))
     else:

--- a/esphome/components/sendspin/media_source/__init__.py
+++ b/esphome/components/sendspin/media_source/__init__.py
@@ -13,6 +13,8 @@ from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 from .. import (
+    _MEMORY_LOCATION_VALIDATOR,
+    CONF_DECODE_MEMORY,
     CONF_FIXED_DELAY,
     CONF_INITIAL_STATIC_DELAY,
     CONF_SENDSPIN_ID,
@@ -57,6 +59,7 @@ def _register(config: ConfigType) -> ConfigType:
             CONF_INITIAL_STATIC_DELAY: config[CONF_INITIAL_STATIC_DELAY],
             CONF_FIXED_DELAY: config[CONF_FIXED_DELAY],
             CONF_TASK_STACK_IN_PSRAM: config.get(CONF_TASK_STACK_IN_PSRAM, False),
+            CONF_DECODE_MEMORY: config.get(CONF_DECODE_MEMORY),
         }
     )
     return config
@@ -82,6 +85,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SAMPLE_RATE, default=48000): cv.int_range(
                 min=16000, max=96000
             ),
+            cv.Optional(CONF_DECODE_MEMORY): _MEMORY_LOCATION_VALIDATOR,
         }
     ),
     cv.only_on_esp32,

--- a/esphome/components/sendspin/media_source/__init__.py
+++ b/esphome/components/sendspin/media_source/__init__.py
@@ -13,11 +13,11 @@ from esphome.cpp_generator import MockObj, TemplateArgsType
 from esphome.types import ConfigType
 
 from .. import (
-    _MEMORY_LOCATION_VALIDATOR,
     CONF_DECODE_MEMORY,
     CONF_FIXED_DELAY,
     CONF_INITIAL_STATIC_DELAY,
     CONF_SENDSPIN_ID,
+    MEMORY_LOCATIONS,
     SendspinHub,
     _validate_task_stack_in_psram,
     register_player_config,
@@ -85,7 +85,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_SAMPLE_RATE, default=48000): cv.int_range(
                 min=16000, max=96000
             ),
-            cv.Optional(CONF_DECODE_MEMORY): _MEMORY_LOCATION_VALIDATOR,
+            cv.Optional(CONF_DECODE_MEMORY): cv.one_of(*MEMORY_LOCATIONS, lower=True),
         }
     ),
     cv.only_on_esp32,

--- a/esphome/idf_component.yml
+++ b/esphome/idf_component.yml
@@ -92,6 +92,6 @@ dependencies:
   esp32async/asynctcp:
     version: 3.4.91
   sendspin/sendspin-cpp:
-    version: 0.3.1
+    version: 0.4.0
   lvgl/lvgl:
     version: 9.5.0

--- a/tests/components/sendspin/common-media_source.yaml
+++ b/tests/components/sendspin/common-media_source.yaml
@@ -7,3 +7,4 @@ media_source:
     initial_static_delay: 5ms
     static_delay_adjustable: true
     fixed_delay: 480us
+    decode_memory: internal


### PR DESCRIPTION
# What does this implement/fix?

**This doesn't completely fix the stuttering on an ESP32, but it does reduce it. I will be making PRs updating the ESPHome audio stack to reduce these further**

On ESP32 devices, starting a new Sendspin stream typically stutters for the first few seconds. This is because the Sendspin server sends a large amount of audio to fill up the clients buffer as fast as possible, and this can cause an underflow in the speaker output (which is just silence) followed up by Sendspin trying to resync.

Sendspin-cpp v0.4.0 ([GitHub](https://github.com/Sendspin/sendspin-cpp) and [Espressif Registry](https://components.espressif.com/components/sendspin/sendspin-cpp/versions/0.4.0/readme)) tries to reduce/mitigate this in several ways:
- Marks all the functions in the httpd -> binary chunk path as hot to reduce cache misses when the callback frequently fires
- Allows the player transfer buffer to be allocated in internal memory (avoiding cache contention with the slower ESP32 psram)
- Allocates the Opus decoder state based on the microOpus sdkconfig settings
- Changes the player task priority to be higher than the websocket server, so the websocket server can't starve the decoder task from CPU cycles (the decoder task still yields to the websocket server task when the ring buffer is empty, so it won't starve in reverse0
- Drops part of a frame after a buffer underflow (so it drops 15 ms of instead of 94 ms of audio for a typical FLAC frame), so the stutter is less pronounced

Using these features, Sendspin can now play stereo Opus audio on an ESP32 (when combined with #16166)!

Beyond the version bump, this PR removes the `priority` setting in the player role config (so it uses the new increased default) and exposes a new setting, `decode_memory` in the media source component to override the default location and allocate that buffer in internal memory.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#6558

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

These settings should help reduce the amount of stuttering on an ESP32 and will allow Opus audio to playback in real time

```yaml
# Example config.yaml

# These sdkconfig options (some are enabled by default) reduce stuttering as well
esp32:
  ...
  framework:
    sdkconfig_options:
      CONFIG_ESP_WIFI_RX_IRAM_OPT: "y" # Unnecessary on an ESP32-S3; uses more internal memory
      CONFIG_ESP_WIFI_IRAM_OPT: "y"  # Unnecessary on an ESP32-S3; uses more internal memory
      CONFIG_ESP_WIFI_EXTRA_IRAM_OPT: "y"  # Unnecessary on an ESP32-S3; uses more internal memory
      CONFIG_LWIP_IRAM_OPTIMIZATION: "y"  # Unnecessary on an ESP32-S3; uses more internal memory

# Pulls in #16166 for audio and this PR for Sendspin (this PR is merged)
external_components:
  - source:
      type: git
      url: https://github.com/esphome/esphome
      ref: "dev"
    components: [audio, sendspin]
    refresh: 0s

audio:
  codecs:
    flac:
      buffer_memory: internal  # Unnecessary on an ESP32-S3; uses more internal memory
    opus:
      state_memory: internal  # Unnecessary on an ESP32-S3; uses more internal memory
      pseudostack:
        threadsafe: false  # Unnecessary on an ESP32-S3; prevents decoding two Opus streams simultaneously

sendspin:

media_source:
  - platform: sendspin
    id: sendspin_source
    decode_memory: internal  # Unnecessary on an ESP32-S3; uses more internal memory


```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [x] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
