### PR TITLE
[tests] Fix flaky host_mode_climate_basic_state integration test

### DIFF
--- a/tests/integration/fixtures/host_mode_climate_basic_state.yaml
+++ b/tests/integration/fixtures/host_mode_climate_basic_state.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: host-climate-test
+  name: host-climate-basic-state
 host:
 api:
 logger:
@@ -10,6 +10,7 @@ climate:
     name: Dual-mode Thermostat
     sensor: host_thermostat_temperature_sensor
     humidity_sensor: host_thermostat_humidity_sensor
+    on_boot_restore_from: default_preset
     humidity_hysteresis: 1.0
     min_cooling_off_time: 20s
     min_cooling_run_time: 20s

--- a/tests/integration/state_utils.py
+++ b/tests/integration/state_utils.py
@@ -8,6 +8,7 @@ import logging
 from typing import TypeVar
 
 from aioesphomeapi import (
+    APIClient,
     BinarySensorState,
     ButtonInfo,
     EntityInfo,
@@ -19,6 +20,42 @@ from aioesphomeapi import (
 _LOGGER = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=EntityInfo)
+S = TypeVar("S", bound=EntityState)
+
+
+async def wait_for_state(
+    client: APIClient,
+    predicate: Callable[[EntityState], bool],
+    timeout: float = 5.0,
+) -> EntityState:
+    """Subscribe to states and wait for one matching ``predicate``.
+
+    Resolves with the first :class:`EntityState` for which ``predicate``
+    returns ``True``. Useful when a component publishes multiple states
+    during setup (e.g. before sensor readings arrive) and the test needs
+    to wait for the state to converge to expected values rather than
+    capturing whichever state happens to arrive first.
+
+    Args:
+        client: Connected API client.
+        predicate: Callable invoked for every received state; the first
+            state for which it returns ``True`` is returned.
+        timeout: Maximum time to wait in seconds.
+
+    Returns:
+        The first state matching ``predicate``.
+
+    Raises:
+        asyncio.TimeoutError: If no matching state arrives within ``timeout``.
+    """
+    future: asyncio.Future[EntityState] = asyncio.get_running_loop().create_future()
+
+    def on_state(state: EntityState) -> None:
+        if not future.done() and predicate(state):
+            future.set_result(state)
+
+    client.subscribe_states(on_state)
+    return await asyncio.wait_for(future, timeout=timeout)
 
 
 def find_entity(

--- a/tests/integration/test_host_mode_climate_basic_state.py
+++ b/tests/integration/test_host_mode_climate_basic_state.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 from aioesphomeapi import (
     ClimateAction,
     ClimateInfo,
@@ -14,6 +12,7 @@ from aioesphomeapi import (
 )
 import pytest
 
+from .state_utils import wait_for_state
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -24,7 +23,6 @@ async def test_host_mode_climate_basic_state(
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
     """Test basic climate state reporting."""
-    loop = asyncio.get_running_loop()
     async with run_compiled(yaml_config), api_client_connected() as client:
         entities, _ = await client.list_entities_services()
         climate_infos = [e for e in entities if isinstance(e, ClimateInfo)]
@@ -35,10 +33,8 @@ async def test_host_mode_climate_basic_state(
         # temperature/humidity sensors come online. Wait for the state to
         # converge to the expected default values rather than relying on
         # whichever state happens to arrive first.
-        converged: asyncio.Future[ClimateState] = loop.create_future()
-
-        def on_state(state: EntityState) -> None:
-            if (
+        def is_default_state(state: EntityState) -> bool:
+            return (
                 isinstance(state, ClimateState)
                 and state.key == test_climate.key
                 and state.mode == ClimateMode.OFF
@@ -49,13 +45,9 @@ async def test_host_mode_climate_basic_state(
                 and state.preset == ClimatePreset.HOME
                 and state.current_humidity == 42.0
                 and state.target_humidity == 20.0
-                and not converged.done()
-            ):
-                converged.set_result(state)
-
-        client.subscribe_states(on_state)
+            )
 
         try:
-            await asyncio.wait_for(converged, timeout=5.0)
+            await wait_for_state(client, is_default_state)
         except TimeoutError:
             pytest.fail("Climate did not converge to expected default state")

--- a/tests/integration/test_host_mode_climate_basic_state.py
+++ b/tests/integration/test_host_mode_climate_basic_state.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
-import aioesphomeapi
-from aioesphomeapi import ClimateAction, ClimateInfo, ClimateMode, ClimatePreset
+import asyncio
+
+from aioesphomeapi import (
+    ClimateAction,
+    ClimateInfo,
+    ClimateMode,
+    ClimatePreset,
+    ClimateState,
+    EntityState,
+)
 import pytest
 
-from .state_utils import InitialStateHelper
 from .types import APIClientConnectedFactory, RunCompiledFunction
 
 
@@ -17,33 +24,38 @@ async def test_host_mode_climate_basic_state(
     api_client_connected: APIClientConnectedFactory,
 ) -> None:
     """Test basic climate state reporting."""
+    loop = asyncio.get_running_loop()
     async with run_compiled(yaml_config), api_client_connected() as client:
-        # Get entities and set up state synchronization
-        entities, services = await client.list_entities_services()
-        initial_state_helper = InitialStateHelper(entities)
+        entities, _ = await client.list_entities_services()
         climate_infos = [e for e in entities if isinstance(e, ClimateInfo)]
         assert len(climate_infos) >= 1, "Expected at least 1 climate entity"
-
-        # Subscribe with the wrapper (no-op callback since we just want initial states)
-        client.subscribe_states(initial_state_helper.on_state_wrapper(lambda _: None))
-
-        # Wait for all initial states to be broadcast
-        try:
-            await initial_state_helper.wait_for_initial_states()
-        except TimeoutError:
-            pytest.fail("Timeout waiting for initial states")
-
-        # Get the climate entity and its initial state
         test_climate = climate_infos[0]
-        climate_state = initial_state_helper.initial_states.get(test_climate.key)
 
-        assert climate_state is not None, "Climate initial state not found"
-        assert isinstance(climate_state, aioesphomeapi.ClimateState)
-        assert climate_state.mode == ClimateMode.OFF
-        assert climate_state.action == ClimateAction.OFF
-        assert climate_state.current_temperature == 22.0
-        assert climate_state.target_temperature_low == 18.0
-        assert climate_state.target_temperature_high == 24.0
-        assert climate_state.preset == ClimatePreset.HOME
-        assert climate_state.current_humidity == 42.0
-        assert climate_state.target_humidity == 20.0
+        # The thermostat publishes multiple states during setup as the
+        # temperature/humidity sensors come online. Wait for the state to
+        # converge to the expected default values rather than relying on
+        # whichever state happens to arrive first.
+        converged: asyncio.Future[ClimateState] = loop.create_future()
+
+        def on_state(state: EntityState) -> None:
+            if (
+                isinstance(state, ClimateState)
+                and state.key == test_climate.key
+                and state.mode == ClimateMode.OFF
+                and state.action == ClimateAction.OFF
+                and state.current_temperature == 22.0
+                and state.target_temperature_low == 18.0
+                and state.target_temperature_high == 24.0
+                and state.preset == ClimatePreset.HOME
+                and state.current_humidity == 42.0
+                and state.target_humidity == 20.0
+                and not converged.done()
+            ):
+                converged.set_result(state)
+
+        client.subscribe_states(on_state)
+
+        try:
+            await asyncio.wait_for(converged, timeout=5.0)
+        except TimeoutError:
+            pytest.fail("Climate did not converge to expected default state")


### PR DESCRIPTION
# What does this implement/fix?

Fixes flaky `tests/integration/test_host_mode_climate_basic_state.py`.

The test shared a host preferences file (`~/.esphome/prefs/host-climate-test.prefs`) with `test_host_mode_climate_control` because both fixtures used `name: host-climate-test`. When `test_host_mode_climate_control` ran first it persisted `mode=HEAT, target_temperature_low=21.5, target_temperature_high=26.5`. The basic_state thermostat then restored that state on its next boot (the thermostat's default `on_boot_restore_from` is `MEMORY`), and the test failed asserting `OFF`.

Changes:
- `tests/integration/fixtures/host_mode_climate_basic_state.yaml`: rename to `name: host-climate-basic-state` so its prefs file is isolated, and set `on_boot_restore_from: default_preset` so it boots deterministically even on repeat runs.
- `tests/integration/test_host_mode_climate_basic_state.py`: replace the `InitialStateHelper` snapshot pattern with a `subscribe_states` loop that waits for the climate state to converge to the expected default values. The first `publish_state()` during thermostat setup can occur before the template sensors' first reading lands, so capturing whichever state arrived first was racy too.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- N/A

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Test runs against the `host` platform via the integration test harness.)

## Example entry for `config.yaml`:

```yaml
# No user-facing config change. Test fixture excerpt:
esphome:
  name: host-climate-basic-state
host:

climate:
  - platform: thermostat
    id: dual_mode_thermostat
    name: Dual-mode Thermostat
    sensor: host_thermostat_temperature_sensor
    humidity_sensor: host_thermostat_humidity_sensor
    on_boot_restore_from: default_preset
    # ...
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).