### PR TITLE
[esp32] Drop printf wrap on IDF 6.0+ (picolibc no longer needs it)

### DIFF
--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1754,13 +1754,13 @@ async def to_code(config):
         # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
         # (~11 KB). See printf_stubs.cpp for implementation.
         #
-        # On IDF 6.0+ picolibc is the libc on every variant. Picolibc's
-        # tinystdio implements vsnprintf by building a string-output FILE
-        # and calling vfprintf, so vfprintf is unconditionally linked in by
-        # any caller of snprintf/vsnprintf — which is effectively every
-        # build. The wrap therefore saves nothing while costing ~170 B of
-        # shim code plus a per-call cookie FILE forward. Force-disable on
-        # IDF 6.0+.
+        # The wrap is only beneficial against newlib. Picolibc's tinystdio
+        # implements vsnprintf by building a string-output FILE and calling
+        # vfprintf, so vfprintf is unconditionally linked in by any caller
+        # of snprintf/vsnprintf — effectively every build — and the wrap
+        # saves nothing while costing ~170 B of shim. IDF 5.x defaults to
+        # newlib on every variant; IDF 6.0+ switches to picolibc on every
+        # variant.
         if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF] or idf_version() >= cv.Version(
             6, 0, 0
         ):

--- a/esphome/components/esp32/__init__.py
+++ b/esphome/components/esp32/__init__.py
@@ -1753,7 +1753,17 @@ async def to_code(config):
 
         # Wrap FILE*-based printf functions to eliminate newlib's _vfprintf_r
         # (~11 KB). See printf_stubs.cpp for implementation.
-        if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF]:
+        #
+        # On IDF 6.0+ picolibc is the libc on every variant. Picolibc's
+        # tinystdio implements vsnprintf by building a string-output FILE
+        # and calling vfprintf, so vfprintf is unconditionally linked in by
+        # any caller of snprintf/vsnprintf — which is effectively every
+        # build. The wrap therefore saves nothing while costing ~170 B of
+        # shim code plus a per-call cookie FILE forward. Force-disable on
+        # IDF 6.0+.
+        if conf[CONF_ADVANCED][CONF_ENABLE_FULL_PRINTF] or idf_version() >= cv.Version(
+            6, 0, 0
+        ):
             cg.add_define("USE_FULL_PRINTF")
         else:
             for symbol in ("vprintf", "printf", "fprintf", "vfprintf"):

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -37,7 +37,14 @@
 #include <cstdarg>
 #include <cstdio>
 
-#ifndef __PICOLIBC__
+#ifdef __PICOLIBC__
+#include <cstddef>
+#include <sys/lock.h>
+#include <type_traits>
+// Pre-initialized by esp_libc_locks_init(); reused as cookie FILE::lock to
+// avoid picolibc flockfile()'s lazy heap allocation leaking on every call.
+extern struct __lock __lock___libc_recursive_mutex;
+#else
 #include "esp_system.h"
 #endif
 
