### PR TITLE
[core] Move per-platform hal_platform.h into components/platform/hal.h

### DIFF
--- a/esphome/components/esp32/hal.h
+++ b/esphome/components/esp32/hal.h
@@ -15,6 +15,8 @@
 #define PROGMEM
 #endif
 
+namespace esphome::esp32 {}
+
 namespace esphome {
 
 // Forward decl from helpers.h (esphome/core/helpers.h) — kept here so this

--- a/esphome/components/esp8266/hal.cpp
+++ b/esphome/components/esp8266/hal.cpp
@@ -18,7 +18,7 @@ namespace esphome::esp8266 {}  // namespace esphome::esp8266
 namespace esphome {
 
 // yield(), micros(), millis_64(), delayMicroseconds(), arch_feed_wdt(),
-// progmem_read_*() are inlined in core/hal/hal_esp8266.h.
+// progmem_read_*() are inlined in components/esp8266/hal.h.
 //
 // Fast accumulator replacement for Arduino's millis() (~3.3 μs via 4× 64-bit
 // multiplies on the LX106). Tracks a running ms counter from 32-bit

--- a/esphome/components/esp8266/hal.h
+++ b/esphome/components/esp8266/hal.h
@@ -25,6 +25,8 @@ extern "C" unsigned long millis(void);
 // NOLINTNEXTLINE(readability-redundant-declaration)
 extern "C" void system_soft_wdt_feed(void);
 
+namespace esphome::esp8266 {}
+
 namespace esphome {
 
 // Forward decl from helpers.h so this header stays cheap.

--- a/esphome/components/host/hal.cpp
+++ b/esphome/components/host/hal.cpp
@@ -15,7 +15,7 @@ namespace esphome::host {}  // namespace esphome::host
 namespace esphome {
 
 // yield(), arch_init(), arch_feed_wdt(), arch_get_cpu_freq_hz() inlined in
-// core/hal/hal_host.h.
+// components/host/hal.h.
 
 uint32_t IRAM_ATTR HOT millis() {
   struct timespec spec;

--- a/esphome/components/host/hal.h
+++ b/esphome/components/host/hal.h
@@ -8,6 +8,8 @@
 #define IRAM_ATTR
 #define PROGMEM
 
+namespace esphome::host {}
+
 namespace esphome {
 
 /// Returns true when executing inside an interrupt handler.

--- a/esphome/components/libretiny/hal.cpp
+++ b/esphome/components/libretiny/hal.cpp
@@ -16,7 +16,7 @@ namespace esphome {
 
 // yield(), delay(), micros(), millis(), millis_64(), delayMicroseconds(),
 // arch_feed_wdt(), arch_get_cpu_cycle_count(), arch_get_cpu_freq_hz()
-// inlined in core/hal/hal_libretiny.h.
+// inlined in components/libretiny/hal.h.
 
 void arch_init() {
   libretiny::setup_preferences();

--- a/esphome/components/libretiny/hal.h
+++ b/esphome/components/libretiny/hal.h
@@ -61,6 +61,8 @@ extern "C" void lt_wdt_feed(void);
 extern "C" uint32_t lt_cpu_get_cycle_count(void);
 extern "C" uint32_t lt_cpu_get_freq(void);
 
+namespace esphome::libretiny {}
+
 namespace esphome {
 
 /// Returns true when executing inside an interrupt handler.

--- a/esphome/components/rp2040/hal.cpp
+++ b/esphome/components/rp2040/hal.cpp
@@ -17,7 +17,7 @@ namespace esphome::rp2040 {}  // namespace esphome::rp2040
 namespace esphome {
 
 // yield(), delay(), micros(), millis(), millis_64(), delayMicroseconds(),
-// arch_feed_wdt(), arch_get_cpu_cycle_count() inlined in core/hal/hal_rp2040.h.
+// arch_feed_wdt(), arch_get_cpu_cycle_count() inlined in components/rp2040/hal.h.
 void arch_restart() {
   watchdog_reboot(0, 0, 10);
   while (1) {

--- a/esphome/components/rp2040/hal.h
+++ b/esphome/components/rp2040/hal.h
@@ -25,6 +25,8 @@ extern "C" uint64_t time_us_64(void);
 extern "C" void watchdog_update(void);
 extern "C" unsigned long ulMainGetRunTimeCounterValue(void);
 
+namespace esphome::rp2040 {}
+
 namespace esphome {
 
 // Forward decl from helpers.h.

--- a/esphome/components/zephyr/hal.cpp
+++ b/esphome/components/zephyr/hal.cpp
@@ -20,7 +20,7 @@ static const device *const WDT = DEVICE_DT_GET(DT_ALIAS(watchdog0));
 
 // yield(), delay(), micros(), millis(), millis_64(), delayMicroseconds(),
 // arch_get_cpu_cycle_count(), arch_get_cpu_freq_hz() inlined in
-// core/hal/hal_zephyr.h.
+// components/zephyr/hal.h.
 
 void arch_init() {
 #ifdef CONFIG_WATCHDOG

--- a/esphome/components/zephyr/hal.h
+++ b/esphome/components/zephyr/hal.h
@@ -9,6 +9,8 @@
 #define IRAM_ATTR
 #define PROGMEM
 
+namespace esphome::zephyr {}
+
 namespace esphome {
 
 /// Returns true when executing inside an interrupt handler.

--- a/esphome/core/hal.h
+++ b/esphome/core/hal.h
@@ -8,22 +8,22 @@
 
 // Per-platform HAL bits (IRAM_ATTR / PROGMEM macros, in_isr_context(),
 // inline yield/delay/micros/millis/millis_64 wrappers, ESP8266 progmem
-// helpers) live under esphome/core/hal/ and are dispatched here based on
-// the active USE_* platform define. Each header guards its body with the
-// matching #ifdef USE_<platform> and re-enters namespace esphome {} so it
-// is safe to be re-included.
+// helpers) live next to each platform component as components/<platform>/hal.h
+// and are dispatched here based on the active USE_* platform define. Each
+// header guards its body with the matching #ifdef USE_<platform> and re-enters
+// namespace esphome {} so it is safe to be re-included.
 #if defined(USE_ESP32)
-#include "esphome/core/hal/hal_esp32.h"
+#include "esphome/components/esp32/hal.h"
 #elif defined(USE_ESP8266)
-#include "esphome/core/hal/hal_esp8266.h"
+#include "esphome/components/esp8266/hal.h"
 #elif defined(USE_LIBRETINY)
-#include "esphome/core/hal/hal_libretiny.h"
+#include "esphome/components/libretiny/hal.h"
 #elif defined(USE_RP2040)
-#include "esphome/core/hal/hal_rp2040.h"
+#include "esphome/components/rp2040/hal.h"
 #elif defined(USE_HOST)
-#include "esphome/core/hal/hal_host.h"
+#include "esphome/components/host/hal.h"
 #elif defined(USE_ZEPHYR)
-#include "esphome/core/hal/hal_zephyr.h"
+#include "esphome/components/zephyr/hal.h"
 #else
 #error "hal.h: not implemented for this platform"
 #endif
@@ -33,12 +33,12 @@ namespace esphome {
 // Cross-platform declarations. delayMicroseconds(), arch_feed_wdt(),
 // arch_get_cpu_cycle_count(), arch_init(), arch_get_cpu_freq_hz() vary
 // per platform (some inline, some out-of-line) so they live in
-// hal/hal_<platform>.h.
+// components/<platform>/hal.h.
 void __attribute__((noreturn)) arch_restart();
 
 #ifndef USE_ESP8266
 // All non-ESP8266 platforms: PROGMEM is a no-op, so these are direct dereferences.
-// ESP8266's out-of-line declarations live in hal/hal_esp8266.h.
+// ESP8266's out-of-line declarations live in components/esp8266/hal.h.
 inline uint8_t progmem_read_byte(const uint8_t *addr) { return *addr; }
 inline const char *progmem_read_ptr(const char *const *addr) { return *addr; }
 inline uint16_t progmem_read_uint16(const uint16_t *addr) { return *addr; }


### PR DESCRIPTION
# What does this implement/fix?

Last step in the HAL reorg started in #15977 and continued in the per-platform follow-ups #16111 (esp32), #16112 (esp8266), #16113 (libretiny), #16114 (rp2040), #16115 (host), #16116 (zephyr) — each of which moved its platform's out-of-line HAL bodies from `components/<platform>/core.cpp` into a new `components/<platform>/hal.cpp`.

This PR moves each platform's HAL header next to its `hal.cpp` inside `components/<platform>/hal.h`, rather than under `core/hal/`. The dispatcher `core/hal.h` is updated to include from the new locations and the now-empty `core/hal/` directory is removed.

```
core/hal.h                      ← dispatcher (unchanged shape)
components/esp32/hal.h          ← was core/hal/hal_esp32.h
components/esp8266/hal.h        ← was core/hal/hal_esp8266.h
components/libretiny/hal.h      ← was core/hal/hal_libretiny.h
components/rp2040/hal.h         ← was core/hal/hal_rp2040.h
components/host/hal.h           ← was core/hal/hal_host.h
components/zephyr/hal.h         ← was core/hal/hal_zephyr.h
```

## Why move instead of keeping the wake-style layout

The wake split (#15978) put per-platform code under `core/wake/wake_<group>.{h,cpp}` because some platforms share an implementation (ESP32 + LibreTiny both use `wake_freertos`). HAL primitives are genuinely per-platform — there is no shared HAL implementation across platforms — so the natural home is alongside each platform component rather than in a separate `core/` subdirectory. With the `.cpp` already in `components/<platform>/`, the `.h` belongs there too.

## What the move includes

- `git mv` the six platform headers into `components/<platform>/hal.h`. Git rename detection shows them as renames with 83–100% similarity.
- Dispatcher `core/hal.h` `#if/#elif` ladder updated to point at the new include paths.
- Each `.h` gains an empty `namespace esphome::<platform> {}` block to satisfy ci-custom's `lint_namespace` check (HAL functions live in `namespace esphome` (root); they are not part of the per-component API — same convention used by the matching `hal.cpp` files).
- Comment-only updates to the five `components/<platform>/hal.cpp` files that referenced the old path.
- The empty `esphome/core/hal/` directory is removed.

No public API change, no behavior change, no symbol changes.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Final step of the HAL reorg started in #15977

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal-only file move; no public API or configuration surface affected)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [x] ESP8266
- [x] RP2040/RP2350
- [x] BK72xx
- [x] RTL87xx
- [x] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes — internal HAL header move.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).