### PR TITLE
[sensor] Document why TimeoutFilterBase intentionally keeps Component

### DIFF
--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -413,7 +413,32 @@ class ThrottleWithPriorityNanFilter : public Filter {
   uint32_t min_time_between_inputs_;
 };
 
-// Base class for timeout filters - contains common loop logic
+// Base class for timeout filters - contains common loop logic.
+//
+// Why this intentionally inherits Component (and does NOT use the self-keyed
+// `App.scheduler.set_timeout(this, ...)` pattern that the other Filter classes
+// migrated to):
+//
+//   - These filters re-arm on every input. On devices with many sensors using
+//     timeout filters (e.g. multi-LD2450 boards with dozens of `has_target`
+//     timeouts) the scheduler-based design churned the bounded SchedulerItem
+//     pool and triggered heap allocations / frees at high rate. See #11922
+//     for the original symptom and switchover to the loop-based design.
+//   - Scheduler `set_timeout(this, ...)` cancels-and-replaces by linear scan
+//     over `items_` and `to_add_`, then heap-inserts. That is O(N) + O(log N)
+//     in the currently-scheduled item count per re-arm. The `loop()` design
+//     here is a single timestamp compare per active filter, with the cost
+//     fully partitioned away (`enable_loop()` / `disable_loop()`) when no
+//     timeout is armed.
+//   - Filters live for the lifetime of the program. Carrying a Component
+//     subobject is a one-time cost per instance, not per-event work, and the
+//     RAM overhead is offset by avoiding heap allocations during operation.
+//
+// Earlier attempts to revert this back to the scheduler (e.g. #16173) were
+// closed because they would re-introduce exactly the heap churn #11922 was
+// fixing. A future scheduler that removes the bounded pool and provides
+// O(1) cancel-and-replace by self-key could change this calculus, but until
+// then this class deliberately stays on the loop-based design.
 class TimeoutFilterBase : public Filter, public Component {
  public:
   void loop() override;

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -420,13 +420,13 @@ class ThrottleWithPriorityNanFilter : public Filter {
 // migrated to):
 //
 // Timeout filters re-arm on every input, so on devices with many sensors
-// using timeout filters (e.g. multi-LD2450 boards) every armed filter
-// requires a live SchedulerItem in RAM at the same time. A SchedulerItem is
+// using timeout filters (e.g. multi-LD2450 boards) every armed filter would
+// require a live SchedulerItem in RAM at the same time. A SchedulerItem is
 // substantially larger than the Component bookkeeping bytes carried by this
 // class, so paying the Component cost per filter (one-time, BSS) is cheaper
 // than paying for a SchedulerItem per filter (live, while armed). #11922
 // is the original symptom and switchover to the loop-based design; #16173
-// attempted to migrate back to the scheduler and was closed for exactly
+// attempted to migrate this onto the scheduler and was closed for exactly
 // this reason — even with the bounded pool removed, RAM-per-armed-filter
 // is dominated by the SchedulerItem itself, not by anything we can shrink
 // in the scheduler.
@@ -436,8 +436,8 @@ class ThrottleWithPriorityNanFilter : public Filter {
 // timeout is armed; while armed, work is a single timestamp compare per
 // active filter, with no per-input scheduler cancel/insert path.
 //
-// Don't try to migrate this class back to the self-keyed scheduler. The
-// math doesn't work — at scale, this design is the smaller one.
+// Don't try to migrate this class onto the self-keyed scheduler. The math
+// doesn't work — at scale, this design is the smaller one.
 class TimeoutFilterBase : public Filter, public Component {
  public:
   void loop() override;

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -419,26 +419,25 @@ class ThrottleWithPriorityNanFilter : public Filter {
 // `App.scheduler.set_timeout(this, ...)` pattern that the other Filter classes
 // migrated to):
 //
-//   - These filters re-arm on every input. On devices with many sensors using
-//     timeout filters (e.g. multi-LD2450 boards with dozens of `has_target`
-//     timeouts) the scheduler-based design churned the bounded SchedulerItem
-//     pool and triggered heap allocations / frees at high rate. See #11922
-//     for the original symptom and switchover to the loop-based design.
-//   - Scheduler `set_timeout(this, ...)` cancels-and-replaces by linear scan
-//     over `items_` and `to_add_`, then heap-inserts. That is O(N) + O(log N)
-//     in the currently-scheduled item count per re-arm. The `loop()` design
-//     here is a single timestamp compare per active filter, with the cost
-//     fully partitioned away (`enable_loop()` / `disable_loop()`) when no
-//     timeout is armed.
-//   - Filters live for the lifetime of the program. Carrying a Component
-//     subobject is a one-time cost per instance, not per-event work, and the
-//     RAM overhead is offset by avoiding heap allocations during operation.
+// Timeout filters re-arm on every input, so on devices with many sensors
+// using timeout filters (e.g. multi-LD2450 boards) every armed filter
+// requires a live SchedulerItem in RAM at the same time. A SchedulerItem is
+// substantially larger than the Component bookkeeping bytes carried by this
+// class, so paying the Component cost per filter (one-time, BSS) is cheaper
+// than paying for a SchedulerItem per filter (live, while armed). #11922
+// is the original symptom and switchover to the loop-based design; #16173
+// attempted to migrate back to the scheduler and was closed for exactly
+// this reason — even with the bounded pool removed, RAM-per-armed-filter
+// is dominated by the SchedulerItem itself, not by anything we can shrink
+// in the scheduler.
 //
-// Earlier attempts to revert this back to the scheduler (e.g. #16173) were
-// closed because they would re-introduce exactly the heap churn #11922 was
-// fixing. A future scheduler that removes the bounded pool and provides
-// O(1) cancel-and-replace by self-key could change this calculus, but until
-// then this class deliberately stays on the loop-based design.
+// The loop-based design has additional advantages on top of the RAM win:
+// `enable_loop()` / `disable_loop()` partitions the cost away when no
+// timeout is armed; while armed, work is a single timestamp compare per
+// active filter, with no per-input scheduler cancel/insert path.
+//
+// Don't try to migrate this class back to the self-keyed scheduler. The
+// math doesn't work — at scale, this design is the smaller one.
 class TimeoutFilterBase : public Filter, public Component {
  public:
   void loop() override;

--- a/esphome/components/sensor/filter.h
+++ b/esphome/components/sensor/filter.h
@@ -427,9 +427,9 @@ class ThrottleWithPriorityNanFilter : public Filter {
 // than paying for a SchedulerItem per filter (live, while armed). #11922
 // is the original symptom and switchover to the loop-based design; #16173
 // attempted to migrate this onto the scheduler and was closed for exactly
-// this reason — even with the bounded pool removed, RAM-per-armed-filter
-// is dominated by the SchedulerItem itself, not by anything we can shrink
-// in the scheduler.
+// this reason — even if the scheduler pool were unbounded, RAM per armed
+// filter would still be dominated by the SchedulerItem itself, not by
+// anything we can shrink in the scheduler.
 //
 // The loop-based design has additional advantages on top of the RAM win:
 // `enable_loop()` / `disable_loop()` partitions the cost away when no


### PR DESCRIPTION
# What does this implement/fix?

Comment-only change. Document why `sensor::TimeoutFilterBase` (and its derived `TimeoutFilterLast` / `TimeoutFilterConfigured`) intentionally still inherits `Component` and uses `loop()` + `enable_loop()` / `disable_loop()`, instead of migrating to the self-keyed `App.scheduler.set_timeout(this, ...)` pattern that the other `Filter` classes have moved to (#16131 for `binary_sensor`, #16132 for `sensor`).

The motivation already exists in the git history — #11922 moved the timeout filters off the scheduler precisely to avoid pool churn on devices with many concurrent timeouts (e.g. multi-LD2450 boards), and a recent attempt to revert that (#16173) was closed for the same reason. But the design intent isn't visible at the call site, so the next person looking at `TimeoutFilterBase` and noticing it's the only `Filter` subclass still inheriting `Component` could very plausibly assume it's an oversight and try to "clean it up" again.

This PR adds a block comment in front of `TimeoutFilterBase` covering:

- Why these filters don't use `App.scheduler` like the rest.
- The original symptom that motivated the loop-based design (#11922).
- The cost comparison: loop-based is one timestamp compare per active filter with the cost fully partitioned away via `enable_loop()` / `disable_loop()`; scheduler-based re-arm is O(N) cancel scan + O(log N) heap insert per input.
- The condition under which it would make sense to revisit this (unbounded scheduler pool + O(1) self-key cancel).

No code or behavior change.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected) — [policy](https://developers.esphome.io/contributing/code/#what-constitutes-a-c-breaking-change)
- [ ] Developer breaking change (an API change that could break external components) — [policy](https://developers.esphome.io/contributing/code/#what-is-considered-public-c-api)
- [ ] Undocumented C++ API change (removal or change of undocumented public methods that lambda users may depend on) — [policy](https://developers.esphome.io/contributing/code/#c-user-expectations)
- [x] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- Documents the rationale established by #11922 and reaffirmed by closing #16173.

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- N/A (internal-only comment)

## Test Environment

- [x] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040/RP2350
- [ ] BK72xx
- [ ] RTL87xx
- [ ] LN882x
- [ ] nRF52840

(Comment-only; clang-format and ci-custom pass on the touched file.)

## Example entry for \`config.yaml\`:

\`\`\`yaml
# No user-facing config changes. Existing timeout filter syntax is unchanged.
sensor:
  - platform: template
    id: my_sensor
    lambda: 'return 42.0;'
    update_interval: 100ms
    filters:
      - timeout: 5s
\`\`\`

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under \`tests/\` folder). (comment-only, no behavior change)

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs). (no user-facing change)