### PR TITLE
[bk72xx] Apply CFG_SUPPORT_BLE=0 SDK option to BK7238

### DIFF
--- a/esphome/components/beken_spi_led_strip/light.py
+++ b/esphome/components/beken_spi_led_strip/light.py
@@ -62,6 +62,7 @@ CONF_IS_WRGB = "is_wrgb"
 SUPPORTED_PINS = {
     libretiny.const.FAMILY_BK7231N: [16],
     libretiny.const.FAMILY_BK7231T: [16],
+    libretiny.const.FAMILY_BK7238: [16],
     libretiny.const.FAMILY_BK7251: [16],
 }
 

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_UART_PORT,
     FAMILIES,
     FAMILY_BK7231N,
+    FAMILY_BK7238,
     FAMILY_COMPONENT,
     FAMILY_FRIENDLY,
     FAMILY_RTL8710B,
@@ -549,7 +550,7 @@ async def component_to_code(config):
         cg.add_platformio_option("custom_fw_version", __version__)
 
     # Apply chip-specific SDK options to save RAM/Flash
-    if config[CONF_FAMILY] == FAMILY_BK7231N:
+    if config[CONF_FAMILY] in (FAMILY_BK7231N, FAMILY_BK7238):
         cg.add_platformio_option(
             "custom_options.sys_config#h", _BK7231N_SYS_CONFIG_OPTIONS
         )

--- a/esphome/components/libretiny/__init__.py
+++ b/esphome/components/libretiny/__init__.py
@@ -57,19 +57,22 @@ CODEOWNERS = ["@kuba2k2"]
 AUTO_LOAD = ["preferences"]
 IS_TARGET_PLATFORM = True
 
-# BK7231N SDK options to disable unused features.
+# BLE 5.x BK SDK options to disable unused features.
 # Disabling BLE saves ~21KB RAM and ~200KB Flash because BLE init code is
 # called unconditionally by the SDK. ESPHome doesn't use BLE on LibreTiny.
 #
-# This only works on BK7231N (BLE 5.x). Other BK72XX chips using BLE 4.2
-# (BK7231T, BK7231Q, BK7251; BK7252 boards use the BK7251 family) have a bug
-# where the BLE library still links and references undefined symbols when
-# CFG_SUPPORT_BLE=0.
+# This only works on BLE 5.x BK chips (BK7231N, BK7238). Other BK72XX chips
+# using BLE 4.2 (BK7231T, BK7231Q, BK7251; BK7252 boards use the BK7251 family)
+# have a bug where the BLE library still links and references undefined symbols
+# when CFG_SUPPORT_BLE=0.
+#
+# On BK7238 the SDK also hangs at WiFi STA enable when BLE init runs, so
+# disabling it is required for reliable boot, not just an optimization.
 #
 # Other options like CFG_TX_EVM_TEST, CFG_RX_SENSITIVITY_TEST, CFG_SUPPORT_BKREG,
 # CFG_SUPPORT_OTA_HTTP, and CFG_USE_SPI_SLAVE were evaluated but provide no  # NOLINT
 # measurable benefit - the linker already strips unreferenced code via -gc-sections.
-_BK7231N_SYS_CONFIG_OPTIONS = [
+_BLE5_BK_SYS_CONFIG_OPTIONS = [
     "CFG_SUPPORT_BLE=0",
 ]
 
@@ -552,7 +555,7 @@ async def component_to_code(config):
     # Apply chip-specific SDK options to save RAM/Flash
     if config[CONF_FAMILY] in (FAMILY_BK7231N, FAMILY_BK7238):
         cg.add_platformio_option(
-            "custom_options.sys_config#h", _BK7231N_SYS_CONFIG_OPTIONS
+            "custom_options.sys_config#h", _BLE5_BK_SYS_CONFIG_OPTIONS
         )
 
     # Tune lwIP for ESPHome's actual needs.


### PR DESCRIPTION
# What does this implement/fix?

BK7238 uses BLE 5.x like BK7231N (not BLE 4.2 like BK7231T/Q/7251), so the same `CFG_SUPPORT_BLE=0` Beken SDK option applies — it cleanly disables the unused BLE init code, saving ~21 KB RAM and ~200 KB flash.

Without this change, BK7238 boards hang at WiFi STA enable. The hang was previously masked: users worked around the lack of native BK7238 support by setting `family: BK7231N` on a custom (unrecognized) board, which routed them through the BK7231N SDK option block. After #16018 added the BK7238 family and registered the BK7238 boards (`xh-wb3s`, `t1-u`, `generic-bk7238`, etc.) the libretiny config validator now forces those boards to `FAMILY_BK7238`, dropping `CFG_SUPPORT_BLE=0`. The Beken SDK then runs BLE init unconditionally during WiFi bring-up, which never returns on BK7238.

This PR extends the SDK option gate so `FAMILY_BK7238` joins `FAMILY_BK7231N`. Confirmed via `git bisect` that the regression was introduced by #16018; confirmed by flashing this patch on a BK7238 (`xh-wb3s`) module — boots cleanly and joins WiFi.

Also adds `FAMILY_BK7238: [16]` to `beken_spi_led_strip` `SUPPORTED_PINS` to match the other BK families.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [x] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
bk72xx:
  board: xh-wb3s   # any BK7238 board: xh-wb3s, t1-u, t1-m, t1-2s, t1-3s, generic-bk7238, generic-bk7238-tuya

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).