### PR TITLE
[zephyr] Add nRF52 component tests so CI runs on zephyr-only changes

### DIFF
--- a/tests/components/zephyr/common.yaml
+++ b/tests/components/zephyr/common.yaml
@@ -1,0 +1,8 @@
+esphome:
+  on_boot:
+    - lambda: |-
+        ESP_LOGD("test", "millis=%u micros=%u cycles=%u",
+                 (unsigned) millis(), (unsigned) micros(),
+                 (unsigned) arch_get_cpu_cycle_count());
+        delay(1);
+        delayMicroseconds(1);

--- a/tests/components/zephyr/test.nrf52-adafruit.yaml
+++ b/tests/components/zephyr/test.nrf52-adafruit.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

The `zephyr` component had no `tests/components/zephyr/` directory, so `determine-jobs.py` skipped memory-impact analysis (and most component-test batches) on PRs that only touched `components/zephyr/` — see #16116. Add a minimal `common.yaml` that exercises the inline HAL primitives (`millis`, `micros`, `arch_get_cpu_cycle_count`, `delay`, `delayMicroseconds`) and a single `test.nrf52-adafruit.yaml` one-liner that includes it; the framework's `build_components_base.nrf52-adafruit.yaml` supplies the board/bootloader/logger config. One board variant is enough — adding more would fire every `test.nrf52-*.yaml` across the repo on each zephyr-only PR.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Developer breaking change (an API change that could break external components)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [x] nRF52840

## Example entry for `config.yaml`:

```yaml
# No user-facing changes — adds CI test fixtures.
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).