### PR TITLE
[core] Support allocating ring buffer in internal memory 

### DIFF
--- a/esphome/core/ring_buffer.cpp
+++ b/esphome/core/ring_buffer.cpp
@@ -1,11 +1,9 @@
 #include "ring_buffer.h"
 
-#include "esphome/core/helpers.h"
-#include "esphome/core/log.h"
-
 #ifdef USE_ESP32
 
-#include "helpers.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
 
@@ -19,12 +17,15 @@ RingBuffer::~RingBuffer() {
   }
 }
 
-std::unique_ptr<RingBuffer> RingBuffer::create(size_t len) {
+std::unique_ptr<RingBuffer> RingBuffer::create(size_t len, MemoryPreference preference) {
   std::unique_ptr<RingBuffer> rb = make_unique<RingBuffer>();
 
   rb->size_ = len;
 
-  RAMAllocator<uint8_t> allocator;
+  const uint8_t type = (preference == MemoryPreference::INTERNAL_FIRST) ? RAMAllocator<uint8_t>::PREFER_INTERNAL
+                                                                        : RAMAllocator<uint8_t>::NONE;
+
+  RAMAllocator<uint8_t> allocator(type);
   rb->storage_ = allocator.allocate(rb->size_);
   if (rb->storage_ == nullptr) {
     return nullptr;

--- a/esphome/core/ring_buffer.h
+++ b/esphome/core/ring_buffer.h
@@ -80,7 +80,12 @@ class RingBuffer {
    */
   BaseType_t reset();
 
-  static std::unique_ptr<RingBuffer> create(size_t len);
+  enum class MemoryPreference {
+    EXTERNAL_FIRST,  // External RAM preferred, fall back to internal (default)
+    INTERNAL_FIRST,  // Internal RAM preferred, fall back to external
+  };
+
+  static std::unique_ptr<RingBuffer> create(size_t len, MemoryPreference preference = MemoryPreference::EXTERNAL_FIRST);
 
  protected:
   /// @brief Discards data from the ring buffer.


### PR DESCRIPTION
# What does this implement/fix?

Adds a second parameter to the ``create`` method to the `RingBuffer` class to control the allocation location preferences. The parameter defaults to `EXTERNAL_FIRST`, matching the current behavior.

Also cleans up the includes to remove a duplicate `helpers.h` and moves both includes past the platform `#ifdef` guard.

This will be useful for optimizing audio components with smaller ring buffers to run well on an ESP32 which has slow PSRAM to reduce stuttering.

### Code Examples

Attempt to allocate in internal memory first, falling back to PSRAM on failure:
```
std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(ring_buffer_size, RingBuffer::MemoryPreference::INTERNAL_FIRST);
```
Attempt to allocate in PSRAM memory first, falling back to internal on failure:
```
// Default parameter approach (existing code uses this)
std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(ring_buffer_size);

// Explicit approach
std::shared_ptr<RingBuffer> temp_ring_buffer = RingBuffer::create(ring_buffer_size, RingBuffer::MemoryPreference::EXTERNAL_FIRST);
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** not applicable

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** not applicable

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

Not applicable
```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