@@ -48,18 +55,7 @@ extern "C" {
 
 #ifdef __PICOLIBC__
 
-#include <cstddef>
-#include <sys/lock.h>
-#include <type_traits>
-
 extern int __real_vfprintf(FILE *stream, const char *fmt, va_list ap);
-
-// Pre-initialized by esp_libc_locks_init() before app_main runs. Picolibc's
-// flockfile() lazily heap-allocates a recursive mutex into FILE::lock when it
-// is null, but our cookie FILE lives on the stack — the mutex would be leaked
-// on every call. Pointing FILE::lock at this already-initialized libc-wide
-// recursive mutex avoids both the per-call allocation and the leak.
-extern struct __lock __lock___libc_recursive_mutex;
 
 namespace {
 

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -17,10 +17,9 @@
  * This wrap is newlib-only. On picolibc, vsnprintf is implemented as
  * vfprintf into a string-output FILE, so vfprintf is unconditionally
  * linked in by any caller of snprintf/vsnprintf and the wrap can never
- * elide it — it just adds shim cost. The Python build glue forces
- * USE_FULL_PRINTF on picolibc builds (RISC-V always, IDF 6.0+ on all
- * variants), so this file compiles to nothing there. The #error below
- * catches a desynchronised gate.
+ * elide it — it just adds shim cost. Codegen forces USE_FULL_PRINTF
+ * on picolibc builds (IDF 6.0+ on all variants) so this file compiles
+ * to nothing there; the #error below catches a desynchronised gate.
  *
  * Saves ~11 KB of flash on newlib.
  *
@@ -31,7 +30,7 @@
 #if defined(USE_ESP_IDF) && !defined(USE_FULL_PRINTF)
 
 #ifdef __PICOLIBC__
-#error "printf wrap is net-negative on picolibc; build glue should set USE_FULL_PRINTF"
+#error "printf wrap is net-negative on picolibc; codegen should set USE_FULL_PRINTF"
 #endif
 
 #include <cstdarg>

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -49,9 +49,17 @@ extern "C" {
 #ifdef __PICOLIBC__
 
 #include <cstddef>
+#include <sys/lock.h>
 #include <type_traits>
 
 extern int __real_vfprintf(FILE *stream, const char *fmt, va_list ap);
+
+// Pre-initialized by esp_libc_locks_init() before app_main runs. Picolibc's
+// flockfile() lazily heap-allocates a recursive mutex into FILE::lock when it
+// is null, but our cookie FILE lives on the stack — the mutex would be leaked
+// on every call. Pointing FILE::lock at this already-initialized libc-wide
+// recursive mutex avoids both the per-call allocation and the leak.
+extern struct __lock __lock___libc_recursive_mutex;
 
 namespace {
 
@@ -78,6 +86,7 @@ const FILE COOKIE_FILE_TEMPLATE = FDEV_SETUP_STREAM(cookie_put, nullptr, nullptr
 int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
   CookieFile cookie;
   cookie.base = COOKIE_FILE_TEMPLATE;
+  cookie.base.lock = &__lock___libc_recursive_mutex;
   cookie.target = stream;
   return __real_vfprintf(&cookie.base, fmt, ap);
 }

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -1,99 +1,48 @@
 /*
- * Linker wrap stubs for FILE*-based printf functions.
+ * Linker wrap stubs for FILE*-based printf functions (newlib only).
  *
  * ESP-IDF SDK components (gpio driver, ringbuf, log_write) reference
- * fprintf(), printf(), vprintf(), and vfprintf() which pull in the full
- * printf implementation (~11 KB on newlib's _vfprintf_r, ~2.8 KB on
- * picolibc's vfprintf). This is a separate implementation from the one
- * used by snprintf/vsnprintf that handles FILE* stream I/O with buffering
- * and locking.
+ * fprintf(), printf(), vprintf(), and vfprintf(), which on newlib pull
+ * in _vfprintf_r (~11 KB) — a separate implementation from the one used
+ * by snprintf/vsnprintf that handles FILE* stream I/O with buffering.
  *
  * ESPHome replaces the ESP-IDF log handler via esp_log_set_vprintf_(),
  * so the SDK's vprintf() path is dead code at runtime. The fprintf()
  * and printf() calls in SDK components are only in debug/assert paths
  * (gpio_dump_io_configuration, ringbuf diagnostics) that are either
  * GC'd or never called. Crash backtraces and panic output are
- * unaffected; they use esp_rom_printf() which is a ROM function
- * and does not go through libc.
+ * unaffected; they use esp_rom_printf() which is a ROM function and
+ * does not go through libc.
  *
- * On picolibc (default for IDF >= 5 on RISC-V, IDF >= 6 everywhere) we
- * route output through a stack-allocated cookie FILE that forwards each
- * byte to the real target stream via fputc(). Picolibc's tinystdio
- * vfprintf walks the FILE::put callback one character at a time, so this
- * costs ~32 bytes of stack for the cookie struct vs. a 512-byte format
- * buffer. The buffered path overflows the loopTask stack on IDF 6.
+ * This wrap is newlib-only. On picolibc, vsnprintf is implemented as
+ * vfprintf into a string-output FILE, so vfprintf is unconditionally
+ * linked in by any caller of snprintf/vsnprintf and the wrap can never
+ * elide it — it just adds shim cost. The Python build glue forces
+ * USE_FULL_PRINTF on picolibc builds (RISC-V always, IDF 6.0+ on all
+ * variants), so this file compiles to nothing there. The #error below
+ * catches a desynchronised gate.
  *
- * On newlib (IDF <= 5 on Xtensa) we keep the original snprintf-then-fwrite
- * path because that loopTask stack budget has plenty of headroom for the
- * 512-byte buffer; the picolibc-only crash above does not affect it.
+ * Saves ~11 KB of flash on newlib.
  *
- * Saves ~11 KB of flash on newlib, ~2.8 KB on picolibc.
- *
- * To disable these wraps, set enable_full_printf: true in the esp32
- * advanced config section.
+ * To disable this wrap on newlib, set enable_full_printf: true in the
+ * esp32 advanced config section.
  */
 
 #if defined(USE_ESP_IDF) && !defined(USE_FULL_PRINTF)
+
+#ifdef __PICOLIBC__
+#error "printf wrap is net-negative on picolibc; build glue should set USE_FULL_PRINTF"
+#endif
+
 #include <cstdarg>
 #include <cstdio>
 
-#ifdef __PICOLIBC__
-#include <cstddef>
-#include <sys/lock.h>
-#include <type_traits>
-// Pre-initialized by esp_libc_locks_init(); reused as cookie FILE::lock to
-// avoid picolibc flockfile()'s lazy heap allocation leaking on every call.
-extern struct __lock __lock___libc_recursive_mutex;
-#else
 #include "esp_system.h"
-#endif
 
 namespace esphome::esp32 {}
 
 // NOLINTBEGIN(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp,readability-identifier-naming)
 extern "C" {
-
-#ifdef __PICOLIBC__
-
-extern int __real_vfprintf(FILE *stream, const char *fmt, va_list ap);
-
-namespace {
-
-struct CookieFile {
-  FILE base;
-  FILE *target;
-};
-
-// cookie_put() recovers CookieFile* from FILE* via reinterpret_cast, which is
-// only well-defined when FILE is the first member at offset 0 and CookieFile
-// is standard-layout.
-static_assert(offsetof(CookieFile, base) == 0, "FILE must be the first member of CookieFile");
-static_assert(std::is_standard_layout<CookieFile>::value, "CookieFile must be standard-layout");
-
-int cookie_put(char c, FILE *stream) {
-  auto *cookie = reinterpret_cast<CookieFile *>(stream);
-  // putc_unlocked: outer flockfile on the cookie already serializes; locking
-  // the target per character would lazy-allocate (and leak) a recursive mutex
-  // when the target is a stack-allocated FILE, e.g. picolibc's internal
-  // string FILE used by vsnprintf — the hot path through esphome::str_sprintf.
-  return putc_unlocked(static_cast<unsigned char>(c), cookie->target);
-}
-
-const FILE COOKIE_FILE_TEMPLATE = FDEV_SETUP_STREAM(cookie_put, nullptr, nullptr, _FDEV_SETUP_WRITE);
-
-}  // namespace
-
-int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
-  CookieFile cookie;
-  cookie.base = COOKIE_FILE_TEMPLATE;
-  cookie.base.lock = &__lock___libc_recursive_mutex;
-  cookie.target = stream;
-  return __real_vfprintf(&cookie.base, fmt, ap);
-}
-
-int __wrap_vprintf(const char *fmt, va_list ap) { return __wrap_vfprintf(stdout, fmt, ap); }
-
-#else  // !__PICOLIBC__
 
 static constexpr size_t PRINTF_BUFFER_SIZE = 512;
 
@@ -125,8 +74,6 @@ int __wrap_vfprintf(FILE *stream, const char *fmt, va_list ap) {
   char buf[PRINTF_BUFFER_SIZE];
   return write_printf_buffer(stream, buf, vsnprintf(buf, sizeof(buf), fmt, ap));
 }
-
-#endif  // __PICOLIBC__
 
 int __wrap_printf(const char *fmt, ...) {
   va_list ap;

--- a/esphome/components/esp32/printf_stubs.cpp
+++ b/esphome/components/esp32/printf_stubs.cpp
@@ -72,7 +72,11 @@ static_assert(std::is_standard_layout<CookieFile>::value, "CookieFile must be st
 
 int cookie_put(char c, FILE *stream) {
   auto *cookie = reinterpret_cast<CookieFile *>(stream);
-  return fputc(static_cast<unsigned char>(c), cookie->target);
+  // putc_unlocked: outer flockfile on the cookie already serializes; locking
+  // the target per character would lazy-allocate (and leak) a recursive mutex
+  // when the target is a stack-allocated FILE, e.g. picolibc's internal
+  // string FILE used by vsnprintf — the hot path through esphome::str_sprintf.
+  return putc_unlocked(static_cast<unsigned char>(c), cookie->target);
 }
 
 const FILE COOKIE_FILE_TEMPLATE = FDEV_SETUP_STREAM(cookie_put, nullptr, nullptr, _FDEV_SETUP_WRITE);


### PR DESCRIPTION
# What does this implement/fix?

`printf_stubs.cpp` wraps `vfprintf`/`vprintf`/`fprintf`/`printf` to work around newlib's bloated `_vfprintf_r` (~11 KB on Xtensa). ESP-IDF 6.0 switches the libc to picolibc on every variant, and picolibc's tinystdio is small enough on its own that the wrap no longer pays for itself — it just adds shim cost.

This PR:

1. Forces `USE_FULL_PRINTF` on IDF 6.0+ in the esp32 Python glue, so the linker `--wrap=` flags are skipped and the wrap stubs compile out. The user-facing `enable_full_printf` option remains a manual override on IDF 5.x.
2. Removes the now-unused picolibc cookie branch from `printf_stubs.cpp`, leaving only the original newlib path. Adds an `#ifdef __PICOLIBC__` `#error` so the file fails the build if anything ever reaches it on picolibc.

A/B on `waveshare-esp32-s3-eth-idf6` (wraps on vs off): flash 398 423 B → 398 251 B, RAM unchanged.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):** N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** N/A

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
esp32:
  board: esp32-s3-devkitc-1
  variant: esp32s3
  framework:
    type: esp-idf
    version: 6.0.1   # wrap auto-disabled on 6.0+
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).