### PR TITLE
[core] Enable ruff FLY (flynt) lint family

### DIFF
--- a/esphome/platformio_runner.py
+++ b/esphome/platformio_runner.py
@@ -101,7 +101,7 @@ def patch_file_downloader() -> None:
     FileDownloader.__init__ = patched_init
 
 
-_IGNORE_LIB_WARNINGS = f"(?:{'|'.join(['Hash', 'Update'])})"
+_IGNORE_LIB_WARNINGS = "(?:Hash|Update)"
 # Regex patterns matched against each line of PlatformIO output. Lines that
 # match are dropped by RedirectText before they reach the parent process.
 # Patterns are anchored at the start of the line (RedirectText uses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ exclude = ['generated']
 select = [
   "E",    # pycodestyle
   "F",    # pyflakes/autoflake
+  "FLY",  # flynt: convert string formatting to f-strings
   "FURB", # refurb
   "I",    # isort
   "PERF", # performance


### PR DESCRIPTION
# What does this implement/fix?

Enables the [`FLY`](https://docs.astral.sh/ruff/rules/#flynt-fly) (flynt) lint family in ruff. `FLY002` flags uses of `str.join()` on a list of literals where an f-string (or plain string) would be clearer.

The repo had exactly one existing violation, in `esphome/platformio_runner.py`:

```python
# Before
_IGNORE_LIB_WARNINGS = f"(?:{'|'.join(['Hash', 'Update'])})"

# After
_IGNORE_LIB_WARNINGS = "(?:Hash|Update)"
```

Both forms produce the same string at runtime; the new form is a plain literal, which is clearer and slightly cheaper at import time.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(No device testing required; lint-only change plus a string-literal substitution.)

## Example entry for `config.yaml`:

```yaml
# N/A — repo tooling change
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).